### PR TITLE
update symfony 2.7.17 / 2.7.18

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "swiftmailer/swiftmailer": "5.*",
         "knplabs/knp-components": "*",
         "doctrine/migrations": "v1.0.0-alpha3@dev",
-        "knplabs/console-service-provider": "@dev",
+        "knplabs/console-service-provider": "v1.0",
         "nesbot/carbon": "~1.20",
         "guzzle/guzzle": "~3.9",
         "egulias/email-validator": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "09f6226a20aff01be5347284789bab81",
+    "hash": "9ebca0362f3c1d09b115d5877cc1311e",
     "content-hash": "067d99b43d670f6a7e62ef7d892273c5",
     "packages": [
         {
@@ -1526,16 +1526,16 @@
         },
         {
             "name": "symfony/class-loader",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
-                "reference": "bec3ae4363035686a4f3b969b1676b83285fd2a9"
+                "reference": "df77b1499cf17ef7b52891201991b4fe0255cb4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/class-loader/zipball/bec3ae4363035686a4f3b969b1676b83285fd2a9",
-                "reference": "bec3ae4363035686a4f3b969b1676b83285fd2a9",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/df77b1499cf17ef7b52891201991b4fe0255cb4b",
+                "reference": "df77b1499cf17ef7b52891201991b4fe0255cb4b",
                 "shasum": ""
             },
             "require": {
@@ -1575,20 +1575,20 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-06 08:59:52"
+            "time": "2016-08-23 09:26:23"
         },
         {
             "name": "symfony/config",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "5781b5c36725db88d2b49a25818ad463e8647a8a"
+                "reference": "c703d0f9b6d99890c8ca78c7ff2f27b720372a18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/5781b5c36725db88d2b49a25818ad463e8647a8a",
-                "reference": "5781b5c36725db88d2b49a25818ad463e8647a8a",
+                "url": "https://api.github.com/repos/symfony/config/zipball/c703d0f9b6d99890c8ca78c7ff2f27b720372a18",
+                "reference": "c703d0f9b6d99890c8ca78c7ff2f27b720372a18",
                 "shasum": ""
             },
             "require": {
@@ -1628,20 +1628,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-26 04:42:31"
+            "time": "2016-08-13 18:45:47"
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "61a73eabb2cf16681eda784b8755c587a869ec42"
+                "reference": "86cbcb081ade8b9bd8617775b6984c5981192840"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/61a73eabb2cf16681eda784b8755c587a869ec42",
-                "reference": "61a73eabb2cf16681eda784b8755c587a869ec42",
+                "url": "https://api.github.com/repos/symfony/console/zipball/86cbcb081ade8b9bd8617775b6984c5981192840",
+                "reference": "86cbcb081ade8b9bd8617775b6984c5981192840",
                 "shasum": ""
             },
             "require": {
@@ -1687,11 +1687,11 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:17:26"
+            "time": "2016-08-19 06:41:18"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -1744,16 +1744,16 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "31106b58d530025c26d7c99004cbf72065a227a4"
+                "reference": "aec192ddd4f5cdf32fe443fd7784a3abfa6ab928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/31106b58d530025c26d7c99004cbf72065a227a4",
-                "reference": "31106b58d530025c26d7c99004cbf72065a227a4",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/aec192ddd4f5cdf32fe443fd7784a3abfa6ab928",
+                "reference": "aec192ddd4f5cdf32fe443fd7784a3abfa6ab928",
                 "shasum": ""
             },
             "require": {
@@ -1797,20 +1797,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:17:26"
+            "time": "2016-08-22 17:42:59"
         },
         {
             "name": "symfony/debug-bundle",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug-bundle.git",
-                "reference": "074330cd712ec1077850a55b2736d5685da228fc"
+                "reference": "e426996ea2ef19cc788778d4157d9681d56a9f9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug-bundle/zipball/074330cd712ec1077850a55b2736d5685da228fc",
-                "reference": "074330cd712ec1077850a55b2736d5685da228fc",
+                "url": "https://api.github.com/repos/symfony/debug-bundle/zipball/e426996ea2ef19cc788778d4157d9681d56a9f9c",
+                "reference": "e426996ea2ef19cc788778d4157d9681d56a9f9c",
                 "shasum": ""
             },
             "require": {
@@ -1858,20 +1858,20 @@
             ],
             "description": "Symfony DebugBundle",
             "homepage": "https://symfony.com",
-            "time": "2016-02-01 19:40:12"
+            "time": "2016-08-17 11:57:44"
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "2425e48aefa361deb0a30eb79d0e7aca48718d65"
+                "reference": "83d66285abaef18e98dc983fd68d2706a51bc252"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/2425e48aefa361deb0a30eb79d0e7aca48718d65",
-                "reference": "2425e48aefa361deb0a30eb79d0e7aca48718d65",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/83d66285abaef18e98dc983fd68d2706a51bc252",
+                "reference": "83d66285abaef18e98dc983fd68d2706a51bc252",
                 "shasum": ""
             },
             "require": {
@@ -1929,11 +1929,11 @@
             ],
             "description": "Symfony Doctrine Bridge",
             "homepage": "https://symfony.com",
