### PR TITLE
#1104 商品登録時に販売価格がマイナスで登録できてしまう

### DIFF
--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -825,6 +825,15 @@ class CsvImportController
             }
         }
 
+        if ($row['送料'] != '') {
+            $delivery_fee = str_replace(',', '', $row['送料']);
+            if (is_numeric($delivery_fee) && $delivery_fee >= 0) {
+                $ProductClass->setDeliveryFee($delivery_fee);
+            } else {
+                $this->addErrors(($data->key() + 1) . '行目の送料は0以上の数値を設定してください。');
+            }
+        }
+
         if ($row['商品規格削除フラグ'] == '') {
             $ProductClass->setDelFlg(Constant::DISABLED);
         } else {

--- a/src/Eccube/Form/Type/Admin/DeliveryType.php
+++ b/src/Eccube/Form/Type/Admin/DeliveryType.php
@@ -92,12 +92,12 @@ class DeliveryType extends AbstractType
                 'allow_delete' => true,
                 'prototype' => true,
             ))
-            ->add('free_all', 'money', array(
+            ->add('free_all', 'price', array(
                 'label' => false,
                 'currency' => 'JPY',
                 'precision' => 0,
                 'required' => false,
-                'mapped' => false,
+                'mapped' => false
             ))
             ->add('delivery_fees', 'collection', array(
                 'label' => '都道府県別設定',

--- a/src/Eccube/Form/Type/Admin/OrderDetailType.php
+++ b/src/Eccube/Form/Type/Admin/OrderDetailType.php
@@ -62,6 +62,10 @@ class OrderDetailType extends AbstractType
                     new Assert\Length(array(
                         'max' => $config['int_len'],
                     )),
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
+                    )),
                 ),
             ))
             ->add('quantity', 'text', array(
@@ -70,6 +74,10 @@ class OrderDetailType extends AbstractType
                     new Assert\Length(array(
                         'max' => $config['int_len'],
                     )),
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
+                    )),
                 ),
             ))
             ->add('tax_rate', 'text', array(
@@ -77,6 +85,10 @@ class OrderDetailType extends AbstractType
                     new Assert\NotBlank(),
                     new Assert\Length(array(
                         'max' => $config['int_len'],
+                    )),
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+(\.\d+)?$/u",
+                        'message' => 'form.type.float.invalid'
                     )),
                 )
             ));

--- a/src/Eccube/Form/Type/Admin/OrderDetailType.php
+++ b/src/Eccube/Form/Type/Admin/OrderDetailType.php
@@ -62,10 +62,6 @@ class OrderDetailType extends AbstractType
                     new Assert\Length(array(
                         'max' => $config['int_len'],
                     )),
-                    new Assert\Regex(array(
-                        'pattern' => "/^\d+$/u",
-                        'message' => 'form.type.numeric.invalid'
-                    )),
                 ),
             ))
             ->add('quantity', 'text', array(

--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -142,10 +142,6 @@ class OrderType extends AbstractType
                     new Assert\Length(array(
                         'max' => $config['int_len'],
                     )),
-                    new Assert\Regex(array(
-                        'pattern' => "/^\d+$/u",
-                        'message' => 'form.type.numeric.invalid'
-                    )),
                 ),
             ))
             ->add('delivery_fee_total', 'money', array(
@@ -157,10 +153,6 @@ class OrderType extends AbstractType
                     new Assert\Length(array(
                         'max' => $config['int_len'],
                     )),
-                    new Assert\Regex(array(
-                        'pattern' => "/^\d+$/u",
-                        'message' => 'form.type.numeric.invalid'
-                    )),
                 ),
             ))
             ->add('charge', 'money', array(
@@ -171,10 +163,6 @@ class OrderType extends AbstractType
                     new Assert\NotBlank(),
                     new Assert\Length(array(
                         'max' => $config['int_len'],
-                    )),
-                    new Assert\Regex(array(
-                        'pattern' => "/^\d+$/u",
-                        'message' => 'form.type.numeric.invalid'
                     )),
                 ),
             ))

