### PR TITLE
ref #751 規格登録後の商品送料が登録できなくなる問題に対応

### DIFF
--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -327,17 +327,19 @@ function fnClass(action) {
                             {{ form_row(form.search_word) }}
                             {% if has_class == false %}
                                 {{ form_row(form.class.delivery_date) }}
+                                {% if BaseInfo.option_product_delivery_fee %}
                                 <div class="form-group">
                                     {{ form_label(form.class.delivery_fee) }}
                                     <div class="col-sm-3 col-lg-3">
                                         {{ form_widget(form.class.delivery_fee) }}
                                     </div>
                                 </div>
+                                {% endif %}
                             {% endif %}
 
                         </div>
                     </div>
-                    
+
                     <div class="box accordion">
                         <div class="box-header toggle">
                             <h3 class="box-title">フリーエリア<svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg></h3>
@@ -346,7 +348,7 @@ function fnClass(action) {
                             {{ form_widget(form.free_area, { attr : { id : 'wysiwyg-area' } } ) }}
                         </div>
                     </div>
-                    
+
                     <div class="row hidden-xs hidden-sm">
                         <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
                             <p><a href="{{ url('admin_product') }}">検索画面に戻る</a></p>
@@ -354,7 +356,7 @@ function fnClass(action) {
                     </div>
 
                 </div><!-- /.col -->
-                
+
                 <div class="col-md-3">
                     <div class="col_inner" id="aside_column">
                         <div class="box no-header">
@@ -443,7 +445,7 @@ function fnClass(action) {
                             </div>
                         </div>
                     </div>
-                </div><!-- /.col --> 
+                </div><!-- /.col -->
 
             </div>
             </form>

--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -114,7 +114,7 @@ $(function(){
                 <div class="item_detail">
                     <!--★通常価格★-->
                     {% if Product.hasProductClass -%}
-                        {% if Product.getPrice01Min == Product.getPrice01Max %}
+                        {% if Product.getPrice01Min is not null and Product.getPrice01Min == Product.getPrice01Max %}
                         <p class="normal_price"> 通常価格：<span class="price01_default">{{ Product.getPrice01IncTaxMin|price }}</span> <span class="small">税込</span></p>
                         {% elseif Product.getPrice01Min is not null and Product.getPrice01Max is not null %}
                         <p class="normal_price"> 通常価格：<span class="price01_default">{{ Product.getPrice01IncTaxMin|price }}</span> ～ <span class="price01_default">{{ Product.getPrice01IncTaxMax|price }}</span> <span class="small">税込</span></p>


### PR DESCRIPTION
ref #751 規格登録後の商品送料が登録できなくなる問題に対応
ref #748 商品規格登録時に通常金額を未入力にすると商品詳細で0円で表示される #748 に対応

上記２件について対応致しました。

※ref #751 について
規格なし商品の場合、「商品ごとの送料設定を無効」に設定していた場合も、商品ごとの送料設定が行えたことに起因するものと思われます。