### PR TITLE
Update symfony 2.7.20

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3428,16 +3428,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.24.2",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "33093f6e310e6976baeac7b14f3a6ec02f2d79b7"
+                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/33093f6e310e6976baeac7b14f3a6ec02f2d79b7",
-                "reference": "33093f6e310e6976baeac7b14f3a6ec02f2d79b7",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
+                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
                 "shasum": ""
             },
             "require": {
@@ -3450,7 +3450,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.24-dev"
+                    "dev-master": "1.27-dev"
                 }
             },
             "autoload": {
@@ -3485,7 +3485,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-09-01 17:50:53"
+            "time": "2016-10-25 19:17:17"
         }
     ],
     "packages-dev": [
@@ -3545,16 +3545,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v1.12.2",
+            "version": "v1.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "baa7112bef3b86c65fcfaae9a7a50436e3902b41"
+                "reference": "78a820c16d13f593303511461eefa939502fb2de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/baa7112bef3b86c65fcfaae9a7a50436e3902b41",
-                "reference": "baa7112bef3b86c65fcfaae9a7a50436e3902b41",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/78a820c16d13f593303511461eefa939502fb2de",
+                "reference": "78a820c16d13f593303511461eefa939502fb2de",
                 "shasum": ""
             },
             "require": {
@@ -3599,7 +3599,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-09-27 07:57:59"
+            "time": "2016-10-30 12:07:10"
         },
         {
             "name": "fzaninotto/faker",
@@ -3701,16 +3701,16 @@
         },
         {
             "name": "phing/phing",
-            "version": "2.15.0",
+            "version": "2.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phingofficial/phing.git",
-                "reference": "bbfcaee391123220fc54e9c6feffeeea3c8775b7"
+                "reference": "0999ab4e94e609dc00998e3d1b88df843054db7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phingofficial/phing/zipball/bbfcaee391123220fc54e9c6feffeeea3c8775b7",
-                "reference": "bbfcaee391123220fc54e9c6feffeeea3c8775b7",
+                "url": "https://api.github.com/repos/phingofficial/phing/zipball/0999ab4e94e609dc00998e3d1b88df843054db7c",
+                "reference": "0999ab4e94e609dc00998e3d1b88df843054db7c",
                 "shasum": ""
             },
             "require": {
@@ -3790,7 +3790,7 @@
                 "task",
                 "tool"
             ],
-            "time": "2016-09-14 19:38:14"
+            "time": "2016-10-13 09:01:45"
         },
         {
             "name": "phpdocumentor/reflection-docblock",

--- a/composer.lock
+++ b/composer.lock
@@ -1536,7 +1536,7 @@
         },
         {
             "name": "symfony/class-loader",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
@@ -1589,7 +1589,7 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
@@ -1642,16 +1642,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "91a8fb9f91aeb00caaeab95818063e3a96bff9e2"
+                "reference": "47766c4c81e6d7790a9e4f029747f9a00da5f64d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/91a8fb9f91aeb00caaeab95818063e3a96bff9e2",
-                "reference": "91a8fb9f91aeb00caaeab95818063e3a96bff9e2",
+                "url": "https://api.github.com/repos/symfony/console/zipball/47766c4c81e6d7790a9e4f029747f9a00da5f64d",
+                "reference": "47766c4c81e6d7790a9e4f029747f9a00da5f64d",
                 "shasum": ""
             },
             "require": {
@@ -1698,11 +1698,11 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-27 17:33:51"
+            "time": "2016-10-05 17:26:56"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -1755,7 +1755,7 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
@@ -1812,7 +1812,7 @@
         },
         {
             "name": "symfony/debug-bundle",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug-bundle.git",
@@ -1873,7 +1873,7 @@
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
@@ -1944,16 +1944,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "fb36832c2917a18b189635abd6d4ab5c2ffd0830"
+                "reference": "1787f6ed531e1325047faf2f5ee3c6130e5f8f93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/fb36832c2917a18b189635abd6d4ab5c2ffd0830",
-                "reference": "fb36832c2917a18b189635abd6d4ab5c2ffd0830",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/1787f6ed531e1325047faf2f5ee3c6130e5f8f93",
+                "reference": "1787f6ed531e1325047faf2f5ee3c6130e5f8f93",
                 "shasum": ""
             },
             "require": {
@@ -1995,11 +1995,11 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:17:26"
+            "time": "2016-10-18 13:42:15"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -2059,16 +2059,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "32963bc5eaa8de768289f2537feade3a21e26b4d"
+                "reference": "a8cfb155a7bad6de2c59406bd387232f76fdc24e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/32963bc5eaa8de768289f2537feade3a21e26b4d",
-                "reference": "32963bc5eaa8de768289f2537feade3a21e26b4d",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/a8cfb155a7bad6de2c59406bd387232f76fdc24e",
+                "reference": "a8cfb155a7bad6de2c59406bd387232f76fdc24e",
                 "shasum": ""
             },
             "require": {
@@ -2104,11 +2104,11 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 07:26:07"
+            "time": "2016-10-14 14:26:34"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -2157,16 +2157,16 @@
         },
         {
             "name": "symfony/form",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/form.git",
-                "reference": "e92a5ac2ccda4fce09b4ebe52444c01ccdea18cc"
+                "reference": "b284ce0d1320e9c72b8e09a5d60d095f3f885ccd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/form/zipball/e92a5ac2ccda4fce09b4ebe52444c01ccdea18cc",
-                "reference": "e92a5ac2ccda4fce09b4ebe52444c01ccdea18cc",
+                "url": "https://api.github.com/repos/symfony/form/zipball/b284ce0d1320e9c72b8e09a5d60d095f3f885ccd",
+                "reference": "b284ce0d1320e9c72b8e09a5d60d095f3f885ccd",
                 "shasum": ""
             },
             "require": {
@@ -2225,20 +2225,20 @@
             ],
             "description": "Symfony Form Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-29 23:48:55"
