### PR TITLE
choiceのfreezeテキストを修正

### DIFF
--- a/src/Eccube/Resource/template/default/Form/form_layout.twig
+++ b/src/Eccube/Resource/template/default/Form/form_layout.twig
@@ -126,7 +126,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {%- block choice_widget_expanded -%}
     {% if freeze %}
         {%- if freeze_display_text -%}
-            {{ choices[form.vars.data].label|default(form.vars.data) }}
+            {% if is_object(form.vars.data) %}
+                {{ form.vars.data.name|default(form.vars.data) }}
+            {% else %}
+                {{ choices[form.vars.data].label|default(form.vars.data) }}
+            {% endif %}
         {%- endif -%}
         <input type="hidden" value="{{ form.vars.data.id|default(form.vars.data) }}" {{ block('widget_attributes') }}>
     {%- else -%}

--- a/src/Eccube/Resource/template/default/Form/form_layout.twig
+++ b/src/Eccube/Resource/template/default/Form/form_layout.twig
@@ -126,7 +126,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {%- block choice_widget_expanded -%}
     {% if freeze %}
         {%- if freeze_display_text -%}
-            {{ form.vars.data.name|default(form.vars.data) }}
+            {{ choices[form.vars.data].label|default(form.vars.data) }}
         {%- endif -%}
         <input type="hidden" value="{{ form.vars.data.id|default(form.vars.data) }}" {{ block('widget_attributes') }}>
     {%- else -%}

--- a/src/Eccube/Resource/template/default/Form/form_layout.twig
+++ b/src/Eccube/Resource/template/default/Form/form_layout.twig
@@ -129,7 +129,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             {% if is_object(form.vars.data) %}
                 {{ form.vars.data.name|default(form.vars.data) }}
             {% else %}
-                {{ choices[form.vars.data].label|default(form.vars.data) }}
+                {% for choice in choices %}
+                    {% if form.vars.data is same as (choice.value) %}
+                        {{ choice.label }}
+                    {% endif %}
+                {% endfor %}
             {% endif %}
         {%- endif -%}
         <input type="hidden" value="{{ form.vars.data.id|default(form.vars.data) }}" {{ block('widget_attributes') }}>

--- a/src/Eccube/Twig/Extension/EccubeExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeExtension.php
@@ -48,6 +48,7 @@ class EccubeExtension extends \Twig_Extension
         $RoutingExtension = $this->app['twig']->getExtension('routing');
 
         return array(
+            new \Twig_SimpleFunction('is_object', array($this, 'isObject')),
             new \Twig_SimpleFunction('calc_inc_tax', array($this, 'getCalcIncTax')),
             new \Twig_SimpleFunction('active_menus', array($this, 'getActiveMenus')),
             new \Twig_SimpleFunction('csrf_token_for_anchor', array($this, 'getCsrfTokenForAnchor'), array('is_safe' => array('all'))),
@@ -223,5 +224,16 @@ class EccubeExtension extends \Twig_Extension
         }
 
         return $RoutingExtension->getUrl('homepage').'404?bind='.$name;
+    }
+
+    /**
+     * Check if the value is object
+     *
+     * @param object $value
+     * @return bool
+     */
+    public function isObject($value)
+    {
+        return is_object($value);
     }
 }


### PR DESCRIPTION
```
$builder
    ->add('hoge', 'choice', array(
        'choices' => array(
            '0' => 'fuga',
            '1' => 'piyo',
        ),
        'expanded' => true,
        'multiple' => false,
    ));
```

上記のフォームでfugaを選択してfreeze表示すると0が表示される。fugaが表示されるよう変更。