### PR TITLE
WIP：メール本文を修正できる機能を管理画面に作成

### DIFF
--- a/src/Eccube/Controller/Admin/Content/MailTemplateController.php
+++ b/src/Eccube/Controller/Admin/Content/MailTemplateController.php
@@ -1,0 +1,159 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Controller\Admin\Content;
+
+use Eccube\Application;
+use Eccube\Controller\AbstractController;
+use Eccube\Util\Cache;
+use Eccube\Util\Str;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpFoundation\Request;
+
+class MailTemplateController extends AbstractController
+{
+
+    public function index(Application $app, Request $request)
+    {
+        // Mailディレクトリ(app/template、Resource/template)からメールファイルを取得
+        $finder = Finder::create()->depth(0);
+        $mailDir = $app['config']['template_default_realdir'].'/Mail';
+
+        $files = array();
+        foreach ($finder->in($mailDir) as $file) {
+            $files[$file->getFilename()] = $file->getFilename();
+        }
+
+        $mailDir = $app['config']['template_realdir'].'/Mail';
+        foreach ($finder->in($mailDir) as $file) {
+            $files[$file->getFilename()] = $file->getFilename();
+        }
+
+        return $app->render('Content/mail.twig', array(
+            'files' => $files,
+        ));
+
+    }
+
+    public function edit(Application $app, Request $request, $name)
+    {
+
+        $readPaths = array(
+            $app['config']['template_realdir'],
+            $app['config']['template_default_realdir'],
+        );
+
+        $fs = new Filesystem();
+        $tplData = null;
+        foreach ($readPaths as $readPath) {
+            $filePath = $readPath.'/Mail/'.$name;
+            if ($fs->exists($filePath)) {
+                $tplData = file_get_contents($filePath);
+                break;
+            }
+        }
+
+        if (!$tplData) {
+            log_info("対象ファイルが存在しません");
+            $app->addError('admin.content.mail.edit.error', 'admin');
+
+            return $app->redirect($app->url('admin_content_mail'));
+        }
+
+        $builder = $app['form.factory']->createBuilder('admin_mail_template');
+
+        $form = $builder->getForm();
+
+        $form->get('tpl_data')->setData($tplData);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+
+            // ファイル生成・更新
+            $filePath = $app['config']['template_realdir'].'/Mail/'.$name;
+
+            $fs = new Filesystem();
+            $pageData = $form->get('tpl_data')->getData();
+            $pageData = Str::convertLineFeed($pageData);
+            $fs->dumpFile($filePath, $pageData);
+
+            $app->addSuccess('admin.register.complete', 'admin');
+
+            // twig キャッシュの削除.
+            Cache::clear($app, false, true);
+
+            return $app->redirect($app->url('admin_content_mail_edit', array(
+                'name' => $name,
+            )));
+        }
+
+        return $app->render('Content/mail_edit.twig', array(
+            'name' => $name,
+            'form' => $form->createView(),
+        ));
+    }
+
+    public function reedit(Application $app, Request $request, $name)
+    {
+
+        $this->isTokenValid($app);
+
+        $readPaths = array(
+            $app['config']['template_default_realdir'],
+        );
+
+        $fs = new Filesystem();
+        $tplData = null;
+        foreach ($readPaths as $readPath) {
+            $filePath = $readPath.'/Mail/'.$name;
+            if ($fs->exists($filePath)) {
+                $tplData = file_get_contents($filePath);
+                break;
+            }
+        }
+
+        if (!$tplData) {
+            log_info("対象ファイルが存在しません");
+            $app->addError('admin.content.mail.edit.error', 'admin');
+
+            return $app->redirect($app->url('admin_content_mail'));
+        }
+
+        $builder = $app['form.factory']->createBuilder('admin_mail_template');
+
+        $form = $builder->getForm();
+
+        $form->get('tpl_data')->setData($tplData);
+
+        $app->addSuccess('admin.content.mail.init.complete', 'admin');
+
+        return $app->render('Content/mail_edit.twig', array(
+            'name' => $name,
+            'form' => $form->createView(),
+        ));
+    }
+
+}

--- a/src/Eccube/Controller/Admin/Content/MailTemplateController.php
+++ b/src/Eccube/Controller/Admin/Content/MailTemplateController.php
@@ -148,6 +148,12 @@ class MailTemplateController extends AbstractController
 
         $form->get('tpl_data')->setData($tplData);
 
