### PR TITLE
translatorキャッシュを追加

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -202,7 +202,7 @@ class Application extends ApplicationTrait
 
         $this->register(new \Silex\Provider\TranslationServiceProvider(), array(
             'locale' => $this['config']['locale'],
-            'translator.cache_dir' => $this['config']['root_dir'].'/app/cache/trans',
+            'translator.cache_dir' => $this['debug'] ? null : $this['config']['root_dir'].'/app/cache/trans',
         ));
         $this['translator'] = $this->share($this->extend('translator', function ($translator, \Silex\Application $app) {
             $translator->addLoader('yaml', new \Symfony\Component\Translation\Loader\YamlFileLoader());

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -202,7 +202,7 @@ class Application extends ApplicationTrait
 
         $this->register(new \Silex\Provider\TranslationServiceProvider(), array(
             'locale' => $this['config']['locale'],
-            'translator.cache_dir' => $this['debug'] ? null : $this['config']['root_dir'].'/app/cache/trans',
+            'translator.cache_dir' => $this['debug'] ? null : $this['config']['root_dir'].'/app/cache/translator',
         ));
         $this['translator'] = $this->share($this->extend('translator', function ($translator, \Silex\Application $app) {
             $translator->addLoader('yaml', new \Symfony\Component\Translation\Loader\YamlFileLoader());

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -133,7 +133,7 @@ class Application extends ApplicationTrait
         $this->register(new \Silex\Provider\UrlGeneratorServiceProvider());
         $this->register(new \Silex\Provider\FormServiceProvider());
         $this->register(new \Silex\Provider\SerializerServiceProvider());
-        $this->register(new \Eccube\ServiceProvider\ValidatorServiceProvider());
+        $this->register(new \Silex\Provider\ValidatorServiceProvider());
 
         $app = $this;
         $this->error(function (\Exception $e, $code) use ($app) {
@@ -202,15 +202,10 @@ class Application extends ApplicationTrait
 
         $this->register(new \Silex\Provider\TranslationServiceProvider(), array(
             'locale' => $this['config']['locale'],
+            'translator.cache_dir' => $this['config']['root_dir'].'/app/cache/trans',
         ));
         $this['translator'] = $this->share($this->extend('translator', function ($translator, \Silex\Application $app) {
             $translator->addLoader('yaml', new \Symfony\Component\Translation\Loader\YamlFileLoader());
-
-            $r = new \ReflectionClass('Symfony\Component\Validator\Validator');
-            $file = dirname($r->getFilename()).'/Resources/translations/validators.'.$app['locale'].'.xlf';
-            if (file_exists($file)) {
-                $translator->addResource('xliff', $file, $app['locale'], 'validators');
-            }
 
             $file = __DIR__.'/Resource/locale/validator.'.$app['locale'].'.yml';
             if (file_exists($file)) {

--- a/src/Eccube/Form/Type/AddCartType.php
+++ b/src/Eccube/Form/Type/AddCartType.php
@@ -32,7 +32,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\ExecutionContext;
+use Symfony\Component\Validator\Context\ExecutionContext;
 
 class AddCartType extends AbstractType
 {

--- a/src/Eccube/ServiceProvider/ValidatorServiceProvider.php
+++ b/src/Eccube/ServiceProvider/ValidatorServiceProvider.php
@@ -23,6 +23,8 @@ use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
  * Symfony Validator component Provider.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * 
+ * @deprecated since 3.0.0, to be removed in 3.1
  */
 class ValidatorServiceProvider implements ServiceProviderInterface
 {


### PR DESCRIPTION
#1824

- translatorのキャッシュを使うように修正（debug時は無効)
- yamlファイルを追加できない不具合が合ったため、ValidatorServiceProviderを独自に作成していたが、silex1.3.4で修正済のためdeprecatedに変更(https://github.com/silexphp/Silex/blob/1.3/doc/changelog.rst#134-2015-09-15)
- xlfをロードしているが、TranslationServiceProviderでロード済なので削除


apache bench 結果

- さくらのクラウド CPU:1コア / メモリ：1GB / ディスク：20G(SSD)
- ab -n 100 -c 10 でトップページを計測(Request Per Secondの値を記載)

- PHP7.0

| -    | 3.0.11 | 本PR       |
|------|--------|------------|
| 1    | 8.61   | 13.26      |
| 2    | 8.57   | 10.71      |
| 3    | 8.43   | 14.07      |
| 4    | 8.00   | 13.53      |
| 5    | 8.55   | 12.73      |
| 平均 | 8.43   | 12.86      |

- PHP5.4

| -    | 3.0.11 | 本PR       |
|------|--------|------------|
| 1    | 4.28   | 5.88       |
| 2    | 4.55   | 6.25       |
| 3    | 4.54   | 6.10       |
| 4    | 4.54   | 6.09       |
| 5    | 4.42   | 6.11       |
| 平均 | 4.47   | 6.08       |