### PR TITLE
受注CSVダウンロードで、商品名を検索条件に入れるとシステムエラー #1236

### DIFF
--- a/src/Eccube/Service/CsvExportService.php
+++ b/src/Eccube/Service/CsvExportService.php
@@ -234,7 +234,6 @@ class CsvExportService
 
         $this->fopen();
 
-        //@see http://www.krueckeberg.org/notes/d2.html :: Iterating over queries directly
         $query = $this->qb->getQuery();
         foreach ($query->getResult() as $iteratableResult) {
             $closure($iteratableResult, $this);

--- a/src/Eccube/Service/CsvExportService.php
+++ b/src/Eccube/Service/CsvExportService.php
@@ -241,6 +241,7 @@ class CsvExportService
             $this->em->detach($iteratableResult);
             $this->em->clear();
             $query->free();
+            flush();
         }
 
         $this->fclose();

--- a/src/Eccube/Service/CsvExportService.php
+++ b/src/Eccube/Service/CsvExportService.php
@@ -234,14 +234,13 @@ class CsvExportService
 
         $this->fopen();
 
+        //@see http://www.krueckeberg.org/notes/d2.html :: Iterating over queries directly
         $query = $this->qb->getQuery();
-        foreach ($query->iterate() as $iteratableResult) {
-            $closure($iteratableResult[0], $this);
-
-            $this->em->detach($iteratableResult[0]);
+        foreach ($query->getResult() as $iteratableResult) {
+            $closure($iteratableResult, $this);
+            $this->em->detach($iteratableResult);
             $this->em->clear();
             $query->free();
-            flush();
         }
 
         $this->fclose();


### PR DESCRIPTION
iteratorを廃止、getResultをforeachの引数に直接渡す様に変更
以下公式サイトより引用
http://www.krueckeberg.org/notes/d2.html

参考にiteratorとgetResultとのメモリ使用量を記述したCSVを添付
→Gitterに添付します


