### PR TITLE
フックポイントでeventオブジェクトを利用できるように対応

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -30,6 +30,10 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Yaml\Yaml;
 
 class Application extends ApplicationTrait
@@ -619,31 +623,49 @@ class Application extends ApplicationTrait
             return new EventDispatcher();
         });
 
+        $app = $this;
+
         // hook point
-        $this->before(function(Request $request, \Silex\Application $app) {
-            $app['eccube.event.dispatcher']->dispatch('eccube.event.app.before');
+        $this->on(KernelEvents::REQUEST, function (GetResponseEvent $event) use ($app) {
+            if (!$event->isMasterRequest()) {
+                return;
+            }
+            $hookpoint = 'eccube.event.app.before';
+            $app['eccube.event.dispatcher']->dispatch($hookpoint, $event);
         }, self::EARLY_EVENT);
 
-        $this->before(function(Request $request, \Silex\Application $app) {
-            $event = 'eccube.event.controller.'.$request->attributes->get('_route').'.before';
-            $app['eccube.event.dispatcher']->dispatch($event);
+        $this->on(KernelEvents::REQUEST, function (GetResponseEvent $event) use ($app) {
+            if (!$event->isMasterRequest()) {
+                return;
+            }
+            $route = $event->getRequest()->attributes->get('_route');
+            $hookpoint = "eccube.event.controller.$route.before";
+            $app['eccube.event.dispatcher']->dispatch($hookpoint, $event);
         });
 
-        $this->after(function(Request $request, Response $response, \Silex\Application $app) {
-            $event = 'eccube.event.controller.'.$request->attributes->get('_route').'.after';
-            $app['eccube.event.dispatcher']->dispatch($event);
+        $this->on(KernelEvents::RESPONSE, function (FilterResponseEvent $event) use ($app) {
+            if (!$event->isMasterRequest()) {
+                return;
+            }
+            $route = $event->getRequest()->attributes->get('_route');
+            $hookpoint = "eccube.event.controller.$route.after";
+            $app['eccube.event.dispatcher']->dispatch($hookpoint, $event);
         });
 
-        $this->after(function(Request $request, Response $response, \Silex\Application $app) {
-            $app['eccube.event.dispatcher']->dispatch('eccube.event.app.after');
+        $this->on(KernelEvents::RESPONSE, function (FilterResponseEvent $event) use ($app) {
+            if (!$event->isMasterRequest()) {
+                return;
+            }
+            $hookpoint = 'eccube.event.app.after';
+            $app['eccube.event.dispatcher']->dispatch($hookpoint, $event);
         }, self::LATE_EVENT);
 
-        $this->finish(function(Request $request, Response $response, \Silex\Application $app) {
-            $event = 'eccube.event.controller.'.$request->attributes->get('_route').'.finish';
-            $app['eccube.event.dispatcher']->dispatch($event);
+        $this->on(KernelEvents::TERMINATE, function (PostResponseEvent $event) use ($app) {
+            $route = $event->getRequest()->attributes->get('_route');
+            $hookpoint = "eccube.event.controller.$route.finish";
+            $app['eccube.event.dispatcher']->dispatch($hookpoint, $event);
         });
 
-        $app = $this;
         $this->on(\Symfony\Component\HttpKernel\KernelEvents::RESPONSE, function(\Symfony\Component\HttpKernel\Event\FilterResponseEvent $event) use ($app) {
             $route = $event->getRequest()->attributes->get('_route');
             $app['eccube.event.dispatcher']->dispatch('eccube.event.render.'.$route.'.before', $event);

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -481,7 +481,6 @@ abstract class EccubeTestCase extends WebTestCase
         $app = Application::getInstance();
         $app['debug'] = true;
         $app->initialize();
-        $app->initPluginEventDispatcher();
         $app->initializePlugin();
         $app['session.test'] = true;
         $app['exception_handler']->disable();

--- a/tests/Eccube/Tests/Plugin/CommonHookPoint/HookPointEvent.php
+++ b/tests/Eccube/Tests/Plugin/CommonHookPoint/HookPointEvent.php
@@ -1,0 +1,97 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Tests\Plugin\CommonHookPoint;
+
+class HookPointEvent
+{
+    /** @var  \Eccube\Application $app */
+    private $app;
+
+    public function __construct($app)
+    {
+        $this->app = $app;
+    }
+
+    public function onAppBefore()
+    {
+        echo 'eccube.event.app.before';
+    }
+
+    public function onAppBeforeWithArgument($event = null)
+    {
+        echo get_class($event);
+    }
+
+    public function onControllerHomepageBefore()
+    {
+        echo 'eccube.event.controller.homepage.before';
+    }
+
+    public function onControllerHomepageBeforeWithArgument($event = null)
+    {
+        echo get_class($event);
+    }
+
+    public function onControllerHomepageAfter()
+    {
+        echo 'eccube.event.controller.homepage.after';
+    }
+
+    public function onControllerHomepageAfterWithArgument($event = null)
+    {
+        echo get_class($event);
+    }
+
+    public function onAppAfter()
+    {
+        echo 'eccube.event.app.after';
+    }
+
+    public function onAppAfterWithArgument($event = null)
+    {
+        echo get_class($event);
+    }
+
+    public function onControllerHomepageFinish()
+    {
+        echo 'eccube.event.controller.homepage.finish';
+    }
+
+    public function onControllerHomepageFinishWithArgument($event = null)
+    {
+        echo get_class($event);
+    }
+
+    public function onAppBeforeRedirect($event = null)
+    {
+        $response = $this->app->redirect($this->app->url('entry'));
+        $event->setResponse($response);
+    }
+
+    public function onControllerHomepageBeforeRedirect($event = null)
+    {
+        $response = $this->app->redirect($this->app->url('help_tradelaw'));
+        $event->setResponse($response);
+    }
+}

--- a/tests/Eccube/Tests/Plugin/Web/CommonHookPointTest.php
+++ b/tests/Eccube/Tests/Plugin/Web/CommonHookPointTest.php
@@ -183,8 +183,6 @@ class CommonHookPointTest extends EccubeTestCase
 
     public function testAppBeforeRedirect()
     {
-        $this->markTestSkipped();
-
         $hookpoint = 'eccube.event.app.before';
         $listener = array($this->event, 'onAppBeforeRedirect');
         $this->app['eccube.event.dispatcher']->addListener($hookpoint, $listener);
@@ -197,8 +195,6 @@ class CommonHookPointTest extends EccubeTestCase
 
     public function testControllerHomepageBeforeRedirect()
     {
-        $this->markTestSkipped();
-
         $hookpoint = 'eccube.event.controller.homepage.before';
         $listener = array($this->event, 'onControllerHomepageBeforeRedirect');
         $this->app['eccube.event.dispatcher']->addListener($hookpoint, $listener);

--- a/tests/Eccube/Tests/Plugin/Web/CommonHookPointTest.php
+++ b/tests/Eccube/Tests/Plugin/Web/CommonHookPointTest.php
@@ -1,0 +1,211 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Tests\Plugin\Web;
+
+use Eccube\Tests\EccubeTestCase;
+use Eccube\Tests\Plugin\CommonHookPoint\HookPointEvent;
+
+/**
+ * 共通フックポイント検証用のテストケース
+ *
+ * CommonHookPointプラグインをロードし、WebTestで画面を巡回させる
+ * フックポイントごとにテストするため、本体のプラグインロード処理を使わず、addListenerで直接イベントクラス登を録している
+ *
+ * CommonHookPointプラグインの各メソッドは、自身のフックポイント名または、引数で渡されるeventオブジェクトのクラス名をechoしている
+ * テストケース側では、出力された内容を`expectOutputString`メソッドで確認し、フックポイントの呼び出しが行われているかを検証する
+ *
+ * また、イベントオブジェクトを利用してリダイレクトできるかどうかも検証する
+ *
+ * @package Eccube\Tests\Plugin\Web
+ */
+class CommonHookPointTest extends EccubeTestCase
+{
+    protected $event;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->event = new HookPointEvent($this->app);
+        $this->client = $this->createClient();
+    }
+
+    public function testAppBefore()
+    {
+        $hookpoint = 'eccube.event.app.before';
+        $listener =  array($this->event, 'onAppBefore');
+        $this->app['eccube.event.dispatcher']->addListener($hookpoint, $listener);
+
+        $this->client->request('GET', '/');
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->expectOutputString($hookpoint);
+
+        $this->app['eccube.event.dispatcher']->removeListener($hookpoint, $this->event);
+    }
+
+    public function testAppBeforeWithArgument()
+    {
+        $hookpoint = 'eccube.event.app.before';
+        $listener = array($this->event, 'onAppBeforeWithArgument');
+        $this->app['eccube.event.dispatcher']->addListener($hookpoint, $listener);
+
+        $this->client->request('GET', '/');
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->expectOutputString('Symfony\Component\HttpKernel\Event\GetResponseEvent');
+
+        $this->app['eccube.event.dispatcher']->removeListener($hookpoint, $listener);
+    }
+
+    public function testControllerHomepageBefore()
+    {
+        $hookpoint = 'eccube.event.controller.homepage.before';
+        $listener = array($this->event, 'onControllerHomepageBefore');
+        $this->app['eccube.event.dispatcher']->addListener($hookpoint, $listener);
+
+        $this->client->request('GET', '/');
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->expectOutputString($hookpoint);
+
+        $this->app['eccube.event.dispatcher']->removeListener($hookpoint, $listener);
+    }
+
+    public function testControllerHomepageBeforeWithArgument()
+    {
+        $hookpoint = 'eccube.event.controller.homepage.before';
+        $listener = array($this->event, 'onControllerHomepageBeforeWithArgument');
+        $this->app['eccube.event.dispatcher']->addListener($hookpoint, $listener);
+
+        $this->client->request('GET', '/');
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->expectOutputString('Symfony\Component\HttpKernel\Event\GetResponseEvent');
+
+        $this->app['eccube.event.dispatcher']->removeListener($hookpoint, $listener);
+    }
+
+    public function testControllerHomepageAfter()
+    {
+        $hookpoint = 'eccube.event.controller.homepage.after';
+        $listener = array($this->event, 'onControllerHomepageAfter');
+        $this->app['eccube.event.dispatcher']->addListener($hookpoint, $listener);
+
+        $this->client->request('GET', '/');
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->expectOutputString($hookpoint);
+
+        $this->app['eccube.event.dispatcher']->removeListener($hookpoint, $listener);
+    }
+
+    public function testControllerHomepageAfterWithArgument()
+    {
+        $hookpoint = 'eccube.event.controller.homepage.after';
+        $listener = array($this->event, 'onControllerHomepageAfterWithArgument');
+        $this->app['eccube.event.dispatcher']->addListener($hookpoint, $listener);
+
+        $this->client->request('GET', '/');
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->expectOutputString('Symfony\Component\HttpKernel\Event\FilterResponseEvent');
+
+        $this->app['eccube.event.dispatcher']->removeListener($hookpoint, $listener);
+    }
+
+    public function testAppAfter()
+    {
+        $hookpoint = 'eccube.event.app.after';
+        $listener = array($this->event, 'onAppAfter');
+        $this->app['eccube.event.dispatcher']->addListener($hookpoint, $listener);
+
+        $this->client->request('GET', '/');
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->expectOutputString($hookpoint);
+
+        $this->app['eccube.event.dispatcher']->removeListener($hookpoint, $listener);
+    }
+
+    public function testAppAfterWithArgument()
+    {
+        $hookpoint = 'eccube.event.app.after';
+        $listener = array($this->event, 'onAppAfterWithArgument');
+        $this->app['eccube.event.dispatcher']->addListener($hookpoint, $listener);
+
+        $this->client->request('GET', '/');
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->expectOutputString('Symfony\Component\HttpKernel\Event\FilterResponseEvent');
+
+        $this->app['eccube.event.dispatcher']->removeListener($hookpoint, $listener);
+    }
+
+    public function testControllerHomepageFinish()
+    {
+        $hookpoint = 'eccube.event.controller.homepage.finish';
+        $listener = array($this->event, 'onControllerHomepageFinish');
+        $this->app['eccube.event.dispatcher']->addListener($hookpoint, $listener);
+
+        $this->client->request('GET', '/');
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->expectOutputString($hookpoint);
+
+        $this->app['eccube.event.dispatcher']->removeListener($hookpoint,$listener);
+    }
+
+    public function testControllerHomepageFinishWithArgument()
+    {
+        $hookpoint = 'eccube.event.controller.homepage.finish';
+        $listener = array($this->event, 'onControllerHomepageFinishWithArgument');
+        $this->app['eccube.event.dispatcher']->addListener($hookpoint, $listener);
+
+        $this->client->request('GET', '/');
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->expectOutputString('Symfony\Component\HttpKernel\Event\PostResponseEvent');
+
+        $this->app['eccube.event.dispatcher']->removeListener($hookpoint,$listener);
+    }
+
+    public function testAppBeforeRedirect()
+    {
+        $this->markTestSkipped();
+
+        $hookpoint = 'eccube.event.app.before';
+        $listener = array($this->event, 'onAppBeforeRedirect');
+        $this->app['eccube.event.dispatcher']->addListener($hookpoint, $listener);
+
+        $this->client->request('GET', '/');
+        $this->assertTrue($this->client->getResponse()->isRedirect());
+
+        $this->app['eccube.event.dispatcher']->removeListener($hookpoint, $listener);
+    }
+
+    public function testControllerHomepageBeforeRedirect()
+    {
+        $this->markTestSkipped();
+
+        $hookpoint = 'eccube.event.controller.homepage.before';
+        $listener = array($this->event, 'onControllerHomepageBeforeRedirect');
+        $this->app['eccube.event.dispatcher']->addListener($hookpoint, $listener);
+
+        $this->client->request('GET', '/');
+        $this->assertTrue($this->client->getResponse()->isRedirect());
+
+        $this->app['eccube.event.dispatcher']->removeListener($hookpoint, $listener);
+    }
+}


### PR DESCRIPTION
#1632 でトランザクションの管理を本体側で行うように変更されます。
その変更により、プラグイン側で、
```
header('Location: '. $app->url('xxxx'));
exit;
```
のような実装でリダイレクトを行っている場合、それまでの更新処理が反映されません。

以下のフックポイント
- eccube.event.app.before
- eccube.event.controller.[route].before
- eccube.event.controller.[route].after
- eccube.event.app.after
- eccube.event.controller.[route].finish

では、これまで引数としてeventオブジェクトが利用できず、リダイレクト処理は上記のようにしか実装できませんでした。

本修正で、プラグイン側では、以下のようにリダイレクト処理を実装することができます。
```
public function onXxxBefore($event = null)
{
        $response = $this->app->redirect($this->app->url('xxx'));
        $event->setResponse($response);
        return;
}
```