--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -142,6 +142,10 @@ class OrderType extends AbstractType
                     new Assert\Length(array(
                         'max' => $config['int_len'],
                     )),
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
+                    )),
                 ),
             ))
             ->add('delivery_fee_total', 'money', array(
@@ -153,6 +157,10 @@ class OrderType extends AbstractType
                     new Assert\Length(array(
                         'max' => $config['int_len'],
                     )),
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
+                    )),
                 ),
             ))
             ->add('charge', 'money', array(
@@ -163,6 +171,10 @@ class OrderType extends AbstractType
                     new Assert\NotBlank(),
                     new Assert\Length(array(
                         'max' => $config['int_len'],
+                    )),
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
                     )),
                 ),
             ))

--- a/src/Eccube/Form/Type/Admin/PaymentRegisterType.php
+++ b/src/Eccube/Form/Type/Admin/PaymentRegisterType.php
@@ -52,7 +52,10 @@ class PaymentRegisterType extends AbstractType
                 'precision' => 0,
                 'constraints' => array(
                     new Assert\NotBlank(),
-                    new Assert\Regex(array('pattern' => '/^\d+$/')),
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
+                    )),
                 ),
             ))
             ->add('rule_min', 'money', array(
@@ -60,7 +63,10 @@ class PaymentRegisterType extends AbstractType
                 'currency' => 'JPY',
                 'precision' => 0,
                 'constraints' => array(
-                    new Assert\Regex(array('pattern' => '/^\d+$/')),
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
+                    )),
                 ),
             ))
             ->add('rule_max', 'money', array(
@@ -69,7 +75,10 @@ class PaymentRegisterType extends AbstractType
                 'precision' => 0,
                 'required' => false,
                 'constraints' => array(
-                    new Assert\Regex(array('pattern' => '/^\d+$/')),
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
+                    )),
                 ),
             ))
             ->add('payment_image_file', 'file', array(

--- a/src/Eccube/Form/Type/Admin/ProductClassType.php
+++ b/src/Eccube/Form/Type/Admin/ProductClassType.php
@@ -113,7 +113,7 @@ class ProductClassType extends AbstractType
                 'constraints' => array(
                     new Assert\Range(array('min' => 0, 'max' => 100)),
                     new Assert\Regex(array(
-                        'pattern' => "^\d+(\.\d+)?$",
+                        'pattern' => "/^\d+(\.\d+)?$/",
                         'message' => 'form.type.float.invalid'
                     )),
                 ),

--- a/src/Eccube/Form/Type/Admin/ProductClassType.php
+++ b/src/Eccube/Form/Type/Admin/ProductClassType.php
@@ -57,10 +57,25 @@ class ProductClassType extends AbstractType
             ->add('stock', 'number', array(
                 'label' => '在庫数',
                 'required' => false,
+                'constraints' => array(
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
+                    )),
+                ),
             ))
             ->add('sale_limit', 'number', array(
                 'label' => '販売制限数',
                 'required' => false,
+                'constraints' => array(
+                    new Assert\Length(array(
+                        'max' => 10,
+                    )),
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
+                    )),
+                ),
             ))
             ->add('price01', 'money', array(
                 'label' => '通常価格',
@@ -70,6 +85,10 @@ class ProductClassType extends AbstractType
                 'constraints' => array(
                     new Assert\Length(array(
                         'max' => 10,
+                    )),
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
                     )),
                 ),
             ))
