### PR TITLE
コードカバレッジを coveralls.io で出力する & ci 高速化

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,4 @@
+# for php-coveralls
+#src_dir: src
+coverage_clover: coverage.clover
+json_path: coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,29 +4,35 @@ git:
   submodules: false
 
 language: php
-sudo: false
+
 cache:
   directories:
     - vendor
     - $HOME/.composer/cache
 php:
-  - 5.3.3
   - 5.3
   - 5.4
   - 5.5
   - 5.6
-  - hhvm
   - 7.0
 
 matrix:
   fast_finish: true
-  exclude:
-    - php: hhvm
-      env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres # driver currently unsupported by HHVM
-  allow_failures:
-    - php: hhvm
+  include:
     - php: 7.0
-    - php: 5.3.3
+      env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
+      sudo: required
+      dist: trusty
+  exclude:
+    - php: 5.3
+      env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
+    - php: 5.4
+      env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
+    - php: 5.5
+      env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
+    - php: 5.6
+      env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
+  allow_failures:
     - PHP: 5.3
       env: DB=sqlite
     - PHP: 5.4
@@ -35,9 +41,13 @@ matrix:
       env: DB=sqlite
     - PHP: 5.6
       env: DB=sqlite
+    - php: 7.0
+      env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
+
 env:
   - DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
   - DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+  - DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
   - DB=sqlite
 
 install:
@@ -45,20 +55,28 @@ install:
   - gem install mailcatcher
 
 before_script:
+  - phpenv config-rm xdebug.ini
+  - if [[ $PHP_SAPI = 'phpdbg' ]]; then echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini ; fi
   - composer self-update || true
   - composer install --dev --no-interaction -o
+  ## apply YamlDriver.php.patch
+  ## see also. https://github.com/doctrine/doctrine2/pull/1205
+  - curl -Ss https://gist.githubusercontent.com/nanasess/d72c796969d8c2eb5082a0567d54a92d/raw/5ba00fb3110b8fe9be65ba53df1f210f26ed1f52/YamlDrive.php.patch | patch -p0 -N || true
   - sh -c "if [ '$DB' = 'mysql' ]; then sh ./eccube_install.sh mysql none; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then sh ./eccube_install.sh pgsql none; fi"
   - sh -c "if [ '$DB' = 'sqlite' ]; then sh ./eccube_install.sh sqlite3 none; fi"
   - mailcatcher
 
 script:
-  - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then phpunit --coverage-clover=coverage.clover ; fi
-  - if [[ $TRAVIS_PHP_VERSION =~ ^[57] ]]; then phpunit ; fi
+  - if [[ $PHP_SAPI = 'phpdbg' ]]; then phpdbg -qrr ./vendor/bin/phpunit --coverage-clover=coverage.clover ; fi
+  - if [[ $PHP_SAPI != 'phpdbg' ]]; then phpunit ; fi
 
 after_script:
-  - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then wget https://scrutinizer-ci.com/ocular.phar ; fi
-  - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover ; fi
+  - if [[ $PHP_SAPI = 'phpdbg' ]]; then wget https://scrutinizer-ci.com/ocular.phar ; fi
+  - if [[ $PHP_SAPI = 'phpdbg' ]]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover ; fi
 
