### PR TITLE
update symfony 2.7.21 -> 2.7.22

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "issues": "https://github.com/EC-CUBE/ec-cube/issues"
     },
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
         "silex/silex": "~1.3",
         "silex/web-profiler": "~1.0",
         "doctrine/orm": "<2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -1541,23 +1541,24 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v5.4.4",
+            "version": "v5.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "545ce9136690cea74f98f86fbb9c92dd9ab1a756"
+                "reference": "cd142238a339459b10da3d8234220963f392540c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/545ce9136690cea74f98f86fbb9c92dd9ab1a756",
-                "reference": "545ce9136690cea74f98f86fbb9c92dd9ab1a756",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/cd142238a339459b10da3d8234220963f392540c",
+                "reference": "cd142238a339459b10da3d8234220963f392540c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "mockery/mockery": "~0.9.1"
+                "mockery/mockery": "~0.9.1",
+                "symfony/phpunit-bridge": "~3.2"
             },
             "type": "library",
             "extra": {
@@ -1590,7 +1591,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2016-11-24 01:01:23"
+            "time": "2016-12-29 10:02:40"
         },
         {
             "name": "symfony/class-loader",
@@ -3490,16 +3491,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "74f723e542368ca2080b252740be5f1113ebb898"
+                "reference": "c6ff71094fde15d12398eaba029434b013dc5e59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/74f723e542368ca2080b252740be5f1113ebb898",
-                "reference": "74f723e542368ca2080b252740be5f1113ebb898",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/c6ff71094fde15d12398eaba029434b013dc5e59",
+                "reference": "c6ff71094fde15d12398eaba029434b013dc5e59",
                 "shasum": ""
             },
             "require": {
@@ -3512,7 +3513,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.29-dev"
+                    "dev-master": "1.30-dev"
                 }
             },
             "autoload": {
@@ -3547,7 +3548,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-12-13 17:28:18"
+            "time": "2016-12-23 11:06:22"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7e4a710dfad670a6b9dbe972d253ffc8",
-    "content-hash": "af0fed65716b85c3cae6f455bef74eda",
+    "hash": "4c552581dc592f3b060ce487ac1dca05",
+    "content-hash": "a602041b10233704ddd5cb2ecc724339",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1593,16 +1593,16 @@
         },
         {
             "name": "symfony/class-loader",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
-                "reference": "c060834942bae87e044d384a8adfaf3f8228ac44"
+                "reference": "65ac4dbf5922f2bb104cf53ba22303722db4031b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/class-loader/zipball/c060834942bae87e044d384a8adfaf3f8228ac44",
-                "reference": "c060834942bae87e044d384a8adfaf3f8228ac44",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/65ac4dbf5922f2bb104cf53ba22303722db4031b",
+                "reference": "65ac4dbf5922f2bb104cf53ba22303722db4031b",
                 "shasum": ""
             },
             "require": {
@@ -1642,25 +1642,28 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-15 09:22:02"
+            "time": "2016-11-29 08:16:08"
         },
         {
             "name": "symfony/config",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "a8ce7c852a515ed62c4393444d09686b3f3f78ec"
+                "reference": "613ea3b4466dc936e1ca0a92842a78d1d8a09855"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/a8ce7c852a515ed62c4393444d09686b3f3f78ec",
-                "reference": "a8ce7c852a515ed62c4393444d09686b3f3f78ec",
+                "url": "https://api.github.com/repos/symfony/config/zipball/613ea3b4466dc936e1ca0a92842a78d1d8a09855",
+                "reference": "613ea3b4466dc936e1ca0a92842a78d1d8a09855",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
                 "symfony/filesystem": "~2.3"
+            },
+            "require-dev": {
+                "symfony/yaml": "~2.7"
             },
             "suggest": {
                 "symfony/yaml": "To use the yaml reference dumper"
@@ -1695,20 +1698,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-03 07:44:55"
+            "time": "2016-12-09 08:40:53"
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "54fb85a818596bc3b33618125fa3ee99b9f45382"
+                "reference": "904569a605f7d4afe584bdf97cb4588f59d88711"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/54fb85a818596bc3b33618125fa3ee99b9f45382",
-                "reference": "54fb85a818596bc3b33618125fa3ee99b9f45382",
+                "url": "https://api.github.com/repos/symfony/console/zipball/904569a605f7d4afe584bdf97cb4588f59d88711",
+                "reference": "904569a605f7d4afe584bdf97cb4588f59d88711",
                 "shasum": ""
             },
             "require": {
@@ -1755,11 +1758,11 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-13 17:41:36"
+            "time": "2016-12-05 13:00:57"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -1812,7 +1815,7 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
@@ -1869,7 +1872,7 @@
         },
         {
             "name": "symfony/debug-bundle",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug-bundle.git",
@@ -1930,16 +1933,16 @@
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "f74575e52dd28219221b083f57748dfbd096f615"
+                "reference": "9f61cdc9c20a6ab0dff256a0a503f75f37566b7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/f74575e52dd28219221b083f57748dfbd096f615",
-                "reference": "f74575e52dd28219221b083f57748dfbd096f615",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/9f61cdc9c20a6ab0dff256a0a503f75f37566b7d",
+                "reference": "9f61cdc9c20a6ab0dff256a0a503f75f37566b7d",
                 "shasum": ""
             },
             "require": {
@@ -1997,20 +2000,20 @@
             ],
             "description": "Symfony Doctrine Bridge",
             "homepage": "https://symfony.com",
