### PR TITLE
インストール時にURLからhtml削除することができる対応

### DIFF
--- a/.htaccess.sample
+++ b/.htaccess.sample
@@ -1,0 +1,16 @@
+<FilesMatch "^composer|^autoload|^cli-config|^COPYING|\.(ini|lock|dist|git|sh|bak|swp)$">
+     order allow,deny
+     deny from all
+</FilesMatch>
+
+<Files ~ "index.php|index_dev.php">
+     order deny,allow
+     allow from all
+</Files>
+
+<IfModule mod_rewrite.c>
+     RewriteEngine On
+     RewriteCond %{REQUEST_FILENAME} !-f
+     RewriteCond %{REQUEST_FILENAME} !^(.*)\.(gif|png|jpg|css|ico|js)$ [NC]
+     RewriteRule ^(.*)$ index.php [QSA,L]
+</IfModule>

--- a/autoload.php
+++ b/autoload.php
@@ -31,4 +31,8 @@ if (extension_loaded('apc') && ini_get('apc.enabled')) {
     $loader->unregister();
 }
 
+//[INFO]index.php,install.phpをEC-CUBEルート直下に移動させる場合は、コメントアウトしている行に置き換える
+define("RELATIVE_PUBLIC_DIR_PATH", '');
+//define("RELATIVE_PUBLIC_DIR_PATH", '/html');
+
 return $loader;

--- a/html/index.php
+++ b/html/index.php
@@ -22,7 +22,9 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+//[INFO]index.php,install.phpをEC-CUBEルート直下に移動させる場合は、コメントアウトしている行に置き換える
 require __DIR__.'/../autoload.php';
+//require __DIR__.'/autoload.php';
 
 ini_set('display_errors', 'Off');
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);

--- a/html/index_dev.php
+++ b/html/index_dev.php
@@ -42,7 +42,9 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
 
+//[INFO]index.php,install.phpをEC-CUBEルート直下に移動させる場合は、コメントアウトしている行に置き換える
 require_once __DIR__.'/../autoload.php';
+//require_once __DIR__.'/autoload.php';
 
 Debug::enable();
 

--- a/html/install.php
+++ b/html/install.php
@@ -26,7 +26,9 @@ if (function_exists('apc_clear_cache')) {
     apc_clear_cache();
 }
 
+//[INFO]index.php,install.phpをEC-CUBEルート直下に移動させる場合は、コメントアウトしている行に置き換える
 require __DIR__ . '/../autoload.php';
+//require __DIR__ . '/autoload.php';
 
 $app = new Eccube\InstallApplication();
 $app['debug'] = true;

--- a/src/Eccube/Controller/Admin/AdminController.php
+++ b/src/Eccube/Controller/Admin/AdminController.php
@@ -67,7 +67,13 @@ class AdminController extends AbstractController
         if (isset($app['config']['eccube_install']) && $app['config']['eccube_install'] == 1) {
             $file = $app['config']['root_dir'] . '/html/install.php';
             if (file_exists($file)) {
-                $app->addWarning('admin.install.warning', 'admin');
+                $message = $app->trans('admin.install.warning', array('installphpPath' => 'html/install.php'));
+                $app->addWarning($message, 'admin');
+            }
+            $fileOnRoot = $app['config']['root_dir'] . '/install.php';
+            if (file_exists($fileOnRoot)) {
+                $message = $app->trans('admin.install.warning', array('installphpPath' => 'install.php'));
+                $app->addWarning($message, 'admin');
             }
         }
 

--- a/src/Eccube/Controller/Admin/Store/TemplateController.php
+++ b/src/Eccube/Controller/Admin/Store/TemplateController.php
@@ -76,7 +76,7 @@ class TemplateController extends AbstractController
                 $config['template_code'] = $templateCode;
                 $config['template_realdir'] = $config['root_dir'].'/app/template/'.$templateCode;
                 $config['template_html_realdir'] = $config['public_path_realdir'].'/template/'.$templateCode;
-                $config['front_urlpath'] = $config['root_urlpath'].'/template/'.$templateCode;
+                $config['front_urlpath'] = $config['root_urlpath'].RELATIVE_PUBLIC_DIR_PATH.'/template/'.$templateCode;
                 $config['block_realdir'] =$config['template_realdir'].'/Block';
 
                 if (file_exists($file.'.php')) {

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -895,7 +895,9 @@ class InstallController
         } else {
             return $app['twig']->render('migration_plugin.twig', array(
                 'Plugins' => $Plugins,
-                'version' => Constant::VERSION));
+                'version' => Constant::VERSION,
+                'publicPath' => '..' . RELATIVE_PUBLIC_DIR_PATH . '/',
+            ));
         }
     }
 
