### PR TITLE
#774 マイページのご注文履歴にお届け先とお問い合わせ事項が表示されない

### DIFF
--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -145,7 +145,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <p>
                             配送方法：　{{ Shipping.shipping_delivery_name }}{{ Shipping.delivery_fee ? '（＋' ~ Shipping.delivery_fee.fee|price ~ '）' : '' }}<br>
                             お届け日：　{{ Shipping.shipping_delivery_date|date_format|default('指定なし') }}<br>
-                            お届け時間：　{{ Shipping.shipping_delivery_time|default('指定なし') }}<br />
+                            お届け時間：　{{ Shipping.shipping_delivery_time|default('指定なし') }}
                         </p>
                     </div>
                     {% if loop.last == false%}<hr>{% endif %}
@@ -159,7 +159,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 <h2 class="heading02">お問い合わせ</h2>
                 <div class="column">
                     <p>
-                        {{ Order.message|default('記載なし')|nl2br|raw }}
+                        {{ Order.message|default('記載なし')|nl2br }}
                     </p>
                 </div>
 

--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -145,7 +145,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <p>
                             配送方法：　{{ Shipping.shipping_delivery_name }}{{ Shipping.delivery_fee ? '（＋' ~ Shipping.delivery_fee.fee|price ~ '）' : '' }}<br>
                             お届け日：　{{ Shipping.shipping_delivery_date|date_format|default('指定なし') }}<br>
-                            お届け時間：　{{ Shipping.shipping_delivery_time|default('指定なし') }}
+                            お届け時間：　{{ Shipping.shipping_delivery_time|default('指定なし') }}<br />
                         </p>
                     </div>
                     {% if loop.last == false%}<hr>{% endif %}
@@ -154,6 +154,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 <div class="column">
                     <p>
                         支払方法：　{{ Order.PaymentMethod }}
+                    </p>
+                </div>
+                <h2 class="heading02">お問い合わせ</h2>
+                <div class="column">
+                    <p>
+                        {{ Order.message|default('記載なし')|nl2br|raw }}
                     </p>
                 </div>
 


### PR DESCRIPTION
・配送情報 : お届け時間が項目漏れの為追加。
・お問い合わせ内容：項目漏れの為追加。