### PR TITLE
カート追加、購入時のバリデーション修正

### DIFF
--- a/src/Eccube/Controller/Block/CartController.php
+++ b/src/Eccube/Controller/Block/CartController.php
@@ -31,7 +31,7 @@ class CartController
     public function index(Application $app)
     {
         /** @var $Cart \Eccube\Entity\Cart */
-        $Cart = $app['eccube.service.cart']->getCart();
+        $Cart = $app['eccube.service.cart']->getCartObj();
         return $app->render('Block/cart.twig', array(
             'Cart' => $Cart,
         ));

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -143,7 +143,16 @@ class ShoppingController extends AbstractController
         // 複数配送の場合、エラーメッセージを一度だけ表示
         if (!$app['session']->has($this->sessionMultipleKey)) {
             if (count($Order->getShippings()) > 1) {
-                $app->addRequestError('shopping.multiple.delivery');
+
+                $BaseInfo = $app['eccube.repository.base_info']->get();
+
+                if (!$BaseInfo->getOptionMultipleShipping()) {
+                    // 複数配送に設定されていないのに複数配送先ができればエラー
+                    $app->addRequestError('cart.product.type.kind');
+                    return $app->redirect($app->url('cart'));
+                }
+
+                $app->addError('shopping.multiple.delivery');
             }
             $app['session']->set($this->sessionMultipleKey, 'multiple');
         }

--- a/src/Eccube/Form/Type/Admin/ProductClassType.php
+++ b/src/Eccube/Form/Type/Admin/ProductClassType.php
@@ -71,6 +71,9 @@ class ProductClassType extends AbstractType
                     new Assert\Length(array(
                         'max' => 10,
                     )),
+                    new Assert\GreaterThanOrEqual(array(
+                        'value' => 1,
+                    )),
                     new Assert\Regex(array(
                         'pattern' => "/^\d+$/u",
                         'message' => 'form.type.numeric.invalid'

--- a/src/Eccube/Repository/DeliveryRepository.php
+++ b/src/Eccube/Repository/DeliveryRepository.php
@@ -25,6 +25,7 @@
 namespace Eccube\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Eccube\Entity\Payment;
 
 /**
  * DelivRepository
@@ -103,9 +104,11 @@ class DeliveryRepository extends EntityRepository
 
             foreach ($paymentOptions as $PaymentOption) {
                 foreach ($payments as $Payment) {
-                    if ($PaymentOption->getPayment()->getId() == $Payment['id']) {
-                        $arr[$Delivery->getId()] = $Delivery;
-                        break;
+                    if ($PaymentOption->getPayment() instanceof Payment) {
+                        if ($PaymentOption->getPayment()->getId() == $Payment['id']) {
+                            $arr[$Delivery->getId()] = $Delivery;
+                            break;
+                        }
                     }
                 }
             }

--- a/src/Eccube/Resource/template/default/Shopping/index.twig
+++ b/src/Eccube/Resource/template/default/Shopping/index.twig
@@ -150,13 +150,31 @@ $(function() {
                     {% endif %}
                     </ul>
                 </div>
-                {% for error in app.session.flashbag.get('eccube.front.request.error')  %}
+                {% for error in app.session.flashbag.get('eccube.front.error')  %}
                     <div id="confirm_flow_box__message" class="message">
                         <p class="errormsg bg-danger">
                             <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>{{ error|trans|nl2br }}
                         </p>
                     </div>
                 {% endfor %}
+                    {% set productStr = app.session.flashbag.get('eccube.front.request.product') %}
+                    {% for error in app.session.flashbag.get('eccube.front.request.error')  %}
+                        {% set idx = loop.index0 %}
+                        {% if productStr[idx] is defined %}
+                            <div id="cart_box__message--{{ loop.index }}" class="message">
+                                <p class="errormsg bg-danger">
+                                    <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>
+                                    {{ error|trans({'%product%':productStr[idx]})|nl2br }}
+                                </p>
+                            </div>
+                        {% else %}
+                            <div id="confirm_flow_box__message--{{ loop.index }}" class="message">
+                                <p class="errormsg bg-danger">
+                                    <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>{{ error|trans|nl2br }}
+                                </p>
+                            </div>
+                        {% endif %}
+                    {% endfor %}
             </div><!-- /.col -->
         </div><!-- /.row -->
         <form id="shopping-form" method="post" action="{{ url('shopping_confirm') }}">

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -222,7 +222,7 @@ class CartService
      */
     public function getProductQuantity($productClassId)
     {
-        $CartItem = $this->cart->getCartItemByIdentifier('Eccube\Entity\ProductClass', (string) $productClassId);
+        $CartItem = $this->cart->getCartItemByIdentifier('Eccube\Entity\ProductClass', (string)$productClassId);
         if ($CartItem) {
             return $CartItem->getQuantity();
         } else {
@@ -246,18 +246,12 @@ class CartService
                 throw new CartException('cart.product.delete');
             }
         }
-        if ($ProductClass->getProduct()->getStatus()->getId() !== Disp::DISPLAY_SHOW) {
-            $this->removeProduct($ProductClass->getId());
+
+        if (!$this->isProductDisplay($ProductClass)) {
             throw new CartException('cart.product.not.status');
         }
 
-        $productName = $ProductClass->getProduct()->getName();
-        if ($ProductClass->hasClassCategory1()) {
-            $productName .= " - ".$ProductClass->getClassCategory1()->getName();
-        }
-        if ($ProductClass->hasClassCategory2()) {
-            $productName .= " - ".$ProductClass->getClassCategory2()->getName();
-        }
+        $productName = $this->getProductName($ProductClass);
 
         // 商品種別に紐づく配送業者を取得
         $deliveries = $this->app['eccube.repository.delivery']->getDeliveries($ProductClass->getProductType());
@@ -281,7 +275,6 @@ class CartService
             if (!$this->canAddProductPayment($ProductClass->getProductType())) {
                 throw new CartException('cart.product.payment.kind');
             }
-
         }
 
         $tmp_subtotal = 0;
@@ -289,7 +282,7 @@ class CartService
         foreach ($this->getCart()->getCartItems() as $cartitem) {
             $pc = $cartitem->getObject();
             if ($pc->getId() != $ProductClass->getId()) {
-                // まず、追加された商品以外のtotal priceをセット
+                // 追加された商品以外のtotal priceをセット
                 $tmp_subtotal += $cartitem->getTotalPrice();
             }
         }
@@ -301,35 +294,18 @@ class CartService
             }
             $tmp_quantity++;
         }
-        $quantity = $tmp_quantity;
+        if ($tmp_quantity == 0) {
+            // 数量が0の場合、エラー
+            throw new CartException('cart.over.price_limit');
+        }
 
-        $tmp_quantity = 0;
-
-        /*
-         * 実際の在庫は ProductClass::ProductStock だが、購入時にロックがかかるため、
-         * ここでは ProductClass::stock で在庫のチェックをする
-         */
-        if (!$ProductClass->getStockUnlimited() && $quantity > $ProductClass->getStock()) {
-            if ($ProductClass->getSaleLimit() && $ProductClass->getStock() > $ProductClass->getSaleLimit()) {
-                $tmp_quantity = $ProductClass->getSaleLimit();
-                $this->addError('cart.over.sale_limit', $productName);
-            } else {
-                $tmp_quantity = $ProductClass->getStock();
-                $this->addError('cart.over.stock', $productName);
-            }
-        }
-        if ($ProductClass->getSaleLimit() && $quantity > $ProductClass->getSaleLimit()) {
-            $tmp_quantity = $ProductClass->getSaleLimit();
-            $this->addError('cart.over.sale_limit', $productName);
-        }
-        if ($tmp_quantity) {
-            $quantity = $tmp_quantity;
-        }
+        // 制限数チェック
+        $quantity = $this->setProductLimit($ProductClass, $productName, $tmp_quantity);
 
         $CartItem = new CartItem();
         $CartItem
             ->setClassName('Eccube\Entity\ProductClass')
-            ->setClassId((string) $ProductClass->getId())
+            ->setClassId((string)$ProductClass->getId())
             ->setPrice($ProductClass->getPrice02IncTax())
             ->setQuantity($quantity);
 
@@ -375,6 +351,7 @@ class CartService
         if ($this->getCart()->getTotalPrice() < 1) {
             // カートになければ支払方法を全て設定
             $this->getCart()->setPayments($payments);
+
             return true;
         }
 
@@ -391,11 +368,43 @@ class CartService
 
         if (count($arr) > 0) {
             $this->getCart()->setPayments($arr);
+
             return true;
         }
 
         // 支払条件に一致しない
         return false;
+
+    }
+
+    /**
+     * カートブロックに表示するカートを取得します。
+     * ブロックに表示するカートはチェックを行わず、セットされているカートを返します。
+     *
+     * @return \Eccube\Entity\Cart
+     */
+    public function getCartObj()
+    {
+
+        foreach ($this->cart->getCartItems() as $CartItem) {
+
+            /** @var \Eccube\Entity\ProductClass $ProductClass */
+            $ProductClass = $CartItem->getObject();
+            if (!$ProductClass) {
+                $this->loadProductClassFromCartItem($CartItem);
+
+                $ProductClass = $CartItem->getObject();
+            }
+
+            if ($ProductClass->getDelFlg()) {
+                // 商品情報が削除されていたらエラー
+                $this->setError('cart.product.delete');
+                // カートから削除
+                $this->removeProduct($ProductClass->getId());
+            }
+        }
+
+        return $this->cart;
 
     }
 
