### PR TITLE
Admin\Order\MailController::mailAll() の$_GETの参照を廃止

### DIFF
--- a/src/Eccube/Controller/Admin/Order/MailController.php
+++ b/src/Eccube/Controller/Admin/Order/MailController.php
@@ -336,10 +336,15 @@ class MailController
                 }
             }
         } else {
-            foreach ($_GET as $key => $value) {
-                $ids = str_replace('ids', '', $key) . ',' . $ids;
-            }
-            $ids = substr($ids, 0, -1);
+            $filter = function ($v) {
+                return preg_match('/^ids\d+$/', $v);
+            };
+            $map = function ($v) {
+                return preg_replace('/[^\d+]/', '', $v);
+            };
+            $keys = array_keys($request->query->all());
+            $idArray = array_map($map, array_filter($keys, $filter));
+            $ids = implode(',', $idArray);
         }
 
         return $app->render('Order/mail_all.twig', array(


### PR DESCRIPTION
#1427