### PR TITLE
setApp(), setConfig() を setApplication() に統一

### DIFF
--- a/src/Eccube/Repository/BlockRepository.php
+++ b/src/Eccube/Repository/BlockRepository.php
@@ -35,9 +35,9 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class BlockRepository extends EntityRepository
 {
-    private $app;
+    protected $app;
 
-    public function setApp($app)
+    public function setApplication($app)
     {
         $this->app = $app;
     }

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -43,7 +43,7 @@ use Symfony\Component\Security\Core\Util\SecureRandom;
  */
 class CustomerRepository extends EntityRepository implements UserProviderInterface
 {
-    public $app;
+    protected $app;
 
     public function setApplication($app)
     {

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -36,12 +36,11 @@ use Doctrine\ORM\QueryBuilder;
  */
 class OrderRepository extends EntityRepository
 {
-    /** @var array */
-    public $config;
+    protected $app;
 
-    public function setConfig(array $config)
+    public function setApplication($app)
     {
-        $this->config = $config;
+        $this->app = $app;
     }
 
     public function changeStatus($orderId, \Eccube\Entity\Master\OrderStatus $Status)
@@ -295,7 +294,7 @@ class OrderRepository extends EntityRepository
         } else {
             // 購入処理中は検索対象から除外
             $qb->andWhere('o.OrderStatus <> :status')
-                ->setParameter('status', $this->config['order_processing']);
+                ->setParameter('status', $this->app['config']['order_processing']);
         }
 
         // name
@@ -472,7 +471,7 @@ class OrderRepository extends EntityRepository
         $qb = $this->createQueryBuilder('o');
         $qb
             ->where('o.OrderStatus <> :OrderStatus')
-            ->setParameter('OrderStatus', $this->config['order_cancel'])
+            ->setParameter('OrderStatus', $this->app['config']['order_cancel'])
             ->setMaxResults(10)
             ->orderBy('o.create_date', 'DESC');
 

--- a/src/Eccube/Repository/PageLayoutRepository.php
+++ b/src/Eccube/Repository/PageLayoutRepository.php
@@ -39,9 +39,9 @@ use Symfony\Component\Finder\Finder;
  */
 class PageLayoutRepository extends EntityRepository
 {
-    private $app;
+    protected $app;
 
-    public function setApp($app)
+    public function setApplication($app)
     {
         $this->app = $app;
     }

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -37,20 +37,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class ProductRepository extends EntityRepository
 {
-    /**
-     * @var array
-     */
-    private $config;
-
-    /**
-     * setConfig
-     *
-     * @param array $config
-     */
-    public function setConfig(array $config)
-    {
-        $this->config = $config;
-    }
 
     /**
      * get Product.

--- a/src/Eccube/Repository/TaxRuleRepository.php
+++ b/src/Eccube/Repository/TaxRuleRepository.php
@@ -38,9 +38,9 @@ class TaxRuleRepository extends EntityRepository
 {
     private $rules = array();
 
-    private $app;
+    protected $app;
 
-    public function setApp($app)
+    public function setApplication($app)
     {
         $this->app = $app;
     }

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -146,8 +146,6 @@ class EccubeServiceProvider implements ServiceProviderInterface
         });
         $app['eccube.repository.product'] = $app->share(function () use ($app) {
             $productRepository = $app['orm.em']->getRepository('Eccube\Entity\Product');
-            $productRepository->setConfig($app['config']);
-
             return $productRepository;
         });
         $app['eccube.repository.product_image'] = $app->share(function () use ($app) {
@@ -173,25 +171,25 @@ class EccubeServiceProvider implements ServiceProviderInterface
         });
         $app['eccube.repository.tax_rule'] = $app->share(function () use ($app) {
             $taxRuleRepository = $app['orm.em']->getRepository('Eccube\Entity\TaxRule');
-            $taxRuleRepository->setApp($app);
+            $taxRuleRepository->setApplication($app);
 
             return $taxRuleRepository;
         });
         $app['eccube.repository.page_layout'] = $app->share(function () use ($app) {
             $pageLayoutRepository = $app['orm.em']->getRepository('Eccube\Entity\PageLayout');
-            $pageLayoutRepository->setApp($app);
+            $pageLayoutRepository->setApplication($app);
 
             return $pageLayoutRepository;
         });
         $app['eccube.repository.block'] = $app->share(function () use ($app) {
             $blockRepository = $app['orm.em']->getRepository('Eccube\Entity\Block');
-            $blockRepository->setApp($app);
+            $blockRepository->setApplication($app);
 
             return $blockRepository;
         });
         $app['eccube.repository.order'] = $app->share(function () use ($app) {
             $orderRepository = $app['orm.em']->getRepository('Eccube\Entity\Order');
-            $orderRepository->setConfig($app['config']);
+            $orderRepository->setApplication($app);
 
             return $orderRepository;
         });
@@ -235,7 +233,7 @@ class EccubeServiceProvider implements ServiceProviderInterface
             $app['orm.em'] = $app->share($app->extend('orm.em', function (\Doctrine\ORM\EntityManager $em, \Silex\Application $app) {
                 // tax_rule
                 $taxRuleRepository = $em->getRepository('Eccube\Entity\TaxRule');
-                $taxRuleRepository->setApp($app);
+                $taxRuleRepository->setApplication($app);
                 $taxRuleService = new \Eccube\Service\TaxRuleService($taxRuleRepository);
                 $em->getEventManager()->addEventSubscriber(new \Eccube\Doctrine\EventSubscriber\TaxRuleEventSubscriber($taxRuleService));
 


### PR DESCRIPTION
- プラグインから利用するメソッドではないため、互換用メソッドは作成していません。
- 継承での拡張を考慮して, private を protected に変更
- ProductRepository::setConfig() は未使用のため削除