### PR TITLE
会員情報編集画面に「検索結果に戻る」リンクを追加

### DIFF
--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -251,6 +251,12 @@
             </div>
             {% endif %}
 
+            <div id="detail_box__footer" class="row hidden-xs hidden-sm">
+                <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
+                    <p><a href="{{ url('admin_customer_page', { page_no : app.session.get('eccube.admin.customer.search.page_no')|default('1') } ) }}?resume=1">検索画面に戻る</a></p>
+                </div>
+            </div>
+
         </div><!-- /.col -->
 
         <div id="common_box" class="col-md-3" id="aside_column">

--- a/tests/Eccube/Tests/Web/Admin/Customer/CustomerEditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Customer/CustomerEditControllerTest.php
@@ -68,6 +68,21 @@ class CustomerEditControllerTest extends AbstractAdminWebTestCase
     }
 
     /**
+     * testIndex
+     */
+    public function testIndexBackButton()
+    {
+        $crawler = $this->client->request(
+            'GET',
+            $this->app->path('admin_customer_edit', array('id' => $this->Customer->getId()))
+        );
+
+        $this->expected = '検索画面に戻る';
+        $this->actual = $crawler->filter('#detail_box__footer')->text();
+        $this->assertContains($this->expected, $this->actual);
+    }
+
+    /**
      * testIndexWithPost
      */
     public function testIndexWithPost()


### PR DESCRIPTION
商品情報編集画面、受注情報編集画面には、検索結果に戻るリンクが存在するため、統一性に欠ける。
ユニットテストケースも追加しています。

refs #1619