### PR TITLE
#775　#780(の一部)  配送時間・お問い合わせ欄がリロード時に消える件の対応

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -269,9 +269,11 @@ class ShoppingController extends AbstractController
 
                 // 支払い情報をセット
                 $payment = $data['payment'];
+                $message = $data['message'];
 
                 $Order->setPayment($payment);
                 $Order->setPaymentMethod($payment->getMethod());
+                $Order->setMessage($message);
                 $Order->setCharge($payment->getCharge());
 
                 $Order->setDeliveryFeeTotal($app['eccube.service.shopping']->getShippingDeliveryFeeTotal($shippings));
@@ -307,11 +309,13 @@ class ShoppingController extends AbstractController
 
             if ($form->isValid()) {
 
-                $data = $form->getData();
+				$data = $form->getData();
                 $payment = $data['payment'];
+                $message = $data['message'];
 
                 $Order->setPayment($payment);
                 $Order->setPaymentMethod($payment->getMethod());
+                $Order->setMessage($message);
                 $Order->setCharge($payment->getCharge());
 
                 $total = $Order->getSubTotal() + $Order->getCharge() + $Order->getDeliveryFeeTotal();
@@ -970,4 +974,87 @@ class ShoppingController extends AbstractController
     {
         return $app->render('Shopping/shopping_error.twig');
     }
+    
+    /**
+     * お届け先変更がクリックされた場合の処理
+     */
+    public function shippingChange(Application $app, Request $request, $id)
+    {
+        $Order = $app['eccube.service.shopping']->getOrder($app['config']['order_processing']);
+
+        $form = $app['eccube.service.shopping']->getShippingForm($Order);
+
+        if ('POST' === $request->getMethod()) {
+            $form->handleRequest($request);
+
+            // バリデート処理
+            if ($form->isValid()) {
+                $data = $form->getData();
+                $message = $data['message'];
+                $Order->setMessage($message);
+                // 受注情報を更新
+                $app['orm.em']->flush();
+                // お届け先設定一覧へリダイレクト
+			    return $app->redirect($app->url('shopping_shipping', array('id' => $id)));
+            }
+        }
+
+	    return $app->redirect($app->url('shopping'));
+    }
+
+    /**
+     * お届け先の設定（非会員）がクリックされた場合の処理
+     */
+    public function shippingEditChange(Application $app, Request $request, $id)
+    {
+        $Order = $app['eccube.service.shopping']->getOrder($app['config']['order_processing']);
+
+        $form = $app['eccube.service.shopping']->getShippingForm($Order);
+
+        if ('POST' === $request->getMethod()) {
+            $form->handleRequest($request);
+
+            // バリデート処理
+            if ($form->isValid()) {
+                $data = $form->getData();
+                $message = $data['message'];
+                $Order->setMessage($message);
+                // 受注情報を更新
+                $app['orm.em']->flush();
+                // お届け先設定一覧へリダイレクト
+			    return $app->redirect($app->url('shopping_shipping_edit', array('id' => $id)));
+            }
+        }
+
+	    return $app->redirect($app->url('shopping'));
+    }
+
+    /**
+     * 複数配送処理がクリックされた場合の処理
+     */
+    public function shippingMultipleChange(Application $app, Request $request)
+    {
+        $Order = $app['eccube.service.shopping']->getOrder($app['config']['order_processing']);
+
+        $form = $app['eccube.service.shopping']->getShippingForm($Order);
+
+        if ('POST' === $request->getMethod()) {
+            $form->handleRequest($request);
+
+            // バリデート処理
+            if ($form->isValid()) {
+                $data = $form->getData();
+                $message = $data['message'];
+                $Order->setMessage($message);
+                // 受注情報を更新
+                $app['orm.em']->flush();
+                // 複数配送設定へリダイレクト
+			    return $app->redirect($app->url('shopping_shipping_multiple'));
+            }
+        }
+
+	    return $app->redirect($app->url('shopping'));
+    }
+
+    
 }

--- a/src/Eccube/ControllerProvider/FrontControllerProvider.php
+++ b/src/Eccube/ControllerProvider/FrontControllerProvider.php
@@ -122,6 +122,9 @@ class FrontControllerProvider implements ControllerProviderInterface
         $c->match('/shopping/shopping_error', '\Eccube\Controller\ShoppingController::shoppingError')->bind('shopping_error');
         $c->match('/shopping/shipping_multiple', '\Eccube\Controller\ShoppingController::shippingMultiple')->bind('shopping_shipping_multiple');
         $c->match('/shopping/shipping_multiple_edit', '\Eccube\Controller\ShoppingController::shippingMultipleEdit')->bind('shopping_shipping_multiple_edit');
+        $c->match('/shopping/shipping_change/{id}', '\Eccube\Controller\ShoppingController::shippingChange')->assert('id', '\d+')->bind('shopping_shipping_change');
+        $c->match('/shopping/shipping_edit_change/{id}', '\Eccube\Controller\ShoppingController::shippingEditChange')->assert('id', '\d+')->bind('shopping_shipping_edit_change');
+        $c->match('/shopping/shipping_multiple_change', '\Eccube\Controller\ShoppingController::shippingMultipleChange')->bind('shopping_shipping_multiple_change');
 
         return $c;
     }

--- a/src/Eccube/Form/Type/ShoppingType.php
+++ b/src/Eccube/Form/Type/ShoppingType.php
@@ -40,6 +40,7 @@ class ShoppingType extends AbstractType
 
         $payments = $options['payments'];
         $payment = $options['payment'];
