### PR TITLE
複数配送のテストケースを追加

### DIFF
--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -170,6 +170,18 @@ abstract class EccubeTestCase extends WebTestCase
     }
 
     /**
+     * CustomerAddress を生成して返す.
+     *
+     * @param Customer $Customer 対象の Customer インスタンス
+     * @param boolean $is_nonmember 非会員の場合 true
+     * @return \Eccube\Entity\CustomerAddress
+     */
+    public function createCustomerAddress(Customer $Customer, $is_nonmember = false)
+    {
+        return $this->app['eccube.fixture.generator']->createCustomerAddress($Customer, $is_nonmember);
+    }
+
+    /**
      * 非会員の Customer オブジェクトを生成して返す.
      *
      * @param string $email メールアドレス. null の場合は, ランダムなメールアドレスが生成される.

--- a/tests/Eccube/Tests/Repository/CustomerRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/CustomerRepositoryGetQueryBuilderBySearchDataTest.php
@@ -257,6 +257,10 @@ class CustomerRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
         $pref_id = 26;
         $Pref = $this->app['eccube.repository.master.pref']->find($pref_id);
         $this->Customer->setPref($Pref);
+        $Pref2 = $this->app['eccube.repository.master.pref']->find(1);
+        $this->Customer1->setPref($Pref2);
+        $this->Customer2->setPref($Pref2);
+        $this->Customer3->setPref($Pref2);
         $this->app['orm.em']->flush();
 
         $this->searchData = array(
@@ -278,6 +282,8 @@ class CustomerRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
         $Female = $this->app['eccube.repository.master.sex']->find(2);
         $this->Customer->setSex($Male);
         $this->Customer1->setSex($Female);
+        $this->Customer2->setSex(null);
+        $this->Customer3->setSex(null);
         $this->app['orm.em']->flush();
 
         $this->searchData = array(
@@ -308,6 +314,9 @@ class CustomerRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
     {
         $birth = '2006-09-01';
         $this->Customer->setBirth(new \DateTime($birth));
+        $this->Customer1->setBirth(null);
+        $this->Customer2->setBirth(null);
+        $this->Customer3->setBirth(null);
         $this->app['orm.em']->flush();
 
         $this->searchData = array(
@@ -325,6 +334,9 @@ class CustomerRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
     {
         $birth = '2006-09-01';
         $this->Customer->setBirth(new \DateTime($birth));
+        $this->Customer1->setBirth(null);
+        $this->Customer2->setBirth(null);
+        $this->Customer3->setBirth(null);
         $this->app['orm.em']->flush();
 
         $this->searchData = array(
@@ -342,6 +354,9 @@ class CustomerRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
     {
         $birth = '2006-09-01';
         $this->Customer->setBirth(new \DateTime($birth));
+        $this->Customer1->setBirth(null);
+        $this->Customer2->setBirth(null);
+        $this->Customer3->setBirth(null);
         $this->app['orm.em']->flush();
 
         $this->searchData = array(
@@ -359,6 +374,9 @@ class CustomerRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
     {
         $birth = '2006-09-01';
         $this->Customer->setBirth(new \DateTime($birth));
+        $this->Customer1->setBirth(null);
+        $this->Customer2->setBirth(null);
+        $this->Customer3->setBirth(null);
         $this->app['orm.em']->flush();
 
         $this->searchData = array(
@@ -377,6 +395,18 @@ class CustomerRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
         $this->Customer
             ->setTel01('090')
             ->setTel02('999')
+            ->setTel03('000');
+        $this->Customer1
+            ->setTel01('090')
+            ->setTel02('111')
+            ->setTel03('000');
+        $this->Customer2
+            ->setTel01('090')
+            ->setTel02('222')
+            ->setTel03('000');
+        $this->Customer3
+            ->setTel01('090')
+            ->setTel02('333')
             ->setTel03('000');
         $this->app['orm.em']->flush();
 

--- a/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataAdminTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataAdminTest.php
@@ -192,13 +192,13 @@ class OrderRepositoryGetQueryBuilderBySearchDataAdminTest extends EccubeTestCase
     public function testTel()
     {
         $this->Order1
-            ->setTel01('090')
+            ->setTel01('999')
             ->setTel02('9999')
             ->setTel03('8888');
         $this->app['orm.em']->flush();
 
         $this->searchData = array(
-            'tel' => '090'
+            'tel' => '999'
         );
         $this->scenario();
 
@@ -242,6 +242,7 @@ class OrderRepositoryGetQueryBuilderBySearchDataAdminTest extends EccubeTestCase
         $Male = $this->app['eccube.repository.master.sex']->find(1);
         $Female = $this->app['eccube.repository.master.sex']->find(2);
         $this->Order1->setSex($Male);
+        $this->Order2->setSex(null);
         $this->app['orm.em']->flush();
 
         $Sexs = new ArrayCollection(array($Male, $Female));

--- a/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataTest.php
@@ -28,15 +28,15 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
         $this->createProduct();
         $this->Customer = $this->createCustomer();
         $this->Customer->setName01('立方体長');
-        $Customer2 = $this->createCustomer();
-        $Customer2->setName01('立方隊員');
+        $this->Customer2 = $this->createCustomer();
+        $this->Customer2->setName01('立方隊員');
         $this->app['orm.em']->persist($this->Customer);
-        $this->app['orm.em']->persist($Customer2);
+        $this->app['orm.em']->persist($this->Customer2);
         $this->app['orm.em']->flush();
 
         $this->Order = $this->createOrder($this->Customer);
         $this->Order1 = $this->createOrder($this->Customer);
-        $this->Order2 = $this->createOrder($Customer2);
+        $this->Order2 = $this->createOrder($this->Customer2);
     }
 
     public function scenario()
@@ -131,11 +131,11 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
 
     public function testTel01()
     {
-        $this->Order1->setTel01('090');
+        $this->Order1->setTel01('999');
         $this->app['orm.em']->flush();
 
         $this->searchData = array(
-            'tel01' => '090'
+            'tel01' => '999'
         );
         $this->scenario();
 
@@ -146,11 +146,11 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
 
     public function testTel02()
     {
-        $this->Order1->setTel02('090');
+        $this->Order1->setTel02('999');
         $this->app['orm.em']->flush();
 
         $this->searchData = array(
-            'tel02' => '090'
+            'tel02' => '999'
         );
         $this->scenario();
 
@@ -161,11 +161,11 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
 
     public function testTel03()
     {
-        $this->Order1->setTel03('090');
+        $this->Order1->setTel03('999');
         $this->app['orm.em']->flush();
 
         $this->searchData = array(
-            'tel03' => '090'
+            'tel03' => '999'
         );
         $this->scenario();
 
@@ -177,6 +177,7 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
     public function testBirthStart()
     {
         $this->Customer->setBirth(new \DateTime('2006-09-01'));
+        $this->Customer2->setBirth(null);
         $this->app['orm.em']->flush();
 
         $this->searchData = array(
@@ -192,6 +193,7 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
     public function testBirthEnd()
     {
         $this->Customer->setBirth(new \DateTime('2006-09-01'));
+        $this->Customer2->setBirth(null);
         $this->app['orm.em']->flush();
 
         $this->searchData = array(
@@ -209,6 +211,7 @@ class OrderRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
         $Male = $this->app['eccube.repository.master.sex']->find(1);
         $Female = $this->app['eccube.repository.master.sex']->find(2);
         $this->Customer->setSex($Male);
+        $this->Customer2->setSex(null);
         $this->app['orm.em']->flush();
 
         $this->searchData = array(

--- a/tests/Eccube/Tests/Service/ShoppingServiceTest.php
+++ b/tests/Eccube/Tests/Service/ShoppingServiceTest.php
@@ -125,7 +125,7 @@ class ShoppingServiceTest extends AbstractServiceTestCase
         $this->actual = $Customer->getEmail();
         $this->verify('セッションのメールアドレスが一致するか');
 
-        $this->expected = 1;
+        $this->expected = $NonMember->getPref()->getId();
         $this->actual = $Customer->getPref()->getId();
         $this->verify('都道府県IDが一致するか');
     }

--- a/tests/Eccube/Tests/Web/AbstractShoppingControllerTestCase.php
+++ b/tests/Eccube/Tests/Web/AbstractShoppingControllerTestCase.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Eccube\Tests\Web;
+
+/**
+ * ShoppingController 用 WebTest の抽象クラス.
+ *
+ * ShoppingController の WebTest をする場合に汎用的に使用する.
+ *
+ * @author Kentaro Ohkouchi
+ */
+abstract class AbstractShoppingControllerTestCase extends AbstractWebTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->initializeMailCatcher();
+    }
+
+    public function tearDown()
+    {
+        $this->cleanUpMailCatcherMessages();
+        parent::tearDown();
+    }
+
+    public function createShippingFormData()
+    {
+        $faker = $this->getFaker();
+        $tel = explode('-', $faker->phoneNumber);
+
+        $email = $faker->safeEmail;
+
+        $form = array(
+            'name' => array(
+                'name01' => $faker->lastName,
+                'name02' => $faker->firstName,
+            ),
+            'kana' => array(
+                'kana01' => $faker->lastKanaName ,
+                'kana02' => $faker->firstKanaName,
+            ),
+            'company_name' => $faker->company,
+            'zip' => array(
+                'zip01' => $faker->postcode1(),
+                'zip02' => $faker->postcode2(),
+            ),
+            'address' => array(
+                'pref' => '5',
+                'addr01' => $faker->city,
+                'addr02' => $faker->streetAddress,
+            ),
+            'tel' => array(
+                'tel01' => $tel[0],
+                'tel02' => $tel[1],
+                'tel03' => $tel[2],
+            ),
+            '_token' => 'dummy'
+        );
+        return $form;
+    }
+
+    protected function scenarioCartIn($client, $product_class_id = 1)
+    {
+        $crawler = $client->request('POST', '/cart/add', array('product_class_id' => $product_class_id));
+        $this->app['eccube.service.cart']->lock();
+        return $crawler;
+    }
+
+    protected function scenarioInput($client, $formData)
+    {
+        $crawler = $client->request(
+            'POST',
+            $this->app->path('shopping_nonmember'),
+            array('nonmember' => $formData)
+        );
+        $this->app['eccube.service.cart']->lock();
+        return $crawler;
+    }
+
+    protected function scenarioConfirm($client)
+    {
+        $crawler = $client->request('GET', $this->app->path('shopping'));
+        return $crawler;
+    }
+
+    protected function scenarioComplete($client, $confirm_url, array $shippings = array())
+    {
+        $faker = $this->getFaker();
+        if (count($shippings) < 1) {
+            $shippings = array(
+                array(
+                    'delivery' => 1,
+                    'deliveryTime' => 1
+                ),
+            );
+        }
+
+        $crawler = $client->request(
+            'POST',
+            $confirm_url,
+            array('shopping' =>
+                  array(
+                      'shippings' => $shippings,
+                      'payment' => 1,
+                      'message' => $faker->text(),
+                      '_token' => 'dummy'
+                  )
+            )
+        );
+        return $crawler;
+    }
+}

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -24,20 +24,8 @@
 
 namespace Eccube\Tests\Web;
 
