### PR TITLE
会員情報登録時に生年月日で未来の日付が入力可能 #1106

### DIFF
--- a/src/Eccube/Form/Type/Admin/CustomerType.php
+++ b/src/Eccube/Form/Type/Admin/CustomerType.php
@@ -93,7 +93,7 @@ class CustomerType extends AbstractType
             ->add('birth', 'birthday', array(
                 'required' => false,
                 'input' => 'datetime',
-                'years' => range(date('Y')-80, date('Y')),
+                'years' => range(date('Y')-$this->config['birth_max'], date('Y')),
                 'widget' => 'choice',
                 'format' => 'yyyy-MM-dd',
                 'empty_value' => array('year' => '----', 'month' => '--', 'day' => '--'),

--- a/src/Eccube/Form/Type/CustomerType.php
+++ b/src/Eccube/Form/Type/CustomerType.php
@@ -108,7 +108,7 @@ class CustomerType extends AbstractType
             ->add('birth', 'birthday', array(
                 'required' => false,
                 'input' => 'datetime',
-                'years' => range(date('Y')-80, date('Y')),
+                'years' => range(date('Y')-$this->config['birth_max'], date('Y')),
                 'widget' => 'choice',
                 'format' => 'yyyy-MM-dd',
                 'empty_value' => array('year' => '----', 'month' => '--', 'day' => '--'),

--- a/src/Eccube/Form/Type/Front/EntryType.php
+++ b/src/Eccube/Form/Type/Front/EntryType.php
@@ -71,7 +71,7 @@ class EntryType extends AbstractType
             ->add('birth', 'birthday', array(
                 'required' => false,
                 'input' => 'datetime',
-                'years' => range(date('Y')-80, date('Y')),
+                'years' => range(date('Y')-$this->config['birth_max'], date('Y')),
                 'widget' => 'choice',
                 'format' => 'yyyy/MM/dd',
                 'empty_value' => array('year' => '----', 'month' => '--', 'day' => '--'),

--- a/src/Eccube/Resource/config/constant.yml.dist
+++ b/src/Eccube/Resource/config/constant.yml.dist
@@ -261,3 +261,4 @@ name_len: 16
 kana_len: 25
 address1_len: 32
 address2_len: 32
+birth_max: 110


### PR DESCRIPTION
生年月日の選択範囲を「110」歳に変更
あわせて、上記定数化