### PR TITLE
IE11 で、電話/FAX番号フォームをフォーカスすると、項目がずれる #1073

### DIFF
--- a/html/template/default/css/style.css
+++ b/html/template/default/css/style.css
@@ -4406,3 +4406,9 @@ fieldset[disabled] .btn-link:focus {
 
 	}
 }
+
+
+/* BootStrap Focus cancel */
+.input_tel input {
+    margin: 5.97px;
+}


### PR DESCRIPTION
BootStrapのFocusによりPadding値が変化していたため、固定値を設定