### PR TITLE
新着情報管理の修正

### DIFF
--- a/src/Eccube/Controller/Admin/Content/ContentsController.php
+++ b/src/Eccube/Controller/Admin/Content/ContentsController.php
@@ -43,7 +43,8 @@ class ContentsController extends NewsController
     }
 
     /**
-     * @param Application $app
+     * (non-PHPdoc)
+     * @see \Eccube\Controller\Admin\Content\NewsController::index()
      * @deprecated 3.1 delete. use NewsController
      */
     public function index(Application $app)
@@ -52,9 +53,8 @@ class ContentsController extends NewsController
     }
 
     /**
-     * @param Application $app
-     * @param Request $request
-     * @param integer $id
+     * (non-PHPdoc)
+     * @see \Eccube\Controller\Admin\Content\NewsController::edit()
      * @deprecated 3.1 delete. use NewsController
      */
     public function edit(Application $app, Request $request, $id = null)
@@ -63,9 +63,8 @@ class ContentsController extends NewsController
     }
 
     /**
-     * @param Application $app
-     * @param Request $request
-     * @param integer $id
+     * (non-PHPdoc)
+     * @see \Eccube\Controller\Admin\Content\NewsController::up()
      * @deprecated 3.1 delete. use NewsController
      */
     public function up(Application $app, Request $request, $id)
@@ -74,9 +73,8 @@ class ContentsController extends NewsController
     }
 
     /**
-     * @param Application $app
-     * @param Request $request
-     * @param integer $id
+     * (non-PHPdoc)
+     * @see \Eccube\Controller\Admin\Content\NewsController::down()
      * @deprecated 3.1 delete. use NewsController
      */
     public function down(Application $app, Request $request, $id)
@@ -85,9 +83,8 @@ class ContentsController extends NewsController
     }
 
     /**
-     * @param Application $app
-     * @param Request $request
-     * @param integer $id
+     * (non-PHPdoc)
+     * @see \Eccube\Controller\Admin\Content\NewsController::delete()
      * @deprecated 3.1 delete. use NewsController
      */
     public function delete(Application $app, Request $request, $id)

