### PR TITLE
受注検索時に発生するwarningの修正

### DIFF
--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -91,7 +91,7 @@ class OrderRepository extends EntityRepository
         }
 
         // status
-        if (isset($searchData['status']) && Str::isNotBlank($searchData['status'])) {
+        if (!empty($searchData['status']) && $searchData['status']) {
             $qb
                 ->andWhere('o.OrderStatus = :status')
                 ->setParameter('status', $searchData['status']);
@@ -288,7 +288,7 @@ class OrderRepository extends EntityRepository
         }
 
         // status
-        if (isset($searchData['status']) && Str::isNotBlank($searchData['status'])) {
+        if (!empty($searchData['status']) && $searchData['status']) {
             $qb
                 ->andWhere('o.OrderStatus = :status')
                 ->setParameter('status', $searchData['status']);


### PR DESCRIPTION
#1054 で、以下のwarningが発生するため、該当箇所を修正しました。
`PHP Deprecated: \Eccube\Util\Str::isBlank() の第一引数は文字型、数値を使用してください in /Users//eccube/src/Eccube/Util/Str.php on line 243`