### PR TITLE
【バグ】会員マスターで、会員名（姓名の間に半角スペースをいれた状態で）検索ができない。 #800

### DIFF
--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -103,6 +103,10 @@ class NameType extends AbstractType
                     new Assert\Length(array(
                         'max' => $this->config['name_len'],
                     )),
+                    new Assert\Regex(array(
+                        'pattern' => '/^\S+$/',
+                        'message' => 'form.type.name.firstname.nothasspace'
+                    ))
                 ),
             ),
             'firstname_options' => array(
@@ -113,6 +117,10 @@ class NameType extends AbstractType
                     new Assert\Length(array(
                         'max' => $this->config['name_len'],
                     )),
+                    new Assert\Regex(array(
+                        'pattern' => '/^\S+$/',
+                        'message' => 'form.type.name.lastname.nothasspace'
+                    ))
                 ),
             ),
             'lastname_name' => '',

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -104,7 +104,7 @@ class NameType extends AbstractType
                         'max' => $this->config['name_len'],
                     )),
                     new Assert\Regex(array(
-                        'pattern' => '/^\S+|[ ]+$/',
+                        'pattern' => '/^\S+|[^ ]+$/',
                         'message' => 'form.type.name.firstname.nothasspace'
                     ))
                 ),
@@ -118,7 +118,7 @@ class NameType extends AbstractType
                         'max' => $this->config['name_len'],
                     )),
                     new Assert\Regex(array(
-                        'pattern' => '/^\S+|[ ]+$/',
+                        'pattern' => '/^\S+|[^ ]+$/',
                         'message' => 'form.type.name.lastname.nothasspace'
                     ))
                 ),

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -104,7 +104,7 @@ class NameType extends AbstractType
                         'max' => $this->config['name_len'],
                     )),
                     new Assert\Regex(array(
-                        'pattern' => '/^\S+|[^ ]+$/',
+                        'pattern' => '/^[\S^ ]+$/',
                         'message' => 'form.type.name.firstname.nothasspace'
                     ))
                 ),
@@ -118,7 +118,7 @@ class NameType extends AbstractType
                         'max' => $this->config['name_len'],
                     )),
                     new Assert\Regex(array(
-                        'pattern' => '/^\S+|[^ ]+$/',
+                        'pattern' => '/^[\S^ ]+$/',
                         'message' => 'form.type.name.lastname.nothasspace'
                     ))
                 ),

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -104,7 +104,7 @@ class NameType extends AbstractType
                         'max' => $this->config['name_len'],
                     )),
                     new Assert\Regex(array(
-                        'pattern' => '/^[\S^ ]+$/',
+                        'pattern' => '/^[\S\|^ ]+$/',
                         'message' => 'form.type.name.firstname.nothasspace'
                     ))
                 ),
@@ -118,7 +118,7 @@ class NameType extends AbstractType
                         'max' => $this->config['name_len'],
                     )),
                     new Assert\Regex(array(
-                        'pattern' => '/^[\S^ ]+$/',
+                        'pattern' => '/^[\S\|^ ]+$/',
                         'message' => 'form.type.name.lastname.nothasspace'
                     ))
                 ),

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -104,7 +104,7 @@ class NameType extends AbstractType
                         'max' => $this->config['name_len'],
                     )),
                     new Assert\Regex(array(
-                        'pattern' => '/^[\S\|^ ]+$/',
+                        'pattern' => '/^[^\s ]+$/u',
                         'message' => 'form.type.name.firstname.nothasspace'
                     ))
                 ),
@@ -118,7 +118,7 @@ class NameType extends AbstractType
                         'max' => $this->config['name_len'],
                     )),
                     new Assert\Regex(array(
-                        'pattern' => '/^[\S\|^ ]+$/',
+                        'pattern' => '/^[^\s ]+$/u',
                         'message' => 'form.type.name.lastname.nothasspace'
                     ))
                 ),

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -104,7 +104,7 @@ class NameType extends AbstractType
                         'max' => $this->config['name_len'],
                     )),
                     new Assert\Regex(array(
-                        'pattern' => '/^\S+$/',
+                        'pattern' => '/^\S+|[ ]+$/',
                         'message' => 'form.type.name.firstname.nothasspace'
                     ))
                 ),
