### PR TITLE
ページ管理フォームのURL及びファイル名のバリデーションを変更

### DIFF
--- a/src/Eccube/ControllerProvider/FrontControllerProvider.php
+++ b/src/Eccube/ControllerProvider/FrontControllerProvider.php
@@ -39,7 +39,7 @@ class FrontControllerProvider implements ControllerProviderInterface
         }
 
         // user定義
-        $c->match('/'.$app['config']['user_data_route'].'/{route}', '\Eccube\Controller\UserDataController::index')->assert('route', '[0-9a-zA-Z_]+')->bind('user_data');
+        $c->match('/'.$app['config']['user_data_route'].'/{route}', '\Eccube\Controller\UserDataController::index')->assert('route', '^([0-9a-zA-Z_\-]+\/?)+(?<!\/)$')->bind('user_data');
 
         // root
         $c->match('/', '\Eccube\Controller\TopController::index')->bind('homepage');

--- a/src/Eccube/ControllerProvider/FrontControllerProvider.php
+++ b/src/Eccube/ControllerProvider/FrontControllerProvider.php
@@ -39,7 +39,7 @@ class FrontControllerProvider implements ControllerProviderInterface
         }
 
         // user定義
-        $c->match('/'.$app['config']['user_data_route'].'/{route}', '\Eccube\Controller\UserDataController::index')->assert('route', '^([0-9a-zA-Z_\-]+\/?)+(?<!\/)$')->bind('user_data');
+        $c->match('/'.$app['config']['user_data_route'].'/{route}', '\Eccube\Controller\UserDataController::index')->assert('route', '([0-9a-zA-Z_\-]+\/?)+(?<!\/)')->bind('user_data');
 
         // root
         $c->match('/', '\Eccube\Controller\TopController::index')->bind('homepage');

--- a/src/Eccube/Form/Type/Admin/MainEditType.php
+++ b/src/Eccube/Form/Type/Admin/MainEditType.php
@@ -67,7 +67,7 @@ class MainEditType extends AbstractType
                         'max' => $app['config']['stext_len'],
                     )),
                     new Assert\Regex(array(
-                        'pattern' => '/^[0-9a-zA-Z_]+$/',
+                        'pattern' => '/^([0-9a-zA-Z_\-]+\/?)+(?<!\/)$/',
                     )),
                 )
             ))
