### PR TITLE
お届け先新規追加」ボタンの表示位置の対応

### DIFF
--- a/html/template/admin/assets/css/dashboard.css
+++ b/html/template/admin/assets/css/dashboard.css
@@ -3219,3 +3219,7 @@ textarea#log {
     filter: alpha(opacity=50);
     opacity: .5;
 }
+
+#shipping_info__button_new {
+    margin-bottom: 20px;
+}


### PR DESCRIPTION
複数配送時の、「お届け先新規追加」ボタンの表示位置が下の枠と被って表示されています。
このバグを対応しました。