### PR TITLE
ブロックのキャッシュクリアのタイミングが正しくないので修正

### DIFF
--- a/src/Eccube/Controller/Admin/Content/BlockController.php
+++ b/src/Eccube/Controller/Admin/Content/BlockController.php
@@ -95,13 +95,14 @@ class BlockController
                     }
                 }
 
+                \Eccube\Util\Cache::clear($app,false);
+
                 $app->addSuccess('admin.register.complete', 'admin');
 
                 return $app->redirect($app->url('admin_content_block_edit', array('id' => $Block->getId())));
             }
         }
 
-        \Eccube\Util\Cache::clear($app,false);
 
         return $app->render('Content/block_edit.twig', array(
             'form' => $form->createView(),


### PR DESCRIPTION
ブロック編集画面表示時にキャッシュクリアをしていたので、更新完了時にキャッシュクリアをするように修正。