@@ -82,19 +101,34 @@ class ProductClassType extends AbstractType
                     new Assert\Length(array(
                         'max' => 10,
                     )),
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
+                    )),
                 ),
             ))
             ->add('tax_rate', 'text', array(
                 'label' => '消費税率',
                 'required' => false,
                 'constraints' => array(
-                    new Assert\Range(array('min' => 0, 'max' => 100))),
+                    new Assert\Range(array('min' => 0, 'max' => 100)),
+                    new Assert\Regex(array(
+                        'pattern' => "^\d+(\.\d+)?$",
+                        'message' => 'form.type.float.invalid'
+                    )),
+                ),
             ))
             ->add('delivery_fee', 'money', array(
                 'label' => '商品送料',
                 'currency' => 'JPY',
                 'precision' => 0,
                 'required' => false,
+                'constraints' => array(
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
+                    )),
+                ),
             ))
             ->add('product_type', 'product_type', array(
                 'label' => '商品種別',

--- a/src/Eccube/Form/Type/Admin/ShopMasterType.php
+++ b/src/Eccube/Form/Type/Admin/ShopMasterType.php
@@ -183,11 +183,21 @@ class ShopMasterType extends AbstractType
                     new Assert\Length(array(
                         'max' => $config['price_len'],
                     )),
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
+                    )),
                 ),
             ))
             ->add('delivery_free_quantity', 'integer', array(
                 'label' => '送料無料条件(数量)',
                 'required' => false,
+                'constraints' => array(
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form.type.numeric.invalid'
+                    )),
+                ),
             ))
             ->add('option_product_delivery_fee', 'choice', array(
                 'label' => '商品ごとの送料設定を有効にする',

--- a/src/Eccube/Form/Type/Admin/TaxRuleType.php
+++ b/src/Eccube/Form/Type/Admin/TaxRuleType.php
@@ -52,7 +52,11 @@ class TaxRuleType extends AbstractType
                 'required' => true,
                 'constraints' => array(
                     new Assert\NotBlank(),
-                    new Assert\Range(array('min' => 0, 'max' => 100))
+                    new Assert\Range(array('min' => 0, 'max' => 100)),
+                    new Assert\Regex(array(
+                        'pattern' => "/^\d+(\.\d+)?$/u",
+                        'message' => 'form.type.float.invalid'
+                    )),
                 ),
             ))
             ->add('calc_rule', 'calc_rule', array(

--- a/src/Eccube/Form/Type/PriceType.php
+++ b/src/Eccube/Form/Type/PriceType.php
@@ -58,6 +58,7 @@ class PriceType extends AbstractType
             'currency' => 'JPY',
             'precision' => 0,
             'constraints' => $constraints,
+            'invalid_message' => 'form.type.numeric.invalid'
         ));
     }
 

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -31,6 +31,7 @@ form.contact.contents.help: ご注文に関するお問い合わせには、必�
 form.member.email.invalid: 同じメールアドレスを入力してください。
 form.member.password.invalid: 同じパスワードを入力してください。
 form.type.numeric.invalid: 数字で入力してください。
+form.type.float.invalid : 数字と小数点のみ入力できます。
 form.member.repeated.confirm: 確認のためもう一度入力してください
 form.type.graph.invalid: 半角英数字で入力してください。
 

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderDetailTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderDetailTypeTest.php
@@ -89,13 +89,13 @@ class OrderDetailTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidPrice_HasMinus()
+    public function testValidPrice_HasMinus()
     {
         $this->app['request'] = new Request();
         $this->formData['price'] = '-123456';
 
         $this->form->submit($this->formData);
-        $this->assertFalse($this->form->isValid());
+        $this->assertTrue($this->form->isValid());
     }
 
     public function testInvalidQuantity_Blank()

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderDetailTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderDetailTypeTest.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Tests\Form\Type\Admin;
+
+use Symfony\Component\HttpFoundation\Request;
+use Eccube\Tests\Form\Type\AbstractTypeTestCase;
+use Eccube\Entity\Product;
+use Eccube\Entity\ProductClass;
+
+class OrderDetailTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
+{
+    /** @var \Eccube\Application */
+    protected $app;
+
+    /** @var \Symfony\Component\Form\FormInterface */
+    protected $form;
+
+    /** @var array デフォルト値（正常系）を設定 */
+    protected $formData = array(
+        'price' => '10000',
+        'quantity'=> '10000',
+        'tax_rate' => '10.0',
+        'Product' => null,
+        'ProductClass' => null
+    );
+
+    public function setUp()
+    {
+        parent::setUp();
+
+
+        // CSRF tokenを無効にしてFormを作成
+        // 会員管理会員登録・編集
+        $this->form = $this->app['form.factory']
+            ->createBuilder('order_detail', null, array(
+                'csrf_protection' => false,
+            ))
+            ->getForm();
+    }
+
+    public function testValidData()
+    {
+        $this->app['request'] = new Request();
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+
+        //var_dump($this->form->getErrorsAsString());die;
+    }
+
+    /*
+    public function testInvalidTel_Blank()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['tel']['tel01'] = '';
+        $this->formData['tel']['tel02'] = '';
+        $this->formData['tel']['tel03'] = '';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+    */
+}

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderDetailTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderDetailTypeTest.php
@@ -26,8 +26,6 @@ namespace Eccube\Tests\Form\Type\Admin;
 
 use Symfony\Component\HttpFoundation\Request;
 use Eccube\Tests\Form\Type\AbstractTypeTestCase;
