### PR TITLE
#1118 商品一覧ページの商品が価格昇順にソートされない

### DIFF
--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -72,8 +72,7 @@ class ProductController
         $pagination = $app['paginator']()->paginate(
             $qb,
             !empty($searchData['pageno']) ? $searchData['pageno'] : 1,
-            $searchData['disp_number']->getId(),
-            array('wrap-queries' => true)
+            $searchData['disp_number']->getId()
         );
 
         // addCart form

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -120,6 +120,7 @@ class ProductRepository extends EntityRepository
         // Order By
         // 価格順
         if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '1') {
+            //follow in keyword HIDDEN,see the http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html
             $qb->addSelect('p.id as HIDDEN pid');
             $qb->addSelect('MIN(pc.price02) as HIDDEN price02_min');
             $qb->innerJoin('p.ProductClasses', 'pc');

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -120,7 +120,7 @@ class ProductRepository extends EntityRepository
         // Order By
         // 価格順
         if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '1') {
-            //follow in keyword HIDDEN,see the http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html
+            //at see http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html
             $qb->addSelect('p.id as HIDDEN pid');
             $qb->addSelect('MIN(pc.price02) as HIDDEN price02_min');
             $qb->innerJoin('p.ProductClasses', 'pc');

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -120,7 +120,7 @@ class ProductRepository extends EntityRepository
         // Order By
         // 価格順
         if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '1') {
-            //at see http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html
+            //@see http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html
             $qb->addSelect('p.id as HIDDEN pid');
             $qb->addSelect('MIN(pc.price02) as HIDDEN price02_min');
             $qb->innerJoin('p.ProductClasses', 'pc');

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -120,8 +120,11 @@ class ProductRepository extends EntityRepository
         // Order By
         // 価格順
         if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '1') {
+            $qb->addSelect('p.id as HIDDEN pid');
+            $qb->addSelect('MIN(pc.price02) as HIDDEN price02_min');
             $qb->innerJoin('p.ProductClasses', 'pc');
-            $qb->orderBy('pc.price02', 'ASC');
+            $qb->groupBy('p.id');
+            $qb->orderBy('price02_min', 'ASC');
             // 新着順
         } else if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '2') {
             $qb->orderBy('p.create_date', 'DESC');
@@ -132,8 +135,6 @@ class ProductRepository extends EntityRepository
                     ->leftJoin('pct.Category', 'c');
             }
             $qb
-                ->orderBy('c.rank', 'DESC')
-                ->addOrderBy('pct.rank', 'DESC')
                 ->addOrderBy('p.id', 'DESC');
         }
 

--- a/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataTest.php
@@ -10,8 +10,6 @@ use Eccube\Entity\Order;
 use Eccube\Entity\OrderDetail;
 use Eccube\Entity\Shipping;
 use Eccube\Entity\ShipmentItem;