-            "time": "2016-07-26 04:38:50"
+            "time": "2016-08-24 13:39:58"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
@@ -1988,16 +1988,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "633a3b9755b8446e3bb2330ba17fbf42b58979eb"
+                "reference": "2b096845cbe49f4616dc90494e1a68d48e9bba23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/633a3b9755b8446e3bb2330ba17fbf42b58979eb",
-                "reference": "633a3b9755b8446e3bb2330ba17fbf42b58979eb",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/2b096845cbe49f4616dc90494e1a68d48e9bba23",
+                "reference": "2b096845cbe49f4616dc90494e1a68d48e9bba23",
                 "shasum": ""
             },
             "require": {
@@ -2044,11 +2044,11 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-28 07:50:15"
+            "time": "2016-08-09 09:00:18"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -2097,16 +2097,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "864a73cc1b5f7a597ce8f74ae31851ffc83d7353"
+                "reference": "2716347131481656cc613d98ec12228bae81c8c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/864a73cc1b5f7a597ce8f74ae31851ffc83d7353",
-                "reference": "864a73cc1b5f7a597ce8f74ae31851ffc83d7353",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/2716347131481656cc613d98ec12228bae81c8c3",
+                "reference": "2716347131481656cc613d98ec12228bae81c8c3",
                 "shasum": ""
             },
             "require": {
@@ -2142,20 +2142,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-26 04:40:54"
+            "time": "2016-08-23 19:36:25"
         },
         {
             "name": "symfony/form",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/form.git",
-                "reference": "4f79e5daaa6ce958cb26e728f7d14adf897534b1"
+                "reference": "498a795e875cbcb87511588e6619d5eb82c45f28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/form/zipball/4f79e5daaa6ce958cb26e728f7d14adf897534b1",
-                "reference": "4f79e5daaa6ce958cb26e728f7d14adf897534b1",
+                "url": "https://api.github.com/repos/symfony/form/zipball/498a795e875cbcb87511588e6619d5eb82c45f28",
+                "reference": "498a795e875cbcb87511588e6619d5eb82c45f28",
                 "shasum": ""
             },
             "require": {
@@ -2214,20 +2214,20 @@
             ],
             "description": "Symfony Form Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:17:26"
+            "time": "2016-08-29 16:54:06"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "8ea4e8784404851b18c828e92140eaaab1f61719"
+                "reference": "91161d0d725579eee0b61c68d7de143d177cecaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/8ea4e8784404851b18c828e92140eaaab1f61719",
-                "reference": "8ea4e8784404851b18c828e92140eaaab1f61719",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/91161d0d725579eee0b61c68d7de143d177cecaa",
+                "reference": "91161d0d725579eee0b61c68d7de143d177cecaa",
                 "shasum": ""
             },
             "require": {
@@ -2270,20 +2270,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:17:26"
+            "time": "2016-08-19 15:01:16"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "58c8d796a51996cd604d6a737dd386846f96c5a3"
+                "reference": "7a678e5dbd07ddc6fd7c6b1c70fb6b2736f33562"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/58c8d796a51996cd604d6a737dd386846f96c5a3",
-                "reference": "58c8d796a51996cd604d6a737dd386846f96c5a3",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/7a678e5dbd07ddc6fd7c6b1c70fb6b2736f33562",
+                "reference": "7a678e5dbd07ddc6fd7c6b1c70fb6b2736f33562",
                 "shasum": ""
             },
             "require": {
@@ -2352,20 +2352,20 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 08:15:38"
+            "time": "2016-09-02 03:05:16"
         },
         {
             "name": "symfony/intl",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/intl.git",
-                "reference": "bae100ee0119fd215c2ccddbaab9b15b55840c11"
+                "reference": "c620d2fa6318284adc463221630f1167d52ed6ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/intl/zipball/bae100ee0119fd215c2ccddbaab9b15b55840c11",
-                "reference": "bae100ee0119fd215c2ccddbaab9b15b55840c11",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/c620d2fa6318284adc463221630f1167d52ed6ac",
+                "reference": "c620d2fa6318284adc463221630f1167d52ed6ac",
                 "shasum": ""
             },
             "require": {
@@ -2429,11 +2429,11 @@
                 "l10n",
                 "localization"
             ],
-            "time": "2016-07-30 07:17:26"
+            "time": "2016-08-26 16:13:58"
         },
         {
             "name": "symfony/monolog-bridge",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bridge.git",
@@ -2493,7 +2493,7 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
@@ -2659,16 +2659,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "5ac3a487982f1b4bf99c7277b73e05539d7504fa"
+                "reference": "232d69cb2e1c3c6621d9c602541a2eaa04dceaab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/5ac3a487982f1b4bf99c7277b73e05539d7504fa",
-                "reference": "5ac3a487982f1b4bf99c7277b73e05539d7504fa",
+                "url": "https://api.github.com/repos/symfony/process/zipball/232d69cb2e1c3c6621d9c602541a2eaa04dceaab",
+                "reference": "232d69cb2e1c3c6621d9c602541a2eaa04dceaab",
                 "shasum": ""
             },
             "require": {
@@ -2704,11 +2704,11 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-28 06:53:02"
+            "time": "2016-08-11 06:52:50"
         },
         {
             "name": "symfony/property-access",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
@@ -2768,16 +2768,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "8b64559584e9b580a777b8706863b8815f891bc9"
+                "reference": "c4509a70fdb18d63decd3c24c44734703ed5c7eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/8b64559584e9b580a777b8706863b8815f891bc9",
-                "reference": "8b64559584e9b580a777b8706863b8815f891bc9",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/c4509a70fdb18d63decd3c24c44734703ed5c7eb",
+                "reference": "c4509a70fdb18d63decd3c24c44734703ed5c7eb",
                 "shasum": ""
             },
             "require": {
@@ -2838,20 +2838,20 @@
                 "uri",
                 "url"
             ],
