### PR TITLE
フロントと管理側のSession名を分ける方法

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -46,9 +46,9 @@ if ($app['config']['eccube_install']) {
     $app->initialize();
     $app->initializePlugin();
     if ($app['config']['http_cache']['enabled']) {
-        $app['http_cache']->run($app['initRequest']);
+        $app['http_cache']->run();
     } else {
-        $app->run($app['initRequest']);
+        $app->run();
     }
 } else {
     $location = str_replace('index.php', 'install.php', $_SERVER['SCRIPT_NAME']);

--- a/html/index.php
+++ b/html/index.php
@@ -46,9 +46,9 @@ if ($app['config']['eccube_install']) {
     $app->initialize();
     $app->initializePlugin();
     if ($app['config']['http_cache']['enabled']) {
-        $app['http_cache']->run();
+        $app['http_cache']->run($app['initRequest']);
     } else {
-        $app->run();
+        $app->run($app['initRequest']);
     }
 } else {
     $location = str_replace('index.php', 'install.php', $_SERVER['SCRIPT_NAME']);

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -249,7 +249,6 @@ class Application extends ApplicationTrait
     public function initSession()
     {
         $cookieName = 'eccube';
-        
         if ($this->isAdminRequest()) {
             $cookieName .= '_admin';
         }
@@ -296,26 +295,26 @@ class Application extends ApplicationTrait
 
                 // 互換性がないのでprofiler とproduction 時のcacheを分離する
                 if (isset($app['profiler'])) {
-                $cacheBaseDir = __DIR__.'/../../app/cache/twig/profiler/';
+                    $cacheBaseDir = __DIR__.'/../../app/cache/twig/profiler/';
                 } else {
-                $cacheBaseDir = __DIR__.'/../../app/cache/twig/production/';
+                    $cacheBaseDir = __DIR__.'/../../app/cache/twig/production/';
                 }
 
                 if ($app->isAdminRequest()) {
-                if (file_exists(__DIR__.'/../../app/template/admin')) {
-                    $paths[] = __DIR__.'/../../app/template/admin';
+                    if (file_exists(__DIR__.'/../../app/template/admin')) {
+                        $paths[] = __DIR__.'/../../app/template/admin';
                     }
                     $paths[] = $app['config']['template_admin_realdir'];
-                $paths[] = __DIR__.'/../../app/Plugin';
-                $cache = $cacheBaseDir.'admin';
+                    $paths[] = __DIR__.'/../../app/Plugin';
+                    $cache = $cacheBaseDir.'admin';
 
                 } else {
                     if (file_exists($app['config']['template_realdir'])) {
                         $paths[] = $app['config']['template_realdir'];
                     }
                     $paths[] = $app['config']['template_default_realdir'];
-                $paths[] = __DIR__.'/../../app/Plugin';
-                $cache = $cacheBaseDir.$app['config']['template_code'];
+                    $paths[] = __DIR__.'/../../app/Plugin';
+                    $cache = $cacheBaseDir.$app['config']['template_code'];
                     $app['front'] = true;
                 }
                 $twig->setCache($cache);

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -168,8 +168,8 @@ class Application extends ApplicationTrait
             }
 
             return $app->render('error.twig', array(
-                    'error_title' => $title,
-                    'error_message' => $message,
+                'error_title' => $title,
+                'error_message' => $message,
             ));
         });
 
@@ -216,19 +216,19 @@ class Application extends ApplicationTrait
             'translator.cache_dir' => $this['debug'] ? null : $this['config']['root_dir'].'/app/cache/translator',
         ));
         $this['translator'] = $this->share($this->extend('translator', function ($translator, \Silex\Application $app) {
-                $translator->addLoader('yaml', new \Symfony\Component\Translation\Loader\YamlFileLoader());
+            $translator->addLoader('yaml', new \Symfony\Component\Translation\Loader\YamlFileLoader());
 
             $file = __DIR__.'/Resource/locale/validator.'.$app['locale'].'.yml';
-                if (file_exists($file)) {
-                    $translator->addResource('yaml', $file, $app['locale'], 'validators');
-                }
+            if (file_exists($file)) {
+                $translator->addResource('yaml', $file, $app['locale'], 'validators');
+            }
 
             $file = __DIR__.'/Resource/locale/message.'.$app['locale'].'.yml';
-                if (file_exists($file)) {
-                    $translator->addResource('yaml', $file, $app['locale']);
-                }
+            if (file_exists($file)) {
+                $translator->addResource('yaml', $file, $app['locale']);
+            }
 
-                return $translator;
+            return $translator;
         }));
     }
 
@@ -254,15 +254,15 @@ class Application extends ApplicationTrait
             $cookieName .= '_admin';
         }
         $this->register(new \Silex\Provider\SessionServiceProvider(), array(
-            'session.storage.save_path' => $this['config']['root_dir'] . '/app/cache/eccube/session',
+            'session.storage.save_path' => $this['config']['root_dir'].'/app/cache/eccube/session',
             'session.storage.options' => array(
                 'name' => $cookieName,
                 'cookie_path' => $this['config']['root_urlpath'] ?: '/',
                 'cookie_secure' => $this['config']['force_ssl'],
                 'cookie_lifetime' => $this['config']['cookie_lifetime'],
                 'cookie_httponly' => true,
-            // cookie_domainは指定しない
-            // http://blog.tokumaru.org/2011/10/cookiedomain.html
+                // cookie_domainは指定しない
+                // http://blog.tokumaru.org/2011/10/cookiedomain.html
             ),
         ));
 
