### PR TITLE
FormEventの無効化

### DIFF
--- a/src/Eccube/Event/FormEventSubscriber.php
+++ b/src/Eccube/Event/FormEventSubscriber.php
@@ -26,116 +26,17 @@ namespace Eccube\Event;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
 
+/**
+ * Class FormEventSubscriber
+ *
+ * @package Eccube\Event
+ *
+ * @deprecated since 3.0.0, to be removed in 3.1
+ */
 class FormEventSubscriber implements EventSubscriberInterface
 {
-    public static function getEvents()
-    {
-        $events = array();
-        // YamlでParseしてがんばる
-        $basePath = __DIR__.'/../../../app/Plugin';
-        $finder = Finder::create()
-            ->in($basePath)
-            ->directories()
-            ->depth(0);
-
-        $app = \Eccube\Application::getInstance();
-
-        foreach ($finder as $dir) {
-            $code = $dir->getBaseName();
-            $path = $dir->getRealPath();
-
-            try {
-                $app['eccube.service.plugin']->checkPluginArchiveContent($path);
-            } catch (\Eccube\Exception\PluginException $e) {
-                $app['monolog']->warning("skip {$code} form events loading. config.yml not foud or invalid.", array(
-                    'path' =>  $path,
-                    'original-message' => $e->getMessage()
-                ));
-                continue;
-            }
-            $config = $app['eccube.service.plugin']->readYml($path.'/config.yml');
-
-            if (isset($config['form'])) {
-                foreach ($config['form'] as $event => $class) {
-                    $events[$event][] = '\\Plugin\\'.$config['code'].'\\'.$class;
-                }
-            }
-        }
-
-        return $events;
-    }
-
     public static function getSubscribedEvents()
     {
-        return array(
-            FormEvents::PRE_SET_DATA => 'onPreSetData',
-            FormEvents::POST_SET_DATA => 'onPostSetData',
-            FormEvents::PRE_SUBMIT => 'onPreSubmit',
-            FormEvents::SUBMIT => 'onSubmit',
-            FormEvents::POST_SUBMIT => 'onPostSubmit',
-        );
-    }
-
-    public function onPreSetData(FormEvent $event)
-    {
-        $events = self::getEvents();
-
-        if (isset($events['onPreSetData'])) {
-            foreach ($events['onPreSetData'] as $formEventClass) {
-                $formEvent = new $formEventClass();
-                $formEvent->onPreSetData($event);
-            }
-        }
-    }
-
-    public function onPostSetData(FormEvent $event)
-    {
-        $events = self::getEvents();
-
-        if (isset($events['onPostSetData'])) {
-            foreach ($events['onPostSetData'] as $formEventClass) {
-                $formEvent = new $formEventClass();
-                $formEvent->onPostSetData($event);
-            }
-        }
-    }
-
-    public function onPreSubmit(FormEvent $event)
-    {
-        $events = self::getEvents();
-
-        if (isset($events['onPreSubmit'])) {
-            foreach ($events['onPreSubmit'] as $formEventClass) {
-                $formEvent = new $formEventClass();
-                $formEvent->onPreSubmit($event);
-            }
-        }
-    }
-
-    public function onSubmit(FormEvent $event)
-    {
-        $events = self::getEvents();
-
-        if (isset($events['onSubmit'])) {
-            foreach ($events['onSubmit'] as $formEventClass) {
-                $formEvent = new $formEventClass();
-                $formEvent->onSubmit($event);
-            }
-        }
-    }
-
-    public function onPostSubmit(FormEvent $event)
-    {
-        $events = self::getEvents();
-
-        if (isset($events['onPostSubmit'])) {
-            foreach ($events['onPostSubmit'] as $formEventClass) {
-                $formEvent = new $formEventClass();
-                $formEvent->onPostSubmit($event);
-            }
-        }
     }
 }

--- a/src/Eccube/Form/Type/AddCartType.php
+++ b/src/Eccube/Form/Type/AddCartType.php
@@ -25,11 +25,11 @@
 namespace Eccube\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormView;
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\ExecutionContext;
@@ -78,8 +78,7 @@ class AddCartType extends AbstractType
                 'constraints' => array(
                     new Assert\Regex(array('pattern' => '/^\d+$/')),
                 ),
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
 
         if ($Product->getStockFind()) {
             $builder

--- a/src/Eccube/Form/Type/AddressType.php
+++ b/src/Eccube/Form/Type/AddressType.php
@@ -72,7 +72,6 @@ class AddressType extends AbstractType
             ->add($options['pref_name'], 'pref', array_merge_recursive($options['options'], $options['pref_options']))
             ->add($options['addr01_name'], 'text', array_merge_recursive($options['options'], $options['addr01_options']))
             ->add($options['addr02_name'], 'text', array_merge_recursive($options['options'], $options['addr02_options']))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber())
         ;
 
         $builder->setAttribute('pref_name', $options['pref_name']);

