### PR TITLE
freeze_display_text=false設定時にも、エラーメッセージが表示されてしまう対応

### DIFF
--- a/src/Eccube/Resource/template/admin/Form/form_layout.twig
+++ b/src/Eccube/Resource/template/admin/Form/form_layout.twig
@@ -62,7 +62,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {%- block form_errors -%}
     {%- if errors|length > 0 -%}
         {%- for error in errors -%}
-            <span class="attention">※ {{ error.messageTemplate|trans(error.messageParameters, 'validators')|replace({'{{ field }}': label}) }}<br /></span>
+            {%- if freeze_display_text -%}
+                <span class="attention">※ {{ error.messageTemplate|trans(error.messageParameters, 'validators')|replace({'{{ field }}': label}) }}<br /></span>
+            {%- endif %}
         {%- endfor -%}
     {%- endif -%}
 {%- endblock form_errors -%}

--- a/src/Eccube/Resource/template/default/Form/form_layout.twig
+++ b/src/Eccube/Resource/template/default/Form/form_layout.twig
@@ -56,7 +56,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     {% if errors|length > 0 -%}
         {% if form.parent %}
             {%- for error in errors -%}
-                <p class="errormsg text-danger">{{ error.message |trans }}</p>
+                {%- if freeze_display_text -%}
+                    <p class="errormsg text-danger">{{ error.message |trans }}</p>
+                {%- endif %}
             {%- endfor -%}
         {%- endif %}
     {%- endif %}


### PR DESCRIPTION
freeze_display_text=false設定時にも、エラーメッセージが表示されてしまう
https://github.com/EC-CUBE/ec-cube/issues/1701

修正内容
エラーメッセージ表示する前に（freeze_display_text == true）チェック追加
備考：フロントと管理側