### PR TITLE
商品詳細画面で商品規格が未選択時のエラーメッセージが不適切 #1107

### DIFF
--- a/src/Eccube/Form/Type/AddCartType.php
+++ b/src/Eccube/Form/Type/AddCartType.php
@@ -187,19 +187,23 @@ class AddCartType extends AbstractType
                     new Assert\NotBlank(),
                     new Assert\NotEqualTo(array(
                         'value' => '__unselected',
-                        'message' => 'This value should be blank.',
+                        'message' => 'form.type.select.notselect'
                     )),
                 ), '[classcategory_id1]');
             }
+            //商品規格2初期状態(未選択)の場合の返却値は「NULL」で「__unselected」ではない
             if ($this->Product->getClassName2()) {
                 $context->validateValue($data['classcategory_id2'], array(
-                    new Assert\NotBlank(),
+                    new Assert\NotBlank(array(
+                        'message' => 'form.type.select.notselect'
+                    )),
                     new Assert\NotEqualTo(array(
                         'value' => '__unselected',
-                        'message' => 'This value should be blank.',
+                        'message' => 'form.type.select.notselect'
                     )),
                 ), '[classcategory_id2]');
             }
+
         }
     }
 }

--- a/src/Eccube/Form/Type/AddCartType.php
+++ b/src/Eccube/Form/Type/AddCartType.php
@@ -194,9 +194,7 @@ class AddCartType extends AbstractType
             //商品規格2初期状態(未選択)の場合の返却値は「NULL」で「__unselected」ではない
             if ($this->Product->getClassName2()) {
                 $context->validateValue($data['classcategory_id2'], array(
-                    new Assert\NotBlank(array(
-                        'message' => 'form.type.select.notselect'
-                    )),
+                    new Assert\NotBlank(),
                     new Assert\NotEqualTo(array(
                         'value' => '__unselected',
                         'message' => 'form.type.select.notselect'

--- a/src/Eccube/Form/Type/AddCartType.php
+++ b/src/Eccube/Form/Type/AddCartType.php
@@ -194,7 +194,9 @@ class AddCartType extends AbstractType
             //商品規格2初期状態(未選択)の場合の返却値は「NULL」で「__unselected」ではない
             if ($this->Product->getClassName2()) {
                 $context->validateValue($data['classcategory_id2'], array(
-                    new Assert\NotBlank(),
+                    new Assert\NotBlank(array(
+                        'message' => 'form.type.select.notselect'
+                    )),
                     new Assert\NotEqualTo(array(
                         'value' => '__unselected',
                         'message' => 'form.type.select.notselect'

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -41,6 +41,8 @@ form.type.customer.company.nothasspace: 会社名にスペース、タブ、改�
 form.type.admin.nottelstyle: 電話番号は半角数字かハイフンのみを入力してください。。
 form.type.admin.notkanastyle: お名前(フリガナ)はカタカナで入力してください。
 
+form.type.select.notselect: 選択されていません。
+
 cart.over.stock: |-
     選択された商品(%product%)の在庫が不足しております。
     一度に在庫数を超える購入はできません。

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -41,7 +41,7 @@ form.type.customer.company.nothasspace: 会社名にスペース、タブ、改�
 form.type.admin.nottelstyle: 電話番号は半角数字かハイフンのみを入力してください。。
 form.type.admin.notkanastyle: お名前(フリガナ)はカタカナで入力してください。
 
-form.type.select.notselect: 選択されていません。
+form.type.select.notselect: 入力されていません。
 
 cart.over.stock: |-
     選択された商品(%product%)の在庫が不足しております。

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -41,7 +41,7 @@ form.type.customer.company.nothasspace: 会社名にスペース、タブ、改�
 form.type.admin.nottelstyle: 電話番号は半角数字かハイフンのみを入力してください。。
 form.type.admin.notkanastyle: お名前(フリガナ)はカタカナで入力してください。
 
-form.type.select.notselect: 入力されていません。
+form.type.select.notselect: 選択されていません。
 
 cart.over.stock: |-
     選択された商品(%product%)の在庫が不足しております。


### PR DESCRIPTION
メッセージ変換不可のため、カスタムメッセージ定義