### PR TITLE
販売制限数を超えて購入できるバグを修正

### DIFF
--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -283,8 +283,13 @@ class CartService
         }
 
         if (!$ProductClass->getStockUnlimited() && $quantity > $ProductClass->getStock()) {
-            $quantity = $ProductClass->getStock();
-            $this->addError('cart.over.stock');
+            if ($ProductClass->getSaleLimit() && $ProductClass->getStock() > $ProductClass->getSaleLimit()) {
+                $quantity = $ProductClass->getSaleLimit();
+                $this->addError('cart.over.sale_limit');
+            } else {
+                $quantity = $ProductClass->getStock();
+                $this->addError('cart.over.stock');
+            }
         } elseif ($ProductClass->getSaleLimit() && $quantity > $ProductClass->getSaleLimit()) {
             $quantity = $ProductClass->getSaleLimit();
             $this->addError('cart.over.sale_limit');

--- a/tests/Eccube/Tests/Service/CartServiceTest.php
+++ b/tests/Eccube/Tests/Service/CartServiceTest.php
@@ -95,6 +95,16 @@ class CartServiceTest extends AbstractServiceTestCase
 
         $cartService->addProduct(1);
         $this->assertEquals(1, $cartService->getProductQuantity(1));
+
+        $cartService->clear();
+
+        $cartService->addProduct(10, 6);
+        $this->assertEquals(5, $cartService->getProductQuantity(10));
+
+        $cartService->clear();
+
+        $cartService->addProduct(10, 101);
+        $this->assertEquals(5, $cartService->getProductQuantity(10));
     }
 
     public function testUpProductQuantity()


### PR DESCRIPTION
販売限定数が5
在庫が100のとき、
購入数を101以上にすると
在庫数の100がカートに入ってしまう