### PR TITLE
refs #862 Swift Mailerから送信されるメールの文字コード設定対応

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -382,6 +382,19 @@ class Application extends ApplicationTrait
 
     public function initMailer()
     {
+
+        // メール送信時の文字エンコード指定(デフォルトはUTF-8)
+        if (isset($this['config']['mail']['charset_iso_2022_jp']) && is_bool($this['config']['mail']['charset_iso_2022_jp'])) {
+            if ($this['config']['mail']['charset_iso_2022_jp'] === true) {
+                \Swift::init(function() {
+                    \Swift_DependencyContainer::getInstance()
+                        ->register('mime.qpheaderencoder')
+                        ->asAliasOf('mime.base64headerencoder');
+                    \Swift_Preferences::getInstance()->setCharset('iso-2022-jp');
+                });
+            }
+        }
+
         $this->register(new \Silex\Provider\SwiftmailerServiceProvider());
         $this['swiftmailer.options'] = $this['config']['mail'];
 

--- a/src/Eccube/Resource/config/mail.yml.dist
+++ b/src/Eccube/Resource/config/mail.yml.dist
@@ -6,3 +6,4 @@ mail:
     password: ${MAIL_PASS}
     encryption: null
     auth_mode: null
+    charset_iso_2022_jp: false


### PR DESCRIPTION
#862 より一部のメールクライアントで文字化けが発生するため、
mail.ymlにiso-2022-jpで送信できるように設定情報を追加。
falseならUTF-8のまま。

http://swiftmailer.org/docs/japanese.html