### PR TITLE
購入履歴に削除された規格の商品があると、マイページ注文履歴でEntity not foundになるのを修正

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -38,6 +38,12 @@ class EditController extends AbstractController
 {
     public function index(Application $app, Request $request, $id = null)
     {
+        /* @var $softDeleteFilter \Eccube\Doctrine\Filter\SoftDeleteFilter */
+        $softDeleteFilter = $app['orm.em']->getFilters()->getFilter('soft_delete');
+        $softDeleteFilter->setExcludes(array(
+            'Eccube\Entity\ProductClass',
+        ));
+
         $TargetOrder = null;
         $OriginOrder = null;
 

--- a/src/Eccube/Controller/Mypage/MypageController.php
+++ b/src/Eccube/Controller/Mypage/MypageController.php
@@ -86,6 +86,12 @@ class MypageController extends AbstractController
     {
         $Customer = $app['user'];
 
+        /* @var $softDeleteFilter \Eccube\Doctrine\Filter\SoftDeleteFilter */
+        $softDeleteFilter = $app['orm.em']->getFilters()->getFilter('soft_delete');
+        $softDeleteFilter->setExcludes(array(
+            'Eccube\Entity\ProductClass',
+        ));
+
         // 購入処理中/決済処理中ステータスの受注を非表示にする.
         $app['orm.em']
             ->getFilters()
@@ -189,7 +195,8 @@ class MypageController extends AbstractController
 
         foreach ($Order->getOrderDetails() as $OrderDetail) {
             try {
-                if ($OrderDetail->getProduct()) {
+                if ($OrderDetail->getProduct() &&
+                    $OrderDetail->getProductClass()) {
                     $app['eccube.service.cart']->addProduct($OrderDetail->getProductClass()->getId(), $OrderDetail->getQuantity())->save();
                 } else {
                     $app->addRequestError('cart.product.delete');

--- a/src/Eccube/Entity/OrderDetail.php
+++ b/src/Eccube/Entity/OrderDetail.php
@@ -444,6 +444,9 @@ class OrderDetail extends \Eccube\Entity\AbstractEntity
      */
     public function getProductClass()
     {
+        if (EntityUtil::isEmpty($this->ProductClass)) {
+            return null;
+        }
         return $this->ProductClass;
     }
     /**

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -98,6 +98,7 @@ class CartService
     {
         /* @var $softDeleteFilter \Eccube\Doctrine\Filter\SoftDeleteFilter */
         $softDeleteFilter = $this->entityManager->getFilters()->getFilter('soft_delete');
+        $excludes = $softDeleteFilter->getExcludes();
         $softDeleteFilter->setExcludes(array(
             'Eccube\Entity\ProductClass',
         ));
@@ -106,7 +107,7 @@ class CartService
             $this->loadProductClassFromCartItem($CartItem);
         }
 
-        $softDeleteFilter->setExcludes(array());
+        $softDeleteFilter->setExcludes($excludes);
     }
 
     /**


### PR DESCRIPTION
商品購入後、当該商品規格を削除すると、マイページの注文履歴でエラー(Entity not found)になる問題を対策しました。

あわせて、以下の修正も入れています。
・注文履歴ページと同様に管理画面の受注情報編集ページでもエラーになるので修正
・再注文時、商品規格が削除されていたらカートには入れないように修正