+        // ファイル生成・更新
+        $filePath = $app['config']['template_realdir'].'/Mail/'.$name;
+
+        $fs = new Filesystem();
+        $fs->dumpFile($filePath, $tplData);
+
         $app->addSuccess('admin.content.mail.init.complete', 'admin');
 
         return $app->render('Content/mail_edit.twig', array(

--- a/src/Eccube/ControllerProvider/AdminControllerProvider.php
+++ b/src/Eccube/ControllerProvider/AdminControllerProvider.php
@@ -148,6 +148,10 @@ class AdminControllerProvider implements ControllerProviderInterface
 
         $c->match('/content/cache', '\Eccube\Controller\Admin\Content\CacheController::index')->bind('admin_content_cache');
 
+        $c->match('/content/mail', '\Eccube\Controller\Admin\Content\MailTemplateController::index')->bind('admin_content_mail');
+        $c->match('/content/mail/{name}/edit', '\Eccube\Controller\Admin\Content\MailTemplateController::edit')->bind('admin_content_mail_edit');
+        $c->put('/content/mail/{name}/reedit', '\Eccube\Controller\Admin\Content\MailTemplateController::reedit')->bind('admin_content_mail_reedit');
+
         // shop
         $c->match('/setting/shop', '\Eccube\Controller\Admin\Setting\Shop\ShopController::index')->bind('admin_setting_shop');
 

--- a/src/Eccube/Form/Type/Admin/MailTemplateType.php
+++ b/src/Eccube/Form/Type/Admin/MailTemplateType.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Form\Type\Admin;
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class MailTemplateType extends AbstractType
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+
+        $builder
+            ->add('tpl_data', 'textarea', array(
+                'label' => 'メール本文',
+                'mapped' => false,
+                'required' => true,
+                'constraints' => array(
+                    new Assert\NotBlank(),
+                ),
+            ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'admin_mail_template';
+    }
+}

--- a/src/Eccube/Resource/config/nav.yml.dist
+++ b/src/Eccube/Resource/config/nav.yml.dist
@@ -61,6 +61,9 @@
       - id: block
         name: ブロック管理
         url: admin_content_block
+      - id: mail
+        name: メール管理
+        url: admin_content_mail
       - id: cache
         name: キャッシュ管理
         url: admin_content_cache

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -173,6 +173,9 @@ admin.content.template.delete.current.error: 現在設定中のテンプレー�
 
 admin.content.cache.save.complete: キャッシュを削除しました。
 
+admin.content.mail.edit.error: 対象ファイルが存在しません。
+admin.content.mail.init.complete: 初期設定に戻しました。
+
 admin.system.security.save.complete: セキュリティ設定を保存しました。
 admin.system.security.route.dir.complete: 管理画面のURLを変更しましたので再ログインをしてください。
 

--- a/src/Eccube/Resource/template/admin/Content/mail.twig
+++ b/src/Eccube/Resource/template/admin/Content/mail.twig
@@ -1,0 +1,56 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set menus = ['content', 'mail'] %}
+
+{% block title %}コンテンツ管理{% endblock %}
+{% block sub_title %}メール管理{% endblock %}
+
+{% block main %}
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="box">
+                    <div class="box-header">
+                        <div class="box-title">
+                            メールファイル一覧
+                        </div>
+                    </div>
+                    <div class="box-body no-padding no-border">
+                        <div class="sortable_list">
+                            <div class="tableish">
+                                {% for file in files %}
+                                    <div class="item_box tr">
+                                        <div class="item_pattern td">
+                                            <a href="{{ url('admin_content_mail_edit', {'name': file}) }}">{{ file }}</a>
+                                        </div>
+                                    </div><!-- /.item_box -->
+                                {% endfor %}
+                            </div>
+                        </div>
+                    </div><!-- /.box-body -->
+                </div><!-- /.box -->
+            </div><!-- /.col -->
+        </div>
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/admin/Content/mail_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/mail_edit.twig
@@ -1,0 +1,70 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set menus = ['content', 'mail'] %}
+
+{% block title %}コンテンツ管理{% endblock %}
+{% block sub_title %}メール管理{% endblock %}
+
+{% form_theme form 'Form/bootstrap_3_horizontal_layout.html.twig' %}
+
+{% block main %}
+    <form class="form-horizontal" method="post" action="{{ url('admin_content_mail_edit', {'name': name}) }}">
+        {{ form_widget(form._token) }}
+        <div class="row" id="aside_wrap">
+            <div class="col-md-9">
+                <div class="box">
+                    <div class="box-header">
+                        <h3 class="box-title">メール編集</h3>
+                        <p>修正時にはtwigタグの取り扱いにご注意ください。</p>
+                    </div>
+                    <div class="box-body">
+                        {{ form_row(form.tpl_data, {'attr': {'rows': '15'}}) }}
+                        <p class="text-right"><a class="btn btn-default" href="{{ url('admin_content_mail_reedit', { 'name': name}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-message="本当に初期設定に戻しますか？入力されている内容は失われます。">初期値に戻す</a></p>
+                    </div>
+                </div>
+
+                <div id="detail_box__footer" class="row">
+                    <div id="detail_box__back_button" class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
+                        <p><a href="{{ url('admin_content_mail') }}">戻る</a></p>
+                    </div>
+                </div>
+
+
+            </div>
+            <div class="col-md-3" id="aside_column">
+                <div id="common_box" class="col_inner">
+                    <div id="common_button_box" class="box no-header">
+                        <div id="common_button_box__body" class="box-body">
+                            <div id="common_button_box__edit_button" class="row text-center">
+                                <div class="col-sm-6 col-sm-offset-3 col-md-12 col-md-offset-0">
+                                    <button class="btn btn-primary btn-block btn-lg" type="submit">設定</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+{% endblock %}

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -367,6 +367,7 @@ class EccubeServiceProvider implements ServiceProviderInterface
             $types[] = new \Eccube\Form\Type\Admin\DeliveryTimeType($app['config']);
             $types[] = new \Eccube\Form\Type\Admin\LogType($app['config']);
             $types[] = new \Eccube\Form\Type\Admin\CacheType($app['config']);