+            "time": "2016-10-16 20:09:53"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "9aeee38f89b7637b2459fd999ad4c3da19984531"
+                "reference": "6a0838a26d54eff153b825e1550c1f6fa05a0941"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9aeee38f89b7637b2459fd999ad4c3da19984531",
-                "reference": "9aeee38f89b7637b2459fd999ad4c3da19984531",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/6a0838a26d54eff153b825e1550c1f6fa05a0941",
+                "reference": "6a0838a26d54eff153b825e1550c1f6fa05a0941",
                 "shasum": ""
             },
             "require": {
@@ -2281,20 +2281,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-21 11:21:12"
+            "time": "2016-10-24 14:36:35"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "fc28887b77fc6d27909d01eaab9ed803dfc9eb49"
+                "reference": "9a9b67d0379eb076a4139d51db9512031bb1c044"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/fc28887b77fc6d27909d01eaab9ed803dfc9eb49",
-                "reference": "fc28887b77fc6d27909d01eaab9ed803dfc9eb49",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/9a9b67d0379eb076a4139d51db9512031bb1c044",
+                "reference": "9a9b67d0379eb076a4139d51db9512031bb1c044",
                 "shasum": ""
             },
             "require": {
@@ -2302,7 +2302,7 @@
                 "psr/log": "~1.0",
                 "symfony/debug": "~2.6,>=2.6.2",
                 "symfony/event-dispatcher": "~2.6,>=2.6.7",
-                "symfony/http-foundation": "~2.7.15|~2.8.8"
+                "symfony/http-foundation": "~2.7.20|~2.8.13"
             },
             "conflict": {
                 "symfony/config": "<2.7"
@@ -2363,11 +2363,11 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-03 18:15:49"
+            "time": "2016-10-27 01:37:19"
         },
         {
             "name": "symfony/intl",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/intl.git",
@@ -2444,7 +2444,7 @@
         },
         {
             "name": "symfony/monolog-bridge",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bridge.git",
@@ -2504,16 +2504,16 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "86d19031b2bc078c939473edef196a434a727d23"
+                "reference": "f8d620f07243e09e61feb3af602eed237574298a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/86d19031b2bc078c939473edef196a434a727d23",
-                "reference": "86d19031b2bc078c939473edef196a434a727d23",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/f8d620f07243e09e61feb3af602eed237574298a",
+                "reference": "f8d620f07243e09e61feb3af602eed237574298a",
                 "shasum": ""
             },
             "require": {
@@ -2554,7 +2554,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2016-06-28 06:24:06"
+            "time": "2016-10-16 20:09:53"
         },
         {
             "name": "symfony/polyfill-apcu",
@@ -2670,7 +2670,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -2719,7 +2719,7 @@
         },
         {
             "name": "symfony/property-access",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
@@ -2779,7 +2779,7 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
@@ -2853,16 +2853,16 @@
         },
         {
             "name": "symfony/security",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security.git",
-                "reference": "3c2e4597e194d96d0eb10106b0a3e410de56f202"
+                "reference": "d0d852abb163a9371a7f07d2bc80824cf2d81b4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security/zipball/3c2e4597e194d96d0eb10106b0a3e410de56f202",
-                "reference": "3c2e4597e194d96d0eb10106b0a3e410de56f202",
+                "url": "https://api.github.com/repos/symfony/security/zipball/d0d852abb163a9371a7f07d2bc80824cf2d81b4d",
+                "reference": "d0d852abb163a9371a7f07d2bc80824cf2d81b4d",
                 "shasum": ""
             },
             "require": {
@@ -2929,11 +2929,11 @@
             ],
             "description": "Symfony Security Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-22 16:04:04"
