### PR TITLE
refs #1246 ブラウザのパスワード自動入力が有効時に自動補完されて誤入力を防ぐため、パスワード項目を追加

### DIFF
--- a/src/Eccube/Form/Type/Admin/CustomerType.php
+++ b/src/Eccube/Form/Type/Admin/CustomerType.php
@@ -104,23 +104,13 @@ class CustomerType extends AbstractType
                     )),
                 ),
             ))
-            // RepeatedPasswordTypeと共通化したい
-            ->add('password', 'text', array(
-                'required' => true,
-                'invalid_message' => 'form.member.password.invalid',
-                'constraints' => array(
-                    new Assert\NotBlank(),
-                    new Assert\Length(array(
-                        'min' => $this->config['password_min_len'],
-                        'max' => $this->config['password_max_len'],
-                    )),
-                    new Assert\Regex(array(
-                        'pattern' => '/^[[:graph:][:space:]]+$/i',
-                        'message' => 'form.type.graph.invalid',
-                    )),
+            ->add('password', 'repeated_password', array(
+                // 'type' => 'password',
+                'first_options'  => array(
+                    'label' => 'パスワード',
                 ),
-                'attr' => array(
-                    'placeholder' => '半角英数字記号'.$this->config['password_min_len'].'～'.$this->config['password_max_len'].'文字',
+                'second_options' => array(
+                    'label' => 'パスワード(確認)',
                 ),
             ))
             ->add('status', 'customer_status', array(

--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -150,10 +150,17 @@
                         </div>
                         {# パスワード #}
                         <div class="form-group">
-                            {{ form_label(form.password) }}
+                            {{ form_label(form.password.first) }}
                             <div class="col-sm-9 col-lg-10">
-                                {{ form_widget(form.password, { type : 'password' }) }}
-                                {{ form_errors(form.password) }}
+                                {{ form_widget(form.password.first, { type : 'password'}) }}
+                                {{ form_errors(form.password.first) }}
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            {{ form_label(form.password.second) }}
+                            <div class="col-sm-9 col-lg-10">
+                                {{ form_widget(form.password.second, { type : 'password'}) }}
+                                {{ form_errors(form.password.second) }}
                             </div>
                         </div>
                         {# 性別 #}

--- a/tests/Eccube/Tests/Form/Type/Admin/CustomerTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/CustomerTypeTest.php
@@ -70,7 +70,10 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
             'month' => '2',
             'day' => '14',
         ),
-        'password' => 'password',
+        'password' => array(
+            'first' => 'password',
+            'second' => 'password',
+        ),
         'status' => 1,
         'note' => 'note',
     );
@@ -236,7 +239,8 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInvalidPassword_Blank()
     {
-        $this->formData['password'] = '';
+        $this->formData['password']['first'] = '';
+        $this->formData['password']['second'] = '';
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
@@ -252,7 +256,7 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInvalidPassword_MinLength()
     {
-        $this->formData['password'] = str_repeat('a', $this->app['config']['password_min_len']-1);
+        $this->formData['password']['first'] = str_repeat('a', $this->app['config']['password_min_len']-1);
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
@@ -260,7 +264,8 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testValidPassword_MaxLength()
     {
-        $this->formData['password'] = str_repeat('a', $this->app['config']['password_max_len']);
+        $this->formData['password']['first'] = str_repeat('a', $this->app['config']['password_max_len']);
+        $this->formData['password']['second'] = str_repeat('a', $this->app['config']['password_max_len']);
 
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());
@@ -268,7 +273,7 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInvalidPassword_MaxLength()
     {
-        $this->formData['password'] = str_repeat('a', $this->app['config']['password_max_len']+1);
+        $this->formData['password']['first'] = str_repeat('a', $this->app['config']['password_max_len']+1);
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());


### PR DESCRIPTION
ブラウザ毎にAutoFillされる仕様が異なり対処方法も煩雑になる恐れがあるため、
ブラウザのパスワード自動入力が有効時に自動補完されて誤入力を防ぐためにパスワード項目を追加することで対応
#1246 