### PR TITLE
カナのチェック　KanaType を作成

### DIFF
--- a/src/Eccube/Event/ConvertKanaEventSubscriber.php
+++ b/src/Eccube/Event/ConvertKanaEventSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Eccube\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+class ConvertKanaEventSubscriber implements EventSubscriberInterface
+{
+    public function __construct($option = 'a', $encoding = 'utf-8')
+    {
+        $this->option = $option;
+        $this->encoding = $encoding;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FormEvents::PRE_SUBMIT   => 'onPreSubmit',
+        );
+    }
+
+    public function onPreSubmit(FormEvent $event)
+    {
+        $data = $event->getData();
+        foreach ($data as &$value) {
+            $value = mb_convert_kana($value, $this->option, $this->encoding);
+        }
+        $event->setData($data);
+    }
+}

--- a/src/Eccube/EventListner/ConvertKanaListener.php
+++ b/src/Eccube/EventListner/ConvertKanaListener.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Eccube\Event;
+namespace Eccube\EventListner;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 
-class ConvertKanaEventSubscriber implements EventSubscriberInterface
+class ConvertKanaListener implements EventSubscriberInterface
 {
     public function __construct($option = 'a', $encoding = 'utf-8')
     {

--- a/src/Eccube/EventListner/ConvertKanaListener.php
+++ b/src/Eccube/EventListner/ConvertKanaListener.php
@@ -24,9 +24,15 @@ class ConvertKanaListener implements EventSubscriberInterface
     public function onPreSubmit(FormEvent $event)
     {
         $data = $event->getData();
-        foreach ($data as &$value) {
-            $value = mb_convert_kana($value, $this->option, $this->encoding);
+
+        if (is_array($data)) {
+            foreach ($data as &$value) {
+                $value = mb_convert_kana($value, $this->option, $this->encoding);
+            }
+        } else {
+            $data = mb_convert_kana($data, $this->option, $this->encoding);
         }
+
         $event->setData($data);
     }
 }

--- a/src/Eccube/Form/Type/Front/EntryType.php
+++ b/src/Eccube/Form/Type/Front/EntryType.php
@@ -45,27 +45,18 @@ class EntryType extends AbstractType
     {
         $builder
             ->add('name', 'name', array(
+                'required' => true,
                 'options' => array(
                     'attr' => array(
                         'maxlength' => $this->config['stext_len'],
-                    ),
-                    'constraints' => array(
-                        new Assert\NotBlank(),
-                        new Assert\Length(array('max' => $this->config['stext_len'])),
                     ),
                 ),
             ))
-            ->add('kana', 'name', array(
+            ->add('kana', 'kana', array(
+                'required' => true,
                 'options' => array(
                     'attr' => array(
                         'maxlength' => $this->config['stext_len'],
-                    ),
-                    'constraints' => array(
-                        new Assert\NotBlank(),
-                        new Assert\Length(array('max' => $this->config['stext_len'])),
-                        new Assert\Regex(array(
-                            'pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u",
-                        )),
                     ),
                 ),
             ))

--- a/src/Eccube/Form/Type/Front/EntryType.php
+++ b/src/Eccube/Form/Type/Front/EntryType.php
@@ -46,19 +46,9 @@ class EntryType extends AbstractType
         $builder
             ->add('name', 'name', array(
                 'required' => true,
-                'options' => array(
-                    'attr' => array(
-                        'maxlength' => $this->config['stext_len'],
-                    ),
-                ),
             ))
             ->add('kana', 'kana', array(
                 'required' => true,
-                'options' => array(
-                    'attr' => array(
-                        'maxlength' => $this->config['stext_len'],
-                    ),
-                ),
             ))
             ->add('company_name', 'text', array(
                 'label' => '会社名',

--- a/src/Eccube/Form/Type/KanaType.php
+++ b/src/Eccube/Form/Type/KanaType.php
@@ -70,7 +70,7 @@ class KanaType extends AbstractType
                     )),
                     new Assert\Length(array(
                         'max' => $this->config['kana_len'],
-                    ))
+                    )),
                 ),
             ),
             'firstname_options' => array(
@@ -80,7 +80,7 @@ class KanaType extends AbstractType
                     )),
                     new Assert\Length(array(
                         'max' => $this->config['kana_len'],
-                    ))
+                    )),
                 ),
             ),
         ));

