### PR TITLE
Config ファイル を PHP で記述できるようにする対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,13 +4,8 @@ composer.phar
 /vendor/
 /app/cache/*
 !/app/cache/.gitkeep
-/app/config/eccube/config.yml
-/app/config/eccube/database.yml
-/app/config/eccube/constant.yml
-/app/config/eccube/mail.yml
-/app/config/eccube/path.yml
-/app/config/eccube/database.yml
-/app/config/eccube/log.yml
+/app/config/eccube/*
+!/app/config/eccube/.gitkeep
 /app/log/*
 !/app/log/.gitkeep
 /app/Plugin/*
@@ -33,6 +28,7 @@ composer.phar
 /html/user_data/*
 !/html/user_data/.gitkeep
 /phpunit.xml
+/src/Eccube/Resource/config/*.dist.php
 /tests/tmp/*
 /reports/*
 .idea

--- a/html/index.php
+++ b/html/index.php
@@ -33,7 +33,10 @@ if (php_sapi_name() === 'cli-server' && is_file($filename)) {
     return false;
 }
 
-$app = \Eccube\Application::getInstance();
+// output_config_php = true に設定することで、Config Yaml ファイルを元に Config PHP ファイルが出力されます。
+// Config PHP ファイルが存在する場合は、 Config Yaml より優先されます。
+// Yaml ファイルをパースする必要が無いため、高速化が期待できます。
+$app = \Eccube\Application::getInstance(array('output_config_php' => false));
 
 // インストールされてなければインストーラにリダイレクト
 if ($app['config']['eccube_install']) {

--- a/html/index_dev.php
+++ b/html/index_dev.php
@@ -52,8 +52,10 @@ if (php_sapi_name() === 'cli-server' && is_file($filename)) {
     return false;
 }
 
-// load configs.
-$app = \Eccube\Application::getInstance();
+// output_config_php = true に設定することで、Config Yaml ファイルを元に Config PHP ファイルが出力されます。
+// Config PHP ファイルが存在する場合は、 Config Yaml より優先されます。
+// Yaml ファイルをパースする必要が無いため、高速化が期待できます。
+$app = \Eccube\Application::getInstance(array('output_config_php' => false));
 
 // debug enable.
 $app['debug'] = true;

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -76,9 +76,10 @@ class Application extends ApplicationTrait
     public function initConfig()
     {
         // load config
-        $this['config'] = $this->share(function() {
+        $app = $this;
+        $this['config'] = $this->share(function() use ($app) {
             $configAll = array();
-            $this->parseConfig('constant', $configAll)
+            $app->parseConfig('constant', $configAll)
                 ->parseConfig('path', $configAll)
                 ->parseConfig('config', $configAll)
                 ->parseConfig('database', $configAll)
@@ -911,7 +912,7 @@ class Application extends ApplicationTrait
      * @param string $distPath config yaml dist を格納したディレクトリ
      * @return Application
      */
-    protected function parseConfig($config_name, array &$configAll, $wrap_key = false, $ymlPath = null, $distPath = null)
+    public function parseConfig($config_name, array &$configAll, $wrap_key = false, $ymlPath = null, $distPath = null)
     {
         $ymlPath = $ymlPath ? $ymlPath : __DIR__.'/../../app/config/eccube';
         $distPath = $distPath ? $distPath : __DIR__.'/../../src/Eccube/Resource/config';

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -152,18 +152,18 @@ class Application extends ApplicationTrait
 
             $configAll = array_replace_recursive($configAll, $config_nav_dist, $config_nav);
 
-            $config_cache = array();
-            $yml = $ymlPath.'/cache.yml';
+            $config_doctrine_cache = array();
+            $yml = $ymlPath.'/doctrine_cache.yml';
             if (file_exists($yml)) {
-                $config_cache = Yaml::parse(file_get_contents($yml));
+                $config_doctrine_cache = Yaml::parse(file_get_contents($yml));
             }
-            $config_cache_dist = array();
-            $cache_yml_dist = $distPath.'/cache.yml.dist';
-            if (file_exists($cache_yml_dist)) {
-                $config_cache_dist = Yaml::parse(file_get_contents($cache_yml_dist));
+            $config_doctrine_cache_dist = array();
+            $doctrine_cache_yml_dist = $distPath.'/doctrine_cache.yml.dist';
+            if (file_exists($doctrine_cache_yml_dist)) {
+                $config_doctrine_cache_dist = Yaml::parse(file_get_contents($doctrine_cache_yml_dist));
             }
 
-            $configAll = array_replace_recursive($configAll, $config_cache_dist, $config_cache);
+            $configAll = array_replace_recursive($configAll, $config_doctrine_cache_dist, $config_doctrine_cache);
 
             return $configAll;
         });
