### PR TITLE
TransactionListener の追加

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -25,6 +25,7 @@ namespace Eccube;
 
 use Eccube\Application\ApplicationTrait;
 use Eccube\Common\Constant;
+use Eccube\EventListener\TransactionListener;
 use Monolog\Logger;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Finder\Finder;
@@ -233,6 +234,9 @@ class Application extends ApplicationTrait
         $this->mount('', new ControllerProvider\FrontControllerProvider());
         $this->mount('/'.trim($this['config']['admin_route'], '/').'/', new ControllerProvider\AdminControllerProvider());
         Request::enableHttpMethodParameterOverride(); // PUTやDELETEできるようにする
+
+        // add transaction listener
+        $this['dispatcher']->addSubscriber(new TransactionListener($this));
 
         $this->initialized = true;
     }

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -39,6 +39,7 @@ class Application extends ApplicationTrait
 
     protected $initialized = false;
     protected $initializedPlugin = false;
+    protected $testMode = false;
 
     public static function getInstance(array $values = array())
     {
@@ -911,6 +912,25 @@ class Application extends ApplicationTrait
                 }
             }
         }
+    }
+
+    /**
+     * PHPUnit を実行中かどうかを設定する.
+     *
+     * @param boolean $testMode PHPUnit を実行中の場合 true
+     */
+    public function setTestMode($testMode) {
+        $this->testMode = $testMode;
+    }
+
+    /**
+     * PHPUnit を実行中かどうか.
+     *
+     * @return boolean PHPUnit を実行中の場合 true
+     */
+    public function isTestMode()
+    {
+        return $this->testMode;
     }
 
     /**

--- a/src/Eccube/EventListener/TransactionListener.php
+++ b/src/Eccube/EventListener/TransactionListener.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\EventListener;
+
+use Eccube\Application;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * トランザクション制御のためのListener
+ *
+ * @package Eccube\EventListener
+ */
+class TransactionListener implements EventSubscriberInterface
+{
+    private $app;
+
+    /**
+     * Constructor function.
+     *
+     * @param Application $app
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Kernel request listener callback.
+     *
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $app = $this->app;
+        $app['orm.em']->getConnection()->setAutoCommit(false);
+        $app['orm.em']->beginTransaction();
+    }
+
+    /**
+     * Kernel exception listener callback.
+     *
+     * @param GetResponseForExceptionEvent $event
+     */
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $app = $this->app;
+        if ($app['orm.em']->getConnection()->isTransactionActive()) {
+            $app['orm.em']->rollback();
+        }
+    }
+
+    /**
+     *  Kernel terminate listener callback.
+     *
+     * @param PostResponseEvent $event
+     */
+    public function onKernelTerminate(PostResponseEvent $event)
+    {
+        $app = $this->app;
+
+        if ($app['orm.em']->getConnection()->isTransactionActive()) {
+            if ($app['orm.em']->getConnection()->isRollbackOnly()) {
+                $app['orm.em']->rollback();
+            } else {
+                $app['orm.em']->commit();
+            }
+        }
+    }
+
+    /**
+     * Return the events to subscribe to.
+     *
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => 'onKernelRequest',
+            KernelEvents::EXCEPTION => 'onKernelException',
+            KernelEvents::TERMINATE => 'onKernelTerminate',
+        );
+    }
+}

--- a/src/Eccube/EventListener/TransactionListener.php
+++ b/src/Eccube/EventListener/TransactionListener.php
@@ -61,8 +61,12 @@ class TransactionListener implements EventSubscriberInterface
         }
 
         $app = $this->app;
-        $app['orm.em']->getConnection()->setAutoCommit(false);
-        $app['orm.em']->beginTransaction();
+        if (!$app->isTestMode()) {
+            $app['orm.em']->getConnection()->setAutoCommit(false);
+            $app['orm.em']->beginTransaction();
+        } else {
+            $this->app->log('TestCase to onKernelRequest of beginTransaction');
+        }
     }
 
     /**
@@ -77,8 +81,12 @@ class TransactionListener implements EventSubscriberInterface
         }
 
         $app = $this->app;
-        if ($app['orm.em']->getConnection()->isTransactionActive()) {
-            $app['orm.em']->rollback();
+        if (!$app->isTestMode()) {
+            if ($app['orm.em']->getConnection()->isTransactionActive()) {
+                $app['orm.em']->rollback();
+            }
+        } else {
+            $this->app->log('TestCase to onKernelException of rollback');
         }
     }
 
@@ -91,12 +99,16 @@ class TransactionListener implements EventSubscriberInterface
     {
         $app = $this->app;
 
-        if ($app['orm.em']->getConnection()->isTransactionActive()) {
-            if ($app['orm.em']->getConnection()->isRollbackOnly()) {
-                $app['orm.em']->rollback();
-            } else {
-                $app['orm.em']->commit();
+        if (!$app->isTestMode()) {
+            if ($app['orm.em']->getConnection()->isTransactionActive()) {
+                if ($app['orm.em']->getConnection()->isRollbackOnly()) {
+                    $app['orm.em']->rollback();
+                } else {
+                    $app['orm.em']->commit();
+                }
             }
+        } else {
+            $this->app->log('TestCase to onKernelTerminate of commit.');
         }
     }
 

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -47,6 +47,7 @@ abstract class EccubeTestCase extends WebTestCase
     public function setUp()
     {
         parent::setUp();
+        $this->app->setTestMode(true);
         if ($this->isSqliteInMemory()) {
             $this->initializeDatabase();
         }

--- a/tests/Eccube/Tests/Form/Type/FaxTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/FaxTypeTest.php
@@ -310,6 +310,9 @@ class FaxTypeTest extends \PHPUnit_Framework_TestCase
         $app = new \Silex\Application();
         $app->register(new \Silex\Provider\FormServiceProvider());
         $app->register(new \Eccube\ServiceProvider\ValidatorServiceProvider());
+        $app['eccube.service.plugin'] = $app->share(function () use ($app) {
+            return new \Eccube\Service\PluginService($app);
+        });
 
         $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app) {
             $types[] = new \Eccube\Form\Type\TelType();

--- a/tests/Eccube/Tests/Form/Type/PriceTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/PriceTypeTest.php
@@ -127,6 +127,9 @@ class PriceTypeTest extends \PHPUnit_Framework_TestCase
         $app = new \Silex\Application();
         $app->register(new \Silex\Provider\FormServiceProvider());
         $app->register(new \Eccube\ServiceProvider\ValidatorServiceProvider());
+        $app['eccube.service.plugin'] = $app->share(function () use ($app) {
+            return new \Eccube\Service\PluginService($app);
+        });
 
         $self = $this;
         $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app, $self) {

--- a/tests/Eccube/Tests/Form/Type/RepeatedEmailTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/RepeatedEmailTypeTest.php
@@ -103,6 +103,9 @@ class RepeatedEmailTypeTest extends \PHPUnit_Framework_TestCase
         $app = new \Silex\Application();
         $app->register(new \Silex\Provider\FormServiceProvider());
         $app->register(new \Eccube\ServiceProvider\ValidatorServiceProvider());
+        $app['eccube.service.plugin'] = $app->share(function () use ($app) {
+            return new \Eccube\Service\PluginService($app);
+        });
 
         // fix php5.3
         $self = $this;

--- a/tests/Eccube/Tests/Form/Type/RepeatedPasswordTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/RepeatedPasswordTypeTest.php
@@ -158,6 +158,9 @@ class RepeatedPasswordTypeTest extends \PHPUnit_Framework_TestCase
         $app = new \Silex\Application();
         $app->register(new \Silex\Provider\FormServiceProvider());
         $app->register(new \Eccube\ServiceProvider\ValidatorServiceProvider());
+        $app['eccube.service.plugin'] = $app->share(function () use ($app) {
+            return new \Eccube\Service\PluginService($app);
+        });
 
         // fix php5.3
         $self = $this;

--- a/tests/Eccube/Tests/Form/Type/TelTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/TelTypeTest.php
@@ -268,6 +268,9 @@ class TelTypeTest extends \PHPUnit_Framework_TestCase
         $app = new \Silex\Application();
         $app->register(new \Silex\Provider\FormServiceProvider());
         $app->register(new \Eccube\ServiceProvider\ValidatorServiceProvider());
+        $app['eccube.service.plugin'] = $app->share(function () use ($app) {
+            return new \Eccube\Service\PluginService($app);
+        });
 
         // fix php5.3
         $self = $this;

--- a/tests/Eccube/Tests/Form/Type/ZipTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/ZipTypeTest.php
@@ -127,6 +127,9 @@ class ZipTypeTest extends \PHPUnit_Framework_TestCase
         $app = new \Silex\Application();
         $app->register(new \Silex\Provider\FormServiceProvider());
         $app->register(new \Eccube\ServiceProvider\ValidatorServiceProvider());
+        $app['eccube.service.plugin'] = $app->share(function () use ($app) {
+            return new \Eccube\Service\PluginService($app);
+        });
 
         // fix php5.3
         $self = $this;

--- a/tests/Eccube/Tests/Transaction/TransactionListenerTest.php
+++ b/tests/Eccube/Tests/Transaction/TransactionListenerTest.php
@@ -1,0 +1,405 @@
+<?php
+
+namespace Eccube\Tests\Transaction;
+
+use Eccube\Application;
+use Eccube\Tests\Mock\CsrfTokenMock;
+use Silex\WebTestCase;
+
+class TransactionListenerTest extends WebTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->app->initDoctrine();
+        $c = $this->app['controllers_factory'];
+        $c->match('/tran1', '\Eccube\Tests\Transaction\TransactionControllerMock::tran1')->bind('tran1');
+        $c->match('/tran2', '\Eccube\Tests\Transaction\TransactionControllerMock::tran2')->bind('tran2');
+        $c->match('/tran3', '\Eccube\Tests\Transaction\TransactionControllerMock::tran3')->bind('tran3');
+        $c->match('/tran4', '\Eccube\Tests\Transaction\TransactionControllerMock::tran4')->bind('tran4');
+        $c->match('/tran5', '\Eccube\Tests\Transaction\TransactionControllerMock::tran5')->bind('tran5');
+        $c->match('/tran6', '\Eccube\Tests\Transaction\TransactionControllerMock::tran6')->bind('tran6');
+        $c->match('/tran7', '\Eccube\Tests\Transaction\TransactionControllerMock::tran7')->bind('tran7');
+        $c->match('/tran8', '\Eccube\Tests\Transaction\TransactionControllerMock::tran8')->bind('tran8');
+        $c->match('/tran9', '\Eccube\Tests\Transaction\TransactionControllerMock::tran9')->bind('tran9');
+        $this->app->mount('', $c);
+
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $this->defaultCompanyName = $BaseInfo->getCompanyName();
+    }
+
+    public function tearDown()
+    {
+        $this->app['orm.em']->close();
+        $this->app['orm.em'] = null;
+        Application::clearInstance();
+        $this->app = null;
+    }
+
+    public function testTran1()
+    {
+        $client = $this->createClient();
+        $crawler = $client->request('GET', '/tran1');
+
+        $this->verify('tran1');
+    }
+
+    public function testTran2()
+    {
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $companyName = $BaseInfo->getCompanyName();
+        $client = $this->createClient();
+        $crawler = $client->request('GET', '/tran2');
+
+        $this->verify($companyName);
+    }
+
+    public function testTran3()
+    {
+        if ($this->app['config']['database']['driver'] == 'pdo_sqlite') {
+            $message = 'sqlite3 is not supported';
+            $this->markTestSkipped($message);
+        }
+
+        $client = $this->createClient();
+        $crawler = $client->request('GET', '/tran3');
+
+        $this->verify('tran3');
+    }
+
+    public function testTran4()
+    {
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $companyName = $BaseInfo->getCompanyName();
+
+        $client = $this->createClient();
+        $crawler = $client->request('GET', '/tran4');
+
+        $this->verify($companyName);
+    }
+
+    public function testTran5()
+    {
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $companyName = $BaseInfo->getCompanyName();
+        $client = $this->createClient();
+        $crawler = $client->request('GET', '/tran5');
+
+        $this->verify($companyName);
+    }
+
+    public function testTran6()
+    {
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $companyName = $BaseInfo->getCompanyName();
+        $client = $this->createClient();
+        $crawler = $client->request('GET', '/tran6');
+
+        $this->verify($companyName);
+    }
+
+    public function testTran7()
+    {
+        if ($this->app['config']['database']['driver'] == 'pdo_sqlite') {
+            $message = 'sqlite3 is not supported';
+            $this->markTestSkipped($message);
+        }
+
+        $client = $this->createClient();
+        $crawler = $client->request('GET', '/tran7');
+
+        $this->verify('tran7-3');
+    }
+
+    public function testTran8()
+    {
+        if ($this->app['config']['database']['driver'] == 'pdo_sqlite') {
+            $message = 'sqlite3 is not supported';
+            $this->markTestSkipped($message);
+        }
+
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $companyName = $BaseInfo->getCompanyName();
+        $client = $this->createClient();
+        $crawler = $client->request('GET', '/tran8');
+
+        $this->verify($companyName);
+    }
+
+    public function testTran9()
+    {
+        $client = $this->createClient();
+        $crawler = $client->request('GET', '/tran9');
+
+        $this->verify('tran9-3');
+    }
+
+    protected function verify($expected, $message = '')
+    {
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $this->app['orm.em']->detach($BaseInfo);
+
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $actual = $BaseInfo->getCompanyName();
+        $this->assertEquals($expected, $actual);
+        $this->app['orm.em']->detach($BaseInfo);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createApplication()
+    {
+        $app = Application::getInstance();
+        $app['debug'] = true;
+        $app->initialize();
+        $app->initPluginEventDispatcher();
+        $app->initializePlugin();
+        $app['session.test'] = true;
+        // exception.handle
+        // $app['exception_handler']->disable();
+
+        $app['form.csrf_provider'] = $app->share(function () {
+            return new CsrfTokenMock();
+        });
+
+        $app->boot();
+
+        return $app;
+    }
+}
+
+class TransactionControllerMock
+{
+
+    public function index(Application $app)
+    {
+        return $app->render('index.twig');
+    }
+
+
+    public function tran1(Application $app)
+    {
+        // update 1
+        $BaseInfo = $app['eccube.repository.base_info']->get();
+        $BaseInfo->setCompanyName('tran1');
+        $app['orm.em']->flush($BaseInfo);
+
+        return $app->render('index.twig');
+    }
+
+    public function tran2(Application $app)
+    {
+        // update 1
+        $BaseInfo = $app['eccube.repository.base_info']->get();
+        $BaseInfo->setCompanyName('tran2-1');
+        $app['orm.em']->flush($BaseInfo);
+
+        // update 2
+        $BaseInfo->setCompanyName('tran2-1');
+        $app['orm.em']->flush($BaseInfo);
+
+        // 1/2 は rollback.
+        throw new \Exception();
+
+        return $app->render('index.twig');
+    }
+
+    public function tran3(Application $app)
+    {
+        $app['orm.em']->beginTransaction();
+
+        try {
+            $BaseInfo = $app['eccube.repository.base_info']->get();
+            $BaseInfo->setCompanyName('tran3');
+            $app['orm.em']->flush($BaseInfo);
+            $app['orm.em']->commit();
+
+        } catch (\Exception $e) {
+            $app['orm.em']->rollback();
+        }
+
+        return $app->render('index.twig');
+    }
+
+    public function tran4(Application $app)
+    {
+        $app['orm.em']->beginTransaction();
+
+        try {
+            // update 1
+            $BaseInfo = $app['eccube.repository.base_info']->get();
+            $BaseInfo->setCompanyName('tran4');
+            $app['orm.em']->flush($BaseInfo);
+            $app['orm.em']->commit();
+
+            // update 1 は rollback
+            throw new \Exception();
+
+        } catch (\Exception $e) {
+            $app['orm.em']->rollback();
+        }
+
+        return $app->render('index.twig');
+    }
+
+    public function tran5(Application $app)
+    {
+        $app['orm.em']->beginTransaction();
+
+        try {
+            // update 1
+            $BaseInfo = $app['eccube.repository.base_info']->get();
+            $BaseInfo->setCompanyName('tran5-1');
+            $app['orm.em']->flush($BaseInfo);
+            $app['orm.em']->commit();
+
+        } catch (\Exception $e) {
+            $app['orm.em']->rollback();
+        }
+
+        $app['orm.em']->beginTransaction();
+
+        try {
+            // update 2
+            $BaseInfo = $app['eccube.repository.base_info']->get();
+            $BaseInfo->setCompanyName('tran5-2');
+            $app['orm.em']->flush($BaseInfo);
+            $app['orm.em']->commit();
+
+        } catch (\Exception $e) {
+            $app['orm.em']->rollback();
+        }
+
+        // update1/2はrollback
+        throw new \Exception();
+
+        return $app->render('index.twig');
+    }
+
+    public function tran6(Application $app)
+    {
+        $app['orm.em']->beginTransaction();
+
+        try {
+            // update 1
+            $BaseInfo = $app['eccube.repository.base_info']->get();
+            $BaseInfo->setCompanyName('tran6-1');
+            $app['orm.em']->flush($BaseInfo);
+            $app['orm.em']->commit();
+
+        } catch (\Exception $e) {
+            $app['orm.em']->rollback();
+        }
+
+        // update 2
+        $BaseInfo->setCompanyName('tran6-2');
+        $app['orm.em']->flush($BaseInfo);
+
+        // update 3
+        $BaseInfo->setCompanyName('tran6-3');
+        $app['orm.em']->flush($BaseInfo);
+
+        // update1/2/3 すべてrollback
+        throw new \Exception();
+
+        return $app->render('index.twig');
+    }
+
+    public function tran7(Application $app)
+    {
+        $app['orm.em']->beginTransaction();
+
+        try {
+            // update 1
+            $BaseInfo = $app['eccube.repository.base_info']->get();
+            $BaseInfo->setCompanyName('tran7-1');
+            $app['orm.em']->flush($BaseInfo);
+            $app['orm.em']->commit();
+
+            // update 1がrollback
+            throw new \Exception();
+
+        } catch (\Exception $e) {
+            // update 1がrollback
+            $app['orm.em']->rollback();
+        }
+
+        // update 2
+        $BaseInfo->setCompanyName('tran7-2');
+        $app['orm.em']->flush($BaseInfo);
+
+        // update 3
+        $BaseInfo->setCompanyName('tran7-3');
+        $app['orm.em']->flush($BaseInfo);
+
+        // update2/3 は 暗黙のtransaction block 内のため、まとめて更新される.
+        return $app->render('index.twig');
+    }
+
+    public function tran8(Application $app)
+    {
+        $app['orm.em']->beginTransaction();
+
+        try {
+            // update 1
+            $BaseInfo = $app['eccube.repository.base_info']->get();
+            $BaseInfo->setCompanyName('tran8-1');
+            $app['orm.em']->flush($BaseInfo);
+            $app['orm.em']->commit();
+
+            // update 1がrollback
+            throw new \Exception();
+
+        } catch (\Exception $e) {
+            // update 1がrollback
+            $app['orm.em']->rollback();
+        }
+
+        // update 2
+        $BaseInfo->setCompanyName('tran8-2');
+        $app['orm.em']->flush($BaseInfo);
+
+        // update 3
+        $BaseInfo->setCompanyName('tran8-3');
+        $app['orm.em']->flush($BaseInfo);
+
+        // update2/3 は 暗黙のtransaction block内のため、2/3はrollbackされる
+        throw new \Exception();
+
+        return $app->render('index.twig');
+    }
+
+    public function tran9(Application $app)
+    {
+        // update 1 ：本体側の更新処理とする
+        $BaseInfo = $app['eccube.repository.base_info']->get();
+        $BaseInfo->setCompanyName('tran9-1');
+        $app['orm.em']->flush($BaseInfo);
+
+        // プラグインAが、beginTransactionして更新を行う
+        $app['orm.em']->beginTransaction();
+
+        try {
+            // update 2
+            $BaseInfo->setCompanyName('tran9-2');
+            $app['orm.em']->flush($BaseInfo);
+            $app['orm.em']->commit();
+
+            // プラグイン内部でエラー
+            throw new \Exception();
+
+        } catch (\Exception $e) {
+            // update 1 / update 2 がrollbackされる.
+            $app['orm.em']->rollback();
+        }
+
+        // update 3：プラグインBが、更新処理を行う.
+        $BaseInfo = $app['eccube.repository.base_info']->get();
+        $BaseInfo->setCompanyName('tran9-3');
+        $app['orm.em']->flush($BaseInfo);
+
+        // update 1/2 はrollback され, update 3の更新処理のみ適応される
+        return $app->render('index.twig');
+    }
+}

--- a/tests/Eccube/Tests/Web/Admin/Content/NewsControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/NewsControllerTest.php
@@ -43,7 +43,7 @@ class NewsControllerTest extends AbstractAdminWebTestCase
     public function testRoutingAdminContentNewsEdit()
     {
         // before
-        $TestCreator = $this->findMember(1);
+        $TestCreator = $this->findMember(2);
         $TestNews = $this->newTestNews($TestCreator);
         $this->insertTestNews($TestNews);
 
@@ -63,7 +63,7 @@ class NewsControllerTest extends AbstractAdminWebTestCase
     public function testRoutingAdminContentNewsDelete()
     {
         // before
-        $TestCreator = $this->findMember(1);
+        $TestCreator = $this->findMember(2);
         $TestNews = $this->newTestNews($TestCreator);
         $this->insertTestNews($TestNews);
 
@@ -83,7 +83,7 @@ class NewsControllerTest extends AbstractAdminWebTestCase
     public function testRoutingAdminContentNewsUp()
     {
         // before
-        $TestCreator = $this->findMember(1);
+        $TestCreator = $this->findMember(2);
         $TestNews1 = $this->newTestNews($TestCreator, 1);
         $TestNews2 = $this->newTestNews($TestCreator, 2);
         $this->insertTestNews($TestNews1);
@@ -106,7 +106,7 @@ class NewsControllerTest extends AbstractAdminWebTestCase
     public function testRoutingAdminContentNewsDown()
     {
         // before
-        $TestCreator = $this->findMember(1);
+        $TestCreator = $this->findMember(2);
         $TestNews1 = $this->newTestNews($TestCreator, 1);
         $TestNews2 = $this->newTestNews($TestCreator, 2);
         $this->insertTestNews($TestNews1);
@@ -145,9 +145,7 @@ class NewsControllerTest extends AbstractAdminWebTestCase
 
     private function findMember($id)
     {
-        return $this->app['orm.em']
-            ->getRepository('Eccube\Entity\Member')
-            ->find($id);
+        return $this->createMember();
     }
 
     private function insertTestNews($TestNews)

--- a/tests/Eccube/Tests/Web/Admin/Product/CategoryContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CategoryContorllerTest.php
@@ -160,9 +160,7 @@ class CategoryControllerTest extends AbstractAdminWebTestCase
     public function testRoutingAdminProductCategoryShow()
     {
         // before
-        $TestCreator = $this->app['orm.em']
-            ->getRepository('\Eccube\Entity\Member')
-            ->find(1);
+        $TestCreator = $this->createMember();
         $TestParentCategory = $this->newTestCategory($TestCreator);
         $this->app['orm.em']->persist($TestParentCategory);
         $this->app['orm.em']->flush();
@@ -193,9 +191,7 @@ class CategoryControllerTest extends AbstractAdminWebTestCase
     public function testRoutingAdminProductCategoryEdit()
     {
         // before
-        $TestCreator = $this->app['orm.em']
-            ->getRepository('\Eccube\Entity\Member')
-            ->find(1);
+        $TestCreator = $this->createMember();
         $TestCategory = $this->newTestCategory($TestCreator);
         $this->app['orm.em']->persist($TestCategory);
         $this->app['orm.em']->flush();
@@ -220,9 +216,7 @@ class CategoryControllerTest extends AbstractAdminWebTestCase
     public function testRoutingAdminProductCategoryDelete()
     {
         // before
-        $TestCreator = $this->app['orm.em']
-            ->getRepository('\Eccube\Entity\Member')
-            ->find(1);
+        $TestCreator = $this->createMember();
         $TestCategory = $this->newTestCategory($TestCreator);
         $this->app['orm.em']->persist($TestCategory);
         $this->app['orm.em']->flush();

--- a/tests/Eccube/Tests/Web/Admin/Product/ClassCategoryContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ClassCategoryContorllerTest.php
@@ -36,9 +36,7 @@ class ClassCategoryControllerTest extends AbstractAdminWebTestCase
     public function testRoutingAdminProductClassCategory()
     {
         // before
-        $TestCreator = $this->app['orm.em']
-            ->getRepository('\Eccube\Entity\Member')
-            ->find(1);
+        $TestCreator = $this->createMember();
         $TestClassName = $this->newTestClassName($TestCreator);
         $this->app['orm.em']->persist($TestClassName);
         $this->app['orm.em']->flush();
@@ -62,9 +60,7 @@ class ClassCategoryControllerTest extends AbstractAdminWebTestCase
     public function testRoutingAdminProductClassCategoryEdit()
     {
         // before
-        $TestCreator = $this->app['orm.em']
-            ->getRepository('\Eccube\Entity\Member')
-            ->find(1);
+        $TestCreator = $this->createMember();
         $TestClassName = $this->newTestClassName($TestCreator);
         $this->app['orm.em']->persist($TestClassName);
         $this->app['orm.em']->flush();
@@ -99,9 +95,7 @@ class ClassCategoryControllerTest extends AbstractAdminWebTestCase
     public function testRoutingAdminProductClassCategoryDelete()
     {
         // before
-        $TestCreator = $this->app['orm.em']
-            ->getRepository('\Eccube\Entity\Member')
-            ->find(1);
+        $TestCreator = $this->createMember();
         $TestClassName = $this->newTestClassName($TestCreator);
         $this->app['orm.em']->persist($TestClassName);
         $this->app['orm.em']->flush();
@@ -136,9 +130,7 @@ class ClassCategoryControllerTest extends AbstractAdminWebTestCase
 
     private function newTestClassName($TestCreator)
     {
-        $Creator = $this->app['orm.em']
-            ->getRepository('\Eccube\Entity\Member')
-            ->find(1);
+        $Creator = $this->createMember();
         $TestClassName = new \Eccube\Entity\ClassName();
         $TestClassName->setName('形状')
             ->setRank(100)

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductClassContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductClassContorllerTest.php
@@ -36,9 +36,7 @@ class ProductClassControllerTest extends AbstractAdminWebTestCase
     public function testRoutingAdminProductProductClassEdit()
     {
         // before
-        $TestCreator = $this->app['orm.em']
-            ->getRepository('\Eccube\Entity\Member')
-            ->find(1);
+        $TestCreator = $this->createMember();
         $TestProduct = $this->newTestProduct($TestCreator);
         $this->app['orm.em']->persist($TestProduct);
         $this->app['orm.em']->flush();
@@ -104,9 +102,7 @@ class ProductClassControllerTest extends AbstractAdminWebTestCase
 
     private function newTestClassName($TestCreator)
     {
-        $Creator = $this->app['orm.em']
-            ->getRepository('\Eccube\Entity\Member')
-            ->find(1);
+        $Creator = $this->createMember();
         $TestClassName = new \Eccube\Entity\ClassName();
         $TestClassName->setName('形状')
             ->setRank(100)

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/AuthorityiControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/AuthorityiControllerTest.php
@@ -70,7 +70,7 @@ class AuthorityiControllerTest extends AbstractAdminWebTestCase
 
     private function newTestAuthorityRole()
     {
-        $TestCreator = $this->app['eccube.repository.member']->find(1);
+        $TestCreator = $this->createMember();
         $AuthorityRole = new \Eccube\Entity\AuthorityRole();
         $Authority = $this->app['eccube.repository.master.authority']->find(0);
         $AuthorityRole->setAuthority($Authority);


### PR DESCRIPTION
- #1518 
-  トランザクションがネストしないよう設定
    - PHPUnit 実行時はトランザクションがネストしてしまい、不要なロールバックが発生するため TransactionListener でトランザクション管理しないよう修正
    - PHPUnit 実行時は \Eccube\Application::testMode = true になるよう設定
    - 論理削除された Member を参照しないよう修正
       - TransactionListener を有効にすると何故かエラーになるため
    - FormServiceProvider を登録した場合は eccube.service.plugin インスタンスを生成するよう修正
       - TransactionListener を有効にすると何故かエラーになるため