### PR TITLE
非会員購入時、確認画面でフリガナの変更ができない #1267

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -710,6 +710,8 @@ class ShoppingController extends AbstractController
                 $Order
                     ->setName01($data['customer_name01'])
                     ->setName02($data['customer_name02'])
+                    ->setKana01($data['customer_kana01'])
+                    ->setKana02($data['customer_kana02'])
                     ->setCompanyName($data['customer_company_name'])
                     ->setTel01($data['customer_tel01'])
                     ->setTel02($data['customer_tel02'])
@@ -1215,13 +1217,25 @@ class ShoppingController extends AbstractController
         $errors[] = $app['validator']->validateValue($data['customer_name01'], array(
             new Assert\NotBlank(),
             new Assert\Length(array('max' => $app['config']['name_len'],)),
-            new Assert\Regex(array('pattern' => '/^[^\s ]+$/u', 'message' => 'form.type.name.firstname.nothasspace'))
+            new Assert\Regex(array('pattern' => '/^[^\s ]+$/u', 'message' => 'form.type.name.secondname.nothasspace'))
         ));
 
         $errors[] = $app['validator']->validateValue($data['customer_name02'], array(
             new Assert\NotBlank(),
             new Assert\Length(array('max' => $app['config']['name_len'], )),
             new Assert\Regex(array('pattern' => '/^[^\s ]+$/u', 'message' => 'form.type.name.firstname.nothasspace'))
+        ));
+
+        $errors[] = $app['validator']->validateValue($data['customer_kana01'], array(
+            new Assert\NotBlank(),
+            new Assert\Length(array('max' => $app['config']['name_len'],)),
+            new Assert\Regex(array('pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u", 'message' => 'form.type.kana.secondname.nothasspace'))
+        ));
+
+        $errors[] = $app['validator']->validateValue($data['customer_kana02'], array(
+            new Assert\NotBlank(),
+            new Assert\Length(array('max' => $app['config']['name_len'], )),
+            new Assert\Regex(array('pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u", 'message' => 'form.type.kana.firstname.nothasspace'))
         ));
 
         $errors[] = $app['validator']->validateValue($data['customer_company_name'], array(

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -37,6 +37,8 @@ form.type.graph.invalid: 半角英数字で入力してください。
 
 form.type.name.firstname.nothasspace: お名前(名)にスペース、タブ、改行は含めないで下さい。
 form.type.name.lastname.nothasspace: お名前(性)にスペース、タブ、改行は含めないで下さい。
+form.type.kana.firstname.nothasspace: お名前(メイ)にスペース、タブ、改行は含めないで下さい。
+form.type.kana.lastname.nothasspace: お名前(セイ)にスペース、タブ、改行は含めないで下さい。
 form.type.customer.company.nothasspace: 会社名にスペース、タブ、改行は含めないで下さい。
 
 form.type.admin.nottelstyle: 電話番号は半角数字かハイフンのみを入力してください。。

--- a/src/Eccube/Resource/template/default/Shopping/index.twig
+++ b/src/Eccube/Resource/template/default/Shopping/index.twig
@@ -190,6 +190,7 @@ $(function(){
                     <h2 class="heading02">お客様情報</h2>
                     <div class="column is-edit">
                         <p class="address"><span class="customer-edit customer-name01">{{ Order.name01 }}</span> <span class="customer-edit customer-name02">{{ Order.name02 }}</span> 様<br>
+                        <span class="customer-edit customer-kana01">{{ Order.kana01 }}</span> <span class="customer-edit customer-kana02">{{ Order.kana02 }}</span> サマ<br>
                         〒<span class="customer-edit customer-zip01">{{ Order.zip01 }}</span>-<span class="customer-edit customer-zip02">{{ Order.zip02 }}</span> <span class="customer-edit customer-pref">{{ Order.pref }}</span><span class="customer-edit customer-addr01">{{ Order.addr01 }}</span><span class="customer-edit customer-addr02">{{ Order.addr02 }}</span><br>
                         <span class="customer-edit customer-tel01">{{ Order.tel01 }}</span>-<span class="customer-edit customer-tel02">{{ Order.tel02 }}</span>-<span class="customer-edit customer-tel03">{{ Order.tel03 }}</span></p>
                         {% if is_granted('ROLE_USER') == false %}
@@ -202,6 +203,8 @@ $(function(){
                         <p class="btn_edit"><button type="button" id="customer" class="btn btn-default btn-sm">変更</button></p>
                         <input type="hidden" id="customer-name01" class="customer-in" name="customer_name01" value="{{ Order.name01 }}">
                         <input type="hidden" id="customer-name02" class="customer-in" name="customer_name02" value="{{ Order.name02 }}">
+                        <input type="hidden" id="customer-kana01" class="customer-in" name="customer_kana01" value="{{ Order.kana01 }}">
+                        <input type="hidden" id="customer-kana02" class="customer-in" name="customer_kana02" value="{{ Order.kana02 }}">
                         <input type="hidden" id="customer-zip01" class="customer-in" name="customer_zip01" value="{{ Order.zip01 }}">
                         <input type="hidden" id="customer-zip02" class="customer-in" name="customer_zip02" value="{{ Order.zip02 }}">
                         <input type="hidden" id="customer-pref" class="customer-in" name="customer_pref" value="{{ Order.pref }}">


### PR DESCRIPTION
非会員の「お客様情報」でカナが変更できないため、現状のAjaxによるUIのままで、カナの更新を行える様に修正

@nanasess
ご意見ごもっともと思いましたが、相談の結果「カナの更新」対応のみ行いました。
