### PR TITLE
ユーザ作成ブロックのtwig保存先をhtml/user_dataからapp/templateへ変更

### DIFF
--- a/src/Eccube/Repository/BlockRepository.php
+++ b/src/Eccube/Repository/BlockRepository.php
@@ -159,7 +159,8 @@ class BlockRepository extends EntityRepository
      */
     public function getWriteTemplatePath($isUser = false)
     {
-        return ($isUser) ? $this->app['config']['user_block_realdir'] : $this->app['config']['block_realdir'];
+        //return ($isUser) ? $this->app['config']['user_block_realdir'] : $this->app['config']['block_realdir'];
+        return $this->app['config']['block_realdir'];
     }
 
     /**
@@ -177,17 +178,10 @@ class BlockRepository extends EntityRepository
      */
     public function getReadTemplateFile($fileName, $isUser = false)
     {
-        if ($isUser) {
-        // User定義
-            $readPaths = array(
-                $this->app['config']['user_block_realdir'],
-            );
-        } else {
-            $readPaths = array(
-                $this->app['config']['block_realdir'],
-                $this->app['config']['block_default_realdir'],
-            );
-        }
+        $readPaths = array(
+            $this->app['config']['block_realdir'],
+            $this->app['config']['block_default_realdir'],
+        );
         foreach ($readPaths as $readPath) {
             $filePath = $readPath . '/' . $fileName . '.twig';
             $fs = new Filesystem();

--- a/src/Eccube/Repository/BlockRepository.php
+++ b/src/Eccube/Repository/BlockRepository.php
@@ -159,7 +159,6 @@ class BlockRepository extends EntityRepository
      */
     public function getWriteTemplatePath($isUser = false)
     {
-        //return ($isUser) ? $this->app['config']['user_block_realdir'] : $this->app['config']['block_realdir'];
         return $this->app['config']['block_realdir'];
     }
 

--- a/src/Eccube/Resource/config/path.yml.dist
+++ b/src/Eccube/Resource/config/path.yml.dist
@@ -24,7 +24,6 @@ user_data_realdir: ${ROOT_DIR}/html/user_data
 # realdir::block
 block_default_realdir: ${ROOT_DIR}/src/Eccube/Resource/template/default/Block
 block_realdir: ${ROOT_DIR}/app/template/${TEMPLATE_CODE}/Block
-user_block_realdir: ${ROOT_DIR}/html/user_data/block
 
 # realdir::template
 template_default_realdir: ${ROOT_DIR}/src/Eccube/Resource/template/default

--- a/src/Eccube/Resource/template/default/block.twig
+++ b/src/Eccube/Resource/template/default/block.twig
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     {% if Block.logic_flg %}
         {{ render(path('block_' ~ Block.file_name)) }}
     {% else %}
-        {{ include('Block/' ~ Block.file_name~ '.twig') }}
+        {{ include('Block/' ~ Block.file_name~ '.twig', ignore_missing = true ) }}
     {% endif %}
     <!-- ▲{{ Block.name }} -->
 {% endfor %}


### PR DESCRIPTION
* ブロック追加時のtwig保存先のPATHを下記探索順の1に変更
* レイアウトで使用しているブロックが見つからない場合でもエラー落ちせず空でレンダリングするように修正
* ブロックの探索PATHの変更に伴いpath.ymlから不要になった項目を削除

1.app/template/[template_name]/Block/hoge.tpl
2.src/Eccube/Resouce/template/Block/hoge.tpl
3.app/Plugin/[PluginCode/ プラグインが設定したパス(ここはまだ未実装)
4.app/Plugin/

ref #688