### PR TITLE
#548 受注管理の不具合修正

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -66,6 +66,18 @@ class EditController extends AbstractController
             $this->calculate($app, $TargetOrder);
 
             if ($form->isValid()) {
+
+                // お支払い方法の更新
+                $TargetOrder->setPaymentMethod($TargetOrder->getPayment()->getMethod());
+
+                // 配送業者・お届け時間の更新
+                $Shippings = $TargetOrder->getShippings();
+                foreach ($Shippings as $Shipping) {
+                    $Shipping->setShippingDeliveryName($Shipping->getDelivery()->getName());
+                    $Shipping->setShippingDeliveryTime($Shipping->getDeliveryTime()->getDeliveryTime());
+                }
+
+                // 登録ボタン押下
                 if ('register' === $request->get('mode')) {
                     // 受注日/発送日/入金日の更新.
                     $this->updateDate($TargetOrder, $OriginOrder);
@@ -343,16 +355,6 @@ class EditController extends AbstractController
         $Order->setTotal($subtotal + $Order->getCharge() + $Order->getDeliveryFeeTotal() - $Order->getDiscount());
         // お支払い合計は、totalと同一金額(2系ではtotal - point)
         $Order->setPaymentTotal($Order->getTotal());
-
-        // お支払い方法の更新
-        $Order->setPaymentMethod($Order->getPayment()->getMethod());
-
-        // お届け先の更新
-        $Shippings = $Order->getShippings();
-        foreach ($Shippings as $Shipping) {
-            $Shipping->setShippingDeliveryName($Shipping->getDelivery()->getName());
-            $Shipping->setShippingDeliveryTime($Shipping->getDeliveryTime()->getDeliveryTime());
-        }
     }
 
     /**

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -24,6 +24,8 @@
 
 namespace Eccube\Entity;
 
+use Eccube\Util\EntityUtil;
+
 /**
  * Order
  */
@@ -1236,6 +1238,9 @@ class Order extends \Eccube\Entity\AbstractEntity
      */
     public function getCustomer()
     {
+        if (EntityUtil::isEmpty($this->Customer)) {
+            return null;
+        }
         return $this->Customer;
     }
 
@@ -1351,6 +1356,9 @@ class Order extends \Eccube\Entity\AbstractEntity
      */
     public function getPayment()
     {
+        if (EntityUtil::isEmpty($this->Payment)) {
+            return null;
+        }
         return $this->Payment;
     }
 

--- a/src/Eccube/Entity/Shipping.php
+++ b/src/Eccube/Entity/Shipping.php
@@ -24,6 +24,8 @@
 
 namespace Eccube\Entity;
 
+use Eccube\Util\EntityUtil;
+
 /**
  * Shipping
  */
@@ -909,6 +911,9 @@ class Shipping extends \Eccube\Entity\AbstractEntity
      */
     public function getDelivery()
     {
+        if (EntityUtil::isEmpty($this->Delivery)) {
+            return null;
+        }
         return $this->Delivery;
     }
 
@@ -932,6 +937,10 @@ class Shipping extends \Eccube\Entity\AbstractEntity
      */
     public function getDeliveryTime()
     {
+        if (EntityUtil::isEmpty($this->DeliveryTime)) {
+            return null;
+        }
+
         return $this->DeliveryTime;
     }
 
@@ -955,6 +964,10 @@ class Shipping extends \Eccube\Entity\AbstractEntity
      */
     public function getDeliveryFee()
     {
+        if (EntityUtil::isEmpty($this->DeliveryFee)) {
+            return null;
+        }
+
         return $this->DeliveryFee;
     }
 }

--- a/src/Eccube/Form/Type/OrderType.php
+++ b/src/Eccube/Form/Type/OrderType.php
@@ -182,8 +182,11 @@ class OrderType extends AbstractType
             ->add('Payment', 'entity', array(
                 'class' => 'Eccube\Entity\Payment',
                 'property' => 'method',
-                'empty_value' => false,
+                'empty_value' => '選択してください',
                 'empty_data' => null,
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                ),
             ))
             ->add('OrderDetails', 'collection', array(
                 'type' => new OrderDetailType($this->app),

--- a/src/Eccube/Form/Type/ShippingType.php
+++ b/src/Eccube/Form/Type/ShippingType.php
@@ -116,15 +116,21 @@ class ShippingType extends AbstractType
                 'label' => '配送業者',
                 'class' => 'Eccube\Entity\Delivery',
                 'property' => 'name',
-                'empty_value' => false,
+                'empty_value' => '選択してください',
                 'empty_data' => null,
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                ),
             ))
             ->add('DeliveryTime', 'entity', array(
                 'label' => 'お届け時間',
                 'class' => 'Eccube\Entity\DeliveryTime',
                 'property' => 'delivery_time',
-                'empty_value' => false,
+                'empty_value' => '選択してください',
                 'empty_data' => null,
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                ),
             ))
             ->add('shipping_delivery_date', null, array(
                 'label' => 'お届け日'


### PR DESCRIPTION
リレーション先のデータが削除された場合の対応を追加しました。
- 受注情報
  - 支払い方法
  - 会員情報
- 配送情報
  - 配送業者
  - お届け時間

合わせてバリデーションが不十分な箇所を修正しました。