+            $types[] = new \Eccube\Form\Type\Admin\MailTemplateType();
 
             $types[] = new \Eccube\Form\Type\Admin\MasterdataType($app);
             $types[] = new \Eccube\Form\Type\Admin\MasterdataEditType($app);

--- a/tests/Eccube/Tests/Web/Admin/Content/MailTemplateControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/MailTemplateControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Tests\Web\Admin\Content;
+
+use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+
+class MailTemplateControllerTest extends AbstractAdminWebTestCase
+{
+
+    public function testRoutingAdminContentMail()
+    {
+        $client = $this->client;
+        $client->request('GET',
+            $this->app->url('admin_content_mail')
+        );
+        $this->assertTrue($client->getResponse()->isSuccessful());
+    }
+
+    public function testRoutingAdminContentMailGet()
+    {
+        $client = $this->client;
+
+        $client->request('GET',
+            $this->app->url('admin_content_mail_edit', array('name' => 'order.twig'))
+        );
+        $this->assertTrue($client->getResponse()->isSuccessful());
+    }
+
+
+    public function testRoutingAdminContentMailEdit()
+    {
+        $client = $this->client;
+
+        $client->request(
+            'POST',
+            $this->app->url('admin_content_mail_edit', array('name' => 'order.twig')),
+            array(
+                'admin_mail_template' => array(
+                    'tpl_data' => 'testtest',
+                    '_token' => 'dummy'
+                ),
+                'name' => 'order.twig'
+            )
+        );
+
+        $this->assertTrue($client->getResponse()->isRedirect($this->app->url('admin_content_mail_edit', array('name' => 'order.twig'))));
+
+        $this->expected = 'testtest';
+        $this->actual = file_get_contents($this->app['config']['template_realdir'].'/Mail/order.twig');
+        $this->verify();
+    }
+
+
+    public function testRoutingAdminContentMailReEdit()
+    {
+        $client = $this->client;
+
+        $crawler = $client->request(
+            'PUT',
+            $this->app->url('admin_content_mail_reedit', array('name' => 'order.twig'))
+        );
+
+        $this->assertTrue($client->getResponse()->isSuccessful());
+
+        $this->expected = file_get_contents($this->app['config']['template_default_realdir'].'/Mail/order.twig');
+        $this->actual = file_get_contents($this->app['config']['template_realdir'].'/Mail/order.twig');
+        $this->verify();
+    }
+
+}


### PR DESCRIPTION
###  メール編集機能について

現在メール本文を修正するためには直接
```
ECCUBEROOT/src/Eccube/Resource/template/default/Mail
```
直下にあるtwigファイルを修正する必要がある。

そのため、管理画面からメール本文を修正する機能を提供する。(ページ管理と似たような機能)


### 修正可能なメール本文

- お問い合わせメール
- 会員仮登録メール
- 会員本登録メール
- 会員退会メール
- パスワードリマインダー
- パスワードリセット
- 受注メール

受注メールに関しては管理画面の[設定]→[基本情報設定]→[メール設定]からメール通知をするときにヘッダー、フッターを設定することが可能。  
ただし、商品購入時の受注メールは`dtb_mail_template`のIDが1のデータでヘッダー、フッターの内容が送信される。

### 提供する機能

- メール編集機能

メール内容はDBで管理されていないため直接Twigファイルを修正する。


### 対応方法
```
ECCUBEROOT/src/Eccube/Resource/template/default/Mail
```
にある対象のメールを修正すると、
```
ECCUBEROOT/app/template/[tepmaltecode]/Mail
```
に保存され、メール送信時は`app/template`へ新しく保存されたメールの内容で送信される。


### 今後の課題
メール設定機能との統合を行い、以下の内容を実現させる。

- メール本文追加、デフォルト送信メールの設定
- 件名の修正
- 本文の修正
