### PR TITLE
[管理画面]CSS調整

### DIFF
--- a/html/admin/assets/css/dashboard.css
+++ b/html/admin/assets/css/dashboard.css
@@ -867,6 +867,13 @@ dd.form-group .errormsg {
     color: inherit;  background: #FDF1F0;
 }
 
+.has-error .help-block, .has-error .radio, .has-error .checkbox, .has-error .radio-inline, .has-error .checkbox-inline {
+    color: #de5d50;
+}
+.has-error .control-label {
+    color: #444;
+}
+
 .form-inline .radio input[type="radio"], .form-inline .checkbox input[type="checkbox"] {
     margin-right: 5px;
 }

--- a/html/admin/assets/css/dashboard.css
+++ b/html/admin/assets/css/dashboard.css
@@ -722,6 +722,7 @@ fieldset[disabled] .btn-link:focus {
     top: 2px;
 	font-size: 13px;
 }
+
 .btn_area2 {
     padding: 16px 0 48px;
 }
@@ -893,6 +894,10 @@ dd.form-group .errormsg {
     border-bottom-left-radius: 0 !important;
     border-top-left-radius: 0 !important;
 }
+.input-group .form-control:first-child, .input-group-addon:first-child, .input-group-btn:first-child > .btn, .input-group-btn:first-child > .btn-group > .btn, .input-group-btn:first-child > .dropdown-toggle, .input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle), .input-group-btn:last-child > .btn-group:not(:last-child) > .btn {
+    border-bottom-right-radius: 0 !important;
+    border-top-right-radius: 0 !important;
+}
 
 #drag-drop-area {
     cursor: pointer;
@@ -906,6 +911,8 @@ dd.form-group .errormsg {
 #drag-drop-area .no-image {
     fill: #d0d0d0;
     font-size: 60px;
+}
+#drag-drop-area {
 }
 
 #wysiwyg-area {
@@ -1232,11 +1239,38 @@ dd.form-group .errormsg {
     border-top: 1px dotted #d1d8d9;
     position: relative;
 }
+.order_list .item_box .icon_edit {
+	top: 16px;
+}
+.order_list .item_name_area {
+	padding-right: 66px;
+	padding-bottom: 8px;
+}
+.order_list .item_box input.form-control {
+	margin: 0;
+}
+.order_list .item_subtotal {
+	margin: 8px 0;
+	padding: 8px 15px;
+}
+.order_list .item_subtotal span {
+	margin-right: 10px;
+}
+
+@media (max-width:768px) {
+	.order_list  .item_box .item_quantity input {
+		width: 66.6667%;
+	}
+}
 .order_list .btn_area {
     padding: 0 0 8px;
 }
