### PR TITLE
購入確認画面 → お届け先の編集で、未選択のエラーメッセージが表示されない #1210

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -453,6 +453,7 @@ class ShoppingController extends AbstractController
                     array(
                         'Customer' => $app->user(),
                         'shippingId' => $id,
+                        'error' => true,
                     )
                 );
             }
@@ -513,6 +514,7 @@ class ShoppingController extends AbstractController
             array(
                 'Customer' => $app->user(),
                 'shippingId' => $id,
+                'error' => false,
             )
         );
     }

--- a/src/Eccube/Resource/template/default/Shopping/shipping.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping.twig
@@ -34,6 +34,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <span class="text-danger">お届け先登録上限の{{ app.config.deliv_addr_max }}件に達しています。お届け先を入力したい場合は、削除か変更を行ってください</span>
                     {% endif %}
                     </p>
+                    {% if error %}
+                        <p class="text-danger">お届け先を指定してください。</p>
+                    {% endif %}
 
                     {% if Customer.CustomerAddresses|length > 0 %}
                      <div class="table address_table">


### PR DESCRIPTION
ShoppingControllerにtwingに渡すエラー判定追記,Shopping/shipping.twigにエラー判定、メッセージ追記