### PR TITLE
#1405 fixing bug : duplication block

### DIFF
--- a/src/Eccube/Repository/PageLayoutRepository.php
+++ b/src/Eccube/Repository/PageLayoutRepository.php
@@ -106,6 +106,18 @@ class PageLayoutRepository extends EntityRepository
         foreach ($anyResults as $anyResult) {
             $BlockPositions = $anyResult->getBlockPositions();
             foreach ($BlockPositions as $BlockPosition) {
+
+                $duplicated = $OwnBlockPosition->filter(
+                    function($entry) use ($BlockPosition) {
+                        if( ($entry->getTargetId() == $BlockPosition->getTargetId()) && ( $entry->getBlockId() == $BlockPosition->getBlockId() )  ){
+                            return true;
+                        }
+                    }
+                );
+                if(count($duplicated) > 0){
+                    continue;
+                }
+
                 if (!$OwnBlockPosition->contains($BlockPosition)) {
                     $ownResult->addBlockPosition($BlockPosition);
                 }
@@ -153,6 +165,18 @@ class PageLayoutRepository extends EntityRepository
         foreach ($anyResults as $anyResult) {
             $BlockPositions = $anyResult->getBlockPositions();
             foreach ($BlockPositions as $BlockPosition) {
+
+                $duplicated = $OwnBlockPosition->filter(
+                    function($entry) use ($BlockPosition) {
+                        if( ($entry->getTargetId() == $BlockPosition->getTargetId()) && ( $entry->getBlockId() == $BlockPosition->getBlockId() )  ){
+                            return true;
+                        }
+                    }
+                );
+                if(count($duplicated) > 0){
+                    continue;
+                }
+
                 if (!$OwnBlockPosition->contains($BlockPosition)) {
                     $ownResult->addBlockPosition($BlockPosition);
                 }


### PR DESCRIPTION
- block A ( active all ) in TOP page
- block A in ITEM page
2 blocks A can show in same area:
tested on travis-ci : https://travis-ci.org/hoand-vn/ec-cube
 