### PR TITLE
refs #1383 規格の初期化時にシステムエラーになる不具合を修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -163,12 +163,6 @@ class ProductController extends AbstractController
 
     public function edit(Application $app, Request $request, $id = null)
     {
-        /* @var $softDeleteFilter \Eccube\Doctrine\Filter\SoftDeleteFilter */
-        $softDeleteFilter = $app['orm.em']->getFilters()->getFilter('soft_delete');
-        $softDeleteFilter->setExcludes(array(
-            'Eccube\Entity\ProductClass'
-        ));
-
         $has_class = false;
         if (is_null($id)) {
             $Product = new \Eccube\Entity\Product();
@@ -462,7 +456,7 @@ class ProductController extends AbstractController
                     $app['orm.em']->persist($Category);
                 }
 
-                // 規格あり商品の場合は, ダミー規格を取得する.
+                // 規格あり商品の場合は, デフォルトの商品規格を取得し登録する.
                 if ($CopyProduct->hasProductClass()) {
                     $softDeleteFilter = $app['orm.em']->getFilters()->getFilter('soft_delete');
                     $softDeleteFilter->setExcludes(array(
@@ -474,7 +468,9 @@ class ProductController extends AbstractController
                         'ClassCategory2' => null,
                         'Product' => $Product,
                     ));
-                    $CopyProduct->addProductClass(clone $dummyClass);
+                    $dummyClass = clone $dummyClass;
+                    $dummyClass->setProduct($CopyProduct);
+                    $CopyProduct->addProductClass($dummyClass);
                     $softDeleteFilter->setExcludes(array());
                 }
 

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -24,7 +24,6 @@
 
 namespace Eccube\Controller\Admin\Product;
 
-use Doctrine\Common\Util\Debug;
 use Eccube\Application;
 use Eccube\Common\Constant;
 use Eccube\Controller\AbstractController;


### PR DESCRIPTION
#1383 の対応です。
上記修正に伴い, 商品編集の際の不具合が見つかりましたので合わせて修正しています.

現象は以下の通り.

1. 規格あり商品の商品規格を初期化する
2. 商品編集画面で、1)の商品を表示する
このとき, 初期化した(削除した)商品規格の価格や在庫数が表示されることがある
そのまま登録を行うと、削除済の商品規格のレコードが更新される

soft_deleteでproduct_classを除外しているため、規格無し商品でgetProductClasses()を呼んだ際に、削除済のエンティティも対象になっていたのが要因. 
https://github.com/EC-CUBE/ec-cube/blob/3.0.8/src/Eccube/Controller/Admin/Product/ProductController.php#L196


