### PR TITLE
フォーム生成でインスタンス化を利用しているのを修正

### DIFF
--- a/src/Eccube/Form/Type/Admin/MasterdataEditType.php
+++ b/src/Eccube/Form/Type/Admin/MasterdataEditType.php
@@ -45,11 +45,9 @@ class MasterdataEditType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $app = $this->app;
-
         $builder
             ->add('data', 'collection', array(
-                'type' => new MasterdataDataType($app),
+                'type' => 'admin_system_masterdata_data',
                 'allow_add' => true,
                 'allow_delete' => true,
                 'prototype' => true,

--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -216,13 +216,13 @@ class OrderType extends AbstractType
                 ),
             ))
             ->add('OrderDetails', 'collection', array(
-                'type' => new OrderDetailType($app),
+                'type' => 'order_detail',
                 'allow_add' => true,
                 'allow_delete' => true,
                 'prototype' => true,
             ))
             ->add('Shippings', 'collection', array(
-                'type' => new ShippingType($app),
+                'type' => 'shipping',
                 'allow_add' => true,
                 'allow_delete' => true,
                 'prototype' => true,

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -374,6 +374,7 @@ class EccubeServiceProvider implements ServiceProviderInterface
             $types[] = new \Eccube\Form\Type\Admin\CacheType($app['config']);
 
             $types[] = new \Eccube\Form\Type\Admin\MasterdataType($app);
+            $types[] = new \Eccube\Form\Type\Admin\MasterdataDataType($app);
             $types[] = new \Eccube\Form\Type\Admin\MasterdataEditType($app);
 
             $types[] = new \Eccube\Form\Type\Admin\PluginLocalInstallType();


### PR DESCRIPTION
フォームを名前でなくインスタンスで生成するとExtensionが効かず、プラグイン等で拡張できない。