-            "time": "2016-11-03 07:44:55"
+            "time": "2016-11-12 11:47:36"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "c70b0f453dace15f99cbbe9022e06d5e791c3c94"
+                "reference": "1a3ea988f1f64f60022515df77e2e1fa4feca0f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/c70b0f453dace15f99cbbe9022e06d5e791c3c94",
-                "reference": "c70b0f453dace15f99cbbe9022e06d5e791c3c94",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/1a3ea988f1f64f60022515df77e2e1fa4feca0f5",
+                "reference": "1a3ea988f1f64f60022515df77e2e1fa4feca0f5",
                 "shasum": ""
             },
             "require": {
@@ -2052,11 +2055,11 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-12 15:48:22"
+            "time": "2016-12-09 18:19:27"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -2116,7 +2119,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -2165,16 +2168,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "0e89934a55c762ed7aad55f707e946b82b7410e3"
+                "reference": "0c68dd978d58b5795c1b3349902cd29a4f8c5ce0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/0e89934a55c762ed7aad55f707e946b82b7410e3",
-                "reference": "0e89934a55c762ed7aad55f707e946b82b7410e3",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0c68dd978d58b5795c1b3349902cd29a4f8c5ce0",
+                "reference": "0c68dd978d58b5795c1b3349902cd29a4f8c5ce0",
                 "shasum": ""
             },
             "require": {
@@ -2210,20 +2213,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-03 07:44:55"
+            "time": "2016-12-03 05:31:03"
         },
         {
             "name": "symfony/form",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/form.git",
-                "reference": "1911cdc468e566338a79ce9d2968c13a1f34c8ff"
+                "reference": "527413c8e6ea7f4557a858f29fc9a6c351f8b3e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/form/zipball/1911cdc468e566338a79ce9d2968c13a1f34c8ff",
-                "reference": "1911cdc468e566338a79ce9d2968c13a1f34c8ff",
+                "url": "https://api.github.com/repos/symfony/form/zipball/527413c8e6ea7f4557a858f29fc9a6c351f8b3e9",
+                "reference": "527413c8e6ea7f4557a858f29fc9a6c351f8b3e9",
                 "shasum": ""
             },
             "require": {
@@ -2282,20 +2285,20 @@
             ],
             "description": "Symfony Form Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-18 20:26:45"
