### PR TITLE
OrderStatusが登録されない

### DIFF
--- a/src/Eccube/Resource/doctrine/Eccube.Entity.Order.dcm.yml
+++ b/src/Eccube/Resource/doctrine/Eccube.Entity.Order.dcm.yml
@@ -300,14 +300,14 @@ Eccube\Entity\Order:
             joinColumn:
                 name: status
                 referencedColumnName: id
-        OrderStatus:
-            targetEntity: Eccube\Entity\Master\OrderStatus
+        OrderStatusColor:
+            targetEntity: Eccube\Entity\Master\OrderStatusColor
             inversedBy: Orders
             joinColumn:
                 name: status
                 referencedColumnName: id
-        OrderStatusColor:
-            targetEntity: Eccube\Entity\Master\OrderStatusColor
+        OrderStatus:
+            targetEntity: Eccube\Entity\Master\OrderStatus
             inversedBy: Orders
             joinColumn:
                 name: status


### PR DESCRIPTION
```
$Order = $app['eccube.service.order']->newOrder();

$OrderStatus = $app['orm.em']->find('Eccube\Entity\Master\OrderStatus', 1);
$Order->setOrderStatus($OrderStatus);

$CustomerOrderStatus = $app['orm.em']->find('Eccube\Entity\Master\CustomerOrderStatus', 2);
$Order->setCustomerOrderStatus($CustomerOrderStatus);

$OrderStatusColor = $app['orm.em']->find('Eccube\Entity\Master\OrderStatusColor', 3);
$Order->setOrderStatusColor($OrderStatusColor);

$app['orm.em']->persist($Order);
$app['orm.em']->flush();
```
上記を実行すると, dtb_order.statusは`3`がinsertされる.

Order.dcm.ymlでは
- OrderStatus
- CustomerOrderStatus
- OrderStatusColor

の順番で記述されてる

これを
- CustomerOrderStatus
- OderStatusColor
- OrderStatus

の順番に変更すると, 期待したとおりに dtb_order.statusは`1`がinsertされる.

ymlでの定義順序が影響してる？


.

