### PR TITLE
Fix admin web test 

### DIFF
--- a/src/Eccube/View/Admin/main_frame.twig
+++ b/src/Eccube/View/Admin/main_frame.twig
@@ -63,7 +63,7 @@
         <div id="site-check">
             <p class="info">
                 <span><strong>ログイン&nbsp;:&nbsp;</strong>{{ app.user.name }}</span>&nbsp;様,&nbsp;&nbsp;
-                <span><strong>最終ログイン日時&nbsp;:&nbsp;</strong>{{ app.user.login_date.format('Y/m/d H:i') }}</span>
+                <span><strong>最終ログイン日時&nbsp;:&nbsp;</strong>{{ app.user.login_date.format('Y/m/d H:i')|default() }}</span>
             </p>
             <ul>
                 <li><a href="{{ url('homepage') }}" class="btn-tool-format" target="_blank"><span>SITE CHECK</span></a></li>

--- a/tests/Eccube/Tests/Web/Admin/AbstractAdminWebTestCase.php
+++ b/tests/Eccube/Tests/Web/Admin/AbstractAdminWebTestCase.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Eccube\Tests\Web\Admin;
+
+use Silex\WebTestCase;
+use Eccube\Application;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+abstract class AbstractAdminWebTestCase extends WebTestCase
+{
+
+    public $client = null;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->client = static::createClient();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createApplication()
+    {
+        $app = new Application(array(
+            'env' => 'test',
+        ));
+        $app['session.test'] = true;
+
+        return $app;
+    }
+
+    public function logIn()
+    {
+
+        $firewall = 'admin';
+
+        $user = $this->app['eccube.repository.member']
+            ->findOneBy(array(
+                'login_id' => 'admin',
+            ));
+
+        $token = new UsernamePasswordToken($user, null, $firewall, array('ROLE_ADMIN'));
+
+        $this->app['session']->set('_security_' . $firewall, serialize($token));
+        $this->app['session']->save();
+
+        $cookie = new Cookie($this->app['session']->getName(), $this->app['session']->getId());
+        $this->client->getCookieJar()->set($cookie);
+    }
+}

--- a/tests/Eccube/Tests/Web/Admin/Basis/BasisControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Basis/BasisControllerTest.php
@@ -1,30 +1,15 @@
 <?php
-namespace Eccube\Tests\Web;
 
-use Silex\WebTestCase;
-use Eccube\Application;
+namespace Eccube\Tests\Web\Admin;
 