@@ -407,6 +416,8 @@ class CartService
     public function getCart()
     {
         foreach ($this->cart->getCartItems() as $CartItem) {
+
+            /** @var \Eccube\Entity\ProductClass $ProductClass */
             $ProductClass = $CartItem->getObject();
             if (!$ProductClass) {
                 $this->loadProductClassFromCartItem($CartItem);
@@ -416,22 +427,23 @@ class CartService
 
             if ($ProductClass->getDelFlg() == Constant::DISABLED) {
                 // 商品情報が有効
-                $stockUnlimited = $ProductClass->getStockUnlimited();
-                if ($stockUnlimited == Constant::DISABLED && $ProductClass->getStock() < 1) {
-                    // 在庫がなければカートから削除
-                    $this->setError('cart.zero.stock');
-                    $this->removeProduct($ProductClass->getId());
+
+                if (!$this->isProductDisplay($ProductClass)) {
+                    $this->setError('cart.product.not.status');
                 } else {
-                    $quantity = $CartItem->getQuantity();
-                    $saleLimit = $ProductClass->getSaleLimit();
-                    if ($stockUnlimited == Constant::DISABLED && $ProductClass->getStock() < $quantity) {
-                        // 購入数が在庫数を超えている場合、メッセージを表示
-                        $this->setError('cart.over.stock');
-                    } elseif (!is_null($saleLimit) && $saleLimit < $quantity) {
-                        // 購入数が販売制限数を超えている場合、メッセージを表示
-                        $this->setError('cart.over.sale_limit');
+
+                    $productName = $this->getProductName($ProductClass);
+
+                    // 制限数チェック
+                    $quantity = $this->setProductLimit($ProductClass, $productName, $CartItem->getQuantity());
+
+                    if ($CartItem->getQuantity() != $quantity) {
+                        // 個数が異なれば更新
+                        $CartItem->setQuantity($quantity);
+                        $this->cart->setCartItem($CartItem);
                     }
                 }
+
             } else {
                 // 商品情報が削除されていたらエラー
                 $this->setError('cart.product.delete');
@@ -449,7 +461,7 @@ class CartService
      */
     public function removeProduct($productClassId)
     {
-        $this->cart->removeCartItemByIdentifier('Eccube\Entity\ProductClass', (string) $productClassId);
+        $this->cart->removeCartItemByIdentifier('Eccube\Entity\ProductClass', (string)$productClassId);
 
         // 支払方法の再設定
         if ($this->BaseInfo->getOptionMultipleShipping() == Constant::ENABLED) {
@@ -486,6 +498,7 @@ class CartService
         if (!is_null($productName)) {
             $this->session->getFlashBag()->add('eccube.front.request.product', $productName);
         }
+
         return $this;
     }
 
@@ -530,6 +543,7 @@ class CartService
             $ProductClass = $item->getObject();
             $productTypes[] = $ProductClass->getProductType();
         }
+
         return array_unique($productTypes);
 
     }
@@ -577,7 +591,127 @@ class CartService
     {
         $this->error = $error;
         $this->session->getFlashBag()->set('eccube.front.request.error', $error);
+
         return $this;
+    }
+
+    /**
+     * 商品名を取得
+     *
+     * @param ProductClass $ProductClass
+     * @return string
+     */
+    private function getProductName(ProductClass $ProductClass)
+    {
+
+        $productName = $ProductClass->getProduct()->getName();
+
+        if ($ProductClass->hasClassCategory1()) {
+            $productName .= " - ".$ProductClass->getClassCategory1()->getName();
+        }
+
+        if ($ProductClass->hasClassCategory2()) {
+            $productName .= " - ".$ProductClass->getClassCategory2()->getName();
+        }
+
+        return $productName;
+    }
+
+
+    /**
+     * 非公開商品の場合、カートから削除
+     *
+     * @param ProductClass $ProductClass
+     * @return bool
+     */
+    private function isProductDisplay(ProductClass $ProductClass)
+    {
+
+        if ($ProductClass->getProduct()->getStatus()->getId() !== Disp::DISPLAY_SHOW) {
+            // 非公開の商品はカートから削除
+            $this->removeProduct($ProductClass->getId());
+
+            return false;
+        }
+
+        return true;
+    }
+
+
+    /**
+     * 在庫数と販売制限数のチェック
+     * 在庫数または販売制限数以上の個数が設定されていれば、それぞれの個数にセットし、
+     * 在庫数と販売制限数ともに個数が超えていれば、少ない方を適用させてメッセージを表示する
+     *
+     * @param ProductClass $ProductClass
+     * @param $productName
+     * @param $quantity
+     * @return int|string
+     */
+    private function setProductLimit(ProductClass $ProductClass, $productName, $quantity)
+    {
+
+        /**
+         * 実際の在庫は ProductClass::ProductStock だが、購入時にロックがかかるため、
+         * ここでは ProductClass::stock で在庫のチェックをする
+         */
+
+        $tmp_quantity = 0;
+
+        // 在庫数(在庫無制限の場合、null)
+        $stock = $ProductClass->getStock();
+        // 在庫無制限(在庫無制限の場合、1)
+        $stockUnlimited = $ProductClass->getStockUnlimited();
+
+        // 販売制限数(設定されていなければnull)
+        $saleLimit = $ProductClass->getSaleLimit();
+
+        if ($stockUnlimited) {
+            // 在庫無制限
+
+            if ($saleLimit && $saleLimit < $quantity) {
+                // 販売制限数を超えていれば販売制限数をセット
+                $tmp_quantity = $saleLimit;
+                $this->addError('cart.over.sale_limit', $productName);
+            }
+        } else {
+            // 在庫制限あり
+
+            if ($stock < 1) {
+                // 在庫がなければカートから削除
+                $this->addError('cart.zero.stock', $productName);
+                $this->removeProduct($ProductClass->getId());
+            } else {
+                // 在庫数チェックと販売制限数チェックどちらを適用するか設定
+                $message = 'cart.over.stock';
+                if ($saleLimit) {
+                    if ($stock > $saleLimit) {
+                        // 販売制限数チェック
+                        $limit = $saleLimit;
+                        $message = 'cart.over.sale_limit';
+                    } else {
+                        // 在庫数チェック
+                        $limit = $stock;
+                    }
+                } else {
+                    // 在庫数チェック
+                    $limit = $stock;
+                }
+
+                if ($limit < $quantity) {
+                    // 在庫数、販売制限数を超えていれば購入可能数までをセット
+                    $tmp_quantity = $limit;
+                    $this->addError($message, $productName);
+                }
+            }
+        }
+
+        if ($tmp_quantity) {
+            $quantity = $tmp_quantity;
+        }
+
+        return $quantity;
+
     }
 
 }

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -215,6 +215,7 @@ class ShoppingService
 
     /**
      * 受注情報を作成
+     *
      * @param $Customer
      * @return \Eccube\Entity\Order
      */
@@ -229,12 +230,14 @@ class ShoppingService
 
     /**
      * 受注情報を作成
+     *
      * @return \Eccube\Entity\Order
      */
     public function newOrder()
     {
         $OrderStatus = $this->app['eccube.repository.order_status']->find($this->app['config']['order_processing']);
         $Order = new \Eccube\Entity\Order($OrderStatus);
+
         return $Order;
     }
 
@@ -599,6 +602,7 @@ class ShoppingService
         foreach ($shipmentItems as $ShipmentItem) {
             $productDeliveryFeeTotal += $ShipmentItem->getProductClass()->getDeliveryFee() * $ShipmentItem->getQuantity();
         }
+
         return $productDeliveryFeeTotal;
     }
 
@@ -711,20 +715,32 @@ class ShoppingService
      */
     public function isOrderProduct($em, \Eccube\Entity\Order $Order)
     {
-        // 商品公開ステータスチェック
         $orderDetails = $Order->getOrderDetails();
 
         foreach ($orderDetails as $orderDetail) {
+
+            // 商品削除チェック
+            if ($orderDetail->getProductClass()->getDelFlg()) {
+                throw new ShoppingException('cart.product.delete');
+            }
+
+            // 商品公開ステータスチェック
             if ($orderDetail->getProduct()->getStatus()->getId() != \Eccube\Entity\Master\Disp::DISPLAY_SHOW) {
                 // 商品が非公開ならエラー
-                return false;
+                throw new ShoppingException('cart.product.not.status');
             }
 
             // 購入制限数チェック
             if (!is_null($orderDetail->getProductClass()->getSaleLimit())) {
                 if ($orderDetail->getQuantity() > $orderDetail->getProductClass()->getSaleLimit()) {
-                    return false;
+                    throw new ShoppingException('cart.over.sale_limit');
                 }
+            }
+
+            // 購入数チェック
+            if ($orderDetail->getQuantity() < 1) {
+                // 購入数量が1未満ならエラー
+                return false;
             }
 
         }
@@ -739,8 +755,10 @@ class ShoppingService
                     $orderDetail->getProductClass()->getProductStock()->getId(), LockMode::PESSIMISTIC_WRITE
                 );
                 // 購入数量と在庫数をチェックして在庫がなければエラー
-                if ($orderDetail->getQuantity() > $productStock->getStock()) {
+                if ($productStock->getStock() < 1) {
                     return false;
+                } elseif ($orderDetail->getQuantity() > $productStock->getStock()) {
+                    throw new ShoppingException('cart.over.stock');
                 }
             }
         }

--- a/tests/Eccube/Tests/Service/CartServiceTest.php
+++ b/tests/Eccube/Tests/Service/CartServiceTest.php
@@ -27,7 +27,6 @@ namespace Eccube\Tests\Service;
 use Eccube\Application;
 use Eccube\Common\Constant;
 use Eccube\Exception\CartException;
-use Eccube\Service\CartService;
 use Eccube\Util\Str;
 
 class CartServiceTest extends AbstractServiceTestCase
@@ -281,10 +280,13 @@ class CartServiceTest extends AbstractServiceTestCase
         $ProductClass->setPrice02($this->app['config']['max_total_fee']);
         $this->app['orm.em']->flush();
 
-        $this->app['eccube.service.cart']->setProductQuantity($ProductClass, 2)->save();
+        try {
+            $this->app['eccube.service.cart']->setProductQuantity($ProductClass, 2)->save();
+        } catch (CartException $e) {
+            $this->actual = $this->app['eccube.service.cart']->getError();
+            $this->expected = 'cart.over.price_limit';
+        }
 
-        $this->actual = $this->app['eccube.service.cart']->getError();
-        $this->expected = 'cart.over.price_limit';
         $this->verify();
     }
 

--- a/tests/Eccube/Tests/Service/ShoppingServiceTest.php
+++ b/tests/Eccube/Tests/Service/ShoppingServiceTest.php
@@ -5,6 +5,7 @@ namespace Eccube\Tests\Service;
 use Eccube\Application;
 use Eccube\Common\Constant;
 use Eccube\Entity\Shipping;
+use Eccube\Exception\ShoppingException;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class ShoppingServiceTest extends AbstractServiceTestCase
@@ -275,11 +276,16 @@ class ShoppingServiceTest extends AbstractServiceTestCase
         }
         $this->app['orm.em']->flush();
 
