### PR TITLE
商品登録画面で、カテゴリーの表示が実際のカテゴリー階層と一致していない

### DIFF
--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -46,6 +46,9 @@ class ProductType extends AbstractType
     {
         $app = $this->app;
 
+        // Category list
+        $Categories = $app['eccube.repository.category']->getList();
+
         $builder
             // 商品規格情報
             ->add('class', 'admin_product_class', array(
@@ -75,6 +78,8 @@ class ProductType extends AbstractType
                'label' => '商品カテゴリ',
                'multiple' => true,
                'mapped' => false,
+                // Choices list (overdrive mapped)
+               'choices' => $this->getCategoryChoice($Categories)
             ))
 
             // 詳細な説明
@@ -145,6 +150,26 @@ class ProductType extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
+    }
+
+    /**
+     * Overdrive choice Category method
+     * @param $Categories
+     * @return array
+     */
+    private function getCategoryChoice($Categories)
+    {
+        $TmpCategories = array();
+
+        foreach ($Categories as $Category) {
+            $TmpCategories[] = $Category;
+            if (count($Category->getChildren()) > 0) {
+                $TmpCate = $this->getCategoryChoice($Category->getChildren());
+                $TmpCategories = array_merge($TmpCategories, $TmpCate);
+            }
+        }
+
+        return $TmpCategories;
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -44,11 +44,6 @@ class ProductType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $app = $this->app;
-
-        // Category list
-        $Categories = $app['eccube.repository.category']->getList();
-
         $builder
             // 商品規格情報
             ->add('class', 'admin_product_class', array(
@@ -79,7 +74,7 @@ class ProductType extends AbstractType
                'multiple' => true,
                'mapped' => false,
                 // Choices list (overdrive mapped)
-               'choices' => $this->getCategoryChoice($Categories)
+               'choices' => $this->getCategoryChoice($this->app)
             ))
 
             // 詳細な説明
@@ -154,22 +149,18 @@ class ProductType extends AbstractType
 
     /**
      * Overdrive choice Category method
-     * @param $Categories
+     * @param \Silex\Application $app
      * @return array
      */
-    private function getCategoryChoice($Categories)
+    private function getCategoryChoice(\Silex\Application $app)
     {
-        $TmpCategories = array();
-
-        foreach ($Categories as $Category) {
-            $TmpCategories[] = $Category;
-            if (count($Category->getChildren()) > 0) {
-                $TmpCate = $this->getCategoryChoice($Category->getChildren());
-                $TmpCategories = array_merge($TmpCategories, $TmpCate);
-            }
+        $RootCategories = $app['eccube.repository.category']->getList();
+        $CategoriesForChoice = array();
+        foreach ($RootCategories as $Root) {
+            $CategoriesForChoice = array_merge($CategoriesForChoice, $Root->getSelfAndDescendants());
         }
 
-        return $TmpCategories;
+        return $CategoriesForChoice;
     }
 
     /**

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -301,7 +301,7 @@ class EccubeServiceProvider implements ServiceProviderInterface
             if (isset($app['security']) && isset($app['eccube.repository.customer_favorite_product'])) {
                 $types[] = new \Eccube\Form\Type\AddCartType($app['config'], $app['security'], $app['eccube.repository.customer_favorite_product']);
             }
-            $types[] = new \Eccube\Form\Type\SearchProductType();
+            $types[] = new \Eccube\Form\Type\SearchProductType($app);
             $types[] = new \Eccube\Form\Type\OrderSearchType($app);
             $types[] = new \Eccube\Form\Type\ShippingItemType($app);
             $types[] = new \Eccube\Form\Type\ShippingMultipleType($app);

--- a/tests/Eccube/Tests/Web/Admin/Product/CategoryContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CategoryContorllerTest.php
@@ -79,6 +79,7 @@ class CategoryControllerTest extends AbstractAdminWebTestCase
             $Category->setUpdateDate(new \DateTime());
             $this->app['orm.em']->persist($Category);
             $this->app['orm.em']->flush();
+
             if (!array_key_exists('child', $category_array)) {
                 continue;
             }
@@ -91,6 +92,9 @@ class CategoryControllerTest extends AbstractAdminWebTestCase
                 $Child->setUpdateDate(new \DateTime());
                 $this->app['orm.em']->persist($Child);
                 $this->app['orm.em']->flush();
+                // add child category
+                $Category->addChild($Child);
+
                 if (!array_key_exists('child', $child_array)) {
                     continue;
                 }
@@ -103,6 +107,8 @@ class CategoryControllerTest extends AbstractAdminWebTestCase
                     $Grandson->setUpdateDate(new \DateTime());
                     $this->app['orm.em']->persist($Grandson);
                     $this->app['orm.em']->flush();
+                    // add child category
+                    $Child->addChild($Grandson);
                 }
             }
         }
@@ -332,9 +338,10 @@ class CategoryControllerTest extends AbstractAdminWebTestCase
             $this->app->url('admin_product_product_new')
         );
 
+        $CategoryLast = $this->app['eccube.repository.category']->findOneBy(array('name' => '子2-2'));
         $categoryNameLastElement = $crawler->filter('#detail_wrap select#admin_product_Category option')->last()->text();
 
-        $this->expected = $Category2->getName();
+        $this->expected = $CategoryLast->getNameWithLevel();
         $this->actual = $categoryNameLastElement;
         $this->verify();
     }

--- a/tests/Eccube/Tests/Web/Admin/Product/CategoryContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CategoryContorllerTest.php
@@ -298,4 +298,44 @@ class CategoryControllerTest extends AbstractAdminWebTestCase
 
         return $TestCategory;
     }
+
+    public function testMoveRankAndShow()
+    {
+        // Give
+        $Category = $this->app['eccube.repository.category']->findOneBy(array('name' => '親1'));
+        $Category2 = $this->app['eccube.repository.category']->findOneBy(array('name' => '親2'));
+        $newRanks = array(
+            $Category->getId() => $Category2->getRank(),
+            $Category2->getId() => $Category->getRank()
+        );
+
+        // When
+        $this->client->request(
+            'POST',
+            $this->app->url('admin_product_category_rank_move'),
+            $newRanks,
+            array(),
+            array(
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+                'CONTENT_TYPE' => 'application/json',
+            )
+        );
+
+        // Then
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $this->expected = $newRanks[$Category->getId()];
+        $this->actual = $Category->getRank();
+        $this->verify();
+
+        $crawler = $this->client->request('GET',
+            $this->app->url('admin_product_product_new')
+        );
+
+        $categoryNameLastElement = $crawler->filter('#detail_wrap select#admin_product_Category option')->last()->text();
+
+        $this->expected = $Category2->getName();
+        $this->actual = $categoryNameLastElement;
+        $this->verify();
+    }
 }

--- a/tests/Eccube/Tests/Web/SearchProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/SearchProductControllerTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Eccube\Tests\Web;
+
+use Eccube\Common\Constant;
+use Eccube\Entity\Category;
+
+class SearchProductControllerTest extends AbstractWebTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->remove();
+        $this->createCategories();
+    }
+
+    public function createCategories()
+    {
+        $categories = array(
+            array('name' => '親1', 'level' => 1, 'rank' => 1,
+                'child' => array(
+                    array('name' => '子1', 'level' => 2, 'rank' => 4,
+                        'child' => array(
+                            array('name' => '孫1', 'level' => 3, 'rank' => 9)
+                        ),
+                    ),
+                ),
+            ),
+            array('name' => '親2', 'level' => 1, 'rank' => 2,
+                'child' => array(
+                    array('name' => '子2-0', 'level' => 2, 'rank' => 5,
+                        'child' => array(
+                            array('name' => '孫2', 'level' => 3, 'rank' => 10)
+                        )
+                    ),
+                    array('name' => '子2-1', 'level' => 2, 'rank' => 6),
+                    array('name' => '子2-2', 'level' => 2, 'rank' => 7)
+                ),
+            ),
+            array('name' => '親3', 'level' => 1, 'rank' => 3,
+                'child' => array(
+                    array('name' => '子3', 'level' => 2, 'rank' => 8,
+                        'child' => array(
+                            array('name' => '孫3', 'level' => 3, 'rank' => 11)
+                        )
+                    )
+                ),
+            ),
+        );
+
+        foreach ($categories as $category_array) {
+            $Category = new Category();
+            $Category->setPropertiesFromArray($category_array);
+            $Category->setDelFlg(Constant::DISABLED);
+            $Category->setCreateDate(new \DateTime());
+            $Category->setUpdateDate(new \DateTime());
+            $this->app['orm.em']->persist($Category);
+            $this->app['orm.em']->flush();
+            if (!array_key_exists('child', $category_array)) {
+                continue;
+            }
+            foreach ($category_array['child'] as $child_array) {
+                $Child = new Category();
+                $Child->setPropertiesFromArray($child_array);
+                $Child->setParent($Category);
+                $Child->setDelFlg(Constant::DISABLED);
+                $Child->setCreateDate(new \DateTime());
+                $Child->setUpdateDate(new \DateTime());
+                $this->app['orm.em']->persist($Child);
+                $this->app['orm.em']->flush();
+                if (!array_key_exists('child', $child_array)) {
+                    continue;
+                }
+                foreach ($child_array['child'] as $grandson_array) {
+                    $Grandson = new Category();
+                    $Grandson->setPropertiesFromArray($grandson_array);
+                    $Grandson->setParent($Child);
+                    $Grandson->setDelFlg(Constant::DISABLED);
+                    $Grandson->setCreateDate(new \DateTime());
+                    $Grandson->setUpdateDate(new \DateTime());
+                    $this->app['orm.em']->persist($Grandson);
+                    $this->app['orm.em']->flush();
+                }
+            }
+        }
+    }
+
+    /**
+     * 既存のデータを論理削除しておく.
+     */
+    public function remove() {
+        $Categories = $this->app['eccube.repository.category']->findAll();
+        foreach ($Categories as $Category) {
+            $Category->setDelFlg(Constant::ENABLED);
+            $this->app['orm.em']->merge($Category);
+        }
+        $this->app['orm.em']->flush();
+    }
+
+    public function testRoutingSearchProduct()
+    {
+        $this->client->request('GET',
+            $this->app->url('block_search_product')
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+    }
+
+    public function testMoveRankAndShow()
+    {
+        // Give
+        $Category = $this->app['eccube.repository.category']->findOneBy(array('name' => '親1'));
+
+        // When
+        $crawler = $this->client->request('GET',
+            $this->app->url('block_search_product')
+        );
+
+        // Then
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $categoryNameLastElement = $crawler->filter('.search select#category_id option')->last()->text();
+
+        $this->expected = $Category->getName();
+        $this->actual = $categoryNameLastElement;
+        $this->verify();
+    }
+}

--- a/tests/Eccube/Tests/Web/SearchProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/SearchProductControllerTest.php
@@ -56,6 +56,7 @@ class SearchProductControllerTest extends AbstractWebTestCase
             $Category->setUpdateDate(new \DateTime());
             $this->app['orm.em']->persist($Category);
             $this->app['orm.em']->flush();
+
             if (!array_key_exists('child', $category_array)) {
                 continue;
             }
@@ -68,6 +69,9 @@ class SearchProductControllerTest extends AbstractWebTestCase
                 $Child->setUpdateDate(new \DateTime());
                 $this->app['orm.em']->persist($Child);
                 $this->app['orm.em']->flush();
+
+                $Category->addChild($Child);
+
                 if (!array_key_exists('child', $child_array)) {
                     continue;
                 }
@@ -80,6 +84,7 @@ class SearchProductControllerTest extends AbstractWebTestCase
                     $Grandson->setUpdateDate(new \DateTime());
                     $this->app['orm.em']->persist($Grandson);
                     $this->app['orm.em']->flush();
+                    $Child->addChild($Grandson);
                 }
             }
         }
@@ -105,10 +110,10 @@ class SearchProductControllerTest extends AbstractWebTestCase
         $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 
-    public function testMoveRankAndShow()
+    public function testCategory()
     {
         // Give
-        $Category = $this->app['eccube.repository.category']->findOneBy(array('name' => '親1'));
+        $Category = $this->app['eccube.repository.category']->findOneBy(array('name' => '孫1'));
 
         // When
         $crawler = $this->client->request('GET',
@@ -120,7 +125,7 @@ class SearchProductControllerTest extends AbstractWebTestCase
 
         $categoryNameLastElement = $crawler->filter('.search select#category_id option')->last()->text();
 
-        $this->expected = $Category->getName();
+        $this->expected = $Category->getNameWithLevel();
         $this->actual = $categoryNameLastElement;
         $this->verify();
     }


### PR DESCRIPTION
This is PR to fix issue #1556:
下記の手順操作で不具合が発生しました。
①カテゴリー1を登録
②カテゴリー2を登録
③カテゴリー1の子カテゴリー1-1、1-2
④カテゴリー1とカテゴリー2の位置を交換
⑤カテゴリー1の子カテゴリーはなくなる、カテゴリー2の子カテゴリーになります。
