### PR TITLE
プラグイン一覧画面のREADME表示を変更

### DIFF
--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -29,15 +29,13 @@ use Eccube\Common\Constant;
 use Eccube\Controller\AbstractController;
 use Eccube\Exception\PluginException;
 use Eccube\Util\Str;
+use Monolog\Logger;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Form\FormError;
-use Monolog\Logger;
 
 class PluginController extends AbstractController
 {
@@ -300,40 +298,6 @@ class PluginController extends AbstractController
         $app->addSuccess('admin.plugin.uninstall.complete', 'admin');
 
         return $app->redirect($app->url('admin_store_plugin'));
-    }
-
-    /**
-     * 対象プラグインの README を返却します。
-     *
-     * @param Application $app
-     * @param unknown $code
-     */
-    public function readme(Application $app, Request $request, $id)
-    {
-        if ($request->isXmlHttpRequest()) {
-            $Plugin = $app['eccube.repository.plugin']->find($id);
-            if (!$Plugin) {
-                $response = new Response(json_encode('NG'), 400);
-                $response->headers->set('Content-Type', 'application/json');
-                return $response;
-            }
-
-            $code = $Plugin->getCode();
-            $readme = $app['config'][$code]['const']['readme'];
-            $data = array(
-                'code' => $code,
-                'name' => $Plugin->getName(),
-                'readme' => $readme,
-            );
-
-            $response = new Response(json_encode($data));
-            $response->headers->set('Content-Type', 'application/json');
-            return $response;
-        }
-
-        $response = new Response(json_encode('NG'), 400);
-        $response->headers->set('Content-Type', 'application/json');
-        return $response;
     }
 
     public function handler(Application $app)

--- a/src/Eccube/ControllerProvider/AdminControllerProvider.php
+++ b/src/Eccube/ControllerProvider/AdminControllerProvider.php
@@ -223,7 +223,6 @@ class AdminControllerProvider implements ControllerProviderInterface
         $c->put('/store/plugin/{id}/disable', '\Eccube\Controller\Admin\Store\PluginController::disable')->assert('id', '\d+')->bind('admin_store_plugin_disable');
         $c->post('/store/plugin/{id}/update', '\Eccube\Controller\Admin\Store\PluginController::update')->assert('id', '\d+')->bind('admin_store_plugin_update');
         $c->delete('/store/plugin/{id}/uninstall', '\Eccube\Controller\Admin\Store\PluginController::uninstall')->assert('id', '\d+')->bind('admin_store_plugin_uninstall');
-        $c->match('/store/plugin/{id}/readme', '\Eccube\Controller\Admin\Store\PluginController::readme')->assert('id', '\d+')->bind('admin_store_plugin_readme');
         $c->match('/store/plugin/handler_up/{handlerId}', '\Eccube\Controller\Admin\Store\PluginController::handler_up')->bind('admin_store_plugin_handler_up');
         $c->match('/store/plugin/handler_down/{handlerId}', '\Eccube\Controller\Admin\Store\PluginController::handler_down')->bind('admin_store_plugin_handler_down');
         $c->match('/store/plugin/authentication_setting', '\Eccube\Controller\Admin\Store\PluginController::authenticationSetting')->bind('admin_store_authentication_setting');

