### PR TITLE
refs #707 メンバー登録時にログインできない不具合対応

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/System/MemberController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/MemberController.php
@@ -69,12 +69,18 @@ class MemberController extends AbstractController
         if ('POST' === $request->getMethod()) {
             $form->handleRequest($request);
             if ($form->isValid()) {
-                if (!is_null($previous_password) 
+                if (!is_null($previous_password)
                     && $Member->getpassword() === $app['config']['default_password']) {
                     // 編集時にPWを変更していなければ
                     // 変更前のパスワード(暗号化済み)をセット
                     $Member->setPassword($previous_password);
                 } else {
+                    $salt = $Member->getSalt();
+                    if (!isset($salt)) {
+                        $salt = $app['eccube.repository.member']->createSalt(5);
+                        $Member->setSalt($salt);
+                    }
+
                     // 入力されたPWを暗号化してセット
                     $password = $app['eccube.repository.member']->encryptPassword($Member);
                     $Member->setPassword($password);

--- a/src/Eccube/Repository/MemberRepository.php
+++ b/src/Eccube/Repository/MemberRepository.php
@@ -25,6 +25,7 @@
 namespace Eccube\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Eccube\Common\Constant;
 use Eccube\Entity\Member;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
@@ -32,6 +33,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\Util\SecureRandom;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+
 /**
  * MemberRepository
  *
@@ -205,8 +207,7 @@ class MemberRepository extends EntityRepository implements UserProviderInterface
                 }
                 $Member
                     ->setRank($rank + 1)
-                    ->setDelFlg(0)
-                    ->setSalt($this->createSalt(5));
+                    ->setDelFlg(Constant::DISABLED);
             }
 
             $em->persist($Member);
@@ -240,7 +241,7 @@ class MemberRepository extends EntityRepository implements UserProviderInterface
                 ->execute();
 
             $Member
-                ->setDelFlg(1)
+                ->setDelFlg(Constant::ENABLED)
                 ->setRank(0);
 
             $em->persist($Member);


### PR DESCRIPTION
メンバーの新規登録時に、パスワードのハッシュ値を取る時とデータベースへ登録する時で<code>salt</code>に異なる値を入れていた。