-            "time": "2016-06-28 06:24:06"
+            "time": "2016-08-16 10:55:04"
         },
         {
             "name": "symfony/security",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security.git",
-                "reference": "b6252ab5498bdf1583d06e9da39b444f552d2975"
+                "reference": "66a4782ddd0539e1b4f2ae2b4058a04af5d21aab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security/zipball/b6252ab5498bdf1583d06e9da39b444f552d2975",
-                "reference": "b6252ab5498bdf1583d06e9da39b444f552d2975",
+                "url": "https://api.github.com/repos/symfony/security/zipball/66a4782ddd0539e1b4f2ae2b4058a04af5d21aab",
+                "reference": "66a4782ddd0539e1b4f2ae2b4058a04af5d21aab",
                 "shasum": ""
             },
             "require": {
@@ -2918,11 +2918,11 @@
             ],
             "description": "Symfony Security Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:17:26"
+            "time": "2016-08-25 17:52:51"
         },
         {
             "name": "symfony/serializer",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
@@ -2985,7 +2985,7 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -3034,7 +3034,7 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
@@ -3097,16 +3097,16 @@
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "cadb6a811ade4dcdce2094aafb002e74648c5766"
+                "reference": "6d59be0dcc3ba11f3718784a71aa31728afee068"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/cadb6a811ade4dcdce2094aafb002e74648c5766",
-                "reference": "cadb6a811ade4dcdce2094aafb002e74648c5766",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/6d59be0dcc3ba11f3718784a71aa31728afee068",
+                "reference": "6d59be0dcc3ba11f3718784a71aa31728afee068",
                 "shasum": ""
             },
             "require": {
@@ -3174,20 +3174,20 @@
             ],
             "description": "Symfony Twig Bridge",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:17:26"
+            "time": "2016-08-31 07:12:09"
         },
         {
             "name": "symfony/validator",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "b50c6268e9309db23fb68898bbe52cc9b67deb11"
+                "reference": "b1b19d26714e5609d3ea4a8a7a676fe0d5f3abe1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/b50c6268e9309db23fb68898bbe52cc9b67deb11",
-                "reference": "b50c6268e9309db23fb68898bbe52cc9b67deb11",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/b1b19d26714e5609d3ea4a8a7a676fe0d5f3abe1",
+                "reference": "b1b19d26714e5609d3ea4a8a7a676fe0d5f3abe1",
                 "shasum": ""
             },
             "require": {
@@ -3247,20 +3247,20 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-26 04:40:54"
+            "time": "2016-08-26 01:04:22"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "b3184011cdc4a2a781b990c69ece4d452c9c8276"
+                "reference": "59d6c753eddd0f508f6a11f80fdf5cbbcfd8c527"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/b3184011cdc4a2a781b990c69ece4d452c9c8276",
-                "reference": "b3184011cdc4a2a781b990c69ece4d452c9c8276",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/59d6c753eddd0f508f6a11f80fdf5cbbcfd8c527",
+                "reference": "59d6c753eddd0f508f6a11f80fdf5cbbcfd8c527",
                 "shasum": ""
             },
             "require": {
@@ -3306,11 +3306,11 @@
                 "debug",
                 "dump"
             ],
