### PR TITLE
消費税率優先順位に関するbug修正【問題アリ】 #1005

### DIFF
--- a/src/Eccube/Repository/TaxRuleRepository.php
+++ b/src/Eccube/Repository/TaxRuleRepository.php
@@ -101,6 +101,10 @@ class TaxRuleRepository extends EntityRepository
         }
         if ($ProductClass instanceof \Eccube\Entity\ProductClass) {
             $productClassId = $ProductClass->getId();
+        } else if ($ProductClass instanceof \Eccube\Entity\ShipmentItem) {
+            // 注文処理時、TaxRuleEventSubscriber::prePersistからの呼び出しで、
+            // $ProductClassにShipmentItemがsetされて呼び出されるのに対応
+            $productClassId = '';
         } elseif ($ProductClass) {
             $productClassId = $ProductClass;
         } else {
@@ -157,7 +161,7 @@ class TaxRuleRepository extends EntityRepository
         }
 
         // ProductClass
-        if ($ProductClass) {
+        if ($ProductClass && $productClassId!='') {
             $qb->andWhere('t.ProductClass IS NULL OR t.ProductClass = :ProductClass');
             $parameters['ProductClass'] = $ProductClass;
         } else {
@@ -177,20 +181,32 @@ class TaxRuleRepository extends EntityRepository
             $priorityKeys[] = preg_replace('/_id\z/', '', $key);
         }
 
+        $ranked = false;
         foreach ($TaxRules as $TaxRule) {
             $rank = 0;
             foreach ($priorityKeys as $index => $key) {
                 if ($TaxRule[$key]) {
                     // 配列の数値添字を重みとして利用する
                     $rank += 1 << ($index + 1);
+                    $ranked = true;
                 }
             }
             $TaxRule->setRank($rank);
         }
 
-        usort($TaxRules, function ($a, $b) {
-            return strcmp($a->getRank(), $b->getRank());
-        });
+        if ($ranked) {
+            usort($TaxRules, function ($a, $b) {
+                if ($a->getRank() == $b->getRank()) {
+                    if ($a->getApplyDate() > $b->getApplyDate()) {
+                        return -1;
+                    } else {
+                        return 1;
+                    }
+                    return 0;
+                }
+                return ($a->getRank() > $b->getRank()) ? -1 : 1;
+            });
+        }
 
         if ($TaxRules) {
             $this->rules[$cacheKey] = $TaxRules[0];

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -335,6 +335,14 @@ function fnClass(action) {
                                     </div>
                                 </div>
                                 {% endif %}
+                                {% if BaseInfo.option_product_tax_rule %}
+                                <div class="form-group">
+                                    {{ form_label(form.class.tax_rate) }}
+                                    <div class="col-sm-3 col-lg-3">
+                                        {{ form_widget(form.class.tax_rate) }}
+                                    </div>
+                                </div>
+                                {% endif %}
                             {% endif %}
 
                         </div>


### PR DESCRIPTION
消費税率優先順位に関するbug修正に伴い以下の項目も修正

* 商品個別税率設定（規格あり／規格なし）の機能がインプリメントされていなかったので追加

これに伴い、以下の問題あり

【問題】dtb_tax_ruleテーブルがソフトデリートな前提だが、product_class_id にunique制約がついている矛盾あり

* 規格あり／規格なしどちらでも、商品個別税率を有効にして、一度設定する
* 設定した個別税率をnullにする（textフィールド空で更新->del_flgが立つ）
* もう一度同じ商品で個別税率を設定しようとすると、product_class_idのunique制約に引っかかり登録できずexception発生

product_class_idのunique制約をなくすか、ソフトデリートではなくし1レコード使い回すので回避できるが、、、
データの意味あいからも、ソフトデリートのままでproduct_class_idのunique制約をとるのがいいと思われる。
どなたかこの点対応お願いします。