### PR TITLE
Add separator for distinguishing type

### DIFF
--- a/src/Eccube/Resource/config/database.yml.dist
+++ b/src/Eccube/Resource/config/database.yml.dist
@@ -1,9 +1,9 @@
 database:
-    driver: ${DBDRIVER}
-    host: ${DBSERVER}
-    dbname: ${DBNAME}
-    port: ${DBPORT}
-    user: ${DBUSER}
-    password : ${DBPASS}
+    driver: '${DBDRIVER}'
+    host: '${DBSERVER}'
+    dbname: '${DBNAME}'
+    port: '${DBPORT}'
+    user: '${DBUSER}'
+    password : '${DBPASS}'
     charset: utf8
     defaultTableOptions: { collate: utf8_general_ci }


### PR DESCRIPTION
When some parameter start from like 0
it will disappear when parsing yaml.
which cause error.