-        $this->expected = false;
-        $this->actual = $this->app['eccube.service.shopping']->isOrderProduct(
-            $this->app['orm.em'],
-            $Order
-        );
+        try {
+            $this->app['eccube.service.shopping']->isOrderProduct(
+                $this->app['orm.em'],
+                $Order
+            );
+        } catch (ShoppingException $e) {
+            $this->actual = $e->getMessage();
+            $this->expected = 'cart.product.not.status';
+        }
+
         $this->verify();
     }
 
@@ -299,11 +305,16 @@ class ShoppingServiceTest extends AbstractServiceTestCase
         }
         $this->app['orm.em']->flush();
 
-        $this->expected = false;
-        $this->actual = $this->app['eccube.service.shopping']->isOrderProduct(
-            $this->app['orm.em'],
-            $Order
-        );
+        try {
+            $this->app['eccube.service.shopping']->isOrderProduct(
+                $this->app['orm.em'],
+                $Order
+            );
+        } catch (ShoppingException $e) {
+            $this->actual = $e->getMessage();
+            $this->expected = 'cart.over.sale_limit';
+        }
+
         $this->verify();
     }
 
@@ -327,11 +338,16 @@ class ShoppingServiceTest extends AbstractServiceTestCase
         }
         $this->app['orm.em']->flush();
 