@@ -502,8 +502,8 @@ class Application extends ApplicationTrait
         }
 
         $cacheDrivers = array();
-        if (array_key_exists('cache', $this['config'])) {
-            $cacheDrivers = $this['config']['cache'];
+        if (array_key_exists('doctrine_cache', $this['config'])) {
+            $cacheDrivers = $this['config']['doctrine_cache'];
         }
 
         $options = array(
@@ -524,7 +524,7 @@ class Application extends ApplicationTrait
         }
 
         $this->register(new \Dflydev\Silex\Provider\DoctrineOrm\DoctrineOrmServiceProvider(), array(
-            'orm.proxies_dir' => __DIR__.'/../../app/cache/doctrine',
+            'orm.proxies_dir' => __DIR__.'/../../app/cache/doctrine/proxies',
             'orm.em.options' => $options
         ));
     }

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -911,11 +911,10 @@ class Application extends ApplicationTrait
      * @param string $distPath config yaml dist を格納したディレクトリ
      * @return Application
      */
-    protected function parseConfig($config_name, array &$configAll,
-                                   $wrap_key = false,
-                                   $ymlPath = __DIR__.'/../../app/config/eccube',
-                                   $distPath = __DIR__.'/../../src/Eccube/Resource/config')
+    protected function parseConfig($config_name, array &$configAll, $wrap_key = false, $ymlPath = null, $distPath = null)
     {
+        $ymlPath = $ymlPath ? $ymlPath : __DIR__.'/../../app/config/eccube';
+        $distPath = $distPath ? $distPath : __DIR__.'/../../src/Eccube/Resource/config';
         $config = array();
         $config_php = $ymlPath.'/'.$config_name.'.php';
         if (!file_exists($config_php)) {

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -77,94 +77,15 @@ class Application extends ApplicationTrait
     {
         // load config
         $this['config'] = $this->share(function() {
-            $ymlPath = __DIR__.'/../../app/config/eccube';
-            $distPath = __DIR__.'/../../src/Eccube/Resource/config';
-
-            $config = array();
-            $config_yml = $ymlPath.'/config.yml';
-            if (file_exists($config_yml)) {
-                $config = Yaml::parse(file_get_contents($config_yml));
-            }
-
-            $config_dist = array();
-            $config_yml_dist = $distPath.'/config.yml.dist';
-            if (file_exists($config_yml_dist)) {
-                $config_dist = Yaml::parse(file_get_contents($config_yml_dist));
-            }
-
-            $config_path = array();
-            $path_yml = $ymlPath.'/path.yml';
-            if (file_exists($path_yml)) {
-                $config_path = Yaml::parse(file_get_contents($path_yml));
-            }
-
-            $config_constant = array();
-            $constant_yml = $ymlPath.'/constant.yml';
-            if (file_exists($constant_yml)) {
-                $config_constant = Yaml::parse(file_get_contents($constant_yml));
-                $config_constant = empty($config_constant) ? array() : $config_constant;
-            }
-
-            $config_constant_dist = array();
-            $constant_yml_dist = $distPath.'/constant.yml.dist';
-            if (file_exists($constant_yml_dist)) {
-                $config_constant_dist = Yaml::parse(file_get_contents($constant_yml_dist));
-            }
-
-            $configAll = array_replace_recursive($config_constant_dist, $config_dist, $config_constant, $config_path, $config);
-
-            $database = array();
-            $yml = $ymlPath.'/database.yml';
-            if (file_exists($yml)) {
-                $database = Yaml::parse(file_get_contents($yml));
-            }
-
-            $mail = array();
-            $yml = $ymlPath.'/mail.yml';
-            if (file_exists($yml)) {
-                $mail = Yaml::parse(file_get_contents($yml));
-            }
-            $configAll = array_replace_recursive($configAll, $database, $mail);
-
-            $config_log = array();
-            $yml = $ymlPath.'/log.yml';
-            if (file_exists($yml)) {
-                $config_log = Yaml::parse(file_get_contents($yml));
-            }
-            $config_log_dist = array();
-            $log_yml_dist = $distPath.'/log.yml.dist';
-            if (file_exists($log_yml_dist)) {
-                $config_log_dist = Yaml::parse(file_get_contents($log_yml_dist));
-            }
-
-            $configAll = array_replace_recursive($configAll, $config_log_dist, $config_log);
-
-            $config_nav = array();
-            $yml = $ymlPath.'/nav.yml';
-            if (file_exists($yml)) {
-                $config_nav = array('nav' => Yaml::parse(file_get_contents($yml)));
-            }
-            $config_nav_dist = array();
-            $nav_yml_dist = $distPath.'/nav.yml.dist';
-            if (file_exists($nav_yml_dist)) {
-                $config_nav_dist = array('nav' => Yaml::parse(file_get_contents($nav_yml_dist)));
-            }
-
-            $configAll = array_replace_recursive($configAll, $config_nav_dist, $config_nav);
-
-            $config_doctrine_cache = array();
-            $yml = $ymlPath.'/doctrine_cache.yml';
-            if (file_exists($yml)) {
-                $config_doctrine_cache = Yaml::parse(file_get_contents($yml));
-            }
-            $config_doctrine_cache_dist = array();
-            $doctrine_cache_yml_dist = $distPath.'/doctrine_cache.yml.dist';
-            if (file_exists($doctrine_cache_yml_dist)) {
-                $config_doctrine_cache_dist = Yaml::parse(file_get_contents($doctrine_cache_yml_dist));
-            }
-
-            $configAll = array_replace_recursive($configAll, $config_doctrine_cache_dist, $config_doctrine_cache);
-
+            $configAll = array();
+            $this->parseConfig('constant', $configAll)
+                ->parseConfig('path', $configAll)
+                ->parseConfig('config', $configAll)
+                ->parseConfig('database', $configAll)
+                ->parseConfig('mail', $configAll)
+                ->parseConfig('log', $configAll)
+                ->parseConfig('nav', $configAll, true)
+                ->parseConfig('doctrine_cache', $configAll);
             return $configAll;
         });
     }
@@ -975,5 +896,41 @@ class Application extends ApplicationTrait
             die();
         }
         return true;
+    }
+
+    /**
+     * Config ファイルをパースし、連想配列を返します.
+     *
+     * @param string $config_name Config 名称
+     * @param array $configAll Config の連想配列
+     * @param boolean $wrap_key Config の連想配列に config_name のキーを生成する場合 true, デフォルト false
+     * @param string $ymlPath config yaml を格納したディレクトリ
+     * @param string $distPath config yaml dist を格納したディレクトリ
+     * @return Application
+     */
+    protected function parseConfig($config_name, array &$configAll,
+                                   $wrap_key = false,
+                                   $ymlPath = __DIR__.'/../../app/config/eccube',
+                                   $distPath = __DIR__.'/../../src/Eccube/Resource/config')
+    {
+        $config = array();
+        $config_yml = $ymlPath.'/'.$config_name.'.yml';
+        if (file_exists($config_yml)) {
+            $config = Yaml::parse(file_get_contents($config_yml));
+            $config = empty($config) ? array() : $config;
+        }
+
+        $config_dist = array();
+        $config_yml_dist = $distPath.'/'.$config_name.'.yml.dist';
+        if (file_exists($config_yml_dist)) {
+            $config_dist = Yaml::parse(file_get_contents($config_yml_dist));
+        }
+
+        if ($wrap_key) {
+            $configAll = array_replace_recursive($configAll, array($config_name => $config_dist), array($config_name => $config));
+        } else {
+            $configAll = array_replace_recursive($configAll, $config_dist, $config);
+        }
+        return $this;
     }
 }

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -152,6 +152,19 @@ class Application extends ApplicationTrait
 
             $configAll = array_replace_recursive($configAll, $config_nav_dist, $config_nav);
 