--- a/src/Eccube/Controller/Admin/Content/ContentsController.php
+++ b/src/Eccube/Controller/Admin/Content/ContentsController.php
@@ -29,130 +29,69 @@ use Eccube\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-class ContentsController extends AbstractController
+/**
+ * @deprecated 3.1 delete. use NewsController
+ */
+class ContentsController extends NewsController
 {
+    /**
+     * @deprecated 3.1 delete. use NewsController
+     */
     public function __construct()
     {
+        parent::__construct();
     }
 
+    /**
+     * @param Application $app
+     * @deprecated 3.1 delete. use NewsController
+     */
     public function index(Application $app)
     {
-        $NewsList = $app['eccube.repository.news']->findBy(array(), array('rank' => 'DESC'));
-
-        $form = $app->form()->getForm();
-
-        return $app->render('Content/index.twig', array(
-            'form' => $form->createView(),
-            'NewsList' => $NewsList,
-        ));
+        return parent::index($app);
     }
 
+    /**
+     * @param Application $app
+     * @param Request $request
+     * @param integer $id
+     * @deprecated 3.1 delete. use NewsController
+     */
     public function edit(Application $app, Request $request, $id = null)
     {
-        if ($id) {
-            $News = $app['eccube.repository.news']->find($id);
-            if (!$News) {
-                throw new NotFoundHttpException();
-            }
-            $News->setLinkMethod((bool) $News->getLinkMethod());
-        } else {
-            $News = new \Eccube\Entity\News();
-        }
-
-        $form = $app['form.factory']
-            ->createBuilder('admin_news', $News)
-            ->getForm();
-
-        if ('POST' === $request->getMethod()) {
-            $form->handleRequest($request);
-            if ($form->isValid()) {
-                $data = $form->getData();
-                if (empty($data['url'])) {
-                    $News->setLinkMethod(Constant::DISABLED);
-                }
-                $status = $app['eccube.repository.news']->save($News);
-                if ($status) {
-                    $app->addSuccess('admin.news.save.complete', 'admin');
-                    return $app->redirect($app->url('admin_content'));
-                } else {
-                    $app->addError('admin.news.save.error', 'admin');
-                }
-            }
-        }
-
-        return $app->render('Content/edit.twig', array(
-            'form' => $form->createView(),
-            'News' => $News,
-        ));
-
+        return parent::edit($app, $request, $id);
     }
 
+    /**
+     * @param Application $app
+     * @param Request $request
+     * @param integer $id
+     * @deprecated 3.1 delete. use NewsController
+     */
     public function up(Application $app, Request $request, $id)
     {
-        $this->isTokenValid($app);
-
-        $TargetNews = $app['eccube.repository.news']->find($id);
-
-        if (!$TargetNews) {
-            throw new NotFoundHttpException();
-        }
-
-        $status = false;
-        if ('PUT' === $request->getMethod()) {
-            $status = $app['eccube.repository.news']->up($TargetNews);
-        }
-
-        if ($status) {
-            $app->addSuccess('admin.news.up.complete', 'admin');
-        } else {
-            $app->addError('admin.news.up.error', 'admin');
-        }
-
-        return $app->redirect($app->url('admin_content'));
+        return parent::up($app, $request, $id);
     }
 
+    /**
+     * @param Application $app
+     * @param Request $request
+     * @param integer $id
+     * @deprecated 3.1 delete. use NewsController
+     */
     public function down(Application $app, Request $request, $id)
     {
-        $this->isTokenValid($app);
-
-        $TargetNews = $app['eccube.repository.news']->find($id);
-
-        if (!$TargetNews) {
-            throw new NotFoundHttpException();
-        }
-
-        $status = false;
-        if ('PUT' === $request->getMethod()) {
-            $status = $app['eccube.repository.news']->down($TargetNews);
-        }
-
-        if ($status) {
-            $app->addSuccess('admin.news.down.complete', 'admin');
-        } else {
-            $app->addError('admin.news.down.error', 'admin');
-        }
-
-        return $app->redirect($app->url('admin_content'));
+        return parent::down($app, $request, $id);
     }
 
+    /**
+     * @param Application $app
+     * @param Request $request
+     * @param integer $id
+     * @deprecated 3.1 delete. use NewsController
+     */
     public function delete(Application $app, Request $request, $id)
     {
-        $this->isTokenValid($app);
-
-        $TargetNews = $app['eccube.repository.news']->find($id);
-        if (!$TargetNews) {
-            throw new NotFoundHttpException();
-        }
-
-        $status = $app['eccube.repository.news']->delete($TargetNews);
-
-        if ($status) {
-            $app->addSuccess('admin.news.delete.complete', 'admin');
-        } else {
-            // fixme : キー名を英語にする
-            $app->addSuccess('admin.news.delete.error', 'admin');
-        }
-
-        return $app->redirect($app->url('admin_content'));
+        return parent::delete($app, $request, $id);
     }
 }

