### PR TITLE
refs #590 ApcまたはWinCache有効時のcache keyをユニークにする

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -22,11 +22,11 @@ if (file_exists($autoload) && is_readable($autoload)) {
 
 // autoloader cache
 if (extension_loaded('apc') && ini_get('apc.enabled')) {
-    $apcLoader = new Symfony\Component\ClassLoader\ApcClassLoader('autoloader.', $loader);
+    $apcLoader = new Symfony\Component\ClassLoader\ApcClassLoader(sha1(__FILE__), $loader);
     $apcLoader->register();
     $loader->unregister();
 } elseif (extension_loaded('wincache') && ini_get('wincache.fcenabled')) {
-    $winCacheLoader = new Symfony\Component\ClassLoader\WinCacheClassLoader('autoloader.', $loader);
+    $winCacheLoader = new Symfony\Component\ClassLoader\WinCacheClassLoader(sha1(__FILE__), $loader);
     $winCacheLoader->register();
     $loader->unregister();
 }


### PR DESCRIPTION
apc環境下で同一サーバにEC-CUBEを複数インストールした場合に別の環境を見てしまうため、
Symfony2と同様にkeyをユニークにする。 #590 
