### PR TITLE
Admin\Content\FileController::create(), upload() の HTTP メソッドチェック追加

### DIFF
--- a/src/Eccube/Controller/Admin/Content/FileController.php
+++ b/src/Eccube/Controller/Admin/Content/FileController.php
@@ -144,8 +144,6 @@ class FileController extends AbstractController
                 $fs->mkdir($nowDir . '/' . $filename);
             }
         }
-
-        return $app->redirect($app->url('admin_content_file'));
     }
 
     public function delete(Application $app, Request $request)

--- a/src/Eccube/Controller/Admin/Content/FileController.php
+++ b/src/Eccube/Controller/Admin/Content/FileController.php
@@ -67,15 +67,17 @@ class FileController extends AbstractController
         $isTopDir = ($topDir === $nowDir);
         $parentDir = substr($nowDir, 0, strrpos($nowDir, '/'));
 
-        switch ($request->get('mode')) {
-            case 'create':
-                $this->create($app, $request);
-                break;
-            case 'upload':
-                $this->upload($app, $request);
-                break;
-            default:
-                break;
+        if ('POST' === $request->getMethod()) {
+            switch ($request->get('mode')) {
+                case 'create':
+                    $this->create($app, $request);
+                    break;
+                case 'upload':
+                    $this->upload($app, $request);
+                    break;
+                default:
+                    break;
+            }
         }
 
         $tree = $this->getTree($topDir, $request);


### PR DESCRIPTION
■Admin\Content\FileController::create(), upload() の HTTP メソッドチェック #1415 
https://github.com/EC-CUBE/ec-cube/issues/1415
修正内容：
リクエストのチェックを追加しました、
POSTのみの時だけcreate()とupload()メソッドを実行する

■Admin\Content\FileController::create() の返り値 #1414
https://github.com/EC-CUBE/ec-cube/issues/1414
修正内容：
create()メソッドの返り値変更（void）