### PR TITLE
パスワード再発行メール送信完了時にメールを複数回送信できてしまうので修正

### DIFF
--- a/src/Eccube/Controller/ForgotController.php
+++ b/src/Eccube/Controller/ForgotController.php
@@ -111,6 +111,8 @@ class ForgotController extends AbstractController
             $encPass = $app['eccube.repository.customer']->encryptPassword($app, $Customer);
             $Customer->setPassword($encPass);
 
+            $Customer->setResetKey(null);
+
             // パスワードを更新
             $app['orm.em']->persist($Customer);
             $app['orm.em']->flush();

--- a/src/Eccube/Controller/ForgotController.php
+++ b/src/Eccube/Controller/ForgotController.php
@@ -70,13 +70,18 @@ class ForgotController extends AbstractController
                         );
                 }
 
-                return $app->render('Forgot/complete.twig');
+                return $app->redirect($app->url('forgot_complete'));
             }
         }
 
         return $app->render('Forgot/index.twig', array(
             'form' => $form->createView(),
         ));
+    }
+
+    public function complete(Application $app, Request $request)
+    {
+        return $app->render('Forgot/complete.twig');
     }
 
     public function reset(Application $app, Request $request, $reset_key)

--- a/src/Eccube/ControllerProvider/FrontControllerProvider.php
+++ b/src/Eccube/ControllerProvider/FrontControllerProvider.php
@@ -69,6 +69,7 @@ class FrontControllerProvider implements ControllerProviderInterface
 
         // forgot
         $c->match('/forgot', '\Eccube\Controller\ForgotController::index')->bind('forgot');
+        $c->match('/forgot/complete', '\Eccube\Controller\ForgotController::complete')->bind('forgot_complete');
         $c->match('/forgot/reset/{reset_key}', '\Eccube\Controller\ForgotController::reset')->bind('forgot_reset');
 
         // block

--- a/src/Eccube/Entity/PageLayout.php
+++ b/src/Eccube/Entity/PageLayout.php
@@ -271,7 +271,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Set id
      *
-     * @param string $id
+     * @param integer $id
      * @return PageLayout
      */
     public function setId($id)
@@ -283,7 +283,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Get id
      *
-     * @return integer 
+     * @return integer
      */
     public function getId()
     {
@@ -306,7 +306,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Get name
      *
-     * @return string 
+     * @return string
      */
     public function getName()
     {
@@ -329,7 +329,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Get url
      *
-     * @return string 
+     * @return string
      */
     public function getUrl()
     {
@@ -352,7 +352,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Get file_name
      *
-     * @return string 
+     * @return string
      */
     public function getFileName()
     {
@@ -375,7 +375,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Get edit_flg
      *
-     * @return integer 
+     * @return integer
      */
     public function getEditFlg()
     {
@@ -398,7 +398,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Get author
      *
-     * @return string 
+     * @return string
      */
     public function getAuthor()
     {
@@ -421,7 +421,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Get description
      *
-     * @return string 
+     * @return string
      */
     public function getDescription()
     {
@@ -444,7 +444,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Get keyword
      *
-     * @return string 
+     * @return string
      */
     public function getKeyword()
     {
@@ -467,7 +467,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Get update_url
      *
-     * @return string 
+     * @return string
      */
     public function getUpdateUrl()
     {
@@ -490,7 +490,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Get create_date
      *
-     * @return \DateTime 
+     * @return \DateTime
      */
     public function getCreateDate()
     {
@@ -513,7 +513,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Get update_date
      *
-     * @return \DateTime 
+     * @return \DateTime
      */
     public function getUpdateDate()
     {
@@ -536,7 +536,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Get meta_robots
      *
-     * @return string 
+     * @return string
      */
     public function getMetaRobots()
     {
@@ -569,7 +569,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Get BlockPositions
      *
-     * @return \Doctrine\Common\Collections\Collection 
+     * @return \Doctrine\Common\Collections\Collection
      */
     public function getBlockPositions()
     {
@@ -592,7 +592,7 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * Get DeviceType
      *
-     * @return \Eccube\Entity\Master\DeviceType 
+     * @return \Eccube\Entity\Master\DeviceType
      */
     public function getDeviceType()
     {


### PR DESCRIPTION
パスワード再発行メール送信完了画面表示後、F5 などで画面を更新すると同じ処理が走り、メールが送信されるので修正。

dtb_page_layout にはパスワード変更画面が含まれていないため、現時点では対応しない。
※余裕があれば対応する。