### PR TITLE
プラグインファイルサイズオーバーのエラー表示

### DIFF
--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -36,6 +36,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Form\FormError;
 
 class PluginController extends AbstractController
 {
@@ -382,6 +383,10 @@ class PluginController extends AbstractController
                         'original-message' => $e->getMessage()
                     ));
                     $errors[] = $e;
+                }
+            }else{
+                if(count($form->getErrors(true))>1){
+                    $errors[] = new FormError('アップロードされたファイルが大きすぎます。');
                 }
             }
         }

--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -384,9 +384,9 @@ class PluginController extends AbstractController
                     ));
                     $errors[] = $e;
                 }
-            }else{
-                if(count($form->getErrors(true))>1){
-                    $errors[] = new FormError('アップロードされたファイルが大きすぎます。');
+            } else {
+                foreach ($form->getErrors(true) as $error) {
+                    $errors[] = $error;
                 }
             }
         }

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -4,6 +4,7 @@ Login memory: 次回から自動的にログインする
 Bad credentials.: ログインできませんでした。<br>入力内容に誤りがないかご確認ください。
 Invalid CSRF token.: もう一度ログイン処理をしてください。
 Your session has timed out, or you have disabled cookies.: もう一度ログイン処理をしてください。
+The uploaded file was too large. Please try to upload a smaller file.: ファイルサイズが大きすぎます。
 
 Name: お名前
 Name01: 姓

--- a/src/Eccube/Resource/template/admin/Store/plugin_install.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_install.twig
@@ -42,7 +42,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     <label class="col-sm-5 control-label">プラグイン<br>(zip、tar、tar.gz形式)</label>
                     <div class="col-sm-7">
                         {{ form_widget(form.plugin_archive, {'attr': {'accept': 'application/zip,application/x-tar,application/x-gzip'}}) }}
-                        {{ form_errors(form.plugin_archive) }}
                         {% for error in errors %}
                             <div class="errormsg text-danger">{{ error.message|trans }}</div>
                         {% endfor %}


### PR DESCRIPTION
refs #1601 

https://github.com/hoand-vn/ec-cube/pull/2 でご指摘があった通り、ファイルサイズオーバーの時に

> The CSRF token is invalid. Please try to resubmit the form.

というバリデーションエラーも同時に発生し、このメッセージは英語のままとなっています。ただ、このエラーとサイズオーバーエラーを見分ける方法がないため上記メッセージはそのままにしてあります。

もしこの対応がまずいようであれば、どなたか解決方法をご提案いただけると(あるいは別途PRしていただけると)幸いです。