### PR TITLE
【管理画面】コンテンツ管理 > ページ管理 > 新規入力画面テーブル「URL・ファイル名」レイアウト崩れ #1097

### DIFF
--- a/html/template/admin/assets/css/dashboard.css
+++ b/html/template/admin/assets/css/dashboard.css
@@ -114,7 +114,9 @@ small, .small {
 .no-border {
     border: 0 none !important;
 }
-
+.word-break{
+    word-wrap: break-word
+}
 
 /* grid setting
 ============================ */

--- a/src/Eccube/Resource/template/admin/Content/page_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/page_edit.twig
@@ -57,7 +57,7 @@
                                 {{ form_errors(form.name) }}
                             </div>
                         </div>
-                        <div class="form-group">
+                        <div class="form-group word-break">
                             {{ form_label(form.url) }}
                             <div class="col-sm-9 col-lg-10 form-inline">
                                 {% if editable %}
@@ -69,7 +69,7 @@
                                 {{ form_errors(form.url) }}
                             </div>
                         </div>
-                        <div class="form-group">
+                        <div class="form-group word-break">
                             {{ form_label(form.file_name) }}
                             <div class="col-sm-9 col-lg-10 form-inline">
                                 {% if editable %}


### PR DESCRIPTION
word-wrap: break-word;を該当divに設定
※実際はForm全体に付与しても問題ないと思われるが、影響範囲が判断しきれずに
該当箇所のみクラス付与