### PR TITLE
Issue329 : パスワードリセットの実装

### DIFF
--- a/app/config/eccube/config.yml.dist
+++ b/app/config/eccube/config.yml.dist
@@ -41,3 +41,5 @@ target_id_footer_bottom: 9
 target_id_header_internal: 10
 
 user_data_route: user_data
+
+customer_reset_expire: 10

--- a/html/install/sql/create_table_mysql.sql
+++ b/html/install/sql/create_table_mysql.sql
@@ -514,6 +514,8 @@ CREATE TABLE dtb_customer (
     point numeric NOT NULL DEFAULT 0,
     note text,
     status smallint NOT NULL DEFAULT 1,
+    reset_key text DEFAULT NULL,
+    reset_expire timestamp DEFAULT NULL,
     create_date timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     update_date timestamp NOT NULL,
     del_flg smallint NOT NULL DEFAULT 0,

--- a/html/install/sql/create_table_pgsql.sql
+++ b/html/install/sql/create_table_pgsql.sql
@@ -514,6 +514,8 @@ CREATE TABLE dtb_customer (
     point numeric NOT NULL DEFAULT 0,
     note text,
     status smallint NOT NULL DEFAULT 1,
+    reset_key text DEFAULT NULL,
+    reset_expire timestamp DEFAULT NULL,
     create_date timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     update_date timestamp NOT NULL,
     del_flg smallint NOT NULL DEFAULT 0,

--- a/src/Eccube/Controller/ForgotController.php
+++ b/src/Eccube/Controller/ForgotController.php
@@ -1,0 +1,128 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Controller;
+
+use Eccube\Application;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\HttpKernel\Exception as HttpException;
+
+class ForgotController extends AbstractController
+{
+
+    public function index(Application $app, Request $request)
+    {
+
+        $form = $app['form.factory']
+            ->createNamedBuilder('', 'forgot')
+            ->getForm();
+
+        if ('POST' === $request->getMethod()) {
+
+            $form->handleRequest($request);
+
+            if ($form->isValid()) {
+
+                $Customer = $app['eccube.repository.customer']
+                            ->getActiveCustomerByEmail($form->get('login_email')->getData());
+
+                if (!is_null($Customer)) {
+
+                    // リセットキーの発行・有効期限の設定
+                    $Customer
+                        ->setResetKey($app['eccube.repository.customer']->getUniqueResetKey($app))
+                        ->setResetExpire(new \DateTime('+' . $app['config']['customer_reset_expire'] .' min'));
+
+                    // リセットキーを更新
+                    $app['orm.em']->persist($Customer);
+                    $app['orm.em']->flush();
+
+                    // 完了URLの生成
+                    $reset_url = $app->url('forgot_reset', array('reset_key' => $Customer->getResetKey()));
+
+                    // メール送信
+                    $app['eccube.service.mail']->sendPasswordResetNotificationMail($Customer, $reset_url);
+
+                    // ログ出力
+                    $app['monolog']->addInfo(
+                            'send reset password mail to:'  . "{$Customer->getId()} {$Customer->getEmail()} {$request->getClientIp()}"
+                        );
+                }
+
+                return $app['view']->render('Forgot/complete.twig');
+            }
+        }
+
+        return $app['view']->render('Forgot/index.twig', array(
+            'form' => $form->createView(),
+        ));
+    }
+
+    public function reset(Application $app, Request $request, $reset_key)
+    {
+
+        $errors = $app['validator']->validateValue($reset_key, array(
+                        new Assert\NotBlank(),
+                        new Assert\Regex(array(
+                            'pattern' => '/^[a-zA-Z0-9]+$/',
+                        )))
+                    );
+
+        if ('GET' === $request->getMethod()
+                && count($errors) === 0) {
+            try {
+                $Customer = $app['eccube.repository.customer']
+                    ->getActiveCustomerByResetKey($reset_key);
+            } catch (\Exception $e) {
+                throw new HttpException\NotFoundHttpException('有効期限が切れているか、無効なURLです。');
+            }
+
+            // パスワードの発行・更新
+            $pass = $app['eccube.repository.customer']->getResetPassword();
+            $Customer->setPassword($pass);
+
+            // 発行したパスワードの暗号化
+            $encPass = $app['eccube.repository.customer']->encryptPassword($app, $Customer);
+            $Customer->setPassword($encPass);
+
+            // パスワードを更新
+            $app['orm.em']->persist($Customer);
+            $app['orm.em']->flush();
+
+            // メール送信
+            $app['eccube.service.mail']->sendPasswordResetCompleteMail($Customer, $pass);
+
+            // ログ出力
+            $app['monolog']->addInfo(
+                    'reset password complete:' . "{$Customer->getId()} {$Customer->getEmail()} {$request->getClientIp()}"
+                );
+
+        } else {
+            throw new HttpException\AccessDeniedHttpException('不正なアクセスです。');
+        }
+
+        return $app['view']->render('Forgot/reset.twig');
+    }
+
+}

--- a/src/Eccube/ControllerProvider/FrontControllerProvider.php
+++ b/src/Eccube/ControllerProvider/FrontControllerProvider.php
@@ -73,7 +73,8 @@ class FrontControllerProvider implements ControllerProviderInterface
         $c->match('/entry/activate/{secret_key}', '\Eccube\Controller\EntryController::activate')->bind('entry_activate');
 
         // forgot
-        $c->match('/forgot', '\Eccube\Page\Forgot\Index')->bind('forgot');
+        $c->match('/forgot', '\Eccube\Controller\ForgotController::index')->bind('forgot');
+        $c->match('/forgot/reset/{reset_key}', '\Eccube\Controller\ForgotController::reset')->bind('forgot_reset');
 
         // frontparts
         $c->match('/frontparts/login_check', '\Eccube\Page\FrontParts\LoginCheck')->bind('frontparts_login_check');

--- a/src/Eccube/Entity/Customer.php
+++ b/src/Eccube/Entity/Customer.php
@@ -212,6 +212,16 @@ class Customer extends \Eccube\Entity\AbstractEntity implements UserInterface
     private $note;
 
     /**
+     * @var string
+     */
+    private $reset_key;
+
+    /**
+     * @var \DateTime
+     */
+    private $reset_expire;
+
+    /**
      * @var \Eccube\Entity\Master\CustomerStatus
      */
     private $Status;
@@ -873,6 +883,52 @@ class Customer extends \Eccube\Entity\AbstractEntity implements UserInterface
     public function getNote()
     {
         return $this->note;
+    }
+
+    /**
+     * Set resetKey
+     *
+     * @param  string   $resetKey
+     * @return Customer
+     */
+    public function setResetKey($resetKey)
+    {
+        $this->reset_key = $resetKey;
+
+        return $this;
+    }
+
+    /**
+     * Get resetKey
+     *
+     * @return string
+     */
+    public function getResetKey()
+    {
+        return $this->reset_key;
+    }
+
+    /**
+     * Set resetExpire
+     *
+     * @param  \DateTime   $resetExpire
+     * @return Customer
+     */
+    public function setResetExpire($resetExpire)
+    {
+        $this->reset_expire = $resetExpire;
+
+        return $this;
+    }
+
+    /**
+     * Get resetExpire
+     *
+     * @return \DateTime
+     */
+    public function getResetExpire()
+    {
+        return $this->reset_expire;
     }
 
     /**

--- a/src/Eccube/Form/Type/ForgotType.php
+++ b/src/Eccube/Form/Type/ForgotType.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Form\Type;
+
+use \Symfony\Component\Form\AbstractType;
+use \Symfony\Component\Form\Extension\Core\Type;
+use \Symfony\Component\Form\FormBuilderInterface;
+use \Symfony\Component\Validator\Constraints as Assert;
+
+class ForgotType extends AbstractType
+{
+    public function __construct()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('login_email', 'text', array(
+            'attr' => array(
+                'max_length' => 50,
+            ),
+            'constraints' => array(
+                new Assert\NotBlank(),
+                new Assert\Email(),
+            ),
+        ))
+        ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'forgot';
+    }
+}

--- a/src/Eccube/Resource/doctrine/Eccube.Entity.Customer.dcm.yml
+++ b/src/Eccube/Resource/doctrine/Eccube.Entity.Customer.dcm.yml
@@ -101,6 +101,12 @@ Eccube\Entity\Customer:
         note:
             type: text
             nullable: true
+        reset_key:
+            type: text
+            nullable: true
+        reset_expire:
+            type: datetime
+            nullable: true
         create_date:
             type: datetime
             nullable: false

--- a/src/Eccube/Resource/template/default/Forgot/complete.twig
+++ b/src/Eccube/Resource/template/default/Forgot/complete.twig
@@ -1,0 +1,49 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block title %}パスワード発行メールの送信 完了{% endblock title %}
+
+{% block main %}
+
+    <div id="contents" class="main_only">
+        <div class="container-fluid inner no-padding">
+            <div id="main">
+                <h1 class="page-heading">パスワード発行メールの送信 完了</h1>
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-md-10 col-md-offset-1">
+                            <p>パスワード再発行メールの送信が完了しました。</p>
+                            <p>ご登録メールアドレスにパスワードを再発行するためのメールを送信いたしました。<br/>
+                            メールの内容をご確認いただきますよう、お願いいたします。</p>
+                            <p>※メールが届かない場合はメールアドレスをご確認の上、再度お試しください。</p>
+                        </div><!-- /.col -->
+                    </div><!-- /.row -->
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}
+
+

--- a/src/Eccube/Resource/template/default/Forgot/index.twig
+++ b/src/Eccube/Resource/template/default/Forgot/index.twig
@@ -1,0 +1,65 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block title %}パスワードの再発行{% endblock title %}
+
+{% block main %}
+    <div id="contents" class="main_only">
+        <div class="container-fluid inner no-padding">
+            <div id="main">
+                <h1 class="page-heading">パスワードの再発行</h1>
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-md-10 col-md-offset-1">
+                            <p>ご登録時のメールアドレスを入力して「次へ」ボタンをクリックしてください。</p>
+                            <p>※新しくパスワードを発行いたしますので、お忘れになったパスワードはご利用できなくなります。</p>
+                            <form name="form1" id="form1" method="post" action="?">
+                                {{ form_widget(form._token) }}
+                                <div class="dl_table">
+                                    <dl>
+                                        <dt>{{ form_label(form.login_email) }}</dt>
+                                        <dd>
+                                            <div class="form-group">
+                                                {{ form_widget(form.login_email) }}
+                                                {{ form_errors(form.login_email) }}
+                                            </div>
+                                        </dd>
+                                    </dl>
+                                </div>
+                                <div class="row no-padding">
+                                <div class="btn_group col-sm-offset-4 col-sm-4">
+                                    <p><button type="submit" class="btn btn-primary btn-block">次のページへ</button></p>
+                                </div>
+                                </div>
+                            </form>
+                        </div><!-- /.col -->
+                    </div><!-- /.row -->
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}
+
+

--- a/src/Eccube/Resource/template/default/Forgot/reset.twig
+++ b/src/Eccube/Resource/template/default/Forgot/reset.twig
@@ -1,0 +1,48 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block title %}パスワード変更（完了ページ）{% endblock title %}
+
+{% block main %}
+
+    <div id="contents" class="main_only">
+        <div class="container-fluid inner no-padding">
+            <div id="main">
+                <h1 class="page-heading">パスワード変更(完了ページ)</h1>
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-md-10 col-md-offset-1">
+                            <h2>新しいパスワードが送信されました。</h2>
+                            <p>新しいパスワード送り致しましたので、メールをご確認ください。</p>
+                            <p>今後ともご愛顧賜りますようよろしくお願い申し上げます。</p>
+                        </div><!-- /.col -->
+                    </div><!-- /.row -->
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}
+
+

--- a/src/Eccube/Resource/template/default/Mail/forgot_mail.twig
+++ b/src/Eccube/Resource/template/default/Mail/forgot_mail.twig
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 　※本メールは、
-{{ BaseInfo.shop_name }}より退会手続きを希望された方に
+{{ BaseInfo.shop_name }}よりパスワード再発行手続きを希望された方に
 　お送りしています。
 　もしお心当たりが無い場合は、
 　その旨 {# 問い合わせ受付メール #}{{ BaseInfo.email02 }} まで

--- a/src/Eccube/Resource/template/default/Mail/forgot_mail.twig
+++ b/src/Eccube/Resource/template/default/Mail/forgot_mail.twig
@@ -1,0 +1,42 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+　※本メールは自動配信メールです。
+　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
+　最適にご覧になれます。
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+　※本メールは、
+{{ BaseInfo.shop_name }}より退会手続きを希望された方に
+　お送りしています。
+　もしお心当たりが無い場合は、
+　その旨 {# 問い合わせ受付メール #}{{ BaseInfo.email02 }} まで
+　ご連絡いただければ幸いです。
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+パスワードを変更するには下記URLにアクセスしてください。
+※入力されたお客様の情報はSSL暗号化通信により保護されます。
+※URLの有効期限は{{ app.config.customer_reset_expire }}分以内です。{{ app.config.customer_reset_expire }}時間を過ぎますとURLは無効となりますので、その場合、もう一度最初から手続きを行ってください。
+
+{{ reset_url }}
+
+上記URLにてパスワードを変更が完了いたしましたら
+改めてご登録内容のご確認メールをお送り致します。

--- a/src/Eccube/Resource/template/default/Mail/reset_complete_mail.twig
+++ b/src/Eccube/Resource/template/default/Mail/reset_complete_mail.twig
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 　※本メールは、
-{{ BaseInfo.shop_name }}より退会手続きを希望された方に
+{{ BaseInfo.shop_name }}よりパスワード再発行手続きを希望された方に
 　お送りしています。
 　もしお心当たりが無い場合は、
 　その旨 {# 問い合わせ受付メール #}{{ BaseInfo.email02 }} まで

--- a/src/Eccube/Resource/template/default/Mail/reset_complete_mail.twig
+++ b/src/Eccube/Resource/template/default/Mail/reset_complete_mail.twig
@@ -1,0 +1,39 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+　※本メールは自動配信メールです。
+　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
+　最適にご覧になれます。
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+　※本メールは、
+{{ BaseInfo.shop_name }}より退会手続きを希望された方に
+　お送りしています。
+　もしお心当たりが無い場合は、
+　その旨 {# 問い合わせ受付メール #}{{ BaseInfo.email02 }} まで
+　ご連絡いただければ幸いです。
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+パスワードを変更いたしました。
+
+新しいパスワード：{{ password }}
+
+このパスワードは一時的なものですので、お早めにご変更下さい。

--- a/src/Eccube/Service/MailService.php
+++ b/src/Eccube/Service/MailService.php
@@ -211,7 +211,7 @@ class MailService
 
         $message = \Swift_Message::newInstance()
             ->setSubject($formData['subject'])
-            ->setFrom(array($BaseInfo->getEmail03() => $BaseInfo->getShopName()))
+            ->setFrom(array('sample@example.com'))
             ->setTo(array($Order->getEmail()))
             ->setTo(array($Order->getEmail()))
             ->setBcc($this->app['config']['mail_cc'])

--- a/src/Eccube/Service/MailService.php
+++ b/src/Eccube/Service/MailService.php
@@ -211,7 +211,7 @@ class MailService
 
         $message = \Swift_Message::newInstance()
             ->setSubject($formData['subject'])
-            ->setFrom(array('sample@example.com'))
+            ->setFrom(array($BaseInfo->getEmail03() => $BaseInfo->getShopName()))
             ->setTo(array($Order->getEmail()))
             ->setTo(array($Order->getEmail()))
             ->setBcc($this->app['config']['mail_cc'])
@@ -219,6 +219,50 @@ class MailService
 
         $this->app->mail($message);
 
+    }
+
+    /**
+     * Send password reset notification mail.
+     *
+     * @param $Customer 会員情報
+     */
+    public function sendPasswordResetNotificationMail(\Eccube\Entity\Customer $Customer, $reset_url)
+    {
+        $body = $this->app['view']->render('Mail/forgot_mail.twig', array(
+            'Customer' => $Customer,
+            'reset_url' => $reset_url
+        ));
+
+        $message = \Swift_Message::newInstance()
+            ->setSubject('[EC-CUBE3] パスワード変更の確認')
+            ->setFrom(array('sample@example.com'))
+            ->setTo(array($Customer->getEmail()))
+            ->setBcc($this->app['config']['mail_cc'])
+            ->setBody($body);
+
+        $this->app->mail($message);
+    }
+
+    /**
+     * Send password reset notification mail.
+     *
+     * @param $Customer 会員情報
+     */
+    public function sendPasswordResetCompleteMail(\Eccube\Entity\Customer $Customer, $password)
+    {
+        $body = $this->app['view']->render('Mail/reset_complete_mail.twig', array(
+                        'Customer' => $Customer,
+                        'password' => $password,
+        ));
+
+        $message = \Swift_Message::newInstance()
+            ->setSubject('[EC-CUBE3] パスワード変更のお知らせ')
+            ->setFrom(array('sample@example.com'))
+            ->setTo(array($Customer->getEmail()))
+            ->setBcc($this->app['config']['mail_cc'])
+            ->setBody($body);
+
+        $this->app->mail($message);
     }
 
 

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -289,6 +289,7 @@ class EccubeServiceProvider implements ServiceProviderInterface
             $types[] = new \Eccube\Form\Type\ShoppingShippingType($app);
             $types[] = new \Eccube\Form\Type\ShipmentItemType();
             $types[] = new \Eccube\Form\Type\CustomerAgreementType($app);
+            $types[] = new \Eccube\Form\Type\ForgotType();
 
             // admin
             $types[] = new \Eccube\Form\Type\Admin\LoginType($app['session']);


### PR DESCRIPTION
パスワードリセット~メール通知~URLクリックによるランダムパスワードの更新・通知
まで実装。
（ 画面・メール文面は https://www.ec-cube.net/forgot/ 準拠 ）

▼既存修正部
- DDL・メタ定義への reset_key / reset_expireカラムの追加
- config.yml.distへの customer_reset_expireの追加
- CustomerRepositoryへの 
  一意なリセットキー発行
  リセットキーでの会員情報取得
  ランダムパスワードの取得を追加

▼TODO:
- ランダムパスワードの発行方式 : CustomerRepository::getResetPassword() で良いかどうか
