### PR TITLE
不要と思われるアノテーションを削除

### DIFF
--- a/src/Eccube/Entity/Customer.php
+++ b/src/Eccube/Entity/Customer.php
@@ -32,8 +32,6 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 /**
  * Customer
- *
- *  @UniqueEntity("email")
  */
 class Customer extends \Eccube\Entity\AbstractEntity implements UserInterface
 {


### PR DESCRIPTION
`UniqueEntity` クラスは `loadValidatorMetadata()` で使用しているが、アノテーション自体は使用していないと思われる。