-            "time": "2016-07-26 04:40:54"
+            "time": "2016-08-31 07:12:09"
         },
         {
             "name": "symfony/web-profiler-bundle",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/web-profiler-bundle.git",
@@ -3368,16 +3368,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "434114468bd22fd7f9dc32695d3d80ab62afaf2f"
+                "reference": "1a9d264853100c597649f0218bb3c08c7bb3cbe8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/434114468bd22fd7f9dc32695d3d80ab62afaf2f",
-                "reference": "434114468bd22fd7f9dc32695d3d80ab62afaf2f",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/1a9d264853100c597649f0218bb3c08c7bb3cbe8",
+                "reference": "1a9d264853100c597649f0218bb3c08c7bb3cbe8",
                 "shasum": ""
             },
             "require": {
@@ -3413,7 +3413,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-11 07:20:55"
+            "time": "2016-08-31 13:10:08"
         },
         {
             "name": "twig/twig",
@@ -4688,7 +4688,7 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v2.7.16",
+            "version": "v2.7.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9ebca0362f3c1d09b115d5877cc1311e",
-    "content-hash": "067d99b43d670f6a7e62ef7d892273c5",
+    "hash": "0a73e596dedf076c5c34994d8f2fa3df",
+    "content-hash": "f5093418e50c33ca9d5af2783e215598",
     "packages": [
         {
             "name": "dflydev/doctrine-orm-service-provider",
@@ -869,7 +869,7 @@
         },
         {
             "name": "knplabs/console-service-provider",
-            "version": "dev-master",
+            "version": "v1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/ConsoleServiceProvider.git",
@@ -4747,8 +4747,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "doctrine/migrations": 20,
-        "knplabs/console-service-provider": 20
+        "doctrine/migrations": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -1527,16 +1527,16 @@
         },
         {
             "name": "symfony/class-loader",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
-                "reference": "df77b1499cf17ef7b52891201991b4fe0255cb4b"
+                "reference": "8ec0c38b8de394c801c1ea5a19c1e37cbdbd6f72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/class-loader/zipball/df77b1499cf17ef7b52891201991b4fe0255cb4b",
-                "reference": "df77b1499cf17ef7b52891201991b4fe0255cb4b",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/8ec0c38b8de394c801c1ea5a19c1e37cbdbd6f72",
+                "reference": "8ec0c38b8de394c801c1ea5a19c1e37cbdbd6f72",
                 "shasum": ""
             },
             "require": {
@@ -1576,11 +1576,11 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "time": "2016-08-23 09:26:23"
+            "time": "2016-09-05 19:55:26"
         },
         {
             "name": "symfony/config",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
@@ -1633,16 +1633,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "86cbcb081ade8b9bd8617775b6984c5981192840"
+                "reference": "cc3d188345b84d27a931db0969b0ff36272f451c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/86cbcb081ade8b9bd8617775b6984c5981192840",
-                "reference": "86cbcb081ade8b9bd8617775b6984c5981192840",
+                "url": "https://api.github.com/repos/symfony/console/zipball/cc3d188345b84d27a931db0969b0ff36272f451c",
+                "reference": "cc3d188345b84d27a931db0969b0ff36272f451c",
                 "shasum": ""
             },
             "require": {
@@ -1688,20 +1688,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-08-19 06:41:18"
+            "time": "2016-09-06 07:26:07"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "f2cc2c55a9982db7bc167385dbf549c640e8cc01"
+                "reference": "8316e61de0e0536b6e2cd3b41d2986d431b9cd2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/f2cc2c55a9982db7bc167385dbf549c640e8cc01",
-                "reference": "f2cc2c55a9982db7bc167385dbf549c640e8cc01",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/8316e61de0e0536b6e2cd3b41d2986d431b9cd2e",
+                "reference": "8316e61de0e0536b6e2cd3b41d2986d431b9cd2e",
                 "shasum": ""
             },
             "require": {
@@ -1741,20 +1741,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-28 06:24:06"
+            "time": "2016-09-06 07:26:07"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "aec192ddd4f5cdf32fe443fd7784a3abfa6ab928"
+                "reference": "659f346c4a81aae6524b6d7043bcfbcfc5a3d67e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/aec192ddd4f5cdf32fe443fd7784a3abfa6ab928",
-                "reference": "aec192ddd4f5cdf32fe443fd7784a3abfa6ab928",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/659f346c4a81aae6524b6d7043bcfbcfc5a3d67e",
+                "reference": "659f346c4a81aae6524b6d7043bcfbcfc5a3d67e",
                 "shasum": ""
             },
             "require": {
@@ -1798,11 +1798,11 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-08-22 17:42:59"
+            "time": "2016-09-06 07:26:07"
         },
         {
             "name": "symfony/debug-bundle",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug-bundle.git",
@@ -1863,16 +1863,16 @@
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "83d66285abaef18e98dc983fd68d2706a51bc252"
+                "reference": "42d02903b2435af78b556f9dceb902babf73740f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/83d66285abaef18e98dc983fd68d2706a51bc252",
-                "reference": "83d66285abaef18e98dc983fd68d2706a51bc252",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/42d02903b2435af78b556f9dceb902babf73740f",
+                "reference": "42d02903b2435af78b556f9dceb902babf73740f",
                 "shasum": ""
             },
             "require": {
@@ -1930,11 +1930,11 @@
             ],
             "description": "Symfony Doctrine Bridge",
             "homepage": "https://symfony.com",
-            "time": "2016-08-24 13:39:58"
+            "time": "2016-09-06 07:26:07"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
@@ -1989,7 +1989,7 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -2049,16 +2049,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "eca040a1645e391a05f7d2f2e6c8d57ce9187443"
+                "reference": "32963bc5eaa8de768289f2537feade3a21e26b4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/eca040a1645e391a05f7d2f2e6c8d57ce9187443",
-                "reference": "eca040a1645e391a05f7d2f2e6c8d57ce9187443",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/32963bc5eaa8de768289f2537feade3a21e26b4d",
+                "reference": "32963bc5eaa8de768289f2537feade3a21e26b4d",
                 "shasum": ""
             },
             "require": {
@@ -2094,11 +2094,11 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-28 06:24:06"
+            "time": "2016-09-06 07:26:07"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -2147,16 +2147,16 @@
         },
         {
             "name": "symfony/form",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/form.git",
-                "reference": "498a795e875cbcb87511588e6619d5eb82c45f28"
+                "reference": "613d3344c3bb064d74d40b2a11b4032c07783af5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/form/zipball/498a795e875cbcb87511588e6619d5eb82c45f28",
-                "reference": "498a795e875cbcb87511588e6619d5eb82c45f28",
+                "url": "https://api.github.com/repos/symfony/form/zipball/613d3344c3bb064d74d40b2a11b4032c07783af5",
+                "reference": "613d3344c3bb064d74d40b2a11b4032c07783af5",
                 "shasum": ""
             },
             "require": {
@@ -2215,20 +2215,20 @@
             ],
             "description": "Symfony Form Component",
             "homepage": "https://symfony.com",
-            "time": "2016-08-29 16:54:06"
+            "time": "2016-09-06 15:01:53"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "91161d0d725579eee0b61c68d7de143d177cecaa"
+                "reference": "4b590c1e6f8045befac815b41a924b9b815f97bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/91161d0d725579eee0b61c68d7de143d177cecaa",
-                "reference": "91161d0d725579eee0b61c68d7de143d177cecaa",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/4b590c1e6f8045befac815b41a924b9b815f97bd",
+                "reference": "4b590c1e6f8045befac815b41a924b9b815f97bd",
                 "shasum": ""
             },
             "require": {
@@ -2271,20 +2271,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-08-19 15:01:16"
+            "time": "2016-09-06 09:29:51"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "7a678e5dbd07ddc6fd7c6b1c70fb6b2736f33562"
+                "reference": "9d738940b2961a9317e07ef8f3ad0795ffdb95d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/7a678e5dbd07ddc6fd7c6b1c70fb6b2736f33562",
-                "reference": "7a678e5dbd07ddc6fd7c6b1c70fb6b2736f33562",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/9d738940b2961a9317e07ef8f3ad0795ffdb95d2",
+                "reference": "9d738940b2961a9317e07ef8f3ad0795ffdb95d2",
                 "shasum": ""
             },
             "require": {
@@ -2353,20 +2353,20 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-02 03:05:16"
+            "time": "2016-09-07 00:54:19"
         },
         {
             "name": "symfony/intl",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/intl.git",
-                "reference": "c620d2fa6318284adc463221630f1167d52ed6ac"
+                "reference": "039bd4427c4b8aeea2ab90a3f405849c69b1a55f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/intl/zipball/c620d2fa6318284adc463221630f1167d52ed6ac",
-                "reference": "c620d2fa6318284adc463221630f1167d52ed6ac",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/039bd4427c4b8aeea2ab90a3f405849c69b1a55f",
+                "reference": "039bd4427c4b8aeea2ab90a3f405849c69b1a55f",
                 "shasum": ""
             },
             "require": {
@@ -2430,11 +2430,11 @@
                 "l10n",
                 "localization"
             ],
