### PR TITLE
BlockRepository の問題点 #928

### DIFF
--- a/src/Eccube/Controller/Admin/Content/BlockController.php
+++ b/src/Eccube/Controller/Admin/Content/BlockController.php
@@ -52,7 +52,10 @@ class BlockController extends AbstractController
             ->find(DeviceType::DEVICE_TYPE_PC);
 
         $Block = $app['eccube.repository.block']
-            ->findOrCreate($id, $DeviceType);
+            ->findOrCreate(array(
+                'id' => $id,
+                'DeviceType' => $DeviceType,
+            ));
 
         if (!$Block) {
             throw new NotFoundHttpException();
@@ -69,9 +72,8 @@ class BlockController extends AbstractController
         if ($id) {
             // テンプレートファイルの取得
             $previous_filename = $Block->getFileName();
-            $file = $app['eccube.repository.block']
-                ->getReadTemplateFile($previous_filename, $deletable);
-            $html = $file['tpl_data'];
+            $html = $app['eccube.repository.block']
+                ->getReadTemplateFile($previous_filename);
         }
 
         $form->get('block_html')->setData($html);

--- a/tests/Eccube/Tests/Repository/BlockRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/BlockRepositoryTest.php
@@ -84,7 +84,7 @@ class BlockRepositoryTest extends EccubeTestCase
         $this->assertNull($Block->getId());
 
         $Block = $this->app['eccube.repository.block']->findOrCreate(array('id' => 999999, 'DeviceType' => $this->DeviceType));
-        $this->assertTrue($Block->getId(), 999999);
+        $this->assertNull($Block->getId());
     }
 
     public function testGetWriteTemplatePath()

--- a/tests/Eccube/Tests/Repository/BlockRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/BlockRepositoryTest.php
@@ -50,7 +50,7 @@ class BlockRepositoryTest extends EccubeTestCase
 
     public function testGetList()
     {
-        $Blocks = $this->app['eccube.repository.block']->getList($this->DeviceType);
+        $Blocks = $this->app['eccube.repository.block']->getList(array('DeviceType' => $this->DeviceType));
 
         $this->assertNotNull($Blocks);
         $this->expected = 10;
@@ -60,7 +60,7 @@ class BlockRepositoryTest extends EccubeTestCase
 
     public function testGetBlock()
     {
-        $Block = $this->app['eccube.repository.block']->getBlock($this->block_id, $this->DeviceType);
+        $Block = $this->app['eccube.repository.block']->getBlock(array('id' => $this->block_id, 'DeviceType' => $this->DeviceType));
         $this->assertNotNull($Block);
         $this->expected = $this->block_id;
         $this->actual = $Block->getId();
@@ -71,19 +71,19 @@ class BlockRepositoryTest extends EccubeTestCase
     {
         // TODO findOrCreate(array $condition) にするべき
         // https://github.com/EC-CUBE/ec-cube/issues/922
-        $Block = $this->app['eccube.repository.block']->findOrCreate($this->block_id, $this->DeviceType);
+        $Block = $this->app['eccube.repository.block']->findOrCreate(array('id' => $this->block_id, 'DeviceType' => $this->DeviceType));
 
         $this->assertNotNull($Block);
         $this->expected = $this->block_id;
         $this->actual = $Block->getId();
         $this->verify('ブロックIDは'.$this->expected.'ではありません');
 
-        $Block = $this->app['eccube.repository.block']->findOrCreate(null, $this->DeviceType);
+        $Block = $this->app['eccube.repository.block']->findOrCreate(array('id' => null, 'DeviceType' => $this->DeviceType));
         $this->assertNotNull($Block);
         $this->assertTrue($Block instanceof \Eccube\Entity\Block);
         $this->assertNull($Block->getId());
 
-        $Block = $this->app['eccube.repository.block']->findOrCreate(999999, $this->DeviceType);
+        $Block = $this->app['eccube.repository.block']->findOrCreate(array('id' => 999999, 'DeviceType' => $this->DeviceType));
         $this->assertNull($Block); // XXX block_id = 999999 の新たなインスタンスを返してほしいが不可能.
     }
 

--- a/tests/Eccube/Tests/Repository/BlockRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/BlockRepositoryTest.php
@@ -50,7 +50,7 @@ class BlockRepositoryTest extends EccubeTestCase
 
     public function testGetList()
     {
-        $Blocks = $this->app['eccube.repository.block']->getList(array('DeviceType' => $this->DeviceType));
+        $Blocks = $this->app['eccube.repository.block']->getList($this->DeviceType);
 
         $this->assertNotNull($Blocks);
         $this->expected = 10;

--- a/tests/Eccube/Tests/Repository/BlockRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/BlockRepositoryTest.php
@@ -84,7 +84,7 @@ class BlockRepositoryTest extends EccubeTestCase
         $this->assertNull($Block->getId());
 
         $Block = $this->app['eccube.repository.block']->findOrCreate(array('id' => 999999, 'DeviceType' => $this->DeviceType));
-        $this->assertNull($Block); // XXX block_id = 999999 の新たなインスタンスを返してほしいが不可能.
+        $this->assertTrue($Block->getId(), 999999);
     }
 
     public function testGetWriteTemplatePath()

--- a/tests/Eccube/Tests/Repository/BlockRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/BlockRepositoryTest.php
@@ -131,7 +131,7 @@ class BlockRepositoryTest extends EccubeTestCase
         // XXX 引数 isUser は使用していない
         $data = $this->app['eccube.repository.block']->getReadTemplateFile($fileName);
         // XXX 実装上は, tpl_data しか使っていない. 配列を返す意味がない
-        $this->actual = $data['tpl_data'];
+        $this->actual = $data;
         $this->expected = 'test';
         $this->verify();
     }

--- a/tests/Eccube/Tests/Repository/BlockRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/BlockRepositoryTest.php
@@ -109,10 +109,7 @@ class BlockRepositoryTest extends EccubeTestCase
 
         file_put_contents($this->app['config']['block_realdir'].'/'.$fileName.'.twig', 'test');
 
-        // XXX 引数 isUser は使用していない
-        $data = $this->app['eccube.repository.block']->getReadTemplateFile($fileName);
-        // XXX 実装上は, tpl_data しか使っていない. 配列を返す意味がない
-        $this->actual = $data['tpl_data'];
+        $this->actual = $this->app['eccube.repository.block']->getReadTemplateFile($fileName);
         $this->expected = 'test';
         $this->verify();
     }


### PR DESCRIPTION
#922 の課題あり
→引数を変更findOneOrCreate($conditions)
#869 の課題あり
→https://github.com/EC-CUBE/ec-cube/pull/1220で対応済み

getWriteTemplatePath() と getReadTemplateFile() の引数 $isUser は使用されていない
→getReadTemplateFileのみ$isUser 廃止

getNewBlockId(), getPageList() は使用されていない(#927 で @deprecated 追加)

getReadTemplateFile() は連想配列を返すが、 tpl_data しか使用しておらず、連想配列を返す意味がない
→連想配列返却を廃止