### PR TITLE
会員検索時のCSVエキスポートに検索条件を反映 #807

### DIFF
--- a/src/Eccube/Controller/Admin/Customer/CustomerController.php
+++ b/src/Eccube/Controller/Admin/Customer/CustomerController.php
@@ -34,6 +34,7 @@ class CustomerController
 {
     public function index(Application $app, Request $request)
     {
+        $session = $request->getSession();
         $pagination = null;
         $searchForm = $app['form.factory']
             ->createBuilder('admin_search_customer')
@@ -43,6 +44,8 @@ class CustomerController
         $searchData = array();
         if ($searchForm->isValid()) {
             $searchData = $searchForm->getData();
+            // sessionのデータ保持
+            $session->set('eccube.admin.customer.search', $searchData);
         }
 
         if ('POST' === $request->getMethod()) {

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -60,7 +60,6 @@ class CsvImportController
      */
     public function csvProduct(Application $app, Request $request)
     {
-
         $form = $app['form.factory']->createBuilder('admin_csv_import')->getForm();
 
         $headers = $this->getProductCsvHeader();
@@ -76,10 +75,13 @@ class CsvImportController
                 if (!empty($formFile)) {
 
                     $data = $this->getImportData($app, $formFile);
+                    if ($data === false) {
+                        $this->addErrors('CSVのフォーマットが一致しません。');
+                        return $this->render($app, $form, $headers, $this->productTwig);
+                    }
 
                     $keys = array_keys($headers);
                     $columnHeaders = $data->getColumnHeaders();
-
                     if ($keys !== $columnHeaders) {
                         $this->addErrors('CSVのフォーマットが一致しません。');
                         return $this->render($app, $form, $headers, $this->productTwig);
@@ -420,10 +422,13 @@ class CsvImportController
                 if (!empty($formFile)) {
 
                     $data = $this->getImportData($app, $formFile);
+                    if ($data === false) {
+                        $this->addErrors('CSVのフォーマットが一致しません。');
+                        return $this->render($app, $form, $headers, $this->categoryTwig);
+                    }
 
                     $keys = array_keys($headers);
                     $columnHeaders = $data->getColumnHeaders();
-
                     if ($keys !== $columnHeaders) {
                         $this->addErrors('CSVのフォーマットが一致しません。');
                         return $this->render($app, $form, $headers, $this->categoryTwig);
@@ -614,7 +619,6 @@ class CsvImportController
      */
     protected function getImportData($app, $formFile)
     {
-
         // アップロードされたCSVファイルを一時ディレクトリに保存
         $this->fileName = 'upload_' . Str::random() . '.' . $formFile->getClientOriginalExtension();
         $formFile->move($app['config']['csv_temp_realdir'], $this->fileName);
@@ -638,9 +642,9 @@ class CsvImportController
         // アップロードされたCSVファイルを行ごとに取得
         $data = new CsvImportService($file, $app['config']['csv_import_delimiter'], $app['config']['csv_import_enclosure']);
 
-        $data->setHeaderRowNumber(0);
+        $ret = $data->setHeaderRowNumber(0);
 
-        return $data;
+        return ($ret !== false) ? $data : false;
     }
 
 

--- a/src/Eccube/Service/CsvImportService.php
+++ b/src/Eccube/Service/CsvImportService.php
@@ -195,6 +195,7 @@ class CsvImportService implements \Iterator, \SeekableIterator, \Countable
      *                        - CsvReader::DUPLICATE_HEADERS_MERGE; merges
      *                        values for duplicate headers into an array
      *                        (dup => [value1, value2, value3])
+     * @return boolean
      */
     public function setHeaderRowNumber($rowNumber, $duplicates = null)
     {
@@ -202,7 +203,11 @@ class CsvImportService implements \Iterator, \SeekableIterator, \Countable
         $this->headerRowNumber = $rowNumber;
         $headers = $this->readHeaderRow($rowNumber);
 
+        if ($headers === false) {
+            return false;            
+        }
         $this->setColumnHeaders($headers);
+        return true;
     }
 
     /**


### PR DESCRIPTION
会員マスターでの検索時に、検索条件をsessionデータとして保存してないのが原因だった。
sessionデータとして保存して解決。
csvエクスポート時のquery builderはこのsessionデータを参照して検索条件を得るという仕組み（受注マスターでも同じ機能ある）