--- a/src/Eccube/Form/Type/KanaType.php
+++ b/src/Eccube/Form/Type/KanaType.php
@@ -49,7 +49,7 @@ class KanaType extends AbstractType
     {
         // ひらがなをカタカナに変換する
         // 引数はmb_convert_kanaのもの
-        $builder->addEventSubscriber(new \Eccube\Event\ConvertKanaEventSubscriber('CV'));
+        $builder->addEventSubscriber(new \Eccube\EventListner\ConvertKanaListener('CV'));
     }
 
     /**

--- a/src/Eccube/Form/Type/KanaType.php
+++ b/src/Eccube/Form/Type/KanaType.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class KanaType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        // ひらがなをカタカナに変換する
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function ($event) {
+            $data = $event->getData();
+            foreach ($data as &$value) {
+                $value = mb_convert_kana($value, 'CV', 'utf-8');
+            }
+            $event->setData($data);
+        }, 255);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'inherit_data' => true,
+            'lastname_options' => array(
+                'constraints' => array(
+                    new Assert\Regex(array(
+                        'pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u",
+                    )),
+                ),
+            ),
+            'firstname_options' => array(
+                'constraints' => array(
+                    new Assert\Regex(array(
+                        'pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u",
+                    )),
+                ),
+            ),
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return 'name';
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'kana';
+    }
+}

--- a/src/Eccube/Form/Type/KanaType.php
+++ b/src/Eccube/Form/Type/KanaType.php
@@ -30,6 +30,16 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * KanaType
+ *
+ * @uses AbstractType
+ * @package
+ * @version $id$
+ * @copyright
+ * @author Nobuhiko Kimoto <info@nob-log.info>
+ * @license
+ */
 class KanaType extends AbstractType
 {
     /**
@@ -38,13 +48,8 @@ class KanaType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         // ひらがなをカタカナに変換する
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, function ($event) {
-            $data = $event->getData();
-            foreach ($data as &$value) {
-                $value = mb_convert_kana($value, 'CV', 'utf-8');
-            }
-            $event->setData($data);
-        }, 255);
+        // 引数はmb_convert_kanaのもの
+        $builder->addEventSubscriber(new \Eccube\Event\ConvertKanaEventSubscriber('CV'));
     }
 
     /**
@@ -78,6 +83,7 @@ class KanaType extends AbstractType
     {
         return 'name';
     }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Eccube/Form/Type/KanaType.php
+++ b/src/Eccube/Form/Type/KanaType.php
@@ -42,6 +42,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class KanaType extends AbstractType
 {
+    public function __construct($config = array('kana_len' => 50))
+    {
+        $this->config = $config;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -58,12 +63,14 @@ class KanaType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'inherit_data' => true,
             'lastname_options' => array(
                 'constraints' => array(
                     new Assert\Regex(array(
                         'pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u",
                     )),
+                    new Assert\Length(array(
+                        'max' => $this->config['kana_len'],
+                    ))
                 ),
             ),
             'firstname_options' => array(
@@ -71,6 +78,9 @@ class KanaType extends AbstractType
                     new Assert\Regex(array(
                         'pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u",
                     )),
+                    new Assert\Length(array(
+                        'max' => $this->config['kana_len'],
+                    ))
                 ),
             ),
         ));

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -29,10 +29,10 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class NameType extends AbstractType
 {
-
     /**
      * {@inheritdoc}
      */
@@ -40,6 +40,17 @@ class NameType extends AbstractType
     {
         $options['lastname_options']['required'] = $options['required'];
         $options['firstname_options']['required'] = $options['required'];
+
+        // required の場合は NotBlank も追加する
+        if ($options['required']) {
+            $options['lastname_options']['constraints'] = array_merge(array(
+                new Assert\NotBlank(array()),
+            ), $options['lastname_options']['constraints']);
+
+            $options['firstname_options']['constraints'] = array_merge(array(
+                new Assert\NotBlank(array()),
+            ), $options['firstname_options']['constraints']);
+        }
 
         if (!isset($options['options']['error_bubbling'])) {
             $options['options']['error_bubbling'] = $options['error_bubbling'];
@@ -53,8 +64,8 @@ class NameType extends AbstractType
         }
 
         $builder
-            ->add($options['lastname_name'], 'text', array_merge($options['options'], $options['lastname_options']))
-            ->add($options['firstname_name'], 'text', array_merge($options['options'], $options['firstname_options']))
+            ->add($options['lastname_name'], 'text', array_merge_recursive($options['options'], $options['lastname_options']))
+            ->add($options['firstname_name'], 'text', array_merge_recursive($options['options'], $options['firstname_options']))
         ;
 
         $builder->setAttribute('lastname_name', $options['lastname_name']);
@@ -79,12 +90,13 @@ class NameType extends AbstractType
     {
         $resolver->setDefaults(array(
             'options' => array(),
-            'lastname_options' => array(),
-            'firstname_options' => array(),
+            'lastname_options' => array('constraints' => array()),
+            'firstname_options' => array('constraints' => array()),
             'lastname_name' => '',
             'firstname_name' => '',
             'error_bubbling' => false,
             'inherit_data' => true,
+            'trim' => true,
         ));
     }
 

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -33,6 +33,11 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class NameType extends AbstractType
 {
+    public function __construct($config = array('name_len' => 50))
+    {
+        $this->config = $config;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -90,8 +95,20 @@ class NameType extends AbstractType
     {
         $resolver->setDefaults(array(
             'options' => array(),
-            'lastname_options' => array('constraints' => array()),
-            'firstname_options' => array('constraints' => array()),
+            'lastname_options' => array(
+                'constraints' => array(
+                    new Assert\Length(array(
+                        'max' => $this->config['name_len'],
+                    ))
+                ),
+            ),
+            'firstname_options' => array(
+                'constraints' => array(
+                    new Assert\Length(array(
+                        'max' => $this->config['name_len'],
+                    ))
+                ),
+            ),
             'lastname_name' => '',
             'firstname_name' => '',
             'error_bubbling' => false,

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -99,14 +99,14 @@ class NameType extends AbstractType
                 'constraints' => array(
                     new Assert\Length(array(
                         'max' => $this->config['name_len'],
-                    ))
+                    )),
                 ),
             ),
             'firstname_options' => array(
                 'constraints' => array(
                     new Assert\Length(array(
                         'max' => $this->config['name_len'],
-                    ))
+                    )),
                 ),
             ),
             'lastname_name' => '',

--- a/src/Eccube/Form/Type/TelType.php
+++ b/src/Eccube/Form/Type/TelType.php
@@ -29,7 +29,7 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class TelType extends AbstractType
@@ -59,14 +59,7 @@ class TelType extends AbstractType
         }
 
         // 全角英数を事前に半角にする
-        // todo 別ファイルに書き出せないか？
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, function ($event) {
-            $data = $event->getData();
-            foreach ($data as &$value) {
-                $value = mb_convert_kana($value, 'a', 'utf-8');
-            }
-            $event->setData($data);
-        }, 255);
+        $builder->addEventSubscriber(new \Eccube\Event\ConvertKanaEventSubscriber());
 
         $builder
             ->add($options['tel01_name'], 'text', array_merge_recursive($options['options'], $options['tel01_options']))
