### PR TITLE
プラグインパージョンアップ時のプラグイン名一致確認は不要なので削除

### DIFF
--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -346,9 +346,6 @@ class PluginService
             if ($plugin->getCode() != $config['code']) {
                 throw new PluginException('new/old plugin code is different.');
             }
-            if ($plugin->getName() != $config['name']) {
-                throw new PluginException('new/old plugin name is different.');
-            }
 
             $pluginBaseDir = $this->calcPluginDir($config['code']);
             $this->deleteFile($tmp); // テンポラリのファイルを削除


### PR DESCRIPTION
ref #1978 

### 確認した内容
- プラグイン名(name)を変更したプラグインにバージョンアップできること。
- プラグイン名(name)が空文字の場合は、エラーとなってバージョンアップ失敗すること。  
⇒  config.yml name empty
