### PR TITLE
Travis-ci でエラーになった場合、ログが大量に出力されて、ブラウザがお亡くなりになるのでコメントアウト

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,5 @@ after_script:
   - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then wget https://scrutinizer-ci.com/ocular.phar ; fi
   - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover ; fi
 
-after_failure: 
-  - 'cat app/log/site_`date +"%Y-%m-%d"`.log'
+# after_failure:
+#   - 'cat app/log/site_`date +"%Y-%m-%d"`.log'


### PR DESCRIPTION
必要であれば、 grep にするか、 WebTest でリクエストログを出力させるのを止めようと思います。