@@ -112,7 +105,7 @@ class TelType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'options' => array(),
@@ -139,6 +132,7 @@ class TelType extends AbstractType
             'tel03_name' => '',
             'error_bubbling' => false,
             'inherit_data' => true,
+            'trim' => true,
         ));
     }
 

--- a/src/Eccube/Form/Type/TelType.php
+++ b/src/Eccube/Form/Type/TelType.php
@@ -59,7 +59,7 @@ class TelType extends AbstractType
         }
 
         // 全角英数を事前に半角にする
-        $builder->addEventSubscriber(new \Eccube\Event\ConvertKanaEventSubscriber());
+        $builder->addEventSubscriber(new \Eccube\EventListner\ConvertKanaListener());
 
         $builder
             ->add($options['tel01_name'], 'text', array_merge_recursive($options['options'], $options['tel01_options']))

--- a/src/Eccube/Resource/config/constant.yml.dist
+++ b/src/Eccube/Resource/config/constant.yml.dist
@@ -255,3 +255,5 @@ csv_import_delimiter: ,
 csv_import_enclosure: '"'
 csv_import_escape: \
 owners_store_url: https://www.ec-cube.net/upgrade/api/index.php
+name_len: 16
+kana_len: 25

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -253,8 +253,8 @@ class EccubeServiceProvider implements ServiceProviderInterface
             return $extensions;
         }));
         $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app) {
-            $types[] = new \Eccube\Form\Type\NameType();
-            $types[] = new \Eccube\Form\Type\KanaType();
+            $types[] = new \Eccube\Form\Type\NameType($app['config']);
+            $types[] = new \Eccube\Form\Type\KanaType($app['config']);
             $types[] = new \Eccube\Form\Type\TelType();
             $types[] = new \Eccube\Form\Type\FaxType(); // 削除予定
             $types[] = new \Eccube\Form\Type\AddressType();

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -254,6 +254,7 @@ class EccubeServiceProvider implements ServiceProviderInterface
         }));
         $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app) {
             $types[] = new \Eccube\Form\Type\NameType();
+            $types[] = new \Eccube\Form\Type\KanaType();
             $types[] = new \Eccube\Form\Type\TelType();
             $types[] = new \Eccube\Form\Type\FaxType(); // 削除予定
             $types[] = new \Eccube\Form\Type\AddressType();

--- a/tests/Eccube/Tests/EventListener/ConvertKanaListenerTest.php
+++ b/tests/Eccube/Tests/EventListener/ConvertKanaListenerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Eccube\Tests\EventListener;
+
+use Symfony\Component\Form\FormEvent;
+use Eccube\EventListner\ConvertKanaListener;
+
+class ConvertKanaListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConvertKana_string()
+    {
+        $data = '１２３４５';
+        $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
+        $event = new FormEvent($form, $data);
+
+        $filter = new ConvertKanaListener();
+        $filter->onPreSubmit($event);
+
+        $this->assertEquals('12345', $event->getData());
+    }
+
+    public function testConvertKana_array()
+    {
+        $data = array('１２３４５');
+        $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
+        $event = new FormEvent($form, $data);
+
+        $filter = new ConvertKanaListener();
+        $filter->onPreSubmit($event);
+
+        $this->assertEquals(array('12345'), $event->getData());
+    }
+
+    public function testConvertKana_HiraganaToKana()
+    {
+        $data = 'あいうえお';
+        $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
+        $event = new FormEvent($form, $data);
+
+        $filter = new ConvertKanaListener('CV');
+        $filter->onPreSubmit($event);
+
+        $this->assertEquals('アイウエオ', $event->getData());
+    }
+}