@@ -118,7 +118,7 @@ class NameType extends AbstractType
                         'max' => $this->config['name_len'],
                     )),
                     new Assert\Regex(array(
-                        'pattern' => '/^\S+$/',
+                        'pattern' => '/^\S+|[ ]+$/',
                         'message' => 'form.type.name.lastname.nothasspace'
                     ))
                 ),

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -144,16 +144,18 @@ class CustomerRepository extends EntityRepository implements UserProviderInterfa
             ->andWhere('c.del_flg = 0');
 
         if (!empty($searchData['multi']) && $searchData['multi']) {
-            if (preg_match('/^\d+$/', $searchData['multi'])) {
+            //スペース除去
+            $clean_key_multi = preg_replace('/\s+|[　]+/u', '',$searchData['multi']);
+            if (preg_match('/^\d+$/', $clean_key_multi)) {
                 $qb
                     ->andWhere('c.id = :customer_id')
-                    ->setParameter('customer_id', $searchData['multi']);
+                    ->setParameter('customer_id', $clean_key_multi); 
             } else {
                 $qb
                     ->andWhere('CONCAT(c.name01, c.name02) LIKE :name OR CONCAT(c.kana01, c.kana02) LIKE :kana OR c.email LIKE :email')
-                    ->setParameter('name', '%' . $searchData['multi'] . '%')
-                    ->setParameter('kana', '%' . $searchData['multi'] . '%')
-                    ->setParameter('email', '%' . $searchData['multi'] . '%');
+                    ->setParameter('name', '%' . $clean_key_multi . '%')
+                    ->setParameter('kana', '%' . $clean_key_multi . '%')
+                    ->setParameter('email', '%' . $clean_key_multi . '%');
             }
         }
 

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -34,6 +34,10 @@ form.type.numeric.invalid: 数字で入力してください。
 form.member.repeated.confirm: 確認のためもう一度入力してください
 form.type.graph.invalid: 半角英数字で入力してください。
 
+form.type.name.firstname.nothasspace: お名前(名)にスペース、タブ、改行は含めないで下さい。
+form.type.name.lastname.nothasspace: お名前(性)にスペース、タブ、改行は含めないで下さい。
+form.type.customer.company.nothasspace: 会社名にスペース、タブ、改行は含めないで下さい。
+
 cart.over.stock: |-
     選択された商品の在庫が不足しております。
     一度に在庫数を超える購入はできません。

--- a/tests/Eccube/Tests/Form/Type/KanaTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/KanaTypeTest.php
@@ -148,6 +148,54 @@ class KanaTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->form->isValid());
     }
 
+    public function testinvaliddata_kana01_haswhitespaceEn()
+    {
+        $data = array(
+            'kana' => array(
+                'kana01' => 'ホゲ ホゲ',
+                'kana02' => 'フガフガ',
+            ));
+
+        $this->form->submit($data);
+        $this->assertfalse($this->form->isvalid());
+    }
+
+    public function testinvaliddata_kana02_haswhitespaceEn()
+    {
+        $data = array(
+            'kana' => array(
+                'kana01' => 'ホゲホゲ',
+                'kana02' => 'フガ フガ',
+            ));
+
+        $this->form->submit($data);
+        $this->assertfalse($this->form->isvalid());
+    }
+
+    public function testinvaliddata_kana01_haswhitespaceJa()
+    {
+        $data = array(
+            'kana' => array(
+                'kana01' => 'ホゲ　ホゲ',
+                'kana02' => 'フガフガ',
+            ));
+
+        $this->form->submit($data);
+        $this->assertfalse($this->form->isvalid());
+    }
+
+    public function testinvaliddata_kana02_haswhitespaceJa()
+    {
+        $data = array(
+            'kana' => array(
+                'kana01' => 'ホゲホゲ',
+                'kana02' => 'フガ　フガ',
+            ));
+
+        $this->form->submit($data);
+        $this->assertfalse($this->form->isvalid());
+    }
+
     /**
      * ひらがな入力されてもカタカナで返す
      */

--- a/tests/Eccube/Tests/Form/Type/NameTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/NameTypeTest.php
@@ -96,4 +96,52 @@ class NameTypeTest extends \PHPUnit_Framework_TestCase
         $this->form->submit($data);
         $this->assertFalse($this->form->isValid());
     }