+            "time": "2016-12-03 11:33:29"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "444e5d19d61447f6f829c90a32aae73773f2777f"
+                "reference": "fd196b0dcd0f4359ecf92da34261f15b767c33e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/444e5d19d61447f6f829c90a32aae73773f2777f",
-                "reference": "444e5d19d61447f6f829c90a32aae73773f2777f",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/fd196b0dcd0f4359ecf92da34261f15b767c33e6",
+                "reference": "fd196b0dcd0f4359ecf92da34261f15b767c33e6",
                 "shasum": ""
             },
             "require": {
@@ -2338,20 +2341,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-13 17:41:36"
+            "time": "2016-11-25 22:28:18"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "6d60132735fc37d44fadc712bb3e94fd92664c11"
+                "reference": "b66719094190176f041229fcf5b758375cd3b8ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/6d60132735fc37d44fadc712bb3e94fd92664c11",
-                "reference": "6d60132735fc37d44fadc712bb3e94fd92664c11",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/b66719094190176f041229fcf5b758375cd3b8ff",
+                "reference": "b66719094190176f041229fcf5b758375cd3b8ff",
                 "shasum": ""
             },
             "require": {
@@ -2420,11 +2423,11 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-21 01:12:54"
+            "time": "2016-12-13 10:53:27"
         },
         {
             "name": "symfony/intl",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/intl.git",
@@ -2501,7 +2504,7 @@
         },
         {
             "name": "symfony/monolog-bridge",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bridge.git",
@@ -2561,7 +2564,7 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
@@ -2727,16 +2730,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "e134ba500a16bead3a059a087b652182f4f85481"
+                "reference": "7ac22a73485e6ae5bf8f072d01daf5563efe9b17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/e134ba500a16bead3a059a087b652182f4f85481",
-                "reference": "e134ba500a16bead3a059a087b652182f4f85481",
+                "url": "https://api.github.com/repos/symfony/process/zipball/7ac22a73485e6ae5bf8f072d01daf5563efe9b17",
+                "reference": "7ac22a73485e6ae5bf8f072d01daf5563efe9b17",
                 "shasum": ""
             },
             "require": {
@@ -2772,11 +2775,11 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-29 02:20:21"
+            "time": "2016-11-21 09:47:03"
         },
         {
             "name": "symfony/property-access",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
@@ -2836,16 +2839,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "c4509a70fdb18d63decd3c24c44734703ed5c7eb"
+                "reference": "aa5c9a9005560937bf6c504124616ad5b823732b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/c4509a70fdb18d63decd3c24c44734703ed5c7eb",
-                "reference": "c4509a70fdb18d63decd3c24c44734703ed5c7eb",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/aa5c9a9005560937bf6c504124616ad5b823732b",
+                "reference": "aa5c9a9005560937bf6c504124616ad5b823732b",
                 "shasum": ""
             },
             "require": {
@@ -2906,20 +2909,20 @@
                 "uri",
                 "url"
             ],
-            "time": "2016-08-16 10:55:04"
+            "time": "2016-11-25 12:07:11"
         },
         {
             "name": "symfony/security",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security.git",
-                "reference": "5540e02397e2ba5b792b4b0308b473c53a9d5574"
+                "reference": "457ab5ad8b4e2f4bb1db7ed3b967ce55f4e9a0ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security/zipball/5540e02397e2ba5b792b4b0308b473c53a9d5574",
-                "reference": "5540e02397e2ba5b792b4b0308b473c53a9d5574",
+                "url": "https://api.github.com/repos/symfony/security/zipball/457ab5ad8b4e2f4bb1db7ed3b967ce55f4e9a0ae",
+                "reference": "457ab5ad8b4e2f4bb1db7ed3b967ce55f4e9a0ae",
                 "shasum": ""
             },
             "require": {
@@ -2986,11 +2989,11 @@
             ],
             "description": "Symfony Security Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-13 17:41:36"
+            "time": "2016-12-06 20:51:50"
         },
         {
             "name": "symfony/serializer",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
@@ -3053,7 +3056,7 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -3102,7 +3105,7 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
@@ -3165,16 +3168,16 @@
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "dc7473d135525c1115c801181459d7a1d0f3e440"
+                "reference": "c21991684d8f8dfa202cc7726baf8097f7c1734f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/dc7473d135525c1115c801181459d7a1d0f3e440",
-                "reference": "dc7473d135525c1115c801181459d7a1d0f3e440",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/c21991684d8f8dfa202cc7726baf8097f7c1734f",
+                "reference": "c21991684d8f8dfa202cc7726baf8097f7c1734f",
                 "shasum": ""
             },
             "require": {
@@ -3242,20 +3245,20 @@
             ],
             "description": "Symfony Twig Bridge",
             "homepage": "https://symfony.com",