--- a/src/Eccube/Resource/template/admin/Store/plugin.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin.twig
@@ -34,24 +34,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         document.forms[form_name].submit();
     }
     $(function(){
-        $('[data-readme]').on('click', function() {
-            var url = '{{ url('admin_store_plugin_readme', {'id': '999999'}) }}';
-            $.ajax({
-                type: 'GET',
-                url: url.replace('999999', $(this).data('readme')),
-                dataType: "json",
-                success: function(data) {
-                    $(".prevention-masked").remove();
-                    $('#readmeModalLabel').text(data.name);
-                    $('#readmeContent').html(data.readme);
-                    $('#readmeModal').modal('show');
-                },
-                error: function() {
-                    $(".prevention-masked").remove();
-                    alert('Failed to read README.');
-                }
-            });
-            return false;
+        $('#readmeModal').on('show.bs.modal', function(event) {
+            var target = $(event.relatedTarget);
+            var modal = $(this)
+            modal.find('#readmeModalLabel').text(target.data('name'));
+            modal.find('#readmeContent').html(target.data('readme'));
         });
     });
 </script>
@@ -93,7 +80,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     </div>
 {% endblock %}
 {% block modal %}
-<div class="modal" id="readmeModal" tabindex="-1" role="dialog" aria-labelledby="readmeModalLabel" aria-hidden="true">
+<div class="modal fade" id="readmeModal" tabindex="-1" role="dialog" aria-labelledby="readmeModalLabel" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/src/Eccube/Resource/template/admin/Store/plugin_table.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_table.twig
@@ -30,7 +30,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     <th>コード</th>
                     <th>アップデート</th>
                     <th>設定</th>
-                    <th>README</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -55,7 +54,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 </a>
                             </td>
                             <td class="tv text-center">{{ Plugin.version }}</td>
-                            <td class="tc">{{ Plugin.code }}</td>
+                            <td class="tc"><p>{{ Plugin.code }}</p>
+                                {% if attribute(app.config[Plugin.code].const, 'readme') is defined %}
+                                    <a href="#" class="view_readme" data-toggle="modal" data-target="#readmeModal" data-name="{{ Plugin.name }}" data-readme="{{ attribute(app.config[Plugin.code].const, 'readme')  }}">詳細を表示</a>
+                                {% endif %}
+                            </td>
                             <td class="tu">
                             {% if Plugin.source == 0 %}
                                 {{ form_widget(form._token) }}
@@ -79,18 +82,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 {% else %}
                                     <p>アップデート対象プラグインはありません。</p>
                                 {% endif %}
-                                <p><a href="{{ Plugin.productUrl }}" target="_blank">詳細</a></p>
+                                <p><a href="{{ Plugin.productUrl }}" target="_blank">詳細情報</a></p>
                             {% endif %}
                             </td>
                             <td class="ta text-center">
                                 {% if configPages[Plugin.code] is defined %}
                                    <a href='{{configPages[Plugin.code]}}'>設定</a>
                                 {% endif %}
-                            </td>
-                            <td class="tr text-center">
-                               {% if attribute(app.config[Plugin.code].const, 'readme') is defined %}
-                               <a class="prevention-mask view_readme" href="" data-readme="{{ Plugin.id }}">README</a>
-                               {% endif %}
                             </td>
                         </tr>
                     </form>

--- a/src/Eccube/Resource/template/admin/Store/unregisterd_plugin_table.twig
+++ b/src/Eccube/Resource/template/admin/Store/unregisterd_plugin_table.twig
@@ -24,7 +24,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 <th>コード</th>
                 <th>アップデート</th>
                 <th>設定</th>
-                <th>README</th>
             </tr>
             </thead>
             <tbody>
@@ -46,7 +45,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             <td class="tv text-center">不明</td>
                         {% endif %}
                         {% if Plugin.code is defined %}
-                            <td class="tc">{{ Plugin.code }}</td>
+                            <td class="tc"><p>{{ Plugin.code }}</p>
+                                {% if attribute(app.config[Plugin.code].const, 'readme') is defined %}
+                                    <a href="#" class="view_readme" data-toggle="modal" data-target="#readmeModal" data-name="{{ Plugin.name }}" data-readme="{{ attribute(app.config[Plugin.code].const, 'readme')  }}">詳細を表示</a>
+                                {% endif %}
+                            </td>
                         {% else %}
                             <td class="tc">不明</td>
                         {% endif %}
@@ -59,11 +62,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             {% else %}
                                 &nbsp;-&nbsp;
                             {% endif %}
-                        </td>
-                        <td class="tr text-center">
-                           {% if attribute(app.config[Plugin.code].const, 'readme') is defined %}
-                           <a class="prevention-mask view_readme" href="" data-readme="{{ Plugin.id }}">README</a>
-                           {% endif %}
                         </td>
                     </tr>
                 </form>


### PR DESCRIPTION
* dtb_pluginがないプラグインをインストールするとシステムエラーが発生するためidを参照しないように変更
* READMEの位置を変更
* 頻繁に閲覧するような画面ではないため、READMEの内容を一度サーバに対して取得させるのではなく、最初から保持しておくようにする。

refs #1643