-use Eccube\Entity\Product;
-use Eccube\Entity\ProductClass;
 
 class OrderDetailTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 {
@@ -42,14 +40,11 @@ class OrderDetailTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         'price' => '10000',
         'quantity'=> '10000',
         'tax_rate' => '10.0',
-        'Product' => null,
-        'ProductClass' => null
     );
 
     public function setUp()
     {
         parent::setUp();
-
 
         // CSRF tokenを無効にしてFormを作成
         // 会員管理会員登録・編集
@@ -60,13 +55,11 @@ class OrderDetailTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
             ->getForm();
     }
 
-    public function testValidData()
+    public function testInValidData()
     {
         $this->app['request'] = new Request();
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
-
-        //var_dump($this->form->getErrorsAsString());die;
     }
 
     /*

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderDetailTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderDetailTypeTest.php
@@ -59,19 +59,114 @@ class OrderDetailTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
     {
         $this->app['request'] = new Request();
         $this->form->submit($this->formData);
-        $this->assertFalse($this->form->isValid());
+        $this->assertTrue($this->form->isValid());
     }
 
-    /*
-    public function testInvalidTel_Blank()
+    public function testInvalidPrice_Blank()
     {
         $this->app['request'] = new Request();
-        $this->formData['tel']['tel01'] = '';
-        $this->formData['tel']['tel02'] = '';
-        $this->formData['tel']['tel03'] = '';
+        $this->formData['price'] = '';
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
-    */
+
+    public function testInvalidPrice_OverMaxLength()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['price'] = '12345678910'; //Max 9
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidPrice_NotNumeric()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['price'] = 'abc';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidPrice_HasMinus()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['price'] = '-123456';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidQuantity_Blank()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['quantity'] = '';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidQuantity_OverMaxLength()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['quantity'] = '12345678910'; //Max 9
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidQuantity_NotNumeric()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['quantity'] = 'abcde';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidQuantity_HasMinus()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['quantity'] = '-123456';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidTaxRate_Blank()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['tax_rate'] = '';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidTaxRate_OverMaxLength()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['tax_rate'] = '12345678910'; //Max 9
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidTaxRate_NotNumeric()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['tax_rate'] = 'abcde';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidTaxRate_HasMinus()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['tax_rate'] = '-12345';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
 }

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
@@ -88,7 +88,7 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
     {
         $this->app['request'] = new Request();
         $this->form->submit($this->formData);
-        $this->assertTrue($this->form->isValid());
+        $this->assertFalse($this->form->isValid());
     }
 
     public function testInvalidTel_Blank()

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
@@ -84,7 +84,7 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
             ->getForm();
     }
 
