### PR TITLE
入力項目（単位：金額）で、カンマありで登録すると、エラーとならず、途中（カンマまで）までしか登録されない対応

### DIFF
--- a/src/Eccube/Form/Type/Admin/DeliveryType.php
+++ b/src/Eccube/Form/Type/Admin/DeliveryType.php
@@ -96,6 +96,8 @@ class DeliveryType extends AbstractType
                 'label' => false,
                 'currency' => 'JPY',
                 'precision' => 0,
+                'scale' => 0,
+                'grouping' => true,
                 'required' => false,
                 'mapped' => false
             ))

--- a/src/Eccube/Form/Type/Admin/OrderDetailType.php
+++ b/src/Eccube/Form/Type/Admin/OrderDetailType.php
@@ -57,6 +57,8 @@ class OrderDetailType extends AbstractType
             ->add('price', 'money', array(
                 'currency' => 'JPY',
                 'precision' => 0,
+                'scale' => 0,
+                'grouping' => true,
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Length(array(

--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -154,6 +154,8 @@ class OrderType extends AbstractType
                 'label' => '値引き',
                 'currency' => 'JPY',
                 'precision' => 0,
+                'scale' => 0,
+                'grouping' => true,
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Length(array(
@@ -165,6 +167,8 @@ class OrderType extends AbstractType
                 'label' => '送料',
                 'currency' => 'JPY',
                 'precision' => 0,
+                'scale' => 0,
+                'grouping' => true,
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Length(array(
@@ -176,6 +180,8 @@ class OrderType extends AbstractType
                 'label' => '手数料',
                 'currency' => 'JPY',
                 'precision' => 0,
+                'scale' => 0,
+                'grouping' => true,
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Length(array(

--- a/src/Eccube/Form/Type/Admin/PaymentRegisterType.php
+++ b/src/Eccube/Form/Type/Admin/PaymentRegisterType.php
@@ -60,6 +60,8 @@ class PaymentRegisterType extends AbstractType
                 'label' => false,
                 'currency' => 'JPY',
                 'precision' => 0,
+                'scale' => 0,
+                'grouping' => true,
                 'constraints' => array(
                     new Assert\Length(array(
                         'max' => $app['config']['int_len'],
@@ -74,6 +76,8 @@ class PaymentRegisterType extends AbstractType
                 'label' => false,
                 'currency' => 'JPY',
                 'precision' => 0,
+                'scale' => 0,
+                'grouping' => true,
                 'required' => false,
                 'constraints' => array(
                     new Assert\Length(array(
@@ -112,6 +116,8 @@ class PaymentRegisterType extends AbstractType
                         'label' => '手数料',
                         'currency' => 'JPY',
                         'precision' => 0,
+                        'scale' => 0,
+                        'grouping' => true,
                         'constraints' => array(
                             new Assert\NotBlank(),
                             new Assert\Length(array(

--- a/src/Eccube/Form/Type/Admin/ProductClassType.php
+++ b/src/Eccube/Form/Type/Admin/ProductClassType.php
@@ -81,6 +81,8 @@ class ProductClassType extends AbstractType
                 'label' => '通常価格',
                 'currency' => 'JPY',
                 'precision' => 0,
+                'scale' => 0,
+                'grouping' => true,
                 'required' => false,
                 'constraints' => array(
                     new Assert\Length(array(
@@ -96,6 +98,8 @@ class ProductClassType extends AbstractType
                 'label' => '販売価格',
                 'currency' => 'JPY',
                 'precision' => 0,
+                'scale' => 0,
+                'grouping' => true,
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Length(array(
@@ -122,6 +126,8 @@ class ProductClassType extends AbstractType
                 'label' => '商品送料',
                 'currency' => 'JPY',
                 'precision' => 0,
+                'scale' => 0,
+                'grouping' => true,
                 'required' => false,
                 'constraints' => array(
                     new Assert\Regex(array(

--- a/src/Eccube/Form/Type/Admin/ShipmentItemType.php
+++ b/src/Eccube/Form/Type/Admin/ShipmentItemType.php
@@ -57,6 +57,8 @@ class ShipmentItemType extends AbstractType
             ->add('price', 'money', array(
                 'currency' => 'JPY',
                 'precision' => 0,
+                'scale' => 0,
+                'grouping' => true,
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Length(array(

--- a/src/Eccube/Form/Type/Admin/ShopMasterType.php
+++ b/src/Eccube/Form/Type/Admin/ShopMasterType.php
@@ -153,6 +153,8 @@ class ShopMasterType extends AbstractType
                 'required' => false,
                 'currency' => 'JPY',
                 'precision' => 0,
+                'scale' => 0,
+                'grouping' => true,
                 'constraints' => array(
                     new Assert\Length(array(
                         'max' => $config['price_len'],

--- a/src/Eccube/Form/Type/PriceType.php
+++ b/src/Eccube/Form/Type/PriceType.php
@@ -57,6 +57,8 @@ class PriceType extends AbstractType
         $resolver->setDefaults(array(
             'currency' => 'JPY',
             'precision' => 0,
+            'scale' => 0,
+            'grouping' => true,
             'constraints' => $constraints,
             'invalid_message' => 'form.type.numeric.invalid'
         ));

--- a/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
@@ -37,6 +37,17 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
     public function createCsvAsArray($has_header = true)
     {
         $faker = $this->getFaker();
+
+        $price01 = $faker->randomNumber(5);
+        if (mt_rand(0, 1)) {
+            $price01 = number_format($price01);
+        }
+
+        $price02 = $faker->randomNumber(5);
+        if (mt_rand(0, 1)) {
+            $price02 = number_format($price02);
+        }
+
         $csv = array(
             '商品ID' => null,
             '公開ステータス(ID)' => 1,
@@ -58,8 +69,8 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
             '在庫数' => 100,
             '在庫数無制限フラグ' => 0,
             '販売制限数' => null,
-            '通常価格' => $faker->randomNumber(5),
-            '販売価格' => $faker->randomNumber(5),
+            '通常価格' => $price01,
+            '販売価格' => $price02,
             '送料' => 0,
             '商品規格削除フラグ' => 0
         );

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductClassControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductClassControllerTest.php
@@ -44,6 +44,7 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
         $app = $this->app;
         $Product = $this->createProduct();
 
+
         // Main
         $redirectUrl = $app->url('admin_product_product_class', array('id' => $Product->getId()));
         $this->client->request(

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
@@ -34,11 +34,22 @@ class ProductControllerTest extends AbstractAdminWebTestCase
     public function createFormData()
     {
         $faker = $this->getFaker();
+
+        $price01 = $faker->randomNumber(5);
+        if (mt_rand(0, 1)) {
+            $price01 = number_format($price01);
+        }
+
+        $price02 = $faker->randomNumber(5);
+        if (mt_rand(0, 1)) {
+            $price02 = number_format($price02);
+        }
+
         $form = array(
             'class' => array(
                 'product_type' => 1,
-                'price01' => $faker->randomNumber(5),
-                'price02' => $faker->randomNumber(5),
+                'price01' => $price01,
+                'price02' => $price01,
                 'stock' => $faker->randomNumber(3),
                 'stock_unlimited' => 0,
                 'code' => $faker->word,

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
@@ -49,7 +49,7 @@ class ProductControllerTest extends AbstractAdminWebTestCase
             'class' => array(
                 'product_type' => 1,
                 'price01' => $price01,
-                'price02' => $price01,
+                'price02' => $price02,
                 'stock' => $faker->randomNumber(3),
                 'stock_unlimited' => 0,
                 'code' => $faker->word,

--- a/tests/Eccube/Tests/Web/Admin/Setting/Shop/DeliveryControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/Shop/DeliveryControllerTest.php
@@ -237,7 +237,7 @@ class DeliveryControllerTest extends AbstractAdminWebTestCase
         // 47 93 ?
         for ($i = 48; $i <= 93; $i++) {
             $tmpFee = $faker->randomNumber(5);
-            if (mt_rand(1, 2) == 1) {
+            if (mt_rand(0, 1)) {
                 $tmpFee = number_format($tmpFee);
             }
             $deliveryFree[$i] = array('fee' => $tmpFee);

--- a/tests/Eccube/Tests/Web/Admin/Setting/Shop/DeliveryControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/Shop/DeliveryControllerTest.php
@@ -236,7 +236,11 @@ class DeliveryControllerTest extends AbstractAdminWebTestCase
         $deliveryFree = array();
         // 47 93 ?
         for ($i = 48; $i <= 93; $i++) {
-            $deliveryFree[$i] = array('fee' => $faker->randomNumber(5));
+            $tmpFee = $faker->randomNumber(5);
+            if (mt_rand(1, 2) == 1) {
+                $tmpFee = number_format($tmpFee);
+            }
+            $deliveryFree[$i] = array('fee' => $tmpFee);
         }
 
         $form = array(

--- a/tests/Eccube/Tests/Web/Admin/Setting/Shop/PaymentControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/Shop/PaymentControllerTest.php
@@ -215,12 +215,22 @@ class PaymentControllerTest extends AbstractAdminWebTestCase
 
     public function createFormData()
     {
+        $charge = 10000;
+        if (mt_rand(0, 1)) {
+            $charge = number_format($charge);
+        }
+
+        $rule_max = 10000;
+        if (mt_rand(0, 1)) {
+            $rule_max = number_format($rule_max);
+        }
+
         $form = array(
             '_token' => 'dummy',
             'method' => 'Test',
-            'charge' => '10000',
+            'charge' => $charge,
             'rule_min' => '100',
-            'rule_max' => '10000',
+            'rule_max' => $rule_max,
             'payment_image' => 'abc.png',
             'payment_image_file' => 'abc.png',
             'charge_flg' => '1',

--- a/tests/Eccube/Tests/Web/Admin/Setting/Shop/ShopControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/Shop/ShopControllerTest.php
@@ -65,6 +65,11 @@ class ShopControllerTest extends AbstractAdminWebTestCase
 
     public function createFormData()
     {
+        $delivery_free_amount = 1000;
+        if (mt_rand(0, 1)) {
+            $delivery_free_amount = number_format($delivery_free_amount);
+        }
+
         $form = array(
             '_token' => 'dummy',
             'company_name' => '会社名',
@@ -96,7 +101,7 @@ class ShopControllerTest extends AbstractAdminWebTestCase
             'email02' => 'eccube@example.com',
             'email03' => 'eccube@example.com',
             'email04' => 'eccube@example.com',
-            'delivery_free_amount' => '1000',
+            'delivery_free_amount' => $delivery_free_amount,
             'delivery_free_quantity' => '1000',
             'good_traded' => '取り扱い商品',
             'message' => 'メッセージ',


### PR DESCRIPTION
入力項目（単位：金額）で、カンマありで登録すると、エラーとならず、途中（カンマまで）までしか登録されない
https://github.com/EC-CUBE/ec-cube/issues/1678

修正内容
入力値タイップに「'scale'と'grouping'」を追加
        ```
'scale' => 0,
'grouping' => true,

```
テストケース：価格フォーマトはバラバラにする。