-            "time": "2016-08-26 16:13:58"
+            "time": "2016-09-06 07:26:07"
         },
         {
             "name": "symfony/monolog-bridge",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bridge.git",
@@ -2494,7 +2494,7 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
@@ -2660,16 +2660,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "232d69cb2e1c3c6621d9c602541a2eaa04dceaab"
+                "reference": "86be324a1898603789765790c6e2288a505f0ead"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/232d69cb2e1c3c6621d9c602541a2eaa04dceaab",
-                "reference": "232d69cb2e1c3c6621d9c602541a2eaa04dceaab",
+                "url": "https://api.github.com/repos/symfony/process/zipball/86be324a1898603789765790c6e2288a505f0ead",
+                "reference": "86be324a1898603789765790c6e2288a505f0ead",
                 "shasum": ""
             },
             "require": {
@@ -2705,11 +2705,11 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-08-11 06:52:50"
+            "time": "2016-09-06 07:26:07"
         },
         {
             "name": "symfony/property-access",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
@@ -2769,7 +2769,7 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
@@ -2843,16 +2843,16 @@
         },
         {
             "name": "symfony/security",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security.git",
-                "reference": "66a4782ddd0539e1b4f2ae2b4058a04af5d21aab"
+                "reference": "bd170760b502967a6b42f90fd8db57646683a345"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security/zipball/66a4782ddd0539e1b4f2ae2b4058a04af5d21aab",
-                "reference": "66a4782ddd0539e1b4f2ae2b4058a04af5d21aab",
+                "url": "https://api.github.com/repos/symfony/security/zipball/bd170760b502967a6b42f90fd8db57646683a345",
+                "reference": "bd170760b502967a6b42f90fd8db57646683a345",
                 "shasum": ""
             },
             "require": {
@@ -2919,11 +2919,11 @@
             ],
             "description": "Symfony Security Component",
             "homepage": "https://symfony.com",
-            "time": "2016-08-25 17:52:51"
+            "time": "2016-09-07 00:21:47"
         },
         {
             "name": "symfony/serializer",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
@@ -2986,7 +2986,7 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -3035,16 +3035,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "7dfe708755d2d11c87c49eb82465ae6fa3c331b1"
+                "reference": "5b78058d0b4ee0cc0bc0f3bdafe02f18cfff2a35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/7dfe708755d2d11c87c49eb82465ae6fa3c331b1",
-                "reference": "7dfe708755d2d11c87c49eb82465ae6fa3c331b1",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/5b78058d0b4ee0cc0bc0f3bdafe02f18cfff2a35",
+                "reference": "5b78058d0b4ee0cc0bc0f3bdafe02f18cfff2a35",
                 "shasum": ""
             },
             "require": {
@@ -3094,20 +3094,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:17:26"
+            "time": "2016-09-06 07:26:07"
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "6d59be0dcc3ba11f3718784a71aa31728afee068"
+                "reference": "1b141e2d3b46dc45977e9bfe5bb1501975f2c4fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/6d59be0dcc3ba11f3718784a71aa31728afee068",
-                "reference": "6d59be0dcc3ba11f3718784a71aa31728afee068",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/1b141e2d3b46dc45977e9bfe5bb1501975f2c4fc",
+                "reference": "1b141e2d3b46dc45977e9bfe5bb1501975f2c4fc",
                 "shasum": ""
             },
             "require": {
@@ -3175,20 +3175,20 @@
             ],
             "description": "Symfony Twig Bridge",
             "homepage": "https://symfony.com",
