### PR TITLE
商品詳細画面のブラウザバック時の挙動を修正

### DIFF
--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -265,7 +265,7 @@ class ProductController
                         $app['session']->getFlashBag()->set('eccube.add.favorite', true);
                         return $app->redirect($app->url('mypage_login'));
                     }
-                } else {
+                } elseif ($addCartData['mode'] === 'add_cart') {
                     try {
                         $app['eccube.service.cart']->addProduct($addCartData['product_class_id'], $addCartData['quantity'])->save();
                     } catch (CartException $e) {

--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -216,7 +216,7 @@ $(function(){
                                 {# カートボタン #}
                                 <div id="detail_cart_box__button_area" class="btn_area">
                                     <ul id="detail_cart_box__insert_button" class="row">
-                                        <li class="col-xs-12 col-sm-8"><button type="submit" id="cart" class="btn btn-primary btn-block prevention-btn prevention-mask">カートに入れる</button></li>
+                                        <li class="col-xs-12 col-sm-8"><button type="submit" id="add-cart" class="btn btn-primary btn-block prevention-btn prevention-mask">カートに入れる</button></li>
                                     </ul>
                                     {% if BaseInfo.option_favorite_product == 1 %}
                                     <ul id="detail_cart_box__favorite_button" class="row">

--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -76,6 +76,9 @@ $(function(){
         $('#mode').val('add_favorite');
     });
 
+    $('#add-cart').click(function() {
+        $('#mode').val('add_cart');
+    });
 });
 </script>
 


### PR DESCRIPTION
#1564 
```php
if ($addCartData['mode'] === 'add_favorite') {
    // お気に入り処理
} else {
    // カート処理
}
```
という判定自体がそもそも微妙なので、modeにadd_cartを設定するよう変更しました。

( #1519 のid重複1点の修正も含む)