### PR TITLE
#726 商品マスターで商品一覧した時の表示件数が違う

### DIFF
--- a/html/index_dev.php
+++ b/html/index_dev.php
@@ -33,7 +33,6 @@ $allow = array(
     'fe80::1',
     '::1',
 );
-/*
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
     || !in_array(@$_SERVER['REMOTE_ADDR'], $allow)
@@ -41,7 +40,6 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
-*/
 require_once __DIR__.'/../vendor/autoload.php';
 
 Debug::enable();

--- a/html/index_dev.php
+++ b/html/index_dev.php
@@ -33,6 +33,7 @@ $allow = array(
     'fe80::1',
     '::1',
 );
+
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
     || !in_array(@$_SERVER['REMOTE_ADDR'], $allow)
@@ -40,6 +41,7 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
+
 require_once __DIR__.'/../vendor/autoload.php';
 
 Debug::enable();

--- a/html/index_dev.php
+++ b/html/index_dev.php
@@ -33,7 +33,7 @@ $allow = array(
     'fe80::1',
     '::1',
 );
-
+/*
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
     || !in_array(@$_SERVER['REMOTE_ADDR'], $allow)
@@ -41,7 +41,7 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
-
+*/
 require_once __DIR__.'/../vendor/autoload.php';
 
 Debug::enable();

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -96,6 +96,11 @@ class ProductController extends AbstractController
                 $page_no = 1;
                 $qb = $app['eccube.repository.product']->getQueryBuilderBySearchDataForAdmin($searchData);
                 $items = $qb->getQuery()->getResult();
+
+                echo '<pre>';
+                var_dump($items);
+                echo '</pre>';
+                exit();
                 $pagination = $app['paginator']()->paginate(array());
                 $pagination->setCurrentPageNumber($page_no);
                 $pagination->setItemNumberPerPage($pageMaxis);

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -54,8 +54,6 @@ class ProductController extends AbstractController
         $page_status = null;
         $active = false;
 