-            "time": "2016-11-14 08:34:35"
+            "time": "2016-12-08 14:02:33"
         },
         {
             "name": "symfony/validator",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "4fd332ff7c756d15cd625f184ea50eb716a66d89"
+                "reference": "1383bea7281e86cc8a17a605dc7ade4da8078a24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/4fd332ff7c756d15cd625f184ea50eb716a66d89",
-                "reference": "4fd332ff7c756d15cd625f184ea50eb716a66d89",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/1383bea7281e86cc8a17a605dc7ade4da8078a24",
+                "reference": "1383bea7281e86cc8a17a605dc7ade4da8078a24",
                 "shasum": ""
             },
             "require": {
@@ -3315,20 +3318,20 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-18 20:46:21"
+            "time": "2016-12-08 12:07:24"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "46559c72e68f4660ab964d2dae58001b957ca276"
+                "reference": "4e9c25651634cfc22474327fa49af5a4997c3438"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/46559c72e68f4660ab964d2dae58001b957ca276",
-                "reference": "46559c72e68f4660ab964d2dae58001b957ca276",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/4e9c25651634cfc22474327fa49af5a4997c3438",
+                "reference": "4e9c25651634cfc22474327fa49af5a4997c3438",
                 "shasum": ""
             },
             "require": {
@@ -3374,27 +3377,28 @@
                 "debug",
                 "dump"
             ],
-            "time": "2016-11-03 07:44:53"
+            "time": "2016-12-06 16:03:37"
         },
         {
             "name": "symfony/web-profiler-bundle",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/web-profiler-bundle.git",
-                "reference": "f9c825e2cabb0380ab9d4a237e9b64bd6c12df22"
+                "reference": "5099c1a82ab8606ccdef7809f808aac9cbbde667"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/f9c825e2cabb0380ab9d4a237e9b64bd6c12df22",
-                "reference": "f9c825e2cabb0380ab9d4a237e9b64bd6c12df22",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/5099c1a82ab8606ccdef7809f808aac9cbbde667",
+                "reference": "5099c1a82ab8606ccdef7809f808aac9cbbde667",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
                 "symfony/http-kernel": "~2.4",
                 "symfony/routing": "~2.2",
-                "symfony/twig-bridge": "~2.7"
+                "symfony/twig-bridge": "~2.7",
+                "twig/twig": "~1.28|~2.0"
             },
             "require-dev": {
                 "symfony/config": "~2.2",
@@ -3432,11 +3436,11 @@
             ],
             "description": "Symfony WebProfilerBundle",
             "homepage": "https://symfony.com",
-            "time": "2016-11-12 17:04:32"
+            "time": "2016-12-09 07:33:13"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
@@ -4764,7 +4768,7 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v2.7.21",
+            "version": "v2.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",

--- a/composer.lock
+++ b/composer.lock
@@ -3489,16 +3489,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.28.2",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "b22ce0eb070e41f7cba65d78fe216de29726459c"
+                "reference": "74f723e542368ca2080b252740be5f1113ebb898"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/b22ce0eb070e41f7cba65d78fe216de29726459c",
-                "reference": "b22ce0eb070e41f7cba65d78fe216de29726459c",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/74f723e542368ca2080b252740be5f1113ebb898",
+                "reference": "74f723e542368ca2080b252740be5f1113ebb898",
                 "shasum": ""
             },
             "require": {
@@ -3511,7 +3511,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.28-dev"
+                    "dev-master": "1.29-dev"
                 }
             },
             "autoload": {
@@ -3546,7 +3546,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-11-23 18:41:40"
+            "time": "2016-12-13 17:28:18"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.0.3",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "5df9ed0ed0c9506ea6404a23450854e5df15cc12"
+                "reference": "a795611394b3c05164fd0eb291b492b39339cba4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/5df9ed0ed0c9506ea6404a23450854e5df15cc12",
-                "reference": "5df9ed0ed0c9506ea6404a23450854e5df15cc12",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/a795611394b3c05164fd0eb291b492b39339cba4",
+                "reference": "a795611394b3c05164fd0eb291b492b39339cba4",
                 "shasum": ""
             },
             "require": {
@@ -27,6 +27,7 @@
                 "php": "^5.3.2 || ^7.0"
             },
             "require-dev": {
+                "psr/log": "^1.0",
                 "symfony/process": "^2.5 || ^3.0"
             },
             "suggest": {
@@ -62,7 +63,7 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2016-07-18 23:07:53"
+            "time": "2016-11-02 18:11:27"
         },
         {
             "name": "dflydev/doctrine-orm-service-provider",
@@ -968,16 +969,16 @@
         },
         {
             "name": "knplabs/knp-components",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/knp-components.git",
-                "reference": "bc49e739d1cce94d783b1e23bc5b263b38dc47da"
+                "reference": "f98bcc6d348fbe863a224b468e11fb5e91e28f2a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/knp-components/zipball/bc49e739d1cce94d783b1e23bc5b263b38dc47da",
-                "reference": "bc49e739d1cce94d783b1e23bc5b263b38dc47da",
+                "url": "https://api.github.com/repos/KnpLabs/knp-components/zipball/f98bcc6d348fbe863a224b468e11fb5e91e28f2a",
+                "reference": "f98bcc6d348fbe863a224b468e11fb5e91e28f2a",
                 "shasum": ""
             },
             "require": {
@@ -1035,7 +1036,7 @@
                 "pager",
                 "paginator"
             ],
