### PR TITLE
分類削除時に、商品で使われているかどうかチェックを追加 #796

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ClassCategoryController.php
+++ b/src/Eccube/Controller/Admin/Product/ClassCategoryController.php
@@ -91,12 +91,23 @@ class ClassCategoryController extends AbstractController
             throw new NotFoundHttpException();
         }
 
-        $status = $app['eccube.repository.class_category']->delete($TargetClassCategory);
-
-        if ($status === true) {
-            $app->addSuccess('admin.class_category.delete.complete', 'admin');
+        $num = $app['orm.em']->createQueryBuilder()
+            ->select('count(p.id)')
+            ->from("Eccube\\Entity\\ProductClass",'p')
+            ->where('p.ClassCategory1 = :id OR p.ClassCategory2 = :id')
+            ->setParameter('id',$id)
+            ->getQuery()
+            ->getSingleScalarResult();
+        if ($num > 0) {
+            $app->addError('admin.class_category.delete.hasproduct', 'admin');
         } else {
-            $app->addError('admin.class_category.delete.error', 'admin');
+            $status = $app['eccube.repository.class_category']->delete($TargetClassCategory);
+
+            if ($status === true) {
+                $app->addSuccess('admin.class_category.delete.complete', 'admin');
+            } else {
+                $app->addError('admin.class_category.delete.error', 'admin');
+            }
         }
 
         return $app->redirect($app->url('admin_product_class_category', array('class_name_id' => $ClassName->getId())));

--- a/src/Eccube/Controller/Admin/Product/ClassCategoryController.php
+++ b/src/Eccube/Controller/Admin/Product/ClassCategoryController.php
@@ -91,10 +91,9 @@ class ClassCategoryController extends AbstractController
             throw new NotFoundHttpException();
         }
 
-        $num = $app['orm.em']->createQueryBuilder()
-            ->select('count(p.id)')
-            ->from("Eccube\\Entity\\ProductClass",'p')
-            ->where('p.ClassCategory1 = :id OR p.ClassCategory2 = :id')
+        $num = $app['eccube.repository.product_class']->createQueryBuilder('pc')
+            ->select('count(pc.id)')
+            ->where('pc.ClassCategory1 = :id OR pc.ClassCategory2 = :id')
             ->setParameter('id',$id)
             ->getQuery()
             ->getSingleScalarResult();

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -81,6 +81,7 @@ admin.class_category.save.complete: 分類を保存しました。
 admin.class_category.save.error: 分類を保存できませんでした。
 admin.class_category.delete.complete: 分類を削除しました。
 admin.class_category.delete.error: 分類を削除できませんでした。
+admin.class_category.delete.hasproduct: この分類は商品で使われているので削除できません。 
 
 admin.category.up.complete: カテゴリを上へ移動しました。
 admin.category.up.error: カテゴリを上へ移動できませんでした。


### PR DESCRIPTION
分類削除時に商品で使われているかどうかチェックされず、使われていても削除できたため報告の例外が発生していた。
分類削除時に使われているかどうかチェックを追加。
規格については、一覧表示時に「分類があるかどうか」で「削除」メニューを表示するかどうかという処理が入っているし、無理矢理削除しようとしても「分類があるかどうか」をチェックしているので現状で問題ないと判断した。