### PR TITLE
再注文時の不具合修正

### DIFF
--- a/src/Eccube/Repository/DeliveryRepository.php
+++ b/src/Eccube/Repository/DeliveryRepository.php
@@ -103,7 +103,7 @@ class DeliveryRepository extends EntityRepository
 
             foreach ($paymentOptions as $PaymentOption) {
                 foreach ($payments as $Payment) {
-                    if ($PaymentOption->getPayment()->getId() == $Payment->getId()) {
+                    if ($PaymentOption->getPayment()->getId() == $Payment['id']) {
                         $arr[$Delivery->getId()] = $Delivery;
                         break;
                     }

--- a/src/Eccube/Repository/PaymentRepository.php
+++ b/src/Eccube/Repository/PaymentRepository.php
@@ -81,22 +81,31 @@ class PaymentRepository extends EntityRepository
 
     /**
      * 支払方法を取得
+     * 条件によってはDoctrineのキャッシュが返されるため、arrayで結果を返すパターンも用意
      *
      * @param $delivery
+     * @param $returnType true : Object、false: arrayが戻り値
      * @return array
      */
-    public function findPayments($delivery)
+    public function findPayments($delivery, $returnType = false)
     {
-        $payments = $this->createQueryBuilder('p')
+
+        $query = $this->createQueryBuilder('p')
             ->innerJoin('Eccube\Entity\PaymentOption', 'po', 'WITH', 'po.payment_id = p.id')
             ->where('po.Delivery = (:delivery)')
             ->orderBy('p.rank', 'DESC')
             ->setParameter('delivery', $delivery)
-            ->getQuery()
-            ->getArrayResult();
+            ->getQuery();
+
+        $query->expireResultCache(false);
+
+        if ($returnType) {
+            $payments = $query->getResult();
+        } else {
+            $payments = $query->getArrayResult();
+        }
 
         return $payments;
-
     }
 
     /**

--- a/src/Eccube/Repository/PaymentRepository.php
+++ b/src/Eccube/Repository/PaymentRepository.php
@@ -93,7 +93,7 @@ class PaymentRepository extends EntityRepository
             ->orderBy('p.rank', 'DESC')
             ->setParameter('delivery', $delivery)
             ->getQuery()
-            ->getResult();
+            ->getArrayResult();
 
         return $payments;
 
@@ -117,8 +117,8 @@ class PaymentRepository extends EntityRepository
 
                 $arr = array();
                 foreach ($p as $payment) {
-                    foreach ($payments as $p) {
-                        if ($payment->getId() == $p->getId()) {
+                    foreach ($payments as $pay) {
+                        if ($payment['id'] == $pay['id']) {
                             $arr[] = $payment;
                             break;
                         }

--- a/src/Eccube/Resource/template/default/Cart/index.twig
+++ b/src/Eccube/Resource/template/default/Cart/index.twig
@@ -48,11 +48,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
                 {% set productStr = app.session.flashbag.get('eccube.front.request.product') %}
                 {% for error in app.session.flashbag.get('eccube.front.request.error')  %}
-                    {% if productStr[0] is defined %}
+                    {% set idx = loop.index0 %}
+                    {% if productStr[idx] is defined %}
                     <div class="message">
                         <p class="errormsg bg-danger">
                             <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>
-                            {{ error|trans({'%product%':productStr[0]})|nl2br }}
+                            {{ error|trans({'%product%':productStr[idx]})|nl2br }}
                         </p>
                     </div>
                     {% else %}

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -263,7 +263,7 @@ class CartService
         if ($ProductClass->hasClassCategory2()) {
             $product_str .= " - ".$ProductClass->getClassCategory2()->getName();
         }
-        $this->session->getFlashBag()->set('eccube.front.request.product', $product_str);
+
         /*
          * 実際の在庫は ProductClass::ProductStock だが、購入時にロックがかかるため、
          * ここでは ProductClass::stock で在庫のチェックをする
@@ -271,15 +271,15 @@ class CartService
         if (!$ProductClass->getStockUnlimited() && $quantity > $ProductClass->getStock()) {
             if ($ProductClass->getSaleLimit() && $ProductClass->getStock() > $ProductClass->getSaleLimit()) {
                 $tmp_quantity = $ProductClass->getSaleLimit();
-                $this->addError('cart.over.sale_limit');
+                $this->addError('cart.over.sale_limit', $product_str);
             } else {
                 $tmp_quantity = $ProductClass->getStock();
-                $this->addError('cart.over.stock');
+                $this->addError('cart.over.stock',  $product_str);
             }
         }
         if ($ProductClass->getSaleLimit() && $quantity > $ProductClass->getSaleLimit()) {
             $tmp_quantity = $ProductClass->getSaleLimit();
-            $this->addError('cart.over.sale_limit');
+            $this->addError('cart.over.sale_limit', $product_str);
         }
         if ($tmp_quantity) {
             $quantity = $tmp_quantity;
@@ -436,13 +436,16 @@ class CartService
 
     /**
      * @param  string $error
+     * @param  string $productName
      * @return \Eccube\Service\CartService
      */
-    public function addError($error = null)
+    public function addError($error = null, $productName = null)
     {
         $this->errors[] = $error;
         $this->session->getFlashBag()->add('eccube.front.request.error', $error);
-
+        if (!is_null($productName)) {
+            $this->session->getFlashBag()->add('eccube.front.request.product', $productName);
+        }
         return $this;
     }
 

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -336,7 +336,7 @@ class CartService
         $arr = array();
         foreach ($payments as $payment) {
             foreach ($this->getCart()->getPayments() as $p) {
-                if ($payment->getId() == $p->getId()) {
+                if ($payment['id'] == $p['id']) {
                     $arr[] = $payment;
                     break;
                 }

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -870,9 +870,10 @@ class ShoppingService
         foreach ($payments as $payment) {
             // 支払方法の制限値内であれば表示
             if (!is_null($payment)) {
-                if (intval($payment->getRuleMin()) <= $subTotal) {
-                    if (is_null($payment->getRuleMax()) || $payment->getRuleMax() >= $subTotal) {
-                        $pays[] = $payment;
+                $pay = $this->app['eccube.repository.payment']->find($payment['id']);
+                if (intval($pay->getRuleMin()) <= $subTotal) {
+                    if (is_null($pay->getRuleMax()) || $pay->getRuleMax() >= $subTotal) {
+                        $pays[] = $pay;
                     }
                 }
             }
@@ -949,7 +950,7 @@ class ShoppingService
             // 配送業者をセット
             $shippings = $Order->getShippings();
             $Shipping = $shippings[0];
-            $payments = $this->app['eccube.repository.payment']->findPayments($Shipping->getDelivery());
+            $payments = $this->app['eccube.repository.payment']->findPayments($Shipping->getDelivery(), true);
 
         }
 


### PR DESCRIPTION
* 複数配送の再注文時に、支払方法を取得した後のオブジェクト結果にDoctrineキャッシュが使われる時があるため、arrayで取得するように変更

* エラーメッセージの表示方法を複数商品がセットされた時でも適切に表示されるように修正