### PR TITLE
[FIX] Fix issue 1995: change search input email to text.

### DIFF
--- a/src/Eccube/Form/Type/Admin/SearchOrderType.php
+++ b/src/Eccube/Form/Type/Admin/SearchOrderType.php
@@ -64,7 +64,7 @@ class SearchOrderType extends AbstractType
             ->add('name', 'text', array(
                 'required' => false,
             ))
-            ->add('email', 'email', array(
+            ->add('email', 'text', array(
                 'required' => false,
             ))
             ->add('tel', 'text', array(


### PR DESCRIPTION
#1995 : Change input type from  'email' => 'text'
- Admin can search all order by  a part of email 
