### PR TITLE
Doctrine migration のバグを修正 refs #581

### DIFF
--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -675,6 +675,7 @@ class InstallController
     {
         return $app['twig']->render('migration.twig');
     }
+
     public function migration_end(InstallApplication $app, Request $request)
     {
         $this->doMigrate();

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -315,7 +315,7 @@ class InstallController
 
         $schemaTool->dropSchema($metadatas);
 
-        $em->getConnection()->executeQuery('DROP TABLE doctrine_migration_versions');
+        $em->getConnection()->executeQuery('DROP TABLE IF EXISTS doctrine_migration_versions');
 
         return $this;
     }


### PR DESCRIPTION
``doctrine_migration_versions`` のテーブルが存在しない場合の修正を行いました。