### PR TITLE
ファイルパス変更

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -115,7 +115,7 @@ class Application extends \Silex\Application
             array('^/mypage/', 'ROLE_USER'),
         );
         $app['eccube.encoder.customer'] = $app->share(function ($app) {
-            return new \Eccube\Framework\Security\Core\Encoder\CustomerPasswordEncoder($app['config']);
+            return new \Eccube\Security\Core\Encoder\CustomerPasswordEncoder($app['config']);
         });
         $app['security.encoder_factory'] = $app->share(function ($app) {
             return new \Symfony\Component\Security\Core\Encoder\EncoderFactory(array(

--- a/src/Eccube/Security/Core/Encoder/CustomerPasswordEncoder.php
+++ b/src/Eccube/Security/Core/Encoder/CustomerPasswordEncoder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Eccube\Framework\Security\Core\Encoder;
+namespace Eccube\Security\Core\Encoder;
 
 use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 


### PR DESCRIPTION
`Eccube\Framework\Security` 以下となっていた、 `CustomerPasswordEncoder` を正しいNamespaceに移動しました。