### PR TITLE
Exceptionのメッセージが表示されない

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -149,19 +149,30 @@ class Application extends ApplicationTrait
                 return;
             }
 
-            switch ($code) {
-                case 403:
-                    $title = 'アクセスできません。';
-                    $message = 'お探しのページはアクセスができない状況にあるか、移動もしくは削除された可能性があります。';
-                    break;
-                case 404:
-                    $title = 'ページがみつかりません。';
-                    $message = 'URLに間違いがないかご確認ください。';
-                    break;
-                default:
-                    $title = 'システムエラーが発生しました。';
-                    $message = '大変お手数ですが、サイト管理者までご連絡ください。';
-                    break;
+            $title = 'システムエラーが発生しました。';
+            $message = '大変お手数ですが、サイト管理者までご連絡ください。';
+            if ($e instanceof \Symfony\Component\HttpKernel\Exception\HttpException) {
+                switch ($code)
+                {
+                    case 400:
+                    case 401:
+                    case 403:
+                    case 405:
+                    case 406:
+                        $title = 'アクセスできません。';
+                        if ($e->getMessage()) {
+                            $message = $e->getMessage();
+                        } else {
+                            $message = 'お探しのページはアクセスができない状況にあるか、移動もしくは削除された可能性があります。';
+                        }
+                        break;
+                    case 404:
+                        $title = 'ページがみつかりません。';
+                        $message = 'URLに間違いがないかご確認ください。';
+                        break;
+                    default:
+                        break;
+                }
             }
 
             return $app->render('error.twig', array(

--- a/src/Eccube/Controller/EntryController.php
+++ b/src/Eccube/Controller/EntryController.php
@@ -184,7 +184,7 @@ class EntryController extends AbstractController
                 $Customer = $app['eccube.repository.customer']
                     ->getNonActiveCustomerBySecretKey($secret_key);
             } catch (\Exception $e) {
-                throw new HttpException\NotFoundHttpException('※ 既に会員登録が完了しているか、無効なURLです。');
+                throw new HttpException\AccessDeniedHttpException('既に会員登録が完了しているか、無効なURLです。');
             }
 
             $CustomerStatus = $app['eccube.repository.customer_status']->find(CustomerStatus::ACTIVE);

--- a/tests/Eccube/Tests/Web/EntryControllerTest.php
+++ b/tests/Eccube/Tests/Web/EntryControllerTest.php
@@ -225,13 +225,13 @@ class EntryControllerTest extends AbstractWebTestCase
     {
         // debugはONの時に404ページ表示しない例外になります。
         if($this->app['debug'] == true){
-            $this->setExpectedException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+            $this->setExpectedException('\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException');
         }
         $client = $this->createClient();
         $crawler = $client->request('GET', $this->app['url_generator']->generate('entry_activate', array('secret_key' => 'aaaaa')));
         // debugはOFFの時に404ページが表示します。
         if($this->app['debug'] == false){
-            $this->expected = 404;
+            $this->expected = 403;
             $this->actual = $client->getResponse()->getStatusCode();
             $this->verify();
         }


### PR DESCRIPTION
HttpException\NotFoundHttpException のエラーメッセージが表示されない
https://github.com/EC-CUBE/ec-cube/issues/739
■問題：
例外に設定したメッセージはどこも表示してない、設定意味ｈありませんみたいです。
Eccube\Applicationですべての固定メッセージ反映されます。
https://github.com/EC-CUBE/ec-cube/blob/master/src/Eccube/Application.php#L152-L163

■意見１
メッセージを反映されないように例外メッセージ表示ロッジク修正いります
例外スローされたときにメッセージあった場合はそのメッセージページで表示する、
例外スローされたときにメッセージ設定してない場合はデフォルトメッセージを表示する

そのロッジクは今のPRに実装されてます

■意見２
NotFoundHttpException場合は404ページ表示します、これはページがないのでメッセージは固定問題ないと思います、
たまにコンテンツがないとき404ページ表示します、こちらはパッケジによって違います、ページありますがコンテンツがないとき404ではないと思います。
こちらは分かりませんのでおまかせします。

■意見３
現在は*HttpExceptionスロー数は100ぐらいありますので

■意見４
セキュリティのために*HttpExceptionのみメッセージのみ反映可能ですこれ以外は固定なメッセージを使う

■WIP
パスワードリセット画面対応しましたがこの対応方法はただしかどうか教えてください。
