### PR TITLE
受注マスター検索の status でインデックスを使用できるように

### DIFF
--- a/src/Eccube/Repository/Master/OrderStatusRepository.php
+++ b/src/Eccube/Repository/Master/OrderStatusRepository.php
@@ -35,6 +35,47 @@ use Doctrine\ORM\Query;
  */
 class OrderStatusRepository extends EntityRepository
 {
+    /**
+     * NOT IN で検索する.
+     *
+     * TODO Abstract メソッドにしたい
+     *
+     * @param array $criteria
+     * @param array $orderBy
+     * @param integer $limit
+     * @param integer $offset
+     * @return array
+     * @see EntityRepository::findBy()
+     */
+    public function findNotContainsBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+    {
+        $qb = $this->createQueryBuilder('o');
+
+        foreach ($criteria as $col => $val) {
+            $qb->andWhere($qb->expr()->notIn('o.'.$col, ':'.$col))
+                ->setParameter($col, (array)$val);
+        }
+
+        if (is_array($orderBy)) {
+            foreach ($orderBy as $sort => $order) {
+                if (array_values($orderBy) === $orderBy) { // 配列 or 連想配列
+                    $sort = $order;
+                    $order = 'ASC';
+                }
+                $qb->orderBy('o.'.$sort, $order);
+            }
+        }
+
+        if ($limit > 0) {
+            $qb->setMaxResults($limit);
+        }
+        if ($offset > 0) {
+            $qb->setFirstResult($offset);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
     public function findAllArray()
     {
 

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -293,8 +293,11 @@ class OrderRepository extends EntityRepository
                 ->setParameter('status', $searchData['status']);
         } else {
             // 購入処理中は検索対象から除外
-            $qb->andWhere('o.OrderStatus <> :status')
-                ->setParameter('status', $this->app['config']['order_processing']);
+            $OrderStatuses = $this->getEntityManager()
+                ->getRepository('Eccube\Entity\Master\OrderStatus')
+                ->findNotContainsBy(array('id' => $this->app['config']['order_processing']));
+            $qb->andWhere($qb->expr()->in('o.OrderStatus', ':status'))
+                ->setParameter('status', $OrderStatuses);
         }
 
         // name

--- a/tests/Eccube/Tests/Repository/Master/OrderStatusRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/Master/OrderStatusRepositoryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Eccube\Tests\Repository\Master;
+
+use Eccube\Tests\EccubeTestCase;
+use Eccube\Application;
+
+
+/**
+ * OrderStatusRepository test cases.
+ *
+ * @author Kentaro Ohkouchi
+ */
+class OrderStatusRepositoryTest extends EccubeTestCase
+{
+
+    protected $OrderStatusRepository;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->OrderStatusRepository = $this->app['orm.em']->getRepository('Eccube\Entity\Master\OrderStatus');
+    }
+
+    public function testFindNotContainsBy()
+    {
+        $OrderStatuses = $this->OrderStatusRepository->findNotContainsBy(array());
+        $this->actual = count($OrderStatuses);
+        $this->expected = 8;
+        $this->verify();
+    }
+
+    public function testFindNotContainsBy1()
+    {
+        $OrderStatuses = $this->OrderStatusRepository->findNotContainsBy(array('name' => '決済処理中'));
+        $this->actual = count($OrderStatuses);
+        $this->expected = 7;
+        $this->verify();
+    }
+
+    public function testFindNotContainsBy2()
+    {
+        $OrderStatuses = $this->OrderStatusRepository->findNotContainsBy(array('name' => array('決済処理中', '新規受付')));
+        $this->actual = count($OrderStatuses);
+        $this->expected = 6;
+        $this->verify();
+    }
+
+    public function testFindNotContainsBy3()
+    {
+        $OrderStatuses = $this->OrderStatusRepository->findNotContainsBy(array('id' => array(1, 2, 3, 4, 5, 6, 7)));
+        $this->actual = count($OrderStatuses);
+        $this->expected = 1;
+        $this->verify();
+    }
+
+    public function testFindNotContainsBy4()
+    {
+        $OrderStatuses = $this->OrderStatusRepository->findNotContainsBy(array(), array('id' => 'DESC'));
+        $this->actual = implode(', ', array_map(
+            function($OrderStatus) {
+                return $OrderStatus->getId();
+            }, $OrderStatuses));
+        $this->expected = '8, 7, 6, 5, 4, 3, 2, 1';
+        $this->verify();
+    }
+
+    public function testFindNotContainsBy5()
+    {
+        $OrderStatuses = $this->OrderStatusRepository->findNotContainsBy(array(), array('id'));
+        $this->actual = implode(', ', array_map(
+            function($OrderStatus) {
+                return $OrderStatus->getId();
+            }, $OrderStatuses));
+        $this->expected = '1, 2, 3, 4, 5, 6, 7, 8';
+        $this->verify();
+    }
+
+    public function testFindNotContainsBy6()
+    {
+        $OrderStatuses = $this->OrderStatusRepository->findNotContainsBy(array(), array('id'), 1);
+        $this->actual = implode(', ', array_map(
+            function($OrderStatus) {
+                return $OrderStatus->getId();
+            }, $OrderStatuses));
+        $this->expected = '1';
+        $this->verify();
+    }
+
+    public function testFindNotContainsBy7()
+    {
+        $OrderStatuses = $this->OrderStatusRepository->findNotContainsBy(array(), array('id'), 2, 2);
+        $this->actual = implode(', ', array_map(
+            function($OrderStatus) {
+                return $OrderStatus->getId();
+            }, $OrderStatuses));
+        $this->expected = '3, 4';
+        $this->verify();
+    }
+}


### PR DESCRIPTION
- #1830
- <> ではなく IN で検索できるよう修正
- OrderStatusRepository::findNotContainsBy() メソッド追加