### PR TITLE
キャッシュ管理画面でtwigディレクトリ以外も削除できるように修正 #1638

### DIFF
--- a/src/Eccube/Controller/Admin/Content/CacheController.php
+++ b/src/Eccube/Controller/Admin/Content/CacheController.php
@@ -46,13 +46,13 @@ class CacheController extends AbstractController
 
             $data = $form->get('cache')->getData();
 
-            // 指定されたキャッシュクリア
             $cacheDir = $app['config']['root_dir'].'/app/cache';
 
             $filesystem = new Filesystem();
 
             foreach ($data as $dir) {
                 if (is_dir($cacheDir.'/'.$dir)) {
+                    // 指定されたキャッシュディレクトリを削除
                     $finder = Finder::create()->in($cacheDir.'/'.$dir);
                     $filesystem->remove($finder);
                 }

--- a/src/Eccube/Controller/Admin/Content/CacheController.php
+++ b/src/Eccube/Controller/Admin/Content/CacheController.php
@@ -26,7 +26,8 @@ namespace Eccube\Controller\Admin\Content;
 
 use Eccube\Application;
 use Eccube\Controller\AbstractController;
-use Eccube\Util\Cache;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Request;
 
 class CacheController extends AbstractController
@@ -35,24 +36,29 @@ class CacheController extends AbstractController
     public function index(Application $app, Request $request)
     {
 
-        $form = $app->form()->getForm();
+        $builder = $app['form.factory']->createBuilder('admin_cache');
 
-        if ('POST' === $request->getMethod()) {
+        $form = $builder->getForm();
 
-            $form->handleRequest($request);
+        $form->handleRequest($request);
 
-            if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
 
-                switch ($request->get('mode')) {
-                    case 'twig':
-                        // Twigキャッシュクリア
-                        Cache::clear($app, false, true);
-                        $app->addSuccess('admin.content.twig.cache.save.complete', 'admin');
-                        break;
-                    default:
-                        break;
+            $data = $form->get('cache')->getData();
+
+            // 指定されたキャッシュクリア
+            $cacheDir = $app['config']['root_dir'].'/app/cache';
+
+            $filesystem = new Filesystem();
+
+            foreach ($data as $dir) {
+                if (is_dir($cacheDir.'/'.$dir)) {
+                    $finder = Finder::create()->in($cacheDir.'/'.$dir);
+                    $filesystem->remove($finder);
                 }
             }
+
+            $app->addSuccess('admin.content.cache.save.complete', 'admin');
         }
 
         return $app->render('Content/cache.twig', array(

--- a/src/Eccube/Form/Type/Admin/CacheType.php
+++ b/src/Eccube/Form/Type/Admin/CacheType.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Form\Type\Admin;
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class CacheType extends AbstractType
+{
+
+    private $config;
+
+    public function __construct($config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+
+        // 対象となるキャッシュディレクトリを取得
+        // eccubeディレクトリは削除対象外とする
+        $finder = Finder::create()->notName('eccube')->depth(0);
+        $cacheDir = $this->config['root_dir'].'/app/cache';
+
+        $cacheDirs = array();
+        foreach ($finder->in($cacheDir) as $file) {
+            $cacheDirs[$file->getFilename()] = $file->getFilename();
+        }
+
+        $builder
+            ->add('cache', 'choice', array(
+                'label' => 'キャッシュディレクトリ',
+                'choices' => $cacheDirs,
+                'expanded' => true,
+                'multiple' => true,
+                'required' => true,
+                // デフォルトでtwigはチェックをいれる
+                'data' => array('twig'),
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                ),
+            ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'admin_cache';
+    }
+}

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -170,7 +170,7 @@ admin.content.template.delete.complete: テンプレートを削除しました�
 admin.content.template.delete.default.error: デフォルトテンプレートは削除できません。
 admin.content.template.delete.current.error: 現在設定中のテンプレートは削除できません。
 
-admin.content.twig.cache.save.complete: Twigキャッシュをクリアしました。
+admin.content.cache.save.complete: キャッシュを削除しました。
 
 admin.system.security.save.complete: セキュリティ設定を保存しました。
 admin.system.security.route.dir.complete: 管理画面のURLを変更しましたので再ログインをしてください。

--- a/src/Eccube/Resource/template/admin/Content/cache.twig
+++ b/src/Eccube/Resource/template/admin/Content/cache.twig
@@ -37,12 +37,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 <div id="cache_box__header" class="box-header">
                     <h3 class="box-title">キャッシュ管理</h3>
                     <div id="cache_box__message" style="margin-left: 10px;">
-                        <p class="text-danger">本番環境にFTPなどでTwigファイルをアップロードして入れ替えた場合、画面を反映させるにはTwigキャッシュをクリアをする必要があります。</p>
-                        <p>キャッシュをクリアをするには「キャッシュクリア」ボタンを押してください。</p>
+                        <p class="text-danger">本番環境にFTPなどでTwigファイルをアップロードして入れ替えた場合、画面を反映させるにはTwigキャッシュを削除する必要があります。</p>
+                        <p>キャッシュ削除するディレクトリを選択してください。</p>
                     </div>
+                    {{ form_row(form.cache) }}
                 </div>
                 <div id="cache_box__clear_button" class="box-body">
-                    <button type="submit" class="btn btn-primary" name="mode" value="twig">キャッシュクリア</button>
+                    <button type="submit" class="btn btn-primary">キャッシュ削除</button>
                 </div>
             </div>
         </div>

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -351,6 +351,7 @@ class EccubeServiceProvider implements ServiceProviderInterface
             $types[] = new \Eccube\Form\Type\Admin\DeliveryFeeType();
             $types[] = new \Eccube\Form\Type\Admin\DeliveryTimeType($app['config']);
             $types[] = new \Eccube\Form\Type\Admin\LogType($app['config']);
+            $types[] = new \Eccube\Form\Type\Admin\CacheType($app['config']);
 
             $types[] = new \Eccube\Form\Type\Admin\MasterdataType($app);
             $types[] = new \Eccube\Form\Type\Admin\MasterdataEditType($app);

--- a/tests/Eccube/Tests/Web/Admin/Content/CacheControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/CacheControllerTest.php
@@ -49,10 +49,10 @@ class CacheControllerTest extends AbstractAdminWebTestCase
 
         // makes the POST request
         $crawler = $client->request('POST', $url, array(
-            'form' => array(
-                '_token' => 'dummy',
+                'admin_cache' => array(
+                    '_token' => 'dummy',
+                    'cache' => array('twig'),
             ),
-            'mode' => 'twig',
         ));
 
         $this->assertFalse(file_exists($cacheDir.'/twig/sample'), 'sampleは削除済');


### PR DESCRIPTION
キャッシュ管理画面でtwigディレクトリ以外を削除できるように修正 #1638 

但し、eccubeディレクトリはセッション情報を保持するディレクトリのため削除対象外とする。
