### PR TITLE
doctrine cache を yaml で設定できるよう修正

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -152,6 +152,19 @@ class Application extends ApplicationTrait
 
             $configAll = array_replace_recursive($configAll, $config_nav_dist, $config_nav);
 
+            $config_doctrine_cache = array();
+            $yml = $ymlPath.'/doctrine_cache.yml';
+            if (file_exists($yml)) {
+                $config_doctrine_cache = Yaml::parse(file_get_contents($yml));
+            }
+            $config_doctrine_cache_dist = array();
+            $doctrine_cache_yml_dist = $distPath.'/doctrine_cache.yml.dist';
+            if (file_exists($doctrine_cache_yml_dist)) {
+                $config_doctrine_cache_dist = Yaml::parse(file_get_contents($doctrine_cache_yml_dist));
+            }
+
+            $configAll = array_replace_recursive($configAll, $config_doctrine_cache_dist, $config_doctrine_cache);
+
             return $configAll;
         });
     }
@@ -488,11 +501,32 @@ class Application extends ApplicationTrait
             }
         }
 
+        $options = array(
+            'mappings' => $ormMappings
+        );
+
+        if (!$this['debug']) {
+            $cacheDrivers = array();
+            if (array_key_exists('doctrine_cache', $this['config'])) {
+                $cacheDrivers = $this['config']['doctrine_cache'];
+            }
+            if (array_key_exists('metadata_cache', $cacheDrivers)) {
+                $options['metadata_cache'] = $cacheDrivers['metadata_cache'];
+            }
+            if (array_key_exists('query_cache', $cacheDrivers)) {
+                $options['query_cache'] = $cacheDrivers['query_cache'];
+            }
+            if (array_key_exists('result_cache', $cacheDrivers)) {
+                $options['result_cache'] = $cacheDrivers['result_cache'];
+            }
+            if (array_key_exists('hydration_cache', $cacheDrivers)) {
+                $options['hydration_cache'] = $cacheDrivers['hydration_cache'];
+            }
+        }
+
         $this->register(new \Dflydev\Silex\Provider\DoctrineOrm\DoctrineOrmServiceProvider(), array(
-            'orm.proxies_dir' => __DIR__.'/../../app/cache/doctrine',
-            'orm.em.options' => array(
-                'mappings' => $ormMappings,
-            ),
+            'orm.proxies_dir' => __DIR__.'/../../app/cache/doctrine/proxies',
+            'orm.em.options' => $options
         ));
     }
 

--- a/src/Eccube/Resource/config/doctrine_cache.yml.dist
+++ b/src/Eccube/Resource/config/doctrine_cache.yml.dist
@@ -1,0 +1,25 @@
+cache:
+  metadata_cache:
+    driver: array
+    path:
+    host:
+    port:
+    password:
+  query_cache:
+    driver: array
+    path:
+    host:
+    port:
+    password:
+  result_cache:
+    driver: array
+    path:
+    host:
+    port:
+    password:
+  hydration_cache:
+    driver: array
+    path:
+    host:
+    port:
+    password:


### PR DESCRIPTION
`app/config/ec-cube/doctrine_cache.yml` を作成することでキャッシュの設定が
できるよう修正(#1638)

以下のような内容の `app/config/ec-cube/doctrine_cache.yml` を作成することで Doctrine cache の設定ができるようにしました。

```yaml
doctrine_cache:
  metadata_cache:
    driver: xcache
    path:
    host:
    port:
    password:
  query_cache:
    driver: memcache
    path:
    host: localhost
    port: 11211
    password:
  result_cache:
    driver: redis
    path:
    host: localhost
    port: 6379
    password:
  hydration_cache:
    driver: memcached
    path:
    host: localhost
    port: 11211
    password:
```

### キャッシュの種類

metadata_cache, query_cache, result_cache, hydration_cache の設定ができます

### driver

array, filesystem, apc, memcache, memcached, redis, xcache が使用できます。
デフォルトは array です

### path

driver: filesystem の場合に、キャッシュを保存するパスを指定します。

### host

driver: memcache, memcached, redis のいずれかの場合に、 キャッシュサーバーのホスト名を指定します。

### port

driver: memcache, memcached, redis のいずれかの場合に、 キャッシュサーバーのポート番号を指定します。

### password

host を指定した場合で認証が必要な場合、パスワードを指定します。

### その他の修正

- orm.proxies_dir のパスを変更
- debug モードの場合はキャッシュしないよう修正