### PR TITLE
商品登録時、子カテゴリを選択すると親カテゴリも登録する

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -362,18 +362,26 @@ class ProductController extends AbstractController
 
                 $count = 1;
                 $Categories = $form->get('Category')->getData();
+                $categoriesIdList = array();
                 foreach ($Categories as $Category) {
-                    $ProductCategory = new \Eccube\Entity\ProductCategory();
-                    $ProductCategory
-                        ->setProduct($Product)
-                        ->setProductId($Product->getId())
-                        ->setCategory($Category)
-                        ->setCategoryId($Category->getId())
-                        ->setRank($count);
-                    $app['orm.em']->persist($ProductCategory);
-                    $count++;
-                    /* @var $Product \Eccube\Entity\Product */
-                    $Product->addProductCategory($ProductCategory);
+                    foreach($Category->getPath() as $ParentCategory){
+                        if (!isset($categoriesIdList[$ParentCategory->getId()])){
+                            $ProductCategory = $this->createProductCategory($Product, $ParentCategory, $count);
+                            $app['orm.em']->persist($ProductCategory);
+                            $count++;
+                            /* @var $Product \Eccube\Entity\Product */
+                            $Product->addProductCategory($ProductCategory);
+                            $categoriesIdList[$ParentCategory->getId()] = true;
+                        }
+                    }
+                    if (!isset($categoriesIdList[$Category->getId()])){
+                        $ProductCategory = $this->createProductCategory($Product, $Category, $count);
+                        $app['orm.em']->persist($ProductCategory);
+                        $count++;
+                        /* @var $Product \Eccube\Entity\Product */
+                        $Product->addProductCategory($ProductCategory);
+                        $categoriesIdList[$Category->getId()] = true;
+                    }
                 }
 
                 // 画像の登録
@@ -778,5 +786,23 @@ class ProductController extends AbstractController
         log_info('商品CSV出力ファイル名', array($filename));
 
         return $response;
+    }
+    
+    /**
+     * ProductCategory作成
+     * @param \Eccube\Entity\Product $Product
+     * @param \Eccube\Entity\Category $Category
+     * @return \Eccube\Entity\ProductCategory
+     */
+    private function createProductCategory($Product, $Category, $count)
+    {
+        $ProductCategory = new \Eccube\Entity\ProductCategory();
+        $ProductCategory->setProduct($Product);
+        $ProductCategory->setProductId($Product->getId());
+        $ProductCategory->setCategory($Category);
+        $ProductCategory->setCategoryId($Category->getId());
+        $ProductCategory->setRank($count);
+        
+        return $ProductCategory;
     }
 }


### PR DESCRIPTION
https://github.com/EC-CUBE/ec-cube/issues/1974　商品登録時、子カテゴリを選択すると親カテゴリも登録されるようにしたい

修正内容：
管理側の商品編集、登録、複製、インポートの時ロッジクを修正しました。
※ユニットテストも追加しました。
