### PR TITLE
curl で取得できない場合は file_get_contents() で取得する

### DIFF
--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -36,6 +36,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Validator\Constraints as Assert;
+use Monolog\Logger;
 
 class PluginController extends AbstractController
 {
@@ -677,19 +678,34 @@ class PluginController extends AbstractController
         $curl = curl_init($url);
         $fileName = $app['config']['root_dir'].'/app/config/eccube/'.$this->certFileName;
         $fp = fopen($fileName, 'w');
+        if ($fp === false) {
+            $app->addError('admin.plugin.download.pem.error', 'admin');
+            $app->log('Cannot fopen to '.$fileName, array(), Logger::ERROR);
+            return $app->redirect($app->url('admin_store_authentication_setting'));
+        }
 
         curl_setopt($curl, CURLOPT_FILE, $fp);
         curl_setopt($curl, CURLOPT_HEADER, 0);
 
-        curl_exec($curl);
+        $results = curl_exec($curl);
+        $error = curl_error($curl);
         curl_close($curl);
+
+        // curl で取得できない場合は file_get_contents で取得を試みる
+        if ($results === false) {
+            $file = file_get_contents($url);
+            if ($file !== false) {
+                fwrite($fp, $file);
+            }
+        }
         fclose($fp);
 
         $f = new Filesystem();
-        if ($f->exists($fileName)) {
+        if ($f->exists($fileName) && filesize($fileName) > 0) {
             $app->addSuccess('admin.plugin.download.pem.complete', 'admin');
         } else {
             $app->addError('admin.plugin.download.pem.error', 'admin');
+            $app->log('curl_error: '.$error, array(), Logger::ERROR);
         }
 
         return $app->redirect($app->url('admin_store_authentication_setting'));


### PR DESCRIPTION
- #1521
- Windows 環境で cacart.pem が存在しない状況では curl が失敗してしまう
  (SSL certificate problem: unable to get local issuer certificate とい
  うエラーになる)ため、 file_get_contents() でフォールバックするよう修正