### PR TITLE
#670 商品一覧の表示件数とページングの不具合

### DIFF
--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -72,7 +72,8 @@ class ProductController
         $pagination = $app['paginator']()->paginate(
             $qb,
             !empty($searchData['pageno']) ? $searchData['pageno'] : 1,
-            $searchData['disp_number']->getId()
+            $searchData['disp_number']->getId(),
+            array('wrap-queries' => true)
         );
 
         // addCart form


### PR DESCRIPTION
いろいろ有りましたが以下で解決
※ページネーションにオプションを設定
https://github.com/EC-CUBE/ec-cube/issues/670

商品マスターで商品一覧した時の表示件数が違う #726 
会員マスター管理画面で2ページ目以降の検索結果が0になってしまう #737 
Dev y master / yoshinaga #954 
#670 商品一覧の表示件数とページングの不具合に対する調査結果とヘルプ依頼 #1015 