### PR TITLE
インストール時に、dtb_memberのデータ登録が行われない問題の修正

### DIFF
--- a/html/install.php
+++ b/html/install.php
@@ -25,4 +25,9 @@ require __DIR__ . '/../autoload.php';
 
 $app = new Eccube\InstallApplication();
 $app['debug'] = true;
+$app->before(function (\Symfony\Component\HttpFoundation\Request $request, \Silex\Application $app) {
+    if (!$request->getSession()->isStarted()) {
+        $request->getSession()->start();
+    }
+});
 $app->run();

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -115,6 +115,8 @@ class InstallController
     // 権限チェック
     public function step2(InstallApplication $app, Request $request)
     {
+        $this->getSessionData($request);
+
         $protectedDirs = $this->getProtectedDirs();
 
         // 権限がある場合, キャッシュディレクトリをクリア


### PR DESCRIPTION
以下を実施してからインストールを行うと再現

- app/config以下を削除
- ブラウザを再起動

sessionのデータが取得できておらず、データが登録されない状態
明示的にsessionを発行するように修正