-.order_list  .item_box > div {
+.order_list .item_box > div {
     vertical-align: top;
+	border-top: 0 none;
+}
+.order_list .item_box .item_tax .input-group {
+    width: 80px;
 }
 .order_list .btn_area li {
     width: 20%;
@@ -1246,7 +1280,7 @@ dd.form-group .errormsg {
     margin-bottom: 8px;
 }
 
-.order_list dl.with-border2 {
+.order_list .with-border2 {
     padding-top: 16px;
 }
 
@@ -1309,9 +1343,12 @@ dd.form-group .errormsg {
     .no-header > .box-body .item_box:first-child > div {
         border-top: 0 none;
     }
-    .order_list  .item_box > div {
-        border-top: 1px dotted #d1d8d9;
-    }
+	.order_list  .item_box .icon_edit {
+		position: absolute;
+	}
+	.order_list  .item_box .icon_edit .btn {
+		margin: 0;
+	}
     .item_box > div:first-child {
         padding-left: 16px;
     }
@@ -1366,16 +1403,37 @@ dd.form-group .errormsg {
 }
 
 
-
 /* amount_area */
 
 .amount_area {
     padding-top: 16px;
     text-align: right;
 }
-.amount_area dl dt {
+.amount_area dt {
+    clear: left;
+    float: left;
+	line-height: 40px;
+	height: 40px;
+	vertical-align: middle;
+    overflow: hidden;
     text-align: right;
-    font-weight: bold;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: normal;
+}
+.amount_area dd.form-group {
+	line-height: 40px;
+	height: 40px;
+	vertical-align: middle;
+}
+.amount_area input {
+	margin: 0;
+}
+
+@media (max-width:768px) {
+	.amount_area dt {
+		width: 30%;
+	}
 }
 
 /* table_list */
@@ -1390,9 +1448,6 @@ dd.form-group .errormsg {
 	border-top: 0 none;
 }
 
-.table_list table {
-    margin-bottom: 0;
-}
 .table_list tr > th, .table_list tr > td {
     vertical-align: middle;
     border-left: 1px solid #d1d8d9;
@@ -1443,6 +1498,10 @@ dl.accordion {
 }
 .accordion .accpanel {
     display: none;
+}
+
+.accordion .toggle.with-icon:hover {
+	opacity: 0.8;
 }
 
 .dropdown-menu {
@@ -1756,7 +1815,7 @@ dl.accordion {
 
     width:230px;
     position: fixed;
-    top: 65px; bottom: 0; left: 0;
+    top: 64px; bottom: 0; left: 0;
     z-index:810;
     display: block;
     color: #d6dadd;
@@ -1906,7 +1965,7 @@ dl.accordion {
     transition:margin-left .3s ease;
     margin-left:230px;
     z-index:820;
-    padding: 0;
+    padding: 0 0 50px;
     margin-top: 64px;
 }
 
@@ -2173,10 +2232,10 @@ ul.link-with-bar li:last-child::after {
     max-width: 5em;
 }
 .form-group .item_price input,
-.form-group .item_quantity input {
+.form-group .item_quantity input,
+.form-group .item_tax input {
     text-align: right;
     width: 50%;
-    margin: 0 1%;
 }
 .item_detail .form-group {
     margin: 8px 0;
@@ -2299,6 +2358,7 @@ ul.link-with-bar li:last-child::after {
     width: 360px;
 }
 @media (max-width: 768px) {
+
     .login-box {
         margin-top: 20px;
         width: 90%;

--- a/html/admin/assets/css/dashboard.css
+++ b/html/admin/assets/css/dashboard.css
@@ -75,6 +75,10 @@ small, .small {
 .icon-with-bg {
     fill: #fff;
 }
+#file_upload:hover {
+	opacity: 0.8;
+	cursor: pointer;
+}
 
 
 /* table reset */
@@ -900,7 +904,6 @@ dd.form-group .errormsg {
 }
 
 #drag-drop-area {
-    cursor: pointer;
     border-radius:3px;
     box-shadow:none;
     border: 1px solid #C4CCCE;
@@ -1065,7 +1068,6 @@ dd.form-group .errormsg {
     padding: 5px 0;
 }
 .form-horizontal .photo_files {
-    cursor: pointer;
     border-radius:3px;
     border: 1px solid #C4CCCE;
     padding: 16px 16px 0 0;
@@ -1099,6 +1101,7 @@ dd.form-group .errormsg {
 }
 .form-horizontal .photo_files li a:hover {
     color: #cdcdcd;
+	cursor: pointer;
 }
 .form-horizontal .photo_files li img {
     max-width: 100%;

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -195,21 +195,21 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </div>
                         {# 住所：都道府県 #}
                         <div class="form-group">
-                            <div class="col-sm-offset-3 col-sm-9 col-lg-offset-2 col-lg-10 form-inline">
+                            <div class="col-sm-offset-2 col-sm-9 col-lg-10 form-inline">
                                 {{ form_widget(form.address.pref) }}
                                 {{ form_errors(form.address.pref) }}
                             </div>
                         </div>
                         {# 住所：住所1 #}
                         <div class="form-group">
-                            <div class="col-sm-offset-3 col-sm-9 col-lg-offset-2 col-lg-10">
+                            <div class="col-sm-offset-2 col-sm-9 col-lg-10">
                                 {{ form_widget(form.address.addr01, { attr : { placeholder : '市区町村名（例：千代田区神田神保町）'}} ) }}
                                 {{ form_errors(form.address.addr01) }}
                             </div>
                         </div>
                         {# 住所：住所2 #}
                         <div class="form-group">
-                            <div class="col-sm-offset-3 col-sm-9 col-lg-offset-2 col-lg-10">
+                            <div class="col-sm-offset-2 col-sm-9 col-lg-10">
                                 {{ form_widget(form.address.addr02, { attr : { placeholder : '番地・ビル名（例：1-3-5）' }}) }}
                                 {{ form_errors(form.address.addr02) }}
                             </div>
@@ -391,21 +391,21 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             </div>
                             {# 住所：都道府県 #}
                             <div class="form-group">
-                                <div class="col-sm-offset-3 col-sm-9 col-lg-offset-2 col-lg-10 form-inline">
+                                <div class="col-sm-offset-2 col-sm-9 col-lg-10 form-inline">
                                     {{ form_widget(shippingForm.address.pref) }}
                                     {{ form_errors(shippingForm.address.pref) }}
                                 </div>
                             </div>
                             {# 住所：住所1 #}
                             <div class="form-group">
-                                <div class="col-sm-offset-3 col-sm-9 col-lg-offset-2 col-lg-10">
+                                <div class="col-sm-offset-2 col-sm-9 col-lg-10">
                                     {{ form_widget(shippingForm.address.addr01, { attr : { placeholder : '市区町村名（例：千代田区神田神保町）'}} ) }}
                                     {{ form_errors(shippingForm.address.addr01) }}
                                 </div>
                             </div>
                             {# 住所：住所2 #}
                             <div class="form-group">
-                                <div class="col-sm-offset-3 col-sm-9 col-lg-offset-2 col-lg-10">
+                                <div class="col-sm-offset-2 col-sm-9 col-lg-10">
                                     {{ form_widget(shippingForm.address.addr02, { attr : { placeholder : '番地・ビル名（例：1-3-5）' }}) }}
                                     {{ form_errors(shippingForm.address.addr02) }}
                                 </div>

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -154,7 +154,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     <div class="row btn_area">
                         <div class="col-xs-8 col-xs-offset-2 col-sm-4 col-sm-offset-4 text-center">
                             <button class="btn btn-primary btn-block btn-lg" onclick="eccube.fnFormModeSubmit('search_form', 'search', '', ''); return false;">
-                                検索する <span class="fa fa-chevron-right"></span>
+                                検索する <svg class="cb cb-angle-right"> <use xlink:href="#cb-angle-right" /></svg>
                             </button>
                         </div>
                         <!-- /.col --> 
@@ -176,7 +176,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     <ul class="sort-dd">
                                     <li class="dropdown">
                                         {% for pageMax in pageMaxis if pageMax.name == page_count %}
-                                            <a class="dropdown-toggle" data-toggle="dropdown">{{ pageMax.name|e }}件<span class="fa fa-chevron-down icon_down"></span></a>
+                                            <a class="dropdown-toggle" data-toggle="dropdown">{{ pageMax.name|e }}件<svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg></a>
                                             <ul class="dropdown-menu">
                                         {% endfor %}
                                         {% for pageMax in pageMaxis if pageMax.name != page_count %}
@@ -185,7 +185,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                             </ul>
                                     </li>
                                     <li class="dropdown">
-                                        <a class="dropdown-toggle" data-toggle="dropdown">CSVダウンロード<span class="fa fa-chevron-down icon_down"></span></a>
+                                        <a class="dropdown-toggle" data-toggle="dropdown">CSVダウンロード<svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg></a>
                                         <ul class="dropdown-menu">
                                             <li><a>CSVダウンロード</a></li>
                                             <li><a>出力項目設定</a></li>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
@@ -73,7 +73,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
                 <div class="box accordion">
                     <div class="box-header toggle">
-                        <h3 class="box-title">お届け時間設定<span class="fa fa-chevron-down icon_down"></span></h3>
+                        <h3 class="box-title">お届け時間設定<svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg></h3>
                     </div><!-- /.box-header -->
                     <div class="box-body accpanel">
                         {% for child in form.delivery_times %}
@@ -108,7 +108,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </div>
                     </div><!-- /.box-header -->
                     <div class="box-body toggle" style="position:relative;">
-                        <h3 class="box-title">都道府県ごとに設定する<span class="fa fa-chevron-down icon_down"></span></h3>
+                        <h3 class="box-title">都道府県ごとに設定する<svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg></h3>
                     </div>
                     <div class="box-body accpanel">
                         {% for child in form.delivery_fees %}

--- a/src/Eccube/Resource/template/admin/Setting/Shop/tax_rule.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/tax_rule.twig
@@ -97,7 +97,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 <td>{{ TaxRule.default_tax_rule  ? '基本税率設定' : TaxRule.apply_date|date('Y/m/d') }}</td>
                                 <td class="icon_edit">
                                     <div class="dropdown">
-                                        <a class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><span class="fa fa-pencil"></span></a>
+                                        <a class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
                                         <ul class="dropdown-menu dropdown-menu-right">
                                             <li><a href="{{ url('admin_setting_shop_tax_edit', { id : TaxRule.id }) }}">編集</a></li>
                                             {% if TaxRule.default_tax_rule %}

--- a/src/Eccube/Resource/template/admin/alert.twig
+++ b/src/Eccube/Resource/template/admin/alert.twig
@@ -23,8 +23,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     {% for message in app.session.flashBag.get('eccube.admin.success') %}
         <div class="row">
             <div class="alert alert-success alert-dismissable">
-                <button aria-hidden="true" data-dismiss="alert" class="close" type="button">×</button>
-                <span class="fa fa-info-circle"></span> {{ message|trans }}
+                <button aria-hidden="true" data-dismiss="alert" class="close" type="button"><svg class="cb cb-close"> <use xlink:href="#cb-close" /></svg></button>
+                <svg class="cb cb-info-circle"> <use xlink:href="#cb-info-circle" /></svg> {{ message|trans }}
             </div>
         </div>
     {% endfor %}
@@ -34,8 +34,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     {% for message in app.session.flashBag.get('eccube.admin.info') %}
         <div class="row">
             <div class="alert alert-info alert-dismissable">
-                <button aria-hidden="true" data-dismiss="alert" class="close" type="button">×</button>
-                <span class="fa fa-info-circle"></span> {{ message|trans }}
+                <button aria-hidden="true" data-dismiss="alert" class="close" type="button"><svg class="cb cb-close"> <use xlink:href="#cb-close" /></svg></button>
+                <svg class="cb cb-info-circle"> <use xlink:href="#cb-info-circle" /></svg> {{ message|trans }}
             </div>
         </div>
     {% endfor %}
@@ -44,8 +44,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     {% for message in app.session.flashBag.get('eccube.admin.warning') %}
         <div class="row">
             <div class="alert alert-warning alert-dismissable">
-                <button aria-hidden="true" data-dismiss="alert" class="close" type="button">×</button>
-                <span class="fa fa-info-circle"></span> {{ message|trans }}
+                <button aria-hidden="true" data-dismiss="alert" class="close" type="button"><svg class="cb cb-close"> <use xlink:href="#cb-close" /></svg></button>
+                <svg class="cb cb-info-circle"> <use xlink:href="#cb-info-circle" /></svg> {{ message|trans }}
             </div>
         </div>
     {% endfor %}
@@ -54,8 +54,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     {% for message in app.session.flashBag.get('eccube.admin.danger') %}
         <div class="row">
             <div class="alert alert-danger alert-dismissable">
-                <button aria-hidden="true" data-dismiss="alert" class="close" type="button">×</button>
-                <span class="fa fa-info-circle"></span> {{ message|trans }}
+                <button aria-hidden="true" data-dismiss="alert" class="close" type="button"><svg class="cb cb-close"> <use xlink:href="#cb-close" /></svg></button>
+                <svg class="cb cb-info-circle"> <use xlink:href="#cb-info-circle" /></svg> {{ message|trans }}
             </div>
         </div>
     {% endfor %}
@@ -64,8 +64,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     {% for message in app.session.flashBag.get('eccube.admin.error') %}
         <div class="row">
             <div class="alert alert-danger alert-dismissable">
-                <button aria-hidden="true" data-dismiss="alert" class="close" type="button">×</button>
-                <span class="fa fa-info-circle"></span> {{ message|trans }}
+                <button aria-hidden="true" data-dismiss="alert" class="close" type="button"><svg class="cb cb-close"> <use xlink:href="#cb-close" /></svg></button>
+                <svg class="cb cb-info-circle"> <use xlink:href="#cb-info-circle" /></svg> {{ message|trans }}
             </div>
         </div>
     {% endfor %}

--- a/src/Eccube/Resource/template/default/Block/cart.twig
+++ b/src/Eccube/Resource/template/default/Block/cart.twig
@@ -20,7 +20,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #}
             <div id="cart_area">
-                <p class="clearfix cart-trigger"><a href="#cart"><span class="fa fa-shopping-cart"></span><span class="badge">3</span><span class="icon_close"></span></a>
+                <p class="clearfix cart-trigger"><a href="#cart"><svg class="cb cb-shopping-cart"><use xlink:href="#cb-shopping-cart" /></svg><span class="badge">3</span><svg class="cb cb-close"><use xlink:href="#cb-close" /></svg></a>
                 <span class="cart_price pc">合計 <span class="price"> \ 21,250</span></span></p>
                 <div id="cart" class="cart">
                     <div class="inner">
@@ -33,7 +33,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 <dd class="item_price">\ 1,728<span class="small">税込</span></dd>
                                 <dd class="item_quantity form-group form-inline">数量：<input type="number" min="1" class="form-control"></dd>
                                 <dd class="icon_edit">
-                                    <button class="no-style"><span class="fa fa-times"></span></button>
+                                    <button class="no-style"><svg class="cb cb-close"><use xlink:href="#cb-close" /></svg></button>
                                 </dd>
                             </dl>
                         </div><!--/item_box-->
@@ -45,7 +45,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 <dd class="item_price">\ 1,728<span class="small">税込</span></dd>
                                 <dd class="item_quantity form-group form-inline">数量：<input type="number" min="1" class="form-control"></dd>
                                 <dd class="icon_edit">
-                                    <button class="no-style"><span class="fa fa-times"></span></button>
+                                    <button class="no-style"><svg class="cb cb-close"><use xlink:href="#cb-close" /></svg></button>
                                 </dd>
                             </dl>
                         </div><!--/item_box-->
@@ -57,7 +57,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 <dd class="item_price">\ 1,728<span class="small">税込</span></dd>
                                 <dd class="item_quantity form-group form-inline">数量：<input type="number" min="1" class="form-control"></dd>
                                 <dd class="icon_edit">
-                                    <button class="no-style"><span class="fa fa-times"></span></button>
+                                    <button class="no-style"><svg class="cb cb-close"><use xlink:href="#cb-close" /></svg></button>
                                 </dd>
                             </dl>
                         </div><!--/item_box-->

--- a/src/Eccube/Resource/template/default/Block/news.twig
+++ b/src/Eccube/Resource/template/default/Block/news.twig
@@ -33,7 +33,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                         <dt>
                                             <span class="date">{{ News.date|date("Y.m.d") }}</span>
                                             <span class="news_title">{{ News.title }}</span>
-                                            <span class="fa fa-chevron-circle-down"></span>
+                                            <span class="angle-circle"><svg class="cb cb-angle-down"><use xlink:href="#cb-angle-down" /></svg></span>
                                         </dt>
 
                                         <dd>{{ News.comment }}</dd>

--- a/src/Eccube/Resource/template/default/Cart/index.twig
+++ b/src/Eccube/Resource/template/default/Cart/index.twig
@@ -40,13 +40,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     </ul>
                                 </div>
 
-                                <div class="message">
-                                    {% for error in app.session.flashbag.get('eccube.front.request.error')  %}
+                                {% for error in app.session.flashbag.get('eccube.front.request.error')  %}
+                                    <div class="message">
                                         <p class="errormsg bg-danger">
                                             <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>{{ error|trans|nl2br }}
                                         </p>
-                                    {% endfor %}
-                                </div>
+                                    </div>
+                                {% endfor %}
 
                                 {% if Cart.CartItems|length > 0 %}
                                 <form name="form" id="form_cart" method="post" action="{{ url('cart') }}">
@@ -140,9 +140,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
                                 </form>
                                 {% else %}
+                                <div class="message">
                                     <p class="errormsg bg-danger">
                                         <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>※ 現在カート内に商品はございません。
                                     </p>
+                                </div>
                                 {% endif %}
 
                             </div><!-- /.col -->

--- a/src/Eccube/Resource/template/default/Product/list.twig
+++ b/src/Eccube/Resource/template/default/Product/list.twig
@@ -67,7 +67,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 <div class="col-sm-3 col-xs-6">
                     <div class="product_item">
                         <a href="{{ url('product_detail', {'id': Product.id}) }}">
-                            <div class="item_photo"><img src="{{ app.config.image_save_urlpath }}{{ Product.main_list_image|no_image_product }}">{#<button type="button" class="btn_circle" data-toggle="modal" data-target="#myModal"><span class="fa fa-ellipsis-h"></span></button>#}</div>
+                            <div class="item_photo"><img src="{{ app.config.image_save_urlpath }}{{ Product.main_list_image|no_image_product }}">{#<button type="button" class="btn_circle" data-toggle="modal" data-target="#myModal"><svg class="cb cb-ellipsis"><use xlink:href="#cb-ellipsis" /></svg></button>#}</div>
                             <dl>
                                 <dt class="item_name">{{ Product.name }}</dt>
                                 {% if Product.hasProductClass %}

--- a/src/Eccube/Resource/template/default/index.twig
+++ b/src/Eccube/Resource/template/default/index.twig
@@ -60,33 +60,41 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 </div>
                 <div class="row">
                    <div class="col-sm-4 col-xs-12">
-                        <div class="product_item">
+                        <div class="pickup_item">
                             <a href="{{ url('product_detail', { id : 1}) }}">
-                                <div class="item_photo"><img src="img/top/img03.jpg"></div>
+                                <div class="item_photo"><img src="img/top/img04.jpg"></div>
+                                <dl>
+                                <dt class="item_name">ダミーダミーダミーダミーダミーダミー</dt>
+                                <dd class="item_comment text-warning">ダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミ・・・</dd>
+                                <dd class="more_link">read more</dd>
+                                </dl> 
                             </a>
                         </div>
                    </div>
                    <div class="col-sm-4 col-xs-12">
-                        <div class="product_item">
+                        <div class="pickup_item">
                             <a href="{{ url('product_detail', { id : 2}) }}">
                                 <div class="item_photo"><img src="img/top/img04.jpg"></div>
                                 <dl>
                                 <dt class="item_name">ダミーダミーダミーダミーダミーダミー</dt>
                                 <dd class="item_comment">ダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミ・・・</dd>
-                                </dl>
+                                <dd class="more_link">read more</dd>
+                                </dl> 
                             </a>
                         </div>
                    </div>
                    <div class="col-sm-4 col-xs-12">
-                        <div class="product_item">
+                        <div class="pickup_item">
                             <a href="{{ url('product_detail', { id : 3}) }}">
                                 <div class="item_photo"><img src="img/top/img05.jpg"></div>
                                 <dl>
                                 <dt class="item_name">ダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミー</dt>
                                 <dd class="item_comment">ダミーダミーダミーダミーダミーダダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミ・・・</dd>
-                                </dl>
+                                <dd class="more_link">read more</dd>
+                                </dl> 
                             </a>
                         </div>
                    </div>
-                </div>
+                </div>                
+                
 {% endblock %}

--- a/src/Eccube/Resource/template/default/index.twig
+++ b/src/Eccube/Resource/template/default/index.twig
@@ -54,7 +54,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             <h5>この季節にぴったりな商品をご用意しました</h5>
                             <p>ダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミダミーダミーダミー
                     ダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミーダミー</p>
-                            <p><a class="btn btn-success" href="{{ url('product_list') }}">一覧を見る<span class="fa fa-chevron-right"></span></a></p>
+                            <p><a class="btn btn-success" href="{{ url('product_list') }}">一覧を見る<svg class="cb cb-angle-right"> <use xlink:href="#cb-angle-right" /></svg></a></p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
以下調整を行いました。

▼管理画面
* 受注管理 > 受注登録・編集ページの調整
* エラーメッセージ表示時のラベルが赤くならないように調整
* 商品管理 > 商品登録
* webフォント⇒SVGアイコンに変更
* ブラウザ画面幅が細くなった時にフォームパーツの左面が合わないところを調整(受注登録・編集)

▼フロント
* webフォント⇒SVGアイコンに変更
* トップページ見た目調整
* カートの中ページ内エラー表示が統一されていなかったので調整