--- a/src/Eccube/Form/Type/Admin/AuthorityRoleType.php
+++ b/src/Eccube/Form/Type/Admin/AuthorityRoleType.php
@@ -25,12 +25,12 @@
 namespace Eccube\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class AuthorityRoleType extends AbstractType
 {
@@ -71,7 +71,6 @@ class AuthorityRoleType extends AbstractType
                     $form['deny_url']->addError(new FormError('拒否URLが入力されていません。'));
                 }
             })
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/BlockType.php
+++ b/src/Eccube/Form/Type/Admin/BlockType.php
@@ -107,8 +107,7 @@ class BlockType extends AbstractType
                 if (count($Block) > 0) {
                     $form['file_name']->addError(new FormError('※ 同じファイル名のデータが存在しています。別のファイル名を入力してください。'));
                 }
-            })
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            });
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/CategoryType.php
+++ b/src/Eccube/Form/Type/Admin/CategoryType.php
@@ -26,8 +26,8 @@ namespace Eccube\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CategoryType extends AbstractType
 {
@@ -53,7 +53,6 @@ class CategoryType extends AbstractType
                     )),
                 ),
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber())
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/ClassCategoryType.php
+++ b/src/Eccube/Form/Type/Admin/ClassCategoryType.php
@@ -26,8 +26,8 @@ namespace Eccube\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class ClassCategoryType extends AbstractType
 {
@@ -53,7 +53,6 @@ class ClassCategoryType extends AbstractType
                     )),
                 ),
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber())
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/ClassNameType.php
+++ b/src/Eccube/Form/Type/Admin/ClassNameType.php
@@ -26,8 +26,8 @@ namespace Eccube\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class ClassNameType extends AbstractType
 {
@@ -53,7 +53,6 @@ class ClassNameType extends AbstractType
                     )),
                 ),
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber())
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/CsvImportType.php
+++ b/src/Eccube/Form/Type/Admin/CsvImportType.php
@@ -57,8 +57,7 @@ class CsvImportType extends AbstractType
                         'maxSizeMessage' => 'CSVファイルは' . $app['config']['csv_size'] . 'M以下でアップロードしてください。',
                     )),
                 ),
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/CustomerAgreementType.php
+++ b/src/Eccube/Form/Type/Admin/CustomerAgreementType.php
@@ -49,8 +49,7 @@ class CustomerAgreementType extends AbstractType
                 'constraints' => array(
                     new Assert\NotBlank()),
             ))
-            ->add('save', 'submit', array('label' => 'この内容で登録する'))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ->add('save', 'submit', array('label' => 'この内容で登録する'));
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/CustomerType.php
+++ b/src/Eccube/Form/Type/Admin/CustomerType.php
@@ -127,8 +127,7 @@ class CustomerType extends AbstractType
                         'max' => $config['ltext_len'],
                     )),
                 ),
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/DeliveryFeeType.php
+++ b/src/Eccube/Form/Type/Admin/DeliveryFeeType.php
@@ -39,7 +39,6 @@ class DeliveryFeeType extends AbstractType
             ->add('fee', 'price', array(
                 'label' => false,
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber())
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/DeliveryTimeType.php
+++ b/src/Eccube/Form/Type/Admin/DeliveryTimeType.php
@@ -46,7 +46,6 @@ class DeliveryTimeType extends AbstractType
             ->add('delivery_time', 'text', array(
                 'label' => false,
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber())
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/DeliveryType.php
+++ b/src/Eccube/Form/Type/Admin/DeliveryType.php
@@ -115,7 +115,6 @@ class DeliveryType extends AbstractType
                     $form['payments']->addError(new FormError('支払方法を選択してください。'));
                 }
             })
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber())
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/LogType.php
+++ b/src/Eccube/Form/Type/Admin/LogType.php
@@ -23,12 +23,11 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Finder\Finder;
 
 class LogType extends AbstractType
 {
@@ -72,8 +71,7 @@ class LogType extends AbstractType
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')),
                     new Assert\NotBlank(),
                 ),
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/LoginType.php
+++ b/src/Eccube/Form/Type/Admin/LoginType.php
@@ -26,8 +26,8 @@ namespace Eccube\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class LoginType extends AbstractType
@@ -60,8 +60,7 @@ class LoginType extends AbstractType
             'constraints' => array(
                 new Assert\NotBlank(),
             ),