+
+    public function testInvalidData_Name01_HasWhiteSpaceEn()
+    {
+        $data = array(
+            'name' => array(
+                'name01' => 'hoge hoge',
+                'name02' => 'にゅうりょく',
+            ));
+
+        $this->form->submit($data);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidData_Name02_HasWhiteSpaceEn()
+    {
+        $data = array(
+            'name' => array(
+                'name01' => 'にゅうりょく',
+                'name02' => 'hoge hoge',
+            ));
+
+        $this->form->submit($data);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidData_Name01_HasWhiteSpaceJa()
+    {
+        $data = array(
+            'name' => array(
+                'name01' => 'hoge　hoge',
+                'name02' => 'にゅうりょく',
+            ));
+
+        $this->form->submit($data);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidData_Name02_HasWhiteSpaceJa()
+    {
+        $data = array(
+            'name' => array(
+                'name01' => 'にゅうりょく',
+                'name02' => 'hoge　hoge',
+            ));
+
+        $this->form->submit($data);
+        $this->assertFalse($this->form->isValid());
+    }
 }

--- a/tests/Eccube/Tests/Repository/CustomerRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/CustomerRepositoryGetQueryBuilderBySearchDataTest.php
@@ -129,6 +129,52 @@ class CustomerRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
 
     }
 
+    public function testMultiWithNameHasSpaceEn()
+    {
+        $this->Customer->setName01('姓');
+        $this->Customer->setName02('名');
+        $this->app['orm.em']->flush();
+
+        $this->searchData = array(
+            'multi' => '姓 名'
+        );
+
+        $this->scenario();
+
+        $this->assertEquals(1, count($this->Results));
+
+        $this->expected = '姓';
+        $this->actual = $this->Results[0]->getName01();
+        $this->verify();
+        $this->expected = '名';
+        $this->actual = $this->Results[0]->getName02();
+        $this->verify();
+
+    }
+
+    public function testMultiWithNameHasSpaceJa()
+    {
+        $this->Customer->setName01('姓');
+        $this->Customer->setName02('名');
+        $this->app['orm.em']->flush();
+
+        $this->searchData = array(
+            'multi' => '姓　名'
+        );
+
+        $this->scenario();
+
+        $this->assertEquals(1, count($this->Results));
+
+        $this->expected = '姓';
+        $this->actual = $this->Results[0]->getName01();
+        $this->verify();
+        $this->expected = '名';
+        $this->actual = $this->Results[0]->getName02();
+        $this->verify();
+
+    }
+
     public function testMultiWithKana()
     {
         $this->Customer->setKana01('セイ')
@@ -143,6 +189,50 @@ class CustomerRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
 
         $this->assertEquals(1, count($this->Results));
 
+        $this->expected = 'メイ';
+        $this->actual = $this->Results[0]->getKana02();
+        $this->verify();
+    }
+
+    public function testMultiWithKanaHasWhiteSpaceEn()
+    {
+        $this->Customer->setKana01('セイ')
+            ->setKana02('メイ');
+        $this->app['orm.em']->flush();
+
+        $this->searchData = array(
+            'multi' => 'セイ メイ'
+        );
+
+        $this->scenario();
+
+        $this->assertEquals(1, count($this->Results));
+
+        $this->expected = 'セイ';
+        $this->actual = $this->Results[0]->getKana01();
+        $this->verify();
+        $this->expected = 'メイ';
+        $this->actual = $this->Results[0]->getKana02();
+        $this->verify();
+    }
+
+    public function testMultiWithKanaHasWhiteSpaceJa()
+    {
+        $this->Customer->setKana01('セイ')
+            ->setKana02('メイ');
+        $this->app['orm.em']->flush();
+
+        $this->searchData = array(
+            'multi' => 'セイ　メイ'
+        );
+
+        $this->scenario();
+
+        $this->assertEquals(1, count($this->Results));
+
+        $this->expected = 'セイ';
+        $this->actual = $this->Results[0]->getKana01();
+        $this->verify();
         $this->expected = 'メイ';
         $this->actual = $this->Results[0]->getKana02();
         $this->verify();


### PR DESCRIPTION
①会員マスター検索時ホワイトスペース除去処理追加
②新規会員登録時名前欄ホワイトスペースバリデート追加