### PR TITLE
【バグ/管理画面>システム設定>メンバー管理】メンバーの並び替えの「下」が「上」に並び替え #989

### DIFF
--- a/src/Eccube/Resource/template/admin/Setting/System/member.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/member.twig
@@ -85,12 +85,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                     {% endif %}
                                                     {% if loop.last == false %}
                                                         <li>
-                                                            <a href="{{ url('admin_setting_system_member_up', {id: Member.id}) }}"  {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">下へ</a>
+                                                            <a href="{{ url('admin_setting_system_member_down', {id: Member.id}) }}"  {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">下へ</a>
                                                         </li>
                                                     {% endif %}
 
                                                 </ul>
-                                            </div>                                        
+                                            </div>
                                         </td>
                                     </tr>
                                     {% endfor %}


### PR DESCRIPTION
①下へのリンクがtwigのurlジェネレーターに「上」への引数が与えられていた。
②urlジェネレーターに「上」への引数を設定