-        ))
-        ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+        ));
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/MailType.php
+++ b/src/Eccube/Form/Type/Admin/MailType.php
@@ -65,7 +65,6 @@ class MailType extends AbstractType
                     new Assert\NotBlank(),
                 ),
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/MainEditType.php
+++ b/src/Eccube/Form/Type/Admin/MainEditType.php
@@ -26,8 +26,8 @@ namespace Eccube\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -160,8 +160,7 @@ class MainEditType extends AbstractType
                 if (count($PageLayout) > 0) {
                     $form['url']->addError(new FormError('※ 同じURLのデータが存在しています。別のURLを入力してください。'));
                 }
-            })
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            });
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/MasterdataType.php
+++ b/src/Eccube/Form/Type/Admin/MasterdataType.php
@@ -26,10 +26,7 @@ namespace Eccube\Form\Type\Admin;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
 
 class MasterdataType extends AbstractType
 {
@@ -80,7 +77,6 @@ class MasterdataType extends AbstractType
             ))
             ;
 
-        $builder->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/MemberType.php
+++ b/src/Eccube/Form/Type/Admin/MemberType.php
@@ -26,8 +26,8 @@ namespace Eccube\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class MemberType extends AbstractType
 {
@@ -106,7 +106,6 @@ class MemberType extends AbstractType
                     new Assert\NotBlank(),
                 ),
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/NewsType.php
+++ b/src/Eccube/Form/Type/Admin/NewsType.php
@@ -25,7 +25,6 @@ namespace Eccube\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -85,8 +84,7 @@ class NewsType extends AbstractType
             ))
             ->add('select', 'hidden', array(
                 'data' => '0',
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/OrderDetailType.php
+++ b/src/Eccube/Form/Type/Admin/OrderDetailType.php
@@ -121,7 +121,6 @@ class OrderDetailType extends AbstractType
             }
         });
 
-        $builder->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -282,7 +282,6 @@ class OrderType extends AbstractType
                 $form['charge']->addError(new FormError('商品が追加されていません。'));
             }
         });
-        $builder->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/PageLayoutType.php
+++ b/src/Eccube/Form/Type/Admin/PageLayoutType.php
@@ -24,10 +24,10 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Doctrine\ORM\EntityRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
-use Doctrine\ORM\EntityRepository;
 
 class PageLayoutType extends AbstractType
 {
@@ -47,8 +47,7 @@ class PageLayoutType extends AbstractType
                         ->where('l.id <> 0')
                         ->orderBy('l.id', 'ASC');
                 },
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/PaymentRegisterType.php
+++ b/src/Eccube/Form/Type/Admin/PaymentRegisterType.php
@@ -99,7 +99,6 @@ class PaymentRegisterType extends AbstractType
                     $form['rule_min']->addError(new FormError('利用条件(下限)は'.$ruleMax.'円以下にしてください。'));
                 }
             })
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber())
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/PluginLocalInstallType.php
+++ b/src/Eccube/Form/Type/Admin/PluginLocalInstallType.php
@@ -24,10 +24,10 @@
 
 namespace Eccube\Form\Type\Admin;
 
-use \Symfony\Component\Form\AbstractType;
-use \Symfony\Component\Form\Extension\Core\Type;
-use \Symfony\Component\Form\FormBuilderInterface;
-use \Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class PluginLocalInstallType extends AbstractType
 {
@@ -50,8 +50,7 @@ class PluginLocalInstallType extends AbstractType
                         'mimeTypesMessage' => 'zipファイル、tarファイル、tar.gzファイルのいずれかをアップロードしてください。',
                     )),
                 ),
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/PluginManagementType.php
+++ b/src/Eccube/Form/Type/Admin/PluginManagementType.php
@@ -65,8 +65,7 @@ class PluginManagementType extends AbstractType
                         'mimeTypesMessage' => 'zipファイル、tarファイル、tar.gzファイルのいずれかをアップロードしてください。',
                     )),
                 ),
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/ProductClassType.php
+++ b/src/Eccube/Form/Type/Admin/ProductClassType.php
@@ -155,8 +155,7 @@ class ProductClassType extends AbstractType
                 if (empty($data['stock_unlimited']) && is_null($data['stock'])) {
                     $form['stock_unlimited']->addError(new FormError('在庫数を入力、もしくは在庫無制限を設定してください。'));
                 }
