### PR TITLE
refs #1118 商品一覧でシステムエラーが発生する不具合の修正

### DIFF
--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -121,10 +121,9 @@ class ProductRepository extends EntityRepository
         // 価格順
         if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '1') {
             //@see http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html
-            $qb->addSelect('p.id as HIDDEN pid');
             $qb->addSelect('MIN(pc.price02) as HIDDEN price02_min');
             $qb->innerJoin('p.ProductClasses', 'pc');
-            $qb->groupBy('p.id');
+            $qb->groupBy('p');
             $qb->orderBy('price02_min', 'ASC');
             // 新着順
         } else if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '2') {


### PR DESCRIPTION
https://github.com/EC-CUBE/ec-cube/issues/1118#issuecomment-155659658 の対応です。
mysqlのONLY_FULL_GROUP_BYオプション利用時や, postgresの一部バージョン(8.4)で動作しない問題を修正しました。