### PR TITLE
削除アイコン表示用に住所数チェック追加 #896

### DIFF
--- a/src/Eccube/Resource/template/default/Mypage/delivery.twig
+++ b/src/Eccube/Resource/template/default/Mypage/delivery.twig
@@ -50,9 +50,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     {% for CustomerAddress in Customer.CustomerAddresses %}
                                         <div class="addr_box tr">
                                             <div class="icon_edit td">
+                                            {% if Customer.CustomerAddresses|length != 1 %}
                                                 <a href="{{ url('mypage_delivery_delete', { id : CustomerAddress.id }) }}">
                                                     <svg class="cb cb-close"><use xlink:href="#cb-close" /></svg>
                                                 </a>
+                                            {% endif %}
                                             </div>
                                             <div class="column is-edit td">
                                                 <label for="address01">


### PR DESCRIPTION
該当twigテンプレート上で、住所数チェックして総数=1なら削除用アイコンを表示しないように変更