### PR TITLE
appveyor：phpのインストールに失敗する問題を対応

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ install:
   #- cinst mysql
   #- SET PATH=C:\tools\mysql\current\bin\;%PATH%
   # Set PHP.
-  - cinst php --version 7.0.9
+  - cinst php --version 7.0.9 --allow-empty-checksums
   - SET PATH=C:\tools\php\;%PATH%
   - copy C:\tools\php\php.ini-production C:\tools\php\php.ini
   - echo date.timezone="Asia/Tokyo" >> C:\tools\php\php.ini


### PR DESCRIPTION
appveyorでphpのインストールに失敗するため、取り急ぎ`--allow-empty-checksums`で対応.
以下エラーログです。
```
Download of php-7.0.9-nts-Win32-VC14-x64.zip (22.84 MB) completed.
WARNING: Missing package checksums are not allowed (by default for HTTP/FTP, 
 HTTPS when feature 'allowEmptyChecksumsSecure' is disabled) for 
 safety and security reasons. Although we strongly advise against it, 
 if you need this functionality, please set the feature 
 'allowEmptyChecksums' ('choco feature enable -n 
 allowEmptyChecksums') 
 or pass in the option '--allow-empty-checksums'. You can also pass 
 checksums at runtime (recommended). See choco install -? for details.
The integrity of the file 'php-7.0.9-nts-Win32-VC14-x64.zip' from 'http://windows.php.net/downloads/releases/archives/php-7.0.9-nts-Win32-VC14-x64.zip' has not been verified by a checksum in the package scripts.
Do you wish to allow the install to continue (not recommended)?
[Y] Yes [N] No (default is "N")
  Confirmation (`-y`) is set.
  Respond within 30 seconds or the default selection will be chosen.
ERROR: Empty checksums are no longer allowed by default for non-secure sources. Please ask the maintainer to add checksums to this package. In the meantime if you need this package to work correctly, please enable the feature allowEmptyChecksums, provide the runtime switch '--allow-empty-checksums', or pass in checksums at runtime (recommended - see 'choco install -?' / 'choco upgrade -?' for details). It is strongly advised against allowing empty checksums for non-internal HTTP/FTP sources.
```