### PR TITLE
SSLを強制した状態で、httpのURLでログイン画面にアクセスした場合ログインが行えない現象に対応

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -555,13 +555,19 @@ class Application extends ApplicationTrait
             ),
         );
 
+        $channel = null;
+        // 強制SSL
+        if ($this['config']['force_ssl'] == \Eccube\Common\Constant::ENABLED) {
+            $channel = "https";
+        }
+
         $this['security.access_rules'] = array(
-            array("^/{$this['config']['admin_route']}/login", 'IS_AUTHENTICATED_ANONYMOUSLY'),
-            array("^/{$this['config']['admin_route']}/", 'ROLE_ADMIN'),
-            array('^/mypage/login', 'IS_AUTHENTICATED_ANONYMOUSLY'),
-            array('^/mypage/withdraw_complete', 'IS_AUTHENTICATED_ANONYMOUSLY'),
-            array('^/mypage/change', 'IS_AUTHENTICATED_FULLY'),
-            array('^/mypage', 'ROLE_USER'),
+            array("^/{$this['config']['admin_route']}/login", 'IS_AUTHENTICATED_ANONYMOUSLY', $channel),
+            array("^/{$this['config']['admin_route']}/", 'ROLE_ADMIN', $channel),
+            array('^/mypage/login', 'IS_AUTHENTICATED_ANONYMOUSLY', $channel),
+            array('^/mypage/withdraw_complete', 'IS_AUTHENTICATED_ANONYMOUSLY', $channel),
+            array('^/mypage/change', 'IS_AUTHENTICATED_FULLY', $channel),
+            array('^/mypage', 'ROLE_USER', $channel),
         );
 
         $this['eccube.password_encoder'] = $this->share(function ($app) {


### PR DESCRIPTION
ref #2011
SSLを強制した状態で、httpのURLでログイン画面にアクセスした場合ログインが行えない。
に対応