--- a/src/Eccube/Controller/Admin/Content/NewsController.php
+++ b/src/Eccube/Controller/Admin/Content/NewsController.php
@@ -60,7 +60,7 @@ class NewsController extends AbstractController
      */
     public function edit(Application $app, Request $request, $id = null)
     {
-        if ($id) {
+        if (!is_null($id)) {
             $News = $app['eccube.repository.news']->find($id);
             if (!$News) {
                 throw new NotFoundHttpException();
@@ -84,6 +84,7 @@ class NewsController extends AbstractController
                 $status = $app['eccube.repository.news']->save($News);
                 if ($status) {
                     $app->addSuccess('admin.news.save.complete', 'admin');
+
                     return $app->redirect($app->url('admin_content'));
                 } else {
                     $app->addError('admin.news.save.error', 'admin');

--- a/src/Eccube/Controller/Admin/Content/NewsController.php
+++ b/src/Eccube/Controller/Admin/Content/NewsController.php
@@ -1,0 +1,194 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Controller\Admin\Content;
+
+use Eccube\Application;
+use Eccube\Common\Constant;
+use Eccube\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class NewsController extends AbstractController
+{
+    /**
+     * 新着情報一覧を表示する。
+     *
+     * @param Application $app
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function index(Application $app)
+    {
+        $NewsList = $app['eccube.repository.news']->findBy(array(), array('rank' => 'DESC'));
+
+        $form = $app->form()->getForm();
+
+        return $app->render('Content/index.twig', array(
+            'form' => $form->createView(),
+            'NewsList' => $NewsList,
+        ));
+    }
+
+    /**
+     * 新着情報を登録・編集する。
+     *
+     * @param Application $app
+     * @param Request $request
+     * @param integer $id
+     * @throws NotFoundHttpException
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     */
+    public function edit(Application $app, Request $request, $id = null)
+    {
+        if ($id) {
+            $News = $app['eccube.repository.news']->find($id);
+            if (!$News) {
+                throw new NotFoundHttpException();
+            }
+            $News->setLinkMethod((bool) $News->getLinkMethod());
+        } else {
+            $News = new \Eccube\Entity\News();
+        }
+
+        $form = $app['form.factory']
+            ->createBuilder('admin_news', $News)
+            ->getForm();
+
+        if ('POST' === $request->getMethod()) {
+            $form->handleRequest($request);
+            if ($form->isValid()) {
+                $data = $form->getData();
+                if (empty($data['url'])) {
+                    $News->setLinkMethod(Constant::DISABLED);
+                }
+                $status = $app['eccube.repository.news']->save($News);
+                if ($status) {
+                    $app->addSuccess('admin.news.save.complete', 'admin');
+                    return $app->redirect($app->url('admin_content'));
+                } else {
+                    $app->addError('admin.news.save.error', 'admin');
+                }
+            }
+        }
+
+        return $app->render('Content/edit.twig', array(
+            'form' => $form->createView(),
+            'News' => $News,
+        ));
+    }
+
+    /**
+     * 指定した新着情報の表示順を1つ上げる。
+     *
+     * @param Application $app
+     * @param Request $request
+     * @param integer $id
+     * @throws NotFoundHttpException
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    public function up(Application $app, Request $request, $id)
+    {
+        $this->isTokenValid($app);
+
+        $TargetNews = $app['eccube.repository.news']->find($id);
+
+        if (!$TargetNews) {
+            throw new NotFoundHttpException();
+        }
+
+        $status = false;
+        if ('PUT' === $request->getMethod()) {
+            $status = $app['eccube.repository.news']->up($TargetNews);
+        }
+
+        if ($status) {
+            $app->addSuccess('admin.news.up.complete', 'admin');
+        } else {
+            $app->addError('admin.news.up.error', 'admin');
+        }
+
+        return $app->redirect($app->url('admin_content_news'));
+    }
+
+    /**
+     * 指定した新着情報の表示順を1つ下げる。
+     *
+     * @param Application $app
+     * @param Request $request
+     * @param integer $id
+     * @throws NotFoundHttpException
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    public function down(Application $app, Request $request, $id)
+    {
+        $this->isTokenValid($app);
+
+        $TargetNews = $app['eccube.repository.news']->find($id);
+
+        if (!$TargetNews) {
+            throw new NotFoundHttpException();
+        }
+
+        $status = false;
+        if ('PUT' === $request->getMethod()) {
+            $status = $app['eccube.repository.news']->down($TargetNews);
+        }
+
+        if ($status) {
+            $app->addSuccess('admin.news.down.complete', 'admin');
+        } else {
+            $app->addError('admin.news.down.error', 'admin');
+        }
+
+        return $app->redirect($app->url('admin_content_news'));
+    }
+
+    /**
+     * 指定した新着情報を削除する。
+     *
+     * @param Application $app
+     * @param Request $request
+     * @param integer $id
+     * @throws NotFoundHttpException
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    public function delete(Application $app, Request $request, $id)
+    {
+        $this->isTokenValid($app);
+
+        $TargetNews = $app['eccube.repository.news']->find($id);
+        if (!$TargetNews) {
+            throw new NotFoundHttpException();
+        }
+
+        $status = $app['eccube.repository.news']->delete($TargetNews);
+
+        if ($status) {
+            $app->addSuccess('admin.news.delete.complete', 'admin');
+        } else {
+            $app->addSuccess('admin.news.delete.error', 'admin');
+        }
+
+        return $app->redirect($app->url('admin_content_news'));
+    }
+}

--- a/src/Eccube/Controller/Admin/Content/NewsController.php
+++ b/src/Eccube/Controller/Admin/Content/NewsController.php
@@ -43,7 +43,7 @@ class NewsController extends AbstractController
 
         $form = $app->form()->getForm();
 
-        return $app->render('Content/index.twig', array(
+        return $app->render('Content/news.twig', array(
             'form' => $form->createView(),
             'NewsList' => $NewsList,
         ));
@@ -91,7 +91,7 @@ class NewsController extends AbstractController
             }
         }
 
-        return $app->render('Content/edit.twig', array(
+        return $app->render('Content/news_edit.twig', array(
             'form' => $form->createView(),
             'News' => $News,
         ));

--- a/src/Eccube/ControllerProvider/AdminControllerProvider.php
+++ b/src/Eccube/ControllerProvider/AdminControllerProvider.php
@@ -111,12 +111,20 @@ class AdminControllerProvider implements ControllerProviderInterface
         $c->match('/order/status/{statusId}', '\Eccube\Controller\Admin\Order\StatusController::index')->bind('admin_order_status');
 
         // content
+        // deprecated /content/ 3.1 delete. use /content/news
         $c->match('/content/', '\Eccube\Controller\Admin\Content\ContentsController::index')->bind('admin_content');
         $c->match('/content/new', '\Eccube\Controller\Admin\Content\ContentsController::edit')->bind('admin_content_new');
         $c->match('/content/{id}/edit', '\Eccube\Controller\Admin\Content\ContentsController::edit')->assert('id', '\d+')->bind('admin_content_edit');
         $c->delete('/content/{id}/delete', '\Eccube\Controller\Admin\Content\ContentsController::delete')->assert('id', '\d+')->bind('admin_content_delete');
         $c->put('/content/{id}/up', '\Eccube\Controller\Admin\Content\ContentsController::up')->assert('id', '\d+')->bind('admin_content_up');
         $c->put('/content/{id}/down', '\Eccube\Controller\Admin\Content\ContentsController::down')->assert('id', '\d+')->bind('admin_content_down');
+
+        $c->match('/content/news', '\Eccube\Controller\Admin\Content\NewsController::index')->bind('admin_content_news');
+        $c->match('/content/news/new', '\Eccube\Controller\Admin\Content\NewsController::edit')->bind('admin_content_news_new');
+        $c->match('/content/news/{id}/edit', '\Eccube\Controller\Admin\Content\NewsController::edit')->assert('id', '\d+')->bind('admin_content_news_edit');
+        $c->delete('/content/news/{id}/delete', '\Eccube\Controller\Admin\Content\NewsController::delete')->assert('id', '\d+')->bind('admin_content_news_delete');
+        $c->put('/content/news/{id}/up', '\Eccube\Controller\Admin\Content\NewsController::up')->assert('id', '\d+')->bind('admin_content_news_up');
+        $c->put('/content/news/{id}/down', '\Eccube\Controller\Admin\Content\NewsController::down')->assert('id', '\d+')->bind('admin_content_news_down');
 
         $c->match('/content/file_manager', '\Eccube\Controller\Admin\Content\FileController::index')->bind('admin_content_file');
         $c->match('/content/file_view', '\Eccube\Controller\Admin\Content\FileController::view')->bind('admin_content_file_view');

--- a/src/Eccube/Form/Type/Admin/NewsType.php
+++ b/src/Eccube/Form/Type/Admin/NewsType.php
@@ -55,7 +55,7 @@ class NewsType extends AbstractType
                     new Assert\NotBlank(),
                 ),
             ))
-            ->add('title', 'textarea', array(
+            ->add('title', 'text', array(
                 'label' => 'タイトル',
                 'required' => true,
                 'constraints' => array(

--- a/src/Eccube/Form/Type/Admin/NewsType.php
+++ b/src/Eccube/Form/Type/Admin/NewsType.php
@@ -51,6 +51,9 @@ class NewsType extends AbstractType
                 'widget' => 'single_text',
                 'format' => 'yyyy-MM-dd',
                 'empty_value' => array('year' => '----', 'month' => '--', 'day' => '--'),
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                ),
             ))
             ->add('title', 'textarea', array(
                 'label' => 'タイトル',

--- a/src/Eccube/Form/Type/Admin/NewsType.php
+++ b/src/Eccube/Form/Type/Admin/NewsType.php
@@ -21,14 +21,13 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-
 namespace Eccube\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class NewsType extends AbstractType
 {
@@ -44,7 +43,6 @@ class NewsType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-
         $builder
             ->add('date', 'date', array(
                 'label' => '日付',
@@ -59,7 +57,7 @@ class NewsType extends AbstractType
                 'required' => true,
                 'constraints' => array(
                     new Assert\NotBlank(),
-                    new Assert\Length(array('max' => $this->config['ltext_len'])),
+                    new Assert\Length(array('max' => $this->config['mtext_len'])),
                 ),
             ))
             ->add('url', 'text', array(
@@ -77,29 +75,25 @@ class NewsType extends AbstractType
             ))
             ->add('comment', 'textarea', array(
                 'label' => '本文',
-                'required' => true,
+                'required' => false,
                 'constraints' => array(
-                    new Assert\NotBlank(),
                     new Assert\Length(array('max' => $this->config['ltext_len'])),
                 ),
             ))
             ->add('select', 'hidden', array(
                 'data' => '0',
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber())
-        ;
-
+            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Eccube\Entity\News',
         ));
-
     }
 
     /**

--- a/src/Eccube/Resource/config/nav.yml.dist
+++ b/src/Eccube/Resource/config/nav.yml.dist
@@ -51,7 +51,7 @@
   child:
       - id: news
         name: 新着情報管理
-        url : admin_content
+        url : admin_content_news
       - id: file
         name: ファイル管理
         url: admin_content_file

--- a/src/Eccube/Resource/template/admin/Content/news.twig
+++ b/src/Eccube/Resource/template/admin/Content/news.twig
@@ -61,7 +61,7 @@ function changeAction(action) {
                                     {% for News in NewsList %}
                                         <tr>
                                             <td>{{ loop.index }}</td>
-                                            <td>{{ News.date|date("Y.m.d") }}</td>
+                                            <td>{{ News.date|date("Y/m/d") }}</td>
                                             <td>{{ News.title }}</td>
                                             <td class="icon_edit">
                                                 <div class="dropdown">

--- a/src/Eccube/Resource/template/admin/Content/news.twig
+++ b/src/Eccube/Resource/template/admin/Content/news.twig
@@ -67,16 +67,16 @@ function changeAction(action) {
                                                 <div class="dropdown">
                                                     <a class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
                                                     <ul class="dropdown-menu dropdown-menu-right">
-                                                        <li><a href="{{ url('admin_content_edit', { 'id' : News.id }) }}" >編集</a></li>
-                                                        <li><a href="{{ url('admin_content_delete', {id: News.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="この新着情報を削除してもよろしいですか？">削除</a></li>
+                                                        <li><a href="{{ url('admin_content_news_edit', { 'id' : News.id }) }}" >編集</a></li>
+                                                        <li><a href="{{ url('admin_content_news_delete', {id: News.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="この新着情報を削除してもよろしいですか？">削除</a></li>
                                                         {% if loop.first == false %}
                                                             <li>
-                                                                <a href="{{ url('admin_content_up', {id: News.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">上へ</a>
+                                                                <a href="{{ url('admin_content_news_up', {id: News.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">上へ</a>
                                                             </li>
                                                         {% endif %}
                                                         {% if loop.last == false %}
                                                             <li>
-                                                                <a href="{{ url('admin_content_down', {id: News.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">下へ</a>
+                                                                <a href="{{ url('admin_content_news_down', {id: News.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">下へ</a>
                                                             </li>
                                                         {% endif %}
 
@@ -94,7 +94,7 @@ function changeAction(action) {
             </div><!-- /.box -->
             <div class="row">
                 <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
-                    <a href="{{ url('admin_content_new') }}" class="btn btn-primary btn-block btn-lg">新規登録</a>
+                    <a href="{{ url('admin_content_news_new') }}" class="btn btn-primary btn-block btn-lg">新規登録</a>
                 </div>
             </div>
 

--- a/src/Eccube/Resource/template/admin/Content/news_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/news_edit.twig
@@ -69,6 +69,7 @@ $(function() {
                             {{ form_label(form.date) }}
                             <div class="col-sm-10">
                                 {{ form_widget(form.date, {'attr': {'class': 'input_cal'}}) }}
+                                {{ form_errors(form.date) }}
                             </div>
                         </div>
 

--- a/src/Eccube/Resource/template/admin/Content/news_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/news_edit.twig
@@ -88,7 +88,7 @@ $(function() {
 
             <div class="row">
                 <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
-                    <p><a href="{{ url('admin_content') }}">戻る</a></p>
+                    <p><a href="{{ url('admin_content_news') }}">戻る</a></p>
                 </div>
             </div>
 

--- a/src/Eccube/Resource/template/default/Block/news.twig
+++ b/src/Eccube/Resource/template/default/Block/news.twig
@@ -19,32 +19,31 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #}
-        <div class="col-sm-9 news_contents">
-            <!-- ▼news_area▼ -->
-            <div id="news_area">
-                <h2 class="heading01">新着情報</h2>
-                <div class="accordion">
-                    <div class="newslist">
+<div class="col-sm-9 news_contents">
+    <div id="news_area">
+        <h2 class="heading01">新着情報</h2>
+        <div class="accordion">
+            <div class="newslist">
 
-                        {% for News in NewsList %}
-                        <dl>
-                            <dt>
-                                <span class="date">{{ News.date|date("Y.m.d") }}</span>
-                                <span class="news_title">
-                                    {{ News.title }}
-                                </span>
-                                <span class="angle-circle"><svg class="cb cb-angle-down"><use xlink:href="#cb-angle-down" /></svg></span>
-                            </dt>
-                            <dd>{{ News.comment }}
-                            {% if News.url %}<br><a href="{{ News.url }}" {% if News.link_method == '1' %}target="_blank"{% endif %}>
-                            詳しくはこちら
-                            </a>{% endif %}
-                            </dd>
-                        </dl>
-                        {% endfor %}
+                {% for News in NewsList %}
+                <dl>
+                    <dt>
+                        <span class="date">{{ News.date|date("Y/m/d") }}</span>
+                        <span class="news_title">
+                            {{ News.title }}
+                        </span>
+                        <span class="angle-circle"><svg class="cb cb-angle-down"><use xlink:href="#cb-angle-down" /></svg></span>
+                    </dt>
+                    <dd>{{ News.comment | nl2br }}
+                        {% if News.url %}<br>
+                        <a href="{{ News.url }}" {% if News.link_method == '1' %}target="_blank"{% endif %}>
+                        詳しくはこちら
+                        </a>{% endif %}
+                    </dd>
+                </dl>
+                {% endfor %}
 
-                    </div>
-                </div>
             </div>
-            <!-- ▲news_area▲ -->
         </div>
+    </div>
+</div>

--- a/src/Eccube/Resource/template/default/Block/news.twig
+++ b/src/Eccube/Resource/template/default/Block/news.twig
@@ -30,16 +30,20 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     <dt>
                         <span class="date">{{ News.date|date("Y/m/d") }}</span>
                         <span class="news_title">
-                            {{ News.title }}
+                            {{ News.title | nl2br }}
                         </span>
+                        {% if News.comment or News.url %}
                         <span class="angle-circle"><svg class="cb cb-angle-down"><use xlink:href="#cb-angle-down" /></svg></span>
+                        {% endif %}
                     </dt>
+                    {% if News.comment or News.url %}
                     <dd>{{ News.comment | nl2br }}
                         {% if News.url %}<br>
                         <a href="{{ News.url }}" {% if News.link_method == '1' %}target="_blank"{% endif %}>
                         詳しくはこちら
                         </a>{% endif %}
                     </dd>
+                    {% endif %}
                 </dl>
                 {% endfor %}
 

--- a/src/Eccube/Resource/template/default/Block/news.twig
+++ b/src/Eccube/Resource/template/default/Block/news.twig
@@ -30,7 +30,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     <dt>
                         <span class="date">{{ News.date|date("Y/m/d") }}</span>
                         <span class="news_title">
-                            {{ News.title | nl2br }}
+                            {{ News.title }}
                         </span>
                         {% if News.comment or News.url %}
                         <span class="angle-circle"><svg class="cb cb-angle-down"><use xlink:href="#cb-angle-down" /></svg></span>

--- a/tests/Eccube/Tests/Web/Admin/Content/NewsControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/NewsControllerTest.php
@@ -138,11 +138,13 @@ class NewsControllerTest extends AbstractAdminWebTestCase
     {
         $TestNews = new \Eccube\Entity\News();
         $TestNews
-            ->setCreateDate(new \DateTime())
+            ->setDate(new \DateTime())
             ->setTitle('テストタイトル')
             ->setComment('テスト内容')
             ->setUrl('http://example.com/')
             ->setRank(100)
+            ->setSelect(0)
+            ->setLinkMethod(0)
             ->setDelFlg(false)
             ->setCreator($TestCreator);
 

--- a/tests/Eccube/Tests/Web/Admin/Content/NewsControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/NewsControllerTest.php
@@ -1,0 +1,151 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Tests\Web\Admin\Content;
+
+use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+
+class NewsControllerTest extends AbstractAdminWebTestCase
+{
+
+    public function testRoutingAdminContentNews()
+    {
+//         self::markTestSkipped();
+
+        $this->client->request('GET', $this->app->url('admin_content_news'));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+    }
+
+    public function testRoutingAdminContentNewsNew()
+    {
+//         self::markTestSkipped();
+
+        $this->client->request('GET', $this->app->url('admin_content_news_new'));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+    }
+
+    public function testRoutingAdminContentNewsEdit()
+    {
+//         self::markTestSkipped();
+
+        $this->client->request('GET',
+            $this->app->url(
+                'admin_content_news_edit',
+                array('id' => 1)
+            )
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+    }
+
+
+    public function testRoutingAdminContentNewsDelete()
+    {
+//         self::markTestSkipped();
+
+        $redirectUrl = $this->app->url('admin_content_news');
+
+        $this->client->request('DELETE',
+            $this->app->url('admin_content_news_delete', array('id' => 1))
+        );
+
+        $actual = $this->client->getResponse()->isRedirect($redirectUrl);
+
+        $this->assertSame(true, $actual);
+    }
+
+    public function testRoutingAdminContentNewsUp()
+    {
+//         self::markTestSkipped();
+
+        // before
+        $TestCreator = $this->app['orm.em']
+            ->getRepository('\Eccube\Entity\Member')
+            ->find(1);
+        $TestNews = $this->newTestNews($TestCreator);
+        $this->app['orm.em']->persist($TestNews);
+        $this->app['orm.em']->flush();
+
+        $test_news_id = $this->app['eccube.repository.news']
+            ->findOneBy(array(
+                'title' => $TestNews->getTitle()
+            ))
+            ->getId();
+
+        // main
+        $redirectUrl = $this->app->url('admin_content_news');
+        $this->client->request('PUT',
+            $this->app->url('admin_content_news_up', array('id' => $test_news_id))
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($redirectUrl));
+
+        // after
+        $this->app['orm.em']->remove($TestNews);
+        $this->app['orm.em']->flush();
+    }
+
+    public function testRoutingAdminContentNewsDown()
+    {
+//         self::markTestSkipped();
+
+        // before
+        $TestCreator = $this->app['orm.em']
+            ->getRepository('\Eccube\Entity\Member')
+            ->find(1);
+        $TestNews = $this->newTestNews($TestCreator);
+        $this->app['orm.em']->persist($TestNews);
+        $this->app['orm.em']->flush();
+
+        $test_news_id = $this->app['eccube.repository.news']
+            ->findOneBy(array(
+                'title' => $TestNews->getTitle()
+            ))
+            ->getId();
+
+        // main
+        $redirectUrl = $this->app->url('admin_content_news');
+        $this->client->request('PUT',
+            $this->app->url('admin_content_news_down', array('id' => $test_news_id))
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($redirectUrl));
+
+        // after
+        $this->app['orm.em']->remove($TestNews);
+        $this->app['orm.em']->flush();
+    }
+
+    private function newTestNews($TestCreator)
+    {
+        $TestNews = new \Eccube\Entity\News();
+        $TestNews
+            ->setCreateDate(new \DateTime())
+            ->setTitle('テストタイトル')
+            ->setComment('テスト内容')
+            ->setUrl('http://example.com/')
+            ->setRank(100)
+            ->setDelFlg(false)
+            ->setCreator($TestCreator);
+
+        return $TestNews;
+    }
+}

--- a/tests/Eccube/Tests/Web/Admin/Content/NewsControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/NewsControllerTest.php
@@ -97,7 +97,8 @@ class NewsControllerTest extends AbstractAdminWebTestCase
         $TestCreator = $this->findMember(1);
         $TestNews1 = $this->newTestNews($TestCreator, 1);
         $TestNews2 = $this->newTestNews($TestCreator, 2);
-        $this->insertTestNews($TestNews);
+        $this->insertTestNews($TestNews1);
+        $this->insertTestNews($TestNews2);
 
         $test_news_id = $this->getTestNewsId($TestNews1);
 
@@ -121,7 +122,8 @@ class NewsControllerTest extends AbstractAdminWebTestCase
         $TestCreator = $this->findMember(1);
         $TestNews1 = $this->newTestNews($TestCreator, 1);
         $TestNews2 = $this->newTestNews($TestCreator, 2);
-        $this->insertTestNews($TestNews);
+        $this->insertTestNews($TestNews1);
+        $this->insertTestNews($TestNews2);
 
         $test_news_id = $this->getTestNewsId($TestNews2);
 


### PR DESCRIPTION
命名が他と異なり気持ち悪いので、以下の点を修正。
* 命名を<code>Contents</code>から<code>News</code>へ変更
* URL、bind なども<code>Contents</code>から<code>News</code>へ変更
* 日付を必須に修正
* タイトルの文字数制限を<code>ltext_len</code>から<code>mtext_len</code>へ変更
* 内容を非必須に修正
* twig のタイトル、内容に<code>nl2br</code>を設定
* twig で内容が空なら内容を表示しないように修正。

以下、確認いただきたい内容です。
* 日付を必須としています（<code>required => true</code>だったため）が、これでよいですか？
* タイトルが<code>textarea</code>となっていますが、<code>text</code>ではなくてよいですか？
