### PR TITLE
#1009 のテスト修正漏れを対応

### DIFF
--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
@@ -141,9 +141,7 @@ class ProductRepositoryGetQueryBuilderBySearchDataTest extends AbstractProductRe
         $this->actual = array($this->Results[0]->getName(),
                               $this->Results[1]->getName(),
                               $this->Results[2]->getName());
-        // XXX dtb_product_class.create_date 降順になっているので要修正
-        // https://github.com/EC-CUBE/ec-cube/issues/958#issuecomment-148012218
-        $this->markTestSkipped();
+
         $this->verify();
     }
 }


### PR DESCRIPTION
#1009 で新着順のproductの降順に変更したので、テストも合わせて修正しました。

