### PR TITLE
管理画面：商品マスタ：商品画像の表示順を修正

### DIFF
--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -149,8 +149,7 @@ class ProductRepository extends EntityRepository
     public function getQueryBuilderBySearchDataForAdmin($searchData)
     {
         $qb = $this->createQueryBuilder('p')
-            ->select(array('p', 'pi'))
-            ->leftJoin('p.ProductImage', 'pi')
+            ->select(array('p'))
             ->innerJoin('p.ProductClasses', 'pc');
 
         // id
@@ -255,8 +254,7 @@ class ProductRepository extends EntityRepository
 
         // Order By
         $qb
-            ->orderBy('p.update_date', 'DESC')
-            ->addOrderBy('pi.rank', 'ASC');
+            ->orderBy('p.update_date', 'DESC');
 
         return $qb;
     }

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -149,7 +149,6 @@ class ProductRepository extends EntityRepository
     public function getQueryBuilderBySearchDataForAdmin($searchData)
     {
         $qb = $this->createQueryBuilder('p')
-            ->select(array('p'))
             ->innerJoin('p.ProductClasses', 'pc');
 
         // id

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -256,7 +256,7 @@ class ProductRepository extends EntityRepository
         // Order By
         $qb
             ->orderBy('p.update_date', 'DESC')
-            ->addOrderBy('pi.rank', 'DESC');
+            ->addOrderBy('pi.rank', 'ASC');
 
         return $qb;
     }

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataAdminTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataAdminTest.php
@@ -235,4 +235,25 @@ class ProductRepositoryGetQueryBuilderBySearchDataAdminTest extends AbstractProd
         $this->actual = count($this->Results);
         $this->verify();
     }
+
+    public function testProductImage()
+    {
+        $this->searchData = array();
+
+        $this->scenario();
+
+        $Products = $this->Results;
+
+        foreach ($Products as $Product) {
+            $this->expected = array(0, 1, 2);
+            $this->actual = array();
+
+            $ProductImages = $Product->getProductImage();
+            foreach ($ProductImages as $ProductImage) {
+                $this->actual[] = $ProductImage->getRank();
+            }
+
+            $this->verify();
+        }
+    }
 }

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
@@ -144,4 +144,25 @@ class ProductRepositoryGetQueryBuilderBySearchDataTest extends AbstractProductRe
 
         $this->verify();
     }
+
+    public function testProductImage()
+    {
+        $this->searchData = array();
+
+        $this->scenario();
+
+        $Products = $this->Results;
+
+        foreach ($Products as $Product) {
+            $this->expected = array(0, 1, 2);
+            $this->actual = array();
+
+            $ProductImages = $Product->getProductImage();
+            foreach ($ProductImages as $ProductImage) {
+                $this->actual[] = $ProductImage->getRank();
+            }
+
+            $this->verify();
+        }
+    }
 }


### PR DESCRIPTION
商品画像の表示順が、フロントの商品一覧・詳細は昇順、管理画面の商品マスタは降順で表示されている。
フロントにあわせて、商品マスタの表示順を昇順に修正しました。