### PR TITLE
ユニットテストの基底クラス追加 #854

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "4.6.*",
+        "fzaninotto/faker":"1.*",
         "phing/phing": "2.*",
         "symfony/browser-kit": ">=2.7,<2.8",
         "sorien/silex-pimple-dumper": "1.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "fb29d90b530a6be782920d6eff45e2ad",
+    "hash": "f41ec0d55746831bdea9dd535e04d7d8",
+    "content-hash": "046b6d1a5f1ebc6a91bf2c79f879aad9",
     "packages": [
         {
             "name": "dflydev/doctrine-orm-service-provider",
@@ -896,7 +897,7 @@
             ],
             "authors": [
                 {
-                    "name": "KnpLabs",
+                    "name": "Knplabs",
                     "homepage": "http://knplabs.com"
                 }
             ],
@@ -3150,6 +3151,58 @@
             ],
             "description": "A tool to automatically fix PHP code style",
             "time": "2015-07-27 20:56:10"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "d0190b156bcca848d401fb80f31f504f37141c8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/d0190b156bcca848d401fb80f31f504f37141c8d",
+                "reference": "d0190b156bcca848d401fb80f31f504f37141c8d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "suggest": {
+                "ext-intl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2015-05-29 06:29:14"
         },
         {
             "name": "phing/phing",

--- a/src/Eccube/Resource/doctrine/migration/Version20150613000000.php
+++ b/src/Eccube/Resource/doctrine/migration/Version20150613000000.php
@@ -803,6 +803,7 @@ class Version20150613000000 extends AbstractMigration
         $this->addSql("INSERT INTO dtb_template (template_id, template_code, device_type_id, template_name, create_date, update_date) VALUES (4, 'sphone', 2, 'スマートフォン', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);");
 
         if ($this->connection->getDatabasePlatform()->getName() == "postgresql") {
+            $this->addSql("SELECT setval('dtb_base_info_id_seq', 2);");
             $this->addSql("SELECT setval('dtb_member_member_id_seq', 2);");
             $this->addSql("SELECT setval('dtb_tax_rule_tax_rule_id_seq', 1);");
             $this->addSql("SELECT setval('dtb_block_block_id_seq', 11);");

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Eccube\Tests;
+
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Migration;
+use Doctrine\DBAL\Migrations\MigrationException;
+use Eccube\Application;
+use Silex\WebTestCase;
+
+
+/**
+ * Abstract class that other unit tests can extend, provides generic methods for EC-CUBE tests.
+ *
+ * @author Kentaro Ohkouchi
+ */
+abstract class EccubeTestCase extends WebTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        // in the case of sqlite in-memory database only.
+        if (array_key_exists('memory', $this->app['config']['database'])
+            && $this->app['config']['database']['memory']) {
+            $this->initializeDatabase();
+        }
+        if (isset($this->app['orm.em'])) {
+            $this->app['orm.em']->getConnection()->beginTransaction();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->app['orm.em']->getConnection()->rollback();
+    }
+
+    /**
+     * データベースを初期化する.
+     *
+     * データベースを初期化し、マイグレーションを行なう.
+     * 全てのデータが初期化されるため注意すること.
+     *
+     * @link http://jamesmcfadden.co.uk/database-unit-testing-with-doctrine-2-and-phpunit/
+     */
+    public function initializeDatabase()
+    {
+        // Get an instance of your entity manager
+        $entityManager = $this->app['orm.em'];
+
+        // Retrieve PDO instance
+        $pdo = $entityManager->getConnection()->getWrappedConnection();
+
+        // Clear Doctrine to be safe
+        $entityManager->clear();
+
+        // Schema Tool to process our entities
+        $tool = new \Doctrine\ORM\Tools\SchemaTool($entityManager);
+        $classes = $entityManager->getMetaDataFactory()->getAllMetaData();
+
+        // Drop all classes and re-build them for each test case
+        $tool->dropSchema($classes);
+        $tool->createSchema($classes);
+        $config = new Configuration($this->app['db']);
+        $config->setMigrationsNamespace('DoctrineMigrations');
+
+        $migrationDir = __DIR__ . '/../../../src/Eccube/Resource/doctrine/migration';
+        $config->setMigrationsDirectory($migrationDir);
+        $config->registerMigrationsFromDirectory($migrationDir);
+
+        $migration = new Migration($config);
+        $migration->migrate(null, false);
+
+        // 通常は eccube_install.sh で追加されるデータを追加する
+        $sql = "INSERT INTO dtb_member (member_id, login_id, password, salt, work, del_flg, authority, creator_id, rank, update_date, create_date,name,department) VALUES (2, 'admin', 'test', 'test', 1, 0, 0, 1, 1, current_timestamp, current_timestamp,'管理者','EC-CUBE SHOP')";
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute();
+
+        $sql = "INSERT INTO dtb_base_info (id, shop_name, email01, email02, email03, email04, update_date, option_product_tax_rule) VALUES (1, 'SHOP_NAME', 'admin@example.com', 'admin@example.com', 'admin@example.com', 'admin@example.com', current_timestamp, 0)";
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createApplication()
+    {
+        $app = new Application();
+        $app['debug'] = true;
+        $app->initialize();
+        $app->initPluginEventDispatcher();
+        $app['session.test'] = true;
+        $app['exception_handler']->disable();
+
+        $app->boot();
+
+        return $app;
+    }
+}

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -21,7 +21,7 @@ abstract class EccubeTestCase extends WebTestCase
     protected $expected;
 
     /**
-     * {@inheritdoc}
+     * Applicaiton を生成しトランザクションを開始する.
      */
     public function setUp()
     {
@@ -37,7 +37,7 @@ abstract class EccubeTestCase extends WebTestCase
     }
 
     /**
-     * {@inheritdoc}
+     * トランザクションをロールバックする.
      */
     public function tearDown()
     {
@@ -107,6 +107,7 @@ abstract class EccubeTestCase extends WebTestCase
      * Expected と Actual を比較する.
      *
      * @param string $message エラーメッセージ
+     * @link http://objectclub.jp/community/memorial/homepage3.nifty.com/masarl/article/junit/scenario-based-testcase.html#verify%20%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89
      */
     public function verify($message = '')
     {

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Migrations\Migration;
 use Doctrine\DBAL\Migrations\MigrationException;
 use Eccube\Application;
 use Silex\WebTestCase;
-
+ use Faker\Factory as Faker;
 
 /**
  * Abstract class that other unit tests can extend, provides generic methods for EC-CUBE tests.
@@ -16,6 +16,10 @@ use Silex\WebTestCase;
  */
 abstract class EccubeTestCase extends WebTestCase
 {
+
+    protected $actual;
+    protected $expected;
+
     /**
      * {@inheritdoc}
      */
@@ -85,6 +89,28 @@ abstract class EccubeTestCase extends WebTestCase
         $sql = "INSERT INTO dtb_base_info (id, shop_name, email01, email02, email03, email04, update_date, option_product_tax_rule) VALUES (1, 'SHOP_NAME', 'admin@example.com', 'admin@example.com', 'admin@example.com', 'admin@example.com', current_timestamp, 0)";
         $stmt = $pdo->prepare($sql);
         $stmt->execute();
+    }
+
+    /**
+     * Faker を生成する.
+     *
+     * @param string $locale ロケールを指定する. デフォルト ja_JP
+     * @return Faker\Generator
+     * @link https://github.com/fzaninotto/Faker
+     */
+    public function getFaker($locale = 'ja_JP')
+    {
+        return Faker::create($locale);
+    }
+
+    /**
+     * Expected と Actual を比較する.
+     *
+     * @param string $message エラーメッセージ
+     */
+    public function verify($message = '')
+    {
+        $this->assertEquals($this->expected, $this->actual, $message);
     }
 
     /**

--- a/tests/Eccube/Tests/Repository/AbstractRepositoryTestCase.php
+++ b/tests/Eccube/Tests/Repository/AbstractRepositoryTestCase.php
@@ -25,6 +25,9 @@ namespace Eccube\Tests\Repository;
 
 use Eccube\Application;
 
+/**
+ * @deprecated Eccube\Tests\EccubeTestCase を使用してください
+ */
 class AbstractRepositoryTestCase extends \PHPUnit_Framework_TestCase
 {
 

--- a/tests/Eccube/Tests/Repository/BaseInfoRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/BaseInfoRepositoryTest.php
@@ -10,6 +10,12 @@ use Eccube\Entity\BaseInfo;
 /**
  * BaseInfoRepository test cases.
  *
+ * このテストケースは、 BaseInfoRepository のテストと、 EccubeTestCase のサンプルコードを兼ねています.
+ *
+ * テストコードのプログラミングスタイルについては、
+ * [JUnit実践講座](http://objectclub.jp/community/memorial/homepage3.nifty.com/masarl/article/junit.html)
+ * が参考になります.
+ *
  * @author Kentaro Ohkouchi
  */
 class BaseInfoRepositoryTest extends EccubeTestCase
@@ -18,26 +24,47 @@ class BaseInfoRepositoryTest extends EccubeTestCase
 
     public function setUp()
     {
+        // テスト時に Application やデータベース接続が不要な場合は、この行を削除してください.
         parent::setUp();
 
+        // ダミーデータを生成する Faker
         $faker = $this->getFaker();
 
-        $this->expected = $faker->company;
-
+        // テスト用のデータを生成する.
         $BaseInfo = new BaseInfo();
         $BaseInfo
-             ->setCompanyName($this->expected)
-             ->setShopName($faker->company)
-             ->setAddr01($faker->address)
-             ->setAddr02($faker->secondaryAddress)
-             ->setEmail01($faker->email)
-             ->setLatitude($faker->latitude)
-             ->setLongitude($faker->longitude)
-             ->setUpdateDate($faker->dateTime('now'));
+            ->setCompanyName('company')
+            ->setShopName($faker->company)
+            ->setAddr01($faker->address)
+            ->setAddr02($faker->secondaryAddress)
+            ->setEmail01($faker->email)
+            ->setLatitude($faker->latitude)
+            ->setLongitude($faker->longitude)
+            ->setUpdateDate($faker->dateTime('now'));
 
-         $this->app['orm.em']->persist($BaseInfo);
-         $this->app['orm.em']->flush();
-         $this->id = $BaseInfo->getId();
+        /*
+         * ここでは Doctrine ORM を使用しているが、オブジェクトキャッシュ等により、
+         * 期待した結果が得られない場合がある.
+         * 必要に応じて、Doctrine DBAL や PDO を使用すること.
+         */
+        $this->app['orm.em']->persist($BaseInfo);
+        $this->app['orm.em']->flush();
+        $this->id = $BaseInfo->getId();
+    }
+
+    public function testGetBaseInfoWithId()
+    {
+        /*
+         * テストコードは、できるだけ問題領域のみを記述すること.
+         * 簡潔に記述することで、実装時にコピー&ペースト可能なサンプルコードとしても活用できます.
+         */
+        $BaseInfo = $this->app['eccube.repository.base_info']->get($this->id);
+        $this->assertNotNull($BaseInfo);
+
+        $this->expected = 'company';
+        $this->actual = $BaseInfo->getCompanyName();
+
+        $this->verify('会社名は '.$this->expected.' ではありません');
     }
 
     public function testGetBaseInfo()
@@ -46,14 +73,4 @@ class BaseInfoRepositoryTest extends EccubeTestCase
         $this->assertNotNull($BaseInfo);
         $this->assertEquals(1, $BaseInfo->getId());
     }
-
-    public function testGetBaseInfoWithId()
-    {
-         $Result = $this->app['eccube.repository.base_info']->get($this->id);
-         $this->assertNotNull($Result);
-
-         $this->actual = $Result->getCompanyName();
-
-         $this->verify('会社名は '.$this->expected.' ではありません');
-     }
 }

--- a/tests/Eccube/Tests/Repository/BaseInfoRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/BaseInfoRepositoryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Eccube\Tests\Repository;
+
+use Eccube\Tests\EccubeTestCase;
+use Eccube\Application;
+use Eccube\Entity\BaseInfo;
+
+
+/**
+ * BaseInfoRepository test cases.
+ *
+ * @author Kentaro Ohkouchi
+ */
+class BaseInfoRepositoryTest extends EccubeTestCase
+{
+    private $id;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $faker = $this->getFaker();
+
+        $this->expected = $faker->company;
+
+        $BaseInfo = new BaseInfo();
+        $BaseInfo
+             ->setCompanyName($this->expected)
+             ->setShopName($faker->company)
+             ->setAddr01($faker->address)
+             ->setAddr02($faker->secondaryAddress)
+             ->setEmail01($faker->email)
+             ->setLatitude($faker->latitude)
+             ->setLongitude($faker->longitude)
+             ->setUpdateDate($faker->dateTime('now'));
+
+         $this->app['orm.em']->persist($BaseInfo);
+         $this->app['orm.em']->flush();
+         $this->id = $BaseInfo->getId();
+    }
+
+    public function testGetBaseInfo()
+    {
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $this->assertNotNull($BaseInfo);
+        $this->assertEquals(1, $BaseInfo->getId());
+    }
+
+    public function testGetBaseInfoWithId()
+    {
+         $Result = $this->app['eccube.repository.base_info']->get($this->id);
+         $this->assertNotNull($Result);
+
+         $this->actual = $Result->getCompanyName();
+
+         $this->verify('会社名は '.$this->expected.' ではありません');
+     }
+}


### PR DESCRIPTION
- \Silex\WebTestCase を継承
- sqlite in-memory DB の使用を考慮し、常に setUp() で Application インスタンスを生成する
- sqlite in-memory DB を使用した場合は、データベースの初期化をする
- setUp()/tearDown() で BEGIN/ROLLBACK する
- Faker でダミーデータ生成をサポート
- Expected と Actual を比較する, verify() メソッド追加.
- 参考実装として BaseInfoRepository のテストケース追加