### PR TITLE
デバッグモード(dev)が設定されている場合、config_dev.ymlを読み込む機能を作成 refs #207

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -107,17 +107,17 @@ class Application extends \Silex\Application
                 if (file_exists($config_dev_file)) {
                     $config_dev = Yaml::parse($config_dev_file);
                     if (isset($config_dev)) {
-                        $confarray = array_merge($confarray, $config_dev);
+                        $confarray = array_replace_recursive($confarray, $config_dev);
                     }
                 }
                 $constant_dev_file = __DIR__ . '/../../app/config/eccube/constant_dev.yml';
                 if (file_exists($constant_dev_file)) {
                     $constant_dev = Yaml::parse($constant_dev_file);
                     if (isset($constant_dev)) {
-                        $confarray = array_merge($confarray, $constant_dev);
+                        $confarray = array_replace_recursive($confarray, $constant_dev);
                     }
                 }
-                return array_merge($conf, $confarray);
+                return array_replace_recursive($conf, $confarray);
             });
         }
 

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -98,6 +98,29 @@ class Application extends \Silex\Application
             return array_merge($config_constant, $config);
         });
 
+        // load config dev
+        if ($app['env'] === 'dev' || $app['env'] === 'test') {
+            $conf = $this['config'];
+            $this['config'] = $app->share(function () use($conf) {
+                $confarray = array();
+                $config_dev_file = __DIR__ . '/../../app/config/eccube/config_dev.yml';
+                if (file_exists($config_dev_file)) {
+                    $config_dev = Yaml::parse($config_dev_file);
+                    if (isset($config_dev)) {
+                        $confarray = array_merge($confarray, $config_dev);
+                    }
+                }
+                $constant_dev_file = __DIR__ . '/../../app/config/eccube/constant_dev.yml';
+                if (file_exists($constant_dev_file)) {
+                    $constant_dev = Yaml::parse($constant_dev_file);
+                    if (isset($constant_dev)) {
+                        $confarray = array_merge($confarray, $constant_dev);
+                    }
+                }
+                return array_merge($conf, $confarray);
+            });
+        }
+
         $this->register(new \Silex\Provider\ServiceControllerServiceProvider());
         $this->register(new \Silex\Provider\SessionServiceProvider());
 

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -110,13 +110,6 @@ class Application extends \Silex\Application
                         $confarray = array_replace_recursive($confarray, $config_dev);
                     }
                 }
-                $constant_dev_file = __DIR__ . '/../../app/config/eccube/constant_dev.yml';
-                if (file_exists($constant_dev_file)) {
-                    $constant_dev = Yaml::parse($constant_dev_file);
-                    if (isset($constant_dev)) {
-                        $confarray = array_replace_recursive($confarray, $constant_dev);
-                    }
-                }
                 return array_replace_recursive($conf, $confarray);
             });
         }


### PR DESCRIPTION
#207 でお伝えしたdevが設定されている時は、
config_dev.ymlとconstant_dev.ymlを読み込むようにしました。
config_dev.yml、constant_dev.ymlは存在しても、しなくても構いません。

固定でconfig_dev.yml、constant_dev.ymlとしていますので、
これ以外のファイル名だと読み込みしません。

使い方ですが、config_dev.ymlに
```
database:
    host: localhost
```
を設定すると
localhostに接続されるようになります。

同様にconfig.ymlに定義されている内容をconfig_yml.devに定義すると
devファイルの内容で上書きされます。


この機能はdevが設定されている環境でのみ有効となります。