### PR TITLE
インストーラ Step4 空のhost,パスワードを許可

### DIFF
--- a/src/Eccube/Form/Type/Install/Step4Type.php
+++ b/src/Eccube/Form/Type/Install/Step4Type.php
@@ -70,9 +70,7 @@ class Step4Type extends AbstractType
             ))
             ->add('database_host', 'text', array(
                 'label' => 'データベースのホスト名',
-                'constraints' => array(
-                    new Assert\Callback(array($this, 'validate')),
-                ),
+                'required' => false,
             ))
             ->add('database_port', 'text', array(
                 'label' => 'ポート番号',
@@ -92,9 +90,7 @@ class Step4Type extends AbstractType
             ))
             ->add('database_password', 'password', array(
                 'label' => 'パスワード',
-                'constraints' => array(
-                    new Assert\Callback(array($this, 'validate')),
-                ),
+                'required' => false,
             ))
             ->addEventListener(FormEvents::POST_SUBMIT, function ($event) {
                 $form = $event->getForm();


### PR DESCRIPTION
主にpostgres向け
* 空のホスト…unixドメインソケットでlistenしている場合に
* 空のパスワード...ident,trust認証など、パスワードが不要な認証方式を利用している場合に