-class ShoppingControllerTest extends AbstractWebTestCase
+class ShoppingControllerTest extends AbstractShoppingControllerTestCase
 {
-
-    public function setUp()
-    {
-        parent::setUp();
-        $this->initializeMailCatcher();
-    }
-
-    public function tearDown()
-    {
-        $this->cleanUpMailCatcherMessages();
-        parent::tearDown();
-    }
 
     public function testRoutingShoppingLogin()
     {
@@ -420,90 +408,5 @@ class ShoppingControllerTest extends AbstractWebTestCase
         // https://github.com/EC-CUBE/ec-cube/issues/1305
         $this->assertRegexp('/111-111-111/', $this->parseMailCatcherSource($Message), '変更した FAX 番号が一致するか');
         $this->assertRegexp('/222-222-222/', $this->parseMailCatcherSource($Message), '変更した 電話番号が一致するか');
-    }
-
-
-    public function createShippingFormData()
-    {
-        $faker = $this->getFaker();
-        $tel = explode('-', $faker->phoneNumber);
-
-        $email = $faker->safeEmail;
-
-        $form = array(
-            'name' => array(
-                'name01' => $faker->lastName,
-                'name02' => $faker->firstName,
-            ),
-            'kana' => array(
-                'kana01' => $faker->lastKanaName ,
-                'kana02' => $faker->firstKanaName,
-            ),
-            'company_name' => $faker->company,
-            'zip' => array(
-                'zip01' => $faker->postcode1(),
-                'zip02' => $faker->postcode2(),
-            ),
-            'address' => array(
-                'pref' => '5',
-                'addr01' => $faker->city,
-                'addr02' => $faker->streetAddress,
-            ),
-            'tel' => array(
-                'tel01' => $tel[0],
-                'tel02' => $tel[1],
-                'tel03' => $tel[2],
-            ),
-            '_token' => 'dummy'
-        );
-        return $form;
-    }
-
-    protected function scenarioCartIn($client)
-    {
-        $crawler = $client->request('POST', '/cart/add', array('product_class_id' => 1));
-        $this->app['eccube.service.cart']->lock();
-        return $crawler;
-    }
-
-    protected function scenarioInput($client, $formData)
-    {
-        $crawler = $client->request(
-            'POST',
-            $this->app->path('shopping_nonmember'),
-            array('nonmember' => $formData)
-        );
-        $this->app['eccube.service.cart']->lock();
-        return $crawler;
-    }
-
-    protected function scenarioConfirm($client)
-    {
-        $crawler = $client->request('GET', $this->app->path('shopping'));
-        return $crawler;
-    }
-
-    protected function scenarioComplete($client, $confirm_url)
-    {
-        $faker = $this->getFaker();
-        $crawler = $client->request(
-            'POST',
-            $confirm_url,
-            array('shopping' =>
-                  array(
-                      'shippings' =>
-                      array(0 =>
-                            array(
-                                'delivery' => 1,
-                                'deliveryTime' => 1
-                            ),
-                      ),
-                      'payment' => 1,
-                      'message' => $faker->text(),
-                      '_token' => 'dummy'
-                  )
-            )
-        );
-        return $crawler;
     }
 }

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Eccube\Tests\Web;
+
+/**
+ * 複数配送指定のテストケース.
+ *
+ * @author Kentaro Ohkouchi
+ */
+class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestCase
+{
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        // 複数配送を有効に
+        $BaseInfo->setOptionMultipleShipping(1);
+        $this->app['orm.em']->flush($BaseInfo);
+    }
+
+    public function tearDown()
+    {
+        $this->cleanUpMailCatcherMessages();
+        parent::tearDown();
+    }
+
+    /**
+     * カート→購入確認画面→複数配送設定画面→購入確認画面→完了画面
+     */
+    public function testCompleteWithLogin()
+    {
+        $faker = $this->getFaker();
+        $Customer = $this->logIn();
+        $CustomerAddress = $this->createCustomerAddress($Customer);
+
+        $client = $this->client;
+        // カート画面
+        $this->scenarioCartIn($client);
+        $this->scenarioCartIn($client); // 2個カート投入
+
+        // 確認画面
+        $crawler = $this->scenarioConfirm($client);
+        $this->expected = 'ご注文内容のご確認';
+        $this->actual = $crawler->filter('h1.page-heading')->text();
+        $this->verify();
+
+        // 複数配送画面
+        $crawler = $client->request('GET', $this->app->path('shopping_shipping_multiple'));
+
+        // 配送先1, 配送先2の情報を返す
+        $shippings = $crawler->filter('#form_shipping_multiple_0_shipping_0_customer_address > option')->each(
+            function ($node, $i) {
+                return array(
+                    'customer_address' => $node->attr('value'),
+                    'quantity' => 1
+                );
+            }
+        );
+
+        $crawler = $client->request(
+            'POST',
+            $this->app->path('shopping_shipping_multiple'),
+            array('form' =>
+                  array(
+                      'shipping_multiple' =>
+                      array(0 =>
+                            array(
+                                // 配送先1, 配送先2 の 情報を渡す
+                                'shipping' => $shippings
+                            )
+                      ),
+                      '_token' => 'dummy'
+                  )
+            )
+        );
+
+        // 確認画面
+        $crawler = $this->scenarioConfirm($client);
+
+        // 完了画面
+        $crawler = $this->scenarioComplete(
+            $client,
+            $this->app->path('shopping_confirm'),
+            array(
+                // 配送先1
+                array(
+                    'delivery' => 1,
+                    'deliveryTime' => 1
+                ),
+                // 配送先2
+                array(
+                    'delivery' => 1,
+                    'deliveryTime' => 1
+                )
+            )
+        );
+
+        $this->assertTrue($client->getResponse()->isRedirect($this->app->url('shopping_complete')));
+
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $Messages = $this->getMailCatcherMessages();
+        $Message = $this->getMailCatcherMessage($Messages[0]->id);
+
+        $this->expected = '[' . $BaseInfo->getShopName() . '] ご注文ありがとうございます';
+        $this->actual = $Message->subject;
+        $this->verify();
+
+        $body = $this->parseMailCatcherSource($Message);
+        $this->assertRegexp('/◎お届け先2/', $body, '複数配送のため, お届け先2が存在する');
+
+        // 生成された受注のチェック
+        $Order = $this->app['eccube.repository.order']->findOneBy(
+            array(
+                'Customer' => $Customer
+            )
+        );
+
+        $OrderNew = $this->app['eccube.repository.order_status']->find($this->app['config']['order_new']);
+        $this->expected = $OrderNew;
+        $this->actual = $Order->getOrderStatus();
+        $this->verify();
+
+        $this->expected = $Customer->getName01();
+        $this->actual = $Order->getName01();
+        $this->verify();
+    }
+}

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
@@ -24,22 +24,8 @@
 
 namespace Eccube\Tests\Web;
 