@@ -282,46 +282,46 @@ class Application extends ApplicationTrait
             'twig.form.templates' => array('Form/form_layout.twig'),
         ));
         $this['twig'] = $this->share($this->extend('twig', function (\Twig_Environment $twig, \Silex\Application $app) {
-                $twig->addExtension(new \Eccube\Twig\Extension\EccubeExtension($app));
-                $twig->addExtension(new \Twig_Extension_StringLoader());
+            $twig->addExtension(new \Eccube\Twig\Extension\EccubeExtension($app));
+            $twig->addExtension(new \Twig_Extension_StringLoader());
 
-                return $twig;
+            return $twig;
         }));
 
         $this->before(function (Request $request, \Silex\Application $app) {
 
             // フロント or 管理画面ごとにtwigの探索パスを切り替える.
             $app['twig'] = $app->share($app->extend('twig', function (\Twig_Environment $twig, \Silex\Application $app) {
-                    $paths = array();
+                $paths = array();
 
-                    // 互換性がないのでprofiler とproduction 時のcacheを分離する
-                    if (isset($app['profiler'])) {
-                    $cacheBaseDir = __DIR__.'/../../app/cache/twig/profiler/';
-                    } else {
-                    $cacheBaseDir = __DIR__.'/../../app/cache/twig/production/';
+                // 互換性がないのでprofiler とproduction 時のcacheを分離する
+                if (isset($app['profiler'])) {
+                $cacheBaseDir = __DIR__.'/../../app/cache/twig/profiler/';
+                } else {
+                $cacheBaseDir = __DIR__.'/../../app/cache/twig/production/';
+                }
+
+                if ($app->isAdminRequest()) {
+                if (file_exists(__DIR__.'/../../app/template/admin')) {
+                    $paths[] = __DIR__.'/../../app/template/admin';
                     }
+                    $paths[] = $app['config']['template_admin_realdir'];
+                $paths[] = __DIR__.'/../../app/Plugin';
+                $cache = $cacheBaseDir.'admin';
 
-                    if ($app->isAdminRequest()) {
-                    if (file_exists(__DIR__.'/../../app/template/admin')) {
-                        $paths[] = __DIR__.'/../../app/template/admin';
-                        }
-                        $paths[] = $app['config']['template_admin_realdir'];
-                    $paths[] = __DIR__.'/../../app/Plugin';
-                    $cache = $cacheBaseDir.'admin';
-
-                    } else {
-                        if (file_exists($app['config']['template_realdir'])) {
-                            $paths[] = $app['config']['template_realdir'];
-                        }
-                        $paths[] = $app['config']['template_default_realdir'];
-                    $paths[] = __DIR__.'/../../app/Plugin';
-                    $cache = $cacheBaseDir.$app['config']['template_code'];
-                        $app['front'] = true;
+                } else {
+                    if (file_exists($app['config']['template_realdir'])) {
+                        $paths[] = $app['config']['template_realdir'];
                     }
-                    $twig->setCache($cache);
-                    $app['twig.loader']->addLoader(new \Twig_Loader_Filesystem($paths));
+                    $paths[] = $app['config']['template_default_realdir'];
+                $paths[] = __DIR__.'/../../app/Plugin';
+                $cache = $cacheBaseDir.$app['config']['template_code'];
+                    $app['front'] = true;
+                }
+                $twig->setCache($cache);
+                $app['twig.loader']->addLoader(new \Twig_Loader_Filesystem($paths));
 
-                    return $twig;
+                return $twig;
             }));
 
             // 管理画面のIP制限チェック.
@@ -433,7 +433,7 @@ class Application extends ApplicationTrait
         $this->register(new \Silex\Provider\DoctrineServiceProvider(), array(
             'dbs.options' => array(
                 'default' => $this['config']['database']
-        )));
+            )));
         $this->register(new \Saxulum\DoctrineOrmManagerRegistry\Silex\Provider\DoctrineOrmManagerRegistryProvider());
 
         // プラグインのmetadata定義を合わせて行う.
@@ -880,11 +880,11 @@ class Application extends ApplicationTrait
             // const
             if (isset($config['const'])) {
                 $this['config'] = $this->share($this->extend('config', function ($eccubeConfig) use ($config) {
-                        $eccubeConfig[$config['code']] = array(
-                            'const' => $config['const'],
-                        );
+                    $eccubeConfig[$config['code']] = array(
+                        'const' => $config['const'],
+                    );
 
-                        return $eccubeConfig;
+                    return $eccubeConfig;
                 }));
             }
 
@@ -927,7 +927,7 @@ class Application extends ApplicationTrait
             // Type: ServiceProvider
             if (isset($config['service'])) {
                 foreach ($config['service'] as $service) {
-                    $class = '\\Plugin\\' . $config['code'] . '\\ServiceProvider\\' . $service;
+                    $class = '\\Plugin\\'.$config['code'].'\\ServiceProvider\\'.$service;
                     if (!class_exists($class)) {
                         $this['monolog']->warning("skip {$code} loading. service provider class not foud.", array(
                             'class' => $class,

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -250,7 +250,7 @@ class Application extends ApplicationTrait
     {
         $cookieName = 'eccube';
         if ($this->isAdminRequest()) {
-            $cookieName .= '_admin';
+            //$cookieName .= '_admin';
         }
         $this->register(new \Silex\Provider\SessionServiceProvider(), array(
             'session.storage.save_path' => $this['config']['root_dir'].'/app/cache/eccube/session',

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of EC-CUBE
  *
@@ -40,8 +39,8 @@ use Symfony\Component\Yaml\Yaml;
 
 class Application extends ApplicationTrait
 {
-
     protected static $instance;
+
     protected $initialized = false;
     protected $initializedPlugin = false;
     protected $testMode = false;
@@ -62,7 +61,7 @@ class Application extends ApplicationTrait
 
     final public function __clone()
     {
-        throw new \Exception('Clone is not allowed against ' . get_class($this));
+        throw new \Exception('Clone is not allowed against '.get_class($this));
     }
 
     public function __construct(array $values = array())
@@ -139,7 +138,7 @@ class Application extends ApplicationTrait
 
         // init provider
         $this->register(new \Silex\Provider\HttpCacheServiceProvider(), array(
-            'http_cache.cache_dir' => __DIR__ . '/../../app/cache/http/',
+            'http_cache.cache_dir' => __DIR__.'/../../app/cache/http/',
         ));
         $this->register(new \Silex\Provider\HttpFragmentServiceProvider());
         $this->register(new \Silex\Provider\UrlGeneratorServiceProvider());
@@ -153,8 +152,7 @@ class Application extends ApplicationTrait
                 return;
             }
 
-            switch ($code)
-            {
+            switch ($code) {
                 case 403:
                     $title = 'アクセスできません。';
                     $message = 'お探しのページはアクセスができない状況にあるか、移動もしくは削除された可能性があります。';
@@ -193,8 +191,9 @@ class Application extends ApplicationTrait
         // mount controllers
         $this->register(new \Silex\Provider\ServiceControllerServiceProvider());
         $this->mount('', new ControllerProvider\FrontControllerProvider());
-        $this->mount('/' . trim($this['config']['admin_route'], '/') . '/', new ControllerProvider\AdminControllerProvider());
+        $this->mount('/'.trim($this['config']['admin_route'], '/').'/', new ControllerProvider\AdminControllerProvider());
         Request::enableHttpMethodParameterOverride(); // PUTやDELETEできるようにする
+
         // add transaction listener
         $this['dispatcher']->addSubscriber(new TransactionListener($this));
 
@@ -206,6 +205,7 @@ class Application extends ApplicationTrait
 
     public function initLocale()
     {
+
         // timezone
         if (!empty($this['config']['timezone'])) {
             date_default_timezone_set($this['config']['timezone']);
@@ -213,17 +213,17 @@ class Application extends ApplicationTrait
 
         $this->register(new \Silex\Provider\TranslationServiceProvider(), array(
             'locale' => $this['config']['locale'],
-            'translator.cache_dir' => $this['debug'] ? null : $this['config']['root_dir'] . '/app/cache/translator',
+            'translator.cache_dir' => $this['debug'] ? null : $this['config']['root_dir'].'/app/cache/translator',
         ));
         $this['translator'] = $this->share($this->extend('translator', function ($translator, \Silex\Application $app) {
                 $translator->addLoader('yaml', new \Symfony\Component\Translation\Loader\YamlFileLoader());
 
-                $file = __DIR__ . '/Resource/locale/validator.' . $app['locale'] . '.yml';
+            $file = __DIR__.'/Resource/locale/validator.'.$app['locale'].'.yml';
                 if (file_exists($file)) {
                     $translator->addResource('yaml', $file, $app['locale'], 'validators');
                 }
 
-                $file = __DIR__ . '/Resource/locale/message.' . $app['locale'] . '.yml';
+            $file = __DIR__.'/Resource/locale/message.'.$app['locale'].'.yml';
                 if (file_exists($file)) {
                     $translator->addResource('yaml', $file, $app['locale']);
                 }
@@ -296,25 +296,26 @@ class Application extends ApplicationTrait
 
                     // 互換性がないのでprofiler とproduction 時のcacheを分離する
                     if (isset($app['profiler'])) {
-                        $cacheBaseDir = __DIR__ . '/../../app/cache/twig/profiler/';
+                    $cacheBaseDir = __DIR__.'/../../app/cache/twig/profiler/';
                     } else {
-                        $cacheBaseDir = __DIR__ . '/../../app/cache/twig/production/';
+                    $cacheBaseDir = __DIR__.'/../../app/cache/twig/production/';
                     }
 
                     if ($app->isAdminRequest()) {
-                        if (file_exists(__DIR__ . '/../../app/template/admin')) {
-                            $paths[] = __DIR__ . '/../../app/template/admin';
+                    if (file_exists(__DIR__.'/../../app/template/admin')) {
+                        $paths[] = __DIR__.'/../../app/template/admin';
                         }
                         $paths[] = $app['config']['template_admin_realdir'];
-                        $paths[] = __DIR__ . '/../../app/Plugin';
-                        $cache = $cacheBaseDir . 'admin';
+                    $paths[] = __DIR__.'/../../app/Plugin';
+                    $cache = $cacheBaseDir.'admin';
+
                     } else {
                         if (file_exists($app['config']['template_realdir'])) {
                             $paths[] = $app['config']['template_realdir'];
                         }
                         $paths[] = $app['config']['template_default_realdir'];
-                        $paths[] = __DIR__ . '/../../app/Plugin';
-                        $cache = $cacheBaseDir . $app['config']['template_code'];
+                    $paths[] = __DIR__.'/../../app/Plugin';
+                    $cache = $cacheBaseDir.$app['config']['template_code'];
                         $app['front'] = true;
                     }
                     $twig->setCache($cache);
@@ -361,11 +362,12 @@ class Application extends ApplicationTrait
                     $roles = array();
                     foreach ($AuthorityRoles as $AuthorityRole) {
                         // 管理画面でメニュー制御するため相対パス全てをセット
-                        $roles[] = $app['request']->getBaseUrl() . '/' . $app['config']['admin_route'] . $AuthorityRole->getDenyUrl();
+                        $roles[] = $app['request']->getBaseUrl().'/'.$app['config']['admin_route'].$AuthorityRole->getDenyUrl();
                     }
 
                     $app['twig']->addGlobal('AuthorityRoles', $roles);
                 }
+
             } else {
                 // フロント画面
                 $request = $event->getRequest();
@@ -441,8 +443,8 @@ class Application extends ApplicationTrait
             'type' => 'yml',
             'namespace' => 'Eccube\Entity',
             'path' => array(
-                __DIR__ . '/Resource/doctrine',
-                __DIR__ . '/Resource/doctrine/master',
+                __DIR__.'/Resource/doctrine',
+                __DIR__.'/Resource/doctrine/master',
             ),
         );
 
@@ -452,11 +454,11 @@ class Application extends ApplicationTrait
             if (isset($config['orm.path']) && is_array($config['orm.path'])) {
                 $paths = array();
                 foreach ($config['orm.path'] as $path) {
-                    $paths[] = $this['config']['plugin_realdir'] . '/' . $config['code'] . $path;
+                    $paths[] = $this['config']['plugin_realdir'].'/'.$config['code'].$path;
                 }
                 $ormMappings[] = array(
                     'type' => 'yml',
-                    'namespace' => 'Plugin\\' . $config['code'] . '\\Entity',
+                    'namespace' => 'Plugin\\'.$config['code'].'\\Entity',
                     'path' => $paths,
                 );
             }
@@ -487,7 +489,7 @@ class Application extends ApplicationTrait
         }
 
         $this->register(new \Dflydev\Silex\Provider\DoctrineOrm\DoctrineOrmServiceProvider(), array(
-            'orm.proxies_dir' => __DIR__ . '/../../app/cache/doctrine/proxies',
+            'orm.proxies_dir' => __DIR__.'/../../app/cache/doctrine/proxies',
             'orm.em.options' => $options,
             'orm.custom.functions.numeric' => array(
                 'EXTRACT' => 'Eccube\Doctrine\ORM\Query\Extract',
@@ -609,6 +611,7 @@ class Application extends ApplicationTrait
         $this['security.access_manager'] = $this->share(function ($app) {
             return new \Symfony\Component\Security\Core\Authorization\AccessDecisionManager($app['security.voters'], 'unanimous');
         });
+
     }
 
     public function initializePlugin()
@@ -681,7 +684,7 @@ class Application extends ApplicationTrait
                 return;
             }
             $route = $event->getRequest()->attributes->get('_route');
-            $app['eccube.event.dispatcher']->dispatch('eccube.event.render.' . $route . '.before', $event);
+            $app['eccube.event.dispatcher']->dispatch('eccube.event.render.'.$route.'.before', $event);
         });
 
         // Request Event
@@ -697,7 +700,7 @@ class Application extends ApplicationTrait
                 return;
             }
 
-            $app['monolog']->debug('KernelEvents::REQUEST ' . $route);
+            $app['monolog']->debug('KernelEvents::REQUEST '.$route);
 
             // 全体
             $app['eccube.event.dispatcher']->dispatch('eccube.event.app.request', $event);
@@ -714,6 +717,7 @@ class Application extends ApplicationTrait
             $app['eccube.event.dispatcher']->dispatch("eccube.event.route.{$route}.request", $event);
 
         }, 30); // Routing(32)が解決しし, 認証判定(8)が実行される前のタイミング.
+
         // Controller Event
         $this->on(\Symfony\Component\HttpKernel\KernelEvents::CONTROLLER, function (\Symfony\Component\HttpKernel\Event\FilterControllerEvent $event) use ($app) {
 
@@ -727,7 +731,7 @@ class Application extends ApplicationTrait
                 return;
             }
 
-            $app['monolog']->debug('KernelEvents::CONTROLLER ' . $route);
+            $app['monolog']->debug('KernelEvents::CONTROLLER '.$route);
 
             // 全体
             $app['eccube.event.dispatcher']->dispatch('eccube.event.app.controller', $event);
@@ -756,7 +760,7 @@ class Application extends ApplicationTrait
                 return;
             }
 
-            $app['monolog']->debug('KernelEvents::RESPONSE ' . $route);
+            $app['monolog']->debug('KernelEvents::RESPONSE '.$route);
 
             // ルーティング単位
             $app['eccube.event.dispatcher']->dispatch("eccube.event.route.{$route}.response", $event);
@@ -786,7 +790,7 @@ class Application extends ApplicationTrait
                 return;
             }
 
-            $app['monolog']->debug('KernelEvents::EXCEPTION ' . $route);
+            $app['monolog']->debug('KernelEvents::EXCEPTION '.$route);
 
             // ルーティング単位
             $app['eccube.event.dispatcher']->dispatch("eccube.event.route.{$route}.exception", $event);
@@ -812,7 +816,7 @@ class Application extends ApplicationTrait
                 return;
             }
 
-            $app['monolog']->debug('KernelEvents::TERMINATE ' . $route);
+            $app['monolog']->debug('KernelEvents::TERMINATE '.$route);
 
             // ルーティング単位
             $app['eccube.event.dispatcher']->dispatch("eccube.event.route.{$route}.terminate", $event);
@@ -857,7 +861,7 @@ class Application extends ApplicationTrait
         // config.yml/event.ymlの定義に沿ってインスタンスの生成を行い, イベント設定を行う.
         foreach ($pluginConfigs as $code => $pluginConfig) {
             // 正しい形式の pluginConfig のみ読み込む
-            $path = $basePath . '/' . $code;
+            $path = $basePath.'/'.$code;
             try {
                 $this['eccube.service.plugin']->checkPluginArchiveContent($path, $pluginConfig['config']);
             } catch (\Eccube\Exception\PluginException $e) {
@@ -891,7 +895,7 @@ class Application extends ApplicationTrait
 
             // Type: Event
             if (isset($config['event'])) {
-                $class = '\\Plugin\\' . $config['code'] . '\\' . $config['event'];
+                $class = '\\Plugin\\'.$config['code'].'\\'.$config['event'];
                 $eventExists = true;
 
                 if (!class_exists($class)) {
@@ -975,7 +979,7 @@ class Application extends ApplicationTrait
             $this['db']->connect();
         } catch (\Doctrine\DBAL\DBALException $e) {
             $this['monolog']->error($e->getMessage());
-            $this['twig.path'] = array(__DIR__ . '/Resource/template/exception');
+            $this['twig.path'] = array(__DIR__.'/Resource/template/exception');
             $html = $this['twig']->render('error.twig', array(
                 'error_title' => 'データーベース接続エラー',
                 'error_message' => 'データーベースを確認してください',
@@ -1006,17 +1010,17 @@ class Application extends ApplicationTrait
      */
     public function parseConfig($config_name, array &$configAll, $wrap_key = false, $ymlPath = null, $distPath = null)
     {
-        $ymlPath = $ymlPath ? $ymlPath : __DIR__ . '/../../app/config/eccube';
-        $distPath = $distPath ? $distPath : __DIR__ . '/../../src/Eccube/Resource/config';
+        $ymlPath = $ymlPath ? $ymlPath : __DIR__.'/../../app/config/eccube';
+        $distPath = $distPath ? $distPath : __DIR__.'/../../src/Eccube/Resource/config';
         $config = array();
-        $config_php = $ymlPath . '/' . $config_name . '.php';
+        $config_php = $ymlPath.'/'.$config_name.'.php';
         if (!file_exists($config_php)) {
-            $config_yml = $ymlPath . '/' . $config_name . '.yml';
+            $config_yml = $ymlPath.'/'.$config_name.'.yml';
             if (file_exists($config_yml)) {
                 $config = Yaml::parse(file_get_contents($config_yml));
                 $config = empty($config) ? array() : $config;
                 if (isset($this['output_config_php']) && $this['output_config_php']) {
-                    file_put_contents($config_php, sprintf('<?php return %s', var_export($config, true)) . ';');
+                    file_put_contents($config_php, sprintf('<?php return %s', var_export($config, true)).';');
                 }
             }
         } else {
@@ -1024,13 +1028,13 @@ class Application extends ApplicationTrait
         }
 
         $config_dist = array();
-        $config_php_dist = $distPath . '/' . $config_name . '.dist.php';
+        $config_php_dist = $distPath.'/'.$config_name.'.dist.php';
         if (!file_exists($config_php_dist)) {
-            $config_yml_dist = $distPath . '/' . $config_name . '.yml.dist';
+            $config_yml_dist = $distPath.'/'.$config_name.'.yml.dist';
             if (file_exists($config_yml_dist)) {
                 $config_dist = Yaml::parse(file_get_contents($config_yml_dist));
                 if (isset($this['output_config_php']) && $this['output_config_php']) {
-                    file_put_contents($config_php_dist, sprintf('<?php return %s', var_export($config_dist, true)) . ';');
+                    file_put_contents($config_php_dist, sprintf('<?php return %s', var_export($config_dist, true)).';');
                 }
             }
         } else {
@@ -1093,6 +1097,7 @@ class Application extends ApplicationTrait
 
             if (strpos($route, 'admin') === 0) {
                 // 管理画面
+
                 // 管理画面ではコンテンツの中身が変更された時点でキャッシュを更新し、キャッシュの適用範囲はprivateに設定
                 $response->setCache(array(
                     'etag' => $etag,
@@ -1102,6 +1107,7 @@ class Application extends ApplicationTrait
                 if ($response->isNotModified($request)) {
                     return $response;
                 }
+
             } else {
                 // フロント画面
                 $cacheRoute = $app['config']['http_cache']['route'];
@@ -1172,7 +1178,7 @@ class Application extends ApplicationTrait
             @mkdir($this['config']['plugin_temp_realdir']);
         }
         $this['monolog']->debug("write plugin config cache", array($pluginConfigs));
-        return file_put_contents($cacheFile, sprintf('<?php return %s', var_export($pluginConfigs, true)) . ';');
+        return file_put_contents($cacheFile, sprintf('<?php return %s', var_export($pluginConfigs, true)).';');
     }
 
     /**
@@ -1197,7 +1203,7 @@ class Application extends ApplicationTrait
      */
     public function getPluginConfigCacheFile()
     {
-        return $this['config']['plugin_temp_realdir'] . '/config_cache.php';
+        return $this['config']['plugin_temp_realdir'].'/config_cache.php';
     }
 
     /**
@@ -1220,7 +1226,7 @@ class Application extends ApplicationTrait
         $pluginConfigs = array();
         foreach ($finder as $dir) {
             $code = $dir->getBaseName();
-            $file = $dir->getRealPath() . '/config.yml';
+            $file = $dir->getRealPath().'/config.yml';
             $config = null;
             if (file_exists($file)) {
                 $config = Yaml::parse(file_get_contents($file));
@@ -1229,7 +1235,7 @@ class Application extends ApplicationTrait
                 continue;
             }
 
-            $file = $dir->getRealPath() . '/event.yml';
+            $file = $dir->getRealPath().'/event.yml';
             $event = null;
             if (file_exists($file)) {
                 $event = Yaml::parse(file_get_contents($file));

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -124,6 +124,9 @@ class Application extends ApplicationTrait
 
         // init locale
         $this->initLocale();
+        
+        // init Request
+        $this->initRequest();
 
         // init session
         if (!$this->isSessionStarted()) {
@@ -228,13 +231,34 @@ class Application extends ApplicationTrait
             return $translator;
         }));
     }
+    
+    public function initRequest()
+    {
+        $this['initRequest'] = Request::createFromGlobals();
+        $pathinfo = rawurldecode($this['initRequest']->getPathInfo());
+         $this['admin'] = false;
+         $this['front'] = false;
+         $pathinfo = rawurldecode($this['initRequest']->getPathInfo());
+         if (strpos($pathinfo, '/' . trim($this['config']['admin_route'], '/') . '/') === 0) {
+             $this['admin'] = true;
+         } else {
+             $this['front'] = true;
+         }
+    }
 
     public function initSession()
     {
+        
+        $cookieName = 'eccube';
+        
+        if ($this->isAdminRequest()) {
+            $cookieName .= '_admin';
+        }
+        
         $this->register(new \Silex\Provider\SessionServiceProvider(), array(
             'session.storage.save_path' => $this['config']['root_dir'].'/app/cache/eccube/session',
             'session.storage.options' => array(
-                'name' => 'eccube',
+                'name' => $cookieName,
                 'cookie_path' => $this['config']['root_urlpath'] ?: '/',
                 'cookie_secure' => $this['config']['force_ssl'],
                 'cookie_lifetime' => $this['config']['cookie_lifetime'],

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -125,9 +125,6 @@ class Application extends ApplicationTrait
         // init locale
         $this->initLocale();
 
-        // init Request
-        $this->initRequest();
-
         // init session
         if (!$this->isSessionStarted()) {
             $this->initSession();
@@ -232,30 +229,12 @@ class Application extends ApplicationTrait
         }));
     }
 
-    public function initRequest()
-    {
-        $this['initRequest'] = Request::createFromGlobals();
-        $pathinfo = rawurldecode($this['initRequest']->getPathInfo());
-         $this['admin'] = false;
-         $this['front'] = false;
-         $pathinfo = rawurldecode($this['initRequest']->getPathInfo());
-         if (strpos($pathinfo, '/' . trim($this['config']['admin_route'], '/') . '/') === 0) {
-             $this['admin'] = true;
-         } else {
-             $this['front'] = true;
-         }
-    }
-
     public function initSession()
     {
-        $cookieName = 'eccube';
-        if ($this->isAdminRequest()) {
-            //$cookieName .= '_admin';
-        }
         $this->register(new \Silex\Provider\SessionServiceProvider(), array(
             'session.storage.save_path' => $this['config']['root_dir'].'/app/cache/eccube/session',
             'session.storage.options' => array(
-                'name' => $cookieName,
+                'name' => 'eccube',
                 'cookie_path' => $this['config']['root_urlpath'] ?: '/',
                 'cookie_secure' => $this['config']['force_ssl'],
                 'cookie_lifetime' => $this['config']['cookie_lifetime'],
@@ -288,6 +267,14 @@ class Application extends ApplicationTrait
         }));
 
         $this->before(function (Request $request, \Silex\Application $app) {
+            $app['admin'] = false;
+            $app['front'] = false;
+            $pathinfo = rawurldecode($request->getPathInfo());
+            if (strpos($pathinfo, '/'.trim($app['config']['admin_route'], '/').'/') === 0) {
+                $app['admin'] = true;
+            } else {
+                $app['front'] = true;
+            }
 
             // フロント or 管理画面ごとにtwigの探索パスを切り替える.
             $app['twig'] = $app->share($app->extend('twig', function (\Twig_Environment $twig, \Silex\Application $app) {

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of EC-CUBE
  *
@@ -39,8 +40,8 @@ use Symfony\Component\Yaml\Yaml;
 
 class Application extends ApplicationTrait
 {
-    protected static $instance;
 
+    protected static $instance;
     protected $initialized = false;
     protected $initializedPlugin = false;
     protected $testMode = false;
@@ -61,7 +62,7 @@ class Application extends ApplicationTrait
 
     final public function __clone()
     {
-        throw new \Exception('Clone is not allowed against '.get_class($this));
+        throw new \Exception('Clone is not allowed against ' . get_class($this));
     }
 
     public function __construct(array $values = array())
@@ -125,6 +126,9 @@ class Application extends ApplicationTrait
         // init locale
         $this->initLocale();
 
+        // init Request
+        $this->initRequest();
+
         // init session
         if (!$this->isSessionStarted()) {
             $this->initSession();
@@ -135,7 +139,7 @@ class Application extends ApplicationTrait
 
         // init provider
         $this->register(new \Silex\Provider\HttpCacheServiceProvider(), array(
-            'http_cache.cache_dir' => __DIR__.'/../../app/cache/http/',
+            'http_cache.cache_dir' => __DIR__ . '/../../app/cache/http/',
         ));
         $this->register(new \Silex\Provider\HttpFragmentServiceProvider());
         $this->register(new \Silex\Provider\UrlGeneratorServiceProvider());
@@ -149,7 +153,8 @@ class Application extends ApplicationTrait
                 return;
             }
 
-            switch ($code) {
+            switch ($code)
+            {
                 case 403:
                     $title = 'アクセスできません。';
                     $message = 'お探しのページはアクセスができない状況にあるか、移動もしくは削除された可能性があります。';
@@ -165,8 +170,8 @@ class Application extends ApplicationTrait
             }
 
             return $app->render('error.twig', array(
-                'error_title' => $title,
-                'error_message' => $message,
+                    'error_title' => $title,
+                    'error_message' => $message,
             ));
         });
 
@@ -188,9 +193,8 @@ class Application extends ApplicationTrait
         // mount controllers
         $this->register(new \Silex\Provider\ServiceControllerServiceProvider());
         $this->mount('', new ControllerProvider\FrontControllerProvider());
-        $this->mount('/'.trim($this['config']['admin_route'], '/').'/', new ControllerProvider\AdminControllerProvider());
+        $this->mount('/' . trim($this['config']['admin_route'], '/') . '/', new ControllerProvider\AdminControllerProvider());
         Request::enableHttpMethodParameterOverride(); // PUTやDELETEできるようにする
-
         // add transaction listener
         $this['dispatcher']->addSubscriber(new TransactionListener($this));
 
@@ -202,7 +206,6 @@ class Application extends ApplicationTrait
 
     public function initLocale()
     {
-
         // timezone
         if (!empty($this['config']['timezone'])) {
             date_default_timezone_set($this['config']['timezone']);
@@ -210,37 +213,56 @@ class Application extends ApplicationTrait
 
         $this->register(new \Silex\Provider\TranslationServiceProvider(), array(
             'locale' => $this['config']['locale'],
-            'translator.cache_dir' => $this['debug'] ? null : $this['config']['root_dir'].'/app/cache/translator',
+            'translator.cache_dir' => $this['debug'] ? null : $this['config']['root_dir'] . '/app/cache/translator',
         ));
         $this['translator'] = $this->share($this->extend('translator', function ($translator, \Silex\Application $app) {
-            $translator->addLoader('yaml', new \Symfony\Component\Translation\Loader\YamlFileLoader());
+                $translator->addLoader('yaml', new \Symfony\Component\Translation\Loader\YamlFileLoader());
 
-            $file = __DIR__.'/Resource/locale/validator.'.$app['locale'].'.yml';
-            if (file_exists($file)) {
-                $translator->addResource('yaml', $file, $app['locale'], 'validators');
-            }
+                $file = __DIR__ . '/Resource/locale/validator.' . $app['locale'] . '.yml';
+                if (file_exists($file)) {
+                    $translator->addResource('yaml', $file, $app['locale'], 'validators');
+                }
 
-            $file = __DIR__.'/Resource/locale/message.'.$app['locale'].'.yml';
-            if (file_exists($file)) {
-                $translator->addResource('yaml', $file, $app['locale']);
-            }
+                $file = __DIR__ . '/Resource/locale/message.' . $app['locale'] . '.yml';
+                if (file_exists($file)) {
+                    $translator->addResource('yaml', $file, $app['locale']);
+                }
 
-            return $translator;
+                return $translator;
         }));
+    }
+
+    public function initRequest()
+    {
+        $this['initRequest'] = Request::createFromGlobals();
+        $pathinfo = rawurldecode($this['initRequest']->getPathInfo());
+         $this['admin'] = false;
+         $this['front'] = false;
+         $pathinfo = rawurldecode($this['initRequest']->getPathInfo());
+         if (strpos($pathinfo, '/' . trim($this['config']['admin_route'], '/') . '/') === 0) {
+             $this['admin'] = true;
+         } else {
+             $this['front'] = true;
+         }
     }
 
     public function initSession()
     {
+        $cookieName = 'eccube';
+        
+        if ($this->isAdminRequest()) {
+            $cookieName .= '_admin';
+        }
         $this->register(new \Silex\Provider\SessionServiceProvider(), array(
-            'session.storage.save_path' => $this['config']['root_dir'].'/app/cache/eccube/session',
+            'session.storage.save_path' => $this['config']['root_dir'] . '/app/cache/eccube/session',
             'session.storage.options' => array(
-                'name' => 'eccube',
+                'name' => $cookieName,
                 'cookie_path' => $this['config']['root_urlpath'] ?: '/',
                 'cookie_secure' => $this['config']['force_ssl'],
                 'cookie_lifetime' => $this['config']['cookie_lifetime'],
                 'cookie_httponly' => true,
-                // cookie_domainは指定しない
-                // http://blog.tokumaru.org/2011/10/cookiedomain.html
+            // cookie_domainは指定しない
+            // http://blog.tokumaru.org/2011/10/cookiedomain.html
             ),
         ));
 
@@ -260,54 +282,45 @@ class Application extends ApplicationTrait
             'twig.form.templates' => array('Form/form_layout.twig'),
         ));
         $this['twig'] = $this->share($this->extend('twig', function (\Twig_Environment $twig, \Silex\Application $app) {
-            $twig->addExtension(new \Eccube\Twig\Extension\EccubeExtension($app));
-            $twig->addExtension(new \Twig_Extension_StringLoader());
+                $twig->addExtension(new \Eccube\Twig\Extension\EccubeExtension($app));
+                $twig->addExtension(new \Twig_Extension_StringLoader());
 
-            return $twig;
+                return $twig;
         }));
 
         $this->before(function (Request $request, \Silex\Application $app) {
-            $app['admin'] = false;
-            $app['front'] = false;
-            $pathinfo = rawurldecode($request->getPathInfo());
-            if (strpos($pathinfo, '/'.trim($app['config']['admin_route'], '/').'/') === 0) {
-                $app['admin'] = true;
-            } else {
-                $app['front'] = true;
-            }
 
             // フロント or 管理画面ごとにtwigの探索パスを切り替える.
             $app['twig'] = $app->share($app->extend('twig', function (\Twig_Environment $twig, \Silex\Application $app) {
-                $paths = array();
+                    $paths = array();
 
-                // 互換性がないのでprofiler とproduction 時のcacheを分離する
-                if (isset($app['profiler'])) {
-                    $cacheBaseDir = __DIR__.'/../../app/cache/twig/profiler/';
-                } else {
-                    $cacheBaseDir = __DIR__.'/../../app/cache/twig/production/';
-                }
-
-                if ($app->isAdminRequest()) {
-                    if (file_exists(__DIR__.'/../../app/template/admin')) {
-                        $paths[] = __DIR__.'/../../app/template/admin';
+                    // 互換性がないのでprofiler とproduction 時のcacheを分離する
+                    if (isset($app['profiler'])) {
+                        $cacheBaseDir = __DIR__ . '/../../app/cache/twig/profiler/';
+                    } else {
+                        $cacheBaseDir = __DIR__ . '/../../app/cache/twig/production/';
                     }
-                    $paths[] = $app['config']['template_admin_realdir'];
-                    $paths[] = __DIR__.'/../../app/Plugin';
-                    $cache = $cacheBaseDir.'admin';
 
-                } else {
-                    if (file_exists($app['config']['template_realdir'])) {
-                        $paths[] = $app['config']['template_realdir'];
+                    if ($app->isAdminRequest()) {
+                        if (file_exists(__DIR__ . '/../../app/template/admin')) {
+                            $paths[] = __DIR__ . '/../../app/template/admin';
+                        }
+                        $paths[] = $app['config']['template_admin_realdir'];
+                        $paths[] = __DIR__ . '/../../app/Plugin';
+                        $cache = $cacheBaseDir . 'admin';
+                    } else {
+                        if (file_exists($app['config']['template_realdir'])) {
+                            $paths[] = $app['config']['template_realdir'];
+                        }
+                        $paths[] = $app['config']['template_default_realdir'];
+                        $paths[] = __DIR__ . '/../../app/Plugin';
+                        $cache = $cacheBaseDir . $app['config']['template_code'];
+                        $app['front'] = true;
                     }
-                    $paths[] = $app['config']['template_default_realdir'];
-                    $paths[] = __DIR__.'/../../app/Plugin';
-                    $cache = $cacheBaseDir.$app['config']['template_code'];
-                    $app['front'] = true;
-                }
-                $twig->setCache($cache);
-                $app['twig.loader']->addLoader(new \Twig_Loader_Filesystem($paths));
+                    $twig->setCache($cache);
+                    $app['twig.loader']->addLoader(new \Twig_Loader_Filesystem($paths));
 
-                return $twig;
+                    return $twig;
             }));
 
             // 管理画面のIP制限チェック.
@@ -348,12 +361,11 @@ class Application extends ApplicationTrait
                     $roles = array();
                     foreach ($AuthorityRoles as $AuthorityRole) {
                         // 管理画面でメニュー制御するため相対パス全てをセット
-                        $roles[] = $app['request']->getBaseUrl().'/'.$app['config']['admin_route'].$AuthorityRole->getDenyUrl();
+                        $roles[] = $app['request']->getBaseUrl() . '/' . $app['config']['admin_route'] . $AuthorityRole->getDenyUrl();
                     }
 
                     $app['twig']->addGlobal('AuthorityRoles', $roles);
                 }
-
             } else {
                 // フロント画面
                 $request = $event->getRequest();
@@ -419,7 +431,7 @@ class Application extends ApplicationTrait
         $this->register(new \Silex\Provider\DoctrineServiceProvider(), array(
             'dbs.options' => array(
                 'default' => $this['config']['database']
-            )));
+        )));
         $this->register(new \Saxulum\DoctrineOrmManagerRegistry\Silex\Provider\DoctrineOrmManagerRegistryProvider());
 
         // プラグインのmetadata定義を合わせて行う.
@@ -429,8 +441,8 @@ class Application extends ApplicationTrait
             'type' => 'yml',
             'namespace' => 'Eccube\Entity',
             'path' => array(
-                __DIR__.'/Resource/doctrine',
-                __DIR__.'/Resource/doctrine/master',
+                __DIR__ . '/Resource/doctrine',
+                __DIR__ . '/Resource/doctrine/master',
             ),
         );
 
@@ -440,11 +452,11 @@ class Application extends ApplicationTrait
             if (isset($config['orm.path']) && is_array($config['orm.path'])) {
                 $paths = array();
                 foreach ($config['orm.path'] as $path) {
-                    $paths[] = $this['config']['plugin_realdir'].'/'.$config['code'].$path;
+                    $paths[] = $this['config']['plugin_realdir'] . '/' . $config['code'] . $path;
                 }
                 $ormMappings[] = array(
                     'type' => 'yml',
-                    'namespace' => 'Plugin\\'.$config['code'].'\\Entity',
+                    'namespace' => 'Plugin\\' . $config['code'] . '\\Entity',
                     'path' => $paths,
                 );
             }
@@ -475,7 +487,7 @@ class Application extends ApplicationTrait
         }
 
         $this->register(new \Dflydev\Silex\Provider\DoctrineOrm\DoctrineOrmServiceProvider(), array(
-            'orm.proxies_dir' => __DIR__.'/../../app/cache/doctrine/proxies',
+            'orm.proxies_dir' => __DIR__ . '/../../app/cache/doctrine/proxies',
             'orm.em.options' => $options,
             'orm.custom.functions.numeric' => array(
                 'EXTRACT' => 'Eccube\Doctrine\ORM\Query\Extract',
@@ -597,7 +609,6 @@ class Application extends ApplicationTrait
         $this['security.access_manager'] = $this->share(function ($app) {
             return new \Symfony\Component\Security\Core\Authorization\AccessDecisionManager($app['security.voters'], 'unanimous');
         });
-
     }
 
     public function initializePlugin()
@@ -670,7 +681,7 @@ class Application extends ApplicationTrait
                 return;
             }
             $route = $event->getRequest()->attributes->get('_route');
-            $app['eccube.event.dispatcher']->dispatch('eccube.event.render.'.$route.'.before', $event);
+            $app['eccube.event.dispatcher']->dispatch('eccube.event.render.' . $route . '.before', $event);
         });
 
         // Request Event
@@ -686,7 +697,7 @@ class Application extends ApplicationTrait
                 return;
             }
 
-            $app['monolog']->debug('KernelEvents::REQUEST '.$route);
+            $app['monolog']->debug('KernelEvents::REQUEST ' . $route);
 
             // 全体
             $app['eccube.event.dispatcher']->dispatch('eccube.event.app.request', $event);
@@ -703,7 +714,6 @@ class Application extends ApplicationTrait
             $app['eccube.event.dispatcher']->dispatch("eccube.event.route.{$route}.request", $event);
 
         }, 30); // Routing(32)が解決しし, 認証判定(8)が実行される前のタイミング.
-
         // Controller Event
         $this->on(\Symfony\Component\HttpKernel\KernelEvents::CONTROLLER, function (\Symfony\Component\HttpKernel\Event\FilterControllerEvent $event) use ($app) {
 
@@ -717,7 +727,7 @@ class Application extends ApplicationTrait
                 return;
             }
 
-            $app['monolog']->debug('KernelEvents::CONTROLLER '.$route);
+            $app['monolog']->debug('KernelEvents::CONTROLLER ' . $route);
 
             // 全体
             $app['eccube.event.dispatcher']->dispatch('eccube.event.app.controller', $event);
@@ -746,7 +756,7 @@ class Application extends ApplicationTrait
                 return;
             }
 
-            $app['monolog']->debug('KernelEvents::RESPONSE '.$route);
+            $app['monolog']->debug('KernelEvents::RESPONSE ' . $route);
 
             // ルーティング単位
             $app['eccube.event.dispatcher']->dispatch("eccube.event.route.{$route}.response", $event);
@@ -776,7 +786,7 @@ class Application extends ApplicationTrait
                 return;
             }
 
-            $app['monolog']->debug('KernelEvents::EXCEPTION '.$route);
+            $app['monolog']->debug('KernelEvents::EXCEPTION ' . $route);
 
             // ルーティング単位
             $app['eccube.event.dispatcher']->dispatch("eccube.event.route.{$route}.exception", $event);
@@ -802,7 +812,7 @@ class Application extends ApplicationTrait
                 return;
             }
 
-            $app['monolog']->debug('KernelEvents::TERMINATE '.$route);
+            $app['monolog']->debug('KernelEvents::TERMINATE ' . $route);
 
             // ルーティング単位
             $app['eccube.event.dispatcher']->dispatch("eccube.event.route.{$route}.terminate", $event);
@@ -847,7 +857,7 @@ class Application extends ApplicationTrait
         // config.yml/event.ymlの定義に沿ってインスタンスの生成を行い, イベント設定を行う.
         foreach ($pluginConfigs as $code => $pluginConfig) {
             // 正しい形式の pluginConfig のみ読み込む
-            $path = $basePath.'/'.$code;
+            $path = $basePath . '/' . $code;
             try {
                 $this['eccube.service.plugin']->checkPluginArchiveContent($path, $pluginConfig['config']);
             } catch (\Eccube\Exception\PluginException $e) {
@@ -866,11 +876,11 @@ class Application extends ApplicationTrait
             // const
             if (isset($config['const'])) {
                 $this['config'] = $this->share($this->extend('config', function ($eccubeConfig) use ($config) {
-                    $eccubeConfig[$config['code']] = array(
-                        'const' => $config['const'],
-                    );
+                        $eccubeConfig[$config['code']] = array(
+                            'const' => $config['const'],
+                        );
 
-                    return $eccubeConfig;
+                        return $eccubeConfig;
                 }));
             }
 
@@ -881,7 +891,7 @@ class Application extends ApplicationTrait
 
             // Type: Event
             if (isset($config['event'])) {
-                $class = '\\Plugin\\'.$config['code'].'\\'.$config['event'];
+                $class = '\\Plugin\\' . $config['code'] . '\\' . $config['event'];
                 $eventExists = true;
 
                 if (!class_exists($class)) {
@@ -913,7 +923,7 @@ class Application extends ApplicationTrait
             // Type: ServiceProvider
             if (isset($config['service'])) {
                 foreach ($config['service'] as $service) {
-                    $class = '\\Plugin\\'.$config['code'].'\\ServiceProvider\\'.$service;
+                    $class = '\\Plugin\\' . $config['code'] . '\\ServiceProvider\\' . $service;
                     if (!class_exists($class)) {
                         $this['monolog']->warning("skip {$code} loading. service provider class not foud.", array(
                             'class' => $class,
@@ -965,7 +975,7 @@ class Application extends ApplicationTrait
             $this['db']->connect();
         } catch (\Doctrine\DBAL\DBALException $e) {
             $this['monolog']->error($e->getMessage());
-            $this['twig.path'] = array(__DIR__.'/Resource/template/exception');
+            $this['twig.path'] = array(__DIR__ . '/Resource/template/exception');
             $html = $this['twig']->render('error.twig', array(
                 'error_title' => 'データーベース接続エラー',
                 'error_message' => 'データーベースを確認してください',
@@ -996,17 +1006,17 @@ class Application extends ApplicationTrait
      */
     public function parseConfig($config_name, array &$configAll, $wrap_key = false, $ymlPath = null, $distPath = null)
     {
-        $ymlPath = $ymlPath ? $ymlPath : __DIR__.'/../../app/config/eccube';
-        $distPath = $distPath ? $distPath : __DIR__.'/../../src/Eccube/Resource/config';
+        $ymlPath = $ymlPath ? $ymlPath : __DIR__ . '/../../app/config/eccube';
+        $distPath = $distPath ? $distPath : __DIR__ . '/../../src/Eccube/Resource/config';
         $config = array();
-        $config_php = $ymlPath.'/'.$config_name.'.php';
+        $config_php = $ymlPath . '/' . $config_name . '.php';
         if (!file_exists($config_php)) {
-            $config_yml = $ymlPath.'/'.$config_name.'.yml';
+            $config_yml = $ymlPath . '/' . $config_name . '.yml';
             if (file_exists($config_yml)) {
                 $config = Yaml::parse(file_get_contents($config_yml));
                 $config = empty($config) ? array() : $config;
                 if (isset($this['output_config_php']) && $this['output_config_php']) {
-                    file_put_contents($config_php, sprintf('<?php return %s', var_export($config, true)).';');
+                    file_put_contents($config_php, sprintf('<?php return %s', var_export($config, true)) . ';');
                 }
             }
         } else {
@@ -1014,13 +1024,13 @@ class Application extends ApplicationTrait
         }
 
         $config_dist = array();
-        $config_php_dist = $distPath.'/'.$config_name.'.dist.php';
+        $config_php_dist = $distPath . '/' . $config_name . '.dist.php';
         if (!file_exists($config_php_dist)) {
-            $config_yml_dist = $distPath.'/'.$config_name.'.yml.dist';
+            $config_yml_dist = $distPath . '/' . $config_name . '.yml.dist';
             if (file_exists($config_yml_dist)) {
                 $config_dist = Yaml::parse(file_get_contents($config_yml_dist));
                 if (isset($this['output_config_php']) && $this['output_config_php']) {
-                    file_put_contents($config_php_dist, sprintf('<?php return %s', var_export($config_dist, true)).';');
+                    file_put_contents($config_php_dist, sprintf('<?php return %s', var_export($config_dist, true)) . ';');
                 }
             }
         } else {
@@ -1083,7 +1093,6 @@ class Application extends ApplicationTrait
 
             if (strpos($route, 'admin') === 0) {
                 // 管理画面
-
                 // 管理画面ではコンテンツの中身が変更された時点でキャッシュを更新し、キャッシュの適用範囲はprivateに設定
                 $response->setCache(array(
                     'etag' => $etag,
@@ -1093,7 +1102,6 @@ class Application extends ApplicationTrait
                 if ($response->isNotModified($request)) {
                     return $response;
                 }
-
             } else {
                 // フロント画面
                 $cacheRoute = $app['config']['http_cache']['route'];
@@ -1164,7 +1172,7 @@ class Application extends ApplicationTrait
             @mkdir($this['config']['plugin_temp_realdir']);
         }
         $this['monolog']->debug("write plugin config cache", array($pluginConfigs));
-        return file_put_contents($cacheFile, sprintf('<?php return %s', var_export($pluginConfigs, true)).';');
+        return file_put_contents($cacheFile, sprintf('<?php return %s', var_export($pluginConfigs, true)) . ';');
     }
 
     /**
@@ -1189,7 +1197,7 @@ class Application extends ApplicationTrait
      */
     public function getPluginConfigCacheFile()
     {
-        return $this['config']['plugin_temp_realdir'].'/config_cache.php';
+        return $this['config']['plugin_temp_realdir'] . '/config_cache.php';
     }
 
     /**
@@ -1212,7 +1220,7 @@ class Application extends ApplicationTrait
         $pluginConfigs = array();
         foreach ($finder as $dir) {
             $code = $dir->getBaseName();
-            $file = $dir->getRealPath().'/config.yml';
+            $file = $dir->getRealPath() . '/config.yml';
             $config = null;
             if (file_exists($file)) {
                 $config = Yaml::parse(file_get_contents($file));
@@ -1221,7 +1229,7 @@ class Application extends ApplicationTrait
                 continue;
             }
 
-            $file = $dir->getRealPath().'/event.yml';
+            $file = $dir->getRealPath() . '/event.yml';
             $event = null;
             if (file_exists($file)) {
                 $event = Yaml::parse(file_get_contents($file));


### PR DESCRIPTION
フロントと管理側のSession名を分ける方法

※Sessionをスタートする前にRequestをスータトする（initRequest()）、adminかfrontわかったらSession名を設定できます。
※index.phpの$app['initRequest']について、二回目Requestをスータトしないように先に作成したRequestを渡す。