--- a/tests/Eccube/Tests/Form/Type/KanaTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/KanaTypeTest.php
@@ -95,11 +95,9 @@ class KanaTypeTest extends \PHPUnit_Framework_TestCase
         $app->register(new \Silex\Provider\FormServiceProvider());
         $app->register(new \Eccube\ServiceProvider\ValidatorServiceProvider());
 
-        # $this を変数に代入して無名関数に引き渡す。
-        $self = $this;
-        $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app, $self) {
-            $config['config']['name_len'] = $self->maxLength;
-            $config['config']['kana_len'] = $self->maxLength;
+        $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app) {
+            $config['config']['name_len'] = 50; // php5.3で落ちてしまうので...
+            $config['config']['kana_len'] = 50;
             $types[] = new \Eccube\Form\Type\NameType($config['config']); // Nameに依存する
             $types[] = new \Eccube\Form\Type\KanaType($config['config']);
             return $types;

--- a/tests/Eccube/Tests/Form/Type/KanaTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/KanaTypeTest.php
@@ -21,16 +21,17 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-
 namespace Eccube\Tests\Form\Type;
 
-class KanaTypeTest extends AbstractTypeTestCase
+class KanaTypeTest extends \PHPUnit_Framework_TestCase
 {
     /** @var \Eccube\Application */
     protected $app;
 
     /** @var \Symfony\Component\Form\FormInterface */
     protected $form;
+
+    protected $maxLength = 50;
 
     /** @var array デフォルト値（正常系）を設定 */
     protected $formData = array(
@@ -75,6 +76,14 @@ class KanaTypeTest extends AbstractTypeTestCase
                     ),
                 ),
             ),
+            array(
+                'data' => array(
+                    'kana' => array(
+                        'kana01' => str_repeat('ア', $this->maxLength),
+                        'kana02' => str_repeat('ア', $this->maxLength),
+                    ),
+                ),
+            ),
         );
     }
 
@@ -87,8 +96,10 @@ class KanaTypeTest extends AbstractTypeTestCase
         $app->register(new \Eccube\ServiceProvider\ValidatorServiceProvider());
 
         $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app) {
-            $types[] = new \Eccube\Form\Type\NameType(); // Nameに依存する
-            $types[] = new \Eccube\Form\Type\KanaType();
+            $config['config']['name_len'] = $this->maxLength;
+            $config['config']['kana_len'] = $this->maxLength;
+            $types[] = new \Eccube\Form\Type\NameType($config['config']); // Nameに依存する
+            $types[] = new \Eccube\Form\Type\KanaType($config['config']);
             return $types;
         }));
 
