### PR TITLE
一覧の最終行のドロップダウンメニューが隠れる件に対応 #406

### DIFF
--- a/html/template/admin/assets/css/dashboard.css
+++ b/html/template/admin/assets/css/dashboard.css
@@ -1715,6 +1715,9 @@ dd.form-group .errormsg {
 .table_list .icon_edit .dropdown-toggle {
     padding: 8px;
 }
+.table_list .btn_area {
+    margin-top: 12px;
+}
 
 /* accordion dropdown */
 

--- a/src/Eccube/Resource/template/admin/Content/index.twig
+++ b/src/Eccube/Resource/template/admin/Content/index.twig
@@ -85,10 +85,8 @@ function changeAction(action) {
                             {% endfor %}
                             </tbody>
                         </table>
-                        <div class="row">
-                            <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
-                                <a href="{{ url('admin_content_new') }}" class="btn btn-primary btn-block btn-lg">新規登録</a>
-                            </div>
+                        <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
+                            <a href="{{ url('admin_content_new') }}" class="btn btn-primary btn-block btn-lg">新規登録</a>
                         </div>
                     </div>
                 </form>

--- a/src/Eccube/Resource/template/admin/Content/index.twig
+++ b/src/Eccube/Resource/template/admin/Content/index.twig
@@ -39,65 +39,60 @@ function changeAction(action) {
 
 {% block main %}
     <div class="row">
-        <div class="col-md-12">
-            <div class="box">
-                <div class="box-header">
-                    <h3 class="box-title">新着情報管理</h3>
-                </div><!-- /.box-header -->
-                <div class="box-body">
-                    <form name="form1" id="form1" method="post" action="">
-                        <div class="table_list">
-                            <div class="table-responsive with-border">
-                                <table class="table table-striped">
-                                    <thead>
-                                    <tr>
-                                        <th>順位</th>
-                                        <th>日付</th>
-                                        <th>タイトル</th>
-                                        <th>&nbsp;</th>
-                                    </tr>
-                                    </thead>
-                                    <tbody>
-                                    {% for News in NewsList %}
-                                        <tr>
-                                            <td>{{ loop.index }}</td>
-                                            <td>{{ News.date|date("Y.m.d") }}</td>
-                                            <td>{{ News.title }}</td>
-                                            <td class="icon_edit">
-                                                <div class="dropdown">
-                                                    <a class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
-                                                    <ul class="dropdown-menu dropdown-menu-right">
-                                                        <li><a href="{{ url('admin_content_edit', { 'id' : News.id }) }}" >編集</a></li>
-                                                        <li><a href="{{ url('admin_content_delete', {id: News.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="この新着情報を削除してもよろしいですか？">削除</a></li>
-                                                        {% if loop.first == false %}
-                                                            <li>
-                                                                <a href="{{ url('admin_content_up', {id: News.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">上へ</a>
-                                                            </li>
-                                                        {% endif %}
-                                                        {% if loop.last == false %}
-                                                            <li>
-                                                                <a href="{{ url('admin_content_down', {id: News.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">下へ</a>
-                                                            </li>
-                                                        {% endif %}
+        <div class="col-md-12 box">
+           <div class="box-header">
+                <h3 class="box-title">新着情報管理</h3>
+            </div><!-- /.box-header -->
+            <div class="box-body">
+                <form name="form1" id="form1" method="post" action="">
+                    <div class="table_list table-responsive with-border">
+                        <table class="table table-striped">
+                            <thead>
+                            <tr>
+                                <th>順位</th>
+                                <th>日付</th>
+                                <th>タイトル</th>
+                                <th>&nbsp;</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {% for News in NewsList %}
+                                <tr>
+                                    <td>{{ loop.index }}</td>
+                                    <td>{{ News.date|date("Y.m.d") }}</td>
+                                    <td>{{ News.title }}</td>
+                                    <td class="icon_edit">
+                                        <div class="dropdown">
+                                            <a class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
+                                            <ul class="dropdown-menu dropdown-menu-right">
+                                                <li><a href="{{ url('admin_content_edit', { 'id' : News.id }) }}" >編集</a></li>
+                                                <li><a href="{{ url('admin_content_delete', {id: News.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="この新着情報を削除してもよろしいですか？">削除</a></li>
+                                                {% if loop.first == false %}
+                                                    <li>
+                                                        <a href="{{ url('admin_content_up', {id: News.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">上へ</a>
+                                                    </li>
+                                                {% endif %}
+                                                {% if loop.last == false %}
+                                                    <li>
+                                                        <a href="{{ url('admin_content_down', {id: News.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">下へ</a>
+                                                    </li>
+                                                {% endif %}
 
-                                                    </ul>
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    {% endfor %}
-                                    </tbody>
-                                </table>
+                                            </ul>
+                                        </div>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                        <div class="row">
+                            <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
+                                <a href="{{ url('admin_content_new') }}" class="btn btn-primary btn-block btn-lg">新規登録</a>
                             </div>
                         </div>
-                    </form>
-                </div>
-            </div><!-- /.box -->
-            <div class="row">
-                <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
-                    <a href="{{ url('admin_content_new') }}" class="btn btn-primary btn-block btn-lg">新規登録</a>
-                </div>
+                    </div>
+                </form>
             </div>
-
         </div>
     </div>
 

--- a/src/Eccube/Resource/template/admin/Customer/index.twig
+++ b/src/Eccube/Resource/template/admin/Customer/index.twig
@@ -211,82 +211,78 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 <!--検索条件設定テーブルここまで-->
 {% if pagination %}
 <div class="row">
-  <div class="col-md-12">
-    <div class="box">
-      {% if pagination and pagination.totalItemCount > 0 %}
-      <div class="box-header with-arrow">
-        <h3 class="box-title">検索結果 <span class="normal"><strong>{{ pagination.totalItemCount }} 件</strong> が該当しました</span></h3>
-      </div><!-- /.box-header -->
-      <div class="box-body">
-        <div class="row">
-          <div class="col-md-12">
-            <ul class="sort-dd">
-              <li class="dropdown">
-              <a class="dropdown-toggle" data-toggle="dropdown">20件<svg class="cb cb-angle-down icon_down"><use xlink:href="#cb-angle-down"></svg></a>
-              <ul class="dropdown-menu">
-                <li><a>50件</a></li>
-                <li><a>100件</a></li>
-              </ul>
-              </li>
-              <li class="dropdown">
-              <a class="dropdown-toggle" data-toggle="dropdown">CSVダウンロード<svg class="cb cb-angle-down icon_down"><use xlink:href="#cb-angle-down"></svg></a>
-              <ul class="dropdown-menu">
-                <li><a href="{{ url('admin_customer_export') }}">CSVダウンロード</a></li>
-                <li><a href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_CUSTOMER') }) }}">出力項目設定</a></li>
-              </ul>
-              </li>
+  <div class="col-md-12 box">
+    {% if pagination and pagination.totalItemCount > 0 %}
+    <div class="box-header with-arrow">
+      <h3 class="box-title">検索結果 <span class="normal"><strong>{{ pagination.totalItemCount }} 件</strong> が該当しました</span></h3>
+    </div><!-- /.box-header -->
+    <div class="box-body">
+      <div class="row">
+        <div class="col-md-12">
+          <ul class="sort-dd">
+            <li class="dropdown">
+            <a class="dropdown-toggle" data-toggle="dropdown">20件<svg class="cb cb-angle-down icon_down"><use xlink:href="#cb-angle-down"></svg></a>
+            <ul class="dropdown-menu">
+              <li><a>50件</a></li>
+              <li><a>100件</a></li>
             </ul>
-          </div>
+            </li>
+            <li class="dropdown">
+            <a class="dropdown-toggle" data-toggle="dropdown">CSVダウンロード<svg class="cb cb-angle-down icon_down"><use xlink:href="#cb-angle-down"></svg></a>
+            <ul class="dropdown-menu">
+              <li><a href="{{ url('admin_customer_export') }}">CSVダウンロード</a></li>
+              <li><a href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_CUSTOMER') }) }}">出力項目設定</a></li>
+            </ul>
+            </li>
+          </ul>
         </div>
-        {% for Customer in pagination %}
-            <div class="table_list">
-                <div class="table-responsive with-border">
-                    <table class="table table-striped">
-                        <thead>
-                        <tr>
-                            <th>会員ID</th>
-                            <th>会員名</th>
-                            <th>電話番号</th>
-                            <th>メールアドレス</th>
-                            <th>&nbsp;</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for Customer in pagination %}
-                        <tr>
-                            <td class="member_id">{{ Customer.id }}</td>
-                            <td class="member_name"><a href="#" onclick="fnChangeActionSubmit('{{ url('admin_customer_edit', { 'id': Customer.id}) }}');return false;">{{ Customer.name01 }}&nbsp;{{ Customer.name02 }}</a></td>
-                            <td class="member_tel">{{ Customer.tel01 }}-{{ Customer.tel02 }}-{{ Customer.tel03 }}</td>
-                            <td class="member_mail">{{ Customer.email }}</td>
-                            <td class="icon_edit">
-                                <div class="dropdown">
-                                    <a class="dropdown-toggle" data-toggle="dropdown"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
-                                    <ul class="dropdown-menu dropdown-menu-right">
-                                        <li><a href="#" onclick="fnChangeActionSubmit('{{ url('admin_customer_edit', { 'id': Customer.id}) }}');return false;">編集</a></li>
-                                        <li><a href="{{ url('admin_customer_delete', { 'id': Customer.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="この会員情報を削除してもよろしいですか？">削除</a></li>
-                                        {% if Customer.Status.id == 1 %}
-                                        <li><a href="{{ url('admin_customer_resend', { 'id': Customer.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-message="仮登録メールを再送してもよろしいですか？">仮会員メール再送</a></li>
-                                        {% endif %}
-                                    </ul>
-                                </div>
-                            </td>
-                        </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        {% endfor %}
+      </div>
+      {% for Customer in pagination %}
+          <div class="table_list table-responsive with-border">
+              <table class="table table-striped">
+                  <thead>
+                  <tr>
+                      <th>会員ID</th>
+                      <th>会員名</th>
+                      <th>電話番号</th>
+                      <th>メールアドレス</th>
+                      <th>&nbsp;</th>
+                  </tr>
+                  </thead>
+                  <tbody>
+                  {% for Customer in pagination %}
+                  <tr>
+                      <td class="member_id">{{ Customer.id }}</td>
+                      <td class="member_name"><a href="#" onclick="fnChangeActionSubmit('{{ url('admin_customer_edit', { 'id': Customer.id}) }}');return false;">{{ Customer.name01 }}&nbsp;{{ Customer.name02 }}</a></td>
+                      <td class="member_tel">{{ Customer.tel01 }}-{{ Customer.tel02 }}-{{ Customer.tel03 }}</td>
+                      <td class="member_mail">{{ Customer.email }}</td>
+                      <td class="icon_edit">
+                          <div class="dropdown">
+                              <a class="dropdown-toggle" data-toggle="dropdown"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
+                              <ul class="dropdown-menu dropdown-menu-right">
+                                  <li><a href="#" onclick="fnChangeActionSubmit('{{ url('admin_customer_edit', { 'id': Customer.id}) }}');return false;">編集</a></li>
+                                  <li><a href="{{ url('admin_customer_delete', { 'id': Customer.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="この会員情報を削除してもよろしいですか？">削除</a></li>
+                                  {% if Customer.Status.id == 1 %}
+                                  <li><a href="{{ url('admin_customer_resend', { 'id': Customer.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-message="仮登録メールを再送してもよろしいですか？">仮会員メール再送</a></li>
+                                  {% endif %}
+                              </ul>
+                          </div>
+                      </td>
+                  </tr>
+                  {% endfor %}
+                  </tbody>
+              </table>
+              {% if pagination.totalItemCount > 0 %}
+                  {% include "pager.twig" with { 'pages' : pagination.paginationData, 'routes' : 'admin_customer_page' } %}
+              {% endif %}
+          </div>
+      {% endfor %}
       </div><!-- /.box-body -->
-      {% if pagination.totalItemCount > 0 %}
-      {% include "pager.twig" with { 'pages' : pagination.paginationData, 'routes' : 'admin_customer_page' } %}
-      {% endif %}
-      {% else %}
-      <div class="box-header with-arrow">
-        <h3 class="box-title">検索条件に該当するデータがありませんでした。</h3>
-      </div><!-- /.box-header -->
-      {% endif %}
-    </div><!-- /.box -->
+    {% else %}
+    <div class="box-header with-arrow">
+      <h3 class="box-title">検索条件に該当するデータがありませんでした。</h3>
+    </div><!-- /.box-header -->
+    {% endif %}
   </div><!-- /.col -->
 </div>
 {% endif %}

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -230,99 +230,95 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 {% if pagination %}
     <div class="row">
-        <div class="col-md-12">
-            <div class="box">
-                {% if pagination.totalItemCount > 0 %}
-                <div class="box-header with-arrow">
-                    <h3 class="box-title">検索結果 <span class="normal"><strong>{{ pagination.totalItemCount }} 件</strong> が該当しました</span></h3>
-                </div><!-- /.box-header -->
-                <div class="box-body">
-                    <div class="row">
-                        <div class="col-md-12">
-                            <ul class="sort-dd">
-                                <li class="dropdown">
-                                    {% for pageMax in pageMaxis if pageMax.name == page_count %}
-                                        <a class="dropdown-toggle" data-toggle="dropdown">{{ pageMax.name|e }}件<svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg></a>
-                                        <ul class="dropdown-menu">
-                                    {% endfor %}
-                                    {% for pageMax in pageMaxis if pageMax.name != page_count %}
-                                            <li><a href="{{ path('admin_order_page', {'page_no': 1, 'page_count': pageMax.name}) }}">{{ pageMax.name|e }}件</a></li>
-                                    {% endfor %}
+        <div class="col-md-12 box">
+            {% if pagination.totalItemCount > 0 %}
+            <div class="box-header with-arrow">
+                <h3 class="box-title">検索結果 <span class="normal"><strong>{{ pagination.totalItemCount }} 件</strong> が該当しました</span></h3>
+            </div><!-- /.box-header -->
+            <div class="box-body">
+                <div class="row">
+                    <div class="col-md-12">
+                        <ul class="sort-dd">
+                            <li class="dropdown">
+                                {% for pageMax in pageMaxis if pageMax.name == page_count %}
+                                    <a class="dropdown-toggle" data-toggle="dropdown">{{ pageMax.name|e }}件<svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg></a>
+                                    <ul class="dropdown-menu">
+                                {% endfor %}
+                                {% for pageMax in pageMaxis if pageMax.name != page_count %}
+                                        <li><a href="{{ path('admin_order_page', {'page_no': 1, 'page_count': pageMax.name}) }}">{{ pageMax.name|e }}件</a></li>
+                                {% endfor %}
+                                    </ul>
+                            </li>
+                            <li class="dropdown">
+                                <a class="dropdown-toggle" data-toggle="dropdown">CSVダウンロード<svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg></a>
+                                <ul class="dropdown-menu">
+                                    <li><a href="{{ url('admin_order_export_order') }}">受注CSVダウンロード</a></li>
+                                    <li><a href="{{ url('admin_order_export_shipping') }}">配送CSVダウンロード</a></li>
+                                    <li><a href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_ORDER') }) }}">受注CSV出力項目設定</a></li>
+                                    <li><a href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_SHIPPING') }) }}">配送CSV出力項目設定</a></li>
+                                </ul>
+                            </li>
+                            <li id="dropmenu" class="dropdown">
+                                <a class="dropdown-toggle" data-toggle="dropdown">その他<svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg></a>
+                                <ul class="dropdown-menu">
+                                    <li><a href="{{ url('admin_order_mail_all') }}">メール一括通知</a></li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <form id="dropdown-form">
+                <div class="table_list table-responsive with-border">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th class="text-center"><input type="checkbox" id="check-all"></th>
+                                <th>受注日</th>
+                                <th>注文番号</th>
+                                <th>お名前</th>
+                                <th>支払方法</th>
+                                <th>購入金額(円)</th>
+                                <th>発送日</th>
+                                <th>対応状況</th>
+                                <th>&nbsp;</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                    {% for Order in pagination %}
+                            <tr>
+                                <td class="text-center"><input type="checkbox" id="check-{{ Order.id }}" data-id="{{ Order.id }}" name="ids{{ Order.id }}"></td>
+                                <td>{{ Order.order_date|date_format }}</td>
+                                <td>{{ Order.id }}</td>
+                                <td>{{ Order.name01 }} {{ Order.name02 }}</td>
+                                <td>{{ Order.payment_method }}</td>
+                                <td class="text-right">{{ Order.payment_total|number_format }}</td>
+                                <td>{{ Order.commit_date|date_format }}</td>
+                                <td>{{ Order.OrderStatus }}</td>
+                                <td class="icon_edit">
+                                    <div class="dropdown">
+                                        <a class="dropdown-toggle" data-toggle="dropdown"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
+                                        <ul class="dropdown-menu dropdown-menu-right">
+                                        <li><a href="{{ url('admin_order_edit', { id : Order.id }) }}">編集</a></li>
+                                        <li><a href="{{ url('admin_order_delete', { id : Order.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="この受注情報を削除してもよろしいですか？">削除</a></li>
+                                        <li><a href="{{ url('admin_order_mail', { id : Order.id }) }}">メール通知</a></li>
                                         </ul>
-                                </li>
-                                <li class="dropdown">
-                                    <a class="dropdown-toggle" data-toggle="dropdown">CSVダウンロード<svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg></a>
-                                    <ul class="dropdown-menu">
-                                        <li><a href="{{ url('admin_order_export_order') }}">受注CSVダウンロード</a></li>
-                                        <li><a href="{{ url('admin_order_export_shipping') }}">配送CSVダウンロード</a></li>
-                                        <li><a href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_ORDER') }) }}">受注CSV出力項目設定</a></li>
-                                        <li><a href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_SHIPPING') }) }}">配送CSV出力項目設定</a></li>
-                                    </ul>
-                                </li>
-                                <li id="dropmenu" class="dropdown">
-                                    <a class="dropdown-toggle" data-toggle="dropdown">その他<svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg></a>
-                                    <ul class="dropdown-menu">
-                                        <li><a href="{{ url('admin_order_mail_all') }}">メール一括通知</a></li>
-                                    </ul>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                    <form id="dropdown-form">
-                    <div class="table_list">
-                        <div class="table-responsive with-border">
-                            <table class="table table-striped">
-                                <thead>
-                                    <tr>
-                                        <th class="text-center"><input type="checkbox" id="check-all"></th>
-                                        <th>受注日</th>
-                                        <th>注文番号</th>
-                                        <th>お名前</th>
-                                        <th>支払方法</th>
-                                        <th>購入金額(円)</th>
-                                        <th>発送日</th>
-                                        <th>対応状況</th>
-                                        <th>&nbsp;</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                            {% for Order in pagination %}
-                                    <tr>
-                                        <td class="text-center"><input type="checkbox" id="check-{{ Order.id }}" data-id="{{ Order.id }}" name="ids{{ Order.id }}"></td>
-                                        <td>{{ Order.order_date|date_format }}</td>
-                                        <td>{{ Order.id }}</td>
-                                        <td>{{ Order.name01 }} {{ Order.name02 }}</td>
-                                        <td>{{ Order.payment_method }}</td>
-                                        <td class="text-right">{{ Order.payment_total|number_format }}</td>
-                                        <td>{{ Order.commit_date|date_format }}</td>
-                                        <td>{{ Order.OrderStatus }}</td>
-                                        <td class="icon_edit">
-                                            <div class="dropdown">
-                                                <a class="dropdown-toggle" data-toggle="dropdown"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
-                                                <ul class="dropdown-menu dropdown-menu-right">
-                                                <li><a href="{{ url('admin_order_edit', { id : Order.id }) }}">編集</a></li>
-                                                <li><a href="{{ url('admin_order_delete', { id : Order.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="この受注情報を削除してもよろしいですか？">削除</a></li>
-                                                <li><a href="{{ url('admin_order_mail', { id : Order.id }) }}">メール通知</a></li>
-                                                </ul>
-                                            </div>
-                                        </td>
-                                    </tr>
-                            {% endfor %}
-                                </tbody>
-                            </table>
-                                    </form>
-                        </div>
-                    </div>
-                </div><!-- /.box-body --> 
-                {% if pagination.totalItemCount > 0 %}
-                    {% include "pager.twig" with { 'pages' : pagination.paginationData, 'routes' : 'admin_order_page' } %}
-                {% endif %}
-                {% else %}
-                <div class="box-header with-arrow">
-                    <h3 class="box-title">検索条件に該当するデータがありませんでした。</h3>
-                </div><!-- /.box-header -->
-                {% endif %}
-            </div><!-- /.box --> 
+                                    </div>
+                                </td>
+                            </tr>
+                    {% endfor %}
+                        </tbody>
+                    </table>
+                    {% if pagination.totalItemCount > 0 %}
+                        {% include "pager.twig" with { 'pages' : pagination.paginationData, 'routes' : 'admin_order_page' } %}
+                        {% endif %}
+                </div>
+                </form>
+            </div><!-- /.box-body --> 
+            {% else %}
+            <div class="box-header with-arrow">
+                <h3 class="box-title">検索条件に該当するデータがありませんでした。</h3>
+            </div><!-- /.box-header -->
+            {% endif %}
         </div><!-- /.col --> 
     </div>
 

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -310,7 +310,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     </table>
                     {% if pagination.totalItemCount > 0 %}
                         {% include "pager.twig" with { 'pages' : pagination.paginationData, 'routes' : 'admin_order_page' } %}
-                        {% endif %}
+                    {% endif %}
                 </div>
                 </form>
             </div><!-- /.box-body --> 

--- a/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
@@ -34,7 +34,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     支払方法
                 </h3>
             </div><!-- /.box-header -->
-            <div class="box-body table_list table-responsive with-border">
+            <div class="box-body">
+            <div class="table_list table-responsive with-border">
                 <table class="table table-striped">
                     <thead>
                     <tr>
@@ -100,11 +101,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         {% endfor %}
                     </tbody>
                 </table>
-                <div class="row">
-                    <div class="col-xs-8 col-xs-offset-2 col-sm-4 col-sm-offset-4 text-center btn_area">
-                    <a href="{{ url('admin_setting_shop_payment_new') }}" class="btn btn-primary btn-block btn-lg">支払方法を新規入力</a>
-                    </div>
+                <div class="col-xs-8 col-xs-offset-2 col-sm-4 col-sm-offset-4 text-center btn_area">
+                <a href="{{ url('admin_setting_shop_payment_new') }}" class="btn btn-primary btn-block btn-lg">支払方法を新規入力</a>
                 </div>
+            </div>
             </div><!-- /.box-body -->
         </div><!-- /.col -->
     </div>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
@@ -28,92 +28,85 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 {% block main %}
     <div class="row">
-        <div class="col-md-12">
-            <div class="box">
-                <div class="box-header with-arrow">
-                    <h3 class="box-title">
-                        支払方法
-                    </h3>
-                </div><!-- /.box-header -->
-                <div class="box-body">
-                    <div class="table_list">
-                        <div class="table-responsive with-border">
-                            <table class="table table-striped">
-                                <thead>
-                                <tr>
-                                    <th>支払方法</th>
-                                    <th>手数料</th>
-                                    <th>利用条件</th>
-                                    <th>&nbsp;</th>
-                                </tr>
-                                </thead>
-                                <tbody>
-                                    <form name="delete_form" id="delete_form" action="" method="post">
-                                    </form>
-                                    {% for Payment in Payments %}
-                                    <tr>
+        <div class="col-md-12 box">
+            <div class="box-header with-arrow">
+                <h3 class="box-title">
+                    支払方法
+                </h3>
+            </div><!-- /.box-header -->
+            <div class="box-body table_list table-responsive with-border">
+                <table class="table table-striped">
+                    <thead>
+                    <tr>
+                        <th>支払方法</th>
+                        <th>手数料</th>
+                        <th>利用条件</th>
+                        <th>&nbsp;</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                        <form name="delete_form" id="delete_form" action="" method="post">
+                        </form>
+                        {% for Payment in Payments %}
+                        <tr>
 
-                                        <td class="member_name">{{ Payment.method }}</td>
-                                        <td class="member_name">
-                                            {{ Payment.charge }}
-                                        </td>
-                                        <td class="member_name">
-                                            {% if Payment.rule_min > 0 %}
-                                                {{ Payment.rule_min }}
+                            <td class="member_name">{{ Payment.method }}</td>
+                            <td class="member_name">
+                                {{ Payment.charge }}
+                            </td>
+                            <td class="member_name">
+                                {% if Payment.rule_min > 0 %}
+                                    {{ Payment.rule_min }}
+                                {% else %}
+                                    0
+                                {% endif %}円
+
+                                {% if Payment.rule_max > 0 %}
+                                    ～{{ Payment.rule_max }}円
+                                {% elseif Payment.rule_max is null %}
+                                    ～無制限
+                                {% endif %}
+                            </td>
+                            <td class="icon_edit">
+                                <div class="dropdown">
+                                    <a class="dropdown-toggle" data-toggle="dropdown"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
+                                    <ul class="dropdown-menu dropdown-menu-right">
+                                        <li>
+                                            {% if Payment.fix_flg == 1 %}
+                                                <a href="{{ url('admin_setting_shop_payment_edit', { id: Payment.id}) }}">編集</a>
                                             {% else %}
-                                                0
-                                            {% endif %}円
-
-                                            {% if Payment.rule_max > 0 %}
-                                                ～{{ Payment.rule_max }}円
-                                            {% elseif Payment.rule_max is null %}
-                                                ～無制限
+                                                <a>編集</a>
                                             {% endif %}
-                                        </td>
-                                        <td class="icon_edit">
-                                            <div class="dropdown">
-                                                <a class="dropdown-toggle" data-toggle="dropdown"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
-                                                <ul class="dropdown-menu dropdown-menu-right">
-                                                    <li>
-                                                        {% if Payment.fix_flg == 1 %}
-                                                            <a href="{{ url('admin_setting_shop_payment_edit', { id: Payment.id}) }}">編集</a>
-                                                        {% else %}
-                                                            <a>編集</a>
-                                                        {% endif %}
-                                                    </li>
-                                                    <li>
-                                                        {% if Payment.fix_flg == 1 %}
-                                                            <a href="{{ url('admin_setting_shop_payment_delete', { id: Payment.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete">削除</a>
-                                                        {% else %}
-                                                            <a>削除</a>
-                                                        {% endif %}
-                                                    </li>
-                                                    <li>
-                                                        {% if loop.first == false %}
-                                                            <li><a href="{{ url('admin_setting_shop_payment_up', {id: Payment.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">上へ</a></li>
-                                                        {% endif %}
-                                                        {% if loop.last == false %}
-                                                            <li><a href="{{ url('admin_setting_shop_payment_down', {id: Payment.id}) }}"  {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">下へ</a></li>
-                                                        {% endif %}
-                                                    </li>
-                                                </ul>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                        </div>
+                                        </li>
+                                        <li>
+                                            {% if Payment.fix_flg == 1 %}
+                                                <a href="{{ url('admin_setting_shop_payment_delete', { id: Payment.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete">削除</a>
+                                            {% else %}
+                                                <a>削除</a>
+                                            {% endif %}
+                                        </li>
+                                        <li>
+                                            {% if loop.first == false %}
+                                                <li><a href="{{ url('admin_setting_shop_payment_up', {id: Payment.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">上へ</a></li>
+                                            {% endif %}
+                                            {% if loop.last == false %}
+                                                <li><a href="{{ url('admin_setting_shop_payment_down', {id: Payment.id}) }}"  {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">下へ</a></li>
+                                            {% endif %}
+                                        </li>
+                                    </ul>
+                                </div>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <div class="row">
+                    <div class="col-xs-8 col-xs-offset-2 col-sm-4 col-sm-offset-4 text-center btn_area">
+                    <a href="{{ url('admin_setting_shop_payment_new') }}" class="btn btn-primary btn-block btn-lg">支払方法を新規入力</a>
                     </div>
-                </div><!-- /.box-body -->
-
-            </div><!-- /.box -->
+                </div>
+            </div><!-- /.box-body -->
         </div><!-- /.col -->
     </div>
 
-    <div class="row">
-        <div class="col-xs-8 col-xs-offset-2 col-sm-4 col-sm-offset-4 text-center btn_area">
-            <a href="{{ url('admin_setting_shop_payment_new') }}" class="btn btn-primary btn-block btn-lg">支払方法を新規入力</a>
-        </div>
-    </div>
 {% endblock %}

--- a/src/Eccube/Resource/template/admin/Setting/System/member.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/member.twig
@@ -38,77 +38,70 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 {% block main %}
     <div class="row">
-        <div class="col-md-12">
-            <div class="box">
-                <div class="box-header">
-                    <h3 class="box-title">メンバー管理</h3>
-                </div><!-- /.box-header -->
-                <div class="box-body">
-                    <form name="form1" id="form1" method="post" action="">
-                        <div class="table_list">
-                            <div class="table-responsive with-border">
-                                <table class="table table-striped">
-                                    <thead>
-                                    <tr>
-                                        <th>権限</th>
-                                        <th>名前</th>
-                                        <th>所属</th>
-                                        <th>稼働</th>
-                                        <th>&nbsp;</th>
-                                    </tr>
-                                    </thead>
-                                    <tbody>
-                                    {% for Member in Members %}
-                                    <tr>
-                                        <td>{{ Member.Authority.name }}</td>
-                                        <td>{{ Member.name }}</td>
-                                        <td>{{ Member.department }}</td>
-                                        <td>{{ Member.Work.name }}</td>
-                                        <td class="icon_edit">
-                                            <div class="dropdown">
-                                                <a class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
-                                                <ul class="dropdown-menu dropdown-menu-right">
-                                                    <li><a href="{{ url('admin_setting_system_member_edit', { 'id' : Member.id }) }}" >編集</a></li>
-                                                    {% if Member.id == app.user.id %}
-                                                        <li>
-                                                            <a>削除</a>
-                                                        </li>
-                                                    {% else %}
-                                                        <li>
-                                                            <a href="{{ url('admin_setting_system_member_delete', {id: Member.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete">削除</a>
-                                                        </li>
-                                                    {% endif %}
-                                                    {% if loop.first == false %}
-                                                        <li>
-                                                            <a href="{{ url('admin_setting_system_member_up', {id: Member.id}) }}"  {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">上へ</a>
-                                                        </li>
-                                                    {% endif %}
-                                                    {% if loop.last == false %}
-                                                        <li>
-                                                            <a href="{{ url('admin_setting_system_member_up', {id: Member.id}) }}"  {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">下へ</a>
-                                                        </li>
-                                                    {% endif %}
+        <div class="col-md-12 box">
+            <div class="box-header">
+                <h3 class="box-title">メンバー管理</h3>
+            </div><!-- /.box-header -->
+            <div class="box-body">
+                <form name="form1" id="form1" method="post" action="">
+                    <div class="table_list table-responsive with-border">
+                        <table class="table table-striped">
+                            <thead>
+                            <tr>
+                                <th>権限</th>
+                                <th>名前</th>
+                                <th>所属</th>
+                                <th>稼働</th>
+                                <th>&nbsp;</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {% for Member in Members %}
+                            <tr>
+                                <td>{{ Member.Authority.name }}</td>
+                                <td>{{ Member.name }}</td>
+                                <td>{{ Member.department }}</td>
+                                <td>{{ Member.Work.name }}</td>
+                                <td class="icon_edit">
+                                    <div class="dropdown">
+                                        <a class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
+                                        <ul class="dropdown-menu dropdown-menu-right">
+                                            <li><a href="{{ url('admin_setting_system_member_edit', { 'id' : Member.id }) }}" >編集</a></li>
+                                            {% if Member.id == app.user.id %}
+                                                <li>
+                                                    <a>削除</a>
+                                                </li>
+                                            {% else %}
+                                                <li>
+                                                    <a href="{{ url('admin_setting_system_member_delete', {id: Member.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete">削除</a>
+                                                </li>
+                                            {% endif %}
+                                            {% if loop.first == false %}
+                                                <li>
+                                                    <a href="{{ url('admin_setting_system_member_up', {id: Member.id}) }}"  {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">上へ</a>
+                                                </li>
+                                            {% endif %}
+                                            {% if loop.last == false %}
+                                                <li>
+                                                    <a href="{{ url('admin_setting_system_member_up', {id: Member.id}) }}"  {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">下へ</a>
+                                                </li>
+                                            {% endif %}
 
-                                                </ul>
-                                            </div>                                        
-                                        </td>
-                                    </tr>
-                                    {% endfor %}
-                                    </tbody>
-                                </table>
+                                        </ul>
+                                    </div>                                        
+                                </td>
+                            </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                        <div class="row">
+                            <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
+                                <a href="{{ url('admin_setting_system_member_new') }}" class="btn btn-primary btn-block btn-lg">新規登録</a>
                             </div>
                         </div>
-                    </form>
-                </div>
-            </div><!-- /.box -->
-            <div class="row">
-                <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
-                    <a href="{{ url('admin_setting_system_member_new') }}" class="btn btn-primary btn-block btn-lg">
-                            新規登録
-                    </a>
-                </div>
+                    </div>
+                </form>
             </div>
-
         </div>
     </div>
 

--- a/src/Eccube/Resource/template/admin/Setting/System/member.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/member.twig
@@ -94,10 +94,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             {% endfor %}
                             </tbody>
                         </table>
-                        <div class="row">
-                            <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
-                                <a href="{{ url('admin_setting_system_member_new') }}" class="btn btn-primary btn-block btn-lg">新規登録</a>
-                            </div>
+                        <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
+                            <a href="{{ url('admin_setting_system_member_new') }}" class="btn btn-primary btn-block btn-lg">新規登録</a>
                         </div>
                     </div>
                 </form>


### PR DESCRIPTION
以下の一覧で「ドロップダウンメニュー隠れ」が起こっていたので対応。

* 受注管理 - 受注マスター
* 会員管理 - 会員マスター
* コンテンツ管理 - 新着情報管理
* 設定 - 基本情報管理 - 支払方法設定
* 設定 - システム情報管理 - メンバー管理

レイアウトで無駄と思われるdiv要素を上部divに結合し、一覧下部にある要素（新規追加ボタンやページネーションなど）の位置を変更し、ドロップダウンメニュー表示域を確保。
