### PR TITLE
フォームのinput要素に閉じタグを追記

### DIFF
--- a/src/Eccube/Resource/template/admin/Form/form_layout.twig
+++ b/src/Eccube/Resource/template/admin/Form/form_layout.twig
@@ -137,11 +137,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 {%- if freeze_display_text -%}
                     {{ choice.label|trans({}, translation_domain) }}
                 {% endif %}
-                <input type="hidden" value="{{ choice.value }}" {{ block('widget_attributes') }}>
+                <input type="hidden" value="{{ choice.value }}" {{ block('widget_attributes') }} />
                 {% set flag = true %}
             {% endif %}
         {% endfor %}
-        {% if flag == false %}<input type="hidden" value="" {{ block('widget_attributes') }}>{% endif %}
+        {% if flag == false %}<input type="hidden" value="" {{ block('widget_attributes') }} />{% endif %}
     {%- else -%}
         {{- parent() -}}
     {%- endif -%}
@@ -153,7 +153,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         {%- if freeze_display_text -%}
             {{ form.vars.data.name|default(form.vars.data) }}
         {%- endif -%}
-        <input type="hidden" value="{{ form.vars.data.id|default(form.vars.data) }}" {{ block('widget_attributes') }}>
+        <input type="hidden" value="{{ form.vars.data.id|default(form.vars.data) }}" {{ block('widget_attributes') }} />
     {%- else -%}
         {{- parent() -}}
     {%- endif -%}

--- a/src/Eccube/Resource/template/default/Form/form_layout.twig
+++ b/src/Eccube/Resource/template/default/Form/form_layout.twig
@@ -112,11 +112,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 {%- if freeze_display_text -%}
                     {{ choice.label|trans({}, translation_domain) }}
                 {% endif %}
-                <input type="hidden" value="{{ choice.value }}" {{ block('widget_attributes') }}>
+                <input type="hidden" value="{{ choice.value }}" {{ block('widget_attributes') }} />
                 {% set flag = true %}
             {% endif %}
         {% endfor %}
-        {% if flag == false %}<input type="hidden" value="" {{ block('widget_attributes') }}>{% endif %}
+        {% if flag == false %}<input type="hidden" value="" {{ block('widget_attributes') }} />{% endif %}
     {%- else -%}
         {{- parent() -}}
     {%- endif -%}
@@ -128,7 +128,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         {%- if freeze_display_text -%}
             {{ form.vars.data.name|default(form.vars.data) }}
         {%- endif -%}
-        <input type="hidden" value="{{ form.vars.data.id|default(form.vars.data) }}" {{ block('widget_attributes') }}>
+        <input type="hidden" value="{{ form.vars.data.id|default(form.vars.data) }}" {{ block('widget_attributes') }} />
     {%- else -%}
         {{- parent() -}}
     {%- endif -%}


### PR DESCRIPTION
input要素に閉じタグが設定されておらず、プラグインでDOM操作を行なうとエラーが発生する。