-# after_failure:
+after_success:
+  - if [[ $PHP_SAPI = 'phpdbg' ]]; then php vendor/bin/coveralls -v -x coverage.clover ; fi
+
+  # after_failure:
 #   - 'cat app/log/site_`date +"%Y-%m-%d"`.log'

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/lg3uh1539cwln2g6?svg=true)](https://ci.appveyor.com/project/ECCUBE/ec-cube)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/EC-CUBE/ec-cube/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/EC-CUBE/ec-cube/?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/EC-CUBE/ec-cube/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/EC-CUBE/ec-cube/?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/EC-CUBE/ec-cube/badge.svg?branch=master)](https://coveralls.io/github/EC-CUBE/ec-cube?branch=master)
   
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/EC-CUBE/ec-cube?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
         "fzaninotto/faker":"1.*",
         "phing/phing": "2.*",
         "symfony/browser-kit": ">=2.7,<2.8",
-        "fabpot/php-cs-fixer": "^1.10"
+        "fabpot/php-cs-fixer": "^1.10",
+        "satooshi/php-coveralls": "~1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -74,5 +74,10 @@
         "psr-4": {
             "Eccube\\Tests\\" : "tests/Eccube/Tests"
         }
+    },
+    "config": {
+        "platform": {
+            "php": "5.3.9"
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0ebcdc1be130c209632e9b266e86d83b",
-    "content-hash": "23fbf2f6d6df97390fb42949f84dddae",
+    "hash": "677a9879b4d4558de19dd93af0a21762",
+    "content-hash": "b08b80e22c16017de81b703fb1a20a75",
     "packages": [
         {
             "name": "dflydev/doctrine-orm-service-provider",
@@ -815,6 +815,7 @@
                 "rest",
                 "web service"
             ],
+            "abandoned": "guzzlehttp/guzzle",
             "time": "2015-03-18 18:23:50"
         },
         {
@@ -4133,6 +4134,64 @@
             "time": "2015-10-02 06:51:40"
         },
         {
+            "name": "satooshi/php-coveralls",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/satooshi/php-coveralls.git",
+                "reference": "da51d304fe8622bf9a6da39a8446e7afd432115c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/satooshi/php-coveralls/zipball/da51d304fe8622bf9a6da39a8446e7afd432115c",
+                "reference": "da51d304fe8622bf9a6da39a8446e7afd432115c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "guzzle/guzzle": "^2.8|^3.0",
+                "php": ">=5.3.3",
+                "psr/log": "^1.0",
+                "symfony/config": "^2.1|^3.0",
+                "symfony/console": "^2.1|^3.0",
+                "symfony/stopwatch": "^2.0|^3.0",
+                "symfony/yaml": "^2.0|^3.0"
+            },
+            "suggest": {
+                "symfony/http-kernel": "Allows Symfony integration"
+            },
+            "bin": [
+                "bin/coveralls"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Satooshi\\": "src/Satooshi/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kitamura Satoshi",
+                    "email": "with.no.parachute@gmail.com",
+                    "homepage": "https://www.facebook.com/satooshi.jp"
+                }
+            ],
+            "description": "PHP client library for Coveralls API",
+            "homepage": "https://github.com/satooshi/php-coveralls",
+            "keywords": [
+                "ci",
+                "coverage",
+                "github",
+                "test"
+            ],
+            "time": "2016-01-20 17:35:46"
+        },
+        {
             "name": "sebastian/comparator",
             "version": "1.2.0",
             "source": {
@@ -4572,5 +4631,8 @@
     "platform": {
         "php": ">=5.3.3"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.3.9"
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,10 @@
     <!-- カバーレージのターゲット -->
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src/Eccube/</directory>
+          <directory suffix=".php">./src/Eccube/</directory>
+          <exclude>
+            <directory suffix=".php">./src/Eccube/Resource</directory>
+          </exclude>
         </whitelist>
     </filter>
 </phpunit>

--- a/src/Eccube/Controller/Admin/Content/ContentsController.php
+++ b/src/Eccube/Controller/Admin/Content/ContentsController.php
@@ -46,9 +46,9 @@ class ContentsController extends NewsController
      * @param Application $app
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function index(Application $app)
+    public function index(Application $app, Request $request = null)
     {
-        return parent::index($app);
+        return parent::index($app, $request);
     }
 
     /**

--- a/tests/Eccube/Tests/Application/TwigTraitTest.php
+++ b/tests/Eccube/Tests/Application/TwigTraitTest.php
@@ -42,6 +42,9 @@ class TwigTraitTest extends \PHPUnit_Framework_TestCase
 
     public function testRenderForStream()
     {
+        if (php_sapi_name() == 'phpdbg') {
+            $this->markTestSkipped('Can not support of ob_*()');
+        }
         $app = $this->createApplication();
 
         $response = $app->render('error.twig', array(), new StreamedResponse());

--- a/tests/Eccube/Tests/Transaction/TransactionListenerTest.php
+++ b/tests/Eccube/Tests/Transaction/TransactionListenerTest.php
@@ -23,6 +23,11 @@ class TransactionListenerTest extends WebTestCase
     public function setUp()
     {
         parent::setUp();
+        if ($this->app['config']['database']['driver'] == 'pdo_sqlite') {
+            // Connection が別物になってしまうため
+            $this->markTestSkipped('Can not support for sqlite3');
+        }
+
         $c = $this->app['controllers_factory'];
         $c->match('/tran1', '\Eccube\Tests\Transaction\TransactionControllerMock::tran1')->bind('tran1');
         $c->match('/tran2', '\Eccube\Tests\Transaction\TransactionControllerMock::tran2')->bind('tran2');


### PR DESCRIPTION
- #1630 の後にマージお願いします
- PHP7 をテスト対象に追加(#1338)
  - Doctrine にパッチを当てることで対応
  - https://gist.githubusercontent.com/nanasess/d72c796969d8c2eb5082a0567d54a92d/raw/5ba00fb3110b8fe9be65ba53df1f210f26ed1f52/YamlDrive.php.patch
- PHP7 の phpdbg を使用しカバレッジ用のファイルを出力
  - phpdbg を使用する場合は memory_limit=-1 に設定
- hhvm を削除
- xdebug を無効化
- src/Eccube/Resource をカバレッジから除外
- ContentsController::index() の引数が継承元と異なっていたため修正
