### PR TITLE
ラベル出力時の「必須」文字を form_label 関数内で出力するように修正

### DIFF
--- a/src/Eccube/Resource/template/default/Contact/index.twig
+++ b/src/Eccube/Resource/template/default/Contact/index.twig
@@ -49,7 +49,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             {{ form_widget(form._token) }}
                             <div class="dl_table">
                                 <dl>
-                                    <dt>{{ form_label(form.name) }}<span class="required">必須</span></dt>
+                                    <dt>{{ form_label(form.name) }}</dt>
                                     <dd class="form-group input_name">
                                         {{ form_widget(form.name.name01) }}
                                         {{ form_widget(form.name.name02) }}
@@ -86,7 +86,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     </dd>
                                 </dl>
                                 <dl>
-                                    <dt>{{ form_label(form.email) }}<span class="required">必須</span></dt>
+                                    <dt>{{ form_label(form.email) }}</dt>
                                     <dd>
                                         <div class="form-group">
                                             {{ form_widget(form.email) }}
@@ -95,7 +95,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     </dd>
                                 </dl>
                                 <dl>
-                                    <dt>{{ form_label(form.contents) }}<span class="required">必須</span></dt>
+                                    <dt>{{ form_label(form.contents) }}</dt>
                                     <dd>
                                         <div class="column">
                                             {{ form_widget(form.contents) }}

--- a/src/Eccube/Resource/template/default/Entry/index.twig
+++ b/src/Eccube/Resource/template/default/Entry/index.twig
@@ -43,7 +43,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 {{ form_widget(form._token) }}
                 <div class="dl_table">
                     <dl>
-                        <dt>{{ form_label(form.name) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.name) }}</dt>
                         <dd class="form-group input_name">
                             {{ form_widget(form.name.name01) }}
                             {{ form_widget(form.name.name02) }}
@@ -52,7 +52,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </dd>
                     </dl>
                     <dl>
-                        <dt>{{ form_label(form.kana) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.kana) }}</dt>
                         <dd class="form-group input_name">
                             {{ form_widget(form.kana.kana01) }}
                             {{ form_widget(form.kana.kana02) }}
@@ -68,7 +68,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </dd>
                     </dl>
                     <dl>
-                        <dt>{{ form_label(form.address) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.address) }}</dt>
                         <dd>
                             <div class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
                             <div class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
@@ -78,7 +78,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </dd>
                     </dl>
                     <dl>
-                        <dt>{{ form_label(form.tel) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.tel) }}</dt>
                         <dd>
                             <div class="form-inline form-group input_tel">
                                 {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
@@ -96,7 +96,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </dd>
                     </dl>
                     <dl>
-                        <dt>{{ form_label(form.email) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.email) }}</dt>
                         <dd>
                             {% for emailField in form.email %}
                             <div class="form-group {% if emailField.vars.errors is not empty %}has-error{% endif %}">
@@ -107,7 +107,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </dd>
                     </dl>
                     <dl>
-                        <dt>{{ form_label(form.password) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.password) }}</dt>
                         <dd>
                             {% for passwordField in form.password %}
                             <div class="form-group {% if passwordField.vars.errors is not empty %}has-error{% endif %}">

--- a/src/Eccube/Resource/template/default/Form/form_layout.twig
+++ b/src/Eccube/Resource/template/default/Form/form_layout.twig
@@ -40,7 +40,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     {%- if form.vars.freeze_display_text -%}
     {% set attr = attr|merge({class: attr.class|default('')}) %}
     <dl>
-        <dt>{{ form_label(form) }}{% if required %} <span class="required">必須</span>{% endif %}</dt>
+        <dt>{{ form_label(form) }}</dt>
         <dd class="form-group{% if not valid %} has-error{% endif %}{% if 'middle' in attr.class %} input_name{% endif %}{% if 'short' in attr.class %} input_tel{% endif %}{% if 'zip' in attr.class %} input_zip{% endif %}">
             {{ form_widget(form) }}
             {{ form_errors(form) }}
@@ -259,3 +259,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         {% endfor -%}
     {%- endif -%}
 {%- endblock address_widget -%}
+
+{%- block form_label -%}
+    {{- parent() -}}
+    {%- if required -%}<span class="required">必須</span>{%- endif -%}
+{%- endblock -%}

--- a/src/Eccube/Resource/template/default/Form/form_layout.twig
+++ b/src/Eccube/Resource/template/default/Form/form_layout.twig
@@ -262,5 +262,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 {%- block form_label -%}
     {{- parent() -}}
