### PR TITLE
Entity HTML when user write HTML code in "フリーエリア"

### DIFF
--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -688,7 +688,7 @@ class Product extends \Eccube\Entity\AbstractEntity
      */
     public function getFreeArea()
     {
-        return $this->free_area;
+        return htmlentities($this->free_area);
     }
 
 


### PR DESCRIPTION
ユーザーが free_areaに HTML を入力した時、右の商品登録ボタンをロードするエラーが出ます。ユーザーのHTMLを暗号化する為に htmlentitiesを利用する事が必要です。