### PR TITLE
配送先ごとにお届け日の算出を行うように変更。

### DIFF
--- a/src/Eccube/Form/Type/ShippingItemType.php
+++ b/src/Eccube/Form/Type/ShippingItemType.php
@@ -55,7 +55,7 @@ class ShippingItemType extends AbstractType
                 $form = $event->getForm();
 
                 // お届け日を取得
-                $deliveryDates = $app['eccube.service.shopping']->getFormDeliveryDates($data->getOrder());
+                $deliveryDates = $app['eccube.service.shopping']->getFormDeliveryDates($data->getOrder(), $data);
 
                 // 配送業者
                 // 商品種別に紐づく配送業者を取得

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -900,9 +900,10 @@ class ShoppingService
      * お届け日を取得
      *
      * @param Order $Order
+     * @param Shipping $Shipping
      * @return array
      */
-    public function getFormDeliveryDates(Order $Order)
+    public function getFormDeliveryDates(Order $Order, Shipping $Shipping)
     {
 
         // お届け日の設定
@@ -910,7 +911,7 @@ class ShoppingService
         $deliveryDateFlag = false;
 
         // 配送時に最大となる商品日数を取得
-        foreach ($Order->getOrderDetails() as $detail) {
+        foreach ($Shipping->getShipmentItems() as $detail) {
             $deliveryDate = $detail->getProductClass()->getDeliveryDate();
             if (!is_null($deliveryDate)) {
                 if ($minDate < $deliveryDate->getValue()) {


### PR DESCRIPTION
fix #1157 
複数配送時に、配送先ごとにお届け日の算出を行うように変更しました。


実装メモ
ShippingからOrderも取得できますが、Serviceの関数なので引数を減らすのは避けました。