### PR TITLE
ログ出力の修正

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -163,11 +163,6 @@ class Application extends ApplicationTrait
 
             return $monolog;
         }));
-
-        $app['listener.requestdump'] = $app->share(function ($app) {
-            return new \Eccube\EventListener\RequestDumpListener($app);
-        });
-        $app['dispatcher']->addSubscriber($app['listener.requestdump']);
     }
 
     public function initialize()
@@ -226,7 +221,7 @@ class Application extends ApplicationTrait
         // mount controllers
         $this->register(new \Silex\Provider\ServiceControllerServiceProvider());
         $this->mount('', new ControllerProvider\FrontControllerProvider());
-        $this->mount('/' . trim($this['config']['admin_route'], '/') . '/', new ControllerProvider\AdminControllerProvider());
+        $this->mount('/'.trim($this['config']['admin_route'], '/').'/', new ControllerProvider\AdminControllerProvider());
         Request::enableHttpMethodParameterOverride(); // PUTやDELETEできるようにする
     }
 
@@ -314,10 +309,9 @@ class Application extends ApplicationTrait
                 } else {
                     $cacheBaseDir = __DIR__.'/../../app/cache/twig/production/';
                 }
-
-                if (strpos($app['request']->getPathInfo(), '/' . trim($app['config']['admin_route'], '/')) === 0) {
-                    if (file_exists(__DIR__ . '/../../app/template/admin')) {
-                        $paths[] = __DIR__ . '/../../app/template/admin';
+                if (strpos($app['request']->getPathInfo(), '/'.trim($app['config']['admin_route'], '/')) === 0) {
+                    if (file_exists(__DIR__.'/../../app/template/admin')) {
+                        $paths[] = __DIR__.'/../../app/template/admin';
                     }
                     $paths[] = $app['config']['template_admin_realdir'];
                     $paths[] = __DIR__.'/../../app/Plugin';

--- a/src/Eccube/EventListener/RequestDumpListener.php
+++ b/src/Eccube/EventListener/RequestDumpListener.php
@@ -127,7 +127,7 @@ class RequestDumpListener implements EventSubscriberInterface
         $log .= $this->logKeyValuePair('REQUEST_URI', $request->getRequestUri());
         $log .= $this->logKeyValuePair('METHOD', $request->getRealMethod());
         $log .= $this->logKeyValuePair('LOCALE', $request->getLocale());
-        // $log .= $this->logArray($request->server->all(), '[server]');
+        // $log .= $this->logArray($request->server->all(), '[server]'); // 大量にログ出力される...
         $log .= $this->logArray($request->headers->all(), '[header]');
         $log .= $this->logArray($request->query->all(), '[get]');
         $log .= $this->logArray($request->request->all(), '[post]');
@@ -180,7 +180,6 @@ class RequestDumpListener implements EventSubscriberInterface
      */
     protected function logKeyValuePair($key, $value, $prefix = '')
     {
-        $copy_value = null;
         if (in_array($key, $this->excludeKeys)) {
             return '';
         }

--- a/src/Eccube/EventListener/RequestDumpListener.php
+++ b/src/Eccube/EventListener/RequestDumpListener.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Eccube\EventListener;
+
+use Eccube\Application;
+use Eccube\Util\EntityUtil;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Monolog\Logger;
+
+/**
+ * リクエストログ出力ため Listener
+ *
+ * ログ出力を除外したいキーは log.yml の exclude_keys で設定します.
+ * addExcludeKey(), removeExcludeKey() でも設定できます.
+ *
+ * @author Kentaro Ohkouchi
+ */
+class RequestDumpListener implements EventSubscriberInterface
+{
+    private $app;
+    private $excludeKeys;
+
+    /**
+     * Constructor function.
+     *
+     * @param Application $app
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+        $this->excludeKeys = $app['config']['log']['exclude_keys'];
+    }
+
+    /**
+     * Kernel request listener callback.
+     *
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+        $log = '** before *****************************************:'.PHP_EOL;
+        $request = $event->getRequest();
+        $log .= $this->logRequest($request);
+        $Session = $request->getSession();
+        if ($request->hasSession()) {
+            $log .= $this->logSession($Session);
+        }
+        $this->app->log($log, array(), Logger::DEBUG);
+    }
+
+    /**
+     * Kernel response listener callback.
+     *
+     * @param FilterResponseEvent $event
+     */
+    public function onResponse(FilterResponseEvent $event)
+    {
+        $log = '** after *****************************************:'.PHP_EOL;
+        $request = $event->getRequest();
+        $log .= $this->logRequest($request);
+        $Session = $request->getSession();
+        if ($request->hasSession()) {
+            $log .= $this->logSession($Session);
+        }
+        $this->app->log($log, array(), Logger::DEBUG);
+    }
+
+    /**
+     * Return the events to subscribe to.
+     *
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST  => 'onKernelRequest',
+            KernelEvents::RESPONSE => 'onResponse',
+        );
+    }
+
+    /**
+     * ログ出力を除外するキーを追加します.
+     *
+     * @param string $key 除外対象のキー
+     */
+    protected function addExcludeKey($key)
+    {
+        $this->excludeKeys[] = $key;
+    }
+
+    /**
+     * ログ出力を除外するキーを削除します.
+     *
+     * @param string $key 削除対象のキー
+     */
+    protected function removeExcludeKey($key)
+    {
+        if (array_key_exists($key, $this->excludeKeys)) {
+            unset($this->excludeKeys[$key]);
+        }
+    }
+
+    /**
+     * Request のログを出力する.
+     *
+     * @param Request $request
+     * @return string Request のログ
+     */
+    protected function logRequest(Request $request)
+    {
+        $log = '';
+        $log .= $this->logKeyValuePair('REMOTE_ADDR', $request->getClientIp());
+        $log .= $this->logKeyValuePair('SCRIPT_NAME', $request->getScriptName());
+        $log .= $this->logKeyValuePair('PATH_INFO', $request->getPathInfo());
+        $log .= $this->logKeyValuePair('BASE_PATH', $request->getBasePath());
+        $log .= $this->logKeyValuePair('BASE_URL', $request->getBaseUrl());
+        $log .= $this->logKeyValuePair('SCHEME', $request->getScheme());
+        $log .= $this->logKeyValuePair('REMOTE_USER', $request->getUser());
+        $log .= $this->logKeyValuePair('HTTP_HOST', $request->getSchemeAndHttpHost());
+        $log .= $this->logKeyValuePair('REQUEST_URI', $request->getRequestUri());
+        $log .= $this->logKeyValuePair('METHOD', $request->getRealMethod());
+        $log .= $this->logKeyValuePair('LOCALE', $request->getLocale());
+        // $log .= $this->logArray($request->server->all(), '[server]');
+        $log .= $this->logArray($request->headers->all(), '[header]');
+        $log .= $this->logArray($request->query->all(), '[get]');
+        $log .= $this->logArray($request->request->all(), '[post]');
+        $log .= $this->logArray($request->attributes->all(), '[attributes]');
+        $log .= $this->logArray($request->cookies->all(), '[cookie]');
+        $log .= $this->logArray($request->files->all(), '[files]');
+        return $log;
+    }
+
+    /**
+     * Session のログを出力する.
+     */
+    protected function logSession(SessionInterface $Session)
+    {
+        return $this->logArray($Session->all(), '[session]');
+    }
+
+    /**
+     * 配列をログ出力する.
+     */
+    protected function logArray(array $values, $prefix = '', $context = array(), $level = Logger::DEBUG)
+    {
+        $log = '';
+        foreach ($values as $key => $val) {
+            $log .= $this->logKeyValuePair($key, $val, $prefix, $context, $level);
+        }
+        return $log;
+    }
+
+    /**
+     * キーと値のペアをログ出力する.
+     *
+     * 除外キーに該当する値は, マスクをかける
+     */
+    protected function logKeyValuePair($key, $value, $prefix = '', $context = array(), $level = Logger::DEBUG)
+    {
+        if (in_array($key, $this->excludeKeys)) {
+            return '';
+        }
+        if (is_null($value) || is_scalar($value) || (is_object($value) && method_exists($value, '__toString'))) {
+            // quiet
+        } elseif (is_object($value)) {
+            $value = '[object '.serialize($value).']';
+        } else {
+            if (is_array($value)) {
+                foreach ($value as $key => &$val) {
+                    if (in_array($key, $this->excludeKeys)
+                        && $prefix != '[header]') { // XXX header にもマスクがかかってしまう
+                        $val = '******';
+                    }
+                }
+            }
+            $value = '['.serialize($value).']';
+        }
+        return '  '.$prefix.' '.$key.'='.$value.PHP_EOL;
+    }
+}

--- a/src/Eccube/EventListener/RequestDumpListener.php
+++ b/src/Eccube/EventListener/RequestDumpListener.php
@@ -43,7 +43,6 @@ class RequestDumpListener implements EventSubscriberInterface
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
-        $request = $event->getRequest();
         $log = '** before *****************************************:'.PHP_EOL;
         $request = $event->getRequest();
         $log .= $this->logRequest($request);
@@ -135,6 +134,7 @@ class RequestDumpListener implements EventSubscriberInterface
         $log .= $this->logArray($request->attributes->all(), '[attributes]');
         $log .= $this->logArray($request->cookies->all(), '[cookie]');
         $log .= $this->logArray($request->files->all(), '[files]');
+
         return $log;
     }
 
@@ -148,6 +148,7 @@ class RequestDumpListener implements EventSubscriberInterface
     {
         $log = '';
         $log .= $this->logKeyValuePair('HTTP_STATUS', $response->getStatusCode());
+
         return $log;
     }
 
@@ -162,12 +163,13 @@ class RequestDumpListener implements EventSubscriberInterface
     /**
      * 配列をログ出力する.
      */
-    protected function logArray(array $values, $prefix = '', $context = array(), $level = Logger::DEBUG)
+    protected function logArray(array $values, $prefix = '')
     {
         $log = '';
         foreach ($values as $key => $val) {
-            $log .= $this->logKeyValuePair($key, $val, $prefix, $context, $level);
+            $log .= $this->logKeyValuePair($key, $val, $prefix);
         }
+
         return $log;
     }
 
@@ -176,7 +178,7 @@ class RequestDumpListener implements EventSubscriberInterface
      *
      * 除外キーに該当する値は, マスクをかける
      */
-    protected function logKeyValuePair($key, $value, $prefix = '', $context = array(), $level = Logger::DEBUG)
+    protected function logKeyValuePair($key, $value, $prefix = '')
     {
         $copy_value = null;
         if (in_array($key, $this->excludeKeys)) {

--- a/src/Eccube/Resource/config/log.yml.dist
+++ b/src/Eccube/Resource/config/log.yml.dist
@@ -2,6 +2,9 @@ log:
     prefix: site_
     suffix:
     format: Y-m-d
-    action_level: WARNING
+    action_level: INFO
     log_level: INFO
     max_files: 90
+    exclude_keys:
+        - password
+        - app

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -349,6 +349,10 @@ class EccubeServiceProvider implements ServiceProviderInterface
 
             return $types;
         }));
+
+        $app['listener.requestdump'] = $app->share(function($app) {
+            return new \Eccube\EventListener\RequestDumpListener($app);
+        });
     }
 
     /**
@@ -360,5 +364,6 @@ class EccubeServiceProvider implements ServiceProviderInterface
      */
     public function boot(BaseApplication $app)
     {
+        $app['dispatcher']->addSubscriber($app['listener.requestdump']);
     }
 }

