### PR TITLE
docs の submodule を https に変更 #882

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs"]
 	path = docs
-	url = git@github.com:EC-CUBE/eccube3-doc.git
+	url = https://github.com/EC-CUBE/eccube3-doc.git


### PR DESCRIPTION
本 changeset を適用した上で、以下のコマンドを実行すると、 ssh から https に変更できます。

```shell
git submodule deinit -f docs
git submodule init
git submodule update
```