### PR TITLE
マスタ検索の簡易検索を部分一致にする対応

### DIFF
--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -270,13 +270,18 @@ class OrderRepository extends EntityRepository
                 ->setParameter('order_id_start', $searchData['order_id_start']);
         }
         // multi
-        if (isset( $searchData['multi']) && Str::isNotBlank($searchData['multi'])) {
+        if (isset($searchData['multi']) && Str::isNotBlank($searchData['multi'])) {
             $multi = preg_match('/^\d+$/', $searchData['multi']) ? $searchData['multi'] : null;
-            $qb
-                ->andWhere('o.id = :multi OR o.name01 LIKE :likemulti OR o.name02 LIKE :likemulti OR ' .
-                           'o.kana01 LIKE :likemulti OR o.kana02 LIKE :likemulti OR o.company_name LIKE :likemulti')
-                ->setParameter('multi', $multi)
-                ->setParameter('likemulti', '%' . $searchData['multi'] . '%');
+            if ($multi === null) {
+                $qb
+                    ->andWhere('o.name01 LIKE :likemulti OR o.name02 LIKE :likemulti OR ' .
+                        'o.kana01 LIKE :likemulti OR o.kana02 LIKE :likemulti OR o.company_name LIKE :likemulti')
+                    ->setParameter('likemulti', '%' . $searchData['multi'] . '%');
+            } else {
+                $qb
+                    ->andWhere('o.id = :multi')
+                    ->setParameter('multi', $multi);
+            }
         }
 
         // order_id_end

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -168,10 +168,13 @@ class ProductRepository extends EntityRepository
         // id
         if (isset($searchData['id']) && Str::isNotBlank($searchData['id'])) {
             $id = preg_match('/^\d+$/', $searchData['id']) ? $searchData['id'] : null;
-            $qb
-                ->andWhere('p.id = :id OR p.name LIKE :likeid OR pc.code LIKE :likeid')
-                ->setParameter('id', $id)
-                ->setParameter('likeid', '%' . $searchData['id'] . '%');
+            if ($id === null) {
+            $qb->andWhere('p.name LIKE :likeid OR pc.code LIKE :likeid')
+                    ->setParameter('likeid', '%' . $searchData['id'] . '%');
+            } else {
+                $qb->andWhere('p.id = :id')
+                    ->setParameter('id', $id);
+            }
         }
 
         // code

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
@@ -55,11 +55,13 @@ class OrderControllerTest extends AbstractAdminWebTestCase
 
     public function testSearchOrderById()
     {
+        $Order = $this->app['eccube.repository.order']->findOneBy(array());
+
         $crawler = $this->client->request(
             'POST', $this->app->url('admin_order'), array(
             'admin_search_order' => array(
                 '_token' => 'dummy',
-                'multi' => '1',
+                'multi' => $Order->getId(),
             )
             )
         );
@@ -81,7 +83,7 @@ class OrderControllerTest extends AbstractAdminWebTestCase
             'POST', $this->app->url('admin_order'), array(
             'admin_search_order' => array(
                 '_token' => 'dummy',
-                'multi' => $Order->getName01(),
+                'multi' => $companyName,
             )
             )
         );

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
@@ -15,7 +15,7 @@ class OrderControllerTest extends AbstractAdminWebTestCase
         $Payment = $this->app['eccube.repository.payment']->find(1);
         $OrderStatus = $this->app['eccube.repository.order_status']->find($this->app['config']['order_new']);
         for ($i = 0; $i < 10; $i++) {
-            $Customer = $this->createCustomer('user-'.$i.'@example.com');
+            $Customer = $this->createCustomer('user-' . $i . '@example.com');
             $Customer->setSex($Sex);
             $Order = $this->createOrder($Customer);
             $Order->setOrderStatus($OrderStatus);
@@ -51,6 +51,45 @@ class OrderControllerTest extends AbstractAdminWebTestCase
             $this->app->url('admin_order')
         );
         $this->assertTrue($this->client->getResponse()->isSuccessful());
+    }
+
+    public function testSearchOrderById()
+    {
+        $crawler = $this->client->request(
+            'POST', $this->app->url('admin_order'), array(
+            'admin_search_order' => array(
+                '_token' => 'dummy',
+                'multi' => '1',
+            )
+            )
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $this->expected = '検索結果 1 件 が該当しました';
+        $this->actual = $crawler->filter('h3.box-title')->text();
+        $this->verify();
+    }
+
+    public function testSearchOrderByName()
+    {
+        $Order = $this->app['eccube.repository.order']->find(1);
+        $companyName = $Order->getCompanyName();
+        $OrderList = $this->app['eccube.repository.order']->findBy(array('company_name' => $companyName));
+        $cnt = count($OrderList);
+
+        $crawler = $this->client->request(
+            'POST', $this->app->url('admin_order'), array(
+            'admin_search_order' => array(
+                '_token' => 'dummy',
+                'multi' => $Order->getName01(),
+            )
+            )
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $this->expected = '検索結果 ' . $cnt . ' 件 が該当しました';
+        $this->actual = $crawler->filter('h3.box-title')->text();
+        $this->verify();
     }
 
     public function testIndexWithPost()

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
@@ -72,7 +72,7 @@ class OrderControllerTest extends AbstractAdminWebTestCase
 
     public function testSearchOrderByName()
     {
-        $Order = $this->app['eccube.repository.order']->find(1);
+        $Order = $this->app['eccube.repository.order']->findOneBy(array());
         $companyName = $Order->getCompanyName();
         $OrderList = $this->app['eccube.repository.order']->findBy(array('company_name' => $companyName));
         $cnt = count($OrderList);

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
@@ -80,6 +80,114 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 
+    public function testProductSearchAll()
+    {
+        $AllProducts = $this->app['eccube.repository.product']->findAll();
+        $cnt = count($AllProducts);
+        $TestProduct = $this->createProduct();
+        $cnt++;
+
+        $post = array('admin_search_product' =>
+            array(
+                '_token' => 'dummy',
+                'id' => '',
+                'category_id' => '',
+                'create_date_start' => '',
+                'create_date_end' => '',
+                'update_date_start' => '',
+                'update_date_end' => '',
+                'link_status' => '',
+        ));
+        $crawler = $this->client->request('POST', $this->app->url('admin_product'), $post);
+        $this->expected = '検索結果 ' . $cnt . ' 件 が該当しました';
+        $this->actual = $crawler->filter('h3.box-title')->text();
+        $this->verify();
+    }
+
+    public function testProductSearchByName()
+    {
+        $TestProduct = $this->createProduct();
+
+        $post = array('admin_search_product' =>
+            array(
+                '_token' => 'dummy',
+                'id' => $TestProduct->getName(),
+                'category_id' => '',
+                'create_date_start' => '',
+                'create_date_end' => '',
+                'update_date_start' => '',
+                'update_date_end' => '',
+                'link_status' => '',
+        ));
+        $crawler = $this->client->request('POST', $this->app->url('admin_product'), $post);
+        $this->expected = '検索結果 1 件 が該当しました';
+        $this->actual = $crawler->filter('h3.box-title')->text();
+        $this->verify();
+    }
+
+    public function testProductSearchById()
+    {
+        $TestProduct = $this->createProduct();
+
+        $post = array('admin_search_product' =>
+            array(
+                '_token' => 'dummy',
+                'id' => $TestProduct->getId(),
+                'category_id' => '',
+                'create_date_start' => '',
+                'create_date_end' => '',
+                'update_date_start' => '',
+                'update_date_end' => '',
+                'link_status' => '',
+        ));
+        $crawler = $this->client->request('POST', $this->app->url('admin_product'), $post);
+        $this->expected = '検索結果 1 件 が該当しました';
+        $this->actual = $crawler->filter('h3.box-title')->text();
+        $this->verify();
+    }
+
+    public function testProductSearchByIdZero()
+    {
+        $TestProduct = $this->createProduct();
+
+        $post = array('admin_search_product' =>
+            array(
+                '_token' => 'dummy',
+                'id' => 99999999,
+                'category_id' => '',
+                'create_date_start' => '',
+                'create_date_end' => '',
+                'update_date_start' => '',
+                'update_date_end' => '',
+                'link_status' => '',
+        ));
+        $crawler = $this->client->request('POST', $this->app->url('admin_product'), $post);
+        $this->expected = '検索条件に該当するデータがありませんでした。';
+        $this->actual = $crawler->filter('h3.box-title')->text();
+        $this->verify();
+    }
+
+    public function testProductSearchByNameZero()
+    {
+        $TestProduct = $this->createProduct();
+
+        $post = array('admin_search_product' =>
+            array(
+                '_token' => 'dummy',
+                'id' => 'not Exists product name',
+                'category_id' => '',
+                'create_date_start' => '',
+                'create_date_end' => '',
+                'update_date_start' => '',
+                'update_date_end' => '',
+                'link_status' => '',
+        ));
+        $crawler = $this->client->request('POST', $this->app->url('admin_product'), $post);
+        $this->expected = '検索条件に該当するデータがありませんでした。';
+        $this->actual = $crawler->filter('h3.box-title')->text();
+        $this->verify();
+    }
+
     public function testRoutingAdminProductProductEdit()
     {
 


### PR DESCRIPTION
マスタ検索の簡易検索を部分一致にする
https://github.com/EC-CUBE/ec-cube/issues/1972

実装について
■商品マスタ
　□半角数のみ　（商品ID完全一致）
　　d0_.product_id = ?
　□半角数のみ以外　（その他カラム部分一致）
　　OR d0_.name LIKE　'%?%'
　　OR d1_.product_code LIKE '%?%'
■受注マスタ
　□半角数のみ　（受注ID完全一致）
　　d0_.order_id = ?
　□半角数のみ以外　（その他カラム部分一致）
　　OR d0_.order_name01 LIKE '%?%'
　　OR d0_.order_name02 LIKE '%?%'
　　OR d0_.order_kana01 LIKE '%?%'
　　OR d0_.order_kana02 LIKE '%?%'
　　OR d0_.order_company_name LIKE '%?%'
　
テストについて
商品と受注検索テスト追加