-            })
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            });
 
         $transformer = new DataTransformer\IntegerToBooleanTransformer();
 

--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -27,8 +27,8 @@ namespace Eccube\Form\Type\Admin;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class ProductType extends AbstractType
 {
@@ -135,7 +135,6 @@ class ProductType extends AbstractType
                 'allow_add' => true,
                 'allow_delete' => true,
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber())
         ;
 
     }

--- a/src/Eccube/Form/Type/Admin/SearchCustomerType.php
+++ b/src/Eccube/Form/Type/Admin/SearchCustomerType.php
@@ -205,7 +205,6 @@ class SearchCustomerType extends AbstractType
                 'multiple' => true,
                 'empty_value' => false,
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/SearchOrderType.php
+++ b/src/Eccube/Form/Type/Admin/SearchOrderType.php
@@ -168,7 +168,6 @@ class SearchOrderType extends AbstractType
                 'label' => '購入商品名',
                 'required' => false,
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/SearchProductType.php
+++ b/src/Eccube/Form/Type/Admin/SearchProductType.php
@@ -24,10 +24,10 @@
 
 namespace Eccube\Form\Type\Admin;
 
-use \Symfony\Component\Form\AbstractType;
-use \Symfony\Component\Form\Extension\Core\Type;
-use \Symfony\Component\Form\FormBuilderInterface;
-use \Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class SearchProductType extends AbstractType
 {
@@ -105,7 +105,6 @@ class SearchProductType extends AbstractType
             ->add('link_status', 'hidden', array(
                 'mapped' => false,
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber())
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/SecurityType.php
+++ b/src/Eccube/Form/Type/Admin/SecurityType.php
@@ -25,11 +25,10 @@
 namespace Eccube\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class SecurityType extends AbstractType
 {
@@ -86,7 +85,6 @@ class SecurityType extends AbstractType
                     }
                 }
             })
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/ShipmentItemType.php
+++ b/src/Eccube/Form/Type/Admin/ShipmentItemType.php
@@ -106,7 +106,6 @@ class ShipmentItemType extends AbstractType
                 }
             }
         });
-        $builder->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/ShippingType.php
+++ b/src/Eccube/Form/Type/Admin/ShippingType.php
@@ -218,8 +218,7 @@ class ShippingType extends AbstractType
                         $form['shipping_delivery_date']->addError(new FormError('商品が追加されていません。'));
                     }
                 }
-            })
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            });
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/ShopMasterType.php
+++ b/src/Eccube/Form/Type/Admin/ShopMasterType.php
@@ -289,7 +289,6 @@ class ShopMasterType extends AbstractType
                 ),
             ))
 
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber())
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/TaxRuleType.php
+++ b/src/Eccube/Form/Type/Admin/TaxRuleType.php
@@ -80,8 +80,7 @@ class TaxRuleType extends AbstractType
                 'constraints' => array(
                     new Assert\NotBlank(),
                 ),
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/TemplateType.php
+++ b/src/Eccube/Form/Type/Admin/TemplateType.php
@@ -27,8 +27,6 @@ namespace Eccube\Form\Type\Admin;
 use Eccube\Form\DataTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -83,8 +81,7 @@ class TemplateType extends AbstractType
                         'mimeTypesMessage' => 'zipファイル、tarファイル、tar.gzファイルのいずれかをアップロードしてください。',
                     )),
                 ),
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/TradelawType.php
+++ b/src/Eccube/Form/Type/Admin/TradelawType.php
@@ -134,8 +134,7 @@ class TradelawType extends AbstractType
                 'constraints' => array(
                     new Assert\NotBlank(),
                 ),
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
     }
 
     public function getName()

--- a/src/Eccube/Form/Type/CustomerType.php
+++ b/src/Eccube/Form/Type/CustomerType.php
@@ -126,8 +126,7 @@ class CustomerType extends AbstractType
             ->add('note', 'textarea', array(
                 'required' => false,
             ))
