### PR TITLE
規格選択時の動的表示対応

### DIFF
--- a/html/template/default/js/eccube.js
+++ b/html/template/default/js/eccube.js
@@ -470,51 +470,53 @@
         }
 
         // 商品コード
-        var $product_code_default = $form.find('[id^=product_code_default]');
-        var $product_code_dynamic = $form.find('[id^=product_code_dynamic]');
+        var  $product_code = $('#item_code_default');
+        if (typeof this.product_code_origin === 'undefined') {
+            // 初期値を保持しておく
+            this.product_code_origin =  $product_code.text();
+        }
         if (classcat2 && typeof classcat2.product_code !== 'undefined') {
-            $product_code_default.hide();
-            $product_code_dynamic.show();
-            $product_code_dynamic.text(classcat2.product_code);
+            $product_code.text(classcat2.product_code);
         } else {
-            $product_code_default.show();
-            $product_code_dynamic.hide();
+            $product_code.text(this.product_code_origin);
         }
 
         // 在庫(品切れ)
-        var $cartbtn_default = $form.find('[id^=cartbtn_default]');
-        var $cartbtn_dynamic = $form.find('[id^=cartbtn_dynamic]');
+        var $cartbtn = $('#add-cart');
         if (classcat2 && classcat2.stock_find === false) {
-
-            $cartbtn_dynamic.text('申し訳ございませんが、只今品切れ中です。').show();
-            $cartbtn_default.hide();
+            $cartbtn.prop('disabled', true);
+            $cartbtn.text('ただいま品切れ中です');
         } else {
-            $cartbtn_dynamic.hide();
-            $cartbtn_default.show();
+            $cartbtn.prop('disabled', false);
+            $cartbtn.text('カートに入れる');
         }
 
         // 通常価格
-        var $price01_default = $form.find('[id^=price01_default]');
-        var $price01_dynamic = $form.find('[id^=price01_dynamic]');
+        var $price01 = $('#detail_description_box__class_normal_range_price')
+            .find('.price01_default')
+            .first();
+        if (typeof this.proce01_origin === 'undefined') {
+            // 初期値を保持しておく
+            this.proce01_origin = $price01.text();
+        }
         if (classcat2 && typeof classcat2.price01 !== 'undefined' && String(classcat2.price01).length >= 1) {
-
-            $price01_dynamic.text(classcat2.price01).show();
-            $price01_default.hide();
+            $price01.text('¥ ' + classcat2.price01);
         } else {
-            $price01_dynamic.hide();
-            $price01_default.show();
+            $price01.text(this.proce01_origin);
         }
 
         // 販売価格
-        var $price02_default = $form.find('[id^=price02_default]');
-        var $price02_dynamic = $form.find('[id^=price02_dynamic]');
+        var $price02 = $('#detail_description_box__class_range_sale_price')
+            .find('.price02_default')
+            .first();
+        if (typeof this.proce02_origin === 'undefined') {
+            // 初期値を保持しておく
+            this.proce02_origin = $price02.text();
+        }
         if (classcat2 && typeof classcat2.price02 !== 'undefined' && String(classcat2.price02).length >= 1) {
-
-            $price02_dynamic.text(classcat2.price02).show();
-            $price02_default.hide();
+            $price02.text('¥ ' + classcat2.price02);
         } else {
-            $price02_dynamic.hide();
-            $price02_default.show();
+            $price02.text(this.proce02_origin);
         }
 
         // ポイント

--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -343,7 +343,13 @@ class Product extends \Eccube\Entity\AbstractEntity
     {
         $this->_calc();
 
-        return min($this->codes);
+        $codes = array();
+        foreach ($this->codes as $code) {
+            if (!is_null($code)) {
+                $codes[] = $code;
+            }
+        }
+        return count($codes) ? min($codes) : null;
     }
 
     /**
@@ -355,7 +361,13 @@ class Product extends \Eccube\Entity\AbstractEntity
     {
         $this->_calc();
 
-        return max($this->codes);
+        $codes = array();
+        foreach ($this->codes as $code) {
+            if (!is_null($code)) {
+                $codes[] = $code;
+            }
+        }
+        return count($codes) ? max($codes) : null;
     }
 
     /**
@@ -394,10 +406,10 @@ class Product extends \Eccube\Entity\AbstractEntity
                 'classcategory_id2' => $class_category_id2,
                 'name'              => $class_category_name2,
                 'stock_find'        => $ProductClass->getStockFind(),
-                'price01'           => number_format($ProductClass->getPrice01IncTax()),
+                'price01'           => $ProductClass->getPrice01() === null ? '' : number_format($ProductClass->getPrice01IncTax()),
                 'price02'           => number_format($ProductClass->getPrice02IncTax()),
                 'product_class_id'  => (string) $ProductClass->getId(),
-                'product_code'      => $ProductClass->getCode(),
+                'product_code'      => $ProductClass->getCode() === null ? '' : $ProductClass->getCode(),
                 'product_type'      => (string) $ProductClass->getProductType()->getId(),
             );
         }

--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -137,7 +137,7 @@ $(function(){
                         {% if Product.getPrice01Min is not null and Product.getPrice01Min == Product.getPrice01Max %}
                         <p id="detail_description_box__class_normal_price" class="normal_price"> 通常価格：<span class="price01_default">{{ Product.getPrice01IncTaxMin|price }}</span> <span class="small">税込</span></p>
                         {% elseif Product.getPrice01Min is not null and Product.getPrice01Max is not null %}
-                        <p id="detail_description_box__class_normal_range_price" class="normal_price"> 通常価格：<span class="price01_default">{{ Product.getPrice01IncTaxMin|price }}</span> ～ <span class="price01_default">{{ Product.getPrice01IncTaxMax|price }}</span> <span class="small">税込</span></p>
+                        <p id="detail_description_box__class_normal_range_price" class="normal_price"> 通常価格：<span class="price01_default">{{ Product.getPrice01IncTaxMin|price }} ～ {{ Product.getPrice01IncTaxMax|price }}</span> <span class="small">税込</span></p>
                         {% endif %}
                     {% else -%}
                         {% if Product.getPrice01Max is not null %}
@@ -150,7 +150,7 @@ $(function(){
                         {% if Product.getPrice02Min == Product.getPrice02Max %}
                         <p id="detail_description_box__class_sale_price" class="sale_price text-primary"> <span class="price02_default">{{ Product.getPrice02IncTaxMin|price }}</span> <span class="small">税込</span></p>
                         {% else %}
-                        <p id="detail_description_box__class_range_sale_price" class="sale_price text-primary"> <span class="price02_default">{{ Product.getPrice02IncTaxMin|price }}</span> ～ <span class="price02_default">{{ Product.getPrice02IncTaxMax|price }}</span> <span class="small">税込</span></p>
+                        <p id="detail_description_box__class_range_sale_price" class="sale_price text-primary"> <span class="price02_default">{{ Product.getPrice02IncTaxMin|price }} ～ {{  Product.getPrice02IncTaxMax|price }}</span> <span class="small">税込</span></p>
                         {% endif %}
                     {% else -%}
                         <p id="detail_description_box__sale_price" class="sale_price text-primary"> <span class="price02_default">{{ Product.getPrice02IncTaxMin|price }}</span> <span class="small">税込</span></p>


### PR DESCRIPTION
- #1349 の修正
- 規格あり商品の動的表示に対応
  - 通常価格
  - 販売価格
  - 商品コード
  - 在庫状態でのカートボタン表示切替

- #1698 での指摘に対応(twig側の修正量を減らす)