### PR TITLE
ページネータの修正

### DIFF
--- a/src/Eccube/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/src/Eccube/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Doctrine ORM
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Doctrine\ORM\Tools\Pagination;
+
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\AST\SelectStatement;
+
+/**
+ * Wraps the query in order to accurately count the root objects.
+ *
+ * Given a DQL like `SELECT u FROM User u` it will generate an SQL query like:
+ * SELECT COUNT(*) (SELECT DISTINCT <id> FROM (<original SQL>))
+ *
+ * Works with composite keys but cannot deal with queries that have multiple
+ * root entities (e.g. `SELECT f, b from Foo, Bar`)
+ *
+ * @author Sander Marechal <s.marechal@jejik.com>
+ */
+class CountOutputWalker extends SqlWalker
+{
+    /**
+     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
+     */
+    private $platform;
+
+    /**
+     * @var \Doctrine\ORM\Query\ResultSetMapping
+     */
+    private $rsm;
+
+    /**
+     * @var array
+     */
+    private $queryComponents;
+
+    /**
+     * Constructor.
+     *
+     * Stores various parameters that are otherwise unavailable
+     * because Doctrine\ORM\Query\SqlWalker keeps everything private without
+     * accessors.
+     *
+     * @param \Doctrine\ORM\Query              $query
+     * @param \Doctrine\ORM\Query\ParserResult $parserResult
+     * @param array                            $queryComponents
+     */
+    public function __construct($query, $parserResult, array $queryComponents)
+    {
+        $this->platform = $query->getEntityManager()->getConnection()->getDatabasePlatform();
+        $this->rsm = $parserResult->getResultSetMapping();
+        $this->queryComponents = $queryComponents;
+
+        parent::__construct($query, $parserResult, $queryComponents);
+    }
+
+    /**
+     * Walks down a SelectStatement AST node, wrapping it in a COUNT (SELECT DISTINCT).
+     *
+     * Note that the ORDER BY clause is not removed. Many SQL implementations (e.g. MySQL)
+     * are able to cache subqueries. By keeping the ORDER BY clause intact, the limitSubQuery
+     * that will most likely be executed next can be read from the native SQL cache.
+     *
+     * @param SelectStatement $AST
+     *
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function walkSelectStatement(SelectStatement $AST)
+    {
+        if ($this->platform->getName() === "mssql") {
+            $AST->orderByClause = null;
+        }
+
+        $sql = parent::walkSelectStatement($AST);
+
+        // Find out the SQL alias of the identifier column of the root entity
+        // It may be possible to make this work with multiple root entities but that
+        // would probably require issuing multiple queries or doing a UNION SELECT
+        // so for now, It's not supported.
+
+        // Get the root entity and alias from the AST fromClause
+        $from = $AST->fromClause->identificationVariableDeclarations;
+        if (count($from) > 1) {
+            throw new \RuntimeException("Cannot count query which selects two FROM components, cannot make distinction");
+        }
+
+        $fromRoot       = reset($from);
+        $rootAlias      = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
+        $rootClass      = $this->queryComponents[$rootAlias]['metadata'];
+        $rootIdentifier = $rootClass->identifier;
+
+        // For every identifier, find out the SQL alias by combing through the ResultSetMapping
+        $sqlIdentifier = array();
+        foreach ($rootIdentifier as $property) {
+            if (isset($rootClass->fieldMappings[$property])) {
+                foreach (array_keys($this->rsm->fieldMappings, $property) as $alias) {
+                    if ($this->rsm->columnOwnerMap[$alias] == $rootAlias) {
+                        $sqlIdentifier[$property] = $alias;
+                    }
+                }
+            }
+
+            if (isset($rootClass->associationMappings[$property])) {
+                $joinColumn = $rootClass->associationMappings[$property]['joinColumns'][0]['name'];
+
+                foreach (array_keys($this->rsm->metaMappings, $joinColumn) as $alias) {
+                    if ($this->rsm->columnOwnerMap[$alias] == $rootAlias) {
+                        $sqlIdentifier[$property] = $alias;
+                    }
+                }
+            }
+        }
+
+        if (count($rootIdentifier) != count($sqlIdentifier)) {
+            throw new \RuntimeException(sprintf(
+                'Not all identifier properties can be found in the ResultSetMapping: %s',
+                implode(', ', array_diff($rootIdentifier, array_keys($sqlIdentifier)))
+            ));
+        }
+
+        // Build the counter query
+        return sprintf('SELECT %s AS dctrn_count FROM (SELECT DISTINCT %s FROM (%s) dctrn_result) dctrn_table',
+            $this->platform->getCountExpression('*'),
+            implode(', ', $sqlIdentifier),
+            $sql
+        );
+    }
+}

--- a/src/Eccube/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/src/Eccube/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -11,7 +11,7 @@
  * to kontakt@beberlei.de so I can send you a copy immediately.
  */
 
-namespace Doctrine\ORM\Tools\Pagination;
+namespace Eccube\Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\AST\SelectStatement;

--- a/src/Eccube/Doctrine/ORM/Tools/Pagination/CountWalker.php
+++ b/src/Eccube/Doctrine/ORM/Tools/Pagination/CountWalker.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Doctrine ORM
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Doctrine\ORM\Tools\Pagination;
+
+use Doctrine\ORM\Query\TreeWalkerAdapter;
+use Doctrine\ORM\Query\AST\SelectStatement;
+use Doctrine\ORM\Query\AST\SelectExpression;
+use Doctrine\ORM\Query\AST\PathExpression;
+use Doctrine\ORM\Query\AST\AggregateExpression;
+
+/**
+ * Replaces the selectClause of the AST with a COUNT statement.
+ *
+ * @category    DoctrineExtensions
+ * @package     DoctrineExtensions\Paginate
+ * @author      David Abdemoulaie <dave@hobodave.com>
+ * @copyright   Copyright (c) 2010 David Abdemoulaie (http://hobodave.com/)
+ * @license     http://hobodave.com/license.txt New BSD License
+ */
+class CountWalker extends TreeWalkerAdapter
+{
+    /**
+     * Distinct mode hint name.
+     */
+    const HINT_DISTINCT = 'doctrine_paginator.distinct';
+
+    /**
+     * Walks down a SelectStatement AST node, modifying it to retrieve a COUNT.
+     *
+     * @param SelectStatement $AST
+     *
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function walkSelectStatement(SelectStatement $AST)
+    {
+        if ($AST->havingClause) {
+            throw new \RuntimeException('Cannot count query that uses a HAVING clause. Use the output walkers for pagination');
+        }
+
+        $queryComponents = $this->_getQueryComponents();
+        // Get the root entity and alias from the AST fromClause
+        $from = $AST->fromClause->identificationVariableDeclarations;
+        
+        if (count($from) > 1) {
+            throw new \RuntimeException("Cannot count query which selects two FROM components, cannot make distinction");
+        }
+       
+        $fromRoot            = reset($from);
+        $rootAlias           = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
+        $rootClass           = $queryComponents[$rootAlias]['metadata'];
+        $identifierFieldName = $rootClass->getSingleIdentifierFieldName();
+
+        $pathType = PathExpression::TYPE_STATE_FIELD;
+        if (isset($rootClass->associationMappings[$identifierFieldName])) {
+            $pathType = PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION;
+        }
+
+        $pathExpression = new PathExpression(
+            PathExpression::TYPE_STATE_FIELD | PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION, $rootAlias,
+            $identifierFieldName
+        );
+        $pathExpression->type = $pathType;
+
+        $distinct = $this->_getQuery()->getHint(self::HINT_DISTINCT);
+        $AST->selectClause->selectExpressions = array(
+            new SelectExpression(
+                new AggregateExpression('count', $pathExpression, $distinct), null
+            )
+        );
+
+        // ORDER BY is not needed, only increases query execution through unnecessary sorting.
+        $AST->orderByClause = null;
+    }
+}
+

--- a/src/Eccube/Doctrine/ORM/Tools/Pagination/CountWalker.php
+++ b/src/Eccube/Doctrine/ORM/Tools/Pagination/CountWalker.php
@@ -11,7 +11,7 @@
  * to kontakt@beberlei.de so I can send you a copy immediately.
  */
 
-namespace Doctrine\ORM\Tools\Pagination;
+namespace Eccube\Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\ORM\Query\TreeWalkerAdapter;
 use Doctrine\ORM\Query\AST\SelectStatement;

--- a/src/Eccube/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/src/Eccube/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -1,0 +1,589 @@
+<?php
+/**
+ * Doctrine ORM
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Doctrine\ORM\Tools\Pagination;
+
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\SQLAnywherePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\ORM\Query\AST\ArithmeticExpression;
+use Doctrine\ORM\Query\AST\ArithmeticFactor;
+use Doctrine\ORM\Query\AST\ArithmeticTerm;
+use Doctrine\ORM\Query\AST\Literal;
+use Doctrine\ORM\Query\AST\OrderByClause;
+use Doctrine\ORM\Query\AST\OrderByItem;
+use Doctrine\ORM\Query\AST\PartialObjectExpression;
+use Doctrine\ORM\Query\AST\PathExpression;
+use Doctrine\ORM\Query\AST\SelectExpression;
+use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
+use Doctrine\ORM\Query\Expr\OrderBy;
+use Doctrine\ORM\Query\Expr\Select;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\AST\SelectStatement;
+
+/**
+ * Wraps the query in order to select root entity IDs for pagination.
+ *
+ * Given a DQL like `SELECT u FROM User u` it will generate an SQL query like:
+ * SELECT DISTINCT <id> FROM (<original SQL>) LIMIT x OFFSET y
+ *
+ * Works with composite keys but cannot deal with queries that have multiple
+ * root entities (e.g. `SELECT f, b from Foo, Bar`)
+ *
+ * @author Sander Marechal <s.marechal@jejik.com>
+ */
+class LimitSubqueryOutputWalker extends SqlWalker
+{
+    /**
+     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
+     */
+    private $platform;
+
+    /**
+     * @var \Doctrine\ORM\Query\ResultSetMapping
+     */
+    private $rsm;
+
+    /**
+     * @var array
+     */
+    private $queryComponents;
+
+    /**
+     * @var int
+     */
+    private $firstResult;
+
+    /**
+     * @var int
+     */
+    private $maxResults;
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    private $em;
+
+    /**
+     * The quote strategy.
+     *
+     * @var \Doctrine\ORM\Mapping\QuoteStrategy
+     */
+    private $quoteStrategy;
+
+    /**
+     * @var array
+     */
+    private $orderByPathExpressions = [];
+
+    /**
+     * @var bool We don't want to add path expressions from sub-selects into the select clause of the containing query.
+     *           This state flag simply keeps track on whether we are walking on a subquery or not
+     */
+    private $inSubSelect = false;
+
+    /**
+     * Constructor.
+     *
+     * Stores various parameters that are otherwise unavailable
+     * because Doctrine\ORM\Query\SqlWalker keeps everything private without
+     * accessors.
+     *
+     * @param \Doctrine\ORM\Query              $query
+     * @param \Doctrine\ORM\Query\ParserResult $parserResult
+     * @param array                            $queryComponents
+     */
+    public function __construct($query, $parserResult, array $queryComponents)
+    {
+        $this->platform = $query->getEntityManager()->getConnection()->getDatabasePlatform();
+        $this->rsm = $parserResult->getResultSetMapping();
+        $this->queryComponents = $queryComponents;
+
+        // Reset limit and offset
+        $this->firstResult = $query->getFirstResult();
+        $this->maxResults = $query->getMaxResults();
+        $query->setFirstResult(null)->setMaxResults(null);
+
+        $this->em               = $query->getEntityManager();
+        $this->quoteStrategy    = $this->em->getConfiguration()->getQuoteStrategy();
+
+        parent::__construct($query, $parserResult, $queryComponents);
+    }
+
+    /**
+     * Check if the platform supports the ROW_NUMBER window function.
+     *
+     * @return bool
+     */
+    private function platformSupportsRowNumber()
+    {
+        return $this->platform instanceof PostgreSqlPlatform
+            || $this->platform instanceof SQLServerPlatform
+            || $this->platform instanceof OraclePlatform
+            || $this->platform instanceof SQLAnywherePlatform
+            || $this->platform instanceof DB2Platform
+            || (method_exists($this->platform, 'supportsRowNumberFunction')
+                && $this->platform->supportsRowNumberFunction());
+    }
+
+    /**
+     * Rebuilds a select statement's order by clause for use in a
+     * ROW_NUMBER() OVER() expression.
+     *
+     * @param SelectStatement $AST
+     */
+    private function rebuildOrderByForRowNumber(SelectStatement $AST)
+    {
+        $orderByClause = $AST->orderByClause;
+        $selectAliasToExpressionMap = [];
+        // Get any aliases that are available for select expressions.
+        foreach ($AST->selectClause->selectExpressions as $selectExpression) {
+            $selectAliasToExpressionMap[$selectExpression->fieldIdentificationVariable] = $selectExpression->expression;
+        }
+
+        // Rebuild string orderby expressions to use the select expression they're referencing
+        foreach ($orderByClause->orderByItems as $orderByItem) {
+            if (is_string($orderByItem->expression) && isset($selectAliasToExpressionMap[$orderByItem->expression])) {
+                $orderByItem->expression = $selectAliasToExpressionMap[$orderByItem->expression];
+            }
+        }
+        $func = new RowNumberOverFunction('dctrn_rownum');
+        $func->orderByClause = $AST->orderByClause;
+        $AST->selectClause->selectExpressions[] = new SelectExpression($func, 'dctrn_rownum', true);
+
+        // No need for an order by clause, we'll order by rownum in the outer query.
+        $AST->orderByClause = null;
+    }
+
+    /**
+     * Walks down a SelectStatement AST node, wrapping it in a SELECT DISTINCT.
+     *
+     * @param SelectStatement $AST
+     *
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function walkSelectStatement(SelectStatement $AST)
+    {
+        if ($this->platformSupportsRowNumber()) {
+            return $this->walkSelectStatementWithRowNumber($AST);
+        }
+        return $this->walkSelectStatementWithoutRowNumber($AST);
+    }
+
+    /**
+     * Walks down a SelectStatement AST node, wrapping it in a SELECT DISTINCT.
+     * This method is for use with platforms which support ROW_NUMBER.
+     *
+     * @param SelectStatement $AST
+     *
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function walkSelectStatementWithRowNumber(SelectStatement $AST)
+    {
+        $hasOrderBy = false;
+        $outerOrderBy = ' ORDER BY dctrn_minrownum ASC';
+        $orderGroupBy = '';
+        if ($AST->orderByClause instanceof OrderByClause) {
+            $hasOrderBy = true;
+            $this->rebuildOrderByForRowNumber($AST);
+        }
+
+        $innerSql = $this->getInnerSQL($AST);
+
+        $sqlIdentifier = $this->getSQLIdentifier($AST);
+
+        if ($hasOrderBy) {
+            $orderGroupBy = ' GROUP BY ' . implode(', ', $sqlIdentifier);
+            $sqlIdentifier[] = 'MIN(' . $this->walkResultVariable('dctrn_rownum') . ') AS dctrn_minrownum';
+        }
+
+        // Build the counter query
+        $sql = sprintf(
+            'SELECT DISTINCT %s FROM (%s) dctrn_result',
+            implode(', ', $sqlIdentifier),
+            $innerSql
+        );
+
+        if ($hasOrderBy) {
+            $sql .= $orderGroupBy . $outerOrderBy;
+        }
+
+        // Apply the limit and offset.
+        $sql = $this->platform->modifyLimitQuery(
+            $sql,
+            $this->maxResults,
+            $this->firstResult
+        );
+
+        // Add the columns to the ResultSetMapping. It's not really nice but
+        // it works. Preferably I'd clear the RSM or simply create a new one
+        // but that is not possible from inside the output walker, so we dirty
+        // up the one we have.
+        foreach ($sqlIdentifier as $property => $alias) {
+            $this->rsm->addScalarResult($alias, $property);
+        }
+
+        return $sql;
+    }
+
+    /**
+     * Walks down a SelectStatement AST node, wrapping it in a SELECT DISTINCT.
+     * This method is for platforms which DO NOT support ROW_NUMBER.
+     *
+     * @param SelectStatement $AST
+     * @param bool $addMissingItemsFromOrderByToSelect
+     *
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function walkSelectStatementWithoutRowNumber(SelectStatement $AST, $addMissingItemsFromOrderByToSelect = true)
+    {
+        // We don't want to call this recursively!
+        if ($AST->orderByClause instanceof OrderByClause && $addMissingItemsFromOrderByToSelect) {
+            // In the case of ordering a query by columns from joined tables, we
+            // must add those columns to the select clause of the query BEFORE
+            // the SQL is generated.
+            $this->addMissingItemsFromOrderByToSelect($AST);
+        }
+
+        // Remove order by clause from the inner query
+        // It will be re-appended in the outer select generated by this method
+        $orderByClause = $AST->orderByClause;
+        $AST->orderByClause = null;
+
+        $innerSql = $this->getInnerSQL($AST);
+
+        $sqlIdentifier = $this->getSQLIdentifier($AST);
+
+        // Build the counter query
+        $sql = sprintf('SELECT DISTINCT %s FROM (%s) dctrn_result',
+            implode(', ', $sqlIdentifier), $innerSql);
+
+        // http://www.doctrine-project.org/jira/browse/DDC-1958
+        $sql = $this->preserveSqlOrdering($sqlIdentifier, $innerSql, $sql, $orderByClause);
+
+        // Apply the limit and offset.
+        $sql = $this->platform->modifyLimitQuery(
+            $sql, $this->maxResults, $this->firstResult
+        );
+
+        // Add the columns to the ResultSetMapping. It's not really nice but
+        // it works. Preferably I'd clear the RSM or simply create a new one
+        // but that is not possible from inside the output walker, so we dirty
+        // up the one we have.
+        foreach ($sqlIdentifier as $property => $alias) {
+            $this->rsm->addScalarResult($alias, $property);
+        }
+
+        // Restore orderByClause
+        $AST->orderByClause = $orderByClause;
+
+        return $sql;
+    }
+
+    /**
+     * Finds all PathExpressions in an AST's OrderByClause, and ensures that
+     * the referenced fields are present in the SelectClause of the passed AST.
+     *
+     * @param SelectStatement $AST
+     */
+    private function addMissingItemsFromOrderByToSelect(SelectStatement $AST)
+    {
+        $this->orderByPathExpressions = [];
+
+        // We need to do this in another walker because otherwise we'll end up
+        // polluting the state of this one.
+        $walker = clone $this;
+
+        // This will populate $orderByPathExpressions via
+        // LimitSubqueryOutputWalker::walkPathExpression, which will be called
+        // as the select statement is walked. We'll end up with an array of all
+        // path expressions referenced in the query.
+        $walker->walkSelectStatementWithoutRowNumber($AST, false);
+        $orderByPathExpressions = $walker->getOrderByPathExpressions();
+
+        // Get a map of referenced identifiers to field names.
+        $selects = [];
+        foreach ($orderByPathExpressions as $pathExpression) {
+            $idVar = $pathExpression->identificationVariable;
+            $field = $pathExpression->field;
+            if (!isset($selects[$idVar])) {
+                $selects[$idVar] = [];
+            }
+            $selects[$idVar][$field] = true;
+        }
+
+        // Loop the select clause of the AST and exclude items from $select
+        // that are already being selected in the query.
+        foreach ($AST->selectClause->selectExpressions as $selectExpression) {
+            if ($selectExpression instanceof SelectExpression) {
+                $idVar = $selectExpression->expression;
+                if (!is_string($idVar)) {
+                    continue;
+                }
+                $field = $selectExpression->fieldIdentificationVariable;
+                if ($field === null) {
+                    // No need to add this select, as we're already fetching the whole object.
+                    unset($selects[$idVar]);
+                } else {
+                    unset($selects[$idVar][$field]);
+                }
+            }
+        }
+
+        // Add select items which were not excluded to the AST's select clause.
+        foreach ($selects as $idVar => $fields) {
+            $AST->selectClause->selectExpressions[] = new SelectExpression(new PartialObjectExpression($idVar, array_keys($fields)), null, true);
+        }
+    }
+
+    /**
+     * Generates new SQL for statements with an order by clause
+     *
+     * @param array           $sqlIdentifier
+     * @param string          $innerSql
+     * @param string          $sql
+     * @param OrderByClause   $orderByClause
+     *
+     * @return string
+     */
+    private function preserveSqlOrdering(array $sqlIdentifier, $innerSql, $sql, $orderByClause)
+    {
+        // If the sql statement has an order by clause, we need to wrap it in a new select distinct
+        // statement
+        if (! $orderByClause instanceof OrderByClause) {
+            return $sql;
+        }
+
+        // Rebuild the order by clause to work in the scope of the new select statement
+        /* @var array $orderBy an array of rebuilt order by items */
+        $orderBy = $this->rebuildOrderByClauseForOuterScope($orderByClause);
+
+        // Build the select distinct statement
+        $sql = sprintf(
+            'SELECT DISTINCT %s FROM (%s) dctrn_result ORDER BY %s',
+            implode(', ', $sqlIdentifier),
+            $innerSql,
+            implode(', ', $orderBy)
+        );
+
+        return $sql;
+    }
+
+    /**
+     * Generates a new order by clause that works in the scope of a select query wrapping the original
+     *
+     * @param OrderByClause $orderByClause
+     * @return array
+     */
+    private function rebuildOrderByClauseForOuterScope(OrderByClause $orderByClause)
+    {
+        $dqlAliasToSqlTableAliasMap
+            = $searchPatterns
+            = $replacements
+            = $dqlAliasToClassMap
+            = $selectListAdditions
+            = $orderByItems
+            = [];
+
+        // Generate DQL alias -> SQL table alias mapping
+        foreach(array_keys($this->rsm->aliasMap) as $dqlAlias) {
+            $dqlAliasToClassMap[$dqlAlias] = $class = $this->queryComponents[$dqlAlias]['metadata'];
+            $dqlAliasToSqlTableAliasMap[$dqlAlias] = $this->getSQLTableAlias($class->getTableName(), $dqlAlias);
+        }
+
+        // Pattern to find table path expressions in the order by clause
+        $fieldSearchPattern = '/(?<![a-z0-9_])%s\.%s(?![a-z0-9_])/i';
+
+        // Generate search patterns for each field's path expression in the order by clause
+        foreach($this->rsm->fieldMappings as $fieldAlias => $fieldName) {
+            $dqlAliasForFieldAlias = $this->rsm->columnOwnerMap[$fieldAlias];
+            $class = $dqlAliasToClassMap[$dqlAliasForFieldAlias];
+
+            // If the field is from a joined child table, we won't be ordering
+            // on it.
+            if (!isset($class->fieldMappings[$fieldName])) {
+                continue;
+            }
+
+            $fieldMapping = $class->fieldMappings[$fieldName];
+
+            // Get the proper column name as will appear in the select list
+            $columnName = $this->quoteStrategy->getColumnName(
+                $fieldName,
+                $dqlAliasToClassMap[$dqlAliasForFieldAlias],
+                $this->em->getConnection()->getDatabasePlatform()
+            );
+
+            // Get the SQL table alias for the entity and field
+            $sqlTableAliasForFieldAlias = $dqlAliasToSqlTableAliasMap[$dqlAliasForFieldAlias];
+            if (isset($fieldMapping['declared']) && $fieldMapping['declared'] !== $class->name) {
+                // Field was declared in a parent class, so we need to get the proper SQL table alias
+                // for the joined parent table.
+                $otherClassMetadata = $this->em->getClassMetadata($fieldMapping['declared']);
+                if (!$otherClassMetadata->isMappedSuperclass) {
+                    $sqlTableAliasForFieldAlias = $this->getSQLTableAlias($otherClassMetadata->getTableName(), $dqlAliasForFieldAlias);
+                    
+                }
+            }
+
+            // Compose search/replace patterns
+            $searchPatterns[] = sprintf($fieldSearchPattern, $sqlTableAliasForFieldAlias, $columnName);
+            $replacements[] = $fieldAlias;
+        }
+
+        foreach($orderByClause->orderByItems as $orderByItem) {
+            // Walk order by item to get string representation of it
+            $orderByItemString = $this->walkOrderByItem($orderByItem);
+
+            // Replace path expressions in the order by clause with their column alias
+            $orderByItemString = preg_replace($searchPatterns, $replacements, $orderByItemString);
+
+            $orderByItems[] = $orderByItemString;
+        }
+
+        return $orderByItems;
+    }
+
+    /**
+     * getter for $orderByPathExpressions
+     *
+     * @return array
+     */
+    public function getOrderByPathExpressions()
+    {
+        return $this->orderByPathExpressions;
+    }
+
+    /**
+     * @param SelectStatement $AST
+     *
+     * @return string
+     *
+     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws \Doctrine\ORM\Query\QueryException
+     */
+    private function getInnerSQL(SelectStatement $AST)
+    {
+        // Set every select expression as visible(hidden = false) to
+        // make $AST have scalar mappings properly - this is relevant for referencing selected
+        // fields from outside the subquery, for example in the ORDER BY segment
+        $hiddens = [];
+
+        foreach ($AST->selectClause->selectExpressions as $idx => $expr) {
+            $hiddens[$idx] = $expr->hiddenAliasResultVariable;
+            $expr->hiddenAliasResultVariable = false;
+        }
+
+        $innerSql = parent::walkSelectStatement($AST);
+
+        // Restore hiddens
+        foreach ($AST->selectClause->selectExpressions as $idx => $expr) {
+            $expr->hiddenAliasResultVariable = $hiddens[$idx];
+        }
+
+        return $innerSql;
+    }
+
+    /**
+     * @param SelectStatement $AST
+     *
+     * @return array
+     */
+    private function getSQLIdentifier(SelectStatement $AST)
+    {
+        // Find out the SQL alias of the identifier column of the root entity.
+        // It may be possible to make this work with multiple root entities but that
+        // would probably require issuing multiple queries or doing a UNION SELECT.
+        // So for now, it's not supported.
+
+        // Get the root entity and alias from the AST fromClause.
+        $from = $AST->fromClause->identificationVariableDeclarations;
+        if (count($from) !== 1) {
+            throw new \RuntimeException('Cannot count query which selects two FROM components, cannot make distinction');
+        }
+
+        $fromRoot       = reset($from);
+        $rootAlias      = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
+        $rootClass      = $this->queryComponents[$rootAlias]['metadata'];
+        $rootIdentifier = $rootClass->identifier;
+
+        // For every identifier, find out the SQL alias by combing through the ResultSetMapping
+        $sqlIdentifier = [];
+        foreach ($rootIdentifier as $property) {
+            if (isset($rootClass->fieldMappings[$property])) {
+                foreach (array_keys($this->rsm->fieldMappings, $property) as $alias) {
+                    if ($this->rsm->columnOwnerMap[$alias] == $rootAlias) {
+                        $sqlIdentifier[$property] = $alias;
+                    }
+                }
+            }
+
+            if (isset($rootClass->associationMappings[$property])) {
+                $joinColumn = $rootClass->associationMappings[$property]['joinColumns'][0]['name'];
+
+                foreach (array_keys($this->rsm->metaMappings, $joinColumn) as $alias) {
+                    if ($this->rsm->columnOwnerMap[$alias] == $rootAlias) {
+                        $sqlIdentifier[$property] = $alias;
+                    }
+                }
+            }
+        }
+
+        if (count($sqlIdentifier) === 0) {
+            throw new \RuntimeException('The Paginator does not support Queries which only yield ScalarResults.');
+        }
+
+        if (count($rootIdentifier) != count($sqlIdentifier)) {
+            throw new \RuntimeException(sprintf(
+                'Not all identifier properties can be found in the ResultSetMapping: %s',
+                implode(', ', array_diff($rootIdentifier, array_keys($sqlIdentifier)))
+            ));
+        }
+
+        return $sqlIdentifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function walkPathExpression($pathExpr)
+    {
+        if (!$this->inSubSelect && !$this->platformSupportsRowNumber() && !in_array($pathExpr, $this->orderByPathExpressions)) {
+            $this->orderByPathExpressions[] = $pathExpr;
+        }
+
+        return parent::walkPathExpression($pathExpr);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function walkSubSelect($subselect)
+    {
+        $this->inSubSelect = true;
+
+        $sql = parent::walkSubselect($subselect);
+
+        $this->inSubSelect = false;
+
+        return $sql;
+    }
+}

--- a/src/Eccube/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/src/Eccube/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -11,7 +11,7 @@
  * to kontakt@beberlei.de so I can send you a copy immediately.
  */
 
-namespace Doctrine\ORM\Tools\Pagination;
+namespace Eccube\Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
@@ -86,7 +86,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
     /**
      * @var array
      */
-    private $orderByPathExpressions = [];
+    private $orderByPathExpressions = array();
 
     /**
      * @var bool We don't want to add path expressions from sub-selects into the select clause of the containing query.
@@ -147,7 +147,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
     private function rebuildOrderByForRowNumber(SelectStatement $AST)
     {
         $orderByClause = $AST->orderByClause;
-        $selectAliasToExpressionMap = [];
+        $selectAliasToExpressionMap = array();
         // Get any aliases that are available for select expressions.
         foreach ($AST->selectClause->selectExpressions as $selectExpression) {
             $selectAliasToExpressionMap[$selectExpression->fieldIdentificationVariable] = $selectExpression->expression;
@@ -306,7 +306,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
      */
     private function addMissingItemsFromOrderByToSelect(SelectStatement $AST)
     {
-        $this->orderByPathExpressions = [];
+        $this->orderByPathExpressions = array();
 
         // We need to do this in another walker because otherwise we'll end up
         // polluting the state of this one.
@@ -320,12 +320,12 @@ class LimitSubqueryOutputWalker extends SqlWalker
         $orderByPathExpressions = $walker->getOrderByPathExpressions();
 
         // Get a map of referenced identifiers to field names.
-        $selects = [];
+        $selects = array();
         foreach ($orderByPathExpressions as $pathExpression) {
             $idVar = $pathExpression->identificationVariable;
             $field = $pathExpression->field;
             if (!isset($selects[$idVar])) {
-                $selects[$idVar] = [];
+                $selects[$idVar] = array();
             }
             $selects[$idVar][$field] = true;
         }
@@ -401,7 +401,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
             = $dqlAliasToClassMap
             = $selectListAdditions
             = $orderByItems
-            = [];
+            = array();
 
         // Generate DQL alias -> SQL table alias mapping
         foreach(array_keys($this->rsm->aliasMap) as $dqlAlias) {
@@ -485,7 +485,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
         // Set every select expression as visible(hidden = false) to
         // make $AST have scalar mappings properly - this is relevant for referencing selected
         // fields from outside the subquery, for example in the ORDER BY segment
-        $hiddens = [];
+        $hiddens = array();
 
         foreach ($AST->selectClause->selectExpressions as $idx => $expr) {
             $hiddens[$idx] = $expr->hiddenAliasResultVariable;
@@ -526,7 +526,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
         $rootIdentifier = $rootClass->identifier;
 
         // For every identifier, find out the SQL alias by combing through the ResultSetMapping
-        $sqlIdentifier = [];
+        $sqlIdentifier = array();
         foreach ($rootIdentifier as $property) {
             if (isset($rootClass->fieldMappings[$property])) {
                 foreach (array_keys($this->rsm->fieldMappings, $property) as $alias) {

--- a/src/Eccube/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/src/Eccube/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * Doctrine ORM
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE. This license can also be viewed
+ * at http://hobodave.com/license.txt
+ *
+ * @category    DoctrineExtensions
+ * @package     DoctrineExtensions\Paginate
+ * @author      David Abdemoulaie <dave@hobodave.com>
+ * @copyright   Copyright (c) 2010 David Abdemoulaie (http://hobodave.com/)
+ * @license     http://hobodave.com/license.txt New BSD License
+ */
+
+namespace Doctrine\ORM\Tools\Pagination;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\TreeWalkerAdapter;
+use Doctrine\ORM\Query\AST\Functions\IdentityFunction;
+use Doctrine\ORM\Query\AST\PathExpression;
+use Doctrine\ORM\Query\AST\SelectExpression;
+use Doctrine\ORM\Query\AST\SelectStatement;
+
+/**
+ * Replaces the selectClause of the AST with a SELECT DISTINCT root.id equivalent.
+ *
+ * @category    DoctrineExtensions
+ * @package     DoctrineExtensions\Paginate
+ * @author      David Abdemoulaie <dave@hobodave.com>
+ * @copyright   Copyright (c) 2010 David Abdemoulaie (http://hobodave.com/)
+ * @license     http://hobodave.com/license.txt New BSD License
+ */
+class LimitSubqueryWalker extends TreeWalkerAdapter
+{
+    /**
+     * ID type hint.
+     */
+    const IDENTIFIER_TYPE = 'doctrine_paginator.id.type';
+
+    /**
+     * Counter for generating unique order column aliases.
+     *
+     * @var int
+     */
+    private $_aliasCounter = 0;
+
+    /**
+     * Walks down a SelectStatement AST node, modifying it to retrieve DISTINCT ids
+     * of the root Entity.
+     *
+     * @param SelectStatement $AST
+     *
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function walkSelectStatement(SelectStatement $AST)
+    {
+        $queryComponents = $this->_getQueryComponents();
+        // Get the root entity and alias from the AST fromClause
+        $from      = $AST->fromClause->identificationVariableDeclarations;
+        $fromRoot  = reset($from);
+        $rootAlias = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
+        $rootClass = $queryComponents[$rootAlias]['metadata'];
+        $selectExpressions = array();
+
+        $this->validate($AST);
+
+        foreach ($queryComponents as $dqlAlias => $qComp) {
+            // Preserve mixed data in query for ordering.
+            if (isset($qComp['resultVariable'])) {
+                $selectExpressions[] = new SelectExpression($qComp['resultVariable'], $dqlAlias);
+                continue;
+            }
+        }
+        
+        $identifier = $rootClass->getSingleIdentifierFieldName();
+        
+        if (isset($rootClass->associationMappings[$identifier])) {
+            throw new \RuntimeException("Paginating an entity with foreign key as identifier only works when using the Output Walkers. Call Paginator#setUseOutputWalkers(true) before iterating the paginator.");
+        }
+
+        $this->_getQuery()->setHint(
+            self::IDENTIFIER_TYPE,
+            Type::getType($rootClass->getTypeOfField($identifier))
+        );
+
+        $pathExpression = new PathExpression(
+            PathExpression::TYPE_STATE_FIELD | PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION,
+            $rootAlias,
+            $identifier
+        );
+        $pathExpression->type = PathExpression::TYPE_STATE_FIELD;
+
+        array_unshift($selectExpressions, new SelectExpression($pathExpression, '_dctrn_id'));
+        $AST->selectClause->selectExpressions = $selectExpressions;
+
+        if (isset($AST->orderByClause)) {
+            foreach ($AST->orderByClause->orderByItems as $item) {
+                if ( ! $item->expression instanceof PathExpression) {
+                    continue;
+                }
+                
+                $AST->selectClause->selectExpressions[] = new SelectExpression(
+                    $this->createSelectExpressionItem($item->expression),
+                    '_dctrn_ord' . $this->_aliasCounter++
+                );
+            }
+        }
+
+        $AST->selectClause->isDistinct = true;
+    }
+
+    /**
+     * Validate the AST to ensure that this walker is able to properly manipulate it.
+     *
+     * @param SelectStatement $AST
+     */
+    private function validate(SelectStatement $AST)
+    {
+        // Prevent LimitSubqueryWalker from being used with queries that include
+        // a limit, a fetched to-many join, and an order by condition that
+        // references a column from the fetch joined table.
+        $queryComponents = $this->getQueryComponents();
+        $query           = $this->_getQuery();
+        $from            = $AST->fromClause->identificationVariableDeclarations;
+        $fromRoot        = reset($from);
+
+        if ($query instanceof Query
+            && $query->getMaxResults()
+            && $AST->orderByClause
+            && count($fromRoot->joins)) {
+            // Check each orderby item.
+            // TODO: check complex orderby items too...
+            foreach ($AST->orderByClause->orderByItems as $orderByItem) {
+                $expression = $orderByItem->expression;
+                if ($orderByItem->expression instanceof PathExpression
+                    && isset($queryComponents[$expression->identificationVariable])) {
+                    $queryComponent = $queryComponents[$expression->identificationVariable];
+                    if (isset($queryComponent['parent'])
+                        && $queryComponent['relation']['type'] & ClassMetadataInfo::TO_MANY) {
+                        throw new \RuntimeException("Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers.");
+                    }
+                }
+            }
+        }
+    }
+    
+    /**
+     * Retrieve either an IdentityFunction (IDENTITY(u.assoc)) or a state field (u.name).
+     * 
+     * @param \Doctrine\ORM\Query\AST\PathExpression $pathExpression
+     * 
+     * @return \Doctrine\ORM\Query\AST\Functions\IdentityFunction
+     */
+    private function createSelectExpressionItem(PathExpression $pathExpression)
+    {
+        if ($pathExpression->type === PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION) {
+            $identity = new IdentityFunction('identity');
+            
+            $identity->pathExpression = clone $pathExpression;
+            
+            return $identity;
+        }
+        
+        return clone $pathExpression;
+    }
+}

--- a/src/Eccube/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/src/Eccube/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -16,7 +16,7 @@
  * @license     http://hobodave.com/license.txt New BSD License
  */
 
-namespace Doctrine\ORM\Tools\Pagination;
+namespace Eccube\Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;

--- a/src/Eccube/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/src/Eccube/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -1,0 +1,279 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Tools\Pagination;
+
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\ORM\NoResultException;
+
+/**
+ * The paginator can handle various complex scenarios with DQL.
+ *
+ * @author Pablo Díez <pablodip@gmail.com>
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @license New BSD
+ */
+class Paginator implements \Countable, \IteratorAggregate
+{
+    /**
+     * @var Query
+     */
+    private $query;
+
+    /**
+     * @var bool
+     */
+    private $fetchJoinCollection;
+
+    /**
+     * @var bool|null
+     */
+    private $useOutputWalkers;
+
+    /**
+     * @var int
+     */
+    private $count;
+
+    /**
+     * Constructor.
+     *
+     * @param Query|QueryBuilder $query               A Doctrine ORM query or query builder.
+     * @param boolean            $fetchJoinCollection Whether the query joins a collection (true by default).
+     */
+    public function __construct($query, $fetchJoinCollection = true)
+    {
+        if ($query instanceof QueryBuilder) {
+            $query = $query->getQuery();
+        }
+
+        $this->query = $query;
+        $this->fetchJoinCollection = (Boolean) $fetchJoinCollection;
+    }
+
+    /**
+     * Returns the query.
+     *
+     * @return Query
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    /**
+     * Returns whether the query joins a collection.
+     *
+     * @return boolean Whether the query joins a collection.
+     */
+    public function getFetchJoinCollection()
+    {
+        return $this->fetchJoinCollection;
+    }
+
+    /**
+     * Returns whether the paginator will use an output walker.
+     *
+     * @return bool|null
+     */
+    public function getUseOutputWalkers()
+    {
+        return $this->useOutputWalkers;
+    }
+
+    /**
+     * Sets whether the paginator will use an output walker.
+     *
+     * @param bool|null $useOutputWalkers
+     *
+     * @return $this
+     */
+    public function setUseOutputWalkers($useOutputWalkers)
+    {
+        $this->useOutputWalkers = $useOutputWalkers;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        if ($this->count === null) {
+            try {
+                $this->count = array_sum(array_map('current', $this->getCountQuery()->getScalarResult()));
+            } catch(NoResultException $e) {
+                $this->count = 0;
+            }
+        }
+
+        return $this->count;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        $offset = $this->query->getFirstResult();
+        $length = $this->query->getMaxResults();
+
+        if ($this->fetchJoinCollection) {
+            $subQuery = $this->cloneQuery($this->query);
+
+            if ($this->useOutputWalker($subQuery)) {
+                $subQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
+            } else {
+                $this->appendTreeWalker($subQuery, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker');
+            }
+
+            $subQuery->setFirstResult($offset)->setMaxResults($length);
+
+            $ids = array_map('current', $subQuery->getScalarResult());
+
+            $whereInQuery = $this->cloneQuery($this->query);
+            // don't do this for an empty id array
+            if (count($ids) == 0) {
+                return new \ArrayIterator(array());
+            }
+
+            $this->appendTreeWalker($whereInQuery, 'Doctrine\ORM\Tools\Pagination\WhereInWalker');
+            $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, count($ids));
+            $whereInQuery->setFirstResult(null)->setMaxResults(null);
+            $whereInQuery->setParameter(WhereInWalker::PAGINATOR_ID_ALIAS, $ids);
+            $whereInQuery->setCacheable($this->query->isCacheable());
+
+            $result = $whereInQuery->getResult($this->query->getHydrationMode());
+        } else {
+            $result = $this->cloneQuery($this->query)
+                ->setMaxResults($length)
+                ->setFirstResult($offset)
+                ->setCacheable($this->query->isCacheable())
+                ->getResult($this->query->getHydrationMode())
+            ;
+        }
+
+        return new \ArrayIterator($result);
+    }
+
+    /**
+     * Clones a query.
+     *
+     * @param Query $query The query.
+     *
+     * @return Query The cloned query.
+     */
+    private function cloneQuery(Query $query)
+    {
+        /* @var $cloneQuery Query */
+        $cloneQuery = clone $query;
+
+        $cloneQuery->setParameters(clone $query->getParameters());
+        $cloneQuery->setCacheable(false);
+
+        foreach ($query->getHints() as $name => $value) {
+            $cloneQuery->setHint($name, $value);
+        }
+
+        return $cloneQuery;
+    }
+
+    /**
+     * Determines whether to use an output walker for the query.
+     *
+     * @param Query $query The query.
+     *
+     * @return bool
+     */
+    private function useOutputWalker(Query $query)
+    {
+        if ($this->useOutputWalkers === null) {
+            return (Boolean) $query->getHint(Query::HINT_CUSTOM_OUTPUT_WALKER) == false;
+        }
+
+        return $this->useOutputWalkers;
+    }
+
+    /**
+     * Appends a custom tree walker to the tree walkers hint.
+     *
+     * @param Query $query
+     * @param string $walkerClass
+     */
+    private function appendTreeWalker(Query $query, $walkerClass)
+    {
+        $hints = $query->getHint(Query::HINT_CUSTOM_TREE_WALKERS);
+
+        if ($hints === false) {
+            $hints = array();
+        }
+
+        $hints[] = $walkerClass;
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, $hints);
+    }
+
+    /**
+     * Returns Query prepared to count.
+     *
+     * @return Query
+     */
+    private function getCountQuery()
+    {
+        /* @var $countQuery Query */
+        $countQuery = $this->cloneQuery($this->query);
+
+        if ( ! $countQuery->hasHint(CountWalker::HINT_DISTINCT)) {
+            $countQuery->setHint(CountWalker::HINT_DISTINCT, true);
+        }
+
+        if ($this->useOutputWalker($countQuery)) {
+            $platform = $countQuery->getEntityManager()->getConnection()->getDatabasePlatform(); // law of demeter win
+
+            $rsm = new ResultSetMapping();
+            $rsm->addScalarResult($platform->getSQLResultCasing('dctrn_count'), 'count');
+
+            $countQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\CountOutputWalker');
+            $countQuery->setResultSetMapping($rsm);
+        } else {
+            $this->appendTreeWalker($countQuery, 'Doctrine\ORM\Tools\Pagination\CountWalker');
+        }
+
+        $countQuery->setFirstResult(null)->setMaxResults(null);
+
+        $parser            = new Parser($countQuery);
+        $parameterMappings = $parser->parse()->getParameterMappings();
+        /* @var $parameters \Doctrine\Common\Collections\Collection|\Doctrine\ORM\Query\Parameter[] */
+        $parameters        = $countQuery->getParameters();
+
+        foreach ($parameters as $key => $parameter) {
+            $parameterName = $parameter->getName();
+
+            if( ! (isset($parameterMappings[$parameterName]) || array_key_exists($parameterName, $parameterMappings))) {
+                unset($parameters[$key]);
+            }
+        }
+
+        $countQuery->setParameters($parameters);
+
+        return $countQuery;
+    }
+}

--- a/src/Eccube/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/src/Eccube/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -17,7 +17,7 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Tools\Pagination;
+namespace Eccube\Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\QueryBuilder;
@@ -141,9 +141,9 @@ class Paginator implements \Countable, \IteratorAggregate
             $subQuery = $this->cloneQuery($this->query);
 
             if ($this->useOutputWalker($subQuery)) {
-                $subQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
+                $subQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Eccube\Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
             } else {
-                $this->appendTreeWalker($subQuery, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker');
+                $this->appendTreeWalker($subQuery, 'Eccube\Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker');
             }
 
             $subQuery->setFirstResult($offset)->setMaxResults($length);
@@ -156,18 +156,18 @@ class Paginator implements \Countable, \IteratorAggregate
                 return new \ArrayIterator(array());
             }
 
-            $this->appendTreeWalker($whereInQuery, 'Doctrine\ORM\Tools\Pagination\WhereInWalker');
+            $this->appendTreeWalker($whereInQuery, 'Eccube\Doctrine\ORM\Tools\Pagination\WhereInWalker');
             $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, count($ids));
             $whereInQuery->setFirstResult(null)->setMaxResults(null);
             $whereInQuery->setParameter(WhereInWalker::PAGINATOR_ID_ALIAS, $ids);
-            $whereInQuery->setCacheable($this->query->isCacheable());
+            //$whereInQuery->setCacheable($this->query->isCacheable());
 
             $result = $whereInQuery->getResult($this->query->getHydrationMode());
         } else {
             $result = $this->cloneQuery($this->query)
                 ->setMaxResults($length)
                 ->setFirstResult($offset)
-                ->setCacheable($this->query->isCacheable())
+                //->setCacheable($this->query->isCacheable())
                 ->getResult($this->query->getHydrationMode())
             ;
         }
@@ -188,7 +188,7 @@ class Paginator implements \Countable, \IteratorAggregate
         $cloneQuery = clone $query;
 
         $cloneQuery->setParameters(clone $query->getParameters());
-        $cloneQuery->setCacheable(false);
+        //$cloneQuery->setCacheable(false);
 
         foreach ($query->getHints() as $name => $value) {
             $cloneQuery->setHint($name, $value);
@@ -251,10 +251,10 @@ class Paginator implements \Countable, \IteratorAggregate
             $rsm = new ResultSetMapping();
             $rsm->addScalarResult($platform->getSQLResultCasing('dctrn_count'), 'count');
 
-            $countQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\CountOutputWalker');
+            $countQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Eccube\Doctrine\ORM\Tools\Pagination\CountOutputWalker');
             $countQuery->setResultSetMapping($rsm);
         } else {
-            $this->appendTreeWalker($countQuery, 'Doctrine\ORM\Tools\Pagination\CountWalker');
+            $this->appendTreeWalker($countQuery, 'Eccube\Doctrine\ORM\Tools\Pagination\CountWalker');
         }
 
         $countQuery->setFirstResult(null)->setMaxResults(null);

--- a/src/Eccube/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
+++ b/src/Eccube/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Tools\Pagination;
+
+use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+
+
+/**
+ * RowNumberOverFunction
+ *
+ * Provides ROW_NUMBER() OVER(ORDER BY...) construct for use in LimitSubqueryOutputWalker
+ *
+ * @since   2.5
+ * @author  Bill Schaller <bill@zeroedin.com>
+ */
+class RowNumberOverFunction extends FunctionNode
+{
+    /**
+     * @var \Doctrine\ORM\Query\AST\OrderByClause
+     */
+    public $orderByClause;
+
+    /**
+     * @override
+     */
+    public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
+    {
+        return 'ROW_NUMBER() OVER(' . trim($sqlWalker->walkOrderByClause(
+            $this->orderByClause
+        )) . ')';
+    }
+
+    /**
+     * @override
+     *
+     * @throws ORMException
+     */
+    public function parse(\Doctrine\ORM\Query\Parser $parser)
+    {
+        throw new ORMException("The RowNumberOverFunction is not intended for, nor is it enabled for use in DQL.");
+    }
+}

--- a/src/Eccube/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
+++ b/src/Eccube/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
@@ -18,7 +18,7 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Tools\Pagination;
+namespace Eccube\Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;

--- a/src/Eccube/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/src/Eccube/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Doctrine ORM
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE. This license can also be viewed
+ * at http://hobodave.com/license.txt
+ *
+ * @category    DoctrineExtensions
+ * @package     DoctrineExtensions\Paginate
+ * @author      David Abdemoulaie <dave@hobodave.com>
+ * @copyright   Copyright (c) 2010 David Abdemoulaie (http://hobodave.com/)
+ * @license     http://hobodave.com/license.txt New BSD License
+ */
+
+namespace Doctrine\ORM\Tools\Pagination;
+
+use Doctrine\ORM\Query\AST\ArithmeticExpression;
+use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
+use Doctrine\ORM\Query\TreeWalkerAdapter;
+use Doctrine\ORM\Query\AST\SelectStatement;
+use Doctrine\ORM\Query\AST\PathExpression;
+use Doctrine\ORM\Query\AST\InExpression;
+use Doctrine\ORM\Query\AST\NullComparisonExpression;
+use Doctrine\ORM\Query\AST\InputParameter;
+use Doctrine\ORM\Query\AST\ConditionalPrimary;
+use Doctrine\ORM\Query\AST\ConditionalTerm;
+use Doctrine\ORM\Query\AST\ConditionalExpression;
+use Doctrine\ORM\Query\AST\ConditionalFactor;
+use Doctrine\ORM\Query\AST\WhereClause;
+
+/**
+ * Replaces the whereClause of the AST with a WHERE id IN (:foo_1, :foo_2) equivalent.
+ *
+ * @category    DoctrineExtensions
+ * @package     DoctrineExtensions\Paginate
+ * @author      David Abdemoulaie <dave@hobodave.com>
+ * @copyright   Copyright (c) 2010 David Abdemoulaie (http://hobodave.com/)
+ * @license     http://hobodave.com/license.txt New BSD License
+ */
+class WhereInWalker extends TreeWalkerAdapter
+{
+    /**
+     * ID Count hint name.
+     */
+    const HINT_PAGINATOR_ID_COUNT = 'doctrine.id.count';
+
+    /**
+     * Primary key alias for query.
+     */
+    const PAGINATOR_ID_ALIAS = 'dpid';
+
+    /**
+     * Replaces the whereClause in the AST.
+     *
+     * Generates a clause equivalent to WHERE IN (:dpid_1, :dpid_2, ...)
+     *
+     * The parameter namespace (dpid) is defined by
+     * the PAGINATOR_ID_ALIAS
+     *
+     * The total number of parameters is retrieved from
+     * the HINT_PAGINATOR_ID_COUNT query hint.
+     *
+     * @param SelectStatement $AST
+     *
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function walkSelectStatement(SelectStatement $AST)
+    {
+        $queryComponents = $this->_getQueryComponents();
+        // Get the root entity and alias from the AST fromClause
+        $from = $AST->fromClause->identificationVariableDeclarations;
+        
+        if (count($from) > 1) {
+            throw new \RuntimeException("Cannot count query which selects two FROM components, cannot make distinction");
+        }
+       
+        $fromRoot            = reset($from);
+        $rootAlias           = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
+        $rootClass           = $queryComponents[$rootAlias]['metadata'];
+        $identifierFieldName = $rootClass->getSingleIdentifierFieldName();
+
+        $pathType = PathExpression::TYPE_STATE_FIELD;
+        if (isset($rootClass->associationMappings[$identifierFieldName])) {
+            $pathType = PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION;
+        }
+
+        $pathExpression       = new PathExpression(PathExpression::TYPE_STATE_FIELD | PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION, $rootAlias, $identifierFieldName);
+        $pathExpression->type = $pathType;
+
+        $count = $this->_getQuery()->getHint(self::HINT_PAGINATOR_ID_COUNT);
+
+        if ($count > 0) {
+            $arithmeticExpression = new ArithmeticExpression();
+            $arithmeticExpression->simpleArithmeticExpression = new SimpleArithmeticExpression(
+                array($pathExpression)
+            );
+            $expression = new InExpression($arithmeticExpression);
+            $expression->literals[] = new InputParameter(":" . self::PAGINATOR_ID_ALIAS);
+
+        } else {
+            $expression = new NullComparisonExpression($pathExpression);
+            $expression->not = false;
+        }
+
+        $conditionalPrimary = new ConditionalPrimary;
+        $conditionalPrimary->simpleConditionalExpression = $expression;
+        if ($AST->whereClause) {
+            if ($AST->whereClause->conditionalExpression instanceof ConditionalTerm) {
+                $AST->whereClause->conditionalExpression->conditionalFactors[] = $conditionalPrimary;
+            } elseif ($AST->whereClause->conditionalExpression instanceof ConditionalPrimary) {
+                $AST->whereClause->conditionalExpression = new ConditionalExpression(array(
+                    new ConditionalTerm(array(
+                        $AST->whereClause->conditionalExpression,
+                        $conditionalPrimary
+                    ))
+                ));
+            } elseif ($AST->whereClause->conditionalExpression instanceof ConditionalExpression
+                || $AST->whereClause->conditionalExpression instanceof ConditionalFactor
+            ) {
+                $tmpPrimary = new ConditionalPrimary;
+                $tmpPrimary->conditionalExpression = $AST->whereClause->conditionalExpression;
+                $AST->whereClause->conditionalExpression = new ConditionalTerm(array(
+                    $tmpPrimary,
+                    $conditionalPrimary
+                ));
+            }
+        } else {
+            $AST->whereClause = new WhereClause(
+                new ConditionalExpression(array(
+                    new ConditionalTerm(array(
+                        $conditionalPrimary
+                    ))
+                ))
+            );
+        }
+    }
+}

--- a/src/Eccube/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/src/Eccube/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -15,7 +15,7 @@
  * @license     http://hobodave.com/license.txt New BSD License
  */
 
-namespace Doctrine\ORM\Tools\Pagination;
+namespace Eccube\Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\ORM\Query\AST\ArithmeticExpression;
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;

--- a/src/Eccube/EventListener/PaginatorListener.php
+++ b/src/Eccube/EventListener/PaginatorListener.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\QuerySubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Knp\Component\Pager\Event\ItemsEvent;
+use Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\QuerySubscriber;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\ORM\Tools\Pagination\CountWalker;
+
+class UsesPaginator implements EventSubscriberInterface
+{
+    const HINT_FETCH_JOIN_COLLECTION = 'knp_paginator.fetch_join_collection';
+
+    public function items(ItemsEvent $event)
+    {
+        if (!class_exists('Doctrine\ORM\Tools\Pagination\Paginator')) {
+            return;
+        }
+        if (!$event->target instanceof Query) {
+            return;
+        }
+        $event->stopPropagation();
+
+        $useOutputWalkers = false;
+        if (isset($event->options['wrap-queries'])) {
+            $useOutputWalkers = $event->options['wrap-queries'];
+        }
+
+        $event->target
+            ->setFirstResult($event->getOffset())
+            ->setMaxResults($event->getLimit())
+            ->setHint(CountWalker::HINT_DISTINCT, $event->options['distinct'])
+        ;
+
+        $fetchJoinCollection = true;
+        if ($event->target->hasHint(self::HINT_FETCH_JOIN_COLLECTION)) {
+            $fetchJoinCollection = $event->target->getHint(self::HINT_FETCH_JOIN_COLLECTION);
+        }
+
+        $paginator = new Paginator($event->target, $fetchJoinCollection);
+        $paginator->setUseOutputWalkers($useOutputWalkers);
+        if (($count = $event->target->getHint(QuerySubscriber::HINT_COUNT)) !== false) {
+            $event->count = intval($count);
+        } else {
+            $event->count = count($paginator);
+        }
+        $event->items = iterator_to_array($paginator);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'knp_pager.items' => array('items', 0)
+        );
+    }
+}

--- a/src/Eccube/EventListener/PaginatorListener.php
+++ b/src/Eccube/EventListener/PaginatorListener.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\QuerySubscriber;
+namespace Eccube\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Knp\Component\Pager\Event\ItemsEvent;
 use Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\QuerySubscriber;
 use Doctrine\ORM\Query;
-use Doctrine\ORM\Tools\Pagination\Paginator;
-use Doctrine\ORM\Tools\Pagination\CountWalker;
+use Eccube\Doctrine\ORM\Tools\Pagination\Paginator;
+use Eccube\Doctrine\ORM\Tools\Pagination\CountWalker;
 
-class UsesPaginator implements EventSubscriberInterface
+class PaginatorListener implements EventSubscriberInterface
 {
     const HINT_FETCH_JOIN_COLLECTION = 'knp_paginator.fetch_join_collection';
 
     public function items(ItemsEvent $event)
     {
-        if (!class_exists('Doctrine\ORM\Tools\Pagination\Paginator')) {
+        if (!class_exists('Eccube\Doctrine\ORM\Tools\Pagination\Paginator')) {
             return;
         }
         if (!$event->target instanceof Query) {
@@ -52,7 +52,17 @@ class UsesPaginator implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            'knp_pager.items' => array('items', 0)
+            /**
+             * Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\QuerySubscriber\UsesPaginator
+             * よりも先に実行させるため, 優先度を1に設定.
+             *
+             * 通常では
+             * - Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\QueryBuilderSubscriber
+             * - Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\QuerySubscriber\UsesPaginator
+             * の順に実行されるが,
+             * 優先度を1に設定し, UsesPaginatorの代わりにPaginatorListenerが動作するようにする
+             */
+            'knp_pager.items' => array('items', 1)
         );
     }
 }

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -232,7 +232,10 @@ class EccubeServiceProvider implements ServiceProviderInterface
         });
 
         $app['paginator'] = $app->protect(function () {
-            return new \Knp\Component\Pager\Paginator();
+            $paginator = new \Knp\Component\Pager\Paginator();
+            $paginator->subscribe(new \Eccube\EventListener\PaginatorListener());
+
+            return $paginator;
         });
 
         $app['eccube.repository.help'] = $app->share(function () use ($app) {

--- a/tests/Eccube/Tests/Doctrine/ORM/Tools/PaginationTest.php
+++ b/tests/Eccube/Tests/Doctrine/ORM/Tools/PaginationTest.php
@@ -1,0 +1,323 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Tests\Doctrine\ORM\Tools;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Eccube\Entity\ProductTag;
+use Eccube\Tests\EccubeTestCase;
+
+class PaginationTest extends EccubeTestCase
+{
+    protected $expectedIds = array();
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // mysqlの場合, トランザクション中にcreate tableを行うと暗黙的にcommitされてしまい, テストデータをロールバックできない
+        // そのため, create tableを行った後に, 再度トランザクションを開始するようにしている
+        /** @var EntityManager $em */
+        $em = $this->app['orm.em'];
+        $conn = $em->getConnection();
+        $conn->rollback();
+        $this->dropTable($conn->getWrappedConnection());
+        $this->createTable($conn->getWrappedConnection());
+        $conn->beginTransaction();
+
+        // テスト用のエンティティを用意
+        $config = $em->getConfiguration();
+        $driver = $config->newDefaultAnnotationDriver(__DIR__, false);
+        $chain = $config->getMetadataDriverImpl();
+        $chain->addDriver($driver, __NAMESPACE__);
+
+        // 初期データより大きい値を指定
+        $price02 = $this->getFaker()->randomNumber(9);
+        for ($i = 0; $i < 30; $i++) {
+            $Product = $this->createProduct(null, 3);
+            $this->expectedIds[] = $Product->getId();
+
+            $ProductClasses = $Product->getProductClasses();
+            foreach ($ProductClasses as $ProductClass) {
+                // product.idの昇順になるよう, product_class.price02を設定する
+                $ProductClass->setPrice02($price02 - $i);
+                $em->flush($ProductClass);
+            }
+        }
+    }
+
+    public function tearDown()
+    {
+        /** @var EntityManager $em */
+        $em = $this->app['orm.em'];
+        $conn = $em->getConnection();
+        $conn->rollback();
+        $this->dropTable($conn->getWrappedConnection());
+        $conn->beginTransaction();
+
+        parent::tearDown();
+    }
+
+    protected function createTable(\Doctrine\DBAL\Driver\Connection $conn)
+    {
+        $sql = 'CREATE TABLE test_entity(id INT, col INT, PRIMARY KEY(id));';
+        $stmt = $conn->prepare($sql);
+        $stmt->execute();
+    }
+
+    protected function dropTable(\Doctrine\DBAL\Driver\Connection $conn)
+    {
+        $sql = 'DROP TABLE IF EXISTS test_entity;';
+        $stmt = $conn->prepare($sql);
+        $stmt->execute();
+    }
+
+    /**
+     * wrap-queries' => true時に, PostgreSQLで正常にソート出来ない不具合が解消されているかどうかのテスト
+     *
+     * @link https://github.com/EC-CUBE/ec-cube/issues/1618
+     */
+    public function testSortWithWrapQueriesTrue()
+    {
+        $qb = $this->app['eccube.repository.product']
+            ->getQueryBuilderBySearchDataForAdmin(array());
+
+        // product_class.price02 でソートするようカスタマイズ
+        $qb->orderBy('pc.price02', 'DESC');
+
+        $pageMax = 10;
+        $pagination = $this->app['paginator']()->paginate(
+            $qb,
+            1,
+            $pageMax,
+            array('wrap-queries' => true)
+        );
+
+        $actualIds = array();
+        foreach ($pagination as $Product) {
+            $actualIds[] = $Product->getId();
+        }
+
+        $this->expected = array_slice($this->expectedIds, 0, $pageMax);
+        $this->actual = $actualIds;
+        $this->verify('product_class.price02 降順なので, id 昇順にソートされるはず');
+        $this->assertEquals($pageMax, count($this->actual), 'paginatorの結果は'.$pageMax.'件');
+    }
+
+    /**
+     * 外部のエンティティとJoinできるかどうかのテスト
+     *
+     * @link https://github.com/EC-CUBE/ec-cube/issues/1916
+     */
+    public function testSortWithJoinPluginEntity()
+    {
+        // idの昇順になるようにcolを設定する
+        $em = $this->app['orm.em'];
+        $count = count($this->expectedIds);
+        foreach ($this->expectedIds as $id) {
+            $TestEntity = new TestEntity();
+            $TestEntity->id = $id;
+            $TestEntity->col = $count--;
+            $em->persist($TestEntity);
+            $em->flush($TestEntity);
+        }
+
+        $qb = $this->app['eccube.repository.product']
+            ->getQueryBuilderBySearchData(array());
+
+        // テスト用のエンティティとjoinし,ソートする.
+        $qb
+            ->addSelect('COALESCE(test.col, 0) as HIDDEN col')
+            ->leftJoin('Eccube\Tests\Doctrine\ORM\Tools\TestEntity', 'test', 'WITH', 'p.id = test.id')
+            ->groupBy('p')
+            ->addGroupBy('test')
+            ->orderBy('col', 'DESC')
+            ->addOrderBy('p.id', 'DESC');
+
+        $Products = $qb->getQuery()->getResult();
+        $expectedIds = array();
+        foreach ($Products as $Product) {
+            $expectedIds[] = $Product->getId();
+        }
+
+        $pageMax = 10;
+        try {
+            $pagination = $this->app['paginator']()->paginate(
+                $qb,
+                1,
+                $pageMax,
+                array('wrap-queries' => true)
+            );
+            $this->assertTrue(true);
+        } catch (\RuntimeException $e) {
+            // \RuntimeExceptionは解消されているはず
+            $this->fail($e->getMessage());
+        }
+
+        $actualIds = array();
+        foreach ($pagination as $Product) {
+            $actualIds[] = $Product->getId();
+        }
+
+        $this->expected = array_slice($this->expectedIds, 0, $pageMax);
+        $this->actual = $actualIds;
+        $this->verify('test_entity.col 降順なので, id 昇順にソートされるはず');
+        $this->assertEquals($pageMax, count($this->actual), 'paginatorの結果は'.$pageMax.'件');
+    }
+
+    /**
+     * EC-CUBE本体のエンティティとjoinし, 検索するテスト
+     */
+    public function testWhereWithJoinEntity()
+    {
+        // `新商品`のTagが登録されたProductを生成
+        $Tag = $this->app['eccube.repository.master.tag']
+            ->find(1);
+        $Member = $this->app['eccube.repository.member']
+            ->find(2);
+        $Product = $this->app['eccube.repository.product']
+            ->find(reset($this->expectedIds));
+
+        $ProductTag = new ProductTag();
+        $ProductTag->setCreator($Member);
+        $ProductTag->setProduct($Product);
+        $ProductTag->setTag($Tag);
+        $Product->addProductTag($ProductTag);
+
+        $this->app['orm.em']->persist($ProductTag);
+        $this->app['orm.em']->flush(array($Product, $ProductTag));
+
+        $qb = $this->app['eccube.repository.product']
+            ->getQueryBuilderBySearchData(array());
+
+        // 商品タグとjoinして検索
+        $qb->innerJoin('p.ProductTag', 'ptag')
+            ->innerJoin('ptag.Tag', 'tag')
+            ->andWhere($qb->expr()->in('ptag.Tag', ':Tag'))
+            ->setParameter(':Tag', $Tag);
+
+        $expectedIds = array();
+        $results = $qb->getQuery()->getResult();
+        foreach ($results as $result) {
+            $expectedIds[] = $result->getId();
+        }
+
+        $pagination = $this->app['paginator']()->paginate(
+            $qb,
+            1,
+            30,
+            array('wrap-queries' => true)
+        );
+
+        $actualIds = array();
+        foreach ($pagination as $result) {
+            $actualIds[] = $result->getId();
+        }
+
+        $this->expected = $expectedIds;
+        $this->actual = $actualIds;
+        // tagが登録されたProductは1件のみ.
+        $this->assertTrue(count($this->actual) === 1);
+        $this->verify();
+    }
+
+    /**
+     * 外部からwhere句を追加するテスト
+     */
+    public function testWhereWithSubQueryPluginEntity()
+    {
+        $TestEntity = new TestEntity();
+        $TestEntity->id = reset($this->expectedIds);
+        $TestEntity->col = 123;
+        $this->app['orm.em']->persist($TestEntity);
+        $this->app['orm.em']->flush($TestEntity);
+
+        $qb = $this->app['eccube.repository.product']
+            ->getQueryBuilderBySearchData(array());
+
+        // テスト用のエンティティを検索するクエリ
+        $repository = $this->app['orm.em']->getRepository('Eccube\Tests\Doctrine\ORM\Tools\TestEntity');
+        $testQb = $repository->createQueryBuilder('test');
+        $testQb->select('test.id');
+        $testQb->where('test.col = :col');
+        $testQb->setParameter('col', 123);
+
+        // 本体のクエリビルダに追加する
+        $qb->andWhere($qb->expr()->in('p.id', $testQb->getDQL()));
+        $parameters = $testQb->getParameters();
+        foreach ($parameters as $parameter) {
+            $qb->setParameter($parameter->getName(), $parameter->getValue());
+        }
+
+        $expectedIds = array();
+        $results = $qb->getQuery()->getResult();
+        foreach ($results as $result) {
+            $expectedIds[] = $result->getId();
+        }
+
+        $pagination = $this->app['paginator']()->paginate(
+            $qb,
+            1,
+            30,
+            array('wrap-queries' => true)
+        );
+
+        $actualIds = array();
+        foreach ($pagination as $result) {
+            $actualIds[] = $result->getId();
+        }
+
+        $this->expected = $expectedIds;
+        $this->actual = $actualIds;
+        // 1件のみマッチする
+        $this->assertTrue(count($this->actual) === 1);
+        $this->verify();
+    }
+}
+
+/**
+ * テスト用のエンティティ
+ *
+ * @ORM\Entity(repositoryClass="Eccube\Tests\Doctrine\ORM\Tools\TestRepository")
+ * @ORM\Table(name="test_entity")
+ */
+class TestEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="NONE")
+     */
+    public $id;
+
+    /**
+     * @ORM\Column(type="integer")
+     */
+    public $col;
+}
+
+class TestRepository extends EntityRepository
+{
+}


### PR DESCRIPTION
#1916

- ~~doctrine2.5のCountOutputWalker をバックポート~~
  - ~~wrap-queries: true時は、上記のCountOutputWalkerを使うように修正~~
- ~~プラグインから拡張されることを想定し, ページネータを利用する箇所はwrap-queries: trueに変更~~

doctrine2.5.5のpaginatorをバックポート

- CountWalker
- LimitSubqueryWalker
- WhereInWalker
- LimitSubqueryOutputWalker 
- CountOutputWalker 
- Paginator

オリジナルからの変更箇所は以下のコミット
https://github.com/EC-CUBE/ec-cube/pull/1922/commits/79409b74515b93b7374461719c37b35e1aa6912b

上記を動作させるため, KnpPagerのUsesPaginatorを移植
https://github.com/EC-CUBE/ec-cube/pull/1922/commits/fce6bbc0eef99d3cbcf2fbece075e75fd3f60ac9

#1916 および #1618 の問題が解消されます。