+        $message = $options['message'];
 
         $builder
             ->add('payment', 'entity', array(
@@ -54,6 +55,7 @@ class ShoppingType extends AbstractType
             ))
             ->add('message', 'textarea', array(
                 'required' => false,
+                'data' => $message,
                 'constraints' => array(
                     new Assert\Length(array('min' => 0, 'max' => 3000))),
             ))
@@ -66,6 +68,7 @@ class ShoppingType extends AbstractType
         $resolver->setDefaults(array(
             'payments' => array(),
             'payment' => null,
+            'message' => null,
         ));
     }
 

--- a/src/Eccube/Resource/template/default/Shopping/index.twig
+++ b/src/Eccube/Resource/template/default/Shopping/index.twig
@@ -33,6 +33,21 @@ $(function(){
         $('#shopping-form').attr('action', '{{ url("shopping_payment") }}').submit();
     });
 
+    $('.btn-toShipping').bind('click', function() {
+        $('#shopping-form').attr('action', $(this).attr('href')).submit();
+		return false;
+    });
+
+    $('.btn-toShippingEdit').bind('click', function() {
+        $('#shopping-form').attr('action', $(this).attr('href')).submit();
+		return false;
+    });
+
+    $('.btn-toShippingMultiple').bind('click', function() {
+        $('#shopping-form').attr('action', $(this).attr('href')).submit();
+		return false;
+    });
+
     {% if is_granted('ROLE_USER') == false %}
     var ref = new Array();
     var name = new Array();
@@ -245,16 +260,16 @@ $(function(){
                                 {{ form_widget(form.shippings[idx].deliveryTime) }}
                             </div>
                             {% if is_granted('ROLE_USER') %}
-                            <p class="btn_edit"><a href="{{ url('shopping_shipping', {'id': shipping.id}) }}" class="btn btn-default btn-sm">変更</a></p>
+                            <p class="btn_edit"><a href="{{ url('shopping_shipping_change', {'id': shipping.id}) }}" class="btn btn-default btn-sm btn-toShipping">変更</a></p>
                             {% else %}
-                            <p class="btn_edit"><a href="{{ url('shopping_shipping_edit', {'id': shipping.id}) }}" class="btn btn-default btn-sm">変更</a></p>
+                            <p class="btn_edit"><a href="{{ url('shopping_shipping_edit_change', {'id': shipping.id}) }}" class="btn btn-default btn-sm btn-toShippingEdit">変更</a></p>
                             {% endif %}
                         </div>
                         {% if loop.last == false%}<hr>{% endif %}
                     {% endfor %}
                     {% if BaseInfo.optionMultipleShipping %}
                         <hr>
-                        <div><a href="{{ url('shopping_shipping_multiple') }}" class="btn btn-default btn-sm">お届け先を追加する</a></div>
+                        <div><a href="{{ url('shopping_shipping_multiple_change') }}" class="btn btn-default btn-sm btn-toShippingMultiple">お届け先を追加する</a></div>
                     {% endif %}
 
                     <h2 class="heading02">お支払方法</h2>

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -756,7 +756,6 @@ class ShoppingService
      */
     public function setOrderUpdate(Order $Order, $data)
     {
-
         // 受注情報を更新
         $Order->setOrderDate(new \DateTime());
         $Order->setOrderStatus($this->app['eccube.repository.order_status']->find($this->app['config']['order_new']));
@@ -958,6 +957,9 @@ class ShoppingService
      */
     public function getShippingForm(Order $Order)
     {
+        $message = '';
+        $message = $Order->getMessage();
+
 
         $deliveries = $this->getDeliveriesOrder($Order);
 
@@ -967,6 +969,7 @@ class ShoppingService
         $builder = $this->app['form.factory']->createBuilder('shopping', null, array(
             'payments' => $payments,
             'payment' => $Order->getPayment(),
+            'message' => $message
         ));
 
         $builder

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -957,9 +957,7 @@ class ShoppingService
      */
     public function getShippingForm(Order $Order)
     {
-        $message = '';
         $message = $Order->getMessage();
-
 
         $deliveries = $this->getDeliveriesOrder($Order);
 
@@ -969,7 +967,7 @@ class ShoppingService
         $builder = $this->app['form.factory']->createBuilder('shopping', null, array(
             'payments' => $payments,
             'payment' => $Order->getPayment(),
-            'message' => $message
+            'message' => $message,
         ));
 
         $builder


### PR DESCRIPTION
・dtb_order/dtb_shippingそのものは正しく登録されている模様（管理画面は問題なし)
・#780（お支払日が消える） そのものではありませんが
  1) 配送情報変更ボタン（会員/非会員)
  2) 複数お届け先追加ボタン
 クリック->各ページ遷移->確認画面へ復帰した場合に「お問い合わせ欄」が初期化されていました。
 当該の問題は、上記各ボタンのアクションが確認フォームの内容をセッションへ格納していない為
 発生していました。

 対処としては、各ボタンクリックで対応するアクションへPOSTし、アクション内で
 1) shopping_shipping
 2) shopping_shipping_edit
 3) shopping_shipping_multiple
へリダイレクトするようにしています。
(各クリックハンドラは全く同じコードですが、現時点ではあえて重複させています。）

また、お問い合わせ欄については、該当Formが初期値を復元していなかった為、初期値を放り込む
ように修正しています。
