### PR TITLE
app/log/ に書き込み権限がないとインストール画面でエラーになる対応

### DIFF
--- a/src/Eccube/InstallApplication.php
+++ b/src/Eccube/InstallApplication.php
@@ -34,8 +34,17 @@ class InstallApplication extends ApplicationTrait
 
         parent::__construct($values);
 
+        $base = __DIR__ . '/../..';
+        $installLog = '/app/log/install.log';
+
+        // log file for install has to be writable
+        if (!is_writable($base . $installLog)) {
+            echo '以下のファイルのアクセス制限を変更してください。<br>' . PHP_EOL;
+            echo '× : '.$installLog.'<br><br>' . PHP_EOL;
+        }
+
         $app->register(new \Silex\Provider\MonologServiceProvider(), array(
-            'monolog.logfile' => __DIR__.'/../../app/log/install.log',
+            'monolog.logfile' => __DIR__.'/../..' . $installLog,
         ));
 
         // load config


### PR DESCRIPTION
app/log/ に書き込み権限がないとインストール画面でエラーになる
https://github.com/EC-CUBE/ec-cube/issues/1205

※本当はapp/log/install.logに書き込み権限がないとインストール画面でエラーになります。

対応について
インストールする前に「app/log/install.log」の書き込み権限をチェックします、×の時メッセージechoする。
```
以下のファイルのアクセス制限を変更してください。
× : /app/log/install.log

```
※PHP Fatal errorはそのままPHPエラーログに出力する