### PR TITLE
Yaml::parse() で file_get_contents() を使用するよう修正

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -60,32 +60,32 @@ class Application extends ApplicationTrait
             $config = array();
             $config_yml = $ymlPath.'/config.yml';
             if (file_exists($config_yml)) {
-                $config = Yaml::parse($config_yml);
+                $config = Yaml::parse(file_get_contents($config_yml));
             }
 
             $config_dist = array();
             $config_yml_dist = $distPath.'/config.yml.dist';
             if (file_exists($config_yml_dist)) {
-                $config_dist = Yaml::parse($config_yml_dist);
+                $config_dist = Yaml::parse(file_get_contents($config_yml_dist));
             }
 
             $config_path = array();
             $path_yml = $ymlPath.'/path.yml';
             if (file_exists($path_yml)) {
-                $config_path = Yaml::parse($path_yml);
+                $config_path = Yaml::parse(file_get_contents($path_yml));
             }
 
             $config_constant = array();
             $constant_yml = $ymlPath.'/constant.yml';
             if (file_exists($constant_yml)) {
-                $config_constant = Yaml::parse($constant_yml);
+                $config_constant = Yaml::parse(file_get_contents($constant_yml));
                 $config_constant = empty($config_constant) ? array() : $config_constant;
             }
 
             $config_constant_dist = array();
             $constant_yml_dist = $distPath.'/constant.yml.dist';
             if (file_exists($constant_yml_dist)) {
-                $config_constant_dist = Yaml::parse($constant_yml_dist);
+                $config_constant_dist = Yaml::parse(file_get_contents($constant_yml_dist));
             }
 
             $configAll = array_replace_recursive($config_constant_dist, $config_dist, $config_constant, $config_path, $config);
@@ -93,25 +93,25 @@ class Application extends ApplicationTrait
             $database = array();
             $yml = $ymlPath.'/database.yml';
             if (file_exists($yml)) {
-                $database = Yaml::parse($yml);
+                $database = Yaml::parse(file_get_contents($yml));
             }
 
             $mail = array();
             $yml = $ymlPath.'/mail.yml';
             if (file_exists($yml)) {
-                $mail = Yaml::parse($yml);
+                $mail = Yaml::parse(file_get_contents($yml));
             }
             $configAll = array_replace_recursive($configAll, $database, $mail);
 
             $config_log = array();
             $yml = $ymlPath.'/log.yml';
             if (file_exists($yml)) {
-                $config_log = Yaml::parse($yml);
+                $config_log = Yaml::parse(file_get_contents($yml));
             }
             $config_log_dist = array();
             $log_yml_dist = $distPath.'/log.yml.dist';
             if (file_exists($log_yml_dist)) {
-                $config_log_dist = Yaml::parse($log_yml_dist);
+                $config_log_dist = Yaml::parse(file_get_contents($log_yml_dist));
             }
 
             $configAll = array_replace_recursive($configAll, $config_log_dist, $config_log);
@@ -119,12 +119,12 @@ class Application extends ApplicationTrait
             $config_nav = array();
             $yml = $ymlPath.'/nav.yml';
             if (file_exists($yml)) {
-                $config_nav = array('nav' => Yaml::parse($yml));
+                $config_nav = array('nav' => Yaml::parse(file_get_contents($yml)));
             }
             $config_nav_dist = array();
             $nav_yml_dist = $distPath.'/nav.yml.dist';
             if (file_exists($nav_yml_dist)) {
-                $config_nav_dist = array('nav' => Yaml::parse($nav_yml_dist));
+                $config_nav_dist = array('nav' => Yaml::parse(file_get_contents($nav_yml_dist)));
             }
 
             $configAll = array_replace_recursive($configAll, $config_nav_dist, $config_nav);