-        //ページネーと処理
-
         if ('POST' === $request->getMethod()) {
 
             $searchForm->handleRequest($request);
@@ -63,49 +61,16 @@ class ProductController extends AbstractController
             if ($searchForm->isValid()) {
                 $searchData = $searchForm->getData();
 
-                /*
-                //ページネーション初期値設定
-                $pageno = !empty($searchData['pageno']) ? $searchData['pageno'] : 1;
-                $maxpage = $searchData['disp_number']->getId();
-                $app['eccube.repository.product']->setOffset((($pageno - 1) * $maxpage));
-                $app['eccube.repository.product']->setLimit($maxpage);
-
-                //ソート条件判定
-                if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '1') {
-                    //件数カウント
-                    $count = $app['eccube.repository.product']->countObjectCollectionBySearchData($searchData);
-                    // ソート:価格降順ブジェクト配列取得
-                    $cobj = $app['eccube.repository.product']->getObjectCollectionBySearchData($searchData);
-                    $pagination = $app['paginator']()->paginate(array());
-                    $pagination->setCurrentPageNumber($pageno);
-                    $pagination->setItemNumberPerPage($maxpage);
-                   $pagination->setTotalItemCount($count);
-                    $pagination->setItems($cobj);
-                }else{
-                    // ソート:新着情報・デフォルト処理時クエリブジェクト取得
-                    $qb = $app['eccube.repository.product']->getQueryBuilderBySearchData($searchData);
-                    $pagination = $app['paginator']()->paginate(
-                        $qb,
-                        $pageno,
-                        $maxpage
-                    );
-                }
-                */
-
                 // paginator
                 $page_no = 1;
                 $qb = $app['eccube.repository.product']->getQueryBuilderBySearchDataForAdmin($searchData);
                 $items = $qb->getQuery()->getResult();
-
-                echo '<pre>';
-                var_dump($items);
-                echo '</pre>';
-                exit();
-                $pagination = $app['paginator']()->paginate(array());
-                $pagination->setCurrentPageNumber($page_no);
-                $pagination->setItemNumberPerPage($pageMaxis);
+                $pagination = $app['paginator']()->paginate(
+                    $qb,
+                    $page_no,
+                    $page_count
+                );
                 $pagination->setTotalItemCount(count($items));
-                $pagination->setItems($items);
 
                 // sessionのデータ保持
                 $session->set('eccube.admin.product.search', $searchData);
@@ -148,11 +113,12 @@ class ProductController extends AbstractController
                     //ページング処理(検索を一回でも行っている場合)
                     $qb = $app['eccube.repository.product']->getQueryBuilderBySearchDataForAdmin($searchData);
                     $items = $qb->getQuery()->getResult();
-                    $pagination = $app['paginator']()->paginate(array());
-                    $pagination->setCurrentPageNumber($page_no);
-                    $pagination->setItemNumberPerPage($page_count);
+                    $pagination = $app['paginator']()->paginate(
+                        $qb,
+                        $page_no,
+                        $pcount
+                    );
                     $pagination->setTotalItemCount(count($items));
-                    $pagination->setItems($items);
 
                     // セッションから検索条件を復元
                     if (!empty($searchData['category_id'])) {
@@ -182,26 +148,7 @@ class ProductController extends AbstractController
                     $active = true;
                 }
             }
-            //ページネーション処理必要
-            //ページング処理(検索を一回でも行っている場合)
-            //$qb = $app['eccube.repository.product']->getQueryBuilderBySearchDataForAdmin($searchData);
-            //@check here@yoshinaga add
-            /*
-            $qb = $app['eccube.repository.product']->getQueryBuilderBySearchDataForAdmin($searchData);
-            $items = $qb->getQuery()->getResult();
-            $pagination = $app['paginator']()->paginate(array());
-            $pagination->setCurrentPageNumber($page_no);
-            $pagination->setItemNumberPerPage($page_count);
-            $pagination->setTotalItemCount(count($items));
-            $pagination->setItems($items);
-            $pagination = $app['paginator']()->paginate(
-                    $qb,
-                    $page_no,
-                    $page_count
-            );
-            */
-            //@check here@yoshinaga add
-        }
+       }
 
         return $app->renderView('Product/index.twig', array(
             'searchForm' => $searchForm->createView(),

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -148,11 +148,28 @@ class ProductRepository extends EntityRepository
      */
     public function getQueryBuilderBySearchDataForAdmin($searchData)
     {
+        /*
+        array (size=7)
+      'id' => null
+      'category_id' => null
+      'status' => 
+        object(Doctrine\Common\Collections\ArrayCollection)[1844]
+          private 'elements' => 
+            array (size=0)
+              empty
+      'create_date_start' => null
+      'create_date_end' => null
+      'update_date_start' => null
+      'update_date_end' => null
+      */
+
         $qb = $this->createQueryBuilder('p')
             ->select(array('p', 'pi'))
             ->leftJoin('p.ProductImage', 'pi')
             ->innerJoin('p.ProductClasses', 'pc');
 
+
+        //使用さえている
         // id
         if (!empty($searchData['id']) && $searchData['id']) {
             $id = preg_match('/^\d+$/', $searchData['id']) ? $searchData['id'] : null;
@@ -182,6 +199,7 @@ class ProductRepository extends EntityRepository
         }
        */
 
+        //使用さえている
         // category
         if (!empty($searchData['category_id']) && $searchData['category_id']) {
             $Categories = $searchData['category_id']->getSelfAndDescendants();
@@ -194,6 +212,7 @@ class ProductRepository extends EntityRepository
             }
         }
 
+        //使用さえている
         // status
         if (!empty($searchData['status']) && $searchData['status']->toArray()) {
             $qb
@@ -201,6 +220,7 @@ class ProductRepository extends EntityRepository
                 ->setParameter('Status', $searchData['status']->toArray());
         }
 
+        //不明→パラメーターに渡されていない
         // link_status
         if (isset($searchData['link_status'])) {
             $qb
@@ -208,6 +228,7 @@ class ProductRepository extends EntityRepository
                 ->setParameter('Status', $searchData['link_status']);
         }
 
+        //不明→パラメーターに渡されていない
         // stock status
         if (isset($searchData['stock_status'])) {
             $qb
@@ -215,6 +236,7 @@ class ProductRepository extends EntityRepository
                 ->setParameter('StockUnlimited', $searchData['stock_status']);
         }
 
+        //使用さえている
         // crate_date
         if (!empty($searchData['create_date_start']) && $searchData['create_date_start']) {
             $date = $searchData['create_date_start']
@@ -224,6 +246,7 @@ class ProductRepository extends EntityRepository
                 ->setParameter('create_date_start', $date);
         }
 
+        //使用さえている
         if (!empty($searchData['create_date_end']) && $searchData['create_date_end']) {
             $date = $searchData['create_date_end']
                 ->modify('+1 days')
@@ -233,6 +256,7 @@ class ProductRepository extends EntityRepository
                 ->setParameter('create_date_end', $date);
         }
 
+        //使用さえている
         // update_date
         if (!empty($searchData['update_date_start']) && $searchData['update_date_start']) {
             $date = $searchData['update_date_start']
@@ -241,6 +265,8 @@ class ProductRepository extends EntityRepository
                 ->andWhere('p.update_date >= :update_date_start')
                 ->setParameter('update_date_start', $date);
         }
+
+        //使用さえている
         if (!empty($searchData['update_date_end']) && $searchData['update_date_end']) {
             $date = $searchData['update_date_end']
                 ->modify('+1 days')
@@ -255,6 +281,10 @@ class ProductRepository extends EntityRepository
         $qb
             ->orderBy('p.update_date', 'DESC')
             ->addOrderBy('pi.rank', 'DESC');
+
+        echo '<pre>';
+        var_dump($qb->getQuery()->getResult());
+        echo '</pre>';
 
         return $qb;
     }

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -148,28 +148,12 @@ class ProductRepository extends EntityRepository
      */
     public function getQueryBuilderBySearchDataForAdmin($searchData)
     {
-        /*
-        array (size=7)
-      'id' => null
-      'category_id' => null
-      'status' => 
-        object(Doctrine\Common\Collections\ArrayCollection)[1844]
-          private 'elements' => 
-            array (size=0)
-              empty
-      'create_date_start' => null
-      'create_date_end' => null
-      'update_date_start' => null
-      'update_date_end' => null
-      */
-
         $qb = $this->createQueryBuilder('p')
             ->select(array('p', 'pi'))
             ->leftJoin('p.ProductImage', 'pi')
             ->innerJoin('p.ProductClasses', 'pc');
 
 
-        //使用さえている
         // id
         if (!empty($searchData['id']) && $searchData['id']) {
             $id = preg_match('/^\d+$/', $searchData['id']) ? $searchData['id'] : null;
@@ -199,7 +183,6 @@ class ProductRepository extends EntityRepository
         }
        */
 
-        //使用さえている
         // category
         if (!empty($searchData['category_id']) && $searchData['category_id']) {
             $Categories = $searchData['category_id']->getSelfAndDescendants();
@@ -212,7 +195,6 @@ class ProductRepository extends EntityRepository
             }
         }
 
-        //使用さえている
         // status
         if (!empty($searchData['status']) && $searchData['status']->toArray()) {
             $qb
@@ -220,7 +202,7 @@ class ProductRepository extends EntityRepository
                 ->setParameter('Status', $searchData['status']->toArray());
         }
 
-        //不明→パラメーターに渡されていない
+        // @comment 本ブロック必要??
         // link_status
         if (isset($searchData['link_status'])) {
             $qb
@@ -228,7 +210,7 @@ class ProductRepository extends EntityRepository
                 ->setParameter('Status', $searchData['link_status']);
         }
 
-        //不明→パラメーターに渡されていない
+        // @comment 本ブロック必要??
         // stock status
         if (isset($searchData['stock_status'])) {
             $qb
@@ -236,7 +218,6 @@ class ProductRepository extends EntityRepository
                 ->setParameter('StockUnlimited', $searchData['stock_status']);
         }
 
-        //使用さえている
         // crate_date
         if (!empty($searchData['create_date_start']) && $searchData['create_date_start']) {
             $date = $searchData['create_date_start']
@@ -246,7 +227,6 @@ class ProductRepository extends EntityRepository
                 ->setParameter('create_date_start', $date);
         }
 
-        //使用さえている
         if (!empty($searchData['create_date_end']) && $searchData['create_date_end']) {
             $date = $searchData['create_date_end']
                 ->modify('+1 days')
@@ -256,7 +236,6 @@ class ProductRepository extends EntityRepository
                 ->setParameter('create_date_end', $date);
         }
 
-        //使用さえている
         // update_date
         if (!empty($searchData['update_date_start']) && $searchData['update_date_start']) {
             $date = $searchData['update_date_start']
@@ -266,7 +245,6 @@ class ProductRepository extends EntityRepository
                 ->setParameter('update_date_start', $date);
         }
 
-        //使用さえている
         if (!empty($searchData['update_date_end']) && $searchData['update_date_end']) {
             $date = $searchData['update_date_end']
                 ->modify('+1 days')

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -282,10 +282,6 @@ class ProductRepository extends EntityRepository
             ->orderBy('p.update_date', 'DESC')
             ->addOrderBy('pi.rank', 'DESC');
 
-        echo '<pre>';
-        var_dump($qb->getQuery()->getResult());
-        echo '</pre>';
-
         return $qb;
     }
 


### PR DESCRIPTION
本件自身の環境では再現しませんでした
https://github.com/EC-CUBE/ec-cube/issues/726/
の内容を元に#670で行ったページネーターの「アイテム件数」を明示的に設定