### PR TITLE
Fixture\Generator で ProductStock と ProductClass を紐づけするよう修正

### DIFF
--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -322,6 +322,10 @@ class Generator {
 
             $this->app['orm.em']->persist($ProductClass);
             $this->app['orm.em']->flush($ProductClass);
+
+            $ProductStock->setProductClass($ProductClass);
+            $ProductStock->setProductClassId($ProductClass->getId());
+            $this->app['orm.em']->flush($ProductStock);
             $Product->addProductClass($ProductClass);
         }
 
@@ -351,6 +355,11 @@ class Generator {
             ->setProduct($Product);
         $this->app['orm.em']->persist($ProductClass);
         $this->app['orm.em']->flush($ProductClass);
+
+        $ProductStock->setProductClass($ProductClass);
+        $ProductStock->setProductClassId($ProductClass->getId());
+        $this->app['orm.em']->flush($ProductStock);
+
         $Product->addProductClass($ProductClass);
 
         $Categories = $this->app['eccube.repository.category']->findAll();


### PR DESCRIPTION
- EC-CUBE 本体には影響ありません
- `Fixture/Generator` で生成した商品を、管理画面から削除しようとするとシステムエラーになってしまうための対策