### PR TITLE
Fix typo. #307

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -207,14 +207,15 @@ class Application extends \Silex\Application
         }
 
         // Mail
-        $this['swiftmailer.option'] = $this['config']['mail'];
+        $this->register(new ServiceProvider\EccubeSwiftmailerServiceProvider());
+        $this['swiftmailer.options'] = $this['config']['mail'];
         // $this->register(new \Silex\Provider\SwiftmailerServiceProvider());
         if ($app['env'] === 'dev' || $app['env'] === 'test') {
             if (isset($this['config']['delivery_address'])) {
                 $this['delivery_address'] = $this['config']['delivery_address'];
             }
         }
-        $this->register(new ServiceProvider\EccubeSwiftmailerServiceProvider());
+
 
         $this['mail.message'] = function () {
             return \Swift_Message::newInstance();


### PR DESCRIPTION
以下が正しいです。

```php
$this['swiftmailer.options'] = $this['config']['mail'];
```

