### PR TITLE
Fix appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,9 +43,7 @@ install:
   - echo extension=php_openssl.dll >> C:\tools\php\php.ini
   - echo extension=php_gd2.dll >> C:\tools\php\php.ini
   - echo extension=php_mbstring.dll >> C:\tools\php\php.ini
-  - echo extension=php_mysql.dll >> C:\tools\php\php.ini
   - echo extension=php_pgsql.dll >> C:\tools\php\php.ini
-  #- echo extension=php_pdo.dll >> C:\tools\php\php.ini
   - echo extension=php_pdo_mysql.dll >> C:\tools\php\php.ini
   - echo extension=php_pdo_pgsql.dll >> C:\tools\php\php.ini
   - echo extension=php_curl.dll >> C:\tools\php\php.ini


### PR DESCRIPTION
- コメントアウトされている行を削除
- PHP7 では php_mysql.dll は存在しないため削除