### PR TITLE
商品詳細画面にブラウザバックしたときのキャッシュを無効化

### DIFF
--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -79,6 +79,13 @@ $(function(){
     $('#add-cart').click(function() {
         $('#mode').val('add_cart');
     });
+
+    // bfcache無効化
+    $(window).bind('pageshow', function(event) {
+        if (event.originalEvent.persisted) {
+            location.reload(true);
+        }
+    });
 });
 </script>
 


### PR DESCRIPTION
#1782

オーバレイだけでなく、ボタンの無効化やhiddenの値も残っているので、Safari/FFでブラウザバックしてきたときにbfcacheが効いている場合はリロードするようにしました。

https://developer.mozilla.org/ja/docs/Using_Firefox_1.5_caching