@@ -916,6 +918,8 @@ class InstallController
         $config_app->boot();
         \Eccube\Util\Cache::clear($config_app, true);
 
-        return $app['twig']->render('migration_end.twig');
+        return $app['twig']->render('migration_end.twig', array(
+            'publicPath' => '..' . RELATIVE_PUBLIC_DIR_PATH . '/',
+        ));
     }
 }

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -112,6 +112,7 @@ class InstallController
 
         return $app['twig']->render('step1.twig', array(
             'form' => $form->createView(),
+            'publicPath' => '..' . RELATIVE_PUBLIC_DIR_PATH . '/',
         ));
     }
 
@@ -134,6 +135,7 @@ class InstallController
 
         return $app['twig']->render('step2.twig', array(
             'protectedDirs' => $protectedDirs,
+            'publicPath' => '..' . RELATIVE_PUBLIC_DIR_PATH . '/',
         ));
     }
 
@@ -198,6 +200,7 @@ class InstallController
 
         return $app['twig']->render('step3.twig', array(
             'form' => $form->createView(),
+            'publicPath' => '..' . RELATIVE_PUBLIC_DIR_PATH . '/',
         ));
     }
 
@@ -241,6 +244,7 @@ class InstallController
 
         return $app['twig']->render('step4.twig', array(
             'form' => $form->createView(),
+            'publicPath' => '..' . RELATIVE_PUBLIC_DIR_PATH . '/',
         ));
     }
 
@@ -302,6 +306,7 @@ class InstallController
 
         return $app['twig']->render('step5.twig', array(
             'form' => $form->createView(),
+            'publicPath' => '..' . RELATIVE_PUBLIC_DIR_PATH . '/',
         ));
     }
 
@@ -318,6 +323,7 @@ class InstallController
 
         return $app['twig']->render('complete.twig', array(
             'admin_url' => $adminUrl,
+            'publicPath' => '..' . RELATIVE_PUBLIC_DIR_PATH . '/',
         ));
     }
 
@@ -785,9 +791,10 @@ class InstallController
         $USER_DATA_ROUTE = 'user_data';
         $ROOT_DIR = realpath(__DIR__ . '/../../../../');
         $ROOT_URLPATH = $request->getBasePath();
+        $ROOT_PUBLIC_URLPATH = $ROOT_URLPATH . RELATIVE_PUBLIC_DIR_PATH;
 
