### PR TITLE
ブロック編集、削除の時にtwigテンプレートのみ削除するように

### DIFF
--- a/src/Eccube/Controller/Admin/Content/BlockController.php
+++ b/src/Eccube/Controller/Admin/Content/BlockController.php
@@ -128,7 +128,8 @@ class BlockController extends AbstractController
                     }
                 }
 
-                \Eccube\Util\Cache::clear($app, false);
+                //twigテンプレートのみ削除
+                \Eccube\Util\Cache::clear($app, false, true);
 
                 $event = new EventArgs(
                     array(
@@ -191,7 +192,8 @@ class BlockController extends AbstractController
             $app['eccube.event.dispatcher']->dispatch(EccubeEvents::ADMIN_CONTENT_BLOCK_DELETE_COMPLETE, $event);
 
             $app->addSuccess('admin.delete.complete', 'admin');
-            \Eccube\Util\Cache::clear($app, false);
+            //twigテンプレートのみ削除
+            \Eccube\Util\Cache::clear($app, false, true);
         }
 
 


### PR DESCRIPTION
https://github.com/EC-CUBE/ec-cube/issues/1953
ブロック編集時、 Doctrine のキャッシュまで削除している #1953