@@ -433,7 +433,7 @@ class Application extends ApplicationTrait
         );
 
         foreach ($finder as $dir) {
-            $config = Yaml::parse($dir->getRealPath().'/config.yml');
+            $config = Yaml::parse(file_get_contents($dir->getRealPath().'/config.yml'));
 
             // Doctrine Extend
             if (isset($config['orm.path']) && is_array($config['orm.path'])) {
@@ -638,7 +638,7 @@ class Application extends ApplicationTrait
             if (!file_exists($dir->getRealPath().'/config.yml')) {
                 continue;
             }
-            $config = Yaml::parse($dir->getRealPath().'/config.yml');
+            $config = Yaml::parse(file_get_contents($dir->getRealPath().'/config.yml'));
 
             $plugin = $this['orm.em']
                 ->getRepository('Eccube\Entity\Plugin')
@@ -666,7 +666,7 @@ class Application extends ApplicationTrait
                 $subscriber = new $class($this);
 
                 if (file_exists($dir->getRealPath().'/event.yml')) {
-                    foreach (Yaml::Parse($dir->getRealPath().'/event.yml') as $event => $handlers) {
+                    foreach (Yaml::parse(file_get_contents($dir->getRealPath().'/event.yml')) as $event => $handlers) {
                         foreach ($handlers as $handler) {
                             if (!isset($priorities[$config['event']][$event][$handler[0]])) { // ハンドラテーブルに登録されていない（ソースにしか記述されていない)ハンドラは一番後ろにする
                                 $priority = \Eccube\Entity\PluginEventHandler::EVENT_PRIORITY_LATEST;

--- a/src/Eccube/ConsoleApplication.php
+++ b/src/Eccube/ConsoleApplication.php
@@ -39,7 +39,7 @@ class ConsoleApplication extends \Silex\Application
         $config = array();
         $file = __DIR__ . '/../../app/config/eccube/database.yml';
         if (file_exists($file)) {
-            $config = Yaml::parse($file);
+            $config = Yaml::parse(file_get_contents($file));
         }
 
         // Doctrine ORM

--- a/src/Eccube/Controller/Admin/Store/TemplateController.php
+++ b/src/Eccube/Controller/Admin/Store/TemplateController.php
@@ -66,7 +66,7 @@ class TemplateController extends AbstractController
 
                 // path.ymlの再構築
                 $file = $app['config']['root_dir'] . '/app/config/eccube/path.yml';
-                $config = Yaml::parse($file);
+                $config = Yaml::parse(file_get_contents($file));
 
                 $templateCode = $Template->getCode();
                 $config['template_code'] = $templateCode;

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -229,7 +229,7 @@ class InstallController
     public function complete(InstallApplication $app, Request $request)
     {
         $config_file = $this->config_path . '/path.yml';
-        $config = Yaml::parse($config_file);
+        $config = Yaml::parse(file_get_contents($config_file));
 
         $host = $request->getSchemeAndHttpHost();
         $basePath = $request->getBasePath();
@@ -294,7 +294,7 @@ class InstallController
     private function setPDO()
     {
         $config_file = $this->config_path . '/database.yml';
-        $config = Yaml::parse($config_file);
+        $config = Yaml::parse(file_get_contents($config_file));
 
         try {
             $this->PDO = \Doctrine\DBAL\DriverManager::getConnection($config['database'], new \Doctrine\DBAL\Configuration());
@@ -329,7 +329,7 @@ class InstallController
     private function getEntityManager()
     {
         $config_file = $this->config_path . '/database.yml';
-        $database = Yaml::parse($config_file);
+        $database = Yaml::parse(file_get_contents($config_file));
 
         $this->app->register(new \Silex\Provider\DoctrineServiceProvider(), array(
             'db.options' => $database['database']
@@ -373,11 +373,11 @@ class InstallController
         $this->resetNatTimer();
 
         $config_file = $this->config_path . '/database.yml';
-        $database = Yaml::parse($config_file);
+        $database = Yaml::parse(file_get_contents($config_file));
         $config['database'] = $database['database'];
 
         $config_file = $this->config_path . '/config.yml';
-        $baseConfig = Yaml::parse($config_file);
+        $baseConfig = Yaml::parse(file_get_contents($config_file));
         $config['config'] = $baseConfig;
 
         $this->PDO->beginTransaction();
@@ -511,7 +511,7 @@ class InstallController
         );
         $fs->dumpFile($config_file, $content);
 
-        $config = Yaml::Parse($config_file);
+        $config = Yaml::parse(file_get_contents($config_file));
         $config['admin_allow_host'] = $adminAllowHosts;
         $yml = Yaml::dump($config);
         file_put_contents($config_file, $yml);
@@ -522,7 +522,7 @@ class InstallController
     private function addInstallStatus()
     {
         $config_file = $this->config_path . '/config.yml';
-        $config = Yaml::parse($config_file);
+        $config = Yaml::parse(file_get_contents($config_file));
         $config['eccube_install'] = 1;
         $yml = Yaml::dump($config);
         file_put_contents($config_file, $yml);
@@ -632,7 +632,7 @@ class InstallController
     private function sendAppData($params)
     {
         $config_file = $this->config_path . '/database.yml';
-        $db_config = Yaml::parse($config_file);
+        $db_config = Yaml::parse(file_get_contents($config_file));
 
         $this->setPDO();
         $stmt = $this->PDO->query('select version() as v');

--- a/src/Eccube/Event/FormEventSubscriber.php
+++ b/src/Eccube/Event/FormEventSubscriber.php
@@ -43,7 +43,7 @@ class FormEventSubscriber implements EventSubscriberInterface
             ->depth(0);
 
         foreach ($finder as $dir) {
-            $config = Yaml::parse($dir->getRealPath() . '/config.yml');
+            $config = Yaml::parse(file_get_contents($dir->getRealPath() . '/config.yml'));
 
             if (isset($config['form'])) {
                 foreach ($config['form'] as $event => $class) {

--- a/src/Eccube/InstallApplication.php
+++ b/src/Eccube/InstallApplication.php
@@ -45,13 +45,13 @@ class InstallApplication extends ApplicationTrait
             $configConstant = array();
             $constantYamlPath = $distPath.'/constant.yml.dist';
             if (file_exists($constantYamlPath)) {
-                $configConstant = Yaml::parse($constantYamlPath);
+                $configConstant = Yaml::parse(file_get_contents($constantYamlPath));
             }
 
             $configLog = array();
             $logYamlPath = $distPath.'/log.yml.dist';
             if (file_exists($logYamlPath)) {
-                $configLog = Yaml::parse($logYamlPath);
+                $configLog = Yaml::parse(file_get_contents($logYamlPath));
             }
 
             $config = array_replace_recursive($configConstant, $configLog);
@@ -60,7 +60,7 @@ class InstallApplication extends ApplicationTrait
         });
 
         $distPath = __DIR__.'/../../src/Eccube/Resource/config';
-        $config_dist = Yaml::parse($distPath.'/config.yml.dist');
+        $config_dist = Yaml::parse(file_get_contents($distPath.'/config.yml.dist'));
         if (!empty($config_dist['timezone'])) {
             date_default_timezone_set($config_dist['timezone']);
         }

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -140,7 +140,11 @@ class PluginService
 
     public function readYml($yml)
     {
-        return Yaml::Parse($yml);
+        if (file_exists($yml)) {
+            return Yaml::parse(file_get_contents($yml));
+        }
+
+        return false;
     }
 
     public function checkSymbolName($string)
@@ -244,8 +248,8 @@ class PluginService
     {
         $pluginDir = $this->calcPluginDir($plugin->getCode());
 
-        $this->callPluginManagerMethod(Yaml::Parse($pluginDir.'/'.self::CONFIG_YML), 'disable');
-        $this->callPluginManagerMethod(Yaml::Parse($pluginDir.'/'.self::CONFIG_YML), 'uninstall');
+        $this->callPluginManagerMethod(Yaml::parse(file_get_contents($pluginDir.'/'.self::CONFIG_YML)), 'disable');
+        $this->callPluginManagerMethod(Yaml::parse(file_get_contents($pluginDir.'/'.self::CONFIG_YML)), 'uninstall');
         $this->unregisterPlugin($plugin);
         $this->deleteFile($pluginDir);
 
@@ -286,7 +290,7 @@ class PluginService
             $em->getConnection()->beginTransaction();
             $plugin->setEnable($enable ? Constant::ENABLED : Constant::DISABLED);
             $em->persist($plugin);
-            $this->callPluginManagerMethod(Yaml::Parse($pluginDir.'/'.self::CONFIG_YML), $enable ? 'enable' : 'disable');
+            $this->callPluginManagerMethod(Yaml::parse(file_get_contents($pluginDir.'/'.self::CONFIG_YML)), $enable ? 'enable' : 'disable');
             $em->flush();
             $em->getConnection()->commit();
         } catch (\Exception $e) {


### PR DESCRIPTION
- Yaml::parse(filename) は Symfony2.2 より非推奨
- #1338