+            "time": "2016-10-06 01:42:44"
         },
         {
             "name": "symfony/serializer",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
@@ -2996,7 +2996,7 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -3045,16 +3045,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "5b78058d0b4ee0cc0bc0f3bdafe02f18cfff2a35"
+                "reference": "f99349cca3041a7397ddc234c12c508cd483d9f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/5b78058d0b4ee0cc0bc0f3bdafe02f18cfff2a35",
-                "reference": "5b78058d0b4ee0cc0bc0f3bdafe02f18cfff2a35",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/f99349cca3041a7397ddc234c12c508cd483d9f7",
+                "reference": "f99349cca3041a7397ddc234c12c508cd483d9f7",
                 "shasum": ""
             },
             "require": {
@@ -3104,7 +3104,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 07:26:07"
+            "time": "2016-10-16 20:09:53"
         },
         {
             "name": "symfony/twig-bridge",
@@ -3189,16 +3189,16 @@
         },
         {
             "name": "symfony/validator",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "ef6e8905b0df226bbee4105df04a4f816d419cd5"
+                "reference": "ed3332ad0e5d7f71370f94a6a42edca1a7444baf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/ef6e8905b0df226bbee4105df04a4f816d419cd5",
-                "reference": "ef6e8905b0df226bbee4105df04a4f816d419cd5",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/ed3332ad0e5d7f71370f94a6a42edca1a7444baf",
+                "reference": "ed3332ad0e5d7f71370f94a6a42edca1a7444baf",
                 "shasum": ""
             },
             "require": {
@@ -3258,20 +3258,20 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-03 16:05:36"
+            "time": "2016-10-19 22:22:52"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "2bcbcad1ca9f18b326e56a9d2dbd22ba4565082b"
+                "reference": "ccf3dc8ff2f4076290055394847105982bcdd718"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/2bcbcad1ca9f18b326e56a9d2dbd22ba4565082b",
-                "reference": "2bcbcad1ca9f18b326e56a9d2dbd22ba4565082b",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/ccf3dc8ff2f4076290055394847105982bcdd718",
+                "reference": "ccf3dc8ff2f4076290055394847105982bcdd718",
                 "shasum": ""
             },
             "require": {
@@ -3317,20 +3317,20 @@
                 "debug",
                 "dump"
             ],
-            "time": "2016-09-29 12:21:39"
+            "time": "2016-10-06 08:40:01"
         },
         {
             "name": "symfony/web-profiler-bundle",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/web-profiler-bundle.git",
-                "reference": "aa86e82e300c98f7b567978180406c5257829003"
+                "reference": "d6a6a89a3340455a73e7efad9d6eb2bb5cac4e60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/aa86e82e300c98f7b567978180406c5257829003",
-                "reference": "aa86e82e300c98f7b567978180406c5257829003",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/d6a6a89a3340455a73e7efad9d6eb2bb5cac4e60",
+                "reference": "d6a6a89a3340455a73e7efad9d6eb2bb5cac4e60",
                 "shasum": ""
             },
             "require": {
@@ -3375,11 +3375,11 @@
             ],
             "description": "Symfony WebProfilerBundle",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 07:26:07"
+            "time": "2016-10-22 15:04:15"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
@@ -4706,7 +4706,7 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v2.7.19",
+            "version": "v2.7.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",


### PR DESCRIPTION
symfony及びその他ライブラリの更新

Symfony 2.7.20 released
http://symfony.com/blog/symfony-2-7-20-released

- symfony/*
  - Updating symfony/* (v2.7.19) to symfony/* (v2.7.20)
- twig/twig
  - Updating twig/twig (v1.24.2) to twig/twig (v1.27.0)
- others
  - Updating phing/phing (2.15.0) to phing/phing (2.15.2)
  - Updating friendsofphp/php-cs-fixer (v1.12.2) to friendsofphp/php-cs-fixer (v1.12.3)
- 備考
  - fzaninotto/faker v1.6.0は https://github.com/fzaninotto/Faker/pull/917 の不具合があるので見送り
  - twig/twigはvfsStream利用時の不具合が解消されたのでアップデート
    - https://github.com/twigphp/Twig/issues/2166