### PR TITLE
管理画面の会員登録フォームのバリデーションを調整 #933

### DIFF
--- a/src/Eccube/Controller/Admin/Customer/CustomerEditController.php
+++ b/src/Eccube/Controller/Admin/Customer/CustomerEditController.php
@@ -108,6 +108,8 @@ class CustomerEditController extends AbstractController
                 return $app->redirect($app->url('admin_customer_edit', array(
                     'id' => $Customer->getId(),
                 )));
+            } else { 
+                $app->addError('admin.customer.save.failed','admin');
             }
         }
 

--- a/src/Eccube/Form/Type/TelType.php
+++ b/src/Eccube/Form/Type/TelType.php
@@ -34,7 +34,7 @@ class TelType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function __construct($config = array('tel_len' => 5))
+    public function __construct($config = array('tel_len' => 5, 'tel_len_min' => 2))
     {
         $this->config = $config;
     }

--- a/src/Eccube/Form/Type/TelType.php
+++ b/src/Eccube/Form/Type/TelType.php
@@ -115,19 +115,19 @@ class TelType extends AbstractType
             'tel01_options' => array(
                 'constraints' => array(
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')), //todo  messageは汎用的に出来ないものか?
-                    new Assert\Length(array('max' => $this->config['tel_len'])),
+                    new Assert\Length(array('max' => $this->config['tel_len'], 'min' => $this->config['tel_len_min'])),
                 ),
             ),
             'tel02_options' => array(
                 'constraints' => array(
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')),
-                    new Assert\Length(array('max' => $this->config['tel_len'])),
+                    new Assert\Length(array('max' => $this->config['tel_len'], 'min' => $this->config['tel_len_min'])),
                 ),
             ),
             'tel03_options' => array(
                 'constraints' => array(
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')),
-                    new Assert\Length(array('max' => $this->config['tel_len'])),
+                    new Assert\Length(array('max' => $this->config['tel_len'], 'min' => $this->config['tel_len_min'])),
                 ),
             ),
             'tel01_name' => '',

--- a/src/Eccube/Resource/config/constant.yml.dist
+++ b/src/Eccube/Resource/config/constant.yml.dist
@@ -213,6 +213,7 @@ start_birth_year: 1970
 stext_len: 50
 tax_rule_priority: 'product_id,product_class_id,pref_id,country_id'
 tel_len: 5
+tel_len_min: 2
 tel_item_len: 12
 template_admin_realdir: /PATH/TO/WEB_ROOT/data/template/admin/
 template_name: default

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -101,6 +101,7 @@ admin.product.csv_import.save.complete: 商品登録CSVファイルをアップ�
 admin.category.csv_import.save.complete: カテゴリ登録CSVファイルをアップロードしました。
 
 admin.customer.save.complete: 会員情報を保存しました。
+admin.customer.save.failed: 会員情報を保存できませんでした。
 admin.customer.delete.complete: 会員情報を削除しました。
 admin.customer.resend.complete: 仮会員登録メールを送信しました。
 

--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -94,6 +94,8 @@
                             <div class="col-sm-9 col-lg-10 input_zip form-inline">
                                 〒{{ form_widget(form.zip.zip01) }}-{{ form_widget(form.zip.zip02) }}
                                 {{ form_errors(form.zip) }}
+                                {{ form_errors(form.zip.zip01) }}
+                                {{ form_errors(form.zip.zip02) }}
                                 <span><button type="button" id="zip-search" class="btn btn-default btn-sm">郵便番号から自動入力</button></span>
                             </div>
                         </div>

--- a/tests/Eccube/Tests/Form/Type/FaxTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/FaxTypeTest.php
@@ -82,7 +82,7 @@ class FaxTypeTest extends \PHPUnit_Framework_TestCase
                 'data' => array(
                     'tel' => array(
                         'tel01' => '01245',
-                        'tel02' => '6',
+                        'tel02' => '60',
                         'tel03' => '7890',
                     ),
                 ),
@@ -177,6 +177,30 @@ class FaxTypeTest extends \PHPUnit_Framework_TestCase
     public function testInvalidTel03_LengthMax()
     {
         $this->formData['tel']['tel03'] = '12345678';
+        $this->form->submit($this->formData);
+
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidTel01_LengthMin()
+    {
+        $this->formData['tel']['tel01'] = '1';
+        $this->form->submit($this->formData);
+
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidTel02_LengthMin()
+    {
+        $this->formData['tel']['tel02'] = '1';
+        $this->form->submit($this->formData);
+
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidTel03_LengthMin()
+    {
+        $this->formData['tel']['tel03'] = '1';
         $this->form->submit($this->formData);
 
         $this->assertFalse($this->form->isValid());

--- a/tests/Eccube/Tests/Form/Type/TelTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/TelTypeTest.php
@@ -31,7 +31,7 @@ class TelTypeTest extends \PHPUnit_Framework_TestCase
     /** @var \Symfony\Component\Form\FormInterface */
     protected $form;
 
-    public $config = array('tel_len' => 5);
+    public $config = array('tel_len' => 5, 'tel_len_min' => 2);
 
     /** @var array デフォルト値（正常系）を設定 */
     protected $formData = array(

--- a/tests/Eccube/Tests/Form/Type/TelTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/TelTypeTest.php
@@ -84,7 +84,7 @@ class TelTypeTest extends \PHPUnit_Framework_TestCase
                 'data' => array(
                     'tel' => array(
                         'tel01' => '01245',
-                        'tel02' => '6',
+                        'tel02' => '60',
                         'tel03' => '7890',
                     ),
                 ),
@@ -179,6 +179,30 @@ class TelTypeTest extends \PHPUnit_Framework_TestCase
     public function testInvalidTel03_LengthMax()
     {
         $this->formData['tel']['tel03'] = '12345678';
+        $this->form->submit($this->formData);
+
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidTel01_LengthMin()
+    {
+        $this->formData['tel']['tel01'] = '1';
+        $this->form->submit($this->formData);
+
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidTel02_LengthMin()
+    {
+        $this->formData['tel']['tel02'] = '1';
+        $this->form->submit($this->formData);
+
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidTel03_LengthMin()
+    {
+        $this->formData['tel']['tel03'] = '1';
         $this->form->submit($this->formData);
 
         $this->assertFalse($this->form->isValid());


### PR DESCRIPTION
電話番号／FAX番号のバリデーション調整
郵便番号のエラーメッセージ表示調整
会員登録フォームでエラー時に「登録できなかった」旨のエラーメッセージ表示