@@ -111,6 +122,30 @@ class KanaTypeTest extends AbstractTypeTestCase
     {
         $this->form->submit($data);
         $this->assertTrue($this->form->isValid());
+    }
+
+    public function testInvalidData_Kana01_MaxLength()
+    {
+        $data = array(
+            'kana' => array(
+                'kana01' => str_repeat('ア', $this->maxLength+1),
+                'kana02' => 'にゅうりょく',
+            ));
+
+        $this->form->submit($data);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidData_Kana02_MaxLength()
+    {
+        $data = array(
+            'kana' => array(
+                'kana01' => 'にゅうりょく',
+                'kana02' => str_repeat('ア', $this->maxLength+1),
+            ));
+
+        $this->form->submit($data);
+        $this->assertFalse($this->form->isValid());
     }
 
     /**

--- a/tests/Eccube/Tests/Form/Type/KanaTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/KanaTypeTest.php
@@ -95,9 +95,11 @@ class KanaTypeTest extends \PHPUnit_Framework_TestCase
         $app->register(new \Silex\Provider\FormServiceProvider());
         $app->register(new \Eccube\ServiceProvider\ValidatorServiceProvider());
 
-        $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app) {
-            $config['config']['name_len'] = $this->maxLength;
-            $config['config']['kana_len'] = $this->maxLength;
+        # $this を変数に代入して無名関数に引き渡す。
+        $self = $this;
+        $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app, $self) {
+            $config['config']['name_len'] = $self->maxLength;
+            $config['config']['kana_len'] = $self->maxLength;
             $types[] = new \Eccube\Form\Type\NameType($config['config']); // Nameに依存する
             $types[] = new \Eccube\Form\Type\KanaType($config['config']);
             return $types;

--- a/tests/Eccube/Tests/Form/Type/KanaTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/KanaTypeTest.php
@@ -1,0 +1,135 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Tests\Form\Type;
+
+class KanaTypeTest extends AbstractTypeTestCase
+{
+    /** @var \Eccube\Application */
+    protected $app;
+
+    /** @var \Symfony\Component\Form\FormInterface */
+    protected $form;
+
+    /** @var array デフォルト値（正常系）を設定 */
+    protected $formData = array(
+        'kana' => array(
+            'kana01' => 'たかはし',
+            'kana02' => 'しんいち',
+        ),
+    );
+
+    /**
+     * getValidTestData
+     *
+     * 正常系のデータパターンを返す
+     *
+     * @access public
+     * @return array
+     */
+    public function getValidTestData()
+    {
+        return array(
+            array(
+                'data' => array(
+                    'kana' => array(
+                        'kana01' => 'たかはし',
+                        'kana02' => 'しんいち',
+                    ),
+                ),
+            ),
+            array(
+                'data' => array(
+                    'kana' => array(
+                        'kana01' => 'タカハシ',
+                        'kana02' => 'しんいち',
+                    ),
+                ),
+            ),
+            array(
+                'data' => array(
+                    'kana' => array(
+                        'kana01' => 'たかはし',
+                        'kana02' => 'シンイチ',
+                    ),
+                ),
+            ),
+        );
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $app = new \Silex\Application();
+        $app->register(new \Silex\Provider\FormServiceProvider());
+        $app->register(new \Eccube\ServiceProvider\ValidatorServiceProvider());
+
+        $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app) {
+            $types[] = new \Eccube\Form\Type\NameType(); // Nameに依存する
+            $types[] = new \Eccube\Form\Type\KanaType();
+            return $types;
+        }));
+
+        // CSRF tokenを無効にしてFormを作成
+        $this->form = $app['form.factory']->createBuilder('form', null, array('csrf_protection' => false))
+            ->add('kana', 'kana')
+            ->getForm();
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        $this->form = null;
+    }
+
+    /**
+     * @dataProvider getValidTestData
+     */
+    public function testValidData($data)
+    {
+        $this->form->submit($data);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    /**
+     * ひらがな入力されてもカタカナで返す
+     */
+    public function testSubmitFromHiraganaToKana()
+    {
+        $input = array(
+            'kana' => array(
+                'kana01' => 'ひらがな',
+                'kana02' => 'にゅうりょく',
+            ));
+
+        $output = array(
+            'kana01' => 'ヒラガナ',
+            'kana02' => 'ニュウリョク',
+        );
+
+        $this->form->submit($input);
+        $this->assertEquals($output, $this->form->getData());
+    }
+}

--- a/tests/Eccube/Tests/Form/Type/NameTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/NameTypeTest.php
@@ -21,17 +21,17 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-
 namespace Eccube\Tests\Form\Type;
 
