### PR TITLE
プラグインの config.yml, event.yml をキャッシュするよう修正

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -410,12 +410,7 @@ class Application extends ApplicationTrait
         $this->register(new \Saxulum\DoctrineOrmManagerRegistry\Silex\Provider\DoctrineOrmManagerRegistryProvider());
 
         // プラグインのmetadata定義を合わせて行う.
-        $pluginBasePath = __DIR__.'/../../app/Plugin';
-        $finder = Finder::create()
-            ->in($pluginBasePath)
-            ->directories()
-            ->depth(0);
-
+        $pluginConfigs = $this->getPluginConfigAll();
         $ormMappings = array();
         $ormMappings[] = array(
             'type' => 'yml',
@@ -426,23 +421,13 @@ class Application extends ApplicationTrait
             ),
         );
 
-        foreach ($finder as $dir) {
-
-            $file = $dir->getRealPath().'/config.yml';
-
-            if (file_exists($file)) {
-                $config = Yaml::parse(file_get_contents($file));
-            } else {
-                $code = $dir->getBaseName();
-                $this['monolog']->warning("skip {$code} orm.path loading. config.yml not found.", array('path' => $file));
-                continue;
-            }
-
+        foreach ($pluginConfigs as $code) {
+            $config = $code['config'];
             // Doctrine Extend
             if (isset($config['orm.path']) && is_array($config['orm.path'])) {
                 $paths = array();
                 foreach ($config['orm.path'] as $path) {
-                    $paths[] = $pluginBasePath.'/'.$config['code'].$path;
+                    $paths[] = $this['config']['plugin_realdir'].'/'.$config['code'].$path;
                 }
                 $ormMappings[] = array(
                     'type' => 'yml',
@@ -821,19 +806,15 @@ class Application extends ApplicationTrait
     public function loadPlugin()
     {
         // プラグインディレクトリを探索.
-        $basePath = __DIR__.'/../../app/Plugin';
-        $finder = Finder::create()
-            ->in($basePath)
-            ->directories()
-            ->depth(0);
-
-        $finder->sortByName();
+        $basePath = $this['config']['plugin_realdir'];
+        $pluginConfigs = $this->getPluginConfigAll();
 
         // ハンドラ優先順位をdbから持ってきてハッシュテーブルを作成
         $priorities = array();
         $handlers = $this['orm.em']
             ->getRepository('Eccube\Entity\PluginEventHandler')
             ->getHandlers();
+
         foreach ($handlers as $handler) {
             if ($handler->getPlugin()->getEnable() && !$handler->getPlugin()->getDelFlg()) {
 
@@ -847,12 +828,11 @@ class Application extends ApplicationTrait
 
         // プラグインをロードする.
         // config.yml/event.ymlの定義に沿ってインスタンスの生成を行い, イベント設定を行う.
-        foreach ($finder as $dir) {
-            //config.ymlのないディレクトリは無視する
-            $path = $dir->getRealPath();
-            $code = $dir->getBaseName();
+        foreach ($pluginConfigs as $code => $pluginConfig) {
+            // 正しい形式の pluginConfig のみ読み込む
+            $path = $basePath.'/'.$code;
             try {
-                $this['eccube.service.plugin']->checkPluginArchiveContent($path);
+                $this['eccube.service.plugin']->checkPluginArchiveContent($path, $pluginConfig['config']);
             } catch (\Eccube\Exception\PluginException $e) {
                 $this['monolog']->warning("skip {$code} config loading. config.yml not foud or invalid.", array(
                     'path' => $path,
@@ -860,7 +840,7 @@ class Application extends ApplicationTrait
                 ));
                 continue;
             }
-            $config = $this['eccube.service.plugin']->readYml($dir->getRealPath().'/config.yml');
+            $config = $pluginConfig['config'];
 
             $plugin = $this['orm.em']
                 ->getRepository('Eccube\Entity\Plugin')
@@ -894,11 +874,11 @@ class Application extends ApplicationTrait
                     $eventExists = false;
                 }
 
-                if ($eventExists && file_exists($dir->getRealPath().'/event.yml')) {
+                if ($eventExists && isset($config['event'])) {
 
                     $subscriber = new $class($this);
 
-                    foreach (Yaml::parse(file_get_contents($dir->getRealPath().'/event.yml')) as $event => $handlers) {
+                    foreach ($pluginConfig['event'] as $event => $handlers) {
                         foreach ($handlers as $handler) {
                             if (!isset($priorities[$config['event']][$event][$handler[0]])) { // ハンドラテーブルに登録されていない（ソースにしか記述されていない)ハンドラは一番後ろにする
                                 $priority = \Eccube\Entity\PluginEventHandler::EVENT_PRIORITY_LATEST;
@@ -1119,5 +1099,123 @@ class Application extends ApplicationTrait
             }
 
         }, -1024);
+    }
+
+    /**
+     * すべてのプラグインの設定情報を返す.
+     *
+     * すべてのプラグインの config.yml 及び event.yml を読み込み、連想配列で返す.
+     * キャッシュファイルが存在する場合は、キャッシュを利用する.
+     * キャッシュファイルが存在しない場合は、キャッシュを生成する.
+     * $app['debug'] = true の場合は、キャッシュを利用しない.
+     *
+     * @return array
+     */
+    public function getPluginConfigAll()
+    {
+        if ($this['debug']) {
+            return $this->parsePluginConfigs();
+        }
+        $pluginConfigCache = $this->getPluginConfigCacheFile();
+        if (file_exists($pluginConfigCache)) {
+            return require $pluginConfigCache;
+        }
+        if ($this->writePluginConfigCache($pluginConfigCache) === false) {
+            return $this->parsePluginConfigs();
+        } else {
+            return require $pluginConfigCache;
+        }
+    }
+
+    /**
+     * プラグイン設定情報のキャッシュを書き込む.
+     *
+     * @param string $cacheFile
+     * @return int|boolean file_put_contents() の結果
+     */
+    public function writePluginConfigCache($cacheFile = null)
+    {
+        if (is_null($cacheFile)) {
+            $cacheFile = $this->getPluginConfigCacheFile();
+        }
+        $pluginConfigs = $this->parsePluginConfigs();
+        if (!file_exists($this['config']['plugin_temp_realdir'])) {
+            @mkdir($this['config']['plugin_temp_realdir']);
+        }
+        $this['monolog']->debug("write plugin config cache", array($pluginConfigs));
+        return file_put_contents($cacheFile, sprintf('<?php return %s', var_export($pluginConfigs, true)).';');
+    }
+
+    /**
+     * プラグイン設定情報のキャッシュファイルを削除する.
+     *
+     * @return boolean
+     */
+    public function removePluginConfigCache()
+    {
+        $cacheFile = $this->getPluginConfigCacheFile();
+        if (file_exists($cacheFile)) {
+            $this['monolog']->debug("remove plugin config cache");
+            return unlink($cacheFile);
+        }
+        return false;
+    }
+
+    /**
+     * プラグイン設定情報のキャッシュファイルパスを返す.
+     *
+     * @return string
+     */
+    public function getPluginConfigCacheFile()
+    {
+        return $this['config']['plugin_temp_realdir'].'/config_cache.php';
+    }
+
+    /**
+     * プラグイン設定情報をパースし, 連想配列で返す.
+     *
+     * すべてのプラグインを探索し、 config.yml 及び event.yml をパースする.
+     * パースした情報を連想配列で返す.
+     *
+     * @return array
+     */
+    public function parsePluginConfigs()
+    {
+
+        $finder = Finder::create()
+            ->in($this['config']['plugin_realdir'])
+            ->directories()
+            ->depth(0);
+        $finder->sortByName();
+
+        $pluginConfigs = array();
+        foreach ($finder as $dir) {
+            $code = $dir->getBaseName();
+            $file = $dir->getRealPath().'/config.yml';
+            $config = null;
+            if (file_exists($file)) {
+                $config = Yaml::parse(file_get_contents($file));
+            } else {
+                $this['monolog']->warning("skip {$code} orm.path loading. config.yml not found.", array('path' => $file));
+                continue;
+            }
+
+            $file = $dir->getRealPath().'/event.yml';
+            $event = null;
+            if (file_exists($file)) {
+                $event = Yaml::parse(file_get_contents($file));
+            } else {
+                $this['monolog']->info("skip {$code} event.yml not found.", array('path' => $file));
+            }
+            if (!is_null($config)) {
+                $pluginConfigs[$code] = array(
+                    'config' => $config,
+                    'event' => $event
+                );
+                $this['monolog']->debug("parse {$code} config", array($code => $pluginConfigs[$code]));
+            }
+        }
+
+        return $pluginConfigs;
     }
 }


### PR DESCRIPTION
- #1812
- debug モードではキャッシュを使用しません
- キャッシュが存在しない場合は自動的に生成します
- キャッシュの更新は、プラグインの install/enable/disable/uninstall/update のタイミングで行います