### PR TITLE
ページ管理でタイトルを変更できるように修正、ページ一覧にrouteとファイル名を表示

### DIFF
--- a/src/Eccube/Resource/template/admin/Content/page.twig
+++ b/src/Eccube/Resource/template/admin/Content/page.twig
@@ -41,7 +41,12 @@
                 <div id="sortable_list_box" class="box-body no-padding no-border">
                     <div id="sortable_list_box__list" class="sortable_list">
                         <div class="tableish">
-
+                            <div class="item_box tr" style="background-color: #F9F9F9;">
+                                <div class="item_pattern td"><strong>ページ名</strong></div>
+                                <div class="item_pattern td"><strong>ルーティング名</strong></div>
+                                <div class="item_pattern td"><strong>ファイル名</strong></div>
+                                <div class="item_pattern td"></div>
+                            </div>
                             {% for PageLayout in PageLayouts %}
                                 <div id="sortable_list_box__item--{{ PageLayout.id }}" class="item_box tr">
                                     <div id="sortable_list_box__name--{{ PageLayout.id }}" class="item_pattern td">

--- a/src/Eccube/Resource/template/admin/Content/page.twig
+++ b/src/Eccube/Resource/template/admin/Content/page.twig
@@ -29,8 +29,6 @@
 {% block sub_title %}ページ管理{% endblock %}
 
 {% block main %}
-<form name="content_page_form" action="" method="post">
-</form>
 <div id="page_wrap" class="container-fluid">
     <div id="page_list" class="row">
         <div id="page_list_box" class="col-md-12">
@@ -48,6 +46,12 @@
                                 <div id="sortable_list_box__item--{{ PageLayout.id }}" class="item_box tr">
                                     <div id="sortable_list_box__name--{{ PageLayout.id }}" class="item_pattern td">
                                         {{ PageLayout.name }}
+                                    </div>
+                                    <div id="sortable_list_box__url--{{ PageLayout.id }}" class="td">
+                                        {{ PageLayout.url }}
+                                    </div>
+                                    <div id="sortable_list_box__file_name--{{ PageLayout.id }}" class="td">
+                                        {% if PageLayout.file_name %}{{ PageLayout.file_name }}.twig{% endif %}
                                     </div>
                                     <div id="sortable_list_box__menu_box--{{ PageLayout.id }}" class="icon_edit td">
                                         <div id="sortable_list_box__menu_box_toggle--{{ PageLayout.id }}" class="dropdown">

--- a/src/Eccube/Resource/template/admin/Content/page_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/page_edit.twig
@@ -48,12 +48,7 @@
                         <div id="detail_box__name" class="form-group">
                             {{ form_label(form.name) }}
                             <div class="col-sm-9 col-lg-10">
-                                {% if editable %}
-                                    {{ form_widget(form.name) }}
-                                {% else %}
-                                    {{ form.name.vars.value }}
-                                    {{ form_widget(form.name, { type : 'hidden' } ) }}
-                                {% endif %}
+                                {{ form_widget(form.name) }}
                                 {{ form_errors(form.name) }}
                             </div>
                         </div>
@@ -128,9 +123,7 @@
                         <div id="common_button_box__body" class="box-body">
                             <div id="common_button_box__insert_button" class="row text-center">
                                 <div class="col-sm-6 col-sm-offset-3 col-md-12 col-md-offset-0">
-                                    <button class="btn btn-primary btn-block btn-lg"
-                                            onclick="document.content_page_form.submit();">登録
-                                    </button>
+                                    <button class="btn btn-primary btn-block btn-lg" type="submit">登録</button>
                                 </div>
                             </div>
                         </div>

--- a/tests/Eccube/Tests/Web/Admin/Content/PageControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/PageControllerTest.php
@@ -90,4 +90,40 @@ class PageControllerTest extends AbstractAdminWebTestCase
 
     }
 
+    public function test_routing_AdminContentPage_edit_name()
+    {
+        $client = $this->client;
+
+        $editable = false;
+
+        $templatePath = $this->app['eccube.repository.page_layout']->getWriteTemplatePath($editable);
+        $PageLayout = $this->app['eccube.repository.page_layout']->find(1);
+
+        $client->request(
+            'POST',
+            $this->app->url(
+                'admin_content_page_edit',
+                array('id' => $PageLayout->getId())
+            ),
+            array(
+                'main_edit' => array(
+                    'id' => $PageLayout->getId(),
+                    'name' => 'testtest',
+                    'url' => $PageLayout->getUrl(),
+                    'file_name' => $PageLayout->getFileName(),
+                    '_token' => 'dummy'
+                ),
+                'page_id' => $PageLayout->getId(),
+                'editable' => $editable,
+                'template_path' => $templatePath,
+            )
+        );
+
+        $this->assertTrue($client->getResponse()->isRedirect($this->app->url('admin_content_page_edit', array('id' => $PageLayout->getId()))));
+
+        $this->expected = 'testtest';
+        $this->actual = $PageLayout->getName();
+        $this->verify();
+    }
+
 }


### PR DESCRIPTION
- 既存からあるページはタイトルが変更できなかったため変更できるようにする。
- ページ一覧にrouteとページに該当するファイル名を表示する。