### PR TITLE
resume パラメータで検索結果を復元できるよう修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -719,7 +719,7 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
             <div id="detail__back_button" class="row hidden-xs hidden-sm">
                 <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
                     {% if id is not null %}
-                        <p><a href="{{ url('admin_order') }}">戻る</a></p>
+                        <p><a href="{{ url('admin_order_page', { page_no: app.session.get('eccube.admin.order.search.page_no')|default('1') }) }}?resume=1">戻る</a></p>
                     {% endif %}
                 </div>
             </div>

--- a/src/Eccube/Resource/template/admin/Order/mail.twig
+++ b/src/Eccube/Resource/template/admin/Order/mail.twig
@@ -146,7 +146,7 @@ $(function() {
         <div id="edit_box__footer" class="row">
             <div id="button_box__button_menu" class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
                 <button type="submit" class="btn btn-primary btn-lg" name="mode" value="confirm">送信内容を確認</button>
-                <p><a href="{{ url('admin_order') }}">検索結果へ戻る</a></p>
+                <p><a href="{{ url('admin_order_page', { page_no: app.session.get('eccube.admin.order.search.page_no')|default('1') }) }}?resume=1">検索結果へ戻る</a></p>
             </div>
         </div>
         </form>

--- a/src/Eccube/Resource/template/admin/Order/mail_all.twig
+++ b/src/Eccube/Resource/template/admin/Order/mail_all.twig
@@ -91,7 +91,7 @@ $(function() {
         <div id="top_box__footer" class="row">
             <div id="top_box__button_menu" class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
                 <button type="submit" class="btn btn-primary btn-lg" name="mode" value="confirm">送信内容を確認</button>
-                <p><a href="{{ url('admin_order') }}">検索結果へ戻る</a></p>
+                <p><a href="{{ url('admin_order_page', { page_no: app.session.get('eccube.admin.order.search.page_no')|default('1') }) }}?resume=1">検索結果へ戻る</a></p>
             </div>
         </div>
         </form>

--- a/src/Eccube/Resource/template/admin/Order/mail_complete.twig
+++ b/src/Eccube/Resource/template/admin/Order/mail_complete.twig
@@ -36,7 +36,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         </div><!-- /.box -->
         <div id="complete_box__footer" class="row">
             <div id="complete_box__back_button" class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
-                <p><a href="{{ url('admin_order') }}">検索結果へ戻る</a></p>
+                <p><a href="{{ url('admin_order_page', { page_no: app.session.get('eccube.admin.order.search.page_no')|default('1') }) }}?resume=1">検索結果へ戻る</a></p>
             </div>
         </div>
 

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -380,7 +380,7 @@ function fnClass(action) {
 
                     <div id="detail_box__footer" class="row hidden-xs hidden-sm">
                         <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
-                            <p><a href="{{ url('admin_product') }}">検索画面に戻る</a></p>
+                            <p><a href="{{ url('admin_product_page', { page_no : app.session.get('admin.product.search.page_no')|default('1') } ) }}?resume=1">検索画面に戻る</a></p>
                         </div>
                     </div>
 

--- a/src/Eccube/Resource/template/admin/Product/product_class.twig
+++ b/src/Eccube/Resource/template/admin/Product/product_class.twig
@@ -309,7 +309,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         <input id="mode" type="hidden" name="mode">
         <button type="submit" class="btn btn-primary btn-lg btn-block" name="mode" value="update">更新</button>
 {% endif %}
-        <p><a href="{{ url('admin_product') }}">前のページに戻る</a></p>
+        <p><a href="{{ url('admin_product_page', { page_no : app.session.get('eccube.admin.product.search.page_no')|default('1') } ) }}?resume=1">前のページに戻る</a></p>
     </div>
 </div>
 </form>

--- a/tests/Eccube/Tests/Plugin/Web/Admin/Customer/CustomerControllerTest.php
+++ b/tests/Eccube/Tests/Plugin/Web/Admin/Customer/CustomerControllerTest.php
@@ -92,7 +92,7 @@ class CustomerControllerTest extends AbstractAdminWebTestCase
             'DELETE',
             $this->app->path('admin_customer_delete', array('id' => $Customer->getId()))
         );
-        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_customer')));
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_customer_page', array('page_no' => 1)).'?resume=1'));
 
         $expected = array(
             EccubeEvents::ADMIN_CUSTOMER_DELETE_COMPLETE,

--- a/tests/Eccube/Tests/Plugin/Web/Admin/Order/OrderControllerTest.php
+++ b/tests/Eccube/Tests/Plugin/Web/Admin/Order/OrderControllerTest.php
@@ -123,7 +123,7 @@ class OrderControllerTest extends AbstractAdminWebTestCase
             'DELETE',
             $this->app->path('admin_order_delete', array('id' => $Order->getId()))
         );
-        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_order')));
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_order_page', array('page_no' => 1)).'?resume=1'));
 
         $expected = array(
             EccubeEvents::ADMIN_ORDER_DELETE_COMPLETE,

--- a/tests/Eccube/Tests/Plugin/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Plugin/Web/Admin/Product/ProductContorllerTest.php
@@ -151,7 +151,7 @@ class ProductControllerTest extends AbstractAdminWebTestCase
             $this->app->url('admin_product_product_delete', array('id' => $Product->getId()))
         );
 
-        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_product')));
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_product_page', array('page_no' => 1)).'?resume=1'));
 
         $expected = array(
             EccubeEvents::ADMIN_PRODUCT_DELETE_COMPLETE,

--- a/tests/Eccube/Tests/Web/Admin/Customer/CustomerControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Customer/CustomerControllerTest.php
@@ -84,7 +84,7 @@ class CustomerControllerTest extends AbstractAdminWebTestCase
             'DELETE',
             $this->app->path('admin_customer_delete', array('id' => $Customer->getId()))
         );
-        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_customer')));
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_customer_page', array('page_no' => 1)).'?resume=1'));
 
         $DeletedCustomer = $this->app['eccube.repository.customer']->find($Customer->getId());
 

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
@@ -107,7 +107,11 @@ class OrderControllerTest extends AbstractAdminWebTestCase
             'DELETE',
             $this->app->path('admin_order_delete', array('id' => $Order->getId()))
         );
-        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_order')));
+        $this->assertTrue($this->client->getResponse()->isRedirect(
+            $this->app->url(
+                'admin_order_page', array('page_no' => 1)
+            ).'?resume=1'
+        ));
 
         $DeletedOrder = $this->app['eccube.repository.order']->find($Order->getId());
 

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
@@ -122,7 +122,7 @@ class ProductControllerTest extends AbstractAdminWebTestCase
             $this->app->url('admin_product_product_delete', array('id' => $Product->getId()))
         );
 
-        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_product')));
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_product_page', array('page_no' => 1)).'?resume=1'));
 
         $DeletedProduct = $this->app['eccube.repository.product']->find($Product->getId());
         $this->expected = 1;


### PR DESCRIPTION
- issues #1084 
- `resume=1` を付与することで、検索結果を復元できるように修正
- 管理画面の以下の機能が対象
   - 商品検索
   - 会員検索
   - 受注検索
