### PR TITLE
管理画面の受注編集のユニットテスト失敗する対応

### DIFF
--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerWithMultipleTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerWithMultipleTest.php
@@ -401,7 +401,7 @@ class EditControllerWithMultipleTest extends AbstractEditControllerTestCase
                 'Product' => $ProductClass->getProduct()->getId(),
                 'ProductClass' => $ProductClass->getId(),
                 'price' => $ProductClass->getPrice02(),
-                'quantity' => $faker->randomNumber(2),
+                'quantity' => $faker->numberBetween(1, 9),
                 'product_name' => $ProductClass->getProduct()->getName(),
                 'product_code' => $ProductClass->getCode(),
             );


### PR DESCRIPTION
https://github.com/EC-CUBE/ec-cube/pull/1725/
受注編集画面の商品追加ロジック等を変更
上のmergeの後たまにユニットテストが失敗しましたのでテストデータを修正しました