### PR TITLE
注文完了後、Myページの受注履歴にメール配信履歴が表示されない #1089

### DIFF
--- a/src/Eccube/Controller/Admin/Order/MailController.php
+++ b/src/Eccube/Controller/Admin/Order/MailController.php
@@ -90,21 +90,8 @@ class MailController
                         $data = $form->getData();
                         $body = $this->createBody($app, $data['header'], $data['footer'], $Order);
 
-                        // メール送信
-                        $app['eccube.service.mail']->sendAdminOrderMail($Order, $data);
-
-                        // 送信履歴を保存.
-                        $MailTemplate = $form->get('template')->getData();
-                        $MailHistory = new MailHistory();
-                        $MailHistory
-                            ->setSubject($data['subject'])
-                            ->setMailBody($body)
-                            ->setMailTemplate($MailTemplate)
-                            ->setSendDate(new \DateTime())
-                            ->setOrder($Order);
-                        $app['orm.em']->persist($MailHistory);
-                        $app['orm.em']->flush($MailHistory);
-
+                        // メール送信 ( 履歴保存 )
+                        $app['eccube.service.mail']->sendAdminOrderMail($Order, $form);
 
                         return $app->redirect($app->url('admin_order_mail_complete'));
                         break;
@@ -221,23 +208,9 @@ class MailController
 
                             $body = $this->createBody($app, $data['header'], $data['footer'], $Order);
 
-                            // メール送信
-                            $app['eccube.service.mail']->sendAdminOrderMail($Order, $data);
-
-                            // 送信履歴を保存.
-                            $MailTemplate = $form->get('template')->getData();
-                            $MailHistory = new MailHistory();
-                            $MailHistory
-                                ->setSubject($data['subject'])
-                                ->setMailBody($body)
-                                ->setMailTemplate($MailTemplate)
-                                ->setSendDate(new \DateTime())
-                                ->setOrder($Order);
-                            $app['orm.em']->persist($MailHistory);
+                            // メール送信 ( 履歴保存 )
+                            $app['eccube.service.mail']->sendAdminOrderMail($Order, $form);
                         }
-
-                        $app['orm.em']->flush($MailHistory);
-
 
                         return $app->redirect($app->url('admin_order_mail_complete'));
                         break;

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -194,7 +194,7 @@ class ShoppingController extends AbstractController
 
                     $em->getConnection()->commit();
                     $em->flush();
-                    $em->close();
+                    //$em->close();
 
                 } catch (\Exception $e) {
                     $em->getConnection()->rollback();

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -194,7 +194,6 @@ class ShoppingController extends AbstractController
 
                     $em->getConnection()->commit();
                     $em->flush();
-                    //$em->close();
 
                 } catch (\Exception $e) {
                     $em->getConnection()->rollback();

--- a/src/Eccube/Resource/doctrine/Eccube.Entity.MailHistory.dcm.yml
+++ b/src/Eccube/Resource/doctrine/Eccube.Entity.MailHistory.dcm.yml
@@ -39,5 +39,5 @@ Eccube\Entity\MailHistory:
             joinColumn:
                 name: creator_id
                 referencedColumnName: member_id
-                nullable: false
+                nullable: true
     lifecycleCallbacks: {  }

--- a/src/Eccube/Resource/doctrine/migration/Version20151110174227.php
+++ b/src/Eccube/Resource/doctrine/migration/Version20151110174227.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20151110174227 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $t=$schema->getTable('dtb_mail_history');
+        if($t->hasColumn('creator_id')){
+            $this->addSql('alter table dtb_mail_history change column creator_id creator_id int(11) default null;');
+            $t->dropColumn('stock_unlimited_tmp');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}


### PR DESCRIPTION
①会員ログイン→商品購入→確認メール送信の後に履歴保存がなかったため追記
②①フロー・管理画面受注のメール送信フローでロジックが異なっていたため、両ロジック修正
③懸案点としては、メール一括送信時に、毎回[flush]を行うためレスポンスがきになる