-            ->add('save', 'submit', array('label' => 'この内容で登録する'))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ->add('save', 'submit', array('label' => 'この内容で登録する'));
     }
 
     /**

--- a/src/Eccube/Form/Type/Front/ContactType.php
+++ b/src/Eccube/Form/Type/Front/ContactType.php
@@ -70,8 +70,7 @@ class ContactType extends AbstractType
                 'constraints' => array(
                     new Assert\NotBlank(),
                 ),
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
     }
 
     /**

--- a/src/Eccube/Form/Type/Front/CustomerAddressType.php
+++ b/src/Eccube/Form/Type/Front/CustomerAddressType.php
@@ -70,8 +70,7 @@ class CustomerAddressType extends AbstractType
             ))
             ->add('fax', 'tel', array(
                 'required' => false,
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
     }
 
     /**

--- a/src/Eccube/Form/Type/Front/CustomerLoginType.php
+++ b/src/Eccube/Form/Type/Front/CustomerLoginType.php
@@ -26,8 +26,8 @@ namespace Eccube\Form\Type\Front;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class CustomerLoginType extends AbstractType
@@ -65,7 +65,6 @@ class CustomerLoginType extends AbstractType
                 new Assert\NotBlank(),
             ),
         ));
-        $builder->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
     }
 
     /**

--- a/src/Eccube/Form/Type/Front/EntryType.php
+++ b/src/Eccube/Form/Type/Front/EntryType.php
@@ -89,8 +89,7 @@ class EntryType extends AbstractType
             ->add('job', 'job', array(
                 'required' => false,
             ))
-            ->add('save', 'submit', array('label' => 'この内容で登録する'))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ->add('save', 'submit', array('label' => 'この内容で登録する'));
     }
 
     /**

--- a/src/Eccube/Form/Type/Front/ForgotType.php
+++ b/src/Eccube/Form/Type/Front/ForgotType.php
@@ -24,10 +24,10 @@
 
 namespace Eccube\Form\Type\Front;
 
-use \Symfony\Component\Form\AbstractType;
-use \Symfony\Component\Form\Extension\Core\Type;
-use \Symfony\Component\Form\FormBuilderInterface;
-use \Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class ForgotType extends AbstractType
 {
@@ -44,8 +44,7 @@ class ForgotType extends AbstractType
                 new Assert\NotBlank(),
                 new Assert\Email(),
             ),
-        ))
-        ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+        ));
     }
 
     /**

--- a/src/Eccube/Form/Type/Front/NonMemberType.php
+++ b/src/Eccube/Form/Type/Front/NonMemberType.php
@@ -75,8 +75,7 @@ class NonMemberType extends AbstractType
             ->add('tel', 'tel', array(
                 'required' => true,
             ))
-            ->add('email', 'repeated_email')
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ->add('email', 'repeated_email');
     }
 
     /**

--- a/src/Eccube/Form/Type/Front/ShoppingShippingType.php
+++ b/src/Eccube/Form/Type/Front/ShoppingShippingType.php
@@ -36,8 +36,6 @@ class ShoppingShippingType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
     }
 
     /**

--- a/src/Eccube/Form/Type/Master/PageMaxType.php
+++ b/src/Eccube/Form/Type/Master/PageMaxType.php
@@ -26,10 +26,9 @@ namespace Eccube\Form\Type\Master;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
-use Doctrine\ORM\EntityRepository;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PageMaxType extends AbstractType
 {
@@ -52,8 +51,7 @@ class PageMaxType extends AbstractType
                 $data = current($values);
                 $event->setData($data);
             }
-        })
-        ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+        });
     }
 
     /**

--- a/src/Eccube/Form/Type/Master/ProductListMaxType.php
+++ b/src/Eccube/Form/Type/Master/ProductListMaxType.php
@@ -26,10 +26,9 @@ namespace Eccube\Form\Type\Master;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
-use Doctrine\ORM\EntityRepository;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ProductListMaxType extends AbstractType
 {
@@ -53,7 +52,6 @@ class ProductListMaxType extends AbstractType
                 $event->setData($data);
             }
         });
-        $builder->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
     }
 
     /**

--- a/src/Eccube/Form/Type/Master/ProductListOrderByType.php
+++ b/src/Eccube/Form/Type/Master/ProductListOrderByType.php
@@ -24,7 +24,6 @@
 
 namespace Eccube\Form\Type\Master;
 
-use Doctrine\ORM\EntityRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -53,7 +52,6 @@ class ProductListOrderByType extends AbstractType
                 $event->setData($data);
             }
         });
-        $builder->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
     }
 
     /**

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -26,8 +26,8 @@ namespace Eccube\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -75,7 +75,6 @@ class NameType extends AbstractType
 
         $builder->setAttribute('lastname_name', $options['lastname_name']);
         $builder->setAttribute('firstname_name', $options['firstname_name']);
-        $builder->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
     }
 
     /**

--- a/src/Eccube/Form/Type/OrderMailType.php
+++ b/src/Eccube/Form/Type/OrderMailType.php
@@ -70,7 +70,6 @@ class OrderMailType extends AbstractType
                     new Assert\NotBlank(),
                 ),
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
         ;
     }
 

--- a/src/Eccube/Form/Type/OrderSearchType.php
+++ b/src/Eccube/Form/Type/OrderSearchType.php
@@ -24,10 +24,10 @@
 
 namespace Eccube\Form\Type;
 
-use \Symfony\Component\Form\AbstractType;
-use \Symfony\Component\Form\Extension\Core\Type;
-use \Symfony\Component\Form\FormBuilderInterface;
-use \Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 // deprecated 3.1で削除予定
 class OrderSearchType extends AbstractType
@@ -152,7 +152,6 @@ class OrderSearchType extends AbstractType
                 'label' => '購入商品名',
                 'required' => false,
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
         ;
     }
 

--- a/src/Eccube/Form/Type/SearchProductType.php
+++ b/src/Eccube/Form/Type/SearchProductType.php
@@ -24,10 +24,10 @@
 
 namespace Eccube\Form\Type;
 
+use Doctrine\ORM\EntityRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Doctrine\ORM\EntityRepository;
 
 class SearchProductType extends AbstractType
 {
@@ -68,7 +68,6 @@ class SearchProductType extends AbstractType
         $builder->add('orderby', 'product_list_order_by', array(
             'label' => '表示順',
         ));
-        $builder->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
     }
 
     /**

--- a/src/Eccube/Form/Type/ShippingItemType.php
+++ b/src/Eccube/Form/Type/ShippingItemType.php
@@ -129,8 +129,7 @@ class ShippingItemType extends AbstractType
                 } else {
                     $data->setShippingDeliveryDate(null);
                 }
-            })
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            });
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Eccube/Form/Type/ShippingMultipleItemType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleItemType.php
@@ -126,8 +126,7 @@ class ShippingMultipleItemType extends AbstractType
 
                 $form['quantity']->setData($quantity);
 
-            })
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            });
 
     }
 

--- a/src/Eccube/Form/Type/ShippingMultipleType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleType.php
@@ -67,8 +67,7 @@ class ShippingMultipleType extends AbstractType
                         'allow_delete' => true,
                     ));
 
-            })
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            });
 
     }
 

--- a/src/Eccube/Form/Type/ShoppingMultipleType.php
+++ b/src/Eccube/Form/Type/ShoppingMultipleType.php
@@ -61,8 +61,7 @@ class ShoppingMultipleType extends AbstractType
                 'required' => false,
                 'empty_value' => '指定なし',
                 'empty_data' => null,
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
 
     }
 

--- a/src/Eccube/Form/Type/ShoppingType.php
+++ b/src/Eccube/Form/Type/ShoppingType.php
@@ -58,8 +58,7 @@ class ShoppingType extends AbstractType
                 'data' => $message,
                 'constraints' => array(
                     new Assert\Length(array('min' => 0, 'max' => 3000))),
-            ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            ));
 
     }
 

--- a/src/Eccube/Form/Type/TelType.php
+++ b/src/Eccube/Form/Type/TelType.php
@@ -25,10 +25,11 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
+
 class TelType extends AbstractType
 {
     /**
@@ -93,7 +94,6 @@ class TelType extends AbstractType
                 $form[$builder->getName().'01']->addError(new FormError('全て入力してください。'));
             }
         });
-        $builder->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
     }
     /**
      * {@inheritdoc}

--- a/src/Eccube/Form/Type/ZipType.php
+++ b/src/Eccube/Form/Type/ZipType.php
@@ -25,8 +25,8 @@ namespace Eccube\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -73,7 +73,6 @@ class ZipType extends AbstractType
 
         $builder->setAttribute('zip01_name', $options['zip01_name']);
         $builder->setAttribute('zip02_name', $options['zip02_name']);
-        $builder->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
     }
 
     /**


### PR DESCRIPTION
FormEventを呼び出さないように修正する。 #1684 
* FormEventSubscriberのイベント呼び出しを無効化
* FormTypeに記述しているaddEventSubscriberを削除

FormEventSubscriberクラスは残しておくが将来削除予定。