### PR TITLE
【機能改善/プラグイン】設置のみのプラグインを事故防止のため管理画面に一覧を表示する #1420

### DIFF
--- a/src/Eccube/Resource/template/admin/Store/plugin.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin.twig
@@ -58,6 +58,17 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     {{ include('Store/plugin_table.twig', {'Plugins': unofficialPlugins}) }}
                 </div><!-- /.box-body -->
             </div><!-- /.box -->
+
+            {% if unregisteredPlugins is not empty %}
+            <div class="box">
+                <div class="box-header">
+                    <h3 class="box-title">独自プラグイン</h3>
+                </div><!-- /.box-header -->
+                <div class="box-body">
+                    {{ include('Store/unregistered_plugin_table.twig', {'Plugins': unregisteredPlugins}) }}
+                </div><!-- /.box-body -->
+            </div><!-- /.box -->
+            {% endif %}
         </div><!-- /.col -->
     </div>
 {% endblock %}

--- a/src/Eccube/Resource/template/admin/Store/unregistered_plugin_table.twig
+++ b/src/Eccube/Resource/template/admin/Store/unregistered_plugin_table.twig
@@ -1,0 +1,73 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+<div class="table_list plugin-table">
+    <div class="table-responsive with-border">
+        <table class="table table-hover table-condensed">
+            <thead>
+            <tr>
+                <th>プラグイン</th>
+                <th>バージョン</th>
+                <th>コード</th>
+                <th>アップデート</th>
+                <th>設定</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for Plugin in Plugins %}
+                <form id="{{ Plugin.name }}" name="{{ Plugin.name }}" method="post" action="">
+                    <tr class="{% if Plugin.enable == 0 %}active{% endif %}">
+                        {% if Plugin.name is defined %}
+                            <td class="tp">
+                                <strong>{{ Plugin.name }}</strong>
+                            </td>
+                        {% else %}
+                            <td class="tp">
+                                <strong>不明</strong>
+                            </td>
+                        {% endif %}
+                        {% if Plugin.version is defined %}
+                            <td class="tv text-center">{{ Plugin.version }}</td>
+                        {% else %}
+                            <td class="tv text-center">不明</td>
+                        {% endif %}
+                        {% if Plugin.code is defined %}
+                            <td class="tc">{{ Plugin.code }}</td>
+                        {% else %}
+                            <td class="tc">不明</td>
+                        {% endif %}
+                        <td class="tu">
+                            &nbsp;-&nbsp;
+                        </td>
+                        <td class="ta text-center">
+                            {% if configPages[Plugin.code] is defined %}
+                                <a target='_blank' href='{{ configPages[Plugin.code] }}'>設定</a>
+                            {% else %}
+                                &nbsp;-&nbsp;
+                            {% endif %}
+                        </td>
+                    </tr>
+                </form>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/tests/Eccube/Tests/Web/Admin/Store/PluginControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Store/PluginControllerTest.php
@@ -1,0 +1,120 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Tests\Web\Admin\Store;
+
+use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Filesystem\Filesystem;
+
+class PluginControllerTest extends AbstractAdminWebTestCase
+{
+    protected $app;
+
+    public function tearDown()
+    {
+        $dirs = array();
+        $finder = new Finder();
+        $iterator = $finder
+            ->in($this->app['config']['plugin_realdir'])
+            ->name('dummy*')
+            ->directories();
+        foreach ($iterator as $dir) {
+            $dirs[] = $dir->getPathName();
+        }
+
+        foreach ($dirs as $dir) {
+            $this->deleteFile($dir);
+        }
+        parent::tearDown();
+    }
+
+    // テスト用のダミープラグインを配置する
+    private function createTempDir()
+    {
+        $t = sys_get_temp_dir()."/plugintest.".sha1(mt_rand());
+        if (!mkdir($t)) {
+            throw new \Exception("$t ".$php_errormsg);
+        }
+
+        return $t;
+    }
+
+    public function deleteFile($path)
+    {
+        $f = new Filesystem();
+
+        return $f->remove($path);
+    }
+
+    public function test_routing_AdminPlugin_index()
+    {
+        // インストールするプラグインを作成する
+        $tmpname = "dummy".sha1(mt_rand());
+        $config = array();
+        $config['name'] = $tmpname."_name";
+        $config['code'] = $tmpname;
+        $config['version'] = $tmpname."_version";
+
+        $tmpdir = $this->createTempDir();
+        $tmpfile = $tmpdir.'/plugin.tar';
+
+        $tar = new \PharData($tmpfile);
+        $tar->addFromString('config.yml', Yaml::dump($config));
+        $service = $this->app['eccube.service.plugin'];
+        $pluginBaseDir = $service->calcPluginDir($config['code']);
+        $service->createPluginDir($pluginBaseDir); // 本来の置き場所を作成
+        $service->unpackPluginArchive($tmpfile, $pluginBaseDir); // 問題なければ本当のplugindirへ
+
+        // インストールできるか
+        $service->checkPluginArchiveContent($pluginBaseDir);
+        $config = $service->readYml($pluginBaseDir.'/'.'config.yml');
+        $event = $service->readYml($pluginBaseDir.'/'.'event.yml');
+        $service->callPluginManagerMethod($config, 'install');
+
+        $crawler = $this->client->request('GET', $this->app->url('admin_store_plugin'));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $this->assertRegExp(
+            '/'.$tmpname.'/',
+            $this->client->getResponse()->getContent()
+        );
+    }
+
+
+    public function testIndexWithNotFound()
+    {
+        $client = $this->createClient();
+        try {
+            $crawler = $this->client->request('GET', $this->app->url('admin_store_plugin').DIRECTORY_SEPARATOR.'test');
+            $this->fail();
+        } catch (NotFoundHttpException $e) {
+            $this->expected = 404;
+            $this->actual = $e->getStatusCode();
+        }
+        $this->verify();
+    }
+}


### PR DESCRIPTION
プラグインフォルダに設置しただけのプラグインも一覧に表示機能を追加
※「アップデート・有効・無効 」は管理画面から行えない
※priveteをprotectedに修正
※旧PRでプラグインのエラーハンドリングを含めていたもの切り分け