### PR TITLE
WebTest での MailCatcher の処理を移動

### DIFF
--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -499,7 +499,9 @@ abstract class EccubeTestCase extends WebTestCase
         } catch (HttpException $e) {
             $this->markTestSkipped($e->getMailCatcherMessage().'['.$e->getStatusCode().']');
         } catch (\Exception $e) {
-            $this->markTestSkipped('MailCatcher is not alivable');
+            $message = 'MailCatcher is not alivable';
+            $this->markTestSkipped($message);
+            $this->app->log($message);
         }
     }
 

--- a/tests/Eccube/Tests/Web/AbstractWebTestCase.php
+++ b/tests/Eccube/Tests/Web/AbstractWebTestCase.php
@@ -40,12 +40,10 @@ abstract class AbstractWebTestCase extends EccubeTestCase
 
         self::$server = static::createClient();
         $this->client = self::$server;
-        $this->initializeMailCatcher();
     }
 
     public function tearDown()
     {
-        $this->cleanUpMailCatcherMessages();
         parent::tearDown();
     }
 

--- a/tests/Eccube/Tests/Web/EntryControllerTest.php
+++ b/tests/Eccube/Tests/Web/EntryControllerTest.php
@@ -29,6 +29,17 @@ use Symfony\Component\HttpKernel\Exception as HttpException;
 
 class EntryControllerTest extends AbstractWebTestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+        $this->initializeMailCatcher();
+    }
+
+    public function tearDown()
+    {
+        $this->cleanUpMailCatcherMessages();
+        parent::tearDown();
+    }
 
     protected function createFormData()
     {


### PR DESCRIPTION
- MailCatcher の初期化/後処理を, 各Webテストケースで実行するよう修正
- MailCatcher が起動していないと, すべてスキップされてしまい使いづらいため
- テストがスキップされた場合は、ログを出力するよう修正