-    public function testValidData()
+    public function testInValidData()
     {
         $this->app['request'] = new Request();
         $this->form->submit($this->formData);
@@ -120,13 +120,13 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testValidDiscount_HasMinus()
+    public function testInValidDiscount_HasMinus()
     {
         $this->app['request'] = new Request();
         $this->formData['discount'] = '-12345';
 
         $this->form->submit($this->formData);
-        $this->assertTrue($this->form->isValid());
+        $this->assertFalse($this->form->isValid());
     }
 
     public function testInvalidDeliveryFeeTotal_OverMaxLength()
@@ -147,13 +147,13 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testValidDeliveryFeeTotal_HasMinus()
+    public function testInValidDeliveryFeeTotal_HasMinus()
     {
         $this->app['request'] = new Request();
         $this->formData['delivery_fee_total'] = '-12345';
 
         $this->form->submit($this->formData);
-        $this->assertTrue($this->form->isValid());
+        $this->assertFalse($this->form->isValid());
     }
 
     public function testInvalidCharge_OverMaxLength()
@@ -174,12 +174,12 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testValidCharge_HasMinus()
+    public function testInValidCharge_HasMinus()
     {
         $this->app['request'] = new Request();
         $this->formData['charge'] = '-12345';
 
         $this->form->submit($this->formData);
-        $this->assertTrue($this->form->isValid());
+        $this->assertFalse($this->form->isValid());
     }
 }

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
@@ -120,13 +120,13 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidDiscount_HasMinus()
+    public function testValidDiscount_HasMinus()
     {
         $this->app['request'] = new Request();
         $this->formData['discount'] = '-12345';
 
         $this->form->submit($this->formData);
-        $this->assertFalse($this->form->isValid());
+        $this->assertTrue($this->form->isValid());
     }
 
     public function testInvalidDeliveryFeeTotal_OverMaxLength()
@@ -147,13 +147,13 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidDeliveryFeeTotal_HasMinus()
+    public function testValidDeliveryFeeTotal_HasMinus()
     {
         $this->app['request'] = new Request();
         $this->formData['delivery_fee_total'] = '-12345';
 
         $this->form->submit($this->formData);
-        $this->assertFalse($this->form->isValid());
+        $this->assertTrue($this->form->isValid());
     }
 
     public function testInvalidCharge_OverMaxLength()
@@ -174,12 +174,12 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidCharge_HasMinus()
+    public function testValidCharge_HasMinus()
     {
         $this->app['request'] = new Request();
         $this->formData['charge'] = '-12345';
 
         $this->form->submit($this->formData);
-        $this->assertFalse($this->form->isValid());
+        $this->assertTrue($this->form->isValid());
     }
 }

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
@@ -65,9 +65,9 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
             'fax03' => '6789',
         ),
         'email' => 'default@example.com',
-        'discount' => '',
-        'delivery_fee_total' => '',
-        'charge' => '',
+        'discount' => '1',
+        'delivery_fee_total' => '1',
+        'charge' => '1',
         'Payment' => '1', // dtb_payment?
     );
 
@@ -88,7 +88,7 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
     {
         $this->app['request'] = new Request();
         $this->form->submit($this->formData);
-        $this->assertFalse($this->form->isValid());
+        $this->assertTrue($this->form->isValid());
     }
 
     public function testInvalidTel_Blank()

--- a/tests/Eccube/Tests/Form/Type/Admin/PaymentRegisterTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/PaymentRegisterTypeTest.php
@@ -1,0 +1,128 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Tests\Form\Type\Admin;
+
+use Symfony\Component\HttpFoundation\Request;
+use Eccube\Tests\Form\Type\AbstractTypeTestCase;
+
+class PaymentRegisterTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
+{
+    /** @var \Eccube\Application */
+    protected $app;
+
+    /** @var \Symfony\Component\Form\FormInterface */
+    protected $form;
+
+    /** @var array デフォルト値（正常系）を設定 */
+    protected $formData = array(
+        'method' => '1',
+        'charge'=> '10000',
+        'rule_min' => '100',
+        'rule_max' => '10000'
+    );
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // CSRF tokenを無効にしてFormを作成
+        // 会員管理会員登録・編集
+        $this->form = $this->app['form.factory']
+            ->createBuilder('payment_register', null, array(
+                'csrf_protection' => false,
+            ))
+            ->getForm();
+    }
+
+    public function testValidData()
+    {
+        $this->app['request'] = new Request();
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testInvalidCharge_Blank()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['charge'] = '';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidCharge_NotNumeric()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['charge'] = 'abc';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidCharge_HasMinus()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['charge'] = '-123456';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidRuleMin_NotNumeric()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['rule_min'] = 'abc';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidRuleMin_HasMinus()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['rule_min'] = '-123456';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidRuleMax_NotNumeric()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['rule_max'] = 'abc';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidRuleMax_HasMinus()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['rule_max'] = '-123456';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+}

