### PR TITLE
refs #1276 #1278 #1331 インストール時にデータベースの初期化をスキップした場合、ログインできなくなる対応

### DIFF
--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -195,10 +195,6 @@ class InstallController
         $form->setData($sessionData);
         if ($this->isValid($request, $form)) {
             $data = $form->getData();
-            // $this
-            //     ->createConfigYamlFile($data)
-            //     ->createMailYamlFile($data)
-            //     ->createPathYamlFile($data, $request);
 
             return $app->redirect($app->url('install_step4'));
         }
@@ -240,7 +236,6 @@ class InstallController
         $form->setData($sessionData);
 
         if ($this->isValid($request, $form)) {
-            // $this->createDatabaseYamlFile($form->getData());
 
             return $app->redirect($app->url('install_step5'));
         }
@@ -638,16 +633,20 @@ class InstallController
     {
         $fs = new Filesystem();
         $config_file = $this->config_path . '/config.yml';
-        $config = Yaml::parse($config_file);
 
         if ($fs->exists($config_file)) {
+            $config = Yaml::parse($config_file);
             $fs->remove($config_file);
         }
 
         if ($auth) {
             $auth_magic = Str::random(32);
         } else {
-            $auth_magic = $config['auth_magic'];
+            if (isset($config['auth_magic'])) {
+                $auth_magic = $config['auth_magic'];
+            } else {
+                $auth_magic = Str::random(32);
+            }
         }
 
         $allowHost = Str::convertLineFeed($data['admin_allow_hosts']);

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -168,9 +168,6 @@ class InstallController
                 $config_file = $this->config_path . '/config.yml';
                 $config = Yaml::parse(file_get_contents($config_file));
 
-                $config_file = $this->config_path . '/config.yml';
-                $config = Yaml::parse(file_get_contents($config_file));
-
                 $allowHost = $config['admin_allow_host'];
                 if (count($allowHost) > 0) {
                     $sessionData['admin_allow_hosts'] = Str::convertLineFeed(implode("\n", $allowHost));

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -162,14 +162,14 @@ class InstallController
 
                 // セキュリティの設定
                 $config_file = $this->config_path . '/path.yml';
-                $config = Yaml::parse($config_file);
+                $config = Yaml::parse(file_get_contents($config_file));
                 $sessionData['admin_dir'] = $config['admin_route'];
 
                 $config_file = $this->config_path . '/config.yml';
-                $config = Yaml::parse($config_file);
+                $config = Yaml::parse(file_get_contents($config_file));
 
                 $config_file = $this->config_path . '/config.yml';
-                $config = Yaml::parse($config_file);
+                $config = Yaml::parse(file_get_contents($config_file));
 
                 $allowHost = $config['admin_allow_host'];
                 if (count($allowHost) > 0) {
@@ -179,7 +179,7 @@ class InstallController
 
                 // メール設定
                 $config_file = $this->config_path . '/mail.yml';
-                $config = Yaml::parse($config_file);
+                $config = Yaml::parse(file_get_contents($config_file));
                 $mail = $config['mail'];
                 $sessionData['mail_backend'] = $mail['transport'];
                 $sessionData['smtp_host'] = $mail['host'];
@@ -222,7 +222,7 @@ class InstallController
                 // すでに登録されていた場合、登録データを表示
 
                 // データベース設定
-                $config = Yaml::parse($config_file);
+                $config = Yaml::parse(file_get_contents($config_file));
                 $database = $config['database'];
                 $sessionData['database'] = $database['driver'];
                 $sessionData['database_host'] = $database['host'];
@@ -310,7 +310,7 @@ class InstallController
     public function complete(InstallApplication $app, Request $request)
     {
         $config_file = $this->config_path . '/path.yml';
-        $config = Yaml::parse($config_file);
+        $config = Yaml::parse(file_get_contents($config_file));
 
         $host = $request->getSchemeAndHttpHost();
         $basePath = $request->getBasePath();
@@ -375,7 +375,7 @@ class InstallController
     private function setPDO()
     {
         $config_file = $this->config_path . '/database.yml';
-        $config = Yaml::parse($config_file);
+        $config = Yaml::parse(file_get_contents($config_file));
 
         try {
             $this->PDO = \Doctrine\DBAL\DriverManager::getConnection($config['database'], new \Doctrine\DBAL\Configuration());
@@ -410,7 +410,7 @@ class InstallController
     private function getEntityManager()
     {
         $config_file = $this->config_path . '/database.yml';
-        $database = Yaml::parse($config_file);
+        $database = Yaml::parse(file_get_contents($config_file));
 
         $this->app->register(new \Silex\Provider\DoctrineServiceProvider(), array(
             'db.options' => $database['database']
@@ -454,11 +454,11 @@ class InstallController
         $this->resetNatTimer();
 
         $config_file = $this->config_path . '/database.yml';
-        $database = Yaml::parse($config_file);
+        $database = Yaml::parse(file_get_contents($config_file));
         $config['database'] = $database['database'];
 
         $config_file = $this->config_path . '/config.yml';
-        $baseConfig = Yaml::parse($config_file);
+        $baseConfig = Yaml::parse(file_get_contents($config_file));
         $config['config'] = $baseConfig;
 
         $this->PDO->beginTransaction();
@@ -514,11 +514,11 @@ class InstallController
         $this->resetNatTimer();
 
         $config_file = $this->config_path . '/database.yml';
-        $database = Yaml::parse($config_file);
+        $database = Yaml::parse(file_get_contents($config_file));
         $config['database'] = $database['database'];
 
         $config_file = $this->config_path . '/config.yml';
-        $baseConfig = Yaml::parse($config_file);
+        $baseConfig = Yaml::parse(file_get_contents($config_file));
         $config['config'] = $baseConfig;
 
         $this->PDO->beginTransaction();
@@ -635,7 +635,7 @@ class InstallController
         $config_file = $this->config_path . '/config.yml';
 
         if ($fs->exists($config_file)) {
-            $config = Yaml::parse($config_file);
+            $config = Yaml::parse(file_get_contents($config_file));
             $fs->remove($config_file);
         }
 
@@ -678,7 +678,7 @@ class InstallController
     private function addInstallStatus()
     {
         $config_file = $this->config_path . '/config.yml';
-        $config = Yaml::parse($config_file);
+        $config = Yaml::parse(file_get_contents($config_file));
         $config['eccube_install'] = 1;
         $yml = Yaml::dump($config);
         file_put_contents($config_file, $yml);
@@ -788,7 +788,7 @@ class InstallController
     private function sendAppData($params)
     {
         $config_file = $this->config_path . '/database.yml';
-        $db_config = Yaml::parse($config_file);
+        $db_config = Yaml::parse(file_get_contents($config_file));
 
         $this->setPDO();
         $stmt = $this->PDO->query('select version() as v');

--- a/src/Eccube/Form/Type/Install/Step3Type.php
+++ b/src/Eccube/Form/Type/Install/Step3Type.php
@@ -120,7 +120,6 @@ class Step3Type extends AbstractType
                 ),
                 'expanded' => true,
                 'multiple' => false,
-                'data' => 'mail',
             ))
             ->add('smtp_host', 'text', array(
                 'label' => 'SMTPホスト',

--- a/src/Eccube/Resource/template/install/step3.twig
+++ b/src/Eccube/Resource/template/install/step3.twig
@@ -61,8 +61,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
                                 <h2>セキュリティの設定</h2>
                                 {{ form_row(form.admin_dir , {attr : {placeholder: 'セキュリティのため推測されにくいディレクトリ名を入力して下さい'}}) }}
-                                {{ form_row(form.admin_force_ssl) }}
-                                {{ form_row(form.admin_allow_hosts) }}
+                                {% if app.request.secure %}
+                                    {{ form_row(form.admin_force_ssl) }}
+                                {% else %}
+                                    <span class="text-danger">httpsからの接続でなければSSL制限を設定できません。</span>
+                                    {{ form_row(form.admin_force_ssl , {attr : {disabled: 'disabled', 'value': null}}) }}
+                                {% endif %}
+                                {{ form_row(form.admin_allow_hosts , {attr : {rows: '5'}}) }}
 
                                 <div class="accordion">
                                     <a href="#" class="toggle">&gt; オプションを表示</a>


### PR DESCRIPTION
インストール時のサイトの設定(step3)から次画面に遷移した時は常にauth_magicが更新されていたため、データベースの初期化が行われない限りauth_magicを更新しないようにする。

また、「データベースの初期化を行わない」を選択した場合、auth_magicは更新しないが画面上に入力された内容は更新出来るようにする。

* インストール時にスキップすると管理者情報が反映されない対応 #1276 
* インストール時にデータベースの初期化をスキップした場合、ログインできなくなる対応 #1278 
* メーラーバックエンドの値が保持されない対応 #1331 