### PR TITLE
#540 管理画面から支払方法削除時の不具合修正

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/Shop/DeliveryController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/DeliveryController.php
@@ -100,8 +100,7 @@ class DeliveryController extends AbstractController
         // 支払方法をセット
         $Payments = array();
         foreach ($Delivery->getPaymentOptions() as $PaymentOption) {
-            $Payments[] = $app['eccube.repository.payment']
-                ->find($PaymentOption->getPaymentId());
+            $Payments[] = $PaymentOption->getPayment();
         }
 
         $form['delivery_times']->setData($Delivery->getDeliveryTimes());
@@ -141,8 +140,7 @@ class DeliveryController extends AbstractController
                         ->setPaymentId($PaymentData->getId())
                         ->setPayment($PaymentData)
                         ->setDeliveryId($DeliveryData->getId())
-                        ->setDelivery($DeliveryData)
-                    ;
+                        ->setDelivery($DeliveryData);
                     $DeliveryData->addPaymentOption($PaymentOption);
                     $app['orm.em']->persist($DeliveryData);
                 }
@@ -180,12 +178,12 @@ class DeliveryController extends AbstractController
         foreach ($Delivs as $Deliv) {
             if ($Deliv->getId() != $id) {
                 $Deliv->setRank($rank);
-                $rank ++;
+                $rank++;
             }
         }
         $app['orm.em']->flush();
 
-        $app->addSuccess('admin.delete.complete', 'admin') ;
+        $app->addSuccess('admin.delete.complete', 'admin');
 
         return $app->redirect($app->url('admin_setting_shop_delivery'));
     }

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -811,6 +811,8 @@ class ShoppingController extends AbstractController
             'class' => 'Eccube\Entity\DeliveryTime',
             'property' => 'deliveryTime',
             'choices' => $delivery->getDeliveryTimes(),
+            'required' => false,
+            'empty_value' => '指定なし',
         ));
 
     }

--- a/src/Eccube/Entity/PaymentOption.php
+++ b/src/Eccube/Entity/PaymentOption.php
@@ -23,6 +23,7 @@
 
 
 namespace Eccube\Entity;
+use Eccube\Util\EntityUtil;
 
 /**
  * PaymentOption
@@ -120,6 +121,9 @@ class PaymentOption extends \Eccube\Entity\AbstractEntity
      */
     public function getDelivery()
     {
+        if (EntityUtil::isEmpty($this->Delivery)) {
+            return null;
+        }
         return $this->Delivery;
     }
 
@@ -143,6 +147,9 @@ class PaymentOption extends \Eccube\Entity\AbstractEntity
      */
     public function getPayment()
     {
+        if (EntityUtil::isEmpty($this->Payment)) {
+            return null;
+        }
         return $this->Payment;
     }
 }

--- a/src/Eccube/Form/Type/DeliveryType.php
+++ b/src/Eccube/Form/Type/DeliveryType.php
@@ -27,6 +27,8 @@ namespace Eccube\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -104,6 +106,14 @@ class DeliveryType extends AbstractType
                 'allow_delete' => true,
                 'prototype' => true,
             ))
+            ->addEventListener(FormEvents::POST_SUBMIT, function ($event) {
+                $form = $event->getForm();
+                $payments = $form['payments']->getData();
+
+                if (empty($payments) || count($payments) < 1) {
+                    $form['payments']->addError(new FormError('支払方法を選択してください。'));
+                }
+            })
             ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber())
         ;
     }

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -327,8 +327,6 @@ function fnClass(action) {
                             {{ form_row(form.search_word) }}
                             {% if has_class == false %}
                                 {{ form_row(form.class.delivery_date) }}
-                            {% endif %}
-                            {% if has_class == false %}
                                 <div class="form-group">
                                     {{ form_label(form.class.delivery_fee) }}
                                     <div class="col-sm-3 col-lg-3">

--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
@@ -63,13 +63,8 @@ $(function(){
                         <h3 class="box-title">支払方法設定</h3>
                     </div><!-- /.box-header -->
                     <div class="box-body">
-                        <div class="form-group form-inline">
-                            {% for child in form.payments %}
-                            <div class="col-sm-2">
-                                {{ form_widget(child) }}
-                            </div>
-                            {% endfor %}
-                        </div>
+                        {{ form_widget(form.payments) }}
+                        {{ form_errors(form.payments) }}
                     </div>
                 </div>
 

--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -118,7 +118,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </p>
                         <p>
                             配送方法：　{{ Shipping.shipping_delivery_name }}（＋{{ Shipping.delivery_fee.fee|price }}）<br>
-                            お届け日：　{{ Shipping.shipping_date|default('指定なし') }}<br>
+                            お届け日：　{{ Shipping.shipping_delivery_date|date_format|default('指定なし') }}<br>
                             お届け時間：　{{ Shipping.shipping_delivery_time|default('指定なし') }}
                         </p>
                     </div>
@@ -126,7 +126,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 <h2 class="heading02">お支払方法</h2>
                 <div class="column">
                     <p>
-                        支払方法：　{{ Order.Payment }}
+                        支払方法：　{{ Order.PaymentMethod }}
                     </p>
                 </div>
 

--- a/src/Eccube/Service/OrderService.php
+++ b/src/Eccube/Service/OrderService.php
@@ -494,9 +494,11 @@ class OrderService
         foreach ($paymentOptions as $paymentOption) {
             $payment = $paymentOption->getPayment();
             // 支払方法の制限値内であれば表示
-            if (intval($payment->getRuleMin()) <= $subTotal) {
-                if (is_null($payment->getRuleMax()) || $payment->getRuleMax() >= $subTotal) {
-                    $payments[] = $payment;
+            if (!is_null($payment)) {
+                if (intval($payment->getRuleMin()) <= $subTotal) {
+                    if (is_null($payment->getRuleMax()) || $payment->getRuleMax() >= $subTotal) {
+                        $payments[] = $payment;
+                    }
                 }
             }
         }


### PR DESCRIPTION
支払方法設定画面から支払方法を新規作成し、配送方法設定画面から追加した支払方法を設定後、
支払方法設定画面から追加した支払方法を削除するとエラーが発生。

対応方法として、
削除された支払方法を参照しないように修正しています。

それと合わせて配送方法設定画面から支払方法が選択されていなければエラーとする処理を追加しています。

