### PR TITLE
PHPUnit のメモリリーク解消

### DIFF
--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -54,6 +54,13 @@ abstract class EccubeTestCase extends WebTestCase
         parent::tearDown();
         $this->app['orm.em']->getConnection()->rollback();
         $this->app['orm.em']->getConnection()->close();
+        $refl = new \ReflectionObject($this);
+        foreach ($refl->getProperties() as $prop) {
+            if (!$prop->isStatic() && 0 !== strpos($prop->getDeclaringClass()->getName(), 'PHPUnit_')) {
+                $prop->setAccessible(true);
+                $prop->setValue($this, null);
+            }
+        }
     }
 
     /**

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -46,6 +46,8 @@ abstract class EccubeTestCase extends WebTestCase
 
     /**
      * トランザクションをロールバックする.
+     *
+     * @link http://stackoverflow.com/questions/13537545/clear-memory-being-used-by-php
      */
     public function tearDown()
     {

--- a/tests/Eccube/Tests/Web/AbstractWebTestCase.php
+++ b/tests/Eccube/Tests/Web/AbstractWebTestCase.php
@@ -46,6 +46,9 @@ abstract class AbstractWebTestCase extends WebTestCase
         }
     }
 
+    /**
+     * @link http://stackoverflow.com/questions/13537545/clear-memory-being-used-by-php
+     */
     public function tearDown()
     {
         parent::tearDown();

--- a/tests/Eccube/Tests/Web/AbstractWebTestCase.php
+++ b/tests/Eccube/Tests/Web/AbstractWebTestCase.php
@@ -53,8 +53,13 @@ abstract class AbstractWebTestCase extends WebTestCase
     {
         parent::tearDown();
         $this->app['orm.em']->getConnection()->close();
-        $this->app = null;
-        $this->client = null;
+        $refl = new \ReflectionObject($this);
+        foreach ($refl->getProperties() as $prop) {
+            if (!$prop->isStatic() && 0 !== strpos($prop->getDeclaringClass()->getName(), 'PHPUnit_')) {
+                $prop->setAccessible(true);
+                $prop->setValue($this, null);
+            }
+        }
     }
 
     public static function tearDownAfterClass()


### PR DESCRIPTION
tearDown() で、 リフレクションを使ってプロパティを初期化します。
まずは影響の大きな WebTest 系に適用