-            "time": "2016-08-31 07:12:09"
+            "time": "2016-09-06 07:26:07"
         },
         {
             "name": "symfony/validator",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "b1b19d26714e5609d3ea4a8a7a676fe0d5f3abe1"
+                "reference": "a0e789fee5eb767885f3188e8859b2520c0a154b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/b1b19d26714e5609d3ea4a8a7a676fe0d5f3abe1",
-                "reference": "b1b19d26714e5609d3ea4a8a7a676fe0d5f3abe1",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/a0e789fee5eb767885f3188e8859b2520c0a154b",
+                "reference": "a0e789fee5eb767885f3188e8859b2520c0a154b",
                 "shasum": ""
             },
             "require": {
@@ -3248,20 +3248,20 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2016-08-26 01:04:22"
+            "time": "2016-09-06 07:59:02"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "59d6c753eddd0f508f6a11f80fdf5cbbcfd8c527"
+                "reference": "fd3a4446b659f1472a55e3b55af486afbdb40185"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/59d6c753eddd0f508f6a11f80fdf5cbbcfd8c527",
-                "reference": "59d6c753eddd0f508f6a11f80fdf5cbbcfd8c527",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/fd3a4446b659f1472a55e3b55af486afbdb40185",
+                "reference": "fd3a4446b659f1472a55e3b55af486afbdb40185",
                 "shasum": ""
             },
             "require": {
@@ -3307,20 +3307,20 @@
                 "debug",
                 "dump"
             ],
-            "time": "2016-08-31 07:12:09"
+            "time": "2016-09-06 07:26:07"
         },
         {
             "name": "symfony/web-profiler-bundle",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/web-profiler-bundle.git",
-                "reference": "b4a76dd77a05f10d09ece57975c6afd56f0bc0f0"
+                "reference": "aa86e82e300c98f7b567978180406c5257829003"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/b4a76dd77a05f10d09ece57975c6afd56f0bc0f0",
-                "reference": "b4a76dd77a05f10d09ece57975c6afd56f0bc0f0",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/aa86e82e300c98f7b567978180406c5257829003",
+                "reference": "aa86e82e300c98f7b567978180406c5257829003",
                 "shasum": ""
             },
             "require": {
@@ -3365,11 +3365,11 @@
             ],
             "description": "Symfony WebProfilerBundle",
             "homepage": "https://symfony.com",
