### PR TITLE
Order に実装可能な OrderService のメソッドを移動

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -362,10 +362,6 @@ class EditController extends AbstractController
     protected function newOrder()
     {
         $Order = new \Eccube\Entity\Order();
-        $Order->setCharge(0);
-        $Order->setDeliveryFeeTotal(0);
-        $Order->setDiscount(0);
-        $Order->setDelFlg(0);
         $Shipping = new \Eccube\Entity\Shipping();
         $Shipping->setDelFlg(0);
         $Order->addShipping($Shipping);

--- a/src/Eccube/Service/OrderService.php
+++ b/src/Eccube/Service/OrderService.php
@@ -28,6 +28,9 @@ use Eccube\Entity\Cart;
 use Eccube\Entity\Customer;
 use Eccube\Entity\Order;
 
+/**
+ * @deprecated since 3.0.0, to be removed in 3.1
+ */
 class OrderService
 {
     /** @var \Eccube\Application */
@@ -43,15 +46,11 @@ class OrderService
      *
      * @param Order $Order
      * @return int
+     * @deprecated since 3.0.0, to be removed in 3.1
      */
     public function getTotalQuantity(Order $Order)
     {
-        $totalQuantity = 0;
-        foreach ($Order->getOrderDetails() as $OrderDetail) {
-            $totalQuantity += $OrderDetail->getQuantity();
-        }
-
-        return $totalQuantity;
+        return $Order->calculateTotalQuantity();
     }
 
     /**
@@ -59,16 +58,11 @@ class OrderService
      *
      * @param Order $Order
      * @return int
+     * @deprecated since 3.0.0, to be removed in 3.1
      */
     public function getSubTotal(Order $Order)
     {
-        $subTotal = 0;
-        foreach ($Order->getOrderDetails() as $OrderDetail) {
-            // 小計
-            $subTotal += $OrderDetail->getPriceIncTax() * $OrderDetail->getQuantity();
-        }
-
-        return $subTotal;
+        return $Order->calculateSubTotal();
     }
 
     /**
@@ -76,16 +70,11 @@ class OrderService
      *
      * @param Order $Order
      * @return int
+     * @deprecated since 3.0.0, to be removed in 3.1
      */
     public function getTotalTax(Order $Order)
     {
-        $tax = 0;
-        foreach ($Order->getOrderDetails() as $OrderDetail) {
-            // 消費税のみの小計
-            $tax += ($OrderDetail->getPriceIncTax() - $OrderDetail->getPrice()) * $OrderDetail->getQuantity();
-        }
-
-        return $tax;
+        return $Order->calculateTotalTax();
     }
 
     /**
@@ -93,18 +82,11 @@ class OrderService
      *
      * @param Order $Order
      * @return array
+     * @deprecated since 3.0.0, to be removed in 3.1
      */
     public function getProductTypes(Order $Order)
     {
-
-        $productTypes = array();
-        foreach ($Order->getOrderDetails() as $OrderDetail) {
-            /* @var $ProductClass \Eccube\Entity\ProductClass */
-            $ProductClass = $OrderDetail->getProductClass();
-            $productTypes[] = $ProductClass->getProductType();
-        }
-        return array_unique($productTypes);
-
+        return $Order->getProductTypes();
     }
 
     /**

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -226,16 +226,8 @@ class ShoppingService
      */
     public function newOrder()
     {
-        $Order = new \Eccube\Entity\Order();
-        $Order->setDiscount(0)
-            ->setSubtotal(0)
-            ->setTotal(0)
-            ->setPaymentTotal(0)
-            ->setCharge(0)
-            ->setTax(0)
-            ->setOrderStatus($this->app['eccube.repository.order_status']->find($this->app['config']['order_processing']))
-            ->setDelFlg(Constant::DISABLED);
-
+        $OrderStatus = $this->app['eccube.repository.order_status']->find($this->app['config']['order_processing']);
+        $Order = new \Eccube\Entity\Order($OrderStatus);
         return $Order;
     }
 

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -246,13 +246,8 @@ abstract class EccubeTestCase extends WebTestCase
         $faker = $this->getFaker();
         $quantity = $faker->randomNumber(2);
         $Pref = $this->app['eccube.repository.master.pref']->find(1);
-        $Order = new Order();
-        $Order->setCustomer($Customer)
-            ->setCharge(0)
-            ->setDeliveryFeeTotal(0)
-            ->setDiscount(0)
-            ->setOrderStatus($this->app['eccube.repository.order_status']->find($this->app['config']['order_processing']))
-            ->setDelFlg(Constant::DISABLED);
+        $Order = new Order($this->app['eccube.repository.order_status']->find($this->app['config']['order_processing']));
+        $Order->setCustomer($Customer);
         $Order->copyProperties($Customer);
         $Order->setPref($Pref);
         $this->app['orm.em']->persist($Order);

--- a/tests/Eccube/Tests/Entity/OrderTest.php
+++ b/tests/Eccube/Tests/Entity/OrderTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Eccube\Tests\Entity;
+
+use Eccube\Common\Constant;
+use Eccube\Entity\Order;
+use Eccube\Tests\EccubeTestCase;
+
+/**
+ * AbstractEntity test cases.
+ *
+ * @author Kentaro Ohkouchi
+ */
+class OrderTest extends EccubeTestCase
+{
+    protected $Customer;
+    protected $Order;
+    protected $rate;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->Customer = $this->createCustomer();
+        $this->Order = $this->createOrder($this->Customer);
+        $TaxRule = $this->app['eccube.repository.tax_rule']->getByRule();
+        $this->rate = $TaxRule->getTaxRate();
+    }
+
+    public function testConstructor()
+    {
+        $OrderStatus = $this->app['eccube.repository.order_status']->find($this->app['config']['order_processing']);
+        $Order = new Order($OrderStatus);
+
+        $this->expected = 0;
+
+        $this->actual = $Order->getDiscount();
+        $this->verify();
+
+        $this->actual = $Order->getSubTotal();
+        $this->verify();
+
+        $this->actual = $Order->getTotal();
+        $this->verify();
+
+        $this->actual = $Order->getPaymentTotal();
+        $this->verify();
+
+        $this->actual = $Order->getCharge();
+        $this->verify();
+
+        $this->actual = $Order->getTax();
+        $this->verify();
+
+        $this->actual = $Order->getDeliveryFeeTotal();
+        $this->verify();
+
+        $this->assertSame($OrderStatus, $Order->getOrderStatus());
+        $this->assertSame(Constant::DISABLED, $Order->getDelFlg());
+    }
+
+    public function testConstructor2()
+    {
+        $Order = new Order();
+
+        $this->expected = 0;
+
+        $this->actual = $Order->getDiscount();
+        $this->verify();
+
+        $this->actual = $Order->getSubTotal();
+        $this->verify();
+
+        $this->actual = $Order->getTotal();
+        $this->verify();
+
+        $this->actual = $Order->getPaymentTotal();
+        $this->verify();
+
+        $this->actual = $Order->getCharge();
+        $this->verify();
+
+        $this->actual = $Order->getTax();
+        $this->verify();
+
+        $this->actual = $Order->getDeliveryFeeTotal();
+        $this->verify();
+
+        $this->assertNull($Order->getOrderStatus());
+        $this->assertSame(Constant::DISABLED, $Order->getDelFlg());
+    }
+
+    public function testGetSubTotal()
+    {
+        $quantity = 3;
+        $price = 100;
+        $rows = count($this->Order->getOrderDetails());
+
+        $subTotal = 0;
+        foreach ($this->Order->getOrderDetails() as $Detail) {
+            $Detail->setPrice($price);
+            $Detail->setQuantity($quantity);
+            $subTotal = $Detail->getPriceIncTax() * $Detail->getQuantity();
+        }
+        $this->Order->setSubTotal($subTotal);
+        $this->app['orm.em']->flush();
+
+        $Result = $this->app['eccube.repository.order']->find($this->Order->getId());
+
+        $this->expected = ($price + ($price * ($this->rate / 100))) * $quantity * $rows;
+        $this->actual = $Result->calculateSubTotal();
+        $this->verify();
+    }
+
+    public function testGetTotalQuantity()
+    {
+        $quantity = 3;
+        $rows = count($this->Order->getOrderDetails());
+
+        $total = 0;
+        foreach ($this->Order->getOrderDetails() as $Detail) {
+            $Detail->setQuantity($quantity);
+            $total += $Detail->getQuantity();
+        }
+        $this->app['orm.em']->flush();
+
+        $Result = $this->app['eccube.repository.order']->find($this->Order->getId());
+
+        $this->expected = $total;
+        $this->actual = $Result->calculateTotalQuantity();
+        $this->verify();
+    }
+
+    public function testGetTotalTax()
+    {
+        $quantity = 3;
+        $price = 100;
+        $rows = count($this->Order->getOrderDetails());
+
+        $totalTax = 0;
+        foreach ($this->Order->getOrderDetails() as $Detail) {
+            $Detail->setPrice($price);
+            $Detail->setQuantity($quantity);
+            $totalTax += ($Detail->getPriceIncTax() - $Detail->getPrice()) * $Detail->getQuantity();
+        }
+        $this->app['orm.em']->flush();
+
+        $Result = $this->app['eccube.repository.order']->find($this->Order->getId());
+
+        $this->expected = ($price * ($this->rate / 100)) * $quantity * $rows;
+        $this->actual = $Result->calculateTotalTax();
+        $this->verify();
+    }
+
+    public function testGetProductTypes()
+    {
+        $this->expected = array($this->app['eccube.repository.master.product_type']->find(1));
+        $this->actual = $this->Order->getProductTypes();
+        $this->verify();
+    }
+}

--- a/tests/Eccube/Tests/Service/OrderServiceTest.php
+++ b/tests/Eccube/Tests/Service/OrderServiceTest.php
@@ -29,10 +29,86 @@ use Eccube\Application;
 class OrderServiceTest extends AbstractServiceTestCase
 {
     protected $app;
+    protected $Customer;
+    protected $Order;
+    protected $rate;
 
     public function setUp()
     {
         parent::setUp();
+        $this->Customer = $this->createCustomer();
+        $this->Order = $this->createOrder($this->Customer);
+        $TaxRule = $this->app['eccube.repository.tax_rule']->getByRule();
+        $this->rate = $TaxRule->getTaxRate();
+    }
+
+    public function testGetSubTotal()
+    {
+        $quantity = 3;
+        $price = 100;
+        $rows = count($this->Order->getOrderDetails());
+
+        $subTotal = 0;
+        foreach ($this->Order->getOrderDetails() as $Detail) {
+            $Detail->setPrice($price);
+            $Detail->setQuantity($quantity);
+            $subTotal = $Detail->getPriceIncTax() * $Detail->getQuantity();
+        }
+        $this->Order->setSubTotal($subTotal);
+        $this->app['orm.em']->flush();
+
+        $Result = $this->app['eccube.repository.order']->find($this->Order->getId());
+
+        $this->expected = ($price + ($price * ($this->rate / 100))) * $quantity * $rows;
+        $this->actual = $this->app['eccube.service.order']->getSubTotal($Result);
+        $this->verify();
+    }
+
+    public function testGetTotalQuantity()
+    {
+        $quantity = 3;
+        $rows = count($this->Order->getOrderDetails());
+
+        $total = 0;
+        foreach ($this->Order->getOrderDetails() as $Detail) {
+            $Detail->setQuantity($quantity);
+            $total += $Detail->getQuantity();
+        }
+        $this->app['orm.em']->flush();
+
+        $Result = $this->app['eccube.repository.order']->find($this->Order->getId());
+
+        $this->expected = $total;
+        $this->actual = $this->app['eccube.service.order']->getTotalQuantity($Result);
+        $this->verify();
+    }
+
+    public function testGetTotalTax()
+    {
+        $quantity = 3;
+        $price = 100;
+        $rows = count($this->Order->getOrderDetails());
+
+        $totalTax = 0;
+        foreach ($this->Order->getOrderDetails() as $Detail) {
+            $Detail->setPrice($price);
+            $Detail->setQuantity($quantity);
+            $totalTax += ($Detail->getPriceIncTax() - $Detail->getPrice()) * $Detail->getQuantity();
+        }
+        $this->app['orm.em']->flush();
+
+        $Result = $this->app['eccube.repository.order']->find($this->Order->getId());
+
+        $this->expected = ($price * ($this->rate / 100)) * $quantity * $rows;
+        $this->actual = $this->app['eccube.service.order']->getTotalTax($Result);
+        $this->verify();
+    }
+
+    public function testGetProductTypes()
+    {
+        $this->expected = array($this->app['eccube.repository.master.product_type']->find(1));
+        $this->actual = $this->app['eccube.service.order']->getProductTypes($this->Order);
+        $this->verify();
     }
 
     public function testNewOrder()
@@ -153,11 +229,5 @@ class OrderServiceTest extends AbstractServiceTestCase
             ->setDelFlg(1);
 
         return $Customer;
-    }
-
-    public function tearDown()
-    {
-        $this->app['orm.em']->getConnection()->close();
-        parent::tearDown();
     }
 }


### PR DESCRIPTION
- OrderService::getTotalQuantity(), getSubTotal(), getTotalTax(), getProductTypes() を Order に移動(#1028)
- ShoppingService::newOrder() を Order のコンストラクタで処理できるように修正(#870)
- OrderService に deprecated を付与
    - 新たにメソッドを追加する場合は @deprecated を削除すること
- OrderTest 追加
- 冗長な処理を削除