### PR TITLE
修复移动端屏幕右半侧滑动失灵的问题

### DIFF
--- a/html/template/default/css/style.css
+++ b/html/template/default/css/style.css
@@ -3210,7 +3210,7 @@ fieldset[disabled] .btn-link:focus {
         transition: visibility 0s 0.3s;
     }
     .drawer-open .drawer {
-        height: auto;
+        height: 100%;
         visibility: visible;
         -webkit-transition: visibility 0s 0s;
         -moz-transition: visibility 0s 0s;

--- a/html/template/default/css/style.css
+++ b/html/template/default/css/style.css
@@ -3203,12 +3203,14 @@ fieldset[disabled] .btn-link:focus {
     /****** Side Setting ********/
 
     .drawer {
+        height: 0;
         visibility: hidden;
         -webkit-transition: visibility 0s 0.3s;
         -moz-transition: visibility 0s 0.3s;
         transition: visibility 0s 0.3s;
     }
     .drawer-open .drawer {
+        height: auto;
         visibility: visible;
         -webkit-transition: visibility 0s 0s;
         -moz-transition: visibility 0s 0s;


### PR DESCRIPTION
fix the problem that it cannot slide the site up-down sometimes on the right side of the mobile screen because of the hidden drawer.

Signed-off-by: rankai <rankai@mointe.cn>