### PR TITLE
お問い合わせフォームの修正

### DIFF
--- a/src/Eccube/Form/Type/Front/ContactType.php
+++ b/src/Eccube/Form/Type/Front/ContactType.php
@@ -47,7 +47,7 @@ class ContactType extends AbstractType
                 'required' => true,
             ))
             ->add('kana', 'kana', array(
-                'required' => true,
+                'required' => false,
             ))
             ->add('zip', 'zip', array(
                 'required' => false,

--- a/src/Eccube/Form/Type/Front/ContactType.php
+++ b/src/Eccube/Form/Type/Front/ContactType.php
@@ -44,41 +44,22 @@ class ContactType extends AbstractType
     {
         $builder
             ->add('name', 'name', array(
-                'options' => array(
-                    'attr' => array(
-                        'maxlength' => $this->config['stext_len'],
-                    ),
-                    'constraints' => array(
-                        new Assert\NotBlank(),
-                        new Assert\Length(array('max' => $this->config['stext_len'])),
-                    ),
-                ),
+                'required' => true,
             ))
-            ->add('kana', 'name', array(
-                'options' => array(
-                    'attr' => array(
-                        'maxlength' => $this->config['stext_len'],
-                    ),
-                    'constraints' => array(
-                        new Assert\NotBlank(),
-                        new Assert\Length(array('max' => $this->config['stext_len'])),
-                        new Assert\Regex(array(
-                            'pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u",
-                        )),
-                    ),
-                ),
+            ->add('kana', 'kana', array(
+                'required' => true,
             ))
             ->add('zip', 'zip', array(
                 'required' => false,
             ))
             ->add('address', 'address', array(
-                'help' => 'form.contact.address.help',
                 'required' => false,
             ))
             ->add('tel', 'tel', array(
                 'required' => false,
             ))
             ->add('email', 'email', array(
+                'required' => true,
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Email(),
@@ -91,7 +72,6 @@ class ContactType extends AbstractType
                 ),
             ))
             ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
-        ;
     }
 
     /**

--- a/src/Eccube/Form/Type/KanaType.php
+++ b/src/Eccube/Form/Type/KanaType.php
@@ -64,6 +64,9 @@ class KanaType extends AbstractType
     {
         $resolver->setDefaults(array(
             'lastname_options' => array(
+                'attr' => array(
+                    'placeholder' => 'Kana01',
+                ),
                 'constraints' => array(
                     new Assert\Regex(array(
                         'pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u",
@@ -74,6 +77,9 @@ class KanaType extends AbstractType
                 ),
             ),
             'firstname_options' => array(
+                'attr' => array(
+                    'placeholder' => 'Kana02',
+                ),
                 'constraints' => array(
                     new Assert\Regex(array(
                         'pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u",

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -96,6 +96,9 @@ class NameType extends AbstractType
         $resolver->setDefaults(array(
             'options' => array(),
             'lastname_options' => array(
+                'attr' => array(
+                    'placeholder' => 'Name01',
+                ),
                 'constraints' => array(
                     new Assert\Length(array(
                         'max' => $this->config['name_len'],
@@ -103,6 +106,9 @@ class NameType extends AbstractType
                 ),
             ),
             'firstname_options' => array(
+                'attr' => array(
+                    'placeholder' => 'Name02',
+                ),
                 'constraints' => array(
                     new Assert\Length(array(
                         'max' => $this->config['name_len'],

--- a/src/Eccube/Resource/template/default/Contact/index.twig
+++ b/src/Eccube/Resource/template/default/Contact/index.twig
@@ -24,106 +24,106 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% block javascript %}
 <script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
 <script>
-  $(function() {
-    $('#zip-search').click(function() {
-      AjaxZip3.zip2addr('contact[zip][zip01]', 'contact[zip][zip02]', 'contact[address][pref]', 'contact[address][addr01]');
+    $(function() {
+        $('#zip-search').click(function() {
+            AjaxZip3.zip2addr('contact[zip][zip01]', 'contact[zip][zip02]', 'contact[address][pref]', 'contact[address][addr01]');
+        });
     });
-  });
 </script>
 {% endblock javascript %}
 
 {% block main %}
 
 <div id="contents" class="main_only">
-  <div class="container-fluid inner no-padding">
-    <div id="main">
-      <h1 class="page-heading">お問い合わせ</h1>
+    <div class="container-fluid inner no-padding">
+        <div id="main">
+            <h1 class="page-heading">お問い合わせ</h1>
 
-      <div class="container-fluid">
-        <div class="row">
-          <div class="col-md-10 col-md-offset-1">
-            <p>内容によっては回答をさしあげるのにお時間をいただくこともございます。<br/>
-              また、休業日は翌営業日以降の対応となりますのでご了承ください。</p>
+            <div class="container-fluid">
+                <div class="row">
+                    <div class="col-md-10 col-md-offset-1">
+                        <p>内容によっては回答をさしあげるのにお時間をいただくこともございます。<br/>
+                            また、休業日は翌営業日以降の対応となりますのでご了承ください。</p>
 
-            <form name="form1" id="form1" method="post" action="{{ url('contact') }}">
-              {{ form_widget(form._token) }}
-              <div class="dl_table">
-                <dl>
-                  <dt>{{ form_label(form.name) }}<span class="required">必須</span></dt>
-                  <dd class="form-group input_name">
-                    {{ form_widget(form.name.name01) }}
-                    {{ form_widget(form.name.name02) }}
-                    {{ form_errors(form.name.name01) }}
-                    {{ form_errors(form.name.name02) }}
-                  </dd>
-                </dl>
-                <dl>
-                  <dt>{{ form_label(form.kana) }}
-                  <dd class="form-group input_name">
-                    {{ form_widget(form.kana.kana01) }}
-                    {{ form_widget(form.kana.kana02) }}
-                    {{ form_errors(form.kana.kana01) }}
-                    {{ form_errors(form.kana.kana02) }}
-                  </dd>
-                </dl>
-                <dl>
-                  <dt>{{ form_label(form.address) }}</dt>
-                  <dd>
-                    <div class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
-                    <div class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
-                      {{ form_widget(form.address) }}
-                      {{ form_errors(form.address) }}
-                    </div>
-                  </dd>
-                </dl>
-                <dl>
-                  <dt>{{ form_label(form.tel) }}</dt>
-                  <dd>
-                    <div class="form-inline form-group input_tel">
-                      {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
-                      {{ form_errors(form.tel) }}
-                    </div>
-                  </dd>
-                </dl>
-                <dl>
-                  <dt>{{ form_label(form.email) }}<span class="required">必須</span></dt>
-                  <dd>
-                    <div class="form-group">
-                      {{ form_widget(form.email) }}
-                      {{ form_errors(form.email) }}
-                    </div>
-                  </dd>
-                </dl>
-                <dl>
-                  <dt>{{ form_label(form.contents) }}<span class="required">必須</span></dt>
-                  <dd>
-                    <div class="column">
-                      {{ form_widget(form.contents) }}
-                      {{ form_errors(form.contents) }}
-                    </div>
-                  </dd>
-                </dl>
-              </div>
-              <input type="hidden" name="mode" value="confirm">
+                        <form name="form1" id="form1" method="post" action="{{ url('contact') }}">
+                            {{ form_widget(form._token) }}
+                            <div class="dl_table">
+                                <dl>
+                                    <dt>{{ form_label(form.name) }}<span class="required">必須</span></dt>
+                                    <dd class="form-group input_name">
+                                        {{ form_widget(form.name.name01) }}
+                                        {{ form_widget(form.name.name02) }}
+                                        {{ form_errors(form.name.name01) }}
+                                        {{ form_errors(form.name.name02) }}
+                                    </dd>
+                                </dl>
+                                <dl>
+                                    <dt>{{ form_label(form.kana) }}
+                                        <dd class="form-group input_name">
+                                            {{ form_widget(form.kana.kana01) }}
+                                            {{ form_widget(form.kana.kana02) }}
+                                            {{ form_errors(form.kana.kana01) }}
+                                            {{ form_errors(form.kana.kana02) }}
+                                        </dd>
+                                    </dl>
+                                    <dl>
+                                        <dt>{{ form_label(form.address) }}</dt>
+                                        <dd>
+                                            <div class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
+                                            <div class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
+                                                {{ form_widget(form.address) }}
+                                                {{ form_errors(form.address) }}
+                                            </div>
+                                        </dd>
+                                    </dl>
+                                    <dl>
+                                        <dt>{{ form_label(form.tel) }}</dt>
+                                        <dd>
+                                            <div class="form-inline form-group input_tel">
+                                                {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
+                                                {{ form_errors(form.tel) }}
+                                            </div>
+                                        </dd>
+                                    </dl>
+                                    <dl>
+                                        <dt>{{ form_label(form.email) }}<span class="required">必須</span></dt>
+                                        <dd>
+                                            <div class="form-group">
+                                                {{ form_widget(form.email) }}
+                                                {{ form_errors(form.email) }}
+                                            </div>
+                                        </dd>
+                                    </dl>
+                                    <dl>
+                                        <dt>{{ form_label(form.contents) }}<span class="required">必須</span></dt>
+                                        <dd>
+                                            <div class="column">
+                                                {{ form_widget(form.contents) }}
+                                                {{ form_errors(form.contents) }}
+                                            </div>
+                                        </dd>
+                                    </dl>
+                                </div>
+                                <input type="hidden" name="mode" value="confirm">
 
-              <div class="row no-padding">
-                <div class="btn_group col-sm-offset-4 col-sm-4">
-                  <p>
-                    <button type="submit" class="btn btn-primary btn-block">確認ページへ</button>
-                  </p>
+                                <div class="row no-padding">
+                                    <div class="btn_group col-sm-offset-4 col-sm-4">
+                                        <p>
+                                            <button type="submit" class="btn btn-primary btn-block">確認ページへ</button>
+                                        </p>
+                                    </div>
+                                </div>
+                            </form>
+                        </div>
+                        <!-- /.col -->
+                    </div>
+                    <!-- /.row -->
+
                 </div>
-              </div>
-            </form>
-          </div>
-          <!-- /.col -->
+            </div>
         </div>
-        <!-- /.row -->
-
-      </div>
     </div>
-  </div>
-</div>
 
-{% endblock %}
+    {% endblock %}
 
 

--- a/src/Eccube/Resource/template/default/Contact/index.twig
+++ b/src/Eccube/Resource/template/default/Contact/index.twig
@@ -51,17 +51,17 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 <dl>
                   <dt>{{ form_label(form.name) }}<span class="required">必須</span></dt>
                   <dd class="form-group input_name">
-                    {{ form_widget(form.name.name01, { attr : { placeholder: '姓' }}) }}
-                    {{ form_widget(form.name.name02, { attr : { placeholder: '名' }}) }}
+                    {{ form_widget(form.name.name01) }}
+                    {{ form_widget(form.name.name02) }}
                     {{ form_errors(form.name.name01) }}
                     {{ form_errors(form.name.name02) }}
                   </dd>
                 </dl>
                 <dl>
-                  <dt>{{ form_label(form.kana) }}<span class="required">必須</span></dt>
+                  <dt>{{ form_label(form.kana) }}
                   <dd class="form-group input_name">
-                    {{ form_widget(form.kana.kana01, { attr : { placeholder: 'セイ' }}) }}
-                    {{ form_widget(form.kana.kana02, { attr : { placeholder: 'メイ' }}) }}
+                    {{ form_widget(form.kana.kana01) }}
+                    {{ form_widget(form.kana.kana02) }}
                     {{ form_errors(form.kana.kana01) }}
                     {{ form_errors(form.kana.kana02) }}
                   </dd>

--- a/src/Eccube/Resource/template/default/Contact/index.twig
+++ b/src/Eccube/Resource/template/default/Contact/index.twig
@@ -24,107 +24,105 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% block javascript %}
 <script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
 <script>
-$(function() {
+  $(function() {
     $('#zip-search').click(function() {
-        AjaxZip3.zip2addr('contact[zip][zip01]', 'contact[zip][zip02]', 'contact[address][pref]', 'contact[address][addr01]');
+      AjaxZip3.zip2addr('contact[zip][zip01]', 'contact[zip][zip02]', 'contact[address][pref]', 'contact[address][addr01]');
     });
-});
+  });
 </script>
 {% endblock javascript %}
 
 {% block main %}
 
-    <div id="contents" class="main_only">
-        <div class="container-fluid inner no-padding">
-            <div id="main">
-                <h1 class="page-heading">お問い合わせ</h1>
+<div id="contents" class="main_only">
+  <div class="container-fluid inner no-padding">
+    <div id="main">
+      <h1 class="page-heading">お問い合わせ</h1>
 
-                <div class="container-fluid">
-                    <div class="row">
-                        <div class="col-md-10 col-md-offset-1">
-                            <p>内容によっては回答をさしあげるのにお時間をいただくこともございます。<br/>
-                                また、休業日は翌営業日以降の対応となりますのでご了承ください。</p>
+      <div class="container-fluid">
+        <div class="row">
+          <div class="col-md-10 col-md-offset-1">
+            <p>内容によっては回答をさしあげるのにお時間をいただくこともございます。<br/>
+              また、休業日は翌営業日以降の対応となりますのでご了承ください。</p>
 
-                            <form name="form1" id="form1" method="post" action="{{ url('contact') }}">
-                                {{ form_widget(form._token) }}
-                                <div class="dl_table">
-                                    <dl>
-                                        <dt>{{ form_label(form.name) }}<span class="required">必須</span></dt>
-                                        <dd class="form-group input_name">
-                                            {{ form_widget(form.name.name01, { attr : { placeholder: '姓' }}) }}
-                                            {{ form_widget(form.name.name02, { attr : { placeholder: '名' }}) }}
-                                            {{ form_errors(form.name.name01) }}
-                                            {{ form_errors(form.name.name02) }}
-                                        </dd>
-                                    </dl>
-                                    <dl>
-                                        <dt>
-                                            {{ form_label(form.kana) }}
-                                        </dt>
-                                        <dd class="form-group input_name">
-                                            {{ form_widget(form.kana.kana01, { attr : { placeholder: 'セイ' }}) }}
-                                            {{ form_widget(form.kana.kana02, { attr : { placeholder: 'メイ' }}) }}
-                                            {{ form_errors(form.kana.kana01) }}
-                                            {{ form_errors(form.kana.kana02) }}
-                                        </dd>
-                                    </dl>
-                                    <dl>
-                                        <dt>{{ form_label(form.address) }}</dt>
-                                        <dd>
-                                            <div class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
-                                            <div class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
-                                                {{ form_widget(form.address) }}
-                                                {{ form_errors(form.address) }}
-                                            </div>
-                                        </dd>
-                                    </dl>
-                                    <dl>
-                                        <dt>{{ form_label(form.tel) }}</dt>
-                                        <dd>
-                                            <div class="form-inline form-group input_tel">
-                                                {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
-                                                {{ form_errors(form.tel) }}
-                                            </div>
-                                        </dd>
-                                    </dl>
-                                    <dl>
-                                        <dt>{{ form_label(form.email) }}<span class="required">必須</span></dt>
-                                        <dd>
-                                            <div class="form-group">
-                                                {{ form_widget(form.email) }}
-                                                {{ form_errors(form.email) }}
-                                            </div>
-                                        </dd>
-                                    </dl>
-                                    <dl>
-                                        <dt>{{ form_label(form.contents) }}<span class="required">必須</span></dt>
-                                        <dd>
-                                            <div class="column">
-                                                {{ form_widget(form.contents) }}
-                                                {{ form_errors(form.contents) }}
-                                            </div>
-                                        </dd>
-                                    </dl>
-                                </div>
-                                <input type="hidden" name="mode" value="confirm">
-
-                                <div class="row no-padding">
-                                    <div class="btn_group col-sm-offset-4 col-sm-4">
-                                        <p>
-                                            <button type="submit" class="btn btn-primary btn-block">確認ページへ</button>
-                                        </p>
-                                    </div>
-                                </div>
-                            </form>
-                        </div>
-                        <!-- /.col -->
+            <form name="form1" id="form1" method="post" action="{{ url('contact') }}">
+              {{ form_widget(form._token) }}
+              <div class="dl_table">
+                <dl>
+                  <dt>{{ form_label(form.name) }}<span class="required">必須</span></dt>
+                  <dd class="form-group input_name">
+                    {{ form_widget(form.name.name01, { attr : { placeholder: '姓' }}) }}
+                    {{ form_widget(form.name.name02, { attr : { placeholder: '名' }}) }}
+                    {{ form_errors(form.name.name01) }}
+                    {{ form_errors(form.name.name02) }}
+                  </dd>
+                </dl>
+                <dl>
+                  <dt>{{ form_label(form.kana) }}<span class="required">必須</span></dt>
+                  <dd class="form-group input_name">
+                    {{ form_widget(form.kana.kana01, { attr : { placeholder: 'セイ' }}) }}
+                    {{ form_widget(form.kana.kana02, { attr : { placeholder: 'メイ' }}) }}
+                    {{ form_errors(form.kana.kana01) }}
+                    {{ form_errors(form.kana.kana02) }}
+                  </dd>
+                </dl>
+                <dl>
+                  <dt>{{ form_label(form.address) }}</dt>
+                  <dd>
+                    <div class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
+                    <div class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
+                      {{ form_widget(form.address) }}
+                      {{ form_errors(form.address) }}
                     </div>
-                    <!-- /.row -->
+                  </dd>
+                </dl>
+                <dl>
+                  <dt>{{ form_label(form.tel) }}</dt>
+                  <dd>
+                    <div class="form-inline form-group input_tel">
+                      {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
+                      {{ form_errors(form.tel) }}
+                    </div>
+                  </dd>
+                </dl>
+                <dl>
+                  <dt>{{ form_label(form.email) }}<span class="required">必須</span></dt>
+                  <dd>
+                    <div class="form-group">
+                      {{ form_widget(form.email) }}
+                      {{ form_errors(form.email) }}
+                    </div>
+                  </dd>
+                </dl>
+                <dl>
+                  <dt>{{ form_label(form.contents) }}<span class="required">必須</span></dt>
+                  <dd>
+                    <div class="column">
+                      {{ form_widget(form.contents) }}
+                      {{ form_errors(form.contents) }}
+                    </div>
+                  </dd>
+                </dl>
+              </div>
+              <input type="hidden" name="mode" value="confirm">
 
+              <div class="row no-padding">
+                <div class="btn_group col-sm-offset-4 col-sm-4">
+                  <p>
+                    <button type="submit" class="btn btn-primary btn-block">確認ページへ</button>
+                  </p>
                 </div>
-            </div>
+              </div>
+            </form>
+          </div>
+          <!-- /.col -->
         </div>
+        <!-- /.row -->
+
+      </div>
     </div>
+  </div>
+</div>
 
 {% endblock %}
 

--- a/tests/Eccube/Tests/Form/Type/Front/ContactTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Front/ContactTypeTest.php
@@ -77,7 +77,39 @@ class ContactTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->assertTrue($this->form->isValid());
     }
 
-    public function testInvalidTel_Blank()
+    public function testInvalid_Blank_Name01()
+    {
+        $this->formData['name']['name01'] = '';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalid_Blank_Name02()
+    {
+        $this->formData['name']['name02'] = '';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalid_Blank_Kana01()
+    {
+        $this->formData['kana']['kana01'] = '';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalid_Blank_Kana02()
+    {
+        $this->formData['kana']['kana02'] = '';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testValidTel_Blank()
     {
         $this->formData['tel']['tel01'] = '';
         $this->formData['tel']['tel02'] = '';
@@ -85,8 +117,13 @@ class ContactTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());
+    }
 
-        // エラーメッセージデバッグ用
-        //var_dump($this->form->getErrorsAsString());die;
+    public function testInvalid_Blank_Contents()
+    {
+        $this->formData['contents'] = '';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
     }
 }

--- a/tests/Eccube/Tests/Form/Type/Front/ContactTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Front/ContactTypeTest.php
@@ -98,7 +98,7 @@ class ContactTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->formData['kana']['kana01'] = '';
 
         $this->form->submit($this->formData);
-        $this->assertFalse($this->form->isValid());
+        $this->assertTrue($this->form->isValid());
     }
 
     public function testInvalid_Blank_Kana02()
@@ -106,7 +106,7 @@ class ContactTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->formData['kana']['kana02'] = '';
 
         $this->form->submit($this->formData);
-        $this->assertFalse($this->form->isValid());
+        $this->assertTrue($this->form->isValid());
     }
 
     public function testValidTel_Blank()


### PR DESCRIPTION
- カナの必須を除去
- placeholderをテンプレートから除去
- name,kana,addressなどの修正を反映
- #408 も修正

