### PR TITLE
refs 874 1016 ブロックの保存先をテンプレートに合わせて保存されるように修正、adminが読み込むテンプレート先を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ composer.phar
 /reports/*
 .idea
 *.php~
+/html/user_data/*

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -303,13 +303,9 @@ class Application extends ApplicationTrait
                     $cacheBaseDir = __DIR__.'/../../app/cache/twig/production/';
                 }
 
-                if (file_exists($app['config']['user_data_realdir'])){
-                    $paths[] = $app['config']['user_data_realdir'];
-                }
-
                 if (strpos($app['request']->getPathInfo(), '/' . trim($app['config']['admin_route'], '/')) === 0) {
-                    if (file_exists($app['config']['template_admin_html_realdir'])) {
-                        $paths[] = $app['config']['template_admin_html_realdir'];
+                    if (file_exists(__DIR__ . '/../../app/template/admin')) {
+                        $paths[] = __DIR__ . '/../../app/template/admin';
                     }
                     $paths[] = $app['config']['template_admin_realdir'];
                     $paths[] = __DIR__.'/../../app/Plugin';

--- a/src/Eccube/Controller/Admin/Content/BlockController.php
+++ b/src/Eccube/Controller/Admin/Content/BlockController.php
@@ -126,6 +126,7 @@ class BlockController extends AbstractController
         $Block = $app['eccube.repository.block']->findOrCreate($id, $DeviceType);
 
         // ユーザーが作ったブロックのみ削除する
+        // テンプレートが変更されていた場合、DBからはブロック削除されるがtwigファイルは残る
         if ($Block->getDeletableFlg() > 0) {
             $tplDir = $app['config']['block_realdir'];
             $file = $tplDir . '/' . $Block->getFileName() . '.twig';

--- a/src/Eccube/Controller/Admin/Store/TemplateController.php
+++ b/src/Eccube/Controller/Admin/Store/TemplateController.php
@@ -73,6 +73,7 @@ class TemplateController extends AbstractController
                 $config['template_realdir'] = $config['root_dir'] . '/app/template/' . $templateCode;
                 $config['template_html_realdir'] = $config['root_dir'] . '/html/template/' . $templateCode;
                 $config['front_urlpath'] = $config['root_urlpath'] . '/template/' . $templateCode;
+                $config['block_realdir'] =$config['template_realdir'] . '/Block';
 
                 file_put_contents($file, Yaml::dump($config));
 


### PR DESCRIPTION
#1016 で発生した不具合も合わせて修正。
/html/user_data 配下はgit管理対象外とする。