### PR TITLE
カバレッジ出力のテストが失敗するのを修正

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,7 @@
           <directory suffix=".php">./src/Eccube/</directory>
           <exclude>
             <directory suffix=".php">./src/Eccube/Resource</directory>
+            <directory suffix=".php">./src/Eccube/Command/PluginCommand/Resource</directory>
           </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
- テストの雛形をテスト対象から除外
