### PR TITLE
Firefox で受注管理画面の「計算結果の更新」ボタンがずれている #1081

### DIFF
--- a/html/template/admin/assets/css/dashboard.css
+++ b/html/template/admin/assets/css/dashboard.css
@@ -747,6 +747,10 @@ fieldset[disabled] .btn-link:focus {
     padding: 16px 0 48px;
 }
 
+.btn_area ul li {
+    display: table-cell;
+    vertical-align: middle;
+}
 
 /*	dl-horizontal
 ============================ */


### PR DESCRIPTION
該当箇所CSSブラウザデフォルト値が反映されていたため、table-cellのvatical-alignで上書き