### PR TITLE
Fix Fixture\Generator

### DIFF
--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -251,6 +251,7 @@ class Generator {
         $Member = $this->app['eccube.repository.member']->find(2);
         $Disp = $this->app['eccube.repository.master.disp']->find(\Eccube\Entity\Master\Disp::DISPLAY_SHOW);
         $ProductType = $this->app['eccube.repository.master.product_type']->find(1);
+        $DeliveryDates = $this->app['eccube.repository.delivery_date']->findAll();
         $Product = new Product();
         if (is_null($product_name)) {
             $product_name = $faker->word;
@@ -279,22 +280,45 @@ class Generator {
             $Product->addProductImage($ProductImage);
         }
 
+        $ClassNames = $this->app['eccube.repository.class_name']->findAll();
+        $ClassName1 = $ClassNames[$faker->numberBetween(0, count($ClassNames) - 1)];
+        $ClassName2 = $ClassNames[$faker->numberBetween(0, count($ClassNames) - 1)];
+        // 同じ ClassName が選択された場合は ClassName1 のみ
+        if ($ClassName1->getId() === $ClassName2->getId()) {
+            $ClassName2 = null;
+        }
+        $ClassCategories1 = $this->app['eccube.repository.class_category']->findBy(array('ClassName' => $ClassName1));
+        $ClassCategories2 = array();
+        if (is_object($ClassName2)) {
+            $ClassCategories2 = $this->app['eccube.repository.class_category']->findBy(array('ClassName' => $ClassName2));
+        }
         for ($i = 0; $i < $product_class_num; $i++) {
             $ProductStock = new ProductStock();
             $ProductStock
                 ->setCreator($Member)
-                ->setStock($faker->randomNumber());
+                ->setStock($faker->randomNumber(3));
             $this->app['orm.em']->persist($ProductStock);
             $this->app['orm.em']->flush($ProductStock);
             $ProductClass = new ProductClass();
             $ProductClass
+                ->setCode($faker->word)
                 ->setCreator($Member)
+                ->setStock($ProductStock->getStock())
                 ->setProductStock($ProductStock)
                 ->setProduct($Product)
                 ->setProductType($ProductType)
                 ->setStockUnlimited(false)
                 ->setPrice02($faker->randomNumber(5))
+                ->setDeliveryDate($DeliveryDates[$faker->numberBetween(0, 8)])
                 ->setDelFlg(Constant::DISABLED);
+
+            if (array_key_exists($i, $ClassCategories1)) {
+                $ProductClass->setClassCategory1($ClassCategories1[$i]);
+            }
+            if (array_key_exists($i, $ClassCategories2)) {
+                $ProductClass->setClassCategory2($ClassCategories2[$i]);
+            }
+
             $this->app['orm.em']->persist($ProductClass);
             $this->app['orm.em']->flush($ProductClass);
             $Product->addProductClass($ProductClass);
@@ -335,14 +359,32 @@ class Generator {
         $faker = $this->getFaker();
         $quantity = $faker->randomNumber(2);
         $Pref = $this->app['eccube.repository.master.pref']->find($faker->numberBetween(1, 47));
+        $Payments = $this->app['eccube.repository.payment']->findAll();
         $Order = new Order($this->app['eccube.repository.order_status']->find($this->app['config']['order_processing']));
         $Order->setCustomer($Customer);
         $Order->copyProperties($Customer);
-        $Order->setPref($Pref);
+        $Order
+            ->setPref($Pref)
+            ->setPayment($Payments[$faker->numberBetween(0, count($Payments) - 1)])
+            ->setPaymentMethod($Order->getPayment()->getMethod())
+            ->setMessage($faker->text())
+            ->setNote($faker->text());
         $this->app['orm.em']->persist($Order);
         $this->app['orm.em']->flush($Order);
         if (!is_object($Delivery)) {
             $Delivery = $this->createDelivery();
+            foreach ($Payments as $Payment) {
+                $PaymentOption = new PaymentOption();
+                $PaymentOption
+                    ->setDeliveryId($Delivery->getId())
+                    ->setPaymentId($Payment->getId())
+                    ->setDelivery($Delivery)
+                    ->setPayment($Payment);
+                $Payment->addPaymentOption($PaymentOption);
+                $this->app['orm.em']->persist($PaymentOption);
+                $this->app['orm.em']->flush($PaymentOption);
+            }
+            $this->app['orm.em']->flush($Payment);
         }
         $DeliveryFee = $this->app['eccube.repository.delivery_fee']->findOneBy(
             array(

--- a/tests/Eccube/Tests/Plugin/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Plugin/Web/Admin/Product/ProductContorllerTest.php
@@ -119,7 +119,7 @@ class ProductControllerTest extends AbstractAdminWebTestCase
 
     public function testEditWithPost()
     {
-        $Product = $this->createProduct();
+        $Product = $this->createProduct(null, 0);
         $formData = $this->createFormData();
         $crawler = $this->client->request(
             'POST',

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
@@ -98,7 +98,7 @@ class ProductControllerTest extends AbstractAdminWebTestCase
 
     public function testEditWithPost()
     {
-        $Product = $this->createProduct();
+        $Product = $this->createProduct(null, 0);
         $formData = $this->createFormData();
         $crawler = $this->client->request(
             'POST',


### PR DESCRIPTION
- 商品規格, お届け可能日を正しく生成するよう修正
- 受注の支払い方法を正しく生成するよう修正
- その他, 不足していた項目を設定するよう修正
- Fixture\Generator が Order::note のデータを生成するようになって, 時折テストが失敗するのを修正