### PR TITLE
PHP5.3のユニットテストのたまにFAIL対応

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -1215,6 +1215,12 @@ class Application extends ApplicationTrait
         $pluginConfigs = array();
         foreach ($finder as $dir) {
             $code = $dir->getBaseName();
+            if (!$code) {
+                //PHP5.3のgetBaseNameバグ対応
+                if (version_compare(PHP_VERSION, '4.0.0') < 0) {
+                    $code = $dir->getFilename();
+                }
+            }
             $file = $dir->getRealPath().'/config.yml';
             $config = null;
             if (file_exists($file)) {

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -1217,7 +1217,7 @@ class Application extends ApplicationTrait
             $code = $dir->getBaseName();
             if (!$code) {
                 //PHP5.3のgetBaseNameバグ対応
-                if (version_compare(PHP_VERSION, '4.0.0') < 0) {
+                if (version_compare(PHP_VERSION, '5.4.0', '<')) {
                     $code = $dir->getFilename();
                 }
             }

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -1217,7 +1217,7 @@ class Application extends ApplicationTrait
             $code = $dir->getBaseName();
             if (!$code) {
                 //PHP5.3のgetBaseNameバグ対応
-                if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+                if (PHP_VERSION_ID < 50400) {
                     $code = $dir->getFilename();
                 }
             }


### PR DESCRIPTION
問題：
たまにPHP5.3の場合は以下のエラー出てます
Eccube\Tests\Service\PluginServiceTest::testPluginConfigCache
Failed asserting that false is true.
tests/Eccube/Tests/Service/PluginServiceTest.php:649

調査結果：
プラグインフォルダースキャンの時SplFileInfo->getBasename()は空になります
https://github.com/EC-CUBE/ec-cube/blob/master/src/Eccube/Application.php#L1217
この問題はPHP5.3の時だけ、色んなDebugしましたがPHPコアーが問題みたい。

対応方法：
PHP5.3の時だけSplFileInfo->getBasename()結果は空場合はSplFileInfo->getFilename()を呼び出す。

備考：
対応は\Eccube\Applicationの中ですのでこの問題テストの時だけではないと思います。
PullReq.を作りました、ご確認お願いします