### PR TITLE
debug == falseのユニットテストに失敗対応

### DIFF
--- a/tests/Eccube/Tests/Web/EntryControllerTest.php
+++ b/tests/Eccube/Tests/Web/EntryControllerTest.php
@@ -223,27 +223,34 @@ class EntryControllerTest extends AbstractWebTestCase
 
     public function testActivateWithNotFound()
     {
-        try {
-            $client = $this->createClient();
-            $crawler = $client->request('GET', $this->app['url_generator']->generate('entry_activate', array('secret_key' => 'aaaaa')));
-            $this->fail();
-        } catch (HttpException\NotFoundHttpException $e) {
-            $this->expected = '※ 既に会員登録が完了しているか、無効なURLです。';
-            $this->actual = $e->getMessage();
+        // debugはONの時に404ページ表示しない例外になります。
+        if($this->app['debug'] == true){
+            $this->expectException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
         }
-        $this->verify();
+        //try {
+        $client = $this->createClient();
+        $crawler = $client->request('GET', $this->app['url_generator']->generate('entry_activate', array('secret_key' => 'aaaaa')));
+        // debugはOFFの時に404ページが表示します。
+        if($this->app['debug'] == false){
+            $this->expected = 404;
+            $this->actual = $client->getResponse()->getStatusCode();
+            $this->verify();
+        }
     }
 
     public function testActivateWithAbort()
     {
-        try {
-            $client = $this->createClient();
-            $crawler = $client->request('GET', $this->app['url_generator']->generate('entry_activate', array('secret_key' => '+++++++')));
-            $this->fail();
-        } catch (HttpException\AccessDeniedHttpException $e) {
-            $this->expected = '不正なアクセスです。';
-            $this->actual = $e->getMessage();
+        // debugはONの時に403ページ表示しない例外になります。
+        if($this->app['debug'] == true){
+            $this->expectException('\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException');
         }
-        $this->verify();
+        $client = $this->createClient();
+        $crawler = $client->request('GET', $this->app['url_generator']->generate('entry_activate', array('secret_key' => '+++++++')));
+        // debugはOFFの時に403ページが表示します。
+        if($this->app['debug'] == false){
+            $this->expected = 403;
+            $this->actual = $client->getResponse()->getStatusCode();
+            $this->verify();
+        }
     }
 }

--- a/tests/Eccube/Tests/Web/EntryControllerTest.php
+++ b/tests/Eccube/Tests/Web/EntryControllerTest.php
@@ -225,7 +225,7 @@ class EntryControllerTest extends AbstractWebTestCase
     {
         // debugはONの時に404ページ表示しない例外になります。
         if($this->app['debug'] == true){
-            $this->expectException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+            $this->setExpectedException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
         }
         $client = $this->createClient();
         $crawler = $client->request('GET', $this->app['url_generator']->generate('entry_activate', array('secret_key' => 'aaaaa')));
@@ -241,7 +241,7 @@ class EntryControllerTest extends AbstractWebTestCase
     {
         // debugはONの時に403ページ表示しない例外になります。
         if($this->app['debug'] == true){
-            $this->expectException('\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException');
+            $this->setExpectedException('\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException');
         }
         $client = $this->createClient();
         $crawler = $client->request('GET', $this->app['url_generator']->generate('entry_activate', array('secret_key' => '+++++++')));

--- a/tests/Eccube/Tests/Web/EntryControllerTest.php
+++ b/tests/Eccube/Tests/Web/EntryControllerTest.php
@@ -227,7 +227,6 @@ class EntryControllerTest extends AbstractWebTestCase
         if($this->app['debug'] == true){
             $this->expectException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
         }
-        //try {
         $client = $this->createClient();
         $crawler = $client->request('GET', $this->app['url_generator']->generate('entry_activate', array('secret_key' => 'aaaaa')));
         // debugはOFFの時に404ページが表示します。

--- a/tests/Eccube/Tests/Web/ForgotControllerTest.php
+++ b/tests/Eccube/Tests/Web/ForgotControllerTest.php
@@ -100,7 +100,7 @@ class ForgotControllerTest extends AbstractWebTestCase
     {
         // debugはONの時に403ページ表示しない例外になります。
         if($this->app['debug'] == true){
-            $this->expectException('\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException');
+            $this->setExpectedException('\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException');
         }
         $client = $this->createClient();
             $crawler = $client->request(
@@ -120,7 +120,7 @@ class ForgotControllerTest extends AbstractWebTestCase
     {
         // debugはONの時に404ページ表示しない例外になります。
         if($this->app['debug'] == true){
-            $this->expectException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+            $this->setExpectedException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
         }
         $client = $this->createClient();
         

--- a/tests/Eccube/Tests/Web/ForgotControllerTest.php
+++ b/tests/Eccube/Tests/Web/ForgotControllerTest.php
@@ -98,33 +98,41 @@ class ForgotControllerTest extends AbstractWebTestCase
 
     public function testResetWithDenied()
     {
+        // debugはONの時に403ページ表示しない例外になります。
+        if($this->app['debug'] == true){
+            $this->expectException('\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException');
+        }
         $client = $this->createClient();
-        try {
             $crawler = $client->request(
                 'GET',
                 '/forgot/reset/a___aaa'
             );
-            $this->fail();
-        } catch (\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException $e) {
-            $this->expected = '不正なアクセスです。';
-            $this->actual = $e->getMessage();
+           
+        // debugはOFFの時に403ページが表示します。
+        if($this->app['debug'] == false){
+            $this->expected = 403;
+            $this->actual = $client->getResponse()->getStatusCode();
+            $this->verify();
         }
-        $this->verify();
     }
 
     public function testResetWithNotFound()
     {
-        $client = $this->createClient();
-        try {
-            $crawler = $client->request(
-                'GET',
-                '/forgot/reset/aaaa'
-            );
-            $this->fail();
-        } catch (\Symfony\Component\HttpKernel\Exception\NotFoundHttpException $e) {
-            $this->expected = '有効期限が切れているか、無効なURLです。';
-            $this->actual = $e->getMessage();
+        // debugはONの時に404ページ表示しない例外になります。
+        if($this->app['debug'] == true){
+            $this->expectException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
         }
-        $this->verify();
+        $client = $this->createClient();
+        
+        $crawler = $client->request(
+           'GET',
+           '/forgot/reset/aaaa'
+        );
+        // debugはOFFの時に404ページが表示します。
+        if($this->app['debug'] == false){
+            $this->expected = 404;
+            $this->actual = $client->getResponse()->getStatusCode();
+            $this->verify();
+        }
     }
 }

--- a/tests/Eccube/Tests/Web/Mypage/MypageControllerTest.php
+++ b/tests/Eccube/Tests/Web/Mypage/MypageControllerTest.php
@@ -137,19 +137,21 @@ class MypageControllerTest extends AbstractWebTestCase
         $Order = $this->app['eccube.fixture.generator']->createOrder($Customer, array($ProductClasses[0]),null,0,0,'order_processing');
         $this->logIn($Customer);
         $client = $this->client;
-        
-        try {
-            $crawler = $client->request(
-                'GET',
-                $this->app->path('mypage_history', array('id' => $Order->getId()))
-            );
-            $this->fail();
-        } catch (NotFoundHttpException $e) {
-            $this->actual = $e->getMessage();
-            $this->expected = '';
+        // debugはONの時に404ページ表示しない例外になります。
+        if($this->app['debug'] == true){
+            $this->expectException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
         }
-        $this->verify();
         
+        $crawler = $client->request(
+            'GET',
+            $this->app->path('mypage_history', array('id' => $Order->getId()))
+        );
+        // debugはOFFの時に404ページが表示します。
+        if($this->app['debug'] == false){
+            $this->expected = 404;
+            $this->actual = $client->getResponse()->getStatusCode();
+            $this->verify();
+        }
     }
 
     public function testHistoryWithNotfound()
@@ -158,18 +160,21 @@ class MypageControllerTest extends AbstractWebTestCase
 
         $this->logIn($Customer);
         $client = $this->client;
-
-        try {
-            $crawler = $client->request(
-                'GET',
-                $this->app->path('mypage_history', array('id' => 999999999))
-            );
-            $this->fail();
-        } catch (NotFoundHttpException $e) {
-            $this->actual = $e->getMessage();
-            $this->expected = '';
+        // debugはONの時に404ページ表示しない例外になります。
+        if($this->app['debug'] == true){
+            $this->expectException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
         }
-        $this->verify();
+
+        $crawler = $client->request(
+            'GET',
+            $this->app->path('mypage_history', array('id' => 999999999))
+        );
+        // debugはOFFの時に404ページが表示します。
+        if($this->app['debug'] == false){
+            $this->expected = 404;
+            $this->actual = $client->getResponse()->getStatusCode();
+            $this->verify();
+        }
     }
 
     /**

--- a/tests/Eccube/Tests/Web/Mypage/MypageControllerTest.php
+++ b/tests/Eccube/Tests/Web/Mypage/MypageControllerTest.php
@@ -139,7 +139,7 @@ class MypageControllerTest extends AbstractWebTestCase
         $client = $this->client;
         // debugはONの時に404ページ表示しない例外になります。
         if($this->app['debug'] == true){
-            $this->expectException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+            $this->setExpectedException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
         }
         
         $crawler = $client->request(
@@ -162,7 +162,7 @@ class MypageControllerTest extends AbstractWebTestCase
         $client = $this->client;
         // debugはONの時に404ページ表示しない例外になります。
         if($this->app['debug'] == true){
-            $this->expectException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+            $this->setExpectedException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
         }
 
         $crawler = $client->request(

--- a/tests/Eccube/Tests/Web/UserDataControllerTest.php
+++ b/tests/Eccube/Tests/Web/UserDataControllerTest.php
@@ -16,6 +16,8 @@ class UserDataControllerTest extends AbstractWebTestCase
         parent::setUp();
         $root = vfsStream::setup('rootDir');
         vfsStream::newDirectory('user_data');
+        // 404ページ表示のためにerror.twigを用意します、内容はダッミーです。
+        vfsStream::newFile('error.twig')->at($root)->setContent('Error 404');
 
         // 一旦別の変数に代入しないと, config 以下の値を書きかえることができない
         $config = $this->app['config'];
@@ -61,17 +63,20 @@ class UserDataControllerTest extends AbstractWebTestCase
 
     public function testIndexWithNotFound()
     {
-        $client = $this->createClient();
-        try {
-            $crawler = $client->request(
-                'GET',
-                '/user_data/aaa'
-            );
-            $this->fail();
-        } catch (NotFoundHttpException $e) {
-            $this->expected = 404;
-            $this->actual = $e->getStatusCode();
+        // debugはONの時に404ページ表示しない例外になります。
+        if($this->app['debug'] == true){
+            $this->expectException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
         }
-        $this->verify();
+        $client = $this->createClient();
+        $crawler = $client->request(
+            'GET',
+            '/user_data/aaa'
+        );
+        // debugはOFFの時に404ページが表示します。
+        if($this->app['debug'] == false){
+            $this->expected = 404;
+            $this->actual = $client->getResponse()->getStatusCode();
+            $this->verify();
+        }
     }
 }

--- a/tests/Eccube/Tests/Web/UserDataControllerTest.php
+++ b/tests/Eccube/Tests/Web/UserDataControllerTest.php
@@ -65,7 +65,7 @@ class UserDataControllerTest extends AbstractWebTestCase
     {
         // debugはONの時に404ページ表示しない例外になります。
         if($this->app['debug'] == true){
-            $this->expectException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+            $this->setExpectedException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
         }
         $client = $this->createClient();
         $crawler = $client->request(


### PR DESCRIPTION
https://github.com/EC-CUBE/ec-cube/issues/1711
debug == false の状態だとユニットテストに失敗する
対応：
debug設定によって結果は違いますのでそれぞれのチェック必要です

-   debug == false の場合は、エラーページがレンダリングされる
-   debug == true の場合は、例外がスローされる
※try / catch方法を外す