+            $config_cache = array();
+            $yml = $ymlPath.'/cache.yml';
+            if (file_exists($yml)) {
+                $config_cache = Yaml::parse(file_get_contents($yml));
+            }
+            $config_cache_dist = array();
+            $cache_yml_dist = $distPath.'/cache.yml.dist';
+            if (file_exists($cache_yml_dist)) {
+                $config_cache_dist = Yaml::parse(file_get_contents($cache_yml_dist));
+            }
+
+            $configAll = array_replace_recursive($configAll, $config_cache_dist, $config_cache);
+
             return $configAll;
         });
     }
@@ -488,11 +501,31 @@ class Application extends ApplicationTrait
             }
         }
 
+        $cacheDrivers = array();
+        if (array_key_exists('cache', $this['config'])) {
+            $cacheDrivers = $this['config']['cache'];
+        }
+
+        $options = array(
+            'mappings' => $ormMappings
+        );
+
+        if (array_key_exists('metadata_cache', $cacheDrivers)) {
+            $options['metadata_cache'] = $cacheDrivers['metadata_cache'];
+        }
+        if (array_key_exists('query_cache', $cacheDrivers)) {
+            $options['query_cache'] = $cacheDrivers['query_cache'];
+        }
+        if (array_key_exists('result_cache', $cacheDrivers)) {
+            $options['result_cache'] = $cacheDrivers['result_cache'];
+        }
+        if (array_key_exists('hydration_cache', $cacheDrivers)) {
+            $options['hydration_cache'] = $cacheDrivers['hydration_cache'];
+        }
+
         $this->register(new \Dflydev\Silex\Provider\DoctrineOrm\DoctrineOrmServiceProvider(), array(
             'orm.proxies_dir' => __DIR__.'/../../app/cache/doctrine',
-            'orm.em.options' => array(
-                'mappings' => $ormMappings,
-            ),
+            'orm.em.options' => $options
         ));
     }
 

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -501,26 +501,28 @@ class Application extends ApplicationTrait
             }
         }
 
