### PR TITLE
VarDumper Componentの導入

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "fzaninotto/faker":"1.*",
         "phing/phing": "2.*",
         "symfony/browser-kit": ">=2.7,<2.8",
-        "fabpot/php-cs-fixer": "^1.10"
+        "fabpot/php-cs-fixer": "^1.10",
+        "symfony/var-dumper": ">=2.7,<2.8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "phing/phing": "2.*",
         "symfony/browser-kit": ">=2.7,<2.8",
         "fabpot/php-cs-fixer": "^1.10",
-        "symfony/var-dumper": ">=2.7,<2.8"
+        "symfony/var-dumper": ">=2.7,<2.8",
+        "symfony/debug-bundle": ">=2.7,<2.8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "707967f59d156625afeb65d38d5047c5",
-    "content-hash": "9be2d3058dd240e65c97d4b3a648d6a6",
+    "hash": "0e63bc780592a5ff91bdebabf32d7f3e",
+    "content-hash": "0c5cea11739d109aebe598f23a861612",
     "packages": [
         {
             "name": "dflydev/doctrine-orm-service-provider",
@@ -897,7 +897,7 @@
             ],
             "authors": [
                 {
-                    "name": "KnpLabs",
+                    "name": "Knplabs",
                     "homepage": "http://knplabs.com"
                 }
             ],
@@ -4391,6 +4391,65 @@
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
             "time": "2015-11-19 16:11:24"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v2.7.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "72bcb27411780eaee9469729aace73c0d46fb2b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/72bcb27411780eaee9469729aace73c0d46fb2b8",
+                "reference": "72bcb27411780eaee9469729aace73c0d46fb2b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "suggest": {
+                "ext-symfony_debug": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2015-11-18 13:41:01"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0e63bc780592a5ff91bdebabf32d7f3e",
-    "content-hash": "0c5cea11739d109aebe598f23a861612",
+    "hash": "2f7b648126dfe261bdeaf5facb1052d2",
+    "content-hash": "a9628f49046e8d5660d923bd8ef4a553",
     "packages": [
         {
             "name": "dflydev/doctrine-orm-service-provider",
@@ -4342,6 +4342,123 @@
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
             "time": "2015-11-02 20:20:53"
+        },
+        {
+            "name": "symfony/debug-bundle",
+            "version": "v2.7.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug-bundle.git",
+                "reference": "e5327dbad8b941c7073accf3fbace4300a602f12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug-bundle/zipball/e5327dbad8b941c7073accf3fbace4300a602f12",
+                "reference": "e5327dbad8b941c7073accf3fbace4300a602f12",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9",
+                "symfony/http-kernel": "~2.6",
+                "symfony/twig-bridge": "~2.6",
+                "symfony/var-dumper": "~2.6"
+            },
+            "require-dev": {
+                "symfony/config": "~2.3",
+                "symfony/dependency-injection": "~2.3",
+                "symfony/web-profiler-bundle": "~2.3"
+            },
+            "suggest": {
+                "symfony/config": "For service container configuration",
+                "symfony/dependency-injection": "For using as a service from the container"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\DebugBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DebugBundle",
+            "homepage": "https://symfony.com",
+            "time": "2015-11-18 13:41:01"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "0b6a8940385311a24e060ec1fe35680e17c74497"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0b6a8940385311a24e060ec1fe35680e17c74497",
+                "reference": "0b6a8940385311a24e060ec1fe35680e17c74497",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2015-11-04 20:28:58"
         },
         {
             "name": "symfony/process",

--- a/html/index_dev.php
+++ b/html/index_dev.php
@@ -83,6 +83,10 @@ $app->register(new \Silex\Provider\WebProfilerServiceProvider(), array(
     'profiler.cache_dir' => __DIR__.'/../app/cache/profiler',
     'profiler.mount_prefix' => '/_profiler',
 ));
+
+// Debug出力
+$app->register(new \Eccube\ServiceProvider\DebugServiceProvider());
+
 $app->register(new \Saxulum\SaxulumWebProfiler\Provider\SaxulumWebProfilerProvider());
 
 $app->run();

--- a/src/Eccube/ServiceProvider/DebugServiceProvider.php
+++ b/src/Eccube/ServiceProvider/DebugServiceProvider.php
@@ -1,0 +1,133 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\ServiceProvider;
+
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+use Symfony\Bridge\Twig\Extension\DumpExtension;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\DataCollector\DumpDataCollector;
+use Symfony\Component\HttpKernel\EventListener\DumpListener;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\VarDumper;
+
+/**
+ * Debu Dump
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Jérôme Macias
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * @see https://github.com/jeromemacias/Silex-Debug/tree/1.0
+ *
+ */
+class DebugServiceProvider implements ServiceProviderInterface
+{
+    public function register(Application $app)
+    {
+        $app['var_dumper.cloner'] = $app->share(function ($app) {
+            $cloner = new VarCloner();
+
+            if (isset($app['debug.max_items'])) {
+                $cloner->setMaxItems($app['debug.max_items']);
+            }
+
+            if (isset($app['debug.max_string_length'])) {
+                $cloner->setMaxString($app['debug.max_string_length']);
+            }
+
+            return $cloner;
+        });
+
+        $app['data_collector.templates'] = array_merge(
+            $app['data_collector.templates'],
+            array(array('dump', '@Debug/Profiler/dump.html.twig'))
+        );
+
+        $app['data_collector.dump'] = $app->share(function ($app) {
+            return new DumpDataCollector($app['stopwatch'], $app['code.file_link_format']);
+        });
+
+        $app['data_collectors'] = $app->share($app->extend('data_collectors', function ($collectors, $app) {
+            $collectors['dump'] = $app->share(function ($app) {
+                return $app['data_collector.dump'];
+            });
+
+            return $collectors;
+        }));
+
+        $app['twig'] = $app->share($app->extend('twig', function ($twig, $app) {
+            if (class_exists('\Symfony\Bridge\Twig\Extension\DumpExtension')) {
+                $twig->addExtension(new DumpExtension($app['var_dumper.cloner']));
+            }
+
+            return $twig;
+        }));
+
+        $app['twig.loader.filesystem'] = $app->share($app->extend('twig.loader.filesystem', function ($loader, $app) {
+            $loader->addPath($app['debug.templates_path'], 'Debug');
+
+            return $loader;
+        }));
+
+        $app['debug.templates_path'] = function () {
+            $r = new \ReflectionClass('Symfony\Bundle\DebugBundle\DependencyInjection\Configuration');
+
+            return dirname(dirname($r->getFileName())).'/Resources/views';
+        };
+    }
+
+    public function boot(Application $app)
+    {
+        // This code is here to lazy load the dump stack. This default
+        // configuration for CLI mode is overridden in HTTP mode on
+        // 'kernel.request' event
+        VarDumper::setHandler(function ($var) use ($app) {
+            $dumper = new CliDumper();
+            $dumper->dump($app['var_dumper.cloner']->cloneVar($var));
+        });
+
+        $app['dispatcher']->addSubscriber(new DumpListener($app['var_dumper.cloner'], $app['data_collector.dump']));
+    }
+}

--- a/src/Eccube/ServiceProvider/DebugServiceProvider.php
+++ b/src/Eccube/ServiceProvider/DebugServiceProvider.php
@@ -35,7 +35,7 @@ use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\VarDumper;
 
 /**
- * Debu Dump
+ * Debug Dump
  *
  * The MIT License (MIT)
  *


### PR DESCRIPTION
使い方はこちらを参照。
http://symfony.com/doc/2.7/components/var_dumper/introduction.html

DebugBundleも導入。
http://symfony.com/doc/current/reference/configuration/debug.html

* Controller
dump($BaseInfo);
→ デバッグツールバー内に出力されます。

* Twig
{{ dump(Cart.CartItems) }}
→ 画面上に表示されます。

require-dev時にしかVarDumper Component、DebugBundleは導入されません。