### PR TITLE
unittestのPHP Fatal error対応

### DIFF
--- a/tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php
@@ -27,6 +27,8 @@ class FileControllerTest extends AbstractAdminWebTestCase
     {
         $dirs = array();
         $finder = new Finder();
+        //failed to open dir: 許可がありません
+        $finder->ignoreUnreadableDirs(true);
         $iterator = $finder
             ->in(sys_get_temp_dir())
             ->name('FileController*')

--- a/tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php
@@ -27,7 +27,7 @@ class FileControllerTest extends AbstractAdminWebTestCase
     {
         $dirs = array();
         $finder = new Finder();
-        //failed to open dir: 許可がありません
+        //許可がありませんDIR対応
         $finder->ignoreUnreadableDirs(true);
         $iterator = $finder
             ->in(sys_get_temp_dir())


### PR DESCRIPTION
unittestの時Fatal errorが発生します。
問題：/tmpの以下にアクセスできないフォルダーあった場合は以下のエラー出ます
PHP Fatal error:  Uncaught UnexpectedValueException: RecursiveDirectoryIterator::__construct(/tmp/systemd-private-c4d4fa77a1244af2a1f45c7a9e0c92cc-nginx.service-sPuldh): failed to open dir: 許可がありません in /var/www/eccube/vendor/symfony/finder/Iterator/RecursiveDirectoryIterator.php:54
対応：可能がないフォルダーは使わないようにします
$finder->ignoreUnreadableDirs(true);　<--追加