### PR TITLE
Web\Admin\Order\EditControllerTest が時折失敗するのを修正

### DIFF
--- a/tests/Eccube/Tests/Web/Admin/Order/AbstractEditControllerTestCase.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/AbstractEditControllerTestCase.php
@@ -38,7 +38,7 @@ abstract class AbstractEditControllerTestCase extends AbstractAdminWebTestCase
                 'Product' => $Product->getId(),
                 'ProductClass' => $ProductClasses[0]->getId(),
                 'price' => $ProductClasses[0]->getPrice02(),
-                'quantity' => $faker->randomNumber(2),
+                'quantity' => $faker->numberBetween(1, 999),
                 'tax_rate' => 8, // XXX ハードコーディング
                 'tax_rule' => 1,
                 'product_name' => $Product->getName(),


### PR DESCRIPTION
`Faker::randomNumber()` だと、数量が 0 になる場合があり、 **商品が選択されていません** というエラーになる