### PR TITLE
Web版のインストーラーに timezone の設定を追加

### DIFF
--- a/src/Eccube/InstallApplication.php
+++ b/src/Eccube/InstallApplication.php
@@ -59,6 +59,12 @@ class InstallApplication extends ApplicationTrait
             return $config;
         });
 
+        $distPath = __DIR__.'/../../src/Eccube/Resource/config';
+        $config_dist = Yaml::parse($distPath.'/config.yml.dist');
+        if (!empty($config_dist['timezone'])) {
+            date_default_timezone_set($config_dist['timezone']);
+        }
+
         $app->register(new \Silex\Provider\SessionServiceProvider());
 
         $app->register(new \Silex\Provider\TwigServiceProvider(), array(


### PR DESCRIPTION
**timezone** が未設定の状態でWeb版のインストーラーを実施すると `Logger`クラス で `Warning: date_default_timezone_get():` が発生します。

`InstallController `クラス で `date_default_timezone_set` が実施されていますが、呼び出し元の`InstallApplication`クラス で`date_default_timezone_set`を実施した方が合理的と思います。

https://github.com/EC-CUBE/ec-cube/blob/master/src/Eccube/Controller/Install/InstallController.php#L68