### PR TITLE
管理者のみが「システム設定」メニューに入れるように変更 #767

### DIFF
--- a/src/Eccube/Resource/template/admin/nav.twig
+++ b/src/Eccube/Resource/template/admin/nav.twig
@@ -32,6 +32,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 {% for level2 in level1.child %}
                     <li class="{% if active_menus(menus)[1] == level2.id %}active{% endif %}">
                         {% if level2.has_child is defined and level2.has_child == true %}
+                            {% if app.user.authority.id == 0 or (app.user.authority.id == 1 and level2.id != 'system')  %}
                             <a class="toggle">
                                 {{ level2.name }}
                                 <svg class="cb cb-angle-down"> <use xlink:href="#cb-angle-down" /></svg>
@@ -45,6 +46,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     </li>
                                 {% endfor %}
                             </ul>
+                            {% endif %}
                         {% else %}
                             <a href="{{ url(level2.url) }}">
                                 {{ level2.name }}


### PR DESCRIPTION
管理者のみ「システム設定」メニューを有効にし、店舗オーナーの場合は「システム設定」メニューを非表示にした。
disableにするだけの方がいいですかね？