### PR TITLE
税率設定画面の入力チェック対応、メール設定画面の入力チェック対応

### DIFF
--- a/src/Eccube/Entity/MailTemplate.php
+++ b/src/Eccube/Entity/MailTemplate.php
@@ -36,7 +36,7 @@ class MailTemplate extends \Eccube\Entity\AbstractEntity
      */
     public function __toString()
     {
-        return $this->getSubject();
+        return $this->getSubject() ? $this->getSubject() : '';
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/TaxRuleType.php
+++ b/src/Eccube/Form/Type/Admin/TaxRuleType.php
@@ -77,6 +77,9 @@ class TaxRuleType extends AbstractType
                     'hours' => '--',
                     'minutes' => '--'
                 ),
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                ),
             ))
             ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
     }


### PR DESCRIPTION
* 税率設定画面で共通税率設定欄の適用日時を入力せずに登録するとシステムエラーが発生、メール設定のメールテンプレート編集時に件名を入力していない不具合対応 #1477
* 税率設定画面の入力チェック対応、メール設定画面の入力チェック対応 #1476