### PR TITLE
timezoneの設定をconfig.yml.distまたはconfig.ymlから呼び出すように修正

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -127,6 +127,12 @@ class Application extends ApplicationTrait
                 $config = Yaml::parse($config_yml);
             }
 
+            $config_dist = array();
+            $config_yml_dist = $distPath . '/config.yml.dist';
+            if (file_exists($config_yml_dist)) {
+                $config_dist = Yaml::parse($config_yml_dist);
+            }
+
             $config_path = array();
             $path_yml = $ymlPath . '/path.yml';
             if (file_exists($path_yml)) {
@@ -146,7 +152,7 @@ class Application extends ApplicationTrait
                 $config_constant_dist = Yaml::parse($constant_yml_dist);
             }
 
-            $configAll = array_replace_recursive($config_constant_dist, $config_constant, $config_path, $config);
+            $configAll = array_replace_recursive($config_constant_dist, $config_dist, $config_constant, $config_path, $config);
 
             $database = array();
             $yml = $ymlPath . '/database.yml';
@@ -236,7 +242,12 @@ class Application extends ApplicationTrait
 
     public function initLocale()
     {
-        date_default_timezone_set('Asia/Tokyo');
+
+        // timezone
+        if (!empty($this['config']['timezone'])) {
+            date_default_timezone_set($this['config']['timezone']);
+        }
+
         $this->register(new \Silex\Provider\TranslationServiceProvider(), array(
             'locale' => $this['config']['locale'],
         ));

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -63,6 +63,12 @@ class InstallController
         $this->config_path = __DIR__ . '/../../../../app/config/eccube';
         $this->dist_path = __DIR__ . '/../../Resource/config';
         $this->cache_path = __DIR__ . '/../../../../app/cache';
+
+        // timezone
+        $config = Yaml::parse($this->dist_path . '/config.yml.dist');
+        if (!empty($config['timezone'])) {
+            date_default_timezone_set($config['timezone']);
+        }
     }
 
     private function isValid(Request $request, Form $form)

--- a/src/Eccube/Resource/config/config.yml.dist
+++ b/src/Eccube/Resource/config/config.yml.dist
@@ -5,3 +5,4 @@ force_ssl: ${FORCE_SSL}
 admin_allow_host:
 cookie_lifetime: 0
 locale: ja
+timezone: Asia/Tokyo


### PR DESCRIPTION
今までconfig.yml.distがApplication.phpでは読み込まれていなかったため読み込まれるように修正し、
timezoneの設定をconfig.yml.distまたはconfig.ymlから呼び出すように修正しました。

* config.yml.distに新たに追加
```
timezone: Asia/Tokyo
```

初期値はAsia/Tokyoにしています。