### PR TITLE
git hooks pre-commit を使って php-cs-fixer による自動コード整形をしませんか？

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -5,7 +5,7 @@ if (version_compare(PHP_VERSION, '5.3.3') < 0) {
     die('Your PHP installation is too old. EC-CUBE requires at least PHP 5.3.3. See the <a href="http://www.ec-cube.net/product/system.php">system requirements</a> page for more information.');
 }
 
-$autoload = __DIR__ . '/vendor/autoload.php';
+$autoload = __DIR__.'/vendor/autoload.php';
 
 if (file_exists($autoload) && is_readable($autoload)) {
     $loader = require $autoload;

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "phing/phing": "2.*",
         "symfony/browser-kit": ">=2.7,<2.8",
         "symfony/css-selector": ">=2.7,<2.8",
-        "sorien/silex-pimple-dumper": "1.0.*"
+        "sorien/silex-pimple-dumper": "1.0.*",
+        "fabpot/php-cs-fixer": "^1.10"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -2939,6 +2939,60 @@
             "time": "2015-06-14 21:17:01"
         },
         {
+            "name": "fabpot/php-cs-fixer",
+            "version": "v1.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "8e21b4fb32c4618a425817d9f0daf3d57a9808d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/8e21b4fb32c4618a425817d9f0daf3d57a9808d1",
+                "reference": "8e21b4fb32c4618a425817d9f0daf3d57a9808d1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.6",
+                "sebastian/diff": "~1.1",
+                "symfony/console": "~2.3",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/filesystem": "~2.1",
+                "symfony/finder": "~2.1",
+                "symfony/process": "~2.3",
+                "symfony/stopwatch": "~2.5"
+            },
+            "require-dev": {
+                "satooshi/php-coveralls": "0.7.*@dev"
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\CS\\": "Symfony/CS/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "time": "2015-07-27 20:56:10"
+        },
+        {
             "name": "phing/phing",
             "version": "2.11.0",
             "source": {
@@ -4077,6 +4131,55 @@
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
             "time": "2015-07-09 16:07:40"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v2.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Process.git",
+                "reference": "48aeb0e48600321c272955132d7606ab0a49adb3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Process/zipball/48aeb0e48600321c272955132d7606ab0a49adb3",
+                "reference": "48aeb0e48600321c272955132d7606ab0a49adb3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-07-01 11:25:50"
         }
     ],
     "aliases": [],

--- a/html/index.php
+++ b/html/index.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of EC-CUBE
  *
@@ -21,7 +22,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-require __DIR__ . '/../autoload.php';
+require __DIR__.'/../autoload.php';
 
 ini_set('display_errors', 'Off');
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
@@ -35,6 +36,6 @@ if ($app['config']['eccube_install']) {
     $app->run();
 } else {
     $location = str_replace('index.php', 'install.php', $_SERVER['SCRIPT_NAME']);
-    header('Location:' . $location);
+    header('Location:'.$location);
     exit;
 }

--- a/html/index_dev.php
+++ b/html/index_dev.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of EC-CUBE
  *
@@ -24,7 +25,6 @@
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\Yaml\Yaml;
 
-
 // This check prevents access to debug front controllers that are deployed by accident to production servers.
 // Feel free to remove this, extend it, or make something more sophisticated.
 
@@ -42,7 +42,6 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
 
-
 require_once __DIR__.'/../vendor/autoload.php';
 
 Debug::enable();
@@ -59,31 +58,29 @@ $app->initializePlugin();
 
 // load config dev
 $conf = $app['config'];
-$app['config'] = $app->share(function () use($conf) {
+$app['config'] = $app->share(function () use ($conf) {
     $confarray = array();
-    $config_dev_file = __DIR__ . '/../app/config/eccube/config_dev.yml';
+    $config_dev_file = __DIR__.'/../app/config/eccube/config_dev.yml';
     if (file_exists($config_dev_file)) {
         $config_dev = Yaml::parse(file_get_contents($config_dev_file));
         if (isset($config_dev)) {
             $confarray = array_replace_recursive($confarray, $config_dev);
         }
     }
+
     return array_replace_recursive($conf, $confarray);
 });
-
 
 // Mail
 if (isset($app['config']['delivery_address'])) {
     $app['mailer']->registerPlugin(new \Swift_Plugins_RedirectingPlugin($app['config']['delivery_address']));
 }
 
-
 // Silex Web Profiler
 $app->register(new \Silex\Provider\WebProfilerServiceProvider(), array(
-    'profiler.cache_dir' => __DIR__ . '/../app/cache/profiler',
+    'profiler.cache_dir' => __DIR__.'/../app/cache/profiler',
     'profiler.mount_prefix' => '/_profiler',
 ));
 $app->register(new \Saxulum\SaxulumWebProfiler\Provider\SaxulumWebProfilerProvider());
-
 
 $app->run();

--- a/html/install.php
+++ b/html/install.php
@@ -21,7 +21,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-if(function_exists('apc_clear_cache')){
+if (function_exists('apc_clear_cache')) {
     apc_clear_cache('user');
     apc_clear_cache();
 }


### PR DESCRIPTION
.git/hooks/pre-commit (http://blog.manaten.net/entry/645)
```
#!/bin/sh
#
# An example hook script to verify what is about to be committed.
# Called by "git commit" with no arguments.  The hook should
# exit with non-zero status after issuing an appropriate message if
# it wants to stop the commit.
#
# To enable this hook, rename this file to "pre-commit".

if git rev-parse --verify HEAD >/dev/null 2>&1
then
	against=HEAD
else
	# Initial commit: diff against an empty tree object
	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
fi

# If you want to allow non-ASCII filenames set this variable to true.
allownonascii=$(git config --bool hooks.allownonascii)

# Redirect output to stderr.
exec 1>&2

IS_ERROR=0
# コミットされるファイルのうち、.phpで終わるもの
for FILE in `git diff-index --name-status $against -- | grep -E '^[AUM].*\.php$'| cut -c3-`; do
    # シンタックスのチェック
    if php -l $FILE; then
        # PSR準拠でコード書き換え
        vendor/bin/php-cs-fixer fix $FILE --fixers=linefeed,trailing_spaces,indentation,controls_spaces,eof_ending,php_closing_tag,phpdoc_params,visibility,braces,elseif,include
        git add $FILE

    else
        IS_ERROR=1
    fi
done
exit $IS_ERROR
```