-            "time": "2016-07-23 15:20:27"
+            "time": "2016-09-06 07:26:07"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
@@ -3535,16 +3535,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v1.12.0",
+            "version": "v1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "ddac737e1c06a310a0bb4b3da755a094a31a916a"
+                "reference": "d33ee60f3d3e6152888b7f3a385f49e5c43bf1bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/ddac737e1c06a310a0bb4b3da755a094a31a916a",
-                "reference": "ddac737e1c06a310a0bb4b3da755a094a31a916a",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/d33ee60f3d3e6152888b7f3a385f49e5c43bf1bf",
+                "reference": "d33ee60f3d3e6152888b7f3a385f49e5c43bf1bf",
                 "shasum": ""
             },
             "require": {
@@ -3589,7 +3589,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-08-17 00:17:27"
+            "time": "2016-09-07 06:48:24"
         },
         {
             "name": "fzaninotto/faker",
@@ -4694,16 +4694,16 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v2.7.17",
+            "version": "v2.7.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "a7995d824787cc5c9327c999068f647760fc91ad"
+                "reference": "f274ce7f6d7119583d50e65a92b4c45ddd5332ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/a7995d824787cc5c9327c999068f647760fc91ad",
-                "reference": "a7995d824787cc5c9327c999068f647760fc91ad",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/f274ce7f6d7119583d50e65a92b4c45ddd5332ee",
+                "reference": "f274ce7f6d7119583d50e65a92b4c45ddd5332ee",
                 "shasum": ""
             },
             "require": {
@@ -4747,7 +4747,7 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-25 16:30:57"
+            "time": "2016-09-06 07:26:09"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -982,16 +982,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.17.2",
+            "version": "1.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "bee7f0dc9c3e0b69a6039697533dca1e845c8c24"
+                "reference": "f42fbdfd53e306bda545845e4dbfd3e72edb4952"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bee7f0dc9c3e0b69a6039697533dca1e845c8c24",
-                "reference": "bee7f0dc9c3e0b69a6039697533dca1e845c8c24",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f42fbdfd53e306bda545845e4dbfd3e72edb4952",
+                "reference": "f42fbdfd53e306bda545845e4dbfd3e72edb4952",
                 "shasum": ""
             },
             "require": {
@@ -1006,13 +1006,13 @@
                 "doctrine/couchdb": "~1.0@dev",
                 "graylog2/gelf-php": "~1.0",
                 "jakub-onderka/php-parallel-lint": "0.9",
+                "php-amqplib/php-amqplib": "~2.4",
                 "php-console/php-console": "^3.1.3",
                 "phpunit/phpunit": "~4.5",
                 "phpunit/phpunit-mock-objects": "2.3.0",
-                "raven/raven": "^0.13",
                 "ruflin/elastica": ">=0.90 <3.0",
-                "swiftmailer/swiftmailer": "~5.3",
-                "videlalvaro/php-amqplib": "~2.4"
+                "sentry/sentry": "^0.13",
+                "swiftmailer/swiftmailer": "~5.3"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
@@ -1020,16 +1020,17 @@
                 "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                 "ext-mongo": "Allow sending log messages to a MongoDB server",
                 "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                 "php-console/php-console": "Allow sending log messages to Google Chrome",
-                "raven/raven": "Allow sending log messages to a Sentry server",
                 "rollbar/rollbar": "Allow sending log messages to Rollbar",
                 "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                "sentry/sentry": "Allow sending log messages to a Sentry server"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.16.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1055,7 +1056,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2015-10-14 12:51:02"
+            "time": "2016-07-29 03:23:52"
         },
         {
             "name": "nesbot/carbon",
@@ -1106,16 +1107,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "1.1.5",
+            "version": "v1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "dd8998b7c846f6909f4e7a5f67fabebfc412a4f7"
+                "reference": "c7e26a21ba357863de030f0b9e701c7d04593774"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/dd8998b7c846f6909f4e7a5f67fabebfc412a4f7",
-                "reference": "dd8998b7c846f6909f4e7a5f67fabebfc412a4f7",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/c7e26a21ba357863de030f0b9e701c7d04593774",
+                "reference": "c7e26a21ba357863de030f0b9e701c7d04593774",
                 "shasum": ""
             },
             "require": {
@@ -1150,7 +1151,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-01-06 13:31:20"
+            "time": "2016-03-18 20:34:03"
         },
         {
             "name": "pimple/pimple",
@@ -3417,16 +3418,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.24.1",
+            "version": "v1.24.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "3566d311a92aae4deec6e48682dc5a4528c4a512"
+                "reference": "33093f6e310e6976baeac7b14f3a6ec02f2d79b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3566d311a92aae4deec6e48682dc5a4528c4a512",
-                "reference": "3566d311a92aae4deec6e48682dc5a4528c4a512",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/33093f6e310e6976baeac7b14f3a6ec02f2d79b7",
+                "reference": "33093f6e310e6976baeac7b14f3a6ec02f2d79b7",
                 "shasum": ""
             },
             "require": {
@@ -3474,7 +3475,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-05-30 09:11:59"
+            "time": "2016-09-01 17:50:53"
         }
     ],
     "packages-dev": [
@@ -3534,35 +3535,35 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v1.11.6",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "41dc93abd2937a85a3889e28765231d574d2bac8"
+                "reference": "ddac737e1c06a310a0bb4b3da755a094a31a916a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/41dc93abd2937a85a3889e28765231d574d2bac8",
-                "reference": "41dc93abd2937a85a3889e28765231d574d2bac8",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/ddac737e1c06a310a0bb4b3da755a094a31a916a",
+                "reference": "ddac737e1c06a310a0bb4b3da755a094a31a916a",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.6",
-                "sebastian/diff": "~1.1",
-                "symfony/console": "~2.3|~3.0",
-                "symfony/event-dispatcher": "~2.1|~3.0",
-                "symfony/filesystem": "~2.1|~3.0",
-                "symfony/finder": "~2.1|~3.0",
-                "symfony/process": "~2.3|~3.0",
-                "symfony/stopwatch": "~2.5|~3.0"
+                "php": "^5.3.6 || >=7.0 <7.2",
+                "sebastian/diff": "^1.1",
+                "symfony/console": "^2.3 || ^3.0",
+                "symfony/event-dispatcher": "^2.1 || ^3.0",
+                "symfony/filesystem": "^2.1 || ^3.0",
+                "symfony/finder": "^2.1 || ^3.0",
+                "symfony/process": "^2.3 || ^3.0",
+                "symfony/stopwatch": "^2.5 || ^3.0"
             },
             "conflict": {
                 "hhvm": "<3.9"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.5|^5",
-                "satooshi/php-coveralls": "^0.7.1"
+                "satooshi/php-coveralls": "^1.0"
             },
             "bin": [
                 "php-cs-fixer"
@@ -3588,7 +3589,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-07-22 06:46:28"
+            "time": "2016-08-17 00:17:27"
         },
         {
             "name": "fzaninotto/faker",
@@ -3690,16 +3691,16 @@
         },
         {
             "name": "phing/phing",
-            "version": "2.12.0",
+            "version": "2.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phingofficial/phing.git",
-                "reference": "63a495a1f619b60404687a0a059039c5046677df"
+                "reference": "7dd73c83c377623def54b58121f46b4dcb35dd61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phingofficial/phing/zipball/63a495a1f619b60404687a0a059039c5046677df",
-                "reference": "63a495a1f619b60404687a0a059039c5046677df",
+                "url": "https://api.github.com/repos/phingofficial/phing/zipball/7dd73c83c377623def54b58121f46b4dcb35dd61",
+                "reference": "7dd73c83c377623def54b58121f46b4dcb35dd61",
                 "shasum": ""
             },
             "require": {
@@ -3708,14 +3709,12 @@
             "require-dev": {
                 "ext-pdo_sqlite": "*",
                 "lastcraft/simpletest": "@dev",
+                "mikey179/vfsstream": "^1.6",
                 "pdepend/pdepend": "2.x",
-                "pear-pear.php.net/console_getopt": "~1.3.0",
-                "pear-pear.php.net/http_request2": "2.2.x",
-                "pear-pear.php.net/net_growl": "2.7.x",
-                "pear-pear.php.net/pear_packagefilemanager": "1.7.x",
-                "pear-pear.php.net/pear_packagefilemanager2": "1.0.x",
-                "pear-pear.php.net/xml_serializer": "0.20.x",
-                "pear/pear_exception": "~1.0",
+                "pear/archive_tar": "1.4.x",
+                "pear/http_request2": "dev-trunk",
+                "pear/net_growl": "dev-trunk",
+                "pear/pear-core-minimal": "1.10.1",
                 "pear/versioncontrol_git": "@dev",
                 "pear/versioncontrol_svn": "~0.5",
                 "phpdocumentor/phpdocumentor": "2.x",
@@ -3724,7 +3723,8 @@
                 "phpunit/phpunit": ">=3.7",
                 "sebastian/git": "~1.0",
                 "sebastian/phpcpd": "2.x",
-                "squizlabs/php_codesniffer": "~2.2"
+                "squizlabs/php_codesniffer": "~2.2",
+                "symfony/yaml": "~2.7"
             },
             "suggest": {
                 "pdepend/pdepend": "PHP version of JDepend",
@@ -3745,7 +3745,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.11.x-dev"
+                    "dev-master": "2.14.x-dev"
                 }
             },
             "autoload": {
@@ -3778,7 +3778,7 @@
                 "task",
                 "tool"
             ],
