### PR TITLE
postgresql9.0以下で商品一覧が動作しない不具合の修正

### DIFF
--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -109,7 +109,11 @@ class ProductRepository extends EntityRepository
             //@see http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html
             $qb->addSelect('MIN(pc.price02) as HIDDEN price02_min');
             $qb->innerJoin('p.ProductClasses', 'pc');
-            $qb->groupBy('p.id');
+            $qb->groupBy('p');
+            // postgres9.0以下は, groupBy('p.id')が利用できない
+            // mysqlおよびpostgresql9.1以上であればgroupBy('p.id')にすることで性能向上が期待できる.
+            // @see https://github.com/EC-CUBE/ec-cube/issues/1904
+            // $qb->groupBy('p.id');
             $qb->orderBy('price02_min', 'ASC');
             $qb->addOrderBy('p.id', 'DESC');
             // 新着順


### PR DESCRIPTION
#1904 

- #1844 の修正を一部差し戻し
- doctrine側(PostgreSQLPlatform)では吸収できなさそう