-class BasisControllerTest extends WebTestCase
+class BasisControllerTest extends AbstractAdminWebTestCase
 {
-
-    /**
-     * {@inheritdoc}
-     */
-    public function createApplication()
-    {
-        $app = new Application(array(
-            'env' => 'test',
-        ));
-
-        return $app;
-    }
 
     public function testRoutingAdminBasis()
     {
-        self::markTestSkipped();
+        $this->logIn();
 
-        $client = $this->createClient();
-        $client->request('GET', $this->app['url_generator']->generate('admin_basis'));
-        $this->assertTrue($client->getResponse()->isSuccessful());
+        $this->client->request('GET', $this->app['url_generator']->generate('admin_basis'));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 }

--- a/tests/Eccube/Tests/Web/Admin/Basis/PointController.php
+++ b/tests/Eccube/Tests/Web/Admin/Basis/PointController.php
@@ -1,30 +1,14 @@
 <?php
-namespace Eccube\Tests\Web;
 
-use Silex\WebTestCase;
-use Eccube\Application;
+namespace Eccube\Tests\Web\Admin;
 
-class PointControllerTest extends WebTestCase
+class PointControllerTest extends AbstractAdminWebTestCase
 {
-
-    /**
-     * {@inheritdoc}
-     */
-    public function createApplication()
-    {
-        $app = new Application(array(
-            'env' => 'test',
-        ));
-
-        return $app;
-    }
-
     public function testRoutingAdminBasisPoint()
     {
-        self::markTestSkipped();
+        $this->logIn();
 
-        $client = $this->createClient();
-        $crawler = $client->request('GET', '/admin/basis/point');
-        $this->assertTrue($client->getResponse()->isSuccessful());
+        $this->client->request('GET', '/admin/basis/point');
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 }

--- a/tests/Eccube/Tests/Web/Admin/Basis/TaxRuleControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Basis/TaxRuleControllerTest.php
@@ -1,56 +1,39 @@
 <?php
-namespace Eccube\Tests\Web;
 
-use Silex\WebTestCase;
-use Eccube\Application;
+namespace Eccube\Tests\Web\Admin;
 
-class TaxRuleControllerTest extends WebTestCase
+class TaxRuleControllerTest extends AbstractAdminWebTestCase
 {
-
-    /**
-     * {@inheritdoc}
-     */
-    public function createApplication()
-    {
-        $app = new Application(array(
-            'env' => 'test',
-        ));
-
-        return $app;
-    }
 
     public function test_routeing_AdminBasisTax_index()
     {
-        self::markTestSkipped();
+        $this->logIn();
 
-        $client = $this->createClient();
-        $client->request('GET', $this->app['url_generator']->generate('admin_basis_tax_rule'));
-        $this->assertTrue($client->getResponse()->isSuccessful());
+        $this->client->request('GET', $this->app['url_generator']->generate('admin_basis_tax_rule'));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 
     public function test_routeing_AdminBasisTax_edit()
     {
-        self::markTestSkipped();
+        $this->logIn();
 
-        $client = $this->createClient();
-        $client->request('GET', $this->app['url_generator']
+        $this->client->request('GET', $this->app['url_generator']
             ->generate('admin_basis_tax_rule_edit', array('tax_rule_id' => 0))
         );
-        $this->assertTrue($client->getResponse()->isSuccessful());
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 
     public function test_routeing_AdminBasisTax_delete()
     {
-        self::markTestSkipped();
+        $this->logIn();
 
         $redirectUrl = $this->app['url_generator']->generate('admin_basis_tax_rule');
 
-        $client = $this->createClient();
-        $client->request('GET', $this->app['url_generator']
+        $this->client->request('GET', $this->app['url_generator']
             ->generate('admin_basis_tax_rule_delete', array('tax_rule_id' => 0))
         );
 
-        $actual = $client->getResponse()->isRedirect($redirectUrl);
+        $actual = $this->client->getResponse()->isRedirect($redirectUrl);
 
         $this->assertSame(true, $actual);
     }

--- a/tests/Eccube/Tests/Web/Admin/Content/PageControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/PageControllerTest.php
@@ -1,89 +1,74 @@
 <?php
-namespace Eccube\Tests\Web;
+namespace Eccube\Tests\Web\Admin;
 
-use Silex\WebTestCase;
-use Eccube\Application;
-
-class PageControllerTest extends WebTestCase
+class PageControllerTest extends AbstractAdminWebTestCase
 {
-
-    /**
-     * {@inheritdoc}
-     */
-    public function createApplication()
-    {
-        $app = new Application(array(
-            'env' => 'test',
-        ));
-
-        return $app;
-    }
 
     public function test_routeing_AdminContentPage_index()
     {
-        self::markTestSkipped();
+        $this->logIn();
 
-        $client = $this->createClient();
-        $client->request('GET', $this->app['url_generator']->generate('admin_content_page'));
-        $this->assertTrue($client->getResponse()->isSuccessful());
+        $this->client->request('GET', $this->app['url_generator']->generate('admin_content_page'));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 
     public function test_routeing_AdminContentPage_edit()
     {
+        // TODO: テンプレートファイルの参照等がconstant.yml.distで定まらずCIで落ちるためスキップ
         self::markTestSkipped();
 
-        $client = $this->createClient();
-        $client->request('GET',
+        $this->logIn();
+
+        $this->client->request('GET',
             $this->app['url_generator']
                 ->generate('admin_content_page_edit',
                     array('page_id' => 1)));
-        $this->assertTrue($client->getResponse()->isSuccessful());
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 
     public function test_routeing_AdminContentPage_editWithDevice()
     {
+        // TODO: テンプレートファイルの参照等がconstant.yml.distで定まらずCIで落ちるためスキップ
         self::markTestSkipped();
 
-        $client = $this->createClient();
-        $client->request('GET',
+        $this->logIn();
+
+        $this->client->request('GET',
             $this->app['url_generator']
                 ->generate('admin_content_page_edit_withDevice',
                     array('page_id' => 1, 'device_id' => 10)));
-        $this->assertTrue($client->getResponse()->isSuccessful());
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 
     public function test_routeing_AdminContentPage_delete()
     {
-        self::markTestSkipped();
+        $this->logIn();
 
         $redirectUrl = $this->app['url_generator']->generate('admin_content_page');
 
-        $client = $this->createClient();
-        $client->request('GET',
+        $this->client->request('GET',
             $this->app['url_generator']
                 ->generate('admin_content_page_delete',
                     array('page_id' => 1)));
 
-        $actual = $client->getResponse()->isRedirect($redirectUrl);
+        $actual = $this->client->getResponse()->isRedirect($redirectUrl);
 
         $this->assertSame(true, $actual);
     }
 
     public function test_routeing_AdminContentPage_deleteWithDevice()
     {
-        self::markTestSkipped();
+        $this->logIn();
 
         $redirectUrl = $this->app['url_generator']->generate('admin_content_page');
 
-        $client = $this->createClient();
-        $client->request('GET',
+        $this->client->request('GET',
             $this->app['url_generator']
                 ->generate('admin_content_page_delete_withDevice',
                     array('page_id' => 1, 'device_id' => 10)));
 
-        $actual = $client->getResponse()->isRedirect($redirectUrl);
+        $actual = $this->client->getResponse()->isRedirect($redirectUrl);
 
         $this->assertSame(true, $actual);
     }
-
 }


### PR DESCRIPTION
管理画面のログイン実装にともなって、テストケースが動かなくなっていたものを修正しました。
管理画面のWEBテスト共通の基底クラスとして、AbstractAdminWebTestCaseも作ってます。