### PR TITLE
カテゴリ管理の修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/CategoryController.php
+++ b/src/Eccube/Controller/Admin/Product/CategoryController.php
@@ -112,19 +112,17 @@ class CategoryController extends AbstractController
             }
         }
 
-        $Children = $app['eccube.repository.category']->getList(null);
         $Categories = $app['eccube.repository.category']->getList($Parent);
-        $TopCategories = $app['eccube.repository.category']->findBy(array('Parent' => null), array('rank' => 'DESC'));
-        $category_count = $app['eccube.repository.category']->getTotalCount();
+
+        // ツリー表示のため、ルートからのカテゴリを取得
+        $TopCategories = $app['eccube.repository.category']->getList(null);
 
         return $app->render('Product/category.twig', array(
             'form' => $form->createView(),
-            'Children' => $Children,
             'Parent' => $Parent,
             'Categories' => $Categories,
             'TopCategories' => $TopCategories,
             'TargetCategory' => $TargetCategory,
-            'category_count' => $category_count,
         ));
     }
 

--- a/src/Eccube/Entity/Category.php
+++ b/src/Eccube/Entity/Category.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Entity;
 
+use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -122,6 +123,25 @@ class Category extends \Eccube\Entity\AbstractEntity
     {
         return array_merge(array($this), $this->getDescendants());
 
+    }
+
+    /**
+     * カテゴリに紐づく商品があるかどうかを調べる.
+     *
+     * ProductCategoriesはExtra Lazyのため, lengthやcountで評価した際にはCOUNTのSQLが発行されるが,
+     * COUNT自体が重いので, LIMIT 1で取得し存在チェックを行う.
+     *
+     * @see http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/working-with-associations.html#filtering-collections
+     * @return bool
+     */
+    public function hasProductCategories()
+    {
+        $criteria = Criteria::create()
+            ->orderBy(array('category_id' => Criteria::ASC))
+            ->setFirstResult(0)
+            ->setMaxResults(1);
+
+        return $this->ProductCategories->matching($criteria)->count() === 1;
     }
 
     /**

--- a/src/Eccube/Resource/doctrine/Eccube.Entity.Category.dcm.yml
+++ b/src/Eccube/Resource/doctrine/Eccube.Entity.Category.dcm.yml
@@ -52,6 +52,7 @@ Eccube\Entity\Category:
         ProductCategories:
             targetEntity: Eccube\Entity\ProductCategory
             mappedBy: Category
+            fetch: EXTRA_LAZY
         Children:
             targetEntity: Eccube\Entity\Category
             mappedBy: Parent

--- a/src/Eccube/Resource/template/admin/Product/category.twig
+++ b/src/Eccube/Resource/template/admin/Product/category.twig
@@ -165,7 +165,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                     <li><a>編集中</a></li>
                                                 {% endif %}
 
-                                                {% if Category.Children|length > 0 or Category.ProductCategories|length > 0 %}
+                                                {% if Category.Children|length > 0 or Category.hasProductCategories %}
                                                     <li><a title="子カテゴリが存在するため削除できません。">削除</a></li>
                                                 {% else %}
                                                     <li>


### PR DESCRIPTION
#1818

ProductCategoryの参照をEXTRA_LAZYに変更しました。

http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/extra-lazy-associations.html

以下のようなコードの場合、countのSQLを発行する挙動になります。
- `{% Category.Category.ProductCategories|length > 0 %}`
- `$Category->getProductCategories()->count();`

また、ProductCategoryの存在チェックのメソッドを追加しました。
countではなく、LIMIT 1で1件取得してチェックするようにしています。

その他修正
- 使用していない変数の削除
- findByからgetListに統一