### PR TITLE
ref #798 【バグ】会員マスターで、会員ID検索ができない。に対応

### DIFF
--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -144,7 +144,7 @@ class CustomerRepository extends EntityRepository implements UserProviderInterfa
             ->andWhere('c.del_flg = 0');
 
         if (!empty($searchData['multi']) && $searchData['multi']) {
-            if (is_int($searchData['multi'])) {
+            if (preg_match('/^\d+$/', $searchData['multi'])) {
                 $qb
                     ->andWhere('c.id = :customer_id')
                     ->setParameter('customer_id', $searchData['multi']);


### PR DESCRIPTION
ref #798 【バグ】会員マスターで、会員ID検索ができない。に対応

数値として、判定されていなかったため正規表現でチェックするように変更

※下記の方法でも対応可能と思います。
is_int($searchData['multi'] + 0)