### PR TITLE
開発者用にHeroku deploy ボタンに対応

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: vendor/bin/heroku-php-apache2 html/

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: vendor/bin/heroku-php-apache2 html/
+web: $(composer config bin-dir)/heroku-php-apache2 html/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
   
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/EC-CUBE/ec-cube?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
 
 + 本ドキュメントはEC-CUBEの開発者を主要な対象者としております。  
 + パッケージ版をご利用の方は[EC-CUBEオフィシャルサイト](http://www.ec-cube.net)をご確認ください。  

--- a/app.json
+++ b/app.json
@@ -1,0 +1,8 @@
+{
+    "name": "EC-CUBE3",
+    "description": "EC-CUBE3 on Heroku",
+    "website": "https://github.com/EC-CUBE/ec-cube",
+    "repository": "https://github.com/EC-CUBE/ec-cube",
+    "keywords": ["php", "postgresql", "ec", "ec-cube", "GitHub"],
+    "addons": ["heroku-postgresql"]
+}

--- a/app.json
+++ b/app.json
@@ -3,6 +3,13 @@
     "description": "EC-CUBE3 on Heroku",
     "website": "https://github.com/EC-CUBE/ec-cube",
     "repository": "https://github.com/EC-CUBE/ec-cube",
-    "keywords": ["php", "postgresql", "ec", "ec-cube", "GitHub"],
-    "addons": ["heroku-postgresql"]
+    "keywords": ["php", "ec", "e-commerce", "ec-cube"],
+    "addons": [
+        "heroku-postgresql"
+    ],
+    "buildpacks": [
+        {
+            "url": "heroku/php"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
         "symfony/web-profiler-bundle": ">=2.7,<2.8",
         "symfony/var-dumper": ">=2.7,<2.8",
         "symfony/debug-bundle": ">=2.7,<2.8",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.6.*",
@@ -78,6 +79,12 @@
         "psr-4": {
             "Eccube\\Tests\\" : "tests/Eccube/Tests"
         }
+    },
+    "scripts": {
+        "compile": [
+            "php eccube_install.php pgsql none --skip-createdb -V",
+            "sed -i -e \"s|${PWD}|/app|\" ${PWD}/app/config/eccube/path.yml"
+        ]
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "8e54f962ea2f007f9295fd81b65892db",
-    "content-hash": "8f623cf24418d568eb9e2bd5a6586d3b",
+    "hash": "ecca4fb38655cbbdb95967d83b0edf49",
+    "content-hash": "3a588a55f37593336ef307b60283da09",
     "packages": [
         {
             "name": "dflydev/doctrine-orm-service-provider",
@@ -4771,7 +4771,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "ext-mbstring": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/eccube_install.php
+++ b/eccube_install.php
@@ -117,6 +117,15 @@ EOF;
 
 function initializeDefaultVariables($database_driver)
 {
+    $database_url = getenv('DATABASE_URL');
+    if ($database_url) {
+        $url = parse_url($database_url);
+        putenv('DBSERVER='.$url['host']);
+        putenv('DBNAME='.substr($url['path'], 1));
+        putenv('DBUSER='.$url['user']);
+        putenv('DBPORT='.$url['port']);
+        putenv('DBPASS='.$url['pass']);
+    }
     switch ($database_driver) {
         case 'pdo_pgsql':
             putenv('ROOTUSER='.(getenv('ROOTUSER') ? getenv('ROOTUSER') : (getenv('DBUSER') ? getenv('DBUSER') : 'postgres')));


### PR DESCRIPTION
背景

- masterやpull requestの動作確認を簡単に行いたい
- インストール完了状態で立ち上げたい

提供するもの
- readmeからherokuボタン押下
- herokuの画面から、デプロイ実行でec-cubeが立ち上がる

実装内容
- データベースは~~SQLite~~PostgreSQL
- インストール処理等はcomposer.jsonのscriptsに定義
   - compileはheroku-buildpack-phpから実行される
   - https://github.com/heroku/heroku-buildpack-php/blob/v114/bin/compile#L259

~~TODO~~

- ~~build packを使わないように修正~~
  - ~~build pack使うほどでもないので~~
  - ~~composer.jsonの定義でできるかどうか調査~~
     - ~~https://devcenter.heroku.com/articles/getting-started-with-symfony~~

- ~~postgresqlで動作できるかどうか調査~~
  - ~~composer.jsonに`require ext-pdo_sqlite:*`しないといけないので~~
  - ~~composer.jsonからだと, DBの初期化処理が通らないなど、問題が有り断念~~

参考

- #530