-        $target = array('${ADMIN_ROUTE}', '${TEMPLATE_CODE}', '${USER_DATA_ROUTE}', '${ROOT_DIR}', '${ROOT_URLPATH}');
-        $replace = array($ADMIN_ROUTE, $TEMPLATE_CODE, $USER_DATA_ROUTE, $ROOT_DIR, $ROOT_URLPATH);
+        $target = array('${ADMIN_ROUTE}', '${TEMPLATE_CODE}', '${USER_DATA_ROUTE}', '${ROOT_DIR}', '${ROOT_URLPATH}', '${ROOT_PUBLIC_URLPATH}');
+        $replace = array($ADMIN_ROUTE, $TEMPLATE_CODE, $USER_DATA_ROUTE, $ROOT_DIR, $ROOT_URLPATH, $ROOT_PUBLIC_URLPATH);
 
         $fs = new Filesystem();
         $content = str_replace(
@@ -859,7 +866,9 @@ class InstallController
      */
     public function migration(InstallApplication $app, Request $request)
     {
-        return $app['twig']->render('migration.twig');
+        return $app['twig']->render('migration.twig', array(
+            'publicPath' => '..' . RELATIVE_PUBLIC_DIR_PATH . '/',
+        ));
     }
 
     /**

--- a/src/Eccube/Resource/config/path.yml.dist
+++ b/src/Eccube/Resource/config/path.yml.dist
@@ -1,9 +1,9 @@
 # duplicated
 root: ${ROOT_URLPATH}/ # root_urlpath
 admin_dir: ${ADMIN_ROUTE}/ # admin_route
-tpl: ${ROOT_URLPATH}/user_data/packages/default/ # front_urlpath
-admin_tpl: ${ROOT_URLPATH}/user_data/packages/admin/ # admin_urlpath
-image_path: ${ROOT_URLPATH}/upload/save_image/ # image_save_urlpath
+tpl: ${ROOT_PUBLIC_URLPATH}/user_data/packages/default/ # front_urlpath
+admin_tpl: ${ROOT_PUBLIC_URLPATH}/user_data/packages/admin/ # admin_urlpath
+image_path: ${ROOT_PUBLIC_URLPATH}/upload/save_image/ # image_save_urlpath
 
 # base valiables
 root_dir: ${ROOT_DIR}
@@ -47,9 +47,9 @@ plugin_temp_realdir: ${ROOT_DIR}/app/cache/plugin
 plugin_html_realdir: ${ROOT_DIR}/html/plugin
 
 # urlpath
-admin_urlpath: ${ROOT_URLPATH}/template/admin
-front_urlpath: ${ROOT_URLPATH}/template/${TEMPLATE_CODE}
-image_save_urlpath: ${ROOT_URLPATH}/upload/save_image
-image_temp_urlpath: ${ROOT_URLPATH}/upload/temp_image
-user_data_urlpath: ${ROOT_URLPATH}/user_data
-plugin_urlpath: ${ROOT_URLPATH}/plugin
+admin_urlpath: ${ROOT_PUBLIC_URLPATH}/template/admin
+front_urlpath: ${ROOT_PUBLIC_URLPATH}/template/${TEMPLATE_CODE}
+image_save_urlpath: ${ROOT_PUBLIC_URLPATH}/upload/save_image
+image_temp_urlpath: ${ROOT_PUBLIC_URLPATH}/upload/temp_image
+user_data_urlpath: ${ROOT_PUBLIC_URLPATH}/user_data
+plugin_urlpath: ${ROOT_PUBLIC_URLPATH}/plugin

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -76,7 +76,7 @@ front.shopping.order.error: 購入処理でエラーが発生しました。
 front.shopping.stock.error: 選択された商品の在庫が不足しております。該当商品をカートから削除しました。
 front.shopping.system.error: 購入処理でシステムエラーが発生しました。大変お手数ですが、サイト管理者までご連絡ください。
 
-admin.install.warning: html/install.php は、インストール完了後にファイルを削除してください
+admin.install.warning: installphpPath は、インストール完了後にファイルを削除してください
 
 admin.register.complete: 登録が完了しました。
 admin.register.failed: 登録できませんでした。

--- a/src/Eccube/Resource/template/install/frame.twig
+++ b/src/Eccube/Resource/template/install/frame.twig
@@ -27,11 +27,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
-    <link rel="icon" href="../template/install/img/common/favicon.ico">
+    <link rel="icon" href="{{ publicPath }}template/install/img/common/favicon.ico">
     <title>ようこそ | EC-CUBEインストール</title>
-    <link href="../template/install/dist/css/bootstrap.min.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}" rel="stylesheet">
-    <link href="../template/install/assets/css/dashboard.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}" rel="stylesheet">
-    <script src="../template/install/assets/js/ie10-viewport-bug-workaround.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
+    <link href="{{ publicPath }}template/install/dist/css/bootstrap.min.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}" rel="stylesheet">
+    <link href="{{ publicPath }}template/install/assets/css/dashboard.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}" rel="stylesheet">
+    <script src="{{ publicPath }}template/install/assets/js/ie10-viewport-bug-workaround.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
     <!--[if lt IE 9]>
     <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
@@ -73,8 +73,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     ================================================== -->
 <!-- Placed at the end of the document so the pages load faster -->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-<script src="../template/install/dist/js/bootstrap.min.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
-<script src="../template/install/assets/js/function.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
+<script src="{{ publicPath }}template/install/dist/js/bootstrap.min.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
+<script src="{{ publicPath }}template/install/assets/js/function.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
 <script>
 $(function() {
     /*
@@ -82,7 +82,7 @@ $(function() {
      */
     $.ajax({
         type: 'GET',
-        url: '../template/install/assets/img/svg.html',
+        url: '{{ publicPath }}template/install/assets/img/svg.html',
         dataType: 'html',
         success: function(data){
             $('body').prepend(data);

--- a/src/Eccube/Resource/template/install/migration_frame.twig
+++ b/src/Eccube/Resource/template/install/migration_frame.twig
@@ -27,11 +27,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
-    <link rel="icon" href="../favicon.ico">
+    <link rel="icon" href="{{ publicPath }}template/install/img/common/favicon.ico">
     <title>ようこそ | EC-CUBEマイグレーション</title>
-    <link href="../template/install/dist/css/bootstrap.min.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}" rel="stylesheet">
-    <link href="../template/install/assets/css/dashboard.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}" rel="stylesheet">
-    <script src="../template/install/assets/js/ie10-viewport-bug-workaround.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
+    <link href="{{ publicPath }}template/install/dist/css/bootstrap.min.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}" rel="stylesheet">
+    <link href="{{ publicPath }}template/install/assets/css/dashboard.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}" rel="stylesheet">
+    <script src="{{ publicPath }}template/install/assets/js/ie10-viewport-bug-workaround.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
     <!--[if lt IE 9]>
     <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
@@ -69,8 +69,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     ================================================== -->
 <!-- Placed at the end of the document so the pages load faster -->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-<script src="../template/install/dist/js/bootstrap.min.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
-<script src="../template/install/assets/js/function.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
+<script src="{{ publicPath }}template/install/dist/js/bootstrap.min.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
+<script src="{{ publicPath }}template/install/assets/js/function.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
 <script>
 $(function() {
     /*
@@ -78,7 +78,7 @@ $(function() {
      */
     $.ajax({
         type: 'GET',
-        url: '../template/install/assets/img/svg.html',
+        url: '{{ publicPath }}template/install/assets/img/svg.html',
         dataType: 'html',
         success: function(data){
             $('body').prepend(data);

--- a/web.config.sample
+++ b/web.config.sample
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <!-- Don't show directory listings for URLs which map to a directory. -->
+    <directoryBrowse enabled="false" />
+    <rewrite>
+      <rules>
+        <rule name="Protect files and directories from prying eyes" stopProcessing="true">
+          <match url="\.(app|src)$" />
+          <action type="CustomResponse" statusCode="403" subStatusCode="0" statusReason="Forbidden" statusDescription="Access is forbidden." />
+        </rule>
+        <rule name="Force simple error message for requests for non-existent favicon.ico" stopProcessing="true">
+          <match url="favicon\.ico" />
+          <action type="CustomResponse" statusCode="404" subStatusCode="1" statusReason="File Not Found" statusDescription="The requested file favicon.ico was not found" />
+        </rule>
+        <!-- Rewrite URLs of the form 'x' to the form 'index.php/x'. -->
+        <rule name="Short URLs" stopProcessing="true">
+          <match url="^(.*)$" ignoreCase="false" />
+          <conditions>
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />
+            <add input="{REQUEST_FILENAME}" matchType="IsDirectory" ignoreCase="false" negate="true" />
+            <add input="{URL}" pattern="^/favicon.ico$" ignoreCase="false" negate="true" />
+          </conditions>
+          <action type="Rewrite" url="index.php/{R:1}" appendQueryString="true" />
+        </rule>
+      </rules>
+    </rewrite>
+    
+    <security>
+      <requestFiltering>
+        <denyUrlSequences>
+          <add sequence="composer" />
+          <add sequence="autoload" />
+          <add sequence="cli-config" />
+          <add sequence="COPYING" />
+        </denyUrlSequences>
+        <fileExtensions>
+          <add fileExtension=".ini" allowed="false" />
+          <add fileExtension=".lock" allowed="false" />
+          <add fileExtension=".dist" allowed="false" />
+          <add fileExtension=".git" allowed="false" />
+          <add fileExtension=".sh" allowed="false" />
+          <add fileExtension=".bak" allowed="false" />
+          <add fileExtension=".swp" allowed="false" />
+        </fileExtensions>
+      </requestFiltering>
+    </security>
+    
+    <httpErrors>
+      <remove statusCode="404" subStatusCode="-1" />
+      <error statusCode="404" prefixLanguageFilePath="" path="/index.php" responseMode="ExecuteURL" />
+    </httpErrors>
+
+    <defaultDocument>
+      <!-- Set the default document -->
+      <files>
+        <remove value="index.php" />
+        <add value="index.php" />
+      </files>
+    </defaultDocument>
+  </system.webServer>
+</configuration>
+


### PR DESCRIPTION
手順を踏むことで、インストール時にURLからhtml削除することができます。
Apache/IIS環境で動作確認済み。

ref https://github.com/EC-CUBE/ec-cube/issues/1709

インストール時の手順はこちら
http://ec-cube.github.io/remove_html.html

### 変更が影響する機能	
1	インストールの表示、path.yml生成
2	マイグレーションの表示
3	install.phpの存在チェック
4	テンプレート切り替え時のpath.yml生成
	
### 環境による動作の違い	
1	Apache(.htaccess)
2	IIS(web.config)
	
### 影響ないことの確認(デグレチェック)	
1	通常インストールしたときの動作（既存どおりの動作を期待）
	
### 本体以外への影響	
1	プラグイン（とくにroot_urlを使用しているプラグインに影響）
2	ルート直下のファイルへのアクセスできないこと（autoload.phpなど）