-            "time": "2015-08-24 21:02:12"
+            "time": "2016-03-10 21:39:23"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -3831,30 +3831,32 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.5.0",
+            "version": "v1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7"
+                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4745ded9307786b730d7a60df5cb5a6c43cf95f7",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
+                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1"
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1",
+                "sebastian/recursion-context": "^1.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "~2.0"
+                "phpspec/phpspec": "^2.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -3887,7 +3889,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2015-08-13 10:07:40"
+            "time": "2016-06-07 08:13:47"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4041,20 +4043,23 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.7",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
             },
             "type": "library",
             "autoload": {
@@ -4078,7 +4083,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-21 08:01:12"
+            "time": "2016-05-12 18:03:57"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -4381,28 +4386,28 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "1.3.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3"
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/863df9687835c62aa423a22412d26fa2ebde3fd3",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "~4.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -4425,31 +4430,31 @@
                 }
             ],
             "description": "Diff implementation",
-            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
                 "diff"
             ],
-            "time": "2015-02-22 15:13:53"
+            "time": "2015-12-08 07:14:41"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.2",
+            "version": "1.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44"
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6324c907ce7a52478eeeaede764f48733ef5ae44",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^4.8 || ^5.0"
             },
             "type": "library",
             "extra": {
@@ -4479,20 +4484,20 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-08-03 06:14:51"
+            "time": "2016-08-18 05:49:44"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e"
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/7ae5513327cb536431847bcc0c10edba2701064e",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
                 "shasum": ""
             },
             "require": {
@@ -4500,12 +4505,13 @@
                 "sebastian/recursion-context": "~1.0"
             },
             "require-dev": {
+                "ext-mbstring": "*",
                 "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -4545,7 +4551,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-06-21 07:55:53"
+            "time": "2016-06-17 09:04:28"
         },
         {
             "name": "sebastian/global-state",
@@ -4600,16 +4606,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
                 "shasum": ""
             },
             "require": {
@@ -4649,7 +4655,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-06-21 08:04:50"
+            "time": "2015-11-11 19:50:13"
         },
         {
             "name": "sebastian/version",


### PR DESCRIPTION
symfony及びその他ライブラリの更新

Symfony 2.7.17 released
http://symfony.com/blog/symfony-2-7-17-released

- symfony
  - Updating symfony/* (v2.7.16) to symfony/* (v2.7.17)

- twig
  - Updating twig/twig (v1.24.1) to twig/twig (v1.24.2)

- monolog
  - Updating monolog/monolog (1.17.2) to monolog/monolog (1.21.0)

- others
  - Updating friendsofphp/php-cs-fixer (v1.11.6) to friendsofphp/php-cs-fixer (v1.12.0)
  - Updating paragonie/random_compat (1.1.5) to paragonie/random_compat (v1.4.1)
  - Updating phpspec/prophecy (v1.5.0) to phpspec/prophecy (v1.6.1)
  - Updating phpunit/php-timer (1.0.7) to phpunit/php-timer (1.0.8)
  - Updating sebastian/environment (1.3.2) to sebastian/environment (1.3.8)
  - Updating sebastian/recursion-context (1.0.1) to sebastian/recursion-context(1.0.2)
  - Updating sebastian/exporter (1.2.1) to sebastian/exporter (1.2.2)
  - Updating sebastian/diff (1.3.0) to sebastian/diff (1.4.1)
  - Updating phing/phing (2.12.0) to phing/phing (2.14.0)
  - Updating knplabs/console-service-provider (dev-master 1f1a331) to knplabs/console-service-provider (v1.0)

- 備考
  - knplabs/console-service-providerは, 2.*に上がってしまうためv1.0で固定
  - fzaninotto/faker v1.6.0は https://github.com/fzaninotto/Faker/pull/917 の不具合があるので見送り