### PR TITLE
受注明細にセットされる課税規則の値を修正

### DIFF
--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -492,7 +492,7 @@ class ShoppingService
             ->setProductCode($ProductClass->getCode())
             ->setPrice($ProductClass->getPrice02())
             ->setQuantity($quantity)
-            ->setTaxRule($TaxRule->getId())
+            ->setTaxRule($TaxRule->getCalcRule()->getId())
             ->setTaxRate($TaxRule->getTaxRate());
 
         $ClassCategory1 = $ProductClass->getClassCategory1();

--- a/tests/Eccube/Tests/Service/ShoppingServiceTest.php
+++ b/tests/Eccube/Tests/Service/ShoppingServiceTest.php
@@ -539,6 +539,10 @@ class ShoppingServiceTest extends AbstractServiceTestCase
      */
     public function testGetNewOrderDetailForTaxRate()
     {
+
+        // 課税規則にセットする修正方法に誤りがあったためテストをスキップする
+        $this->markTestSkipped();
+
         $DefaultTaxRule = $this->app['eccube.repository.tax_rule']->find(1);
         $DefaultTaxRule->setApplyDate(new \DateTime('-2 day'));
         $this->app['orm.em']->flush();

--- a/tests/Eccube/Tests/Service/ShoppingServiceTest.php
+++ b/tests/Eccube/Tests/Service/ShoppingServiceTest.php
@@ -4,6 +4,7 @@ namespace Eccube\Tests\Service;
 
 use Eccube\Application;
 use Eccube\Common\Constant;
+use Eccube\Entity\Master\Taxrule;
 use Eccube\Entity\Shipping;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
@@ -587,5 +588,40 @@ class ShoppingServiceTest extends AbstractServiceTestCase
         $this->expected = $TaxRule->getId();
         $this->actual = $OrderDetail->getTaxRule();
         $this->verify('受注詳細の税率が正しく設定されている');
+    }
+
+    /**
+     * #2005のテストケース
+     * @link https://github.com/EC-CUBE/ec-cube/issues/2005
+     */
+    public function testOrderDetailForTaxRate()
+    {
+
+        $Product = $this->app['eccube.repository.product']->find(1);
+        $ProductClasses = $Product->getProductClasses();
+
+        foreach ($ProductClasses as $ProductClass) {
+            $ProductClass->setPrice02(649);
+        }
+        $this->app['orm.em']->flush($Product);
+
+        $this->CartService->setProductQuantity($Product->getId(), 1)->save();
+
+        $Order = $this->app['eccube.service.shopping']->createOrder($this->Customer);
+        $TaxRule = $this->app['eccube.repository.tax_rule']->getByRule();
+
+        $TaxRule->setTaxRate(Taxrule::FLOOR);
+        $this->app['orm.em']->flush($TaxRule);
+
+        // 受注明細で設定された金額
+        foreach ($Order->getOrderDetails() as $OrderDetail) {
+
+            $this->expected = ($OrderDetail->getPrice() + $this->app['eccube.service.tax_rule']->calcTax($OrderDetail->getPrice(), $OrderDetail->getTaxRate(), $OrderDetail->getTaxRule())) * $OrderDetail->getQuantity();
+
+            $this->actual = ($OrderDetail->getPrice() + $this->app['eccube.service.tax_rule']->calcTax($OrderDetail->getPrice(), $OrderDetail->getTaxRate(), $TaxRule->getCalcRule()->getId())) * $OrderDetail->getQuantity();
+
+            $this->verify();
+        }
+
     }
 }


### PR DESCRIPTION
#2005 の対応
課税規則をセットする内容を元の状態に戻し、課税区分IDを受注明細にセットする方法は別途検討する。

#1856 で管理画面の受注登録時も修正が行われていたが、
#1725 が後からマージされたため管理画面の不具合は偶然にもこの対応で修正されており、今回はフロントのみ対応している。