@@ -80,7 +80,7 @@ class MainEditType extends AbstractType
                         'max' => $app['config']['stext_len'],
                     )),
                     new Assert\Regex(array(
-                        'pattern' => '/^[0-9a-zA-Z\/_]+$/',
+                        'pattern' => '/^([0-9a-zA-Z_\-]+\/?)+$/',
                     )),
                 )
             ))

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -234,6 +234,16 @@ abstract class EccubeTestCase extends WebTestCase
     }
 
     /**
+     * PageLayout オブジェクトを生成して返す
+     *
+     * @return \Eccube\Entity\PageLayout
+     */
+    public function createPageLayout()
+    {
+        return $this->app['eccube.fixture.generator']->createPageLayout();
+    }
+
+    /**
      * テーブルのデータを全て削除する.
      *
      * このメソッドは、参照制約の関係で、 Doctrine ORM ではデータ削除できない場合に使用する.

--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -9,8 +9,10 @@ use Eccube\Entity\CustomerAddress;
 use Eccube\Entity\Delivery;
 use Eccube\Entity\DeliveryTime;
 use Eccube\Entity\DeliveryFee;
+use Eccube\Entity\Master\DeviceType;
 use Eccube\Entity\Order;
 use Eccube\Entity\OrderDetail;
+use Eccube\Entity\PageLayout;
 use Eccube\Entity\Payment;
 use Eccube\Entity\PaymentOption;
 use Eccube\Entity\Product;
@@ -581,6 +583,31 @@ class Generator {
 
         $this->app['orm.em']->flush($Delivery);
         return $Delivery;
+    }
+
+    /**
+     * ページを生成する
+     *
+     * @return PageLayout
+     */
+    public function createPageLayout()
+    {
+        $faker = $this->getFaker();
+        $DeviceType = $this->app['eccube.repository.master.device_type']->find(DeviceType::DEVICE_TYPE_PC);
+        /** @var PageLayout $PageLayout */
+        $PageLayout = $this->app['eccube.repository.page_layout']->newPageLayout($DeviceType);
+        $PageLayout
+            ->setName($faker->word)
+            ->setUrl($faker->word)
+            ->setFileName($faker->word)
+            ->setAuthor($faker->word)
+            ->setDescription($faker->word)
+            ->setKeyword($faker->word)
+            ->setMetaRobots($faker->word)
+        ;
+        $this->app['orm.em']->persist($PageLayout);
+        $this->app['orm.em']->flush($PageLayout);
+        return $PageLayout;
     }
 
     /**

--- a/tests/Eccube/Tests/Form/Type/Admin/MainEditTestType.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/MainEditTestType.php
@@ -1,0 +1,254 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Tests\Form\Type\Admin;
+
+class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
+{
+    /** @var \Eccube\Application */
+    protected $app;
+
+    /** @var \Symfony\Component\Form\FormInterface */
+    protected $form;
+
+    /** @var array デフォルト値（正常系）を設定 */
+    protected $formData = array(
+        'name' => 'テストページ',
+        'url' => 'test',
+        'file_name' => 'foo/bar/baz',
+        'tpl_data' => 'contents',
+        'author' => '',
+        'description' => '',
+        'keyword' => '',
+        'meta_robots' => '',
+        'DeviceType' => '10',
+    );
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $options = array(
+            'csrf_protection' => false,
+        );
+        $this->form = $this->app['form.factory']
+            ->createBuilder('main_edit', null, $options)
+            ->getForm();
+    }
+
+    public function testValidData()
+    {
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testInValidName_Blank()
+    {
+        $this->formData['name'] = '';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidName_MaxLength()
+    {
+        $this->formData['name'] = '123456789012345678901234567890123456789012345678901';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testValidUrl_Slash()
+    {
+        $this->formData['url'] = 'hoge/fuga/piyo';
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testValidUrl_Symbol()
+    {
+        $this->formData['url'] = '-_';
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testInValidUrl_Blank()
+    {
+        $this->formData['url'] = '';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidUrl_StartsWithSlash()
+    {
+        $this->formData['url'] = '/hoge/fuga/piyo';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidUrl_EndsWithSlash()
+    {
+        $this->formData['url'] = 'hoge/fuga/piyo/';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidUrl_ContinuousSlash()
+    {
+        $this->formData['url'] = 'hoge/fuga//piyo';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidUrl_MaxLength()
+    {
+        $this->formData['url'] = '123456789012345678901234567890123456789012345678901';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidUrl_DuplicateUrl()
+    {
+        $PageLayout = $this->createPageLayout();
+        $this->formData['url'] = $PageLayout->getUrl();
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testValidFileName_Slash()
+    {
+        $this->formData['file_name'] = 'hoge/fuga/piyo';
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testValidFileName_Symbol()
+    {
+        $this->formData['file_name'] = '-_';
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testValidFileName_EndsWithSlash()
+    {
+        $this->formData['file_name'] = 'hoge/fuga/piyo/';
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testInValidFileName_Blank()
+    {
+        $this->formData['file_name'] = '';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidFileName_StartsWithSlash()
+    {
+        $this->formData['file_name'] = '/hoge/fuga/piyo';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidFileName_ContinuousSlash()
+    {
+        $this->formData['file_name'] = 'hoge/fuga//piyo';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidFileName_DuplicateSlash()
+    {
+        $this->formData['file_name'] = 'hoge/fuga//piyo';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidFileName_MaxLength()
+    {
+        $this->formData['file_name'] = '123456789012345678901234567890123456789012345678901';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testValidTplData_Blank()
+    {
+        $this->formData['tpl_data'] = '';
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testValidAuthor_Blank()
+    {
+        $this->formData['author'] = '';
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testInValidAuthor_MaxLength()
+    {
+        $this->formData['author'] = '123456789012345678901234567890123456789012345678901';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testValidDescription_Blank()
+    {
+        $this->formData['description'] = '';
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testInValidDescription_MaxLength()
+    {
+        $this->formData['description'] = '123456789012345678901234567890123456789012345678901';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testValidKeyword_Blank()
+    {
+        $this->formData['keyword'] = '';
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testInValidKeyword_MaxLength()
+    {
+        $this->formData['keyword'] = '123456789012345678901234567890123456789012345678901';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testValidMetaRobots_Blank()
+    {
+        $this->formData['meta_robots'] = '';
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testInValidMetaRobots_MaxLength()
+    {
+        $this->formData['meta_robots'] = '123456789012345678901234567890123456789012345678901';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+}

--- a/tests/Eccube/Tests/Form/Type/Admin/MainEditTestType.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/MainEditTestType.php
@@ -71,7 +71,7 @@ class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInValidName_MaxLength()
     {
-        $this->formData['name'] = '123456789012345678901234567890123456789012345678901';
+        $this->formData['name'] = str_repeat('1', $this->app['config']['stext_len'] + 1);
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
@@ -120,7 +120,7 @@ class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInValidUrl_MaxLength()
     {
-        $this->formData['url'] = '123456789012345678901234567890123456789012345678901';
+        $this->formData['url'] = str_repeat('1', $this->app['config']['stext_len'] + 1);;
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
@@ -184,7 +184,7 @@ class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInValidFileName_MaxLength()
     {
-        $this->formData['file_name'] = '123456789012345678901234567890123456789012345678901';
+        $this->formData['file_name'] = str_repeat('1', $this->app['config']['stext_len'] + 1);;
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
@@ -205,7 +205,7 @@ class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInValidAuthor_MaxLength()
     {
-        $this->formData['author'] = '123456789012345678901234567890123456789012345678901';
+        $this->formData['author'] = str_repeat('1', $this->app['config']['stext_len'] + 1);;
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
@@ -219,7 +219,7 @@ class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInValidDescription_MaxLength()
     {
-        $this->formData['description'] = '123456789012345678901234567890123456789012345678901';
+        $this->formData['description'] = str_repeat('1', $this->app['config']['stext_len'] + 1);;
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
@@ -233,7 +233,7 @@ class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInValidKeyword_MaxLength()
     {
-        $this->formData['keyword'] = '123456789012345678901234567890123456789012345678901';
+        $this->formData['keyword'] = str_repeat('1', $this->app['config']['stext_len'] + 1);;
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
@@ -247,7 +247,7 @@ class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInValidMetaRobots_MaxLength()
     {
-        $this->formData['meta_robots'] = '123456789012345678901234567890123456789012345678901';
+        $this->formData['meta_robots'] = str_repeat('1', $this->app['config']['stext_len'] + 1);;
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }

--- a/tests/Eccube/Tests/Form/Type/Admin/MainEditTestType.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/MainEditTestType.php
@@ -2,7 +2,7 @@
 /*
  * This file is part of EC-CUBE
  *
- * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ * Copyright(c) 2000-2016 LOCKON CO.,LTD. All Rights Reserved.
  *
  * http://www.lockon.co.jp/
  *


### PR DESCRIPTION
SEOのためにURLの階層化をしたいとの要望から。

# URL
- 使用できる文字列に ```-_/``` を追加
- ```/``` は、文頭・文末及び連続での出現を許容しない

# ファイル名
- 使用できる文字列に ```-_/``` を追加
- ```/``` は、文頭及び連続での出現を許容しない

# テスト関係
- ページ管理フォームのテストケースを追加
- PageLayoutの自動生成を追加