-        $this->expected = false;
-        $this->actual = $this->app['eccube.service.shopping']->isOrderProduct(
-            $this->app['orm.em'],
-            $Order
-        );
+        try {
+            $this->app['eccube.service.shopping']->isOrderProduct(
+                $this->app['orm.em'],
+                $Order
+            );
+        } catch (ShoppingException $e) {
+            $this->actual = $e->getMessage();
+            $this->expected = 'cart.over.stock';
+        }
+
         $this->verify();
     }
 

--- a/tests/Eccube/Tests/Web/CartValidationTest.php
+++ b/tests/Eccube/Tests/Web/CartValidationTest.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Tests\Web;
+
+use Eccube\Entity\Product;
+use Symfony\Component\HttpKernel\Client;
+
+class CartValidationTest extends AbstractWebTestCase
+{
+
+    // 商品詳細画面からカート画面のvalidation
+
+    /**
+     * 在庫制限チェック
+     */
+    public function testValidationStock()
+    {
+        /** @var Product $Product */
+        $Product = $this->createProduct('test1');
+
+        $ProductClass = $Product->getProductClasses()->get(1);
+
+        // 在庫数を設定
+        $ProductClass->setStock(1);
+        $this->app['orm.em']->persist($ProductClass);
+
+        $arr = array(
+            'product_id' => $Product->getId(),
+            'mode' => 'add_cart',
+            'product_class_id' => $ProductClass->getId(),
+            'quantity' => 9999,
+            '_token' => 'dummy',
+        );
+
+        /** @var Client $client */
+        $client = $this->client;
+
+        $client->request(
+            'POST',
+            $this->app->url('product_detail', array('id' => $Product->getId())),
+            $arr
+        );
+
+        $crawler = $client->followRedirect();
+
+        // エラーメッセージは改行されているため2回に分けてチェック
+
+        $message = $crawler->filter('.errormsg')->text();
+
+        $this->assertContains('選択された商品(test1)の在庫が不足しております。', $message);
+
+        $this->assertContains( '一度に在庫数を超える購入はできません。', $message);
+
+    }
+
+}


### PR DESCRIPTION
カート追加、商品購入までに以下のチェックが行われ、適切にエラーメッセージを表示するように修正 #1273 
- 商品削除
- 商品非公開
- 商品の在庫切れ
- 商品の在庫制限(個数のまるめ処理)
- 販売制限数(個数のまるめ処理)
- 商品を購入できる金額の上限(カートへセット時のみチェック)
- 商品種別が異なる(複数配送ではない)
- お支払い方法が異なる(共通のお支払い方法がなし、複数配送である)
