### PR TITLE
refs #1288 受注管理画面でお届け先の数量変更が明細に反映されない不具合対応

### DIFF
--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -234,42 +234,39 @@ class OrderType extends AbstractType
         $app = $this->app;
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($app) {
 
-            if ('calc' === $app['request']->get('mode')) {
+            $data = $event->getData();
 
-                $data = $event->getData();
+            $orderDetails = &$data['OrderDetails'];
+            $shippings = &$data['Shippings'];
 
-                $orderDetails = &$data['OrderDetails'];
-                $shippings = &$data['Shippings'];
-
-                $shipmentItems = array();
-                foreach ($shippings as &$shipping) {
-                    $items = &$shipping['ShipmentItems'];
-                    if (count($items) > 0) {
-                        foreach ($items as &$item) {
-                            $shipmentItems[] = &$item;
-                        }
+            $shipmentItems = array();
+            foreach ($shippings as &$shipping) {
+                $items = &$shipping['ShipmentItems'];
+                if (count($items) > 0) {
+                    foreach ($items as &$item) {
+                        $shipmentItems[] = &$item;
                     }
                 }
-
-                if (count($orderDetails) > 0) {
-                    $orderDetailsCount = count($orderDetails);
-                    $shipmentItemsCount = count($shipmentItems);
-                    for ($i = 0; $i < $orderDetailsCount; $i++) {
-                        for ($j = 0; $j < $shipmentItemsCount; $j++) {
-                            $itemidx = &$shipmentItems[$j]['itemidx'];
-                            if ($itemidx == $i) {
-                                $shipmentItem = &$shipmentItems[$j];
-                                $shipmentItem['price'] = $orderDetails[$i]['price'];
-                                $orderDetail = &$orderDetails[$i];
-                                $orderDetail['quantity'] = $shipmentItems[$j]['quantity'];
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                $event->setData($data);
             }
+
+            if (count($orderDetails) > 0) {
+                $orderDetailsCount = count($orderDetails);
+                $shipmentItemsCount = count($shipmentItems);
+                for ($i = 0; $i < $orderDetailsCount; $i++) {
+                    for ($j = 0; $j < $shipmentItemsCount; $j++) {
+                        $itemidx = &$shipmentItems[$j]['itemidx'];
+                        if ($itemidx == $i) {
+                            $shipmentItem = &$shipmentItems[$j];
+                            $shipmentItem['price'] = $orderDetails[$i]['price'];
+                            $orderDetail = &$orderDetails[$i];
+                            $orderDetail['quantity'] = $shipmentItems[$j]['quantity'];
+                            break;
+                        }
+                    }
+                }
+            }
+
+            $event->setData($data);
 
         });
         $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
@@ -69,6 +69,8 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         'delivery_fee_total' => '1',
         'charge' => '1',
         'Payment' => '1', // dtb_payment?
+        'OrderDetails' => array(),
+        'Shippings' => array(),
     );
 
     public function setUp()


### PR DESCRIPTION
複数配送ではない時でも「計算結果の更新」ボタンを押さないと数量変更が明細に反映されない不具合を対応 #1288 