### PR TITLE
使用していないdtb_category_total_countとdtb_category_countテーブルの結合を削除

### DIFF
--- a/src/Eccube/Entity/Category.php
+++ b/src/Eccube/Entity/Category.php
@@ -160,16 +160,6 @@ class Category extends \Eccube\Entity\AbstractEntity
     private $del_flg;
 
     /**
-     * @var \Eccube\Entity\CategoryCount
-     */
-    private $CategoryCount;
-
-    /**
-     * @var \Eccube\Entity\CategoryTotalCount
-     */
-    private $CategoryTotalCount;
-
-    /**
      * @var \Doctrine\Common\Collections\Collection
      */
     private $ProductCategories;
@@ -344,52 +334,6 @@ class Category extends \Eccube\Entity\AbstractEntity
     public function getDelFlg()
     {
         return $this->del_flg;
-    }
-
-    /**
-     * Set CategoryCount
-     *
-     * @param  \Eccube\Entity\CategoryCount $categoryCount
-     * @return Category
-     */
-    public function setCategoryCount(\Eccube\Entity\CategoryCount $categoryCount = null)
-    {
-        $this->CategoryCount = $categoryCount;
-
-        return $this;
-    }
-
-    /**
-     * Get CategoryCount
-     *
-     * @return \Eccube\Entity\CategoryCount
-     */
-    public function getCategoryCount()
-    {
-        return $this->CategoryCount;
-    }
-
-    /**
-     * Set CategoryTotalCount
-     *
-     * @param  \Eccube\Entity\CategoryTotalCount $categoryTotalCount
-     * @return Category
-     */
-    public function setCategoryTotalCount(\Eccube\Entity\CategoryTotalCount $categoryTotalCount = null)
-    {
-        $this->CategoryTotalCount = $categoryTotalCount;
-
-        return $this;
-    }
-
-    /**
-     * Get CategoryTotalCount
-     *
-     * @return \Eccube\Entity\CategoryTotalCount
-     */
-    public function getCategoryTotalCount()
-    {
-        return $this->CategoryTotalCount;
     }
 
     /**

--- a/src/Eccube/Resource/doctrine/Eccube.Entity.Category.dcm.yml
+++ b/src/Eccube/Resource/doctrine/Eccube.Entity.Category.dcm.yml
@@ -57,11 +57,4 @@ Eccube\Entity\Category:
             mappedBy: Parent
             orderBy:
                 rank: DESC
-    oneToOne:
-        CategoryCount:
-            targetEntity: CategoryCount
-            mappedBy: Category
-        CategoryTotalCount:
-            targetEntity: CategoryTotalCount
-            mappedBy: Category
     lifecycleCallbacks: {  }


### PR DESCRIPTION
dtb_category_total_countとdtb_category_count の結合を削除する。 #1686 

* Category.dcm.ymlファイルにoneToOneで結合されている条件を削除し、
* Category.phpから該当の関数を削除する。

dtb_category_total_countとdtb_category_countのテーブルは残しておくが将来削除予定。