### PR TITLE
refs #1299 不要なデバック用コードを削除

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -572,7 +572,6 @@ class ShoppingController extends AbstractController
         // 配送先住所最大値判定
         $Customer = $app->user();
         if ($Customer instanceof Customer) {
-            error_log("hoge");
             $addressCurrNum = count($app->user()->getCustomerAddresses());
             $addressMax = $app['config']['deliv_addr_max'];
             if ($addressCurrNum >= $addressMax) {


### PR DESCRIPTION
【改善要望】error_log("hoge")が入っている #1299  に対応