### PR TITLE
Travis-ci ubuntu 12.04 on PHP5.6 で xdebug を使用してカバレッジを出力する

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ php:
 matrix:
   fast_finish: true
   include:
-    - php: 7.0
+    - php: 7.0 # for coverrage
       env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
       sudo: required
       dist: trusty
@@ -30,7 +30,7 @@ matrix:
       env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
     - php: 5.5
       env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
-    - php: 5.6
+    - php: 7.0
       env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
   allow_failures:
     - PHP: 5.3
@@ -41,7 +41,9 @@ matrix:
       env: DB=sqlite
     - PHP: 5.6
       env: DB=sqlite
-    - php: 7.0
+    - php: 5.6 # for coverrage (travis で phpdbg が動かなくなったため, phpdbg が動くようになるまでの暫定)
+      env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
+    - php: 7.0 # dist: trusty を動かすためのダミー. 実際にテストは実行されない
       env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
 
 env:
@@ -55,7 +57,8 @@ install:
   - gem install mailcatcher
 
 before_script:
-  - phpenv config-rm xdebug.ini
+  - CODENAME=$(lsb_release -c -s)
+  - if [[ $PHP_SAPI != 'phpdbg' ]] || [[ $CODENAME = 'trusty' ]]; then phpenv config-rm xdebug.ini ; fi
   - if [[ $PHP_SAPI = 'phpdbg' ]]; then echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini ; fi
   - composer self-update || true
   - composer install --dev --no-interaction -o
@@ -64,8 +67,9 @@ before_script:
   - sh -c "if [ '$DB' = 'sqlite' ]; then sh ./eccube_install.sh sqlite3 none; fi"
   - mailcatcher
 
-script:
-  - if [[ $PHP_SAPI = 'phpdbg' ]]; then phpdbg -qrr ./vendor/bin/phpunit --coverage-clover=coverage.clover ; fi
+script: # PHP7 + precise のテストは実行されない
+  - if [[ $PHP_SAPI = 'phpdbg' ]] && [[ $CODENAME = 'trusty' ]]; then phpdbg -qrr ./vendor/bin/phpunit --coverage-clover=coverage.clover ; fi
+  - if [[ $PHP_SAPI = 'phpdbg' ]] && [[ $CODENAME = 'precise' ]] && [[ $TRAVIS_PHP_VERSION =~ ^[5] ]]; then phpunit --coverage-clover=coverage.clover ; fi # (travis で phpdbg が動かなくなったため, phpdbg が動くようになるまでの暫定)
   - if [[ $PHP_SAPI != 'phpdbg' ]]; then phpunit ; fi
 
 after_script:


### PR DESCRIPTION
- phpdbg が travis-ci でエラーになるための暫定措置
- 暫定的に PHP5.6 + xdebug でカバレッジを出力します
- phpdbg が動作するようになったら、 PHP5.6 + xdebug は削除します