### PR TITLE
CartService の不具合修正

### DIFF
--- a/tests/Eccube/Tests/Service/CartServiceTest.php
+++ b/tests/Eccube/Tests/Service/CartServiceTest.php
@@ -64,8 +64,6 @@ class CartServiceTest extends AbstractServiceTestCase
 
     public function testClear_Products()
     {
-        self::markTestSkipped();
-
         $cartService = $this->app['eccube.service.cart'];
         $cartService->addProduct(1);
         $cartService->clear();
@@ -75,8 +73,6 @@ class CartServiceTest extends AbstractServiceTestCase
 
     public function testAddProducts_ProductClassEntity()
     {
-        self::markTestSkipped();
-
         $cartService = $this->app['eccube.service.cart'];
         $cartService->addProduct(1);
 
@@ -88,8 +84,6 @@ class CartServiceTest extends AbstractServiceTestCase
 
     public function testAddProducts_Quantity()
     {
-        self::markTestSkipped();
-
         $cartService = $this->app['eccube.service.cart'];
         $this->assertCount(0, $cartService->getCart()->getCartItems());
 
@@ -109,8 +103,6 @@ class CartServiceTest extends AbstractServiceTestCase
 
     public function testUpProductQuantity()
     {
-        self::markTestSkipped();
-
         $cartService = $this->app['eccube.service.cart'];
         $cartService->setProductQuantity(1, 1);
         $cartService->upProductQuantity(1);
@@ -122,8 +114,6 @@ class CartServiceTest extends AbstractServiceTestCase
 
     public function testDownProductQuantity()
     {
-        self::markTestSkipped();
-
         $cartService = $this->app['eccube.service.cart'];
 
         $cartService->setProductQuantity(1, 2);
@@ -136,8 +126,6 @@ class CartServiceTest extends AbstractServiceTestCase
 
     public function testDownProductQuantity_Remove()
     {
-        self::markTestSkipped();
-
         $cartService = $this->app['eccube.service.cart'];
 
         $cartService->setProductQuantity(1, 1);
@@ -150,8 +138,6 @@ class CartServiceTest extends AbstractServiceTestCase
 
     public function testRemoveProduct()
     {
-        self::markTestSkipped();
-
         $cartService = $this->app['eccube.service.cart'];
 
         $cartService->setProductQuantity(1, 2);
@@ -182,5 +168,4 @@ class CartServiceTest extends AbstractServiceTestCase
 
         $this->assertCount(2, $cartService->getMessages());
     }
-
 }


### PR DESCRIPTION
- 存在しない product_class_id を追加しようとした場合に CartException をスローするよう修正(#1131)
- 公開/非公開ステータスチェックの比較に Constant::ENABLED を使用していたのを修正
- 在庫チェックに関するコメント追記
- setProductQuantity() の異常系テスト追加