### PR TITLE
デバッグ出力の修正

### DIFF
--- a/src/Eccube/ServiceProvider/DebugServiceProvider.php
+++ b/src/Eccube/ServiceProvider/DebugServiceProvider.php
@@ -123,8 +123,15 @@ class DebugServiceProvider implements ServiceProviderInterface
         // configuration for CLI mode is overridden in HTTP mode on
         // 'kernel.request' event
         VarDumper::setHandler(function ($var) use ($app) {
-            $dumper = new CliDumper();
-            $dumper->dump($app['var_dumper.cloner']->cloneVar($var));
+            $dumper = $app['data_collector.dump'];
+            $cloner = $app['var_dumper.cloner'];
+
+            $handler = function ($var) use ($dumper, $cloner) {
+                $dumper->dump($cloner->cloneVar($var));
+            };
+
+            VarDumper::setHandler($handler);
+            $handler($var);
         });
 
         $app['dispatcher']->addSubscriber(new DumpListener($app['var_dumper.cloner'], $app['data_collector.dump']));

--- a/src/Eccube/ServiceProvider/DebugServiceProvider.php
+++ b/src/Eccube/ServiceProvider/DebugServiceProvider.php
@@ -32,6 +32,7 @@ use Symfony\Component\HttpKernel\DataCollector\DumpDataCollector;
 use Symfony\Component\HttpKernel\EventListener\DumpListener;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use Symfony\Component\VarDumper\VarDumper;
 
 /**
@@ -85,7 +86,7 @@ class DebugServiceProvider implements ServiceProviderInterface
         }));
 
         $app['data_collector.dump'] = $app->share(function ($app) {
-            return new DumpDataCollector($app['stopwatch'], $app['code.file_link_format']);
+            return new DumpDataCollector($app['stopwatch'], $app['code.file_link_format'], null, null, new HtmlDumper());
         });
 
         $app['data_collectors'] = $app->share($app->extend('data_collectors', function ($collectors, $app) {


### PR DESCRIPTION
#1853 

- ツールバーに表示するため、VarDumper::setHandlerの設定をDebugBuldleに合わせる
  - https://github.com/symfony/debug-bundle/blob/master/DebugBundle.php#L32
- 画面上の表示がCliDumperになっているようなので、DumpDataCollectorにHtmlDumperを渡すように修正