### PR TITLE
PdoSessionHandler を使用しないよう修正

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -29,7 +29,6 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 use Symfony\Component\Yaml\Yaml;
 
 class Application extends ApplicationTrait
@@ -271,6 +270,7 @@ class Application extends ApplicationTrait
     public function initSession()
     {
         $this->register(new \Silex\Provider\SessionServiceProvider(), array(
+            'session.storage.save_path' => $this['config']['root_dir'] . '/app/cache/eccube/session',
             'session.storage.options' => array(
                 'name' => 'eccube',
                 'cookie_path' => $this['config']['root_urlpath'] ?: '/',
@@ -281,17 +281,6 @@ class Application extends ApplicationTrait
                 // http://blog.tokumaru.org/2011/10/cookiedomain.html
             ),
         ));
-        $this['session.db_options'] = array(
-            'db_table'      => 'dtb_session',
-        );
-
-        $app = $this;
-        $this['session.storage.handler'] = function() use ($app) {
-            return new PdoSessionHandler(
-                $app['dbs']['session']->getWrappedConnection(),
-                $app['session.db_options']
-            );
-        };
     }
 
     public function initRendering()
@@ -440,8 +429,7 @@ class Application extends ApplicationTrait
     {
         $this->register(new \Silex\Provider\DoctrineServiceProvider(), array(
             'dbs.options' => array(
-                'default' => $this['config']['database'],
-                'session' => $this['config']['database'],
+                'default' => $this['config']['database']
         )));
         $this->register(new \Saxulum\DoctrineOrmManagerRegistry\Silex\Provider\DoctrineOrmManagerRegistryProvider());
 

--- a/src/Eccube/Resource/doctrine/migration/Version20160114093442.php
+++ b/src/Eccube/Resource/doctrine/migration/Version20160114093442.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160114093442 extends AbstractMigration
+{
+    const NAME = 'dtb_session';
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        if ($schema->hasTable(self::NAME)) {
+            $schema->dropTable(self::NAME);
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}


### PR DESCRIPTION
- #1183, #671, #1216 
- フロントエンドを冗長化したい場合は Redis など、他の性能の優れたキャッシュ用DBの使用が望ましい