### PR TITLE
受注管理での商品追加で、在庫の無い商品が追加可能 #1094

### DIFF
--- a/src/Eccube/Form/Type/Admin/ProductClassType.php
+++ b/src/Eccube/Form/Type/Admin/ProductClassType.php
@@ -62,6 +62,9 @@ class ProductClassType extends AbstractType
                         'pattern' => "/^\d+$/u",
                         'message' => 'form.type.numeric.invalid'
                     )),
+                    new Assert\GreaterThan(array(
+                        'value' => '0',
+                    )),
                 ),
             ))
             ->add('sale_limit', 'number', array(


### PR DESCRIPTION
バリデーで0以下を受け付けない様に修正