### PR TITLE
プラグインインストールに失敗した際に空白ページになる #1329

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -709,6 +709,10 @@ class Application extends ApplicationTrait
             if (isset($config['service'])) {
                 foreach ($config['service'] as $service) {
                     $class = '\\Plugin\\'.$config['code'].'\\ServiceProvider\\'.$service;
+                    if (!class_exists($class)) {
+                        $this['monolog']->warning('該当クラスが見つかりません:' . $class);
+                        continue;
+                    }
                     $this->register(new $class($this));
                 }
             }


### PR DESCRIPTION
[事象]
プラグインインストール時に、エラーで処理がとまってしまう

[原因]
設定ファイル、ディレクトリ、クラス取得時にエラーハンドリングがないのが問題

[対応]
適切なエラーハンドリングを追加

[補足]
※以下Application.phpの内容とあわせて完成
https://github.com/EC-CUBE/ec-cube/pull/1422/files