### PR TITLE
フロントのページリンクに「最初へ」「最後へ」リンクを追加

### DIFF
--- a/src/Eccube/Resource/config/config.yml.dist
+++ b/src/Eccube/Resource/config/config.yml.dist
@@ -6,3 +6,4 @@ admin_allow_host:
 cookie_lifetime: 0
 locale: ja
 timezone: Asia/Tokyo
+pageinrange: false

--- a/src/Eccube/Resource/template/default/pagination.twig
+++ b/src/Eccube/Resource/template/default/pagination.twig
@@ -19,14 +19,34 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #}
+{% if app.config.pageinrange  is defined %}
+    {% set pageinrange  = app.config.pageinrange %}
+{% else  %}
+    {% set pageinrange  = false %}
+{% endif %}
+
 {% if pages.pageCount > 1 %}
 <div id="pagination_wrap" class="pagination">
     <ul>
+
+        {% if pageinrange and pages.firstPageInRange != 1 %}
+            {# 最初へリンクを表示 #}
+            <li class="pagenation__item-first">
+                <a href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({'pageno': pages.first})) }}"
+                   aria-label="First"><span aria-hidden="true">最初へ</span></a>
+            </li>
+        {% endif %}
+
         {% if pages.previous is defined %}
             <li class="pagenation__item-previous">
                 <a href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({'pageno': pages.previous})) }}"
                    aria-label="Previous"><span aria-hidden="true">前へ</span></a>
             </li>
+        {% endif %}
+
+        {% if pageinrange and pages.firstPageInRange != 1 %}
+            {# 1ページリンクが表示されない場合、「...」を表示 #}
+            <li>...</li>
         {% endif %}
 
         {% for page in pages.pagesInRange %}
@@ -37,10 +57,23 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             {% endif %}
         {% endfor %}
 
+        {% if pageinrange and pages.last != pages.lastPageInRange %}
+            {# 最終ページリンクが表示されない場合、「...」を表示 #}
+            <li>...</li>
+        {% endif %}
+
         {% if pages.next is defined %}
             <li class="pagenation__item-next">
                 <a href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({'pageno': pages.next})) }}"
                    aria-label="Next"><span aria-hidden="true">次へ</span></a>
+            </li>
+        {% endif %}
+
+        {% if pageinrange and pages.last != pages.lastPageInRange %}
+            {# 最後へリンクを表示 #}
+            <li class="pagenation__item-last">
+                <a href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({'pageno': pages.last})) }}"
+                   aria-label="Last"><span aria-hidden="true">最後へ</span></a>
             </li>
         {% endif %}
     </ul>


### PR DESCRIPTION
フロントのページリンクは現在「前へ」「次へ」しか表示されないが、
![pagelink1](https://cloud.githubusercontent.com/assets/12592005/19032061/b5939522-8992-11e6-9797-e40f3ef973f9.png)

`config.yml`に新たに追加した`pageinrange`に`true`を設定することで「最初へ」「最後へ」リンクを表示するようにする。

![pagelink2](https://cloud.githubusercontent.com/assets/12592005/19032281/c0776a12-8993-11e6-9921-5890fe7538b1.png)

![pagelink3](https://cloud.githubusercontent.com/assets/12592005/19032285/c58daa02-8993-11e6-82c7-6d601b7ec656.png)

![pagelink4](https://cloud.githubusercontent.com/assets/12592005/19032290/cb0dcfc0-8993-11e6-8733-467f78e9e6e5.png)