-use Eccube\Entity\Master\ProductListMax;
-use Eccube\Entity\Master\ProductListOrderBy;
 
 /**
  * OrderRepository::getQueryBuilderBySearchDataTest test cases.
@@ -24,8 +22,6 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
     protected $Order;
     protected $Results;
     protected $searchData;
-    protected $ProductListMax;
-    protected $ProductListOrderBy;
 
     public function setUp() {
         parent::setUp();
@@ -41,9 +37,6 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
         $this->Order = $this->createOrder($this->Customer);
         $this->Order1 = $this->createOrder($this->Customer);
         $this->Order2 = $this->createOrder($Customer2);
-
-        $this->ProductListMax = new \Eccube\Entity\Master\ProductListMax();
-        $this->ProductListOrderBy = new \Eccube\Entity\Master\ProductListOrderBy();
     }
 
     public function scenario()
@@ -336,70 +329,6 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
         $this->scenario();
 
         $this->expected = 2;
-        $this->actual = count($this->Results);
-        $this->verify();
-    }
-
-    public function testPaginationEventByOrderPrice()
-    {
-        $this->ProductListMax->setId(15);
-        $this->ProductListMax->setName('15件');
-        $this->ProductListMax->setRank(0);
-
-        $this->ProductListOrderBy->setId(1);
-        $this->ProductListOrderBy->setName('価格順');
-        $this->ProductListOrderBy->setRank(0);
-
-
-        $this->searchData = array(
-            'mode' => NULL,
-            'category_id' => NULL,
-            'name' => NULL,
-            'pageno' => '1',
-            'disp_number' => $this->ProductListMax,
-            'orderby' => $this->ProductListOrderBy
-        );
-        $this->scenario();
-
-        $pagination = $app['paginator']()->paginate(
-            $this->Results,
-            $this->searchData['pageno'],
-            $thi->searchData['disp_number']->getId()
-        );
-
-        $this->expected = count($pagination);
-        $this->actual = count($this->Results);
-        $this->verify();
-    }
-
-    public function testPaginationEventByOrderCreated()
-    {
-        $this->ProductListMax->setId(15);
-        $this->ProductListMax->setName('15件');
-        $this->ProductListMax->setRank(0);
-
-        $this->ProductListOrderBy->setId(2);
-        $this->ProductListOrderBy->setName('新着順');
-        $this->ProductListOrderBy->setRank(0);
-
-
-        $this->searchData = array(
-            'mode' => NULL,
-            'category_id' => NULL,
-            'name' => NULL,
-            'pageno' => '1',
-            'disp_number' => $this->ProductListMax,
-            'orderby' => $this->ProductListOrderBy
-        );
-        $this->scenario();
-
-        $pagination = $app['paginator']()->paginate(
-            $this->Results,
-            $this->searchData['pageno'],
-            $thi->searchData['disp_number']->getId()
-        );
-
-        $this->expected = count($pagination);
         $this->actual = count($this->Results);
         $this->verify();
     }

--- a/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataTest.php
@@ -42,8 +42,8 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
         $this->Order1 = $this->createOrder($this->Customer);
         $this->Order2 = $this->createOrder($Customer2);
 
-        $ProductListMax = new \Eccube\Entity\Master\ProductListMax();
-        $ProductListOrderBy = new \Eccube\Entity\Master\ProductListOrderBy();
+        $this->ProductListMax = new \Eccube\Entity\Master\ProductListMax();
+        $this->ProductListOrderBy = new \Eccube\Entity\Master\ProductListOrderBy();
     }
 
     public function scenario()
@@ -342,13 +342,13 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
 
     public function testPaginationEventByOrderPrice()
     {
-        $ProductListMax->setId(15);
-        $ProductListMax->setName('15件');
-        $ProductListMax->setRank(0);
+        $this->ProductListMax->setId(15);
+        $this->ProductListMax->setName('15件');
+        $this->ProductListMax->setRank(0);
 
-        $ProductListOrderBy->setId(1);
-        $ProductListOrderBy->setName('価格順');
-        $ProductListOrderBy->setRank(0);
+        $this->ProductListOrderBy->setId(1);
+        $this->ProductListOrderBy->setName('価格順');
+        $this->ProductListOrderBy->setRank(0);
 
 
         $this->searchData = array(
@@ -356,8 +356,8 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
             'category_id' => NULL,
             'name' => NULL,
             'pageno' => '1',
-            'disp_number' => $ProductListMax,
-            'orderby' => $ProductListOrderBy
+            'disp_number' => $this->ProductListMax,
+            'orderby' => $this->ProductListOrderBy
         );
         $this->scenario();
 
@@ -374,13 +374,13 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
 
     public function testPaginationEventByOrderCreated()
     {
-        $ProductListMax->setId(15);
-        $ProductListMax->setName('15件');
-        $ProductListMax->setRank(0);
+        $this->ProductListMax->setId(15);
+        $this->ProductListMax->setName('15件');
+        $this->ProductListMax->setRank(0);
 
-        $ProductListOrderBy->setId(2);
-        $ProductListOrderBy->setName('新着順');
-        $ProductListOrderBy->setRank(0);
+        $this->ProductListOrderBy->setId(2);
+        $this->ProductListOrderBy->setName('新着順');
+        $this->ProductListOrderBy->setRank(0);
 
 
         $this->searchData = array(
@@ -388,8 +388,8 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
             'category_id' => NULL,
             'name' => NULL,
             'pageno' => '1',
-            'disp_number' => $ProductListMax,
-            'orderby' => $ProductListOrderBy
+            'disp_number' => $this->ProductListMax,
+            'orderby' => $this->ProductListOrderBy
         );
         $this->scenario();
 

--- a/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataTest.php
@@ -10,6 +10,8 @@ use Eccube\Entity\Order;
 use Eccube\Entity\OrderDetail;
 use Eccube\Entity\Shipping;
 use Eccube\Entity\ShipmentItem;
+use Eccube\Entity\Master\ProductListMax;
+use Eccube\Entity\Master\ProductListOrderBy;
 
 /**
  * OrderRepository::getQueryBuilderBySearchDataTest test cases.
@@ -22,6 +24,8 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
     protected $Order;
     protected $Results;
     protected $searchData;
+    protected $ProductListMax;
+    protected $ProductListOrderBy;
 
     public function setUp() {
         parent::setUp();
@@ -37,6 +41,9 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
         $this->Order = $this->createOrder($this->Customer);
         $this->Order1 = $this->createOrder($this->Customer);
         $this->Order2 = $this->createOrder($Customer2);
+
+        $ProductListMax = new \Eccube\Entity\Master\ProductListMax();
+        $ProductListOrderBy = new \Eccube\Entity\Master\ProductListOrderBy();
     }
 
     public function scenario()
@@ -329,6 +336,70 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
         $this->scenario();
 
         $this->expected = 2;
+        $this->actual = count($this->Results);
+        $this->verify();
+    }
+
+    public function testPaginationEventByOrderPrice()
+    {
+        $ProductListMax->setId(15);
+        $ProductListMax->setName('15件');
+        $ProductListMax->setRank(0);
+
+        $ProductListOrderBy->setId(1);
+        $ProductListOrderBy->setName('価格順');
+        $ProductListOrderBy->setRank(0);
+
+
+        $this->searchData = array(
+            'mode' => NULL,
+            'category_id' => NULL,
+            'name' => NULL,
+            'pageno' => '1',
+            'disp_number' => $ProductListMax,
+            'orderby' => $ProductListOrderBy
+        );
+        $this->scenario();
+
+        $pagination = $app['paginator']()->paginate(
+            $this->Results,
+            $this->searchData['pageno'],
+            $thi->searchData['disp_number']->getId()
+        );
+
+        $this->expected = count($pagination);
+        $this->actual = count($this->Results);
+        $this->verify();
+    }
+
+    public function testPaginationEventByOrderCreated()
+    {
+        $ProductListMax->setId(15);
+        $ProductListMax->setName('15件');
+        $ProductListMax->setRank(0);
+
+        $ProductListOrderBy->setId(2);
+        $ProductListOrderBy->setName('新着順');
+        $ProductListOrderBy->setRank(0);
+
+
+        $this->searchData = array(
+            'mode' => NULL,
+            'category_id' => NULL,
+            'name' => NULL,
+            'pageno' => '1',
+            'disp_number' => $ProductListMax,
+            'orderby' => $ProductListOrderBy
+        );
+        $this->scenario();
+
+        $pagination = $app['paginator']()->paginate(
+            $this->Results,
+            $this->searchData['pageno'],
+            $thi->searchData['disp_number']->getId()
+        );
+
+        $this->expected = count($pagination);
         $this->actual = count($this->Results);
         $this->verify();
     }

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
@@ -13,6 +13,8 @@ use Eccube\Entity\ProductStock;
 use Doctrine\ORM\NoResultException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Doctrine\Common\Collections\ArrayCollection;
+use Eccube\Entity\Master\ProductListMax;
+use Eccube\Entity\Master\ProductListOrderBy;
 
 /**
  * ProductRepository#getQueryBuilderBySearchData test cases.
@@ -23,6 +25,14 @@ class ProductRepositoryGetQueryBuilderBySearchDataTest extends AbstractProductRe
 {
     protected $Results;
     protected $searchData;
+    protected $ProductListMax;
+    protected $ProductListOrderBy;
+
+    public function setUp() {
+        parent::setUp();
+        $this->ProductListMax = new \Eccube\Entity\Master\ProductListMax();
+        $this->ProductListOrderBy = new \Eccube\Entity\Master\ProductListOrderBy();
+    }
 
     public function scenario()
     {
@@ -164,5 +174,69 @@ class ProductRepositoryGetQueryBuilderBySearchDataTest extends AbstractProductRe
 
             $this->verify();
         }
+    }
+
+    public function testPaginationEventByOrderPrice()
+    {
+        $this->ProductListMax->setId(15);
+        $this->ProductListMax->setName('15件');
+        $this->ProductListMax->setRank(0);
+
+        $this->ProductListOrderBy->setId(1);
+        $this->ProductListOrderBy->setName('価格順');
+        $this->ProductListOrderBy->setRank(0);
+
+
+        $this->searchData = array(
+            'mode' => NULL,
+            'category_id' => NULL,
+            'name' => NULL,
+            'pageno' => '1',
+            'disp_number' => $this->ProductListMax,
+            'orderby' => $this->ProductListOrderBy
+        );
+        $this->scenario();
+
+        $pagination = $this->app['paginator']()->paginate(
+            $this->Results,
+            $this->searchData['pageno'],
+            $thi->searchData['disp_number']->getId()
+        );
+
+        $this->expected = count($pagination);
+        $this->actual = count($this->Results);
+        $this->verify();
+    }
+
+    public function testPaginationEventByOrderCreated()
+    {
+        $this->ProductListMax->setId(15);
+        $this->ProductListMax->setName('15件');
+        $this->ProductListMax->setRank(0);
+
+        $this->ProductListOrderBy->setId(2);
+        $this->ProductListOrderBy->setName('新着順');
+        $this->ProductListOrderBy->setRank(0);
+
+
+        $this->searchData = array(
+            'mode' => NULL,
+            'category_id' => NULL,
+            'name' => NULL,
+            'pageno' => '1',
+            'disp_number' => $this->ProductListMax,
+            'orderby' => $this->ProductListOrderBy
+        );
+        $this->scenario();
+
+        $pagination = $this->app['paginator']()->paginate(
+            $this->Results,
+            $this->searchData['pageno'],
+            $thi->searchData['disp_number']->getId()
+        );
+
+        $this->expected = count($pagination);
+        $this->actual = count($this->Results);
+        $this->verify();
     }
 }

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
@@ -200,7 +200,7 @@ class ProductRepositoryGetQueryBuilderBySearchDataTest extends AbstractProductRe
         $pagination = $this->app['paginator']()->paginate(
             $this->Results,
             $this->searchData['pageno'],
-            $thi->searchData['disp_number']->getId()
+            $this->searchData['disp_number']->getId()
         );
 
         $this->expected = count($pagination);
@@ -232,7 +232,7 @@ class ProductRepositoryGetQueryBuilderBySearchDataTest extends AbstractProductRe
         $pagination = $this->app['paginator']()->paginate(
             $this->Results,
             $this->searchData['pageno'],
-            $thi->searchData['disp_number']->getId()
+            $this->searchData['disp_number']->getId()
         );
 
         $this->expected = count($pagination);


### PR DESCRIPTION
①groupBy追加( p.id )
②orderByをMINのエイリアスに対し実行
③①②のセレクトに対し、「HIDDEN」を付与
→取得結果に①②select句の内容は含まれない