### PR TITLE
refs #1116 RememberMeで使用しているkeyを修正

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -495,7 +495,7 @@ class Application extends ApplicationTrait
                     'target_url' => '/',
                 ),
                 'remember_me' => array(
-                    'key' => sha1($this['config']['auth_magic']),
+                    'key' => sha1(__DIR__),
                     'name' => 'eccube_rememberme',
                     // lifetimeはデフォルトの1年間にする
                     // 'lifetime' => $this['config']['cookie_lifetime'],


### PR DESCRIPTION
RememberMeで使用しているkeyを
``` 'key' => sha1(__DIR__) ```
に修正する #1116 
この修正が入ったEC-CUBEをバージョンアップ時はRememberMeが無効になり、
再度ログインが必要になるため注意が必要。
