### PR TITLE
MailTemplateRepository の member_id がベタ書き対応

### DIFF
--- a/src/Eccube/Repository/MailTemplateRepository.php
+++ b/src/Eccube/Repository/MailTemplateRepository.php
@@ -38,15 +38,8 @@ class MailTemplateRepository extends EntityRepository
     public function findOrCreate($id)
     {
         if ($id == 0) {
-            $Creator = $this
-                ->getEntityManager()
-                ->getRepository('\Eccube\Entity\Member')
-                ->findOneBy(array(), array('rank' => 'ASC'));
-
             $MailTemplate = new \Eccube\Entity\MailTemplate();
-            $MailTemplate
-                ->setDelFlg(Constant::DISABLED)
-                ->setCreator($Creator);
+            $MailTemplate->setDelFlg(Constant::DISABLED);
         } else {
             $MailTemplate = $this->find($id);
 

--- a/src/Eccube/Repository/MailTemplateRepository.php
+++ b/src/Eccube/Repository/MailTemplateRepository.php
@@ -35,15 +35,13 @@ use Eccube\Common\Constant;
  */
 class MailTemplateRepository extends EntityRepository
 {
-    public function findOrCreate($id, $Creator = null)
+    public function findOrCreate($id)
     {
         if ($id == 0) {
-            if ($Creator == null) {
-                $Creator = $this
-                    ->getEntityManager()
-                    ->getRepository('\Eccube\Entity\Member')
-                    ->findOneBy(array(), array('rank' => 'ASC'));
-            }
+            $Creator = $this
+                ->getEntityManager()
+                ->getRepository('\Eccube\Entity\Member')
+                ->findOneBy(array(), array('rank' => 'ASC'));
 
             $MailTemplate = new \Eccube\Entity\MailTemplate();
             $MailTemplate

--- a/src/Eccube/Repository/MailTemplateRepository.php
+++ b/src/Eccube/Repository/MailTemplateRepository.php
@@ -25,6 +25,7 @@
 namespace Eccube\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Eccube\Common\Constant;
 
 /**
  * MailTemplateRepository
@@ -34,20 +35,20 @@ use Doctrine\ORM\EntityRepository;
  */
 class MailTemplateRepository extends EntityRepository
 {
-    public function findOrCreate($id)
+    public function findOrCreate($id, $Creator = null)
     {
         if ($id == 0) {
-            $Creator = $this
-                ->getEntityManager()
-                ->getRepository('\Eccube\Entity\Member')
-                ->find(2);
+            if ($Creator == null) {
+                $Creator = $this
+                    ->getEntityManager()
+                    ->getRepository('\Eccube\Entity\Member')
+                    ->findOneBy(array(), array('rank' => 'ASC'));
+            }
 
             $MailTemplate = new \Eccube\Entity\MailTemplate();
             $MailTemplate
-                ->setDelFlg(0)
-                ->setCreator($Creator)
-            ;
-
+                ->setDelFlg(Constant::DISABLED)
+                ->setCreator($Creator);
         } else {
             $MailTemplate = $this->find($id);
 


### PR DESCRIPTION
MailTemplateRepository の member_id がベタ書き対応
https://github.com/EC-CUBE/ec-cube/issues/894

修正内容：
クラス｛MailTemplateRepository｝のメッソド｛findOrCreate｝変更しました。
Member引数で渡すようにしました、Member渡してなかった場合はいままでとおなじ自動的に取得する、ただベタ書きではなくって｛rankのASC｝レーコドを取得する
