### PR TITLE
translatorのキャッシュを削除するように修正

### DIFF
--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -28,7 +28,6 @@ use Eccube\Application;
 use Eccube\Common\Constant;
 use Eccube\Controller\AbstractController;
 use Eccube\Exception\PluginException;
-use Eccube\Util\Cache;
 use Eccube\Util\Str;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -199,8 +198,6 @@ class PluginController extends AbstractController
                     $fs->remove($tmpDir);
 
                     $app->addSuccess('admin.plugin.update.complete', 'admin');
-
-                    Cache::clear($app, false);
 
                     return $app->redirect($app->url('admin_store_plugin'));
 
@@ -578,9 +575,6 @@ class PluginController extends AbstractController
 
                                 $service->update($Plugin, $tmpDir.'/'.$tmpFile);
                                 $app->addSuccess('admin.plugin.update.complete', 'admin');
-
-                                Cache::clear($app, false);
-
                             }
 
                             $fs = new Filesystem();

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -26,6 +26,7 @@ namespace Eccube\Service;
 
 use Eccube\Common\Constant;
 use Eccube\Exception\PluginException;
+use Eccube\Util\Cache;
 use Eccube\Util\Str;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
@@ -48,6 +49,7 @@ class PluginService
 
         try {
             $this->app->removePluginConfigCache();
+            Cache::clear($this->app, false);
             $tmp = $this->createTempDir();
 
             $this->unpackPluginArchive($path, $tmp); //一旦テンポラリに展開
@@ -269,6 +271,7 @@ class PluginService
     {
         $pluginDir = $this->calcPluginDir($plugin->getCode());
         $this->app->removePluginConfigCache();
+        Cache::clear($this->app, false);
         $this->callPluginManagerMethod(Yaml::parse(file_get_contents($pluginDir.'/'.self::CONFIG_YML)), 'disable');
         $this->callPluginManagerMethod(Yaml::parse(file_get_contents($pluginDir.'/'.self::CONFIG_YML)), 'uninstall');
         $this->unregisterPlugin($plugin);
@@ -308,6 +311,7 @@ class PluginService
         $em = $this->app['orm.em'];
         try {
             $this->app->removePluginConfigCache();
+            Cache::clear($this->app, false);
             $pluginDir = $this->calcPluginDir($plugin->getCode());
             $em->getConnection()->beginTransaction();
             $plugin->setEnable($enable ? Constant::ENABLED : Constant::DISABLED);
@@ -330,6 +334,7 @@ class PluginService
         $tmp = null;
         try {
             $this->app->removePluginConfigCache();
+            Cache::clear($this->app, false);
             $tmp = $this->createTempDir();
 
             $this->unpackPluginArchive($path, $tmp); //一旦テンポラリに展開

--- a/src/Eccube/Util/Cache.php
+++ b/src/Eccube/Util/Cache.php
@@ -70,6 +70,10 @@ class Cache
                 $finder = Finder::create()->in($cacheDir.'/twig');
                 $filesystem->remove($finder);
             }
+            if (is_dir($cacheDir.'/translator')) {
+                $finder = Finder::create()->in($cacheDir.'/translator');
+                $filesystem->remove($finder);
+            }
         }
 
         return true;


### PR DESCRIPTION
#1882 の修正です

- Cache::clearにtranslatorを追加
- コントローラでキャッシュクリアしていたのを、PluginServiceへ移動