### PR TITLE
お届け先の複数指定画面で、住所の表示順番が不正のため、対応する。

### DIFF
--- a/src/Eccube/Entity/CustomerAddress.php
+++ b/src/Eccube/Entity/CustomerAddress.php
@@ -158,7 +158,7 @@ class CustomerAddress extends \Eccube\Entity\AbstractEntity
      */
     public function getShippingMultipleDefaultName()
     {
-        return $this->getName01() . ' ' . $this->getAddr02() . ' ' . $this->getPref()->getName() . $this->getAddr01();
+        return $this->getName01() . ' ' . $this->getPref()->getName() . ' ' . $this->getAddr01() . ' ' . $this->getAddr02();
     }
     
     /**

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
@@ -126,4 +126,43 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
         $this->actual = $Order->getName01();
         $this->verify();
     }
+
+    public function testDisplayCustomerAddress()
+    {
+        $faker = $this->getFaker();
+        $Customer = $this->logIn();
+        $CustomerAddress = $this->createCustomerAddress($Customer);
+
+        $client = $this->client;
+        // 2個カート投入
+        $this->scenarioCartIn($client);
+        $this->scenarioCartIn($client);
+
+        // 確認画面
+        $crawler = $this->scenarioConfirm($client);
+        $this->expected = 'ご注文内容のご確認';
+        $this->actual = $crawler->filter('h1.page-heading')->text();
+        $this->verify();
+
+        // 複数配送画面
+        $crawler = $client->request('GET', $this->app->path('shopping_shipping_multiple'));
+        // 配送先1, 配送先2の情報を返す
+        $shippings = $crawler->filter('#form_shipping_multiple_0_shipping_0_customer_address > option')->each(
+            function ($node, $i) {
+
+                return array(
+                    'customer_address' => $node->html(),
+                    'quantity' => 1
+                );
+            }
+        );
+
+        $address = $Customer->getName01() . ' ' . $Customer->getPref()->getName() . ' ' . $Customer->getAddr01() . ' ' . $Customer->getAddr02();
+        $this->expected = $address;
+        $this->actual = $shippings[0]['customer_address'];
+        $this->verify();
+
+    }
+
+
 }


### PR DESCRIPTION
複数配送のお届け先の複数指定画面で、住所の表示順番に違和感があります。

[姓][番地][都道府県][市区町村]
　　↑
　番地が前に来ている
期待値

[姓][都道府県][市区町村][番地]