### PR TITLE
テストにおける会員登録でsaltをセットするよう変更

### DIFF
--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -88,6 +88,7 @@ class Generator {
             ->setEmail($email)
             ->setPref($Pref)
             ->setPassword('password')
+            ->setSalt($this->app['eccube.repository.customer']->createSalt(5))
             ->setSecretKey($this->app['eccube.repository.customer']->getUniqueSecretKey($this->app))
             ->setStatus($Status)
             ->setDelFlg(Constant::DISABLED);


### PR DESCRIPTION
テスト用会員データ登録でsaltがセットされていない。

salt未設定時のハッシュ化処理が[パスワード暗号化時](https://github.com/EC-CUBE/ec-cube/blob/master/src/Eccube/Security/Core/Encoder/PasswordEncoder.php#L56)と[認証時](https://github.com/EC-CUBE/ec-cube/blob/master/src/Eccube/Security/Core/Encoder/PasswordEncoder.php#L84)で異なるためどうやっても認証が通らない。



ただ[Memberではsaltのセットが行われている](https://github.com/EC-CUBE/ec-cube/blob/master/tests/Eccube/Tests/Fixture/Generator.php#L60)。もしCustomerだけsaltをセットしていない特段の理由がある場合は補足をお願いします。