### PR TITLE
会員情報登録時に生年月日で未来の日付が入力可能 #1106

### DIFF
--- a/src/Eccube/Form/Type/Admin/CustomerType.php
+++ b/src/Eccube/Form/Type/Admin/CustomerType.php
@@ -94,6 +94,8 @@ class CustomerType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'years' => range(date('Y')-80, date('Y')),
+                'months' => range(1, date('m')),
+                'days' => range(1, date('d')),
                 'widget' => 'choice',
                 'format' => 'yyyy-MM-dd',
                 'empty_value' => array('year' => '----', 'month' => '--', 'day' => '--'),

--- a/src/Eccube/Form/Type/Admin/CustomerType.php
+++ b/src/Eccube/Form/Type/Admin/CustomerType.php
@@ -94,11 +94,15 @@ class CustomerType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'years' => range(date('Y')-80, date('Y')),
-                'months' => range(1, date('m')),
-                'days' => range(1, date('d')),
                 'widget' => 'choice',
                 'format' => 'yyyy-MM-dd',
                 'empty_value' => array('year' => '----', 'month' => '--', 'day' => '--'),
+                'constraints' => array(
+                    new Assert\LessThanOrEqual(array(
+                        'value' => date('Y-m-d'),
+                        'message' => 'form.type.select.selectisfuturedate',
+                    )),
+                ),
             ))
             // RepeatedPasswordTypeと共通化したい
             ->add('password', 'text', array(

--- a/src/Eccube/Form/Type/CustomerType.php
+++ b/src/Eccube/Form/Type/CustomerType.php
@@ -108,6 +108,9 @@ class CustomerType extends AbstractType
             ->add('birth', 'birthday', array(
                 'required' => false,
                 'input' => 'datetime',
+                'years' => range(date('Y')-80, date('Y')),
+                'months' => range(1, date('m')),
+                'days' => range(1, date('d')),
                 'widget' => 'choice',
                 'format' => 'yyyy-MM-dd',
                 'empty_value' => array('year' => '----', 'month' => '--', 'day' => '--'),

--- a/src/Eccube/Form/Type/CustomerType.php
+++ b/src/Eccube/Form/Type/CustomerType.php
@@ -109,11 +109,15 @@ class CustomerType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'years' => range(date('Y')-80, date('Y')),
-                'months' => range(1, date('m')),
-                'days' => range(1, date('d')),
                 'widget' => 'choice',
                 'format' => 'yyyy-MM-dd',
                 'empty_value' => array('year' => '----', 'month' => '--', 'day' => '--'),
+                'constraints' => array(
+                    new Assert\LessThanOrEqual(array(
+                        'value' => date('Y-m-d'),
+                        'message' => 'form.type.select.selectisfuturedate',
+                    )),
+                ),
             ))
             ->add('password', 'repeated')
             ->add('status', 'customer_status', array(

--- a/src/Eccube/Form/Type/Front/EntryType.php
+++ b/src/Eccube/Form/Type/Front/EntryType.php
@@ -72,11 +72,15 @@ class EntryType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'years' => range(date('Y')-80, date('Y')),
-                'months' => range(1, date('m')),
-                'days' => range(1, date('d')),
                 'widget' => 'choice',
                 'format' => 'yyyy/MM/dd',
                 'empty_value' => array('year' => '----', 'month' => '--', 'day' => '--'),
+                'constraints' => array(
+                    new Assert\LessThanOrEqual(array(
+                        'value' => date('Y-m-d'),
+                        'message' => 'form.type.select.selectisfuturedate',
+                    )),
+                ),
             ))
             ->add('sex', 'sex', array(
                 'required' => false,

--- a/src/Eccube/Form/Type/Front/EntryType.php
+++ b/src/Eccube/Form/Type/Front/EntryType.php
@@ -72,6 +72,8 @@ class EntryType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'years' => range(date('Y')-80, date('Y')),
+                'months' => range(1, date('m')),
+                'days' => range(1, date('d')),
                 'widget' => 'choice',
                 'format' => 'yyyy/MM/dd',
                 'empty_value' => array('year' => '----', 'month' => '--', 'day' => '--'),

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -44,6 +44,8 @@ form.type.admin.notkanastyle: お名前(フリガナ)はカタカナで入力し
 
 form.type.select.notselect: 入力されていません。
 
+form.type.select.selectisfuturedate: 未来の日付は選択出来ません。
+
 cart.over.stock: |-
     選択された商品(%product%)の在庫が不足しております。
     一度に在庫数を超える購入はできません。


### PR DESCRIPTION
以下画面誕生日セレクトボックス「月・日」の生成時に当日までの範囲を設定
管理画面/会員登録編集
ユーザー画面/会員登録
マイページ/会員情報編集