-class NameTypeTest extends AbstractTypeTestCase
+class NameTypeTest extends \PHPUnit_Framework_TestCase
 {
-
     /** @var \Eccube\Application */
     protected $app;
 
     /** @var \Symfony\Component\Form\FormInterface */
     protected $form;
+
+    protected $maxLength = 50;
 
     /** @var array デフォルト値（正常系）を設定 */
     protected $formData = array(
@@ -45,20 +45,55 @@ class NameTypeTest extends AbstractTypeTestCase
     {
         parent::setUp();
 
+        $app = new \Silex\Application();
+        $app->register(new \Silex\Provider\FormServiceProvider());
+        $app->register(new \Eccube\ServiceProvider\ValidatorServiceProvider());
+
+        $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app) {
+            $config['config']['name_len'] = $this->maxLength;
+            $types[] = new \Eccube\Form\Type\NameType($config['config']); // Nameに依存する
+            return $types;
+        }));
+
         // CSRF tokenを無効にしてFormを作成
-        $this->form = $this->app['form.factory']
-            ->createBuilder('form', null, array(
-                'csrf_protection' => false,
-            ))
+        $this->form = $app['form.factory']->createBuilder('form', null, array('csrf_protection' => false))
             ->add('name', 'name')
             ->getForm();
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        $this->form = null;
     }
 
     public function testValidData()
     {
         $this->form->submit($this->formData);
-
         $this->assertTrue($this->form->isValid());
     }
 
+    public function testInvalidData_Name01_MaxLength()
+    {
+        $data = array(
+            'name' => array(
+                'name01' => str_repeat('ア', $this->maxLength+1),
+                'name02' => 'にゅうりょく',
+            ));
+
+        $this->form->submit($data);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidData_Name02_MaxLength()
+    {
+        $data = array(
+            'name' => array(
+                'name01' => 'にゅうりょく',
+                'name02' => str_repeat('ア', $this->maxLength+1),
+            ));
+
+        $this->form->submit($data);
+        $this->assertFalse($this->form->isValid());
+    }
 }

--- a/tests/Eccube/Tests/Form/Type/NameTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/NameTypeTest.php
@@ -49,11 +49,8 @@ class NameTypeTest extends \PHPUnit_Framework_TestCase
         $app->register(new \Silex\Provider\FormServiceProvider());
         $app->register(new \Eccube\ServiceProvider\ValidatorServiceProvider());
 
-        # $this を変数に代入して無名関数に引き渡す。
-        $self = $this;
-        $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app, $self) {
-            // PHP5.3対応
-            $config['config']['name_len'] = $self->maxLength;
+        $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app) {
+            $config['config']['name_len'] = 50;
             $types[] = new \Eccube\Form\Type\NameType($config['config']); // Nameに依存する
             return $types;
         }));

--- a/tests/Eccube/Tests/Form/Type/NameTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/NameTypeTest.php
@@ -49,8 +49,11 @@ class NameTypeTest extends \PHPUnit_Framework_TestCase
         $app->register(new \Silex\Provider\FormServiceProvider());
         $app->register(new \Eccube\ServiceProvider\ValidatorServiceProvider());
 
-        $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app) {
-            $config['config']['name_len'] = $this->maxLength;
+        # $this を変数に代入して無名関数に引き渡す。
+        $self = $this;
+        $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app, $self) {
+            // PHP5.3対応
+            $config['config']['name_len'] = $self->maxLength;
             $types[] = new \Eccube\Form\Type\NameType($config['config']); // Nameに依存する
             return $types;
         }));

--- a/tests/Eccube/Tests/Form/Type/TelTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/TelTypeTest.php
@@ -222,4 +222,24 @@ class TelTypeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($this->form->isValid());
     }
+
+
+    public function testSubmitFromZenToHan()
+    {
+        $input = array(
+            'tel' => array(
+                'tel01' => '１２３４５',
+                'tel02' => '１２３４５',
+                'tel03' => '６７８９０',
+            ));
+
+        $output = array(
+            'tel01' => '12345',
+            'tel02' => '12345',
+            'tel03' => '67890',
+        );
+
+        $this->form->submit($input);
+        $this->assertEquals($output, $this->form->getData());
+    }
 }


### PR DESCRIPTION
- NameTypeの子供
- ひらがなをカナに変換
- とりあえず会員登録画面だけに適用、残り(#408 など)は随時変更
- kana_len name_len の追加 (2系の時にみんなstext_lenになってて変える時に予想外の影響範囲があったので)