### PR TITLE
【WIP】app/log/ に書き込み権限がないとインストール画面でエラーになる #1205

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -28,6 +28,14 @@ ini_set('display_errors', 'Off');
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
 
 $app = new Eccube\Application();
+$baseDir = '../';
+$checkLogFile = $baseDir.'app'.DIRECTORY_SEPARATOR.'log'.DIRECTORY_SEPARATOR.'install.log';
+
+if (!is_writable($checkLogFile)) {
+    chmod($checkLogFile, 0766);
+    echo 'app/log/install.log に書き込み権限(770)を与えてください';
+    exit();
+}
 
 // インストールされてなければインストーラにリダイレクト
 if ($app['config']['eccube_install']) {

--- a/html/index.php
+++ b/html/index.php
@@ -31,12 +31,6 @@ $app = new Eccube\Application();
 $baseDir = '../';
 $checkLogFile = $baseDir.'app'.DIRECTORY_SEPARATOR.'log'.DIRECTORY_SEPARATOR.'install.log';
 
-if (!is_writable($checkLogFile)) {
-    chmod($checkLogFile, 0766);
-    echo 'app/log/install.log に書き込み権限(770)を与えてください';
-    exit();
-}
-
 // インストールされてなければインストーラにリダイレクト
 if ($app['config']['eccube_install']) {
     $app->initialize();

--- a/html/index.php
+++ b/html/index.php
@@ -28,8 +28,7 @@ ini_set('display_errors', 'Off');
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
 
 $app = new Eccube\Application();
-$baseDir = '../';
-$checkLogFile = $baseDir.'app'.DIRECTORY_SEPARATOR.'log'.DIRECTORY_SEPARATOR.'install.log';
+
 
 // インストールされてなければインストーラにリダイレクト
 if ($app['config']['eccube_install']) {

--- a/html/index.php
+++ b/html/index.php
@@ -29,7 +29,6 @@ error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
 
 $app = new Eccube\Application();
 
-
 // インストールされてなければインストーラにリダイレクト
 if ($app['config']['eccube_install']) {
     $app->initialize();

--- a/html/install.php
+++ b/html/install.php
@@ -21,6 +21,11 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+ini_set('display_errors', 'Off');
+if (!is_writable($checkLogFile)) {
+    die('app/log/install.log をウェブサーバーから書き込めるようにしてください');
+}
+
 if (function_exists('apc_clear_cache')) {
     apc_clear_cache('user');
     apc_clear_cache();

--- a/html/install.php
+++ b/html/install.php
@@ -21,6 +21,8 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+$baseDir = '../';
+$checkLogFile = $baseDir.'app'.DIRECTORY_SEPARATOR.'log'.DIRECTORY_SEPARATOR.'install.log';
 ini_set('display_errors', 'Off');
 if (!is_writable($checkLogFile)) {
     die('app/log/install.log をウェブサーバーから書き込めるようにしてください');


### PR DESCRIPTION
Monologでエラーがでて、symfony2起動前にエラーとなるので、index.phpで判定、内容をecho表示
※対応が適切かどうかはご意見ください。