### PR TITLE
refs #986 お届け先の複数指定時に商品個数が1つしかなければ配送先が設定できない不具合修正  

### DIFF
--- a/src/Eccube/Form/Type/ShippingMultipleItemType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleItemType.php
@@ -115,8 +115,13 @@ class ShippingMultipleItemType extends AbstractType
                 }
 
                 $quantity = 0;
-                foreach ($data->getShipmentItems() as $ShipmentItem) {
-                    $quantity += $ShipmentItem->getQuantity();
+                $Order = $data->getOrder();
+                $shippings = $Order->getShippings();
+                if (count($shippings) > 1) {
+                    // お届け先を複数に分割していた場合、登録されている個数を設定
+                    foreach ($data->getShipmentItems() as $ShipmentItem) {
+                        $quantity += $ShipmentItem->getQuantity();
+                    }
                 }
 
                 $form['quantity']->setData($quantity);

--- a/src/Eccube/Resource/template/default/Shopping/shipping_multiple.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping_multiple.twig
@@ -138,30 +138,26 @@ $(function() {
                             </div>
                         </div><!--/cart_item-->
 
-                        {% if itemvalue > 1 %}
-                            <div id="item{{ idx }}">
-                                {% for shipping in form.shipping_multiple[idx].shipping %}
-                                    <div id="item{{ idx }}-{{ loop.index0 }}" class="shipping_item item{{ idx }} form-inline" style="margin-bottom: 5px;">
-                                        <div class="form-group">
-                                            <label>お届け先</label>
-                                            {{ form_widget(shipping.customer_address, {'attr': {'class': 'shipping'}}) }}
-                                            {{ form_errors(shipping.customer_address) }}
-                                        </div>
-                                        <div class="form-group">
-                                            <label>数量</label>
-                                            {{ form_widget(shipping.quantity, {'attr': {'class': 'quantity'}}) }}
-                                            {{ form_errors(shipping.quantity) }}
-                                        </div>
-                                        <button type="button" class="btn btn-default btn-sm delete" data-itemidx="{{ idx }}-{{ loop.index0 }}" style="{% if loop.index0 == 0 %}display: none;{% endif %}">削除</button>
+                        <div id="item{{ idx }}">
+                            {% for shipping in form.shipping_multiple[idx].shipping %}
+                                <div id="item{{ idx }}-{{ loop.index0 }}" class="shipping_item item{{ idx }} form-inline" style="margin-bottom: 5px;">
+                                    <div class="form-group">
+                                        <label>お届け先</label>
+                                        {{ form_widget(shipping.customer_address, {'attr': {'class': 'shipping'}}) }}
+                                        {{ form_errors(shipping.customer_address) }}
                                     </div>
-                                {% endfor %}
-                            </div>
-                            <p>
-                                <button type="button" class="btn btn-default btn-sm add" data-idx="{{ idx }}">お届け先追加</button>
-                            </p>
-                        {% else %}
-                            数量が1のためお届け先の追加はできません。
-                        {% endif %}
+                                    <div class="form-group">
+                                        <label>数量</label>
+                                        {{ form_widget(shipping.quantity, {'attr': {'class': 'quantity'}}) }}
+                                        {{ form_errors(shipping.quantity) }}
+                                    </div>
+                                    <button type="button" class="btn btn-default btn-sm delete" data-itemidx="{{ idx }}-{{ loop.index0 }}" style="{% if loop.index0 == 0 %}display: none;{% endif %}">削除</button>
+                                </div>
+                            {% endfor %}
+                        </div>
+                        <p>
+                            <button type="button" class="btn btn-default btn-sm add" data-idx="{{ idx }}">お届け先追加</button>
+                        </p>
                     {% endfor %}
                     <div class="row no-padding">
                         <div class="btn_group col-sm-offset-4 col-sm-4">


### PR DESCRIPTION
#986 に関連してお届け先が複数に分割されていない場合、
お届け先の複数指定画面で表示する個数の初期値を0に修正