### PR TITLE
ブロック管理のtwig出力先と探索パスを変更　#669

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -302,9 +302,13 @@ class Application extends ApplicationTrait
                     $cacheBaseDir = __DIR__ . '/../../app/cache/twig/production/';
                 }
 
+                if (file_exists($app['config']['user_data_realdir'])){
+                    $paths[] = $app['config']['user_data_realdir'];
+                }
+
                 if (strpos($app['request']->getPathInfo(), '/' . trim($app['config']['admin_route'], '/')) === 0) {
-                    if (file_exists(__DIR__ . '/../../app/template/admin')) {
-                        $paths[] = __DIR__ . '/../../app/template/admin';
+                    if (file_exists($app['config']['template_admin_html_realdir'])) {
+                        $paths[] = $app['config']['template_admin_html_realdir'];
                     }
                     $paths[] = $app['config']['template_admin_realdir'];
                     $paths[] = __DIR__ . '/../../app/Plugin';

--- a/src/Eccube/Resource/config/path.yml.dist
+++ b/src/Eccube/Resource/config/path.yml.dist
@@ -24,7 +24,7 @@ user_data_realdir: ${ROOT_DIR}/html/user_data
 # realdir::block
 block_default_realdir: ${ROOT_DIR}/src/Eccube/Resource/template/default/Block
 block_realdir: ${ROOT_DIR}/app/template/${TEMPLATE_CODE}/Block
-user_block_realdir: ${ROOT_DIR}/html/user_data/block
+user_block_realdir: ${ROOT_DIR}/html/user_data/Block
 
 # realdir::template
 template_default_realdir: ${ROOT_DIR}/src/Eccube/Resource/template/default

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -44,8 +44,8 @@ class SystemService
         $rsm = new \Doctrine\ORM\Query\ResultSetMapping();
         $rsm->addScalarResult('version', 'v');
 
-        $version = $this->app['orm.em']->createNativeQuery('SELECT VERSION()', $rsm)
-                                 ->getSingleScalarResult();
+        $version = $this->app['orm.em']->createNativeQuery('SELECT version() as version', $rsm)->getSingleScalarResult();
+
         if ($this->app['config']['database']['driver'] == 'pdo_mysql') {
             return 'MySQL ' . $version;
         } else {

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -1,4 +1,6 @@
-s file is part of EC-CUBE
+<?php
+/*
+ * This file is part of EC-CUBE
  *
  * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
  *


### PR DESCRIPTION
* ブロック管理で出力したtwigテンプレートをレンダリング時に参照できるようにTwigテンプレートの探索PATHにhtml/user_data/Block を追加
* ブロック管理のTwig出力先PATHを他のテンプレートのディレクトリに合わせてhtml/user_data/blockからhtml/user_data/Block へ

ディレクトリ名が変更されますので、既にブロックを登録している状態からマイグレーションする場合は、
mv html/user_data/block html/user_data/Block 
する必要があります。