-    {%- if required -%}<span class="required">必須</span>{%- endif -%}
+    {%- if not freeze -%}
+        {%- if required -%}<span class="required">必須</span>{%- endif -%}
+    {%- endif -%}
 {%- endblock -%}

--- a/src/Eccube/Resource/template/default/Mypage/change.twig
+++ b/src/Eccube/Resource/template/default/Mypage/change.twig
@@ -46,7 +46,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 {{ form_widget(form._token) }}
                 <div class="dl_table">
                     <dl>
-                        <dt>{{ form_label(form.name) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.name) }}</dt>
                         <dd class="form-group input_name">
                             {{ form_widget(form.name.name01) }}
                             {{ form_widget(form.name.name02) }}
@@ -55,7 +55,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </dd>
                     </dl>
                     <dl>
-                        <dt>{{ form_label(form.kana) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.kana) }}</dt>
                         <dd class="form-group input_name">
                             {{ form_widget(form.kana.kana01) }}
                             {{ form_widget(form.kana.kana02) }}
@@ -71,7 +71,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </dd>
                     </dl>
                     <dl>
-                        <dt>{{ form_label(form.address) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.address) }}</dt>
                         <dd>
                             <div class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
                             <div class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
@@ -81,7 +81,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </dd>
                     </dl>
                     <dl>
-                        <dt>{{ form_label(form.tel) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.tel) }}</dt>
                         <dd>
                             <div class="form-inline form-group input_tel">
                                 {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
@@ -99,7 +99,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </dd>
                     </dl>
                     <dl>
-                        <dt>{{ form_label(form.email) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.email) }}</dt>
                         <dd>
                             {% for emailField in form.email %}
                             <div class="form-group {% if emailField.vars.errors is not empty %}has-error{% endif %}">
@@ -110,7 +110,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </dd>
                     </dl>
                     <dl>
-                        <dt>{{ form_label(form.password) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.password) }}</dt>
                         <dd>
                             {% for passwordField in form.password %}
                             <div class="form-group {% if passwordField.vars.errors is not empty %}has-error{% endif %}">

