### PR TITLE
DeliveryTimeRepository::findOrCreate() を非推奨に

### DIFF
--- a/src/Eccube/Repository/DeliveryTimeRepository.php
+++ b/src/Eccube/Repository/DeliveryTimeRepository.php
@@ -34,6 +34,9 @@ use Doctrine\ORM\EntityRepository;
  */
 class DeliveryTimeRepository extends EntityRepository
 {
+    /**
+     * @deprecated since 3.0.0, to be removed in 3.1
+     */
     public function findOrCreate(array $conditions)
     {
         $DeliveryTime = $this->findOneBy($conditions);


### PR DESCRIPTION
- 配送業者のお届け時間を検索するメソッドだが、順不同で先頭の1件しか返さない。
- 本体でも使用していない。