### PR TITLE
商品管理のサブナビからレビュー管理を削除

### DIFF
--- a/src/Eccube/View/Admin/Product/subnavi.twig
+++ b/src/Eccube/View/Admin/Product/subnavi.twig
@@ -7,5 +7,4 @@
     <li id="navi-products-upload-csv-category"><a href="{{ url('admin_products_upload_csv_category') }}"><span>カテゴリ登録CSV</span></a></li>
     <li id="navi-products-maker"><a href="{{ url('admin_products_maker') }}"><span>メーカー登録</span></a></li>
     <li id="navi-products-rank"><a href="{{ url('admin_products_product_rank') }}'"><span>商品並び替え</span></a></li>
-    <li id="navi-products-review"><a href="{{ url('admin_products_review') }}"><span>レビュー管理</span></a></li>
 </ul>


### PR DESCRIPTION
レビュー管理はデフォルトインストールプラグインとして扱う方向のため、削除いたしました。