### PR TITLE
商品マスターで、在庫なしで絞り込まれた一覧でCSVダウンロードを行うように修正 #1887

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ install:
   #- cinst mysql
   #- SET PATH=C:\tools\mysql\current\bin\;%PATH%
   # Set PHP.
-  - cinst php --version 7.0.9
+  - cinst php --version 7.0.9 --allow-empty-checksums
   - SET PATH=C:\tools\php\;%PATH%
   - copy C:\tools\php\php.ini-production C:\tools\php\php.ini
   - echo date.timezone="Asia/Tokyo" >> C:\tools\php\php.ini

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -216,7 +216,7 @@ $(function() {
                                     <li id="result_list__csv_menu" class="dropdown">
                                         <a class="dropdown-toggle" data-toggle="dropdown">CSVダウンロード<svg class="cb cb-angle-down icon_down"><use xlink:href="#cb-angle-down"></svg></a>
                                         <ul class="dropdown-menu">
-                                            <li><a href="{{ url('admin_product_export', { 'status' : page_status}) }}">CSVダウンロード</a></li>
+                                            <li><a href="{{ url('admin_product_export', {'status' : page_status}) }}">CSVダウンロード</a></li>
                                             <li><a href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_PRODUCT') }) }}">出力項目設定</a></li>
                                         </ul>
                                     </li>

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -216,7 +216,7 @@ $(function() {
                                     <li id="result_list__csv_menu" class="dropdown">
                                         <a class="dropdown-toggle" data-toggle="dropdown">CSVダウンロード<svg class="cb cb-angle-down icon_down"><use xlink:href="#cb-angle-down"></svg></a>
                                         <ul class="dropdown-menu">
-                                            <li><a href="{{ url('admin_product_export') }}">CSVダウンロード</a></li>
+                                            <li><a href="{{ url('admin_product_export', { 'status' : page_status}) }}">CSVダウンロード</a></li>
                                             <li><a href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_PRODUCT') }) }}">出力項目設定</a></li>
                                         </ul>
                                     </li>

--- a/src/Eccube/Service/CsvExportService.php
+++ b/src/Eccube/Service/CsvExportService.php
@@ -410,7 +410,16 @@ class CsvExportService
         } else {
             $searchData = array();
         }
-
+        //商品マスターで在庫なしを選択後にCSVダウンロードをすると在庫なし以外の商品も含まれる
+        $status = $request->get('status');
+        if ($status) {
+            if ($status != $this->config['admin_product_stock_status']) {
+                $em = $this->getEntityManager();
+                $searchData['link_status'] = $em->getRepository('\Eccube\Entity\Master\Disp')->find($status);
+            } else {
+                $searchData['stock_status'] = Constant::DISABLED;
+            }
+        }
         // 商品データのクエリビルダを構築.
         $qb = $this->productRepository
             ->getQueryBuilderBySearchDataForAdmin($searchData);


### PR DESCRIPTION
商品マスターで在庫なしを選択後にCSVダウンロードをすると在庫なし以外の商品も含まれる
在庫なしを選択したら絞り込まれた商品でCSVダウンロードを行う。