--- a/src/Eccube/Util/EntityUtil.php
+++ b/src/Eccube/Util/EntityUtil.php
@@ -71,5 +71,27 @@ class EntityUtil
         return !self::isEmpty($entity);
     }
 
-
+    /**
+     * エンティティのプロパティを配列で返す.
+     *
+     * このメソッドはエンティティの内容をログ出力する際などに使用する.
+     * AbstractEntity::toArray() と異なり再帰処理しない.
+     * プロパティの値がオブジェクトの場合は、クラス名を出力する.
+     *
+     * @param object $entity 対象のエンティティ
+     * @return array エンティティのプロパティの配列
+     */
+    public static function dumpToArray($entity)
+    {
+        $objReflect = new \ReflectionClass($entity);
+        $arrProperties = $objReflect->getProperties();
+        $arrResults = array();
+        foreach ($arrProperties as $objProperty) {
+            $objProperty->setAccessible(true);
+            $name = $objProperty->getName();
+            $value = $objProperty->getValue($entity);
+            $arrResults[$name] = is_object($value) ? get_class($value) : $value;
+        }
+        return $arrResults;
+    }
 }

--- a/tests/Eccube/Tests/Util/EntityUtilTest.php
+++ b/tests/Eccube/Tests/Util/EntityUtilTest.php
@@ -4,6 +4,7 @@ namespace Eccube\Tests\Util;
 
 use Eccube\Tests\EccubeTestCase;
 use Eccube\Application;