--- a/tests/Eccube/Tests/Form/Type/Admin/ProductClassTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/ProductClassTypeTest.php
@@ -36,7 +36,7 @@ class ProductClassTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     /** @var array デフォルト値（正常系）を設定 */
     protected $formData = array(
-        'code' => 'code01',
+        'code' => '1',
         'stock' => '100',
         'sale_limit' => '100',
         'price01' => '100',

--- a/tests/Eccube/Tests/Form/Type/Admin/ProductClassTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/ProductClassTypeTest.php
@@ -26,7 +26,7 @@ namespace Eccube\Tests\Form\Type\Admin;
 
 use Symfony\Component\HttpFoundation\Request;
 
-class ProductClassTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
+class ProductClassTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 {
     /** @var \Eccube\Application */
     protected $app;

--- a/tests/Eccube/Tests/Form/Type/Admin/ProductClassTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/ProductClassTypeTest.php
@@ -52,7 +52,7 @@ class ProductClassTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         // CSRF tokenを無効にしてFormを作成
         // 会員管理会員登録・編集
         $this->form = $this->app['form.factory']
-            ->createBuilder('prduct_class', null, array(
+            ->createBuilder('product_class', null, array(
                 'csrf_protection' => false,
             ))
             ->getForm();

--- a/tests/Eccube/Tests/Form/Type/Admin/ProductClassTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/ProductClassTypeTest.php
@@ -36,39 +36,13 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     /** @var array デフォルト値（正常系）を設定 */
     protected $formData = array(
-        'name' => array(
-            'name01' => 'たかはし',
-            'name02' => 'しんいち',
-        ),
-        'kana'=> array(
-            'kana01' => 'タカハシ',
-            'kana02' => 'シンイチ',
-        ),
-        'company_name' => 'ロックオン',
-        'zip' => array(
-            'zip01' => '530',
-            'zip02' => '0001',
-        ),
-        'address' => array(
-            'pref' => '5',
-            'addr01' => '北区',
-            'addr02' => '梅田',
-        ),
-        'tel' => array(
-            'tel01' => '012',
-            'tel02' => '345',
-            'tel03' => '6789',
-        ),
-        'fax' => array(
-            'fax01' => '112',
-            'fax02' => '345',
-            'fax03' => '6789',
-        ),
-        'email' => 'default@example.com',
-        'discount' => '',
-        'delivery_fee_total' => '',
-        'charge' => '',
-        'Payment' => '1', // dtb_payment?
+        'code' => 'code01',
+        'stock' => '100',
+        'sale_limit' => '100',
+        'price01' => '100',
+        'price02' => '100',
+        'tax_rate' => '10.0',
+        'delivery_fee' => '100',
     );
 
     public function setUp()
@@ -78,7 +52,7 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         // CSRF tokenを無効にしてFormを作成
         // 会員管理会員登録・編集
         $this->form = $this->app['form.factory']
-            ->createBuilder('order', null, array(
+            ->createBuilder('prduct_class', null, array(
                 'csrf_protection' => false,
             ))
             ->getForm();
@@ -88,96 +62,157 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
     {
         $this->app['request'] = new Request();
         $this->form->submit($this->formData);
-        $this->assertFalse($this->form->isValid());
+        $this->assertTrue($this->form->isValid());
     }
 
-    public function testInvalidTel_Blank()
+    public function testInvalidStock_NotNumeric()
     {
         $this->app['request'] = new Request();
-        $this->formData['tel']['tel01'] = '';
-        $this->formData['tel']['tel02'] = '';
-        $this->formData['tel']['tel03'] = '';
+        $this->formData['stock'] = 'abcde';
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidDiscount_OverMaxLength()
+    public function testInvalidStock_HasMinus()
     {
         $this->app['request'] = new Request();
-        $this->formData['discount'] = '12345678910'; //Max 9
+        $this->formData['stock'] = '-12345';
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidDiscount_NotNumeric()
+    public function testInvalidSaleLimit_OverMaxLength()
     {
         $this->app['request'] = new Request();
-        $this->formData['discount'] = 'abcde';
+        $this->formData['sale_limit'] = '12345678910'; //Max 10
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidDiscount_HasMinus()
+    public function testInvalidSaleLimit_NotNumeric()
     {
         $this->app['request'] = new Request();
-        $this->formData['discount'] = '-12345';
+        $this->formData['sale_limit'] = 'abcde';
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidDeliveryFeeTotal_OverMaxLength()
+    public function testInvalidSaleLimit_HasMinus()
     {
         $this->app['request'] = new Request();
-        $this->formData['delivery_fee_total'] = '12345678910'; //Max 9
+        $this->formData['sale_limit'] = '-12345';
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidDeliveryFeeTotal_NotNumeric()
+    public function testInvalidPrice01_OverMaxLength()
     {
         $this->app['request'] = new Request();
-        $this->formData['delivery_fee_total'] = 'abcde';
+        $this->formData['price01'] = '12345678910'; //Max 10
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidDeliveryFeeTotal_HasMinus()
+    public function testInvalidPrice01_NotNumeric()
     {
         $this->app['request'] = new Request();
-        $this->formData['delivery_fee_total'] = '-12345';
+        $this->formData['price01'] = 'abcde';
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidCharge_OverMaxLength()
+    public function testInvalidPrice01_HasMinus()
     {
         $this->app['request'] = new Request();
-        $this->formData['charge'] = '12345678910'; //Max 9
+        $this->formData['price01'] = '-12345';
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidCharge_NotNumeric()
+    public function testInvalidPrice02_Blank()
     {
         $this->app['request'] = new Request();
-        $this->formData['charge'] = 'abcde';
+        $this->formData['price02'] = ''; //Max 10
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidCharge_HasMinus()
+    public function testInvalidPrice02_OverMaxLength()
     {
         $this->app['request'] = new Request();
-        $this->formData['charge'] = '-12345';
+        $this->formData['price02'] = '12345678910'; //Max 10
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidPrice02_NotNumeric()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['price02'] = 'abcde';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidPrice02_HasMinus()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['price02'] = '-12345';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidTaxRate_OverMinLength()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['tax_rate'] = str_repeat('2', 101);
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidTaxRate_NotNumeric()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['tax_rate'] = 'abcde';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidTaxRate_HasMinus()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['tax_rate'] = '-12345';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidDeliveryFee_NotNumeric()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['delivery_fee'] = 'abcde';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidDeliveryFee_HasMinus()
+    {
+        $this->app['request'] = new Request();
+        $this->formData['delivery_fee'] = '-12345';
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());

--- a/tests/Eccube/Tests/Form/Type/Admin/ProductClassTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/ProductClassTypeTest.php
@@ -26,7 +26,7 @@ namespace Eccube\Tests\Form\Type\Admin;
 
 use Symfony\Component\HttpFoundation\Request;
 
-class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
+class ProductClassTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 {
     /** @var \Eccube\Application */
     protected $app;

--- a/tests/Eccube/Tests/Form/Type/Admin/ProductClassTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/ProductClassTypeTest.php
@@ -36,7 +36,6 @@ class ProductClassTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     /** @var array デフォルト値（正常系）を設定 */
     protected $formData = array(
-        'code' => '1',
         'stock' => '100',
         'sale_limit' => '100',
         'price01' => '100',
@@ -58,11 +57,11 @@ class ProductClassTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
             ->getForm();
     }
 
-    public function testValidData()
+    public function testInValidData()
     {
         $this->app['request'] = new Request();
         $this->form->submit($this->formData);
-        $this->assertTrue($this->form->isValid());
+        $this->assertFalse($this->form->isValid());
     }
 
     public function testInvalidStock_NotNumeric()

--- a/tests/Eccube/Tests/Form/Type/Admin/ProductClassTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/ProductClassTypeTest.php
@@ -52,7 +52,7 @@ class ProductClassTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         // CSRF tokenを無効にしてFormを作成
         // 会員管理会員登録・編集
         $this->form = $this->app['form.factory']
-            ->createBuilder('product_class', null, array(
+            ->createBuilder('admin_product_class', null, array(
                 'csrf_protection' => false,
             ))
             ->getForm();

--- a/tests/Eccube/Tests/Form/Type/Admin/ShopMasterTestType.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/ShopMasterTestType.php
@@ -68,10 +68,11 @@ class ShopMasterTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         'email02' => 'eccube@example.com',
         'email03' => 'eccube@example.com',
         'email04' => 'eccube@example.com',
+        'delivery_free_amount' => '1000',
+        'delivery_free_quantity' => '1000',
         /*
         'good_traded' => '取り扱い商品',
         'message' => 'メッセージ',
-        'delivery_free_amount' => '1000',
         'option_product_delivery_fee' => '0',
         'option_delivery_fee' => '0',
         'option_multiple_shipping' => '0',
@@ -123,5 +124,45 @@ class ShopMasterTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());
+    }
+
+    public function testInValidDeliveryFreeAmount_OverMaxLength()
+    {
+        $this->formData['delivery_free_amount'] = '123456789'; //Max 8
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidDeliveryFreeAmount_NotNumeric()
+    {
+        $this->formData['delivery_free_amount'] = 'abcde';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidDeliveryFreeAmount_HasMinus()
+    {
+        $this->formData['delivery_free_amount'] = '-12345';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidDeliveryFreeQuantity_NotNumeric()
+    {
+        $this->formData['delivery_free_quantity'] = 'abcde';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidDeliveryFreeQuantity_HasMinus()
+    {
+        $this->formData['delivery_free_quantity'] = '-12345';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
     }
 }

--- a/tests/Eccube/Tests/Form/Type/TaxRuleTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/TaxRuleTypeTest.php
@@ -54,4 +54,43 @@ class TaxRuleTypeTest extends AbstractTypeTestCase
         $this->assertSame('tax_rule', $this->form->getName());
     }
 
+    public function testInValidDeliveryTaxRate_Blank()
+    {
+        $this->formData['tax_rate'] = '';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidDeliveryTaxRate_OverMaxRength()
+    {
+        $this->formData['tax_rate'] = str_repeat('2', 101);
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidDeliveryTaxRate_NotNumeric()
+    {
+        $this->formData['tax_rate'] = 'abcde';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidDeliveryTaxRate_HasMinus()
+    {
+        $this->formData['tax_rate'] = '-12345';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testValidDeliveryTaxRate_HasMinus()
+    {
+        $this->formData['tax_rate'] = '10.0';
+
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
 }


### PR DESCRIPTION
■対応内容
①後述項目に対して「金額」に対して「マイナス値」判定バリデーション設定
②後述項目に対して「税率」対して「実数」判定バリデーション設定
③上記設定にともない、各エラー文言統一

■特記
①あらかじめ、Typeに対して、Typeでバリデーションを行っているものがあるが、
constraintsを追記しているものTypeバリデーションが機能していないため、
constraintsで①②独自定義
②また金額に対するTypeに「Price」と「Money」があるが、統一可能ではないかと思います。

[ 商品( CSV取り込み含む ) ]
規格価格/在庫/販売制限数( type: money )
[ 受注 ]
受注登録・受注編集/受注商品情報 金額 数量 税率 値引き 送料 手数料 ( type: money )
[ 基本情報設定 ]
ショップマスター/送料無料条件 ( type: money )
配送方法設定金額 ( type: price )
支払い方法設定 ( type: money )
税率