### PR TITLE
お取り寄せの場合は、配送日数の選択ができないよう修正

### DIFF
--- a/src/Eccube/Resource/doctrine/migration/Version20160908161616.php
+++ b/src/Eccube/Resource/doctrine/migration/Version20160908161616.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20160908161616 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // DeliveryDate のお届け日数を修正
+        // see https://github.com/EC-CUBE/ec-cube/issues/1732
+        $app = \Eccube\Application::getInstance();
+        $em = $app["orm.em"];
+        $DeliveryDate = $app['eccube.repository.delivery_date']->find(9);
+        if ($DeliveryDate->getValue() === 0) {
+            $DeliveryDate->setValue(-1);
+            $em->flush($DeliveryDate);
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $app = \Eccube\Application::getInstance();
+        $em = $app["orm.em"];
+        $DeliveryDate = $app['eccube.repository.delivery_date']->find(9);
+        if ($DeliveryDate->getValue() === -1) {
+            $DeliveryDate->setValue(0);
+            $em->flush($DeliveryDate);
+        }
+    }
+}

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -913,6 +913,12 @@ class ShoppingService
         foreach ($Order->getOrderDetails() as $detail) {
             $deliveryDate = $detail->getProductClass()->getDeliveryDate();
             if (!is_null($deliveryDate)) {
+                if ($deliveryDate->getValue() < 0) {
+                    // 配送日数がマイナスの場合はお取り寄せなのでスキップする
+                    $deliveryDateFlag = false;
+                    break;
+                }
+
                 if ($minDate < $deliveryDate->getValue()) {
                     $minDate = $deliveryDate->getValue();
                 }

--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -251,6 +251,7 @@ class Generator {
         $Member = $this->app['eccube.repository.member']->find(2);
         $Disp = $this->app['eccube.repository.master.disp']->find(\Eccube\Entity\Master\Disp::DISPLAY_SHOW);
         $ProductType = $this->app['eccube.repository.master.product_type']->find(1);
+        $DeliveryDates = $this->app['eccube.repository.delivery_date']->findAll();
         $Product = new Product();
         if (is_null($product_name)) {
             $product_name = $faker->word;
@@ -279,22 +280,45 @@ class Generator {
             $Product->addProductImage($ProductImage);
         }
 
+        $ClassNames = $this->app['eccube.repository.class_name']->findAll();
+        $ClassName1 = $ClassNames[$faker->numberBetween(0, count($ClassNames) - 1)];
+        $ClassName2 = $ClassNames[$faker->numberBetween(0, count($ClassNames) - 1)];
+        // 同じ ClassName が選択された場合は ClassName1 のみ
+        if ($ClassName1->getId() === $ClassName2->getId()) {
+            $ClassName2 = null;
+        }
+        $ClassCategories1 = $this->app['eccube.repository.class_category']->findBy(array('ClassName' => $ClassName1));
+        $ClassCategories2 = array();
+        if (is_object($ClassName2)) {
+            $ClassCategories2 = $this->app['eccube.repository.class_category']->findBy(array('ClassName' => $ClassName2));
+        }
         for ($i = 0; $i < $product_class_num; $i++) {
             $ProductStock = new ProductStock();
             $ProductStock
                 ->setCreator($Member)
-                ->setStock($faker->randomNumber());
+                ->setStock($faker->randomNumber(3));
             $this->app['orm.em']->persist($ProductStock);
             $this->app['orm.em']->flush($ProductStock);
             $ProductClass = new ProductClass();
             $ProductClass
+                ->setCode($faker->word)
                 ->setCreator($Member)
+                ->setStock($ProductStock->getStock())
                 ->setProductStock($ProductStock)
                 ->setProduct($Product)
                 ->setProductType($ProductType)
                 ->setStockUnlimited(false)
                 ->setPrice02($faker->randomNumber(5))
+                ->setDeliveryDate($DeliveryDates[$faker->numberBetween(0, 8)])
                 ->setDelFlg(Constant::DISABLED);
+
+            if (array_key_exists($i, $ClassCategories1)) {
+                $ProductClass->setClassCategory1($ClassCategories1[$i]);
+            }
+            if (array_key_exists($i, $ClassCategories2)) {
+                $ProductClass->setClassCategory2($ClassCategories2[$i]);
+            }
+
             $this->app['orm.em']->persist($ProductClass);
             $this->app['orm.em']->flush($ProductClass);
             $Product->addProductClass($ProductClass);
@@ -335,14 +359,32 @@ class Generator {
         $faker = $this->getFaker();
         $quantity = $faker->randomNumber(2);
         $Pref = $this->app['eccube.repository.master.pref']->find($faker->numberBetween(1, 47));
+        $Payments = $this->app['eccube.repository.payment']->findAll();
         $Order = new Order($this->app['eccube.repository.order_status']->find($this->app['config']['order_processing']));
         $Order->setCustomer($Customer);
         $Order->copyProperties($Customer);
-        $Order->setPref($Pref);
+        $Order
+            ->setPref($Pref)
+            ->setPayment($Payments[$faker->numberBetween(0, count($Payments) - 1)])
+            ->setPaymentMethod($Order->getPayment()->getMethod())
+            ->setMessage($faker->text())
+            ->setNote($faker->text());
         $this->app['orm.em']->persist($Order);
         $this->app['orm.em']->flush($Order);
         if (!is_object($Delivery)) {
             $Delivery = $this->createDelivery();
+            foreach ($Payments as $Payment) {
+                $PaymentOption = new PaymentOption();
+                $PaymentOption
+                    ->setDeliveryId($Delivery->getId())
+                    ->setPaymentId($Payment->getId())
+                    ->setDelivery($Delivery)
+                    ->setPayment($Payment);
+                $Payment->addPaymentOption($PaymentOption);
+                $this->app['orm.em']->persist($PaymentOption);
+                $this->app['orm.em']->flush($PaymentOption);
+            }
+            $this->app['orm.em']->flush($Payment);
         }
         $DeliveryFee = $this->app['eccube.repository.delivery_fee']->findOneBy(
             array(

--- a/tests/Eccube/Tests/Plugin/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Plugin/Web/Admin/Product/ProductContorllerTest.php
@@ -119,7 +119,7 @@ class ProductControllerTest extends AbstractAdminWebTestCase
 
     public function testEditWithPost()
     {
-        $Product = $this->createProduct();
+        $Product = $this->createProduct(null, 0);
         $formData = $this->createFormData();
         $crawler = $this->client->request(
             'POST',

--- a/tests/Eccube/Tests/Service/ShoppingServiceTest.php
+++ b/tests/Eccube/Tests/Service/ShoppingServiceTest.php
@@ -455,6 +455,35 @@ class ShoppingServiceTest extends AbstractServiceTestCase
     }
 
     /**
+     * #1732 のテストケース
+     * @link https://github.com/EC-CUBE/ec-cube/issues/1732
+     */
+    public function testGetFormDeliveryDatesWithStockPending()
+    {
+        $DeliveryDate1 = $this->app['eccube.repository.delivery_date']->find(1);
+        $DeliveryDate9 = $this->app['eccube.repository.delivery_date']->find(9);
+        $Order = $this->createOrder($this->Customer);
+        $i = 0;
+        foreach ($Order->getOrderDetails() as $Detail) {
+            if ($i === 0) {
+                // 1件のみ「お取り寄せ」に設定する
+                $Detail->getProductClass()->setDeliveryDate($DeliveryDate9);
+            } else {
+                $Detail->getProductClass()->setDeliveryDate($DeliveryDate1);
+            }
+
+            $i++;
+        }
+        $this->app['orm.em']->flush();
+
+        $DeliveryDates = $this->app['eccube.service.shopping']->getFormDeliveryDates($Order);
+
+        $this->expected = 0;
+        $this->actual = count($DeliveryDates);
+        $this->verify('お取り寄せを含む場合はお届け日選択不可');
+    }
+
+    /**
      * #1238 のテストケース
      * @link https://github.com/EC-CUBE/ec-cube/issues/1238
      */

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
@@ -98,7 +98,7 @@ class ProductControllerTest extends AbstractAdminWebTestCase
 
     public function testEditWithPost()
     {
-        $Product = $this->createProduct();
+        $Product = $this->createProduct(null, 0);
         $formData = $this->createFormData();
         $crawler = $this->client->request(
             'POST',


### PR DESCRIPTION
- #1732 
- マイグレーションにて dtb_delivery_date.id = 9 を決め打ちにしているため、カスタマイズしている場合は注意すること
- #1746 の後にマージお願いします