### PR TITLE
Cart のインターフェースの変更

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "require-dev": {
         "satooshi/php-coveralls": "dev-master",
-        "phpunit/phpunit": "3.7.*",
+        "phpunit/phpunit": "4.6.*",
         "phing/phing": "2.*",
         "symfony/browser-kit": "~2.3",
         "symfony/css-selector": "~2.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "8c30cfb2ab94a9a067b95c5ea96f204a",
+    "hash": "70704c6c3972e6348fc8f8ad187c26a6",
     "packages": [
         {
             "name": "dflydev/doctrine-orm-service-provider",
@@ -3327,6 +3327,60 @@
     ],
     "packages-dev": [
         {
+            "name": "doctrine/instantiator",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "f976e5de371104877ebc89bd8fecb0019ed9c119"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f976e5de371104877ebc89bd8fecb0019ed9c119",
+                "reference": "f976e5de371104877ebc89bd8fecb0019ed9c119",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "2.0.*@ALPHA"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Instantiator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2014-10-13 12:58:55"
+        },
+        {
             "name": "guzzle/guzzle",
             "version": "v3.9.3",
             "source": {
@@ -3512,47 +3566,157 @@
             "time": "2015-02-19 15:49:46"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "1.2.18",
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b"
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
-                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": ">=1.3.0@stable",
-                "phpunit/php-text-template": ">=1.2.0@stable",
-                "phpunit/php-token-stream": ">=1.1.3,<1.3.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "3.7.*@dev"
+                "phpunit/phpunit": "~4.0"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.0.5"
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "phpDocumentor": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "time": "2015-02-03 12:10:50"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "8724cd239f8ef4c046f55a3b18b4d91cc7f3e4c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/8724cd239f8ef4c046f55a3b18b4d91cc7f3e4c5",
+                "reference": "8724cd239f8ef4c046f55a3b18b4d91cc7f3e4c5",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "phpdocumentor/reflection-docblock": "~2.0",
+                "sebastian/comparator": "~1.1"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2015-03-27 19:31:25"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "2.0.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "934fd03eb6840508231a7f73eb8940cf32c3b66c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/934fd03eb6840508231a7f73eb8940cf32c3b66c",
+                "reference": "934fd03eb6840508231a7f73eb8940cf32c3b66c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "~1.3",
+                "sebastian/environment": "~1.0",
+                "sebastian/version": "~1.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "~4"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.2.1",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
                 "classmap": [
-                    "PHP/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -3570,7 +3734,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-09-02 10:13:14"
+            "time": "2015-04-11 04:35:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3709,45 +3873,44 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.2.2",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "ad4e1e23ae01b483c16f600ff1bebec184588e32"
+                "reference": "eab81d02569310739373308137284e0158424330"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/ad4e1e23ae01b483c16f600ff1bebec184588e32",
-                "reference": "ad4e1e23ae01b483c16f600ff1bebec184588e32",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/eab81d02569310739373308137284e0158424330",
+                "reference": "eab81d02569310739373308137284e0158424330",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
                 "php": ">=5.3.3"
             },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
                 "classmap": [
-                    "PHP/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Wrapper around PHP's tokenizer extension.",
@@ -3755,62 +3918,61 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2014-03-03 05:10:30"
+            "time": "2015-04-08 04:46:07"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "3.7.38",
+            "version": "4.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6"
+                "reference": "163232991e652e6efed2f8470326fffa61e848e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/38709dc22d519a3d1be46849868aa2ddf822bcf6",
-                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/163232991e652e6efed2f8470326fffa61e848e2",
+                "reference": "163232991e652e6efed2f8470326fffa61e848e2",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-spl": "*",
                 "php": ">=5.3.3",
-                "phpunit/php-code-coverage": "~1.2",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.1",
+                "phpspec/prophecy": "~1.3,>=1.3.1",
+                "phpunit/php-code-coverage": "~2.0,>=2.0.11",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "~1.0",
-                "phpunit/phpunit-mock-objects": "~1.2",
-                "symfony/yaml": "~2.0"
-            },
-            "require-dev": {
-                "pear-pear.php.net/pear": "1.9.4"
+                "phpunit/phpunit-mock-objects": "~2.3",
+                "sebastian/comparator": "~1.1",
+                "sebastian/diff": "~1.2",
+                "sebastian/environment": "~1.2",
+                "sebastian/exporter": "~1.2",
+                "sebastian/global-state": "~1.0",
+                "sebastian/version": "~1.0",
+                "symfony/yaml": "~2.1|~3.0"
             },
             "suggest": {
                 "phpunit/php-invoker": "~1.1"
             },
             "bin": [
-                "composer/bin/phpunit"
+                "phpunit"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.7.x-dev"
+                    "dev-master": "4.6.x-dev"
                 }
             },
             "autoload": {
                 "classmap": [
-                    "PHPUnit/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                "",
-                "../../symfony/yaml/"
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -3822,45 +3984,51 @@
                 }
             ],
             "description": "The PHP Unit Testing framework.",
-            "homepage": "http://www.phpunit.de/",
+            "homepage": "https://phpunit.de/",
             "keywords": [
                 "phpunit",
                 "testing",
                 "xunit"
             ],
-            "time": "2014-10-17 09:04:17"
+            "time": "2015-04-11 05:23:21"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "1.2.3",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "5794e3c5c5ba0fb037b11d8151add2a07fa82875"
+                "reference": "74ffb87f527f24616f72460e54b595f508dccb5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5794e3c5c5ba0fb037b11d8151add2a07fa82875",
-                "reference": "5794e3c5c5ba0fb037b11d8151add2a07fa82875",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/74ffb87f527f24616f72460e54b595f508dccb5c",
+                "reference": "74ffb87f527f24616f72460e54b595f508dccb5c",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "~1.0,>=1.0.2",
                 "php": ">=5.3.3",
-                "phpunit/php-text-template": ">=1.1.1@stable"
+                "phpunit/php-text-template": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
             },
             "suggest": {
                 "ext-soap": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
-                    "PHPUnit/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -3877,7 +4045,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2013-01-13 10:24:48"
+            "time": "2015-04-02 05:36:41"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -3953,6 +4121,377 @@
                 "test"
             ],
             "time": "2014-11-11 15:35:34"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "1dd8869519a225f7f2b9eb663e225298fade819e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1dd8869519a225f7f2b9eb663e225298fade819e",
+                "reference": "1dd8869519a225f7f2b9eb663e225298fade819e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2015-01-29 16:28:08"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/863df9687835c62aa423a22412d26fa2ebde3fd3",
+                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2015-02-22 15:13:53"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "5a8c7d31914337b69923db26c4221b81ff5a196e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5a8c7d31914337b69923db26c4221b81ff5a196e",
+                "reference": "5a8c7d31914337b69923db26c4221b81ff5a196e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2015-01-01 10:01:08"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "84839970d05254c73cde183a721c7af13aede943"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/84839970d05254c73cde183a721c7af13aede943",
+                "reference": "84839970d05254c73cde183a721c7af13aede943",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2015-01-27 07:23:06"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
+                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2014-10-06 09:23:50"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "3989662bbb30a29d20d9faa04a846af79b276252"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/3989662bbb30a29d20d9faa04a846af79b276252",
+                "reference": "3989662bbb30a29d20d9faa04a846af79b276252",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2015-01-24 09:48:32"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "ab931d46cd0d3204a91e1b9a40c4bc13032b58e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/ab931d46cd0d3204a91e1b9a40c4bc13032b58e4",
+                "reference": "ab931d46cd0d3204a91e1b9a40c4bc13032b58e4",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2015-02-24 06:35:25"
         },
         {
             "name": "symfony/browser-kit",

--- a/src/Eccube/Controller/CartController.php
+++ b/src/Eccube/Controller/CartController.php
@@ -7,55 +7,49 @@ use Symfony\Component\HttpFoundation\Request;
 
 class CartController
 {
-    public function __construct()
-    {
-    }
-
     public function index(Application $app)
     {
-        $cart = $app['eccube.service.cart'];
-        $products = $cart->getProducts();
         $title = 'カゴの中';
+        $Cart = $app['eccube.service.cart']->getCart();
 
-        return $app['view']->render(
-            'Cart/index.twig',
-            compact('title', 'products')
+        return $app['view']->render('Cart/index.twig',
+            compact('title', 'Cart')
         );
     }
 
     public function add(Application $app, Request $request)
     {
         $productClassId = $request->get('product_class_id');
-        $quantity = $request->request->has('quantity') ? $request->get('quantity'): 1;
-        $app['eccube.service.cart']->addProduct($productClassId, $quantity);
+        $quantity = $request->request->has('quantity') ? $request->get('quantity') : 1;
+        $app['eccube.service.cart']->addProduct($productClassId, $quantity)->save();
 
         return $app->redirect($app['url_generator']->generate('cart'));
     }
 
     public function up(Application $app, $productClassId)
     {
-        $app['eccube.service.cart']->upProductQuantity($productClassId);
+        $app['eccube.service.cart']->upProductQuantity($productClassId)->save();
 
         return $app->redirect($app['url_generator']->generate('cart'));
     }
 
     public function down(Application $app, $productClassId)
     {
-        $app['eccube.service.cart']->downProductQuantity($productClassId);
+        $app['eccube.service.cart']->downProductQuantity($productClassId)->save();
 
         return $app->redirect($app['url_generator']->generate('cart'));
     }
 
     public function remove(Application $app, $productClassId)
     {
-        $app['eccube.service.cart']->removeProduct($productClassId);
+        $app['eccube.service.cart']->removeProduct($productClassId)->save();
 
         return $app->redirect($app['url_generator']->generate('cart'));
     }
 
     public function setQuantity(Application $app, $productClassId, $quantity)
     {
-        $app['eccube.service.cart']->setProductQuantity($productClassId, $quantity);
+        $app['eccube.service.cart']->setProductQuantity($productClassId, $quantity)->save();
 
         return $app->redirect($app['url_generator']->generate('cart'));
     }

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -126,7 +126,7 @@ class ProductController
 
                     return $app->redirect($app['url_generator']->generate('product_detail', array('productId' => $Product->getId())));
                 } else {
-                    $app['eccube.service.cart']->addProduct($addCartData['product_class_id'], $addCartData['quantity']);
+                    $app['eccube.service.cart']->addProduct($addCartData['product_class_id'], $addCartData['quantity'])->save();
 
                     return $app->redirect($app['url_generator']->generate('cart'));
                 }

--- a/src/Eccube/Entity/CartItem.php
+++ b/src/Eccube/Entity/CartItem.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Eccube\Entity;
+
+class CartItem extends \Eccube\Entity\AbstractEntity
+{
+
+    private $class_name;
+    private $class_id;
+    private $price;
+    private $quantity;
+    private $object;
+
+    public function __construct()
+    {
+    }
+
+    public function __sleep()
+    {
+        return array('class_name', 'class_id', 'price', 'quantity');
+    }
+
+    /**
+     * @param string $class_name
+     * @return CartItem
+     */
+    public function setClassName($class_name)
+    {
+        $this->class_name = $class_name;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassName()
+    {
+        return $this->class_name;
+    }
+
+    /**
+     * @param string $class_id
+     * @return CartItem
+     */
+    public function setClassId($class_id)
+    {
+        $this->class_id = $class_id;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassId()
+    {
+        return $this->class_id;
+    }
+
+    /**
+     * @param integer $price
+     * @return CartItem
+     */
+    public function setPrice($price)
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getPrice()
+    {
+        return $this->price;
+    }
+
+    /**
+     * @param integer $quantity
+     * @return CartItem
+     */
+    public function setQuantity($quantity)
+    {
+        $this->quantity = $quantity;
+
+        return $this;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getQuantity()
+    {
+        return $this->quantity;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getTotalPrice()
+    {
+        return $this->getPrice() * $this->getQuantity();
+    }
+
+    /**
+     * @param object $object
+     * @return CartItem
+     */
+    public function setObject($object)
+    {
+        $this->object = $object;
+
+        return $this;
+    }
+
+    /**
+     * @return object
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+}

--- a/src/Eccube/Resource/locale/ja.yml
+++ b/src/Eccube/Resource/locale/ja.yml
@@ -20,8 +20,12 @@ form.reminder.empty_value: 選択してください
 form.contact.address.help: 住所は2つに分けてご記入ください。マンション名は必ず記入してください。
 form.contact.contents.help: ※ご注文に関するお問い合わせには、必ず「ご注文番号」をご記入くださいますようお願いいたします。
 
-cart.over.stock: ※ 選択された商品の在庫が不足しております。<br />一度に在庫数を超える購入はできません。
-cart.over.sale_limit: ※ 選択された商品は販売制限しております。<br />一度に販売制限数を超える購入はできません。
+cart.over.stock: |-
+    ※ 選択された商品の在庫が不足しております。
+    一度に在庫数を超える購入はできません。
+cart.over.sale_limit: |-
+    ※ 選択された商品は販売制限しております。
+    一度に販売制限数を超える購入はできません。
 
 admin.register.complete: ※ 登録が完了しました。
 admin.customer.delete.complete: ※ 会員を削除しました。

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -3,37 +3,64 @@
 namespace Eccube\Service;
 
 use Eccube\Application;
+use Eccube\Entity\Cart;
+use Eccube\Entity\CartItem;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Doctrine\ORM\EntityManager;
 
 class CartService
 {
-    private $app;
-
-    private $cart;
-
-    private $errors;
-
-    private $messages;
-
     const PRODUCT_TYPE_NORMAL = 1;
 
     const PRODUCT_TYPE_DOWNLOAD = 2;
 
-    public function __construct(Application $app)
+    /**
+     * @var Session 
+     */
+    private $session;
+
+    /**
+     * @var EntityManager 
+     */
+    private $entityManagaer;
+
+    /**
+     * @var \Eccube\Entity\Cart 
+     */
+    private $cart;
+
+    /**
+     * @var array
+     */
+    private $errors = array();
+
+    /**
+     * @var array
+     */
+    private $messages = array();
+
+    public function __construct(Session $session, EntityManager $entityManagaer)
     {
-        $this->app = $app;
+        $this->session = $session;
+        $this->entityManagaer = $entityManagaer;
 
-        $this->cart = $app['eccube.entity.cart'];
+        if ($this->session->has('cart')) {
+            $this->cart = $this->session->get('cart');
+        } else {
+            $this->cart = new \Eccube\Entity\Cart();
+        }
+    }
 
-        $this->errors = array();
-
-        $this->messages = array();
+    public function save()
+    {
+        return $this->session->set('cart', $this->cart);
     }
 
     public function unlock()
     {
         $this->cart
-            ->setPreOrderId(null)
-            ->setLock(false);
+            ->setLock(false)
+            ->setPreOrderId(null);
     }
 
     public function lock()
@@ -41,153 +68,193 @@ class CartService
         $this->cart->setLock(true);
     }
 
+    /**
+     * @return bool
+     */
     public function isLocked()
     {
         return $this->cart->getLock();
     }
 
-    public function setPreOrderId($id)
+    /**
+     * @param string $pre_order_id
+     * @return \Eccube\Service\CartService
+     */
+    public function setPreOrderId($pre_order_id)
     {
-        $this->cart->setPreOrderId($id);
+        $this->cart->setPreOrderId($pre_order_id);
 
         return $this;
     }
 
+    /**
+     * @return string
+     */
     public function getPreOrderId()
     {
         return $this->cart->getPreOrderId();
     }
 
+    /**
+     * @return \Eccube\Service\CartService
+     */
     public function clear()
     {
         $this->cart
             ->setPreOrderId(null)
             ->setLock(false)
-            ->clearProducts();
+            ->clearCartItems();
 
         return $this;
     }
 
-    public function getProducts()
+    public function getCart()
     {
-        $products = $this->cart->getProducts();
+        foreach ($this->cart->getCartItems() as $CartItem) {
+            $ProductClass = $this->entityManagaer->getRepository($CartItem->getClassName())->find($CartItem->getClassId());
+            $CartItem->setObject($ProductClass);
+        }
 
-        if (count($products) > 0) {
-            foreach ($products as $productClassId => $product) {
-                $productClassData = $this->app['orm.em']
-                    ->getRepository('\Eccube\Entity\ProductClass')
-                    ->find($productClassId);
-                $productData = $this->app['orm.em']
-                    ->getRepository('\Eccube\Entity\Product')
-                    ->find($productClassData->getProduct()->getId());
-
-                $products[$productClassId] = array(
-                    // 'tax_rate' => $product['tax_rate'],
-                    'quantity' => $product['quantity'],
-                    'Product' => $productData,
-                    'ProductClass' => $productClassData,
-                );
-            }
-            return $products;
-        } 
-
-        return array();    
+        return $this->cart;
     }
 
+    /**
+     * 
+     * @param string $productClassId
+     * @param integer $quantity
+     * @return \Eccube\Service\CartService
+     */
     public function addProduct($productClassId, $quantity = 1)
     {
-        $products = $this->cart->getProducts();
+        $quantity += $this->getProductQuantity($productClassId);
+        $this->setProductQuantity($productClassId, $quantity);
 
-        if (isset($products[$productClassId])) {
-            $quantity += $products[$productClassId]['quantity'];
-        }
-
-        return $this->setProductQuantity($productClassId, $quantity);
+        return $this;
     }
 
+    /**
+     * @param string $productClassId
+     * @return integer
+     */
     public function getProductQuantity($productClassId)
     {
-        $quantity = 0;
-
-        $products = $this->cart->getProducts();
-
-        if (isset($products[$productClassId]) && isset($products[$productClassId]['quantity'])) {
-            $quantity = $products[$productClassId]['quantity'];
+        $CartItem = $this->cart->getCartItemByIdentifier('Eccube\Entity\ProductClass', (string) $productClassId);
+        if ($CartItem) {
+            return $CartItem->getQuantity();
+        } else {
+            return 0;
         }
-
-        return $quantity;
     }
 
+    /**
+     * @param string $productClassId
+     * @return \Eccube\Service\CartService
+     */
     public function upProductQuantity($productClassId)
     {
         $quantity = $this->getProductQuantity($productClassId) + 1;
+        $this->setProductQuantity($productClassId, $quantity);
 
-        return $this->setProductQuantity($productClassId, $quantity);
+        return $this;
     }
 
+    /**
+     * @param string $productClassId
+     * @return \Eccube\Service\CartService
+     */
     public function downProductQuantity($productClassId)
     {
         $quantity = $this->getProductQuantity($productClassId) - 1;
 
         if ($quantity > 0) {
-            return $this->setProductQuantity($productClassId, $quantity);
-        }
-
-        return $this->removeProduct($productClassId);
-    }
-
-    public function setProductQuantity($productClassId, $quantity)
-    {
-        $product = $this->app['orm.em']->getRepository('Eccube\Entity\ProductClass')
-            ->find($productClassId);
-        
-        $stock = $product->getStock();
-        $stockUnlimited = $product->getStockUnlimited();
-        $saleLimit = $product->getSaleLimit();
-        if (!$stockUnlimited && $quantity > $stock) {
-            $quantity = $stock;
-            $this->setError('cart.over.stock');
-        } elseif ($saleLimit && $quantity > $saleLimit) {
-            $quantity = $saleLimit;
-            $this->setError('cart.over.sale_limit');
-        }
-
-        if ($quantity > 0) {
-            $this->cart->setProductQuantity($productClassId, $quantity);
+            $this->setProductQuantity($productClassId, $quantity);
+        } else {
+            $this->removeProduct($productClassId);
         }
 
         return $this;
     }
 
+    /**
+     * @param \Eccube\Entity\ProductClass|integer $ProductClass
+     * @param integer $quantity
+     * @return \Eccube\Service\CartService
+     * @throws \Exception
+     */
+    public function setProductQuantity($ProductClass, $quantity)
+    {
+        if (!$ProductClass instanceof \Eccube\Entity\ProductClass) {
+            $ProductClass = $this->entityManagaer
+                ->getRepository('Eccube\Entity\ProductClass')
+                ->find($ProductClass);
+        }
+        if (!$ProductClass || $ProductClass->getProduct()->getStatus() !== 1) {
+            throw new \Exception();
+        }
+
+        if (!$ProductClass->getStockUnlimited() && $quantity > $ProductClass->getStock()) {
+            $quantity = $ProductClass->getStock();
+            $this->addError('cart.over.stock');
+        } elseif ($ProductClass->getSaleLimit() && $quantity > $ProductClass->getSaleLimit()) {
+            $quantity = $ProductClass->getSaleLimit();
+            $this->addError('cart.over.sale_limit');
+        }
+
+        $CartItem = new CartItem();
+        $CartItem
+            ->setClassName('Eccube\Entity\ProductClass')
+            ->setClassId((string) $ProductClass->getId())
+            ->setPrice($ProductClass->getPrice02IncTax())
+            ->setQuantity($quantity);
+
+        $this->cart->setCartItem($CartItem);
+
+        return $this;
+    }
+
+    /**
+     * @param string $productClassId
+     * @return \Eccube\Service\CartService
+     */
     public function removeProduct($productClassId)
     {
-        $this->cart->removeProduct($productClassId);
+        $this->cart->removeCartItemByIdentifier('Eccube\Entity\ProductClass', (string) $productClassId);
 
         return $this;
     }
 
+    /**
+     * @return string[]
+     */
     public function getErrors()
     {
         return $this->errors;
     }
 
-    public function setError($error)
+    /**
+     * @param string $error
+     * @return \Eccube\Service\CartService
+     */
+    public function addError($error = null)
     {
-
         $this->errors[] = $error;
-
-        if ($this->errors) {
-            $this->app['session']->getFlashBag()->add('errors', $error);
-        }
+        $this->session->getFlashBag()->add('errors', $error);
 
         return $this;
     }
 
+    /**
+     * @return string[]
+     */
     public function getMessages()
     {
         return $this->messages;
     }
 
+    /**
+     * @param string $message
+     * @return \Eccube\Service\CartService
+     */
     public function setMessage($message)
     {
         $this->messages[] = $message;

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -26,16 +26,11 @@ class EccubeServiceProvider implements ServiceProviderInterface
             return new \Eccube\Service\ViewService($app);
         });
         $app['eccube.service.cart'] = $app->share(function() use ($app) {
-            return new \Eccube\Service\CartService($app);
+            return new \Eccube\Service\CartService($app['session'], $app['orm.em']);
         });
         $app['eccube.service.tax_rule'] = $app->share(function() use ($app) {
             return new \Eccube\Service\TaxRuleService($app);
         });
-
-        // Entity
-        $app['eccube.entity.cart'] = function() use ($app) {
-            return new \Eccube\Entity\Cart($app);
-        };
 
         // Repository
         $app['eccube.repository.master.constant'] = $app->share(function() use ($app) {

--- a/src/Eccube/View/Cart/index.twig
+++ b/src/Eccube/View/Cart/index.twig
@@ -6,102 +6,131 @@
     <div id="undercolumn_cart">
         <h2 class="title">{{ title }}</h2>
 
+        {% if app.config.use_point %}
+            <!--★ポイント案内★-->
+            <div class="point_announce">
+                {% if is_granted('ROLE_USER') %}
+                    <span class="user_name">{{ app.user.last_name }} 様</span>の、現在の所持ポイントは「<span class="point">{{ app.user.point|number_format }} pt</span>」です。<br />
+                {% else %}
+                    ポイント制度をご利用になられる場合は、会員登録後ログインしてくださいますようお願い致します。<br />
+                {% endif %}
+                ポイントは商品購入時に<span class="price">1pt＝{{ app.config.point_value }}円</span>として使用することができます。<br />
+            </div>
+        {% endif %}
+
         <p class="totalmoney_area">
+            {# カゴの中に商品がある場合にのみ表示 #}
+            {#{% if Carts|length > 1 %}
+                <span class="attentionSt"><!--{foreach from=$cartKeys item=key name=cartKey}--><!--{$arrProductType[$key]|h}--><!--{if !$smarty.foreach.cartKey.last}-->、<!--{/if}--><!--{/foreach}-->は同時購入できません。<br />
+                    お手数ですが、個別に購入手続きをお願い致します。
+                </span>
+            {% endif %}#}
+
             {% for error in app.session.flashbag.get('errors')  %}
-                {{ error|trans|raw }}<br />
+                <p class="attention">{{ error|trans|nl2br }}<p>
             {% endfor %}
         </p>
 
-        {% if products|length > 0 %}
-        <div class="form_area">
-            <form name="form" id="form_cart" method="post" action="{{ url('cart') }}">
-                <p>
-                    カゴの中の商品の合計金額は「<span class="price">{{ total_inctax|default(0) }}円</span>」です。
-                    {{ message.deliv_fee|default('') }}
-                </p>
+        {% if Cart.CartItems|length > 0 %}
+            <div class="form_area">
+                <form name="form" id="form_cart" method="post" action="{{ url('cart') }}">
+                    {#
+                    {% if Carts|length > 1 %}
+                        <h3>{{ arrProductType[key] }}</h3>
+                        {% set purchasing_goods_name = arrProductType[key] %}
+                    {% else %}
+                    #}
+                        {% set purchasing_goods_name = "カゴの中の商品" %}
+                    {#
+                    {% endif %}
+                    #}
+                    <p>
+                        {{ purchasing_goods_name }}の合計金額は「<span class="price">{{ Cart.total_price|number_format }}円</span>」です。
+                        {{ message.deliv_fee|default('') }}
+                    </p>
 
-                <table summary="商品情報">
-                    <col width="10%" />
-                    <col width="15%" />
-                    <col width="30%" />
-                    <col width="15%" />
-                    <col width="15%" />
-                    <col width="15%" />
-                    <tr>
-                        <th class="alignC">削除</th>
-                        <th class="alignC">商品写真</th>
-                        <th class="alignC">商品名</th>
-                        <th class="alignC">単価</th>
-                        <th class="alignC">数量</th>
-                        <th class="alignC">小計</th>
-                    </tr>
-
-                    {% for product in products %}
-                        {% set key = loop.index %}
+                    <table summary="商品情報">
+                        <col width="10%" />
+                        <col width="15%" />
+                        <col width="30%" />
+                        <col width="15%" />
+                        <col width="15%" />
+                        <col width="15%" />
                         <tr>
-                            <td class="alignC">
-                                <a href="{{ url('cart_remove', {'productClassId': product.ProductClass.id }) }}">削除</a>
-                            </td>
-                            <td class="alignC">
-                                <a class="expansion" target="_blank" href="{{ app.config.root }}{{ app.config.image_path }}{{ product.Product.main_image }}">
-                                   <img src="{{ app.config.root }}{{ app.config.image_path }}{{ product.Product.main_image }}" style="max-width: 65px;max-height: 65px;" alt="{{ product.Product.name }}" />
-                                </a>
-                            </td>
-                            <td>
-                                {# 商品名 #}
-                                <strong>{{ product.Product.name }}</strong>
-                                {% if product.Product.classcategory_name1 is defined %}
-                                    <div>{{ product.Product.ClassCategory.classcategory_name1 }}</div>
-                                {% endif %}
-                                {% if product.Product.classcategory_name2 is defined %}
-                                    <div>{{ product.Product.classcategory_name2|default('') }}</div>
-                                {% endif %}
-                            </td>
-                            <td class="alignR">
-                                {{ product.ProductClass.price02|default(0) }}
-                            </td>
-                            <td class="alignC">
-                                {{ product.quantity }}
-                                <ul id="quantity_level">
-                                    <li>
-                                        <a href="{{ url('cart_up', {'productClassId': product.ProductClass.id}) }}"><img src="{{ app.config.tpl }}img/button/btn_plus.jpg" width="16" height="16" alt="＋" /></a>
-                                    </li>
-                                    {% if product.quantity > 1 %}
-                                        <li>
-                                            <a href="{{ url('cart_down', {'productClassId': product.ProductClass.id}) }}"><img src="{{ app.config.tpl }}img/button/btn_minus.jpg" width="16" height="16" alt="-" /></a>
-                                        </li>
+                            <th class="alignC">削除</th>
+                            <th class="alignC">商品写真</th>
+                            <th class="alignC">商品名</th>
+                            <th class="alignC">単価</th>
+                            <th class="alignC">数量</th>
+                            <th class="alignC">小計</th>
+                        </tr>
+
+                        {% for CartItem in Cart.CartItems %}
+                            {% set ProductClass = CartItem.Object %}
+                            {% set Product = ProductClass.Product %}
+                            <tr>
+                                <td class="alignC">
+                                    <a href="{{ url('cart_remove', {'productClassId': ProductClass.id }) }}">削除</a>
+                                </td>
+                                <td class="alignC">
+                                    <a class="expansion" target="_blank" href="{{ app.config.image_path }}{{ Product.main_image|no_image_main_list }}">
+                                       <img src="{{ app.config.image_path }}{{ Product.main_image|no_image_main_list }}" style="max-width: 65px;max-height: 65px;" alt="{{ Product.name }}" />
+                                    </a>
+                                </td>
+                                <td>
+                                    {# 商品名 #}
+                                    <strong>{{ Product.name }}</strong>
+                                    {% if ProductClass.ClassCategory1 %}
+                                        <div>{{ ProductClass.ClassCategory1.ClassName.name }}：{{ ProductClass.ClassCategory1.name }}</div>
                                     {% endif %}
-                                </ul>
-                            </td>
-                            <td class="alignR">{{ product.Product.total_inctax|default(0) }}円</td>
-                        </tr>
-                        {% endfor %}
-                        <tr>
-                            <th colspan="5" class="alignR">合計</th>
-                            <td class="alignR">
-                                <span class="price">{{ total_price|default(0) }}円</span>
-                            </td>
-                        </tr>
-                    </table>
-                    <p class="alignC">上記内容でよろしければ「購入手続きへ」ボタンをクリックしてください。</p>
-                <div class="btn_area">
-                    <ul>
-                        <li>
-                            <!--{if $tpl_prev_url != ""}-->
-                                <a href="<!--{$tpl_prev_url|h}-->">
-                                    <img class="hover_change_image" src="{{ app.config.tpl }}img/button/btn_back.jpg" alt="戻る" name="back<!--{$key|h}-->" /></a>
-                            <!--{/if}-->
-                        </li>
-                        <li>
-                            <!--{if strlen($tpl_error) == 0}-->
-                                <input type="image" class="hover_change_image" src="{{ app.config.tpl }}img/button/btn_buystep.jpg" alt="購入手続きへ" name="confirm" />
-                            <!--{/if}-->
-                        </li>
-                    </ul>
-                </div>
-            </form>
-        </div>
-
+                                    {% if ProductClass.ClassCategory2 %}
+                                        <div>{{ ProductClass.ClassCategory2.ClassName.name }}：{{ ProductClass.ClassCategory2.name }}</div>
+                                    {% endif %}
+                                </td>
+                                <td class="alignR">
+                                    {{ CartItem.price|number_format }}円
+                                </td>
+                                <td class="alignC">
+                                    {{ CartItem.quantity|number_format }}
+                                    <ul id="quantity_level">
+                                        <li>
+                                            <a href="{{ url('cart_up', {'productClassId': ProductClass.id}) }}"><img src="{{ app.config.tpl }}img/button/btn_plus.jpg" width="16" height="16" alt="＋" /></a>
+                                        </li>
+                                        {% if CartItem.quantity > 1 %}
+                                            <li>
+                                                <a href="{{ url('cart_down', {'productClassId': ProductClass.id}) }}"><img src="{{ app.config.tpl }}img/button/btn_minus.jpg" width="16" height="16" alt="-" /></a>
+                                            </li>
+                                        {% endif %}
+                                    </ul>
+                                </td>
+                                <td class="alignR">{{ CartItem.total_price|number_format }}円</td>
+                            </tr>
+                            {% endfor %}
+                            <tr>
+                                <th colspan="5" class="alignR">合計</th>
+                                <td class="alignR">
+                                    <span class="price">{{ Cart.total_price|number_format }}円</span>
+                                </td>
+                            </tr>
+                        </table>
+                        <p class="alignC">上記内容でよろしければ「購入手続きへ」ボタンをクリックしてください。</p>
+                    <div class="btn_area">
+                        <ul>
+                            <li>
+                                <!--{if $tpl_prev_url != ""}-->
+                                    <a href="<!--{$tpl_prev_url|h}-->">
+                                        <img class="hover_change_image" src="{{ app.config.tpl }}img/button/btn_back.jpg" alt="戻る" name="back<!--{$key|h}-->" /></a>
+                                <!--{/if}-->
+                            </li>
+                            <li>
+                                <!--{if strlen($tpl_error) == 0}-->
+                                    <input type="image" class="hover_change_image" src="{{ app.config.tpl }}img/button/btn_buystep.jpg" alt="購入手続きへ" name="confirm" />
+                                <!--{/if}-->
+                            </li>
+                        </ul>
+                    </div>
+                </form>
+            </div>
         {% else %}
             <p class="empty">
                 <span class="attention">※ 現在カート内に商品はございません。</span>

--- a/tests/Eccube/Tests/Service/CartServiceTest.php
+++ b/tests/Eccube/Tests/Service/CartServiceTest.php
@@ -19,130 +19,132 @@ class CartServiceTest extends \PHPUnit_Framework_TestCase
 
     public function testUnlock()
     {
-        $cart = $this->app['eccube.service.cart'];
-        $cart->unlock();
+        $cartService = $this->app['eccube.service.cart'];
+        $cartService->unlock();
 
-        $this->assertFalse($cart->isLocked());
+        $this->assertFalse($cartService->isLocked());
     }
 
     public function testLock()
     {
-        $cart = $this->app['eccube.service.cart'];
-        $cart->lock();
+        $cartService = $this->app['eccube.service.cart'];
+        $cartService->lock();
 
-        $this->assertTrue($cart->isLocked());
+        $this->assertTrue($cartService->isLocked());
     }
 
     public function testClear_PreOrderId()
     {
-        $cart = $this->app['eccube.service.cart'];
-        $cart->clear();
+        $cartService = $this->app['eccube.service.cart'];
+        $cartService->clear();
 
-        $this->assertNull($cart->getPreOrderId());
+        $this->assertNull($cartService->getPreOrderId());
     }
 
     public function testClear_Lock()
     {
-        $cart = $this->app['eccube.service.cart'];
-        $cart->clear();
+        $cartService = $this->app['eccube.service.cart'];
+        $cartService->clear();
 
-        $this->assertFalse($cart->isLocked());
+        $this->assertFalse($cartService->isLocked());
+        $this->assertCount(0, $cartService->getCart()->getCartItems());
     }
 
     public function testClear_Products()
     {
-        $cart = $this->app['eccube.service.cart'];
-        $cart->clear();
+        $cartService = $this->app['eccube.service.cart'];
+        $cartService->addProduct(1);
+        $cartService->clear();
 
-        $this->assertCount(0, $cart->getProducts());
+        $this->assertCount(0, $cartService->getCart()->getCartItems());
     }
 
     public function testAddProducts_ProductClassEntity()
     {
-        $cart = $this->app['eccube.service.cart'];
-        $cart->addProduct(1);
+        $cartService = $this->app['eccube.service.cart'];
+        $cartService->addProduct(1);
 
-        $products = $cart->getProducts();
-        $productClassId = $products[1]['ProductClass']->getId();
+        $CartItems = $cartService->getCart()->getCartItems();
 
-        $this->assertEquals(1, $productClassId);
+        $this->assertEquals('Eccube\Entity\ProductClass', $CartItems[0]->getClassName());
+        $this->assertEquals(1, $CartItems[0]->getClassId());
     }
 
     public function testAddProducts_Quantity()
     {
-        $cart = $this->app['eccube.service.cart'];
-        $this->assertCount(0, $cart->getProducts());
+        $cartService = $this->app['eccube.service.cart'];
+        $this->assertCount(0, $cartService->getCart()->getCartItems());
 
-        $cart->addProduct(1);
-        $this->assertEquals(1, $cart->getProductQuantity(1));
+        $cartService->addProduct(1);
+        $this->assertEquals(1, $cartService->getProductQuantity(1));
     }
 
     public function testUpProductQuantity()
     {
-        $cart = $this->app['eccube.service.cart'];
-        $cart->setProductQuantity(1, 1);
-        $cart->upProductQuantity(1);
+        $cartService = $this->app['eccube.service.cart'];
+        $cartService->setProductQuantity(1, 1);
+        $cartService->upProductQuantity(1);
 
-        $quantity = $cart->getProductQuantity(1);
+        $quantity = $cartService->getProductQuantity(1);
 
         $this->assertEquals(2, $quantity);
     }
 
     public function testDownProductQuantity()
     {
-        $cart = $this->app['eccube.service.cart'];
+        $cartService = $this->app['eccube.service.cart'];
 
-        $cart->setProductQuantity(1, 2);
-        $cart->downProductQuantity(1);
+        $cartService->setProductQuantity(1, 2);
+        $cartService->downProductQuantity(1);
 
-        $quantity = $cart->getProductQuantity(1);
+        $quantity = $cartService->getProductQuantity(1);
 
         $this->assertEquals(1, $quantity);
     }
 
     public function testDownProductQuantity_Remove()
     {
-        $cart = $this->app['eccube.service.cart'];
+        $cartService = $this->app['eccube.service.cart'];
 
-        $cart->setProductQuantity(1, 1);
-        $cart->downProductQuantity(1);
+        $cartService->setProductQuantity(1, 1);
+        $cartService->downProductQuantity(1);
 
-        $quantity = $cart->getProductQuantity(1);
-
-        $this->assertCount(0, $cart->getProducts());
+        $quantity = $cartService->getProductQuantity(1);
+        $this->assertEquals(0, $quantity);
+        $this->assertCount(0, $cartService->getCart()->getCartItems());
     }
 
     public function testRemoveProduct()
     {
-        $cart = $this->app['eccube.service.cart'];
+        $cartService = $this->app['eccube.service.cart'];
 
-        $cart->setProductQuantity(1, 2);
-        $cart->removeProduct(1);
+        $cartService->setProductQuantity(1, 2);
+        $cartService->removeProduct(1);
 
-        $this->assertCount(0, $cart->getProducts());
+        $this->assertCount(0, $cartService->getCart()->getCartItems());
     }
 
     public function testGetErrors()
     {
-        $cart = $this->app['eccube.service.cart'];
+        $cartService = $this->app['eccube.service.cart'];
 
-        $this->assertCount(0, $cart->getErrors());
-        
-        $cart->setError('foo');
-        $cart->setError('bar');
-        
-        $this->assertCount(2, $cart->getErrors());
+        $this->assertCount(0, $cartService->getErrors());
+
+        $cartService->addError('foo');
+        $cartService->addError('bar');
+
+        $this->assertCount(2, $cartService->getErrors());
     }
 
     public function testGetMessages()
     {
-        $cart = $this->app['eccube.service.cart'];
-        $this->assertCount(0, $cart->getMessages());
+        $cartService = $this->app['eccube.service.cart'];
+        $this->assertCount(0, $cartService->getMessages());
 
-        $cart->setMessage('foo');
-        $cart->setMessage('bar');
+        $cartService->setMessage('foo');
+        $cartService->setMessage('bar');
 
-        $this->assertCount(2, $cart->getMessages());
+        $this->assertCount(2, $cartService->getMessages());
     }
 
 }

--- a/tests/Eccube/Tests/Web/CartControllerTest.php
+++ b/tests/Eccube/Tests/Web/CartControllerTest.php
@@ -7,7 +7,6 @@ use Eccube\Application;
 
 class CartControllerTest extends WebTestCase
 {
-
     /**
      * {@inheritdoc}
      */
@@ -23,14 +22,14 @@ class CartControllerTest extends WebTestCase
     public function testRoutingCart()
     {
         $client = $this->createClient();
-        $crawler = $client->request('GET', '/cart/');
+        $client->request('GET', '/cart/');
         $this->assertTrue($client->getResponse()->isSuccessful());
     }
 
     public function testRoutingCartAdd()
     {
         $client = $this->createClient();
-        $crawler = $client->request('POST', '/cart/add/', array('product_class_id' => 1));
+        $client->request('POST', '/cart/add/', array('product_class_id' => 1));
 
         $this->assertTrue($client->getResponse()->isRedirection());
     }
@@ -38,29 +37,28 @@ class CartControllerTest extends WebTestCase
     public function testRoutingCartUp()
     {
         $client = $this->createClient();
-        $crawler = $client->request('GET', '/cart/up/1');
+        $client->request('GET', '/cart/up/1');
         $this->assertTrue($client->getResponse()->isRedirection());
     }
 
     public function testRoutingCartDown()
     {
         $client = $this->createClient();
-        $crawler = $client->request('GET', '/cart/down/1');
+        $client->request('GET', '/cart/down/1');
         $this->assertTrue($client->getResponse()->isRedirection());
     }
 
     public function testRoutingCartSetQuantity()
     {
         $client = $this->createClient();
-        $crawler = $client->request('GET', '/cart/setQuantity/2/1');
+        $client->request('GET', '/cart/setQuantity/2/1');
         $this->assertTrue($client->getResponse()->isRedirection());
     }
 
     public function testRoutingCartRemove()
     {
         $client = $this->createClient();
-        $crawler = $client->request('GET', '/cart/remove/1');
+        $client->request('GET', '/cart/remove/1');
         $this->assertTrue($client->getResponse()->isRedirection());
     }
-
 }

--- a/tests/Eccube/Tests/Web/ContactControllerTest.php
+++ b/tests/Eccube/Tests/Web/ContactControllerTest.php
@@ -5,7 +5,7 @@ namespace Eccube\Tests\Web;
 use Silex\WebTestCase;
 use Eccube\Application;
 
-class ProductControllerTest extends WebTestCase
+class RoutingTest extends WebTestCase
 {
     /**
      * {@inheritdoc}
@@ -19,17 +19,17 @@ class ProductControllerTest extends WebTestCase
         return $app;
     }
 
-    public function testRoutingList()
+    public function testRoutingIndex()
     {
         $client = $this->createClient();
-        $client->request('GET', $this->app['url_generator']->generate('product_list'));
+        $client->request('GET', $this->app['url_generator']->generate('contact'));
         $this->assertTrue($client->getResponse()->isSuccessful());
     }
 
-    public function testRoutingDetail()
+    public function testRoutingComplete()
     {
         $client = $this->createClient();
-        $client->request('GET', $this->app['url_generator']->generate('product_detail', array('productId' => '1')));
+        $client->request('GET', $this->app['url_generator']->generate('contact_complete'));
         $this->assertTrue($client->getResponse()->isSuccessful());
     }
 }

--- a/tests/Eccube/Tests/Web/EntryControllerTest.php
+++ b/tests/Eccube/Tests/Web/EntryControllerTest.php
@@ -5,9 +5,8 @@ namespace Eccube\Tests\Web;
 use Silex\WebTestCase;
 use Eccube\Application;
 
-class RoutingTest extends WebTestCase
+class EntryControllerTest extends WebTestCase
 {
-
     /**
      * {@inheritdoc}
      */
@@ -20,18 +19,17 @@ class RoutingTest extends WebTestCase
         return $app;
     }
 
-    public function testRoutingContact()
+    public function testRoutingIndex()
     {
         $client = $this->createClient();
-        $crawler = $client->request('GET', '/contact/');
+        $client->request('GET', $this->app['url_generator']->generate('entry'));
         $this->assertTrue($client->getResponse()->isSuccessful());
     }
 
-    public function testRoutingEntry()
+    public function testRoutingComplete()
     {
         $client = $this->createClient();
-        $crawler = $client->request('GET', '/entry/');
+        $client->request('GET', $this->app['url_generator']->generate('entry_complete'));
         $this->assertTrue($client->getResponse()->isSuccessful());
     }
-
 }

--- a/tests/Eccube/Tests/Web/HelpControllerTest.php
+++ b/tests/Eccube/Tests/Web/HelpControllerTest.php
@@ -7,7 +7,6 @@ use Eccube\Application;
 
 class HelpControllerTest extends WebTestCase
 {
-
     /**
      * {@inheritdoc}
      */
@@ -26,7 +25,7 @@ class HelpControllerTest extends WebTestCase
     public function testRoutingHelpTradelaw()
     {
         $client = $this->createClient();
-        $crawler = $client->request('GET', '/help/tradelaw');
+        $client->request('GET', $this->app['url_generator']->generate('help_tradelaw'));
         $this->assertTrue($client->getResponse()->isSuccessful());
     }
 
@@ -36,7 +35,7 @@ class HelpControllerTest extends WebTestCase
     public function testRoutingHelpAbout()
     {
         $client = $this->createClient();
-        $crawler = $client->request('GET', '/help/about');
+        $client->request('GET', $this->app['url_generator']->generate('help_about'));
         $this->assertTrue($client->getResponse()->isSuccessful());
     }
 
@@ -46,7 +45,7 @@ class HelpControllerTest extends WebTestCase
     public function testRoutingHelpGuide()
     {
         $client = $this->createClient();
-        $crawler = $client->request('GET', '/help/guide');
+        $client->request('GET', $this->app['url_generator']->generate('help_guide'));
         $this->assertTrue($client->getResponse()->isSuccessful());
     }
 
@@ -56,8 +55,7 @@ class HelpControllerTest extends WebTestCase
     public function testRoutingHelpPrivacy()
     {
         $client = $this->createClient();
-        $crawler = $client->request('GET', '/help/privacy');
+        $client->request('GET', $this->app['url_generator']->generate('help_privacy'));
         $this->assertTrue($client->getResponse()->isSuccessful());
     }
-
 }


### PR DESCRIPTION
`Cart` でarrayとobjectが混在していたため、関係を整理しました。

プラグインで拡張されることを見越し、以下の内容になっています。
* Eccube/Entity/Cart
* Eccube/Entity/CartItem
* Eccube/Service/Cart

* Serviceで保存などを行うsaveメソッドがあり、永続化が可能になっています。
もし、DBに保存したい場合にはserviceのsaveメソッドを変更すれば可能になります。
IoT / マルチデバイスを見込んだ実装です。
* `CartItem` で `ClassName` と `ClassId` を持てるようになっています。
例えば、ProductClass以外のItemをCartに入れる拡張を見込んでいます。