### PR TITLE
IE11 で、電話/FAX番号フォームをフォーカスすると、項目がずれる #1073Firefox で受注管理画面の「計算結果の更新」ボタンがずれている #1081

### DIFF
--- a/html/template/admin/assets/css/dashboard.css
+++ b/html/template/admin/assets/css/dashboard.css
@@ -747,11 +747,6 @@ fieldset[disabled] .btn-link:focus {
     padding: 16px 0 48px;
 }
 
-.btn_area ul li {
-    display: table-cell;
-    vertical-align: middle;
-}
-
 /*	dl-horizontal
 ============================ */
 
@@ -1333,6 +1328,7 @@ textarea.form-control{
     width: 20%;
     min-width: 160px;
     display: inline-block;
+    vertical-align: middle;
     margin-right: 8px;
     margin-bottom: 8px;
 }


### PR DESCRIPTION
@k-yamamuraのレビューに基づき、CSSの箇所を該当箇所のみに変更