### PR TITLE
テンプレート切り替え時のpath.yml生成処理が、不正な出力をする不具合を修正

### DIFF
--- a/src/Eccube/Controller/Admin/Store/TemplateController.php
+++ b/src/Eccube/Controller/Admin/Store/TemplateController.php
@@ -69,7 +69,7 @@ class TemplateController extends AbstractController
                 if (file_exists($file.'.php')) {
                     $config = require $file.'.php';
                 } elseif (file_exists($file.'.yml')) {
-                    $config = Yaml::parse(file_get_contents($file));
+                    $config = Yaml::parse(file_get_contents($file.'.yml'));
                 }
 
                 $templateCode = $Template->getCode();


### PR DESCRIPTION
3.0.11対応でのデグレです。(3.0.10は大丈夫)
テンプレート切り替えると、path.ymlが壊れて500エラーになっていました。