### PR TITLE
Travis CI の高速化

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ php:
 matrix:
   fast_finish: true
   include:
-    - php: 7.0 # for coverrage
+    - php: 7.0.12 # for coverrage
       env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
       sudo: required
       dist: trusty
@@ -43,7 +43,7 @@ matrix:
       env: DB=sqlite
     - php: 5.6 # for coverrage (travis で phpdbg が動かなくなったため, phpdbg が動くようになるまでの暫定)
       env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
-    - php: 7.0 # dist: trusty を動かすためのダミー. 実際にテストは実行されない
+    - php: 7.0.12 # dist: trusty を動かすためのダミー. 実際にテストは実行されない
       env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
       env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
     - php: 5.5
       env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
+    - php: 5.6
+      env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
     - php: 7.0
       env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,6 @@ matrix:
       env: DB=sqlite
     - PHP: 5.6
       env: DB=sqlite
-    - php: 5.6 # for coverrage (travis で phpdbg が動かなくなったため, phpdbg が動くようになるまでの暫定)
-      env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
     - php: 7.0.12 # dist: trusty を動かすためのダミー. 実際にテストは実行されない
       env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
 
@@ -67,7 +65,6 @@ before_script:
 
 script: # PHP7 + precise のテストは実行されない
   - if [[ $PHP_SAPI = 'phpdbg' ]] && [[ $CODENAME = 'trusty' ]]; then phpdbg -qrr ./vendor/bin/phpunit --coverage-clover=coverage.clover ; fi
-  - if [[ $PHP_SAPI = 'phpdbg' ]] && [[ $CODENAME = 'precise' ]] && [[ $TRAVIS_PHP_VERSION =~ ^[5] ]]; then phpunit --coverage-clover=coverage.clover ; fi # (travis で phpdbg が動かなくなったため, phpdbg が動くようになるまでの暫定)
   - if [[ $PHP_SAPI != 'phpdbg' ]]; then phpunit ; fi
 
 after_script:


### PR DESCRIPTION
- Ubuntu trusty で、PHP のマイナーバージョンを指定
  - trusty では、バージョンを決め打ちしないと、上位バージョンを使ってくれない模様
  - phpdbg でテストが落ちる問題は、 PHP7.0.9 以降で解消しているため、 PHP7.0.12 を指定
- 暫定的に実行していた PHP5.6 でのカバレッジ出力を削除
- カバレッジ出力用のテストパラメータ変更のため、本体には影響ありません