### PR TITLE
vendor以下での利用を可能に

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -12,13 +12,14 @@ if (extension_loaded('wincache')) {
     ini_set('wincache.fcenabled', 1);
 }
 
-$autoload = __DIR__.'/vendor/autoload.php';
-
-if (file_exists($autoload) && is_readable($autoload)) {
-    $loader = require $autoload;
+if (file_exists(__DIR__.'/vendor.phar')) {
+    $loader = require  __DIR__.'/vendor.phar';
+} elseif (file_exists(__DIR__.'/vendor/autoload.php')) {
+    $loader = require __DIR__.'/vendor/autoload.php';
 } else {
     die('Composer is not installed.');
 }
+$loader->addPsr4('Plugin\\', __DIR__ . '/app/Plugin');
 
 // autoloader cache
 if (extension_loaded('apc') && ini_get('apc.enabled')) {

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,6 @@
     "autoload": {
         "psr-4": {
             "Eccube\\": "src/Eccube",
-            "Plugin\\": "app/Plugin",
             "Dbtlr\\MigrationProvider\\Provider\\": "src/silex-doctrine-migrations"
         }
     },

--- a/src/Eccube/ControllerProvider/InstallControllerProvider.php
+++ b/src/Eccube/ControllerProvider/InstallControllerProvider.php
@@ -31,22 +31,21 @@ class InstallControllerProvider implements ControllerProviderInterface
 {
     public function connect(Application $app)
     {
+        // installer
         /* @var $controllers \Silex\ControllerCollection */
         $controllers = $app['controllers_factory'];
-
-        // installer
-        $controllers->match('', "\\Eccube\\Controller\\Install\\InstallController::index")->bind('install');
+        $controllers->match('/', "\\Eccube\\Controller\\Install\\InstallController::index")->bind('install');
         $controllers->match('/step1', "\\Eccube\\Controller\\Install\\InstallController::step1")->bind('install_step1');
         $controllers->match('/step2', "\\Eccube\\Controller\\Install\\InstallController::step2")->bind('install_step2');
         $controllers->match('/step3', "\\Eccube\\Controller\\Install\\InstallController::step3")->bind('install_step3');
         $controllers->match('/step4', "\\Eccube\\Controller\\Install\\InstallController::step4")->bind('install_step4');
         $controllers->match('/step5', "\\Eccube\\Controller\\Install\\InstallController::step5")->bind('install_step5');
-
         $controllers->match('/complete', "\\Eccube\\Controller\\Install\\InstallController::complete")->bind('install_complete');
 
         $controllers->match('/migration', "\\Eccube\\Controller\\Install\\InstallController::migration")->bind('migration');
         $controllers->match('/migration_plugin', "\\Eccube\\Controller\\Install\\InstallController::migration_plugin")->bind('migration_plugin');
         $controllers->match('/migration_end', "\\Eccube\\Controller\\Install\\InstallController::migration_end")->bind('migration_end');
+
         return $controllers;
     }
 }

--- a/src/Eccube/Resource/config/path.yml.dist
+++ b/src/Eccube/Resource/config/path.yml.dist
@@ -26,13 +26,10 @@ image_temp_realdir: ${ROOT_DIR}/html/upload/temp_image
 user_data_realdir: ${ROOT_DIR}/html/user_data
 
 # realdir::block
-block_default_realdir: ${ROOT_DIR}/src/Eccube/Resource/template/default/Block
 block_realdir: ${ROOT_DIR}/app/template/${TEMPLATE_CODE}/Block
 
 # realdir::template
-template_default_realdir: ${ROOT_DIR}/src/Eccube/Resource/template/default
 template_default_html_realdir: ${ROOT_DIR}/html/template/default
-template_admin_realdir: ${ROOT_DIR}/src/Eccube/Resource/template/admin
 template_admin_html_realdir: ${ROOT_DIR}/html/template/admin
 template_realdir: ${ROOT_DIR}/app/template/${TEMPLATE_CODE}
 template_html_realdir: ${ROOT_DIR}/html/template/${TEMPLATE_CODE}


### PR DESCRIPTION
refs #591, #864 

EC-CUBE本体をcomposerディレクトリのおいた場合も動作するようにしました。
修正は以下になります。
- `vendor/ec-cube/ec-cube/` 以下に置くことが可能に
- 上記に伴い、 `path.yml` の一部パラメータを廃止

本チケットのメリットは今後の複数バージョンでのプラグインテストが容易になることです。

以下の様なかたちで、 `composer.json` を記載するだけで、それぞれのバージョン環境が用意できます。
Pluginの自動テストに有効な対応となります。

```
{
    "require": {
        "ec-cube/ec-cube": "3.0.10"
    },
    "minimum-stability": "dev",
    "prefer-stable": true
}
```
