### PR TITLE
plugin_realdir にテストの残骸が残らないよう修正

### DIFF
--- a/tests/Eccube/Tests/Service/PluginServiceTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceTest.php
@@ -35,6 +35,7 @@ class PluginServiceTest extends AbstractServiceTestCase
 
     public function tearDown()
     {
+        parent::tearDown();
         $dirs = array();
         $finder = new Finder();
         $iterator = $finder
@@ -49,6 +50,7 @@ class PluginServiceTest extends AbstractServiceTestCase
             $this->deleteFile($dir);
         }
     }
+
     /*
        正しいプラグインの条件
        * tar/zipアーカイブである

--- a/tests/Eccube/Tests/Service/PluginServiceTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceTest.php
@@ -26,11 +26,29 @@ namespace Eccube\Tests\Service;
 use Eccube\Application;
 use Symfony\Component\Yaml\Yaml;
 use Eccube\Common\Constant;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Filesystem\Filesystem;
 
 class PluginServiceTest extends AbstractServiceTestCase
 {
     protected $app;
 
+    public function tearDown()
+    {
+        $dirs = array();
+        $finder = new Finder();
+        $iterator = $finder
+            ->in($this->app['config']['plugin_realdir'])
+            ->name('dummy*')
+            ->directories();
+        foreach ($iterator as $dir) {
+            $dirs[] = $dir->getPathName();
+        }
+
+        foreach ($dirs as $dir) {
+            $this->deleteFile($dir);
+        }
+    }
     /*
        正しいプラグインの条件
        * tar/zipアーカイブである
@@ -48,18 +66,16 @@ class PluginServiceTest extends AbstractServiceTestCase
         }
         return $t;
     }
+
     public function deleteFile($path)
     {
-        $f=new Filesystem();
+        $f = new Filesystem();
         return $f->remove($path);
     }
-
 
     // 必要最小限のファイルのプラグインのインストールとアンインストールを検証
     public function testInstallPluginMinimum()
     {
-        #self::markTestSkipped();
-
         // インストールするプラグインを作成する
         $tmpname="dummy".sha1(mt_rand());
         $config=array();
@@ -97,8 +113,6 @@ class PluginServiceTest extends AbstractServiceTestCase
     // 必須ファイルがないプラグインがインストール出来ないこと
     public function testInstallPluginEmptyError()
     {
-        #self::markTestSkipped();
-
         $this->setExpectedException(
           '\Eccube\Exception\PluginException', 'config.yml not found or syntax error'
         );
@@ -119,7 +133,6 @@ class PluginServiceTest extends AbstractServiceTestCase
     // config.ymlのフォーマット確認
     public function testConfigYmlFormat()
     {
-#        self::markTestSkipped();
         $service = $this->app['eccube.service.plugin'];
         $tmpname='dummy'.mt_rand();
         $tmpfile=sys_get_temp_dir().'/dummy'.mt_rand();
@@ -203,7 +216,6 @@ class PluginServiceTest extends AbstractServiceTestCase
     // config.ymlに異常な項目がある場合
     public function testnstallPluginMalformedConfigError()
     {
-        #self::markTestSkipped();
         $service = $this->app['eccube.service.plugin'];
         $tmpdir=$this->createTempDir();
         $tmpfile=$tmpdir.'/plugin.tar';
@@ -226,8 +238,6 @@ class PluginServiceTest extends AbstractServiceTestCase
     // イベント定義を含むプラグインのインストールとアンインストールを検証
     public function testInstallPluginWithEvent()
     {
-        #self::markTestSkipped();
-
         // インストールするプラグインを作成する
         $tmpname="dummy".sha1(mt_rand());
         $config=array();
@@ -453,12 +463,9 @@ EOD;
 
     }
 
-     // インストーラを含むプラグインが正しくインストールできるか
+    // インストーラを含むプラグインが正しくインストールできるか
     public function testInstallPluginWithManager()
     {
-        #self::markTestSkipped();
-
-
         // インストールするプラグインを作成する
         $tmpname="dummy".sha1(mt_rand());
         $config=array();
@@ -538,8 +545,6 @@ EOD;
     // const定義を含むpluginのインストール
     public function testInstallPluginWithConst()
     {
-        #self::markTestSkipped();
-
         // インストールするプラグインを作成する
         $tmpname="dummy".sha1(mt_rand());
         $config=array();
@@ -577,5 +582,4 @@ EOD;
         // アンインストールできるか
         $this->assertTrue($service->uninstall($plugin));
     }
-
 }

--- a/tests/Eccube/Tests/Service/PluginServiceTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceTest.php
@@ -35,7 +35,6 @@ class PluginServiceTest extends AbstractServiceTestCase
 
     public function tearDown()
     {
-        parent::tearDown();
         $dirs = array();
         $finder = new Finder();
         $iterator = $finder
@@ -49,6 +48,7 @@ class PluginServiceTest extends AbstractServiceTestCase
         foreach ($dirs as $dir) {
             $this->deleteFile($dir);
         }
+        parent::tearDown();
     }
 
     /*


### PR DESCRIPTION
- `plugin_realdir` にテストの残骸が溜まると、EC-CUBE 全体の性能劣化が顕著だったので、きちんと削除するよう修正
- コメントアウトされていた不要な `markTestSkipped()` を削除