### PR TITLE
ブロックを新規に作成する際の重複エラーチェックが正しくされない不具合を修正 ref #715

### DIFF
--- a/src/Eccube/Form/Type/BlockType.php
+++ b/src/Eccube/Form/Type/BlockType.php
@@ -64,14 +64,17 @@ class BlockType extends AbstractType
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Length(array(
-                        'max' => $app['config']['lltext_len'],
+                        'max' => $app['config']['stext_len'],
+                    )),
+                    new Assert\Regex(array(
+                        'pattern' => '/^[0-9a-zA-Z\/_]+$/',
                     )),
                 )
             ))
             ->add('block_html', 'textarea', array(
                 'label' => 'ブロックデータ',
                 'mapped' => false,
-                'required' => true,
+                'required' => false,
                 'constraints' => array()
             ))
             ->add('DeviceType', 'entity', array(
@@ -92,9 +95,12 @@ class BlockType extends AbstractType
                     ->setParameter('file_name', $file_name)
                     ->andWhere('b.DeviceType = :DeviceType')
                     ->setParameter('DeviceType', $DeviceType)
-                    ->andWhere('b.id <> :block_id')
-                    ->setParameter('block_id', $block_id)
                 ;
+                if (isset($block_id)) {
+                    $qb
+                        ->andWhere('b.id <> :block_id')
+                        ->setParameter('block_id', $block_id);
+                }
 
                 $Block = $qb
                     ->getQuery()


### PR DESCRIPTION
ブロックデータが空でも問題はないと思うので、<code>required</code>は<code>false</code>にしました。