### PR TITLE
refs #1297 共有のデータベースを使ってインストールした時にDBエラーが発生したのを防ぐ対応

### DIFF
--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -449,6 +449,7 @@ class InstallController
         try {
             $migration = $this->getMigration();
             // nullを渡すと最新バージョンまでマイグレートする
+            $this->PDO->ping();
             $migration->migrate(null, false);
         } catch (MigrationException $e) {
         }

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -448,8 +448,11 @@ class InstallController
     {
         try {
             $migration = $this->getMigration();
-            // nullを渡すと最新バージョンまでマイグレートする
+
+            // DBとのコネクションを維持するためpingさせる
             $this->PDO->ping();
+
+            // nullを渡すと最新バージョンまでマイグレートする
             $migration->migrate(null, false);
         } catch (MigrationException $e) {
         }


### PR DESCRIPTION
レンタルサーバで共有のデータベースを使っていた場合、
データベースの設定を変更できないためping処理を入れてDBとのコネクションが無くなるのを回避する。 #1297

この処理を入れてもエラーが発生する場合、別途対応方法を検討する。