### PR TITLE
travis-ci でファイルベースの sqlite3 を使用するよう修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_script:
   - composer install --dev --no-interaction -o
   - sh -c "if [ '$DB' = 'mysql' ]; then sh ./eccube_install.sh mysql none; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then sh ./eccube_install.sh pgsql none; fi"
-  - sh -c "if [ '$DB' = 'sqlite' ]; then sh ./eccube_install.sh sqlite3-in-memory none; fi"
+  - sh -c "if [ '$DB' = 'sqlite' ]; then sh ./eccube_install.sh sqlite3 none; fi"
   - mailcatcher
 
 script:


### PR DESCRIPTION
- https://docs.travis-ci.com/user/database-setup/#SQLite3
  こちらには in-memory の指定となっているが、ファイルベースの方が速く、
  動作上問題なさそうなため。
- ただし、実装の仕方が悪いと database locked で落ちる可能性もある