-class ShoppingControllerWithNonmemberTest extends AbstractWebTestCase
+class ShoppingControllerWithNonmemberTest extends AbstractShoppingControllerTestCase
 {
-
-    protected $Product;
-
-    public function setUp()
-    {
-        parent::setUp();
-        $this->initializeMailCatcher();
-    }
-
-    public function tearDown()
-    {
-        $this->cleanUpMailCatcherMessages();
-        parent::tearDown();
-    }
 
     public function testRoutingShoppingLogin()
     {
@@ -313,88 +299,12 @@ class ShoppingControllerWithNonmemberTest extends AbstractWebTestCase
     public function createNonmemberFormData()
     {
         $faker = $this->getFaker();
-        $tel = explode('-', $faker->phoneNumber);
-
         $email = $faker->safeEmail;
-
-        $form = array(
-            'name' => array(
-                'name01' => $faker->lastName,
-                'name02' => $faker->firstName,
-            ),
-            'kana' => array(
-                'kana01' => $faker->lastKanaName ,
-                'kana02' => $faker->firstKanaName,
-            ),
-            'company_name' => $faker->company,
-            'zip' => array(
-                'zip01' => $faker->postcode1(),
-                'zip02' => $faker->postcode2(),
-            ),
-            'address' => array(
-                'pref' => '5',
-                'addr01' => $faker->city,
-                'addr02' => $faker->streetAddress,
-            ),
-            'tel' => array(
-                'tel01' => $tel[0],
-                'tel02' => $tel[1],
-                'tel03' => $tel[2],
-            ),
-            'email' => array(
-                'first' => $email,
-                'second' => $email,
-            ),
-            '_token' => 'dummy'
+        $form = parent::createShippingFormData();
+        $form['email'] = array(
+            'first' => $email,
+            'second' => $email
         );
         return $form;
-    }
-
-    protected function scenarioCartIn($client)
-    {
-        $crawler = $client->request('POST', '/cart/add', array('product_class_id' => 1));
-        $this->app['eccube.service.cart']->lock();
-        return $crawler;
-    }
-
-    protected function scenarioInput($client, $formData)
-    {
-        $crawler = $client->request(
-            'POST',
-            $this->app->path('shopping_nonmember'),
-            array('nonmember' => $formData)
-        );
-        $this->app['eccube.service.cart']->lock();
-        return $crawler;
-    }
-
-    protected function scenarioConfirm($client)
-    {
-        $crawler = $client->request('GET', $this->app->path('shopping'));
-        return $crawler;
-    }
-
-    protected function scenarioComplete($client, $confirm_url)
-    {
-        $faker = $this->getFaker();
-        $crawler = $client->request(
-            'POST',
-            $confirm_url,
-            array('shopping' =>
-                  array(
-                      'shippings' =>
-                      array(0 =>
-                            array(
-                                'delivery' => 1,
-                                'deliveryTime' => 1
-                            ),
-                      ),
-                      'payment' => 1,
-                      'message' => $faker->text(),
-                      '_token' => 'dummy'
-                  )
-            )
-        );
-        return $crawler;
     }
 }


### PR DESCRIPTION
- 複数配送のテストケースを追加
- ShoppingControllerTestCase の抽象化
   - 複数配送のテストを別ファイルにしたいので.
- 顧客データ生成で不足していた処理を追加
   - scenarioCartIn() で product_class_id を指定できるよう修正
   - CustomerAddress の追加をサポート
   - scenarioComplete() で配送情報を引数で渡せるよう修正(複数配送向けの修正)
   - 不用意なメール送信防止のため $faker->email を $faker->safeEmail に変更
   - 検索結果が正しくなるよう Customer 関連のテストケースを修正