### PR TITLE
空のCSVファイルインポート(商品／カテゴリ)に対応 #811

### DIFF
--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -60,7 +60,6 @@ class CsvImportController
      */
     public function csvProduct(Application $app, Request $request)
     {
-
         $form = $app['form.factory']->createBuilder('admin_csv_import')->getForm();
 
         $headers = $this->getProductCsvHeader();
@@ -76,10 +75,13 @@ class CsvImportController
                 if (!empty($formFile)) {
 
                     $data = $this->getImportData($app, $formFile);
+                    if($data===false) {
+                        $this->addErrors('CSVのフォーマットが一致しません。');
+                        return $this->render($app, $form, $headers, $this->productTwig);
+                    }
 
                     $keys = array_keys($headers);
                     $columnHeaders = $data->getColumnHeaders();
-
                     if ($keys !== $columnHeaders) {
                         $this->addErrors('CSVのフォーマットが一致しません。');
                         return $this->render($app, $form, $headers, $this->productTwig);
@@ -420,10 +422,13 @@ class CsvImportController
                 if (!empty($formFile)) {
 
                     $data = $this->getImportData($app, $formFile);
+                    if($data===false) {
+                        $this->addErrors('CSVのフォーマットが一致しません。');
+                        return $this->render($app, $form, $headers, $this->categoryTwig);
+                    }
 
                     $keys = array_keys($headers);
                     $columnHeaders = $data->getColumnHeaders();
-
                     if ($keys !== $columnHeaders) {
                         $this->addErrors('CSVのフォーマットが一致しません。');
                         return $this->render($app, $form, $headers, $this->categoryTwig);
@@ -614,7 +619,6 @@ class CsvImportController
      */
     protected function getImportData($app, $formFile)
     {
-
         // アップロードされたCSVファイルを一時ディレクトリに保存
         $this->fileName = 'upload_' . Str::random() . '.' . $formFile->getClientOriginalExtension();
         $formFile->move($app['config']['csv_temp_realdir'], $this->fileName);
@@ -638,9 +642,9 @@ class CsvImportController
         // アップロードされたCSVファイルを行ごとに取得
         $data = new CsvImportService($file, $app['config']['csv_import_delimiter'], $app['config']['csv_import_enclosure']);
 
-        $data->setHeaderRowNumber(0);
+        $ret = $data->setHeaderRowNumber(0);
 
-        return $data;
+        return ($ret!==false)?$data:false;
     }
 
 

--- a/src/Eccube/Service/CsvImportService.php
+++ b/src/Eccube/Service/CsvImportService.php
@@ -195,6 +195,7 @@ class CsvImportService implements \Iterator, \SeekableIterator, \Countable
      *                        - CsvReader::DUPLICATE_HEADERS_MERGE; merges
      *                        values for duplicate headers into an array
      *                        (dup => [value1, value2, value3])
+     * @return boolean
      */
     public function setHeaderRowNumber($rowNumber, $duplicates = null)
     {
@@ -202,7 +203,11 @@ class CsvImportService implements \Iterator, \SeekableIterator, \Countable
         $this->headerRowNumber = $rowNumber;
         $headers = $this->readHeaderRow($rowNumber);
 
+        if($headers===false) {
+            return false;            
+        }
         $this->setColumnHeaders($headers);
+        return true;
     }
 
     /**


### PR DESCRIPTION
インポートCSVファイルのヘッダー取得処理のタイミングがおかしかったので追加。
（元の処理もそのまま残してある）
CsvImportServiceのsetHeaderRowNumberメソッドでheaderがないと判定されたらfalseを返し、CsvImportControllerでfalseを受け取ったらエラー処理実施。
商品登録およびカテゴリ登録、双方で同じ処理追加。
