### PR TITLE
プラグイン一覧のソート順をnameからcodeに変更

### DIFF
--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -52,7 +52,7 @@ class PluginController extends AbstractController
         $pluginForms = array();
         $configPages = array();
 
-        $Plugins = $app['eccube.repository.plugin']->findBy(array(), array('name' => 'ASC'));
+        $Plugins = $app['eccube.repository.plugin']->findBy(array(), array('code' => 'ASC'));
 
         // ファイル設置プラグインの取得.
         $unregisterdPlugins = $this->getUnregisteredPlugins($Plugins, $app);


### PR DESCRIPTION
PostgreSQL場合はdtb_plugin.name でソートすると表示順正しくないです。
PostgreSQLのLC_COLLATE「ja_JP.UTF-8」の時だけ正しくないみたい
詳しくはこちらです
http://soudai1025.blogspot.jp/2015/08/mysqlpostgresql.html

PostgreSQL と MySQL でプラグイン一覧のソート順が異なる 
https://github.com/EC-CUBE/ec-cube/issues/1933

結果は同じなるようにソートのカラム変更しました「name -> code」
