### PR TITLE
オーナーズストアプラグインのインストール要件の緩和(#1531)

### DIFF
--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -130,6 +130,7 @@ class PluginController extends AbstractController
                                     $plugin->setNewVersion($item['version']);
                                     $plugin->setLastUpdateDate($item['last_update_date']);
                                     $plugin->setProductUrl($item['product_url']);
+                                    $plugin->setEccubeVersion($item['eccube_version']);
 
                                     if ($plugin->getVersion() != $item['version']) {
                                         // バージョンが異なる

--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -134,11 +134,8 @@ class PluginController extends AbstractController
 
                                     if ($plugin->getVersion() != $item['version']) {
                                         // バージョンが異なる
-                                        if (in_array(Constant::VERSION, $item['eccube_version'])) {
-                                            // 対象バージョン
-                                            $plugin->setUpdateStatus(3);
-                                            break;
-                                        }
+                                        $plugin->setUpdateStatus(3);
+                                        break;
                                     }
                                 }
                             }

--- a/src/Eccube/Entity/Plugin.php
+++ b/src/Eccube/Entity/Plugin.php
@@ -100,6 +100,10 @@ class Plugin
      */
     private $product_url;
 
+    /**
+     * @var array
+     */
+    private $eccube_version;
 
     /**
      * @var \Doctrine\Common\Collections\Collection
@@ -116,7 +120,7 @@ class Plugin
     /**
      * Get id
      *
-     * @return integer 
+     * @return integer
      */
     public function getId()
     {
@@ -139,7 +143,7 @@ class Plugin
     /**
      * Get name
      *
-     * @return string 
+     * @return string
      */
     public function getName()
     {
@@ -162,7 +166,7 @@ class Plugin
     /**
      * Get code
      *
-     * @return string 
+     * @return string
      */
     public function getCode()
     {
@@ -185,7 +189,7 @@ class Plugin
     /**
      * Get class_name
      *
-     * @return string 
+     * @return string
      */
     public function getClassName()
     {
@@ -208,7 +212,7 @@ class Plugin
     /**
      * Get enable
      *
-     * @return integer 
+     * @return integer
      */
     public function getEnable()
     {
@@ -231,7 +235,7 @@ class Plugin
     /**
      * Get version
      *
-     * @return string 
+     * @return string
      */
     public function getVersion()
     {
@@ -254,7 +258,7 @@ class Plugin
     /**
      * Get create_date
      *
-     * @return \DateTime 
+     * @return \DateTime
      */
     public function getCreateDate()
     {
@@ -277,7 +281,7 @@ class Plugin
     /**
      * Get update_date
      *
-     * @return \DateTime 
+     * @return \DateTime
      */
     public function getUpdateDate()
     {
@@ -420,6 +424,34 @@ class Plugin
     public function getProductUrl()
     {
         return $this->product_url;
+    }
+
+    /**
+     * Set eccube_version
+     *
+     * @param array $eccube_version
+     * @return Plugin
+     */
+    public function setEccubeVersion($eccube_version)
+    {
+        $this->eccube_version = $eccube_version;
+
+        return $this;
+    }
+
+    /**
+     * Get eccube_version
+     *
+     * @return array
+     */
+    public function getEccubeVersion()
+    {
+        return $this->eccube_version;
+    }
+
+    public function getEccubeVersionAsString()
+    {
+        return implode(', ', $this->getEccubeVersion());
     }
 
     public function getPluginEventHandlers()

--- a/src/Eccube/Resource/template/admin/Store/plugin_owners_panel.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_owners_panel.twig
@@ -26,16 +26,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             <span class="glyphicon glyphicon-star"></span> <strong>おすすめ追加機能</strong> <span class="glyphicon glyphicon-star"></span>
         </p>
     {% endif %}
-    {% if version_check == 0 %}
-        <p class="text-danger">こちらのプラグインは使用できません。<br>EC-CUBE対応バージョンを確認してください。</p>
-    {% endif %}
     <div class="plugin-logo">
         <a href="{{ item.product_url }}" target="_blank"><img class="img-rounded" src="{{ item.product_image_url }}"></a>
     </div>
     <div class="plugin-content-top">
         <div class="plugin-title">
-            {% if version_check == 1 %}
-                <span class="pull-right">
+            <span class="pull-right">
                 {% if item.update_status == 2 %}
                     <h4><span class="label label-success">インストール済</span></h4>
                 {% elseif item.update_status == 3 %}
@@ -45,9 +41,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 {% else %}
                     <a class="btn btn-warning btn-xs" href="{{ url('admin_store_plugin_upgrade', {'action': 'install', 'id': item.product_id, 'version': item.version}) }}">今すぐインストール</a>
                 {% endif %}
-                </span>
-            {% endif %}
-            <a class="plugin-name" href="{{ item.product_url }}" target="_blank">{{ item.name }}</a>
+            </span>
+              <a class="plugin-name" href="{{ item.product_url }}" target="_blank">{{ item.name }}</a>
         </div>
         <div class="plugin-description">
         {% if item.promotion == 1 %}
@@ -65,6 +60,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             <dt class="plugin-eccubeversion">EC-CUBE対応バージョン</dt><dd>{% for version in item.eccube_version %}{{ version }} {%- if loop.last == false%}, {% endif -%}{% endfor %}</dd>
             <dt class="plugin-size">ファイルサイズ</dt><dd>約 {{ (item.file_size / 1024)|round(0, 'ceil')|number_format }} KB</dd>
         </dl>
+        {% if version_check == 0 %}
+            <p class="text-danger">このプラグインはEC-CUBE {{ constant('Eccube\\Common\\Constant::VERSION') }}をサポートしていないため、正常に動作しない可能性があります。</p>
+        {% endif %}
         <p class="plugin-developer">
             <strong>提供元</strong> : {% if item.developer_url is not null %}<a href="{{ item.developer_url }}" target="_blank">{{ item.developer }}</a>{% else %}{{ item.developer }}{% endif %}
         </p>

--- a/src/Eccube/Resource/template/admin/Store/plugin_table.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_table.twig
@@ -72,6 +72,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     </p>
                                     <ul class="plugin-meta dl-horizontal">
                                         <li class="plugin-version">プラグインバージョン : {{ Plugin.newVersion }}</li>
+                                        <li class="plugin-version">EC-CUBE対応バージョン : {{ Plugin.eccubeVersionAsString }}</li>
                                         <li class="plugin-update">更新日 : {{ Plugin.lastUpdateDate|time_ago }}</li>
                                     </ul>
                                 {% else %}


### PR DESCRIPTION
- バージョン相違のある場合でもインストール実行できるよう修正
- バージョン相違のある場合は警告を追加
- インストール済みプラグイン更新バージョンがある場合、対応バージョンを表示するよう修正