### PR TITLE
カートのエラーメッセージを複数表示可能にし、メッセージに該当商品名などを表示 #879

### DIFF
--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -35,13 +35,13 @@ form.member.repeated.confirm: 確認のためもう一度入力してくださ�
 form.type.graph.invalid: 半角英数字で入力してください。
 
 cart.over.stock: |-
-    選択された商品の在庫が不足しております。
+    選択された商品(%product%)の在庫が不足しております。
     一度に在庫数を超える購入はできません。
 cart.over.sale_limit: |-
-    選択された商品は販売制限しております。
+    選択された商品(%product%)は販売制限しております。
     一度に販売制限数を超える購入はできません。
 cart.zero.stock: |-
-    選択された商品の在庫が不足しております。
+    選択された商品(%product%)の在庫が不足しております。
     該当商品をカートから削除しました。
 cart.product.type.kind: この商品は同時に購入することはできません。
 cart.product.payment.kind: お支払方法が異なるためこの商品は同時に購入することはできません。

--- a/src/Eccube/Resource/template/default/Cart/index.twig
+++ b/src/Eccube/Resource/template/default/Cart/index.twig
@@ -48,11 +48,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
                 {% set productStr = app.session.flashbag.get('eccube.front.request.product') %}
                 {% for error in app.session.flashbag.get('eccube.front.request.error')  %}
+                    {% if productStr[0] is defined %}
                     <div class="message">
                         <p class="errormsg bg-danger">
-                            <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>{{ error|trans({'%product%':productStr[0]})|nl2br }}
+                            <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>
+                            {{ error|trans({'%product%':productStr[0]})|nl2br }}
                         </p>
                     </div>
+                    {% endif %}
                 {% endfor %}
                 {% for error in app.session.flashbag.get('eccube.front.cart.error')  %}
                     <div class="message">

--- a/src/Eccube/Resource/template/default/Cart/index.twig
+++ b/src/Eccube/Resource/template/default/Cart/index.twig
@@ -46,10 +46,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     </ul>
                 </div>
 
+                {% set productStr = app.session.flashbag.get('eccube.front.request.product') %}
                 {% for error in app.session.flashbag.get('eccube.front.request.error')  %}
                     <div class="message">
                         <p class="errormsg bg-danger">
-                            <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>{{ error|trans|nl2br }}
+                            <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>{{ error|trans({'%product%':productStr[0]})|nl2br }}
                         </p>
                     </div>
                 {% endfor %}

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -228,17 +228,30 @@ class CartService
 
         }
 
+        $tmp_quantity = 0;
+        $product_str = $ProductClass->getProduct()->getName();
+        if($ProductClass->hasClassCategory1()) {
+            $product_str .= " - ".$ProductClass->getClassCategory1()->getName();
+        }
+        if($ProductClass->hasClassCategory2()) {
+            $product_str .= " - ".$ProductClass->getClassCategory2()->getName();
+        }
+        $this->session->getFlashBag()->set('eccube.front.request.product', $product_str);
         if (!$ProductClass->getStockUnlimited() && $quantity > $ProductClass->getStock()) {
             if ($ProductClass->getSaleLimit() && $ProductClass->getStock() > $ProductClass->getSaleLimit()) {
-                $quantity = $ProductClass->getSaleLimit();
-                $this->setError('cart.over.sale_limit');
+                $tmp_quantity = $ProductClass->getSaleLimit();
+                $this->addError('cart.over.sale_limit');
             } else {
-                $quantity = $ProductClass->getStock();
-                $this->setError('cart.over.stock');
+                $tmp_quantity = $ProductClass->getStock();
+                $this->addError('cart.over.stock');
             }
-        } elseif ($ProductClass->getSaleLimit() && $quantity > $ProductClass->getSaleLimit()) {
-            $quantity = $ProductClass->getSaleLimit();
-            $this->setError('cart.over.sale_limit');
+        }
+        if ($ProductClass->getSaleLimit() && $quantity > $ProductClass->getSaleLimit()) {
+            $tmp_quantity = $ProductClass->getSaleLimit();
+            $this->addError('cart.over.sale_limit');
+        }
+        if ($tmp_quantity) {
+            $quantity = $tmp_quantity;
         }
 
         $CartItem = new CartItem();
@@ -397,7 +410,7 @@ class CartService
     public function addError($error = null)
     {
         $this->errors[] = $error;
-        $this->session->getFlashBag()->add('eccube.front.cart.error', $error);
+        $this->session->getFlashBag()->add('eccube.front.request.error', $error);
 
         return $this;
     }


### PR DESCRIPTION
カートでのエラーメッセージを複数表示可能にして、メッセージ内に該当商品名／規格1／規格2を表示するように変更。