### PR TITLE
価格が高い順のソートを追加

### DIFF
--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -133,11 +133,11 @@ class ProductRepository extends EntityRepository
             $qb->addOrderBy('p.id', 'DESC');
             // 価格高い順
         } else if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == $config['product_order_price_higher']) {
-            $qb->addSelect('MIN(pc.price02) as HIDDEN price02_min');
+            $qb->addSelect('MAX(pc.price02) as HIDDEN price02_max');
             $qb->innerJoin('p.ProductClasses', 'pc');
             $qb->groupBy('p');
-            $qb->orderBy('price02_min', 'DESC');
-            $qb->addOrderBy('p.id', 'ASC');
+            $qb->orderBy('price02_max', 'DESC');
+            $qb->addOrderBy('p.id', 'DESC');
             // 新着順
         } else if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == $config['product_order_newer']) {
             $qb->orderBy('p.create_date', 'DESC');

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -117,7 +117,7 @@ class ProductRepository extends EntityRepository
             $qb->orderBy('price02_min', 'ASC');
             $qb->addOrderBy('p.id', 'DESC');
             // 価格高い順
-        } else if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '3') {
+        } else if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '100') {
             $qb->addSelect('MIN(pc.price02) as HIDDEN price02_min');
             $qb->innerJoin('p.ProductClasses', 'pc');
             $qb->groupBy('p');

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Repository;
 
+use Eccube\Application;
 use Eccube\Util\Str;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\NoResultException;
@@ -37,6 +38,19 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class ProductRepository extends EntityRepository
 {
+
+    /**
+     * @var \Eccube\Application
+     */
+    protected $app;
+
+    /**
+     * @param Application $app
+     */
+    public function setApplication(Application $app)
+    {
+        $this->app = $app;
+    }
 
     /**
      * get Product.
@@ -105,7 +119,8 @@ class ProductRepository extends EntityRepository
 
         // Order By
         // 価格低い順
-        if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '1') {
+        $config = $this->app['config'];
+        if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == $config['product_order_price_lower']) {
             //@see http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html
             $qb->addSelect('MIN(pc.price02) as HIDDEN price02_min');
             $qb->innerJoin('p.ProductClasses', 'pc');
@@ -117,14 +132,14 @@ class ProductRepository extends EntityRepository
             $qb->orderBy('price02_min', 'ASC');
             $qb->addOrderBy('p.id', 'DESC');
             // 価格高い順
-        } else if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '100') {
+        } else if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == $config['product_order_price_higher']) {
             $qb->addSelect('MIN(pc.price02) as HIDDEN price02_min');
             $qb->innerJoin('p.ProductClasses', 'pc');
             $qb->groupBy('p');
             $qb->orderBy('price02_min', 'DESC');
             $qb->addOrderBy('p.id', 'ASC');
             // 新着順
-        } else if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '2') {
+        } else if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == $config['product_order_newer']) {
             $qb->orderBy('p.create_date', 'DESC');
         } else {
             if ($categoryJoin === false) {

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -104,7 +104,7 @@ class ProductRepository extends EntityRepository
         }
 
         // Order By
-        // 価格順
+        // 価格低い順
         if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '1') {
             //@see http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html
             $qb->addSelect('MIN(pc.price02) as HIDDEN price02_min');
@@ -116,6 +116,13 @@ class ProductRepository extends EntityRepository
             // $qb->groupBy('p.id');
             $qb->orderBy('price02_min', 'ASC');
             $qb->addOrderBy('p.id', 'DESC');
+            // 価格高い順
+        } else if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '3') {
+            $qb->addSelect('MIN(pc.price02) as HIDDEN price02_min');
+            $qb->innerJoin('p.ProductClasses', 'pc');
+            $qb->groupBy('p');
+            $qb->orderBy('price02_min', 'DESC');
+            $qb->addOrderBy('p.id', 'ASC');
             // 新着順
         } else if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == '2') {
             $qb->orderBy('p.create_date', 'DESC');

--- a/src/Eccube/Resource/config/constant.yml.dist
+++ b/src/Eccube/Resource/config/constant.yml.dist
@@ -263,3 +263,6 @@ address1_len: 32
 address2_len: 32
 birth_max: 110
 cacert_pem_url: https://curl.haxx.se/ca/cacert.pem
+product_order_price_lower: 1
+product_order_newer: 2
+product_order_price_higher: 3

--- a/src/Eccube/Resource/doctrine/migration/Version20161108095350.php
+++ b/src/Eccube/Resource/doctrine/migration/Version20161108095350.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Eccube\Application;
+use Eccube\Entity\Master\ProductListOrderBy;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20161108095350 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $app = Application::getInstance();
+        $repository = $app['orm.em']->getRepository('Eccube\Entity\Master\ProductListOrderBy');
+
+        // 価格が高い順ソートの追加
+        $ProductListOrderBy = $repository->find(3);
+        if (is_null($ProductListOrderBy)) {
+            $rank = $repository->createQueryBuilder('pl')
+                ->select('MAX(pl.rank)')
+                ->getQuery()
+                ->getSingleScalarResult();
+            $ProductListOrderBy = new ProductListOrderBy();
+            $ProductListOrderBy->setId(3);
+            $ProductListOrderBy->setName('価格が高い順');
+            $ProductListOrderBy->setRank($rank + 1);
+            $app['orm.em']->persist($ProductListOrderBy);
+            $app['orm.em']->flush($ProductListOrderBy);
+        }
+
+        // "価格順"の名称を"価格が低い順"へ変更
+        $ProductListOrderBy = $repository->find(1);
+        if (!is_null($ProductListOrderBy) && $ProductListOrderBy->getName() === '価格順') {
+            $ProductListOrderBy->setName('価格が低い順');
+            $app['orm.em']->persist($ProductListOrderBy);
+            $app['orm.em']->flush($ProductListOrderBy);
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}

--- a/src/Eccube/Resource/doctrine/migration/Version20161108095350.php
+++ b/src/Eccube/Resource/doctrine/migration/Version20161108095350.php
@@ -40,7 +40,7 @@ class Version20161108095350 extends AbstractMigration
             ->getQuery()
             ->getArrayResult();
 
-        if ($entities === $default) {
+        if ($entities !== $default) {
             return;
         }
 

--- a/src/Eccube/Resource/doctrine/migration/Version20161108095350.php
+++ b/src/Eccube/Resource/doctrine/migration/Version20161108095350.php
@@ -21,14 +21,14 @@ class Version20161108095350 extends AbstractMigration
         $repository = $app['orm.em']->getRepository('Eccube\Entity\Master\ProductListOrderBy');
 
         // 価格が高い順ソートの追加
-        $ProductListOrderBy = $repository->find(3);
+        $ProductListOrderBy = $repository->find(100);
         if (is_null($ProductListOrderBy)) {
             $rank = $repository->createQueryBuilder('pl')
                 ->select('MAX(pl.rank)')
                 ->getQuery()
                 ->getSingleScalarResult();
             $ProductListOrderBy = new ProductListOrderBy();
-            $ProductListOrderBy->setId(3);
+            $ProductListOrderBy->setId(100);
             $ProductListOrderBy->setName('価格が高い順');
             $ProductListOrderBy->setRank($rank + 1);
             $app['orm.em']->persist($ProductListOrderBy);

--- a/src/Eccube/Resource/doctrine/migration/Version20161108095350.php
+++ b/src/Eccube/Resource/doctrine/migration/Version20161108095350.php
@@ -22,8 +22,7 @@ class Version20161108095350 extends AbstractMigration
         $app = Application::getInstance();
         $repository = $app['orm.em']->getRepository('Eccube\Entity\Master\ProductListOrderBy');
 
-        $isDefault = true;
-
+        // mtb_product_list_orderbyが初期状態から変更がある場合は、マイグレーションを適用しない
         $default = array(
             array(
                 'id' => 1,
@@ -36,20 +35,16 @@ class Version20161108095350 extends AbstractMigration
                 'rank' => 1,
             ),
         );
+        $entities = $repository->createQueryBuilder('pl')
+            ->orderBy('pl.id', 'ASC')
+            ->getQuery()
+            ->getArrayResult();
 
-        // mtb_product_list_orderbyが初期状態から変更がないかどうかの判定
-        $entities = $repository->findBy(array(), array('id' => 'ASC'));
-        foreach ($entities as $entity) {
-            if (!in_array($entity->toArray(), $default, true)) {
-                $isDefault = false;
-            }
-        }
-
-        // mtb_product_list_orderbyに変更がある場合は何もしない
-        if (!$isDefault) {
+        if ($entities === $default) {
             return;
         }
 
+        // 価格が高い順を追加
         $ProductListOrderBy = new ProductListOrderBy();
         $ProductListOrderBy->setId(3);
         $ProductListOrderBy->setName('価格が高い順');

--- a/src/Eccube/Resource/doctrine/migration/Version20161108095350.php
+++ b/src/Eccube/Resource/doctrine/migration/Version20161108095350.php
@@ -63,16 +63,18 @@ class Version20161108095350 extends AbstractMigration
         $app['orm.em']->flush($ProductListOrderBy);
 
         // constant.ymlへ価格が高い順のIDを記録.
-        $file = $app['config']['root_dir'].'/app/config/eccube/constant.yml';
-        $fs = new Filesystem();
+        if ($id !== $app['config']['product_order_price_higher']) {
+            $file = $app['config']['root_dir'].'/app/config/eccube/constant.yml';
+            $fs = new Filesystem();
 
-        $constant = $fs->exists($file)
-            ? Yaml::parse(file_get_contents($file))
-            : array();
+            $constant = $fs->exists($file)
+                ? Yaml::parse(file_get_contents($file))
+                : array();
 
-        $constant['product_order_price_higher'] = $id;
-        $yaml = Yaml::dump($constant);
-        $fs->dumpFile($file, $yaml);
+            $constant['product_order_price_higher'] = $id;
+            $yaml = Yaml::dump($constant);
+            $fs->dumpFile($file, $yaml);
+        }
 
         // "価格順"の名称を"価格が低い順"へ変更
         $ProductListOrderBy = $repository->find(1);
@@ -93,7 +95,6 @@ class Version20161108095350 extends AbstractMigration
             $app['orm.em']->flush($entity);
 
             $entity = $repository->find($id);
-            dump($entity);
             $entity->setRank(1);
             $app['orm.em']->flush($entity);
         }

--- a/src/Eccube/Resource/doctrine/migration/Version20161108095350.php
+++ b/src/Eccube/Resource/doctrine/migration/Version20161108095350.php
@@ -20,6 +20,28 @@ class Version20161108095350 extends AbstractMigration
         $app = Application::getInstance();
         $repository = $app['orm.em']->getRepository('Eccube\Entity\Master\ProductListOrderBy');
 
+        $isDefault = true;
+        $default = array(
+            array(
+                'id' => 1,
+                'name' => '価格順',
+                'rank' => 0,
+            ),
+            array(
+                'id' => 2,
+                'name' => '新着順',
+                'rank' => 1,
+            ),
+        );
+
+        // mtb_product_list_orderbyが初期状態から変更がないかどうかの判定
+        $entities = $repository->findBy(array(), array('id' => 'ASC'));
+        foreach ($entities as $entity) {
+            if (!in_array($entity->toArray(), $default, true)) {
+                $isDefault = false;
+            }
+        }
+
         // 価格が高い順ソートの追加
         $ProductListOrderBy = $repository->find(100);
         if (is_null($ProductListOrderBy)) {
@@ -41,6 +63,22 @@ class Version20161108095350 extends AbstractMigration
             $ProductListOrderBy->setName('価格が低い順');
             $app['orm.em']->persist($ProductListOrderBy);
             $app['orm.em']->flush($ProductListOrderBy);
+        }
+
+        // mtb_product_list_orderbyが初期状態から変更がなければ、価格が低い順->価格が高い順->新着順の順にrankを振り直す
+        if ($isDefault) {
+            $entity = $repository->find(1);
+            $entity->setRank(0);
+            $app['orm.em']->flush($entity);
+
+            $entity = $repository->find(2);
+            $entity->setRank(2);
+            $app['orm.em']->flush($entity);
+
+            $entity = $repository->find(100);
+            dump($entity);
+            $entity->setRank(1);
+            $app['orm.em']->flush($entity);
         }
     }
 

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -153,6 +153,8 @@ class EccubeServiceProvider implements ServiceProviderInterface
         });
         $app['eccube.repository.product'] = $app->share(function () use ($app) {
             $productRepository = $app['orm.em']->getRepository('Eccube\Entity\Product');
+            $productRepository->setApplication($app);
+
             return $productRepository;
         });
         $app['eccube.repository.product_image'] = $app->share(function () use ($app) {

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
@@ -148,7 +148,7 @@ class ProductRepositoryGetQueryBuilderBySearchDataTest extends AbstractProductRe
         }
         $this->app['orm.em']->flush();
 
-        $ProductListOrderBy = $this->app['orm.em']->getRepository('\Eccube\Entity\Master\ProductListOrderBy')->find(3);
+        $ProductListOrderBy = $this->app['orm.em']->getRepository('\Eccube\Entity\Master\ProductListOrderBy')->find(100);
         $this->searchData = array(
             'orderby' => $ProductListOrderBy
         );

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
@@ -148,7 +148,9 @@ class ProductRepositoryGetQueryBuilderBySearchDataTest extends AbstractProductRe
         }
         $this->app['orm.em']->flush();
 
-        $ProductListOrderBy = $this->app['orm.em']->getRepository('\Eccube\Entity\Master\ProductListOrderBy')->find(100);
+        $ProductListOrderBy = $this->app['orm.em']
+            ->getRepository('\Eccube\Entity\Master\ProductListOrderBy')
+            ->find($this->app['config']['product_order_price_higher']);
         $this->searchData = array(
             'orderby' => $ProductListOrderBy
         );

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
@@ -128,6 +128,40 @@ class ProductRepositoryGetQueryBuilderBySearchDataTest extends AbstractProductRe
         $this->verify();
     }
 
+    /**
+     * 価格が高い順のソート
+     */
+    public function testOrderByPriceHigher()
+    {
+        $Products = $this->app['eccube.repository.product']->findAll();
+        $Products[0]->setName('りんご');
+        foreach ($Products[0]->getProductClasses() as $ProductClass) {
+            $ProductClass->setPrice02(100);
+        }
+        $Products[1]->setName('アイス');
+        foreach ($Products[1]->getProductClasses() as $ProductClass) {
+            $ProductClass->setPrice02(1000);
+        }
+        $Products[2]->setName('お鍋');
+        foreach ($Products[2]->getProductClasses() as $ProductClass) {
+            $ProductClass->setPrice02(10000);
+        }
+        $this->app['orm.em']->flush();
+
+        $ProductListOrderBy = $this->app['orm.em']->getRepository('\Eccube\Entity\Master\ProductListOrderBy')->find(3);
+        $this->searchData = array(
+            'orderby' => $ProductListOrderBy
+        );
+
+        $this->scenario();
+
+        $this->expected = array('お鍋', 'アイス', 'りんご');
+        $this->actual = array($this->Results[0]->getName(),
+            $this->Results[1]->getName(),
+            $this->Results[2]->getName());
+        $this->verify();
+    }
+
     public function testOrderByNewer()
     {
         $Products = $this->app['eccube.repository.product']->findAll();


### PR DESCRIPTION
#1902 

商品一覧画面のソート順序に`価格が高い順`を追加
合わせて既存の`価格順`を、`価格が低い順`に変更する

![sort](https://cloud.githubusercontent.com/assets/8196725/20087274/5ad9f240-a5ba-11e6-8bf1-de83c7256677.png)

カスタマイズ等で、mtb_product_list_orderby.idが既に利用されていることを想定して、以下を検討

`価格が高い順`のIDについて
  - ~~mtb_product_list_orderby.idは100で追加する~~
  - ~~※以降本体で追加する場合は、100番台を使う~~
  - constant.ymlにIDを定義する
    - product_order_price_lower: 1 (価格が低い順)
    - product_order_newer: 2 (新着順)
    - product_order_price_higher: 3 (価格が高い順、デフォルト値3)

 マイグレーション仕様
  - ~~`価格が高い順`を追加~~
    - ~~IDはmax+1で登録~~
    - ~~デフォルト値(3)と異なる場合は、`app/config/eccube/constant.yml`に発番されたIDを定義する~~
  - ~~`価格順`は`価格が低い順`に名称を変更~~
  - ~~mtb_product_list_orderbyが初期状態から変更がなければ、以下の順にrankを振り直す~~
      - ~~価格が低い順(id:1)~~
      - ~~価格が高い順(id:100)~~
      - ~~価格が高い順(id:3)~~
      - ~~新着順(id:2)~~
  - mtb_product_list_orderbyが初期状態から変更がない場合に限り、マイグレーションを適用
    - `価格が高い順`を追加
       - IDは3で登録
    - `価格順`は`価格が低い順`に名称を変更
    - 以下の順にrankを振り直す
       - 価格が低い順(id:1)
       - 価格が高い順(id:3)
       - 新着順(id:2)

カスタマイズを行っていて、価格が高い順のソートを利用する際の対応

- app/config/eccube/constant.ymlを作成
  - `product_order_price_higher: xxx(任意のid)`を定義
- マスタデータ管理でmtb_product_list_orderbyに以下を追加
  - id: product_order_price_higherに指定したID
  - name: 価格が高い順

    
