### PR TITLE
console ルーティング出力内容の絞込と並び替え

### DIFF
--- a/src/Eccube/Command/RouterCommand.php
+++ b/src/Eccube/Command/RouterCommand.php
@@ -47,8 +47,8 @@ class RouterCommand extends \Knp\Command\Command
             ->setDefinition(array(
                 new InputArgument('name', InputArgument::OPTIONAL, 'A route name'),
             ))
-            ->addOption('order', null, InputOption::VALUE_OPTIONAL, '[null/ASC/DESC]. If argument orderby set, Default is ASC.')
-            ->addOption('orderby', null, InputOption::VALUE_OPTIONAL, '[null/name/path]. If argument order set, Default is name.')
+            ->addOption('sort', null, InputOption::VALUE_OPTIONAL, '[null/ASC/DESC]. If argument orderby set, Default is ASC.')
+            ->addOption('orderby', null, InputOption::VALUE_OPTIONAL, '[null/name/path]. If argument sort set, Default is name.')
             ->setDescription('Displays current routes for an application')
             ->setHelp(<<<EOF
 The <info>%command.name%</info> displays the configured routes:
@@ -66,7 +66,7 @@ EOF
         $console = new Application();
 
         $filtername = $input->getArgument('name');
-        $order = $input->getOption('order');
+        $sort = $input->getOption('sort');
         $orderby = $input->getOption('orderby');
 
         $table = $console->getHelperSet()->get('table');
@@ -98,15 +98,15 @@ EOF
         $routes = $this->app['routes']->all();
 
         // 引数で並び替える。
-        if (!empty($order)) {
+        if (!empty($sort)) {
             $orderby = (!empty($orderby)) ? $orderby : "name";
         }
         if (!empty($orderby)) {
-            $order = (!empty($order)) ? $order : "ASC";
+            $sort = (!empty($sort)) ? $sort : "ASC";
         }
 
         if (strtoupper($orderby) === "NAME") {
-            if (strtoupper($order) === "DESC") {
+            if (strtoupper($sort) === "DESC") {
                 krsort($routes);
             } else {
                 ksort($routes);

--- a/src/Eccube/Command/RouterCommand.php
+++ b/src/Eccube/Command/RouterCommand.php
@@ -25,6 +25,7 @@ namespace Eccube\Command;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Helper\TableHelper;
@@ -46,6 +47,8 @@ class RouterCommand extends \Knp\Command\Command
             ->setDefinition(array(
                 new InputArgument('name', InputArgument::OPTIONAL, 'A route name'),
             ))
+            ->addOption('order', null, InputOption::VALUE_OPTIONAL, '[null/ASC/DESC]. If argument orderby set, Default is ASC.')
+            ->addOption('orderby', null, InputOption::VALUE_OPTIONAL, '[null/name/path]. If argument order set, Default is name.')
             ->setDescription('Displays current routes for an application')
             ->setHelp(<<<EOF
 The <info>%command.name%</info> displays the configured routes:
@@ -62,6 +65,10 @@ EOF
 
         $console = new Application();
 
+        $filtername = $input->getArgument('name');
+        $order = $input->getOption('order');
+        $orderby = $input->getOption('orderby');
+
         $table = $console->getHelperSet()->get('table');
         $table->setHeaders(array('Name', 'Path', 'Pattern'));
         $table->setLayout(TableHelper::LAYOUT_DEFAULT);
@@ -70,6 +77,10 @@ EOF
         $collection     = $controllers->flush();
 
         foreach ($collection as $name => $route) {
+            if (!empty($filtername) && !preg_match("/$filtername/", $name)) {
+                continue;
+            }
+
             $requirements = array();
             foreach ($route->getRequirements() as $key => $requirement) {
                 // $requirements[] = $key . ' => ' . $requirement;
@@ -81,15 +92,39 @@ EOF
                 $route->getPath(),
                 join(', ', $requirements)
             ));
-
         }
 
 
         $routes = $this->app['routes']->all();
 
+        // 引数で並び替える。
+        if (!empty($order)) {
+            $orderby = (!empty($orderby)) ? $orderby : "name";
+        }
+        if (!empty($orderby)) {
+            $order = (!empty($order)) ? $order : "ASC";
+        }
+
+        if (strtoupper($orderby) === "NAME") {
+            if (strtoupper($order) === "DESC") {
+                krsort($routes);
+            } else {
+                ksort($routes);
+            }
+        } else if (strtoupper($orderby) === "PATH") {
+            uasort($routes, function($a, $b) {
+                return strcmp($a->getPattern(), $b->getPattern());
+            });
+        }
+
         $maxName = 4;
         $maxMethod = 6;
         foreach ($routes as $name => $route) {
+            if (!empty($filtername) && !preg_match("/$filtername/", $name)) {
+                unset($routes[$name]);
+                continue;
+            }
+
             $requirements = $route->getRequirements();
             $method = isset($requirements['_method'])
                 ? strtoupper(is_array($requirements['_method'])


### PR DESCRIPTION
scrutinizerのエラーはいてたので、PRサイド送ります。

ルーティングを出力するコマンドで、探しやすいように、

* 引数の文字列でフィルタ
* orderオプション：並び順
* orderbyオプション：nameかpathのどちらかで並び替え

出来るようにしました。

example:
```bash
$ php app/console router:debug
$ php app/console router:debug product
$ php app/console router:debug --order=dsc
$ php app/console router:debug --orderby=path --order=asc
$ php app/console router:debug product --orderby=path
```

#265 には触れていません。