### PR TITLE
支払方法設定の不具合 #676

### DIFF
--- a/src/Eccube/Form/Type/PaymentRegisterType.php
+++ b/src/Eccube/Form/Type/PaymentRegisterType.php
@@ -52,18 +52,25 @@ class PaymentRegisterType extends AbstractType
                 'precision' => 0,
                 'constraints' => array(
                     new Assert\NotBlank(),
+                    new Assert\Regex(array('pattern' => '/^\d+$/')),
                 ),
             ))
             ->add('rule_min', 'money', array(
                 'label' => false,
                 'currency' => 'JPY',
                 'precision' => 0,
+                'constraints' => array(
+                    new Assert\Regex(array('pattern' => '/^\d+$/')),
+                ),
             ))
             ->add('rule_max', 'money', array(
                 'label' => false,
                 'currency' => 'JPY',
                 'precision' => 0,
                 'required' => false,
+                'constraints' => array(
+                    new Assert\Regex(array('pattern' => '/^\d+$/')),
+                ),
             ))
             ->add('payment_image_file', 'file', array(
                 'label' => 'ロゴ画像',
@@ -80,7 +87,7 @@ class PaymentRegisterType extends AbstractType
                 $ruleMax = $form['rule_max']->getData();
                 $ruleMin = $form['rule_min']->getData();
                 if (!empty($ruleMin) && !empty($ruleMax) && $ruleMax < $ruleMin) {
-                    $form['rule_min']->addError(new FormError('利用条件(上限)は' . $ruleMin . '円以下にしてください。'));
+                    $form['rule_min']->addError(new FormError('利用条件(下限)は' . $ruleMax . '円以下にしてください。'));
                 }
             })
             ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber())


### PR DESCRIPTION
* 金額に、小数点や負の整数が入力できる  
正規表現(/^\d+$/)をバリデートに追加して対処しました。また、
'precision' => 0,
だと小数を入力しても整数にして検査しているようなので、見かけ上
小数が入力できてしまいますが、この場合はどう対処すればよいのでしょうか。
* 利用条件のエラーメッセージが逆に表示されている  
エラーメッセージを修正しましたが、この逆というのは修正通りの意図で
合っていますでしょうか。