-            "time": "2016-04-21 06:26:20"
+            "time": "2016-12-06 18:10:24"
         },
         {
             "name": "monolog/monolog",
@@ -3606,16 +3607,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v1.12.4",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "c5a9d66dd27f02a3ffba4ec451ce27702604cdc8"
+                "reference": "0ea4f7ed06ca55da1d8fc45da26ff87f261c4088"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/c5a9d66dd27f02a3ffba4ec451ce27702604cdc8",
-                "reference": "c5a9d66dd27f02a3ffba4ec451ce27702604cdc8",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/0ea4f7ed06ca55da1d8fc45da26ff87f261c4088",
+                "reference": "0ea4f7ed06ca55da1d8fc45da26ff87f261c4088",
                 "shasum": ""
             },
             "require": {
@@ -3660,7 +3661,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-11-15 09:10:47"
+            "time": "2016-12-01 00:05:05"
         },
         {
             "name": "fzaninotto/faker",
@@ -4029,16 +4030,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -4072,7 +4073,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4c552581dc592f3b060ce487ac1dca05",
-    "content-hash": "a602041b10233704ddd5cb2ecc724339",
+    "hash": "5ae430035a8af594a3b60addd579f535",
+    "content-hash": "929561db408877892cf5faba409177f6",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -4833,7 +4833,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
         "ext-mbstring": "*"
     },
     "platform-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -1040,16 +1040,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.21.0",
+            "version": "1.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "f42fbdfd53e306bda545845e4dbfd3e72edb4952"
+                "reference": "bad29cb8d18ab0315e6c477751418a82c850d558"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f42fbdfd53e306bda545845e4dbfd3e72edb4952",
-                "reference": "f42fbdfd53e306bda545845e4dbfd3e72edb4952",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bad29cb8d18ab0315e6c477751418a82c850d558",
+                "reference": "bad29cb8d18ab0315e6c477751418a82c850d558",
                 "shasum": ""
             },
             "require": {
@@ -1060,7 +1060,7 @@
                 "psr/log-implementation": "1.0.0"
             },
             "require-dev": {
-                "aws/aws-sdk-php": "^2.4.9",
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
                 "doctrine/couchdb": "~1.0@dev",
                 "graylog2/gelf-php": "~1.0",
                 "jakub-onderka/php-parallel-lint": "0.9",
@@ -1114,7 +1114,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2016-07-29 03:23:52"
+            "time": "2016-11-26 00:15:39"
         },
         {
             "name": "nesbot/carbon",


### PR DESCRIPTION
symfony及びその他ライブラリの更新

Symfony 2.7.22 released
http://symfony.com/blog/symfony-2-7-22-released

- symfony/*
  - Updating symfony/* (v2.7.21) to symfony/* (v2.7.22)
- twig/twig
  - Updating twig/twig (v1.28.2) to twig/twig (v1.30.0)
- swiftmailer/swiftmailer
  - Updating swiftmailer/swiftmailer (v5.4.4) to swiftmailer/swiftmailer (v5.4.5)
- others
  - Updating composer/ca-bundle (1.0.3) to composer/ca-bundle (1.0.6)
  - Updating knplabs/knp-components (1.3.3) to knplabs/knp-components (1.3.4)
  - Updating friendsofphp/php-cs-fixer (v1.12.4) to friendsofphp/php-cs-fixer (v1.13.1)
- 備考
  - fzaninotto/faker v1.6.0は https://github.com/fzaninotto/Faker/pull/917 の不具合があるので見送り