### PR TITLE
Fixture\Generator を画像の生成に対応

### DIFF
--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -245,9 +245,12 @@ class Generator {
      *
      * @param string $product_name 商品名. null の場合はランダムな文字列が生成される.
      * @param integer $product_class_num 商品規格の生成数
+     * @param string $image_type 生成する画像タイプ.
+     *        abstract, animals, business, cats, city, food, night, life, fashion, people, nature, sports, technics, transport から選択可能
+     *        null の場合は、画像を生成せずにファイル名のみを設定する.
      * @return \Eccube\Entity\Product
      */
-    public function createProduct($product_name = null, $product_class_num = 3)
+    public function createProduct($product_name = null, $product_class_num = 3, $image_type = null)
     {
         $faker = $this->getFaker();
         $Member = $this->app['eccube.repository.member']->find(2);
@@ -272,9 +275,18 @@ class Generator {
 
         for ($i = 0; $i < 3; $i++) {
             $ProductImage = new ProductImage();
+            if ($image_type) {
+                $image = $faker->image(
+                    __DIR__.'/../../../../html/upload/save_image',
+                    $faker->numberBetween(480, 640),
+                    $faker->numberBetween(480, 640),
+                    $image_type, false);
+            } else {
+                $image = $faker->word.'.jpg';
+            }
             $ProductImage
                 ->setCreator($Member)
-                ->setFileName($faker->word.'.jpg')
+                ->setFileName($image)
                 ->setRank($i)
                 ->setProduct($Product);
             $this->app['orm.em']->persist($ProductImage);


### PR DESCRIPTION
`$app['eccube.fixture.generator']->createProduct(null, 3, 'cats');` とすると、こんな感じで画像まで生成できるようにしました。

![2016-12-19 15 36 59](https://cloud.githubusercontent.com/assets/815715/21303347/2b522d0a-c601-11e6-96f5-b9a477f3b93c.png)

see. https://github.com/fzaninotto/Faker#fakerproviderimage