--- a/src/Eccube/Resource/template/default/Mypage/delivery_edit.twig
+++ b/src/Eccube/Resource/template/default/Mypage/delivery_edit.twig
@@ -49,7 +49,7 @@ $(function() {
                     <div class="dl_table">
 
                         <dl>
-                            <dt>{{ form_label(form.name) }}<span class="required">必須</span></dt>
+                            <dt>{{ form_label(form.name) }}</dt>
                             <dd class="form-group input_name">
                                 {{ form_widget(form.name.name01, { attr : { placeholder: '姓' }}) }}
                                 {{ form_widget(form.name.name02, { attr : { placeholder: '名' }}) }}
@@ -58,7 +58,7 @@ $(function() {
                             </dd>
                         </dl>
                         <dl>
-                            <dt>{{ form_label(form.kana) }}<span class="required">必須</span></dt>
+                            <dt>{{ form_label(form.kana) }}</dt>
                             <dd class="form-group input_name">
                                 {{ form_widget(form.kana.kana01, { attr : { placeholder: 'セイ' }}) }}
                                 {{ form_widget(form.kana.kana02, { attr : { placeholder: 'メイ' }}) }}
@@ -75,7 +75,7 @@ $(function() {
                         </dl>
 
                         <dl>
-                            <dt>{{ form_label(form.address) }}<span class="required">必須</span></dt>
+                            <dt>{{ form_label(form.address) }}</dt>
                             <dd>
                                 <div class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
                                 <div class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
@@ -86,7 +86,7 @@ $(function() {
                         </dl>
 
                         <dl>
-                            <dt>{{ form_label(form.tel) }}<span class="required">必須</span></dt>
+                            <dt>{{ form_label(form.tel) }}</dt>
                             <dd>
                                 <div class="form-inline form-group input_tel">
                                     {{ form_widget(form.tel, {attr : {class : 'short'}}) }}

--- a/src/Eccube/Resource/template/default/Shopping/nonmember.twig
+++ b/src/Eccube/Resource/template/default/Shopping/nonmember.twig
@@ -51,7 +51,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 {{ form_widget(form._token) }}
                 <div class="dl_table">
                     <dl>
-                        <dt>{{ form_label(form.name) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.name) }}</dt>
                         <dd class="form-group input_name">
                             {{ form_widget(form.name.name01) }}
                             {{ form_widget(form.name.name02) }}
@@ -60,7 +60,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </dd>
                     </dl>
                     <dl>
-                        <dt>{{ form_label(form.kana) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.kana) }}</dt>
                         <dd class="form-group input_name">
                             {{ form_widget(form.kana.kana01) }}
                             {{ form_widget(form.kana.kana02) }}
@@ -76,7 +76,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </dd>
                     </dl>
                     <dl>
-                        <dt>{{ form_label(form.address) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.address) }}</dt>
                         <dd>
                             <div class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
                             <div class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
@@ -86,7 +86,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </dd>
                     </dl>
                     <dl>
-                        <dt>{{ form_label(form.tel) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.tel) }}</dt>
                         <dd>
                             <div class="form-inline form-group input_tel">
                                 {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
@@ -95,7 +95,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </dd>
                     </dl>
                     <dl>
-                        <dt>{{ form_label(form.email) }}<span class="required">必須</span></dt>
+                        <dt>{{ form_label(form.email) }}</dt>
                         <dd>
                             <div class="form-group {% if form.email.first.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.email.first) }}</div>
                             <div class="form-group {% if form.email.second.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.email.second, {attr: {placeholder: '確認のためもう一度入力してください'}}) }}

--- a/src/Eccube/Resource/template/default/Shopping/shipping_edit.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping_edit.twig
@@ -41,7 +41,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             {{ form_widget(form._token) }}
             <div class="dl_table">
                 <dl>
-                    <dt>{{ form_label(form.name) }}<span class="required">必須</span></dt>
+                    <dt>{{ form_label(form.name) }}</dt>
                     <dd class="form-group input_name">
                         {{ form_widget(form.name.name01) }}
                         {{ form_widget(form.name.name02) }}
@@ -50,7 +50,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     </dd>
                 </dl>
                 <dl>
-                    <dt>{{ form_label(form.kana) }}<span class="required">必須</span></dt>
+                    <dt>{{ form_label(form.kana) }}</dt>
                     <dd class="form-group input_name">
                         {{ form_widget(form.kana.kana01) }}
                         {{ form_widget(form.kana.kana02) }}
@@ -66,7 +66,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     </dd>
                 </dl>
                 <dl>
-                    <dt>{{ form_label(form.address) }}<span class="required">必須</span></dt>
+                    <dt>{{ form_label(form.address) }}</dt>
                     <dd>
                         <div class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
                         <div class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
@@ -76,7 +76,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     </dd>
                 </dl>
                 <dl>
-                    <dt>{{ form_label(form.tel) }}<span class="required">必須</span></dt>
+                    <dt>{{ form_label(form.tel) }}</dt>
                     <dd>
                         <div class="form-inline form-group input_tel">
                             {{ form_widget(form.tel, {attr : {class : 'short'}}) }}

--- a/src/Eccube/Resource/template/default/Shopping/shipping_multiple_edit.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping_multiple_edit.twig
@@ -41,7 +41,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             {{ form_widget(form._token) }}
             <div class="dl_table">
                 <dl>
-                    <dt>{{ form_label(form.name) }}<span class="required">必須</span></dt>
+                    <dt>{{ form_label(form.name) }}</dt>
                     <dd class="form-group input_name">
                         {{ form_widget(form.name.name01) }}
                         {{ form_widget(form.name.name02) }}
@@ -50,7 +50,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     </dd>
                 </dl>
                 <dl>
-                    <dt>{{ form_label(form.kana) }}<span class="required">必須</span></dt>
+                    <dt>{{ form_label(form.kana) }}</dt>
                     <dd class="form-group input_name">
                         {{ form_widget(form.kana.kana01) }}
                         {{ form_widget(form.kana.kana02) }}
@@ -66,7 +66,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     </dd>
                 </dl>
                 <dl>
-                    <dt>{{ form_label(form.address) }}<span class="required">必須</span></dt>
+                    <dt>{{ form_label(form.address) }}</dt>
                     <dd>
                         <div class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
                         <div class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
@@ -76,7 +76,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     </dd>
                 </dl>
                 <dl>
-                    <dt>{{ form_label(form.tel) }}<span class="required">必須</span></dt>
+                    <dt>{{ form_label(form.tel) }}</dt>
                     <dd>
                         <div class="form-inline form-group input_tel">
                             {{ form_widget(form.tel, {attr : {class : 'short'}}) }}


### PR DESCRIPTION
カスタマイズしていて、form_row と form_label で必須の記載方法がずれたり、記述忘れが出たり、「必須」と「*」が混在したりしまうことがあったため、form_label 内で`<span class="required">必須</span>`を出力するように修正。