+use Eccube\Entity\AbstractEntity;
 use Eccube\Entity\Product;
 use Eccube\Entity\ProductClass;
 use Eccube\Entity\Member;
@@ -114,5 +115,68 @@ class EntityUtilTest extends EccubeTestCase
          * LAZY loading しようとすると Entity was not found のエラーとなる
          */
         $this->assertFalse(EntityUtil::isNotEmpty($Member));
+    }
+
+    public function testDumpToArray()
+    {
+        $arrProps = array(
+            'field1' => 1,
+            'field2' => 2,
+            'field3' => 3,
+        );
+
+        $entity = new TestEntity($arrProps);
+
+        $arrProps['testField4'] = 'Doctrine\Common\Collections\ArrayCollection';
+        $this->expected = $arrProps;
+        $this->actual = EntityUtil::dumpToArray($entity);
+        $this->verify();
+    }
+}
+
+class TestEntity extends AbstractEntity
+{
+    private $field1;
+    private $field2;
+    /** public field */
+    public $field3;
+    /** camel case */
+    private $testField4;
+
+    public function __construct($arrProps = array())
+    {
+        $this->testField4 = new \Doctrine\Common\Collections\ArrayCollection();
+        if (is_array($arrProps) && count($arrProps) > 0) {
+            $this->setPropertiesFromArray($arrProps);
+        }
+    }
+
+    public function getField1()
+    {
+        return $this->field1;
+    }
+    public function setField1($field1)
+    {
+        $this->field1 = $field1;
+        return $this;
+    }
+    public function getField2()
+    {
+        return $this->field2;
+    }
+    public function setField2($field2)
+    {
+        $this->field2 = $field2;
+        return $this;
+    }
+
+    public function setTestField4($testField4)
+    {
+        $this->testField4 = $testField4;
+        return $this;
+    }
+    public function getTestField4()
+    {
+        return $this->testField4;
     }
 }


### PR DESCRIPTION
本番運用時に INFO ログを出力するよう設定
- action_level を INFO に変更
- DEBUG レベルにすると, Request の情報も出力する
- exclude_keys に該当する値にはマスクをかける
- ログを改行するよう修正
- ログ出力用に `EntityUtil::dumpToArray()` 追加。 ただし、 serialize() で間に合ったので使用していない