### PR TITLE
fix:ブロック挿入用の入れ子構造が、デザインと合っていない

### DIFF
--- a/src/Eccube/Resource/template/default/default_frame.twig
+++ b/src/Eccube/Resource/template/default/default_frame.twig
@@ -74,15 +74,15 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
     <div id="contents" class="{{ PageLayout.theme }}">
 
-        <div id="contents_top">
-            {# ▼TOP COLUMN #}
-            {% if PageLayout.ContentsTop %}
+        {# ▼TOP COLUMN #}
+        {% if PageLayout.ContentsTop %}
+            <div id="contents_top">
                 {# ▼上ナビ #}
                 {{ include('block.twig', {'Blocks': PageLayout.ContentsTop}) }}
                 {# ▲上ナビ #}
-            {% endif %}
-            {# ▲TOP COLUMN #}
-        </div>
+            </div>
+        {% endif %}
+        {# ▲TOP COLUMN #}
 
         <div class="container-fluid inner">
             {# ▼LEFT COLUMN #}
@@ -127,31 +127,31 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             {% endif %}
             {# ▲RIGHT COLUMN #}
 
-            {# ▼BOTTOM COLUMN #}
-            {% if PageLayout.ContentsBottom %}
-                <div id="contents_bottom">
-                    {# ▼下ナビ #}
-                    {{ include('block.twig', {'Blocks': PageLayout.ContentsBottom}) }}
-                    {# ▲下ナビ #}
-                </div>
-            {% endif %}
-            {# ▲BOTTOM COLUMN #}
-
         </div>
-
-        <footer id="footer">
-            {# ▼Footer COLUMN#}
-            {% if PageLayout.Footer %}
-                {# ▼上ナビ #}
-                {{ include('block.twig', {'Blocks': PageLayout.Footer}) }}
-                {# ▲上ナビ #}
-            {% endif %}
-            {# ▲Footer COLUMN#}
-
-        </footer>
+    
+        {# ▼BOTTOM COLUMN #}
+        {% if PageLayout.ContentsBottom %}
+            <div id="contents_bottom">
+                {# ▼下ナビ #}
+                {{ include('block.twig', {'Blocks': PageLayout.ContentsBottom}) }}
+                {# ▲下ナビ #}
+            </div>
+        {% endif %}
+        {# ▲BOTTOM COLUMN #}
 
     </div>
 
+    <footer id="footer">
+        {# ▼Footer COLUMN#}
+        {% if PageLayout.Footer %}
+            {# ▼上ナビ #}
+            {{ include('block.twig', {'Blocks': PageLayout.Footer}) }}
+            {# ▲上ナビ #}
+        {% endif %}
+        {# ▲Footer COLUMN#}
+
+    </footer>
+    
     <div id="drawer" class="drawer sp">
     </div>
 


### PR DESCRIPTION
管理画面のブロック管理にあるフレームデザインに沿って、外枠のマークアップをなおしました。
入れ子がずれるため、影響範囲が大きいはずですが、外観のチェックおよびCSSの調整はまだ行っていません。

なお、
Line 130あたりdiv#contents_bottomは、ブロックが含まれていなければ表示されませんが、
Line77からLine85までのdiv#contents_topは、ブロック含まれていなくても表示されてしまいますので、どちらかに統一した方が良いかと思います。
このcommitでは、div#contents_topがブロックが含まれていない時には表示されないように変更しました。

![image](https://cloud.githubusercontent.com/assets/1335922/12697558/78b7a1a0-c7ca-11e5-8c8a-76e1e9894963.png)