-        $cacheDrivers = array();
-        if (array_key_exists('doctrine_cache', $this['config'])) {
-            $cacheDrivers = $this['config']['doctrine_cache'];
-        }
-
         $options = array(
             'mappings' => $ormMappings
         );
 
-        if (array_key_exists('metadata_cache', $cacheDrivers)) {
-            $options['metadata_cache'] = $cacheDrivers['metadata_cache'];
-        }
-        if (array_key_exists('query_cache', $cacheDrivers)) {
-            $options['query_cache'] = $cacheDrivers['query_cache'];
-        }
-        if (array_key_exists('result_cache', $cacheDrivers)) {
-            $options['result_cache'] = $cacheDrivers['result_cache'];
-        }
-        if (array_key_exists('hydration_cache', $cacheDrivers)) {
-            $options['hydration_cache'] = $cacheDrivers['hydration_cache'];
+        if (!$this['debug']) {
+            $cacheDrivers = array();
+            if (array_key_exists('doctrine_cache', $this['config'])) {
+                $cacheDrivers = $this['config']['doctrine_cache'];
+            }
+
+            if (array_key_exists('metadata_cache', $cacheDrivers)) {
+                $options['metadata_cache'] = $cacheDrivers['metadata_cache'];
+            }
+            if (array_key_exists('query_cache', $cacheDrivers)) {
+                $options['query_cache'] = $cacheDrivers['query_cache'];
+            }
+            if (array_key_exists('result_cache', $cacheDrivers)) {
+                $options['result_cache'] = $cacheDrivers['result_cache'];
+            }
+            if (array_key_exists('hydration_cache', $cacheDrivers)) {
+                $options['hydration_cache'] = $cacheDrivers['hydration_cache'];
+            }
         }
 
         $this->register(new \Dflydev\Silex\Provider\DoctrineOrm\DoctrineOrmServiceProvider(), array(

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -50,8 +50,13 @@ class SecurityController extends AbstractController
                 // 現在のセキュリティ情報を更新
                 $adminRoot = $app['config']['admin_route'];
 
-                $configFile = $app['config']['root_dir'] . '/app/config/eccube/config.yml';
-                $config = Yaml::parse(file_get_contents($configFile));
+                $configFile = $app['config']['root_dir'].'/app/config/eccube/config';
+                if (file_exists($configFile.'.php')) {
+                    $config = require $configFile.'.php';
+                } elseif (file_exists($configFile.'.yml')) {
+                    $config = Yaml::parse(file_get_contents($configFile.'.yml'));
+                }
+
                 // trim処理
                 $allowHost = Str::convertLineFeed($data['admin_allow_host']);
                 if (empty($allowHost)) {
@@ -76,15 +81,31 @@ class SecurityController extends AbstractController
                 $form = $builder->getForm();
                 $form->setData($data);
 
-                file_put_contents($configFile, Yaml::dump($config));
+                if (file_exists($configFile.'.php')) {
+                    file_put_contents($configFile.'.php', sprintf('<?php return %s', var_export($config, true)).';');
+                }
+                if (file_exists($configFile.'.yml')) {
+                    file_put_contents($configFile.'.yml', Yaml::dump($config));
+                }
 
                 if ($adminRoot != $data['admin_route_dir']) {
-                    // admin_routeが変更されればpath.ymlを更新
-                    $pathFile = $app['config']['root_dir'] . '/app/config/eccube/path.yml';
-                    $config = Yaml::parse(file_get_contents($pathFile));
+                    // admin_routeが変更されればpath.(yml|php)を更新
+                    $pathFile = $app['config']['root_dir'].'/app/config/eccube/path';
+
+                    if (file_exists($pathFile.'.php')) {
+                        $config = require $pathFile.'.php';
+                    } elseif (file_exists($pathFile.'.yml')) {
+                        $config = Yaml::parse(file_get_contents($pathFile.'.yml'));
+                    }
+
                     $config['admin_route'] = $data['admin_route_dir'];
 
-                    file_put_contents($pathFile, Yaml::dump($config));
+                    if (file_exists($pathFile.'.php')) {
+                        file_put_contents($pathFile.'.php', sprintf('<?php return %s', var_export($config, true)).';');
+                    }
+                    if (file_exists($pathFile.'.yml')) {
+                        file_put_contents($pathFile.'.yml', Yaml::dump($config));
+                    }
 
                     $app->addSuccess('admin.system.security.route.dir.complete', 'admin');
 
@@ -92,7 +113,7 @@ class SecurityController extends AbstractController
                     $this->getSecurity($app)->setToken(null);
 
                     // 管理者画面へ再ログイン
-                    return $app->redirect($request->getBaseUrl() . '/' . $config['admin_route']);
+                    return $app->redirect($request->getBaseUrl().'/'.$config['admin_route']);
                 }
 
                 $app->addSuccess('admin.system.security.save.complete', 'admin');

--- a/src/Eccube/Controller/Admin/Store/TemplateController.php
+++ b/src/Eccube/Controller/Admin/Store/TemplateController.php
@@ -64,18 +64,27 @@ class TemplateController extends AbstractController
                 $Template = $app['eccube.repository.template']
                     ->find($form['selected']->getData());
 
-                // path.ymlの再構築
-                $file = $app['config']['root_dir'] . '/app/config/eccube/path.yml';
-                $config = Yaml::parse(file_get_contents($file));
+                // path.(yml|php)の再構築
+                $file = $app['config']['root_dir'].'/app/config/eccube/path';
+                if (file_exists($file.'.php')) {
+                    $config = require $file.'.php';
+                } elseif (file_exists($file.'.yml')) {
+                    $config = Yaml::parse(file_get_contents($file));
+                }
 
                 $templateCode = $Template->getCode();
                 $config['template_code'] = $templateCode;
-                $config['template_realdir'] = $config['root_dir'] . '/app/template/' . $templateCode;
-                $config['template_html_realdir'] = $config['public_path_realdir'] . '/template/' . $templateCode;
-                $config['front_urlpath'] = $config['root_urlpath'] . '/template/' . $templateCode;
-                $config['block_realdir'] =$config['template_realdir'] . '/Block';
+                $config['template_realdir'] = $config['root_dir'].'/app/template/'.$templateCode;
+                $config['template_html_realdir'] = $config['public_path_realdir'].'/template/'.$templateCode;
+                $config['front_urlpath'] = $config['root_urlpath'].'/template/'.$templateCode;
+                $config['block_realdir'] =$config['template_realdir'].'/Block';
 
-                file_put_contents($file, Yaml::dump($config));
+                if (file_exists($file.'.php')) {
+                    file_put_contents($file.'.php', sprintf('<?php return %s', var_export($config, true)).';');
+                }
+                if (file_exists($file.'.yml')) {
+                    file_put_contents($file.'.yml', Yaml::dump($config));
+                }
 
                 $app->addSuccess('admin.content.template.save.complete', 'admin');
 

--- a/src/Eccube/Resource/config/cache.yml.dist
+++ b/src/Eccube/Resource/config/cache.yml.dist
@@ -1,0 +1,25 @@
+cache:
+  metadata_cache:
+    driver: array
+    path:
+    host:
+    port:
+    password:
+  query_cache:
+    driver: array
+    path:
+    host:
+    port:
+    password:
+  result_cache:
+    driver: array
+    path:
+    host:
+    port:
+    password:
+  hydration_cache:
+    driver: array
+    path:
+    host:
+    port:
+    password:


### PR DESCRIPTION
- #1672 の後にマージをお願いします
- #1638
- Application::initConfig() のリファクタリング
- Config PHP ファイルが存在する場合は、 Config Yaml より優先されます。
- $app['output_config_php'] オプションの追加
   - output_config_php = true に設定することで、Config Yaml ファイルを元に Config PHP ファイルが出力されます。
- Config PHP ファイルを使用すると、 Yaml ファイルをパースする必要が無いため、高速化が期待できます。

PHP5.4以降でしたら、以下のような、可読性のよい Config PHP ファイルを使用できます。

```php
<?php
// app/config/eccube/config.php
return [
    'auth_magic' => 'tmdKGUaT8iaB2ROAhpL0oKLXOGbe4Uut',
    'password_hash_algos' => 'sha256',
    'shop_name' => 'EC-CUBE3',
    'force_ssl' => null,
    'admin_allow_host' => [],
    'cookie_lifetime' => 0,
    'locale' => 'ja',
    'timezonee' => 'Asia/Tokyo',
    'eccube_install' => 1
];

```