### PR TITLE
mac, safariにて、商品登録等の登録系画面の右側にある「登録」ボタンが、画面スクロール対応

### DIFF
--- a/src/Eccube/Resource/template/admin/Content/block_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/block_edit.twig
@@ -31,12 +31,12 @@
 {% form_theme form 'Form/bootstrap_3_horizontal_layout.html.twig' %}
 
 {% block main %}
+<div class="row" id="aside_wrap">
 <form name="content_block_form" id="content_block_form" method="post" action="
 {%- if block_id is not null %}{{ url('admin_content_block_edit', {id: block_id}) }}{% else %}{{ url('admin_content_block_new')}}{% endif -%}">
     {{ form_widget(form._token) }}
     {{ form_widget(form.id) }}
     {{ form_widget(form.DeviceType, { attr : { style : 'display: none;' } } ) }}
-    <div class="row" id="aside_wrap">
         <div id="detail_wrap" class="col-md-9">
             <div id="detail_box" class="box form-horizontal">
                 <div id="detail_box__header" class="box-header">
@@ -92,8 +92,8 @@
 
         </div>
         <!-- /.col -->
-        <div class="col_inner" id="aside_column">
-            <div id="common_box" class="col-md-3">
+        <div class="col-md-3" id="aside_column">
+            <div id="common_box" class="col_inner">
                 <div id="common_button_box" class="box no-header">
                     <div id="common_button_box__body" class="box-body">
                         <div id="common_button_box__insert_button" class="row text-center">
@@ -108,7 +108,7 @@
             </div>
         </div>
         <!-- /.col -->
-    </div>
-
 </form>
+</div>
+
 {% endblock %}

--- a/src/Eccube/Resource/template/admin/Content/block_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/block_edit.twig
@@ -92,8 +92,8 @@
 
         </div>
         <!-- /.col -->
-        <div id="common_box" class="col-md-3">
-            <div class="col_inner" id="aside_column">
+        <div class="col_inner" id="aside_column">
+            <div id="common_box" class="col-md-3">
                 <div id="common_button_box" class="box no-header">
                     <div id="common_button_box__body" class="box-body">
                         <div id="common_button_box__insert_button" class="row text-center">

--- a/src/Eccube/Resource/template/admin/Content/file.twig
+++ b/src/Eccube/Resource/template/admin/Content/file.twig
@@ -155,8 +155,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             </div>
         </div><!-- /.col -->
         
-        <div id="common_box" class="col-md-3">
-            <div class="col_inner" id="aside_column">
+        <div class="col_inner" id="aside_column">
+            <div id="common_box" class="col-md-3">
                 <div id="tree_box" class="box no-header">
                     <div id="tree_box__body" class="box-body">
                         <div id="tree_box__tree" class="row">

--- a/src/Eccube/Resource/template/admin/Content/file.twig
+++ b/src/Eccube/Resource/template/admin/Content/file.twig
@@ -52,6 +52,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 {% endblock javascript %}
 {% block main %}
+<div class="row" id="aside_wrap">
     <form name="form1" id="form1" method="post" action="?"  enctype="multipart/form-data">
     <input type="hidden" name="mode" value="" />
     <input type="hidden" name="now_file" value="{{ tpl_now_dir }}" />
@@ -59,7 +60,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     <input type="hidden" name="tree_select_file" value="{{ tpl_now_dir }}" />
     <input type="hidden" name="tree_status" value="" />
     <input type="hidden" name="select_file" value="" />
-    <div class="row" id="aside_wrap">
 
         <div id="upload_wrap" class="col-md-9">
             <div id="upload_list_box" class="box">
@@ -155,8 +155,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             </div>
         </div><!-- /.col -->
         
-        <div class="col_inner" id="aside_column">
-            <div id="common_box" class="col-md-3">
+        <div class="col-md-3" id="aside_column">
+            <div id="common_box" class="col_inner">
                 <div id="tree_box" class="box no-header">
                     <div id="tree_box__body" class="box-body">
                         <div id="tree_box__tree" class="row">
@@ -169,8 +169,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             </div>
         </div><!-- /.col --> 
 
-    </div>
     </form>
+</div>
 
 
 {% endblock %}

--- a/src/Eccube/Resource/template/admin/Content/layout.twig
+++ b/src/Eccube/Resource/template/admin/Content/layout.twig
@@ -284,8 +284,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     </div>
                 </div>
             </div>
-            <div id="aside_column" class="col_inner">
-                <div id="common_box" class="col-md-3">
+            <div id="aside_column" class="col-md-3">
+                <div id="common_box" class="col_inner">
                     <div id="common_button_box" class="box no-header">
                         <div id="common_button_box__body" class="box-body">
                             <div id="common_button_box__insert_button" class="row text-center">

--- a/src/Eccube/Resource/template/admin/Content/layout.twig
+++ b/src/Eccube/Resource/template/admin/Content/layout.twig
@@ -284,8 +284,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     </div>
                 </div>
             </div>
-            <div id="common_box" class="col-md-3">
-                <div id="aside_column" class="col_inner">
+            <div id="aside_column" class="col_inner">
+                <div id="common_box" class="col-md-3">
                     <div id="common_button_box" class="box no-header">
                         <div id="common_button_box__body" class="box-body">
                             <div id="common_button_box__insert_button" class="row text-center">

--- a/src/Eccube/Resource/template/admin/Content/layout.twig
+++ b/src/Eccube/Resource/template/admin/Content/layout.twig
@@ -68,9 +68,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% endblock javascript %}
 
 {% block main %}
+ <div class="row" id="aside_wrap">
     <form name="form1" id="form1" method="post" action="{{ url('admin_content_layout_edit', {id: TargetPageLayout.id}) }}">
         {{ form_widget(form._token) }}
-        <div class="row" id="aside_wrap">
             <div id="detail_wrap" class="col-md-9">
                 {# ▼レイアウトここから #}
                 <div id="detail_box" class="box">
@@ -320,6 +320,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
                 </div>
             </div><!-- /.col -->
-        </div>
     </form>
+</div>
 {% endblock %}

--- a/src/Eccube/Resource/template/admin/Content/news_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/news_edit.twig
@@ -103,8 +103,8 @@ $(function() {
 
         </div><!-- /.col -->
 
-        <div class="col_inner" id="aside_column">
-            <div id="common_box" class="col-md-3">
+        <div class="col-md-3" id="aside_column">
+            <div id="common_box" class="col_inner">
                 <div id="common_box__body" class="box no-header">
                     <div id="common_button_box" class="box-body">
                         <div id="common_button_box__insert_button" class="row text-center">

--- a/src/Eccube/Resource/template/admin/Content/news_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/news_edit.twig
@@ -103,8 +103,8 @@ $(function() {
 
         </div><!-- /.col -->
 
-        <div id="common_box" class="col-md-3">
-            <div class="col_inner" id="aside_column">
+        <div class="col_inner" id="aside_column">
+            <div id="common_box" class="col-md-3">
                 <div id="common_box__body" class="box no-header">
                     <div id="common_button_box" class="box-body">
                         <div id="common_button_box__insert_button" class="row text-center">

--- a/src/Eccube/Resource/template/admin/Content/page_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/page_edit.twig
@@ -117,8 +117,8 @@
                 </div>
             </div>
             <!-- /.col -->
-            <div id="common_box" class="col-md-3">
-                <div class="col_inner" id="aside_column">
+            <div class="col_inner" id="aside_column">
+                <div id="common_box" class="col-md-3">
                     <div id="common_button_box" class="box no-header">
                         <div id="common_button_box__body" class="box-body">
                             <div id="common_button_box__insert_button" class="row text-center">

--- a/src/Eccube/Resource/template/admin/Content/page_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/page_edit.twig
@@ -31,12 +31,12 @@
 {% form_theme form 'Form/bootstrap_3_horizontal_layout.html.twig' %}
 
 {% block main %}
+<div class="row" id="aside_wrap">
     <form role="form" name="content_page_form" id="content_page_form" method="post"
           action="{%- if page_id is not null %}{{ url('admin_content_page_edit', {id: page_id}) }}{% else %}{{ url('admin_content_page_new') }}{% endif -%}">
         {{ form_widget(form._token) }}
         {{ form_widget(form.id) }}
         {{ form_widget(form.DeviceType, { attr : { style : 'display: none;' } } ) }}
-        <div class="row" id="aside_wrap">
             <div id="detail" class="col-md-9">
                 <div id="detail_box" class="box form-horizontal">
                     <div id="detail_box__header" class="box-header">
@@ -117,8 +117,8 @@
                 </div>
             </div>
             <!-- /.col -->
-            <div class="col_inner" id="aside_column">
-                <div id="common_box" class="col-md-3">
+            <div class="col-md-3" id="aside_column">
+                <div id="common_box" class="col_inner">
                     <div id="common_button_box" class="box no-header">
                         <div id="common_button_box__body" class="box-body">
                             <div id="common_button_box__insert_button" class="row text-center">
@@ -133,6 +133,6 @@
                 </div>
             </div>
             <!-- /.col -->
-        </div>
     </form>
+</div>
 {% endblock %}

--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -259,8 +259,8 @@
 
         </div><!-- /.col -->
 
-        <div id="aside_column" class="col_inner">
-            <div id="common_box" class="col-md-3">
+        <div id="aside_column" class="col-md-3">
+            <div id="common_box" class="col_inner">
                 <div id="button_box" class="box no-header">
                     <div id="button_box__body" class="box-body">
                         <div class="row">

--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -259,8 +259,8 @@
 
         </div><!-- /.col -->
 
-        <div id="common_box" class="col-md-3">
-            <div id="aside_column" class="col_inner">
+        <div id="aside_column" class="col_inner">
+            <div id="common_box" class="col-md-3">
                 <div id="button_box" class="box no-header">
                     <div id="button_box__body" class="box-body">
                         <div class="row">

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -186,9 +186,9 @@ function fnClass(action) {
 {% endblock javascript %}
 
 {% block main %}
+        <div class="row" id="aside_wrap">
             <form role="form" name="form1" id="form1" method="post" action="" novalidate enctype="multipart/form-data">
             {{ form_widget(form._token) }}
-            <div class="row" id="aside_wrap">
                 <div id="detail_wrap" class="col-md-9">
                     <div id="detail_box" class="box form-horizontal">
                         <div id="detail_box__header" class="box-header">
@@ -369,8 +369,8 @@ function fnClass(action) {
 
                 </div><!-- /.col -->
 
-                <div class="col_inner" id="aside_column">
-                    <div id="common_box" class="col-md-3">
+                <div class="col-md-3" id="aside_column">
+                    <div id="common_box" class="col_inner">
                         <div id="common_button_box" class="box no-header">
                             <div id="common_button_box__body" class="box-body">
                                 <div id="common_button_box__status" class="row">
@@ -459,7 +459,7 @@ function fnClass(action) {
                     </div>
                 </div><!-- /.col -->
 
-            </div>
             </form>
+        </div>
 
 {% endblock %}

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -369,8 +369,8 @@ function fnClass(action) {
 
                 </div><!-- /.col -->
 
-                <div id="common_box" class="col-md-3">
-                    <div class="col_inner" id="aside_column">
+                <div class="col_inner" id="aside_column">
+                    <div id="common_box" class="col-md-3">
                         <div id="common_button_box" class="box no-header">
                             <div id="common_button_box__body" class="box-body">
                                 <div id="common_button_box__status" class="row">

--- a/src/Eccube/Resource/template/admin/Setting/Shop/csv.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/csv.twig
@@ -129,7 +129,7 @@ $(function() {
                     </div>
                 </div>
             </div>
-            <div id="common_box" class="col-md-3" id="aside_column">
+            <div class="col-md-3" id="aside_column">
                 <div id="common_button_box" class="col_inner">
                     <div id="common_button_box__body" class="box no-header">
                         <div id="common_button_box__confirm_button" class="box-body">
@@ -142,6 +142,6 @@ $(function() {
                     </div><!-- /.box -->
                 </div>
             </div><!-- /.col -->
-        </div>
     </form>
+</div>
 {% endblock %}

--- a/src/Eccube/Resource/template/admin/Setting/Shop/csv.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/csv.twig
@@ -130,16 +130,18 @@ $(function() {
                 </div>
             </div>
             <div class="col-md-3" id="aside_column">
-                <div id="common_button_box" class="col_inner">
-                    <div id="common_button_box__body" class="box no-header">
-                        <div id="common_button_box__confirm_button" class="box-body">
-                            <div class="row text-center">
-                                <div class="col-sm-6 col-sm-offset-3 col-md-12 col-md-offset-0">
-                                    <button class="btn btn-primary btn-block btn-lg" type="submit">設定</button>
+                <div id="common_box" class="col_inner">
+                    <div id="common_button_box" class="box no-header">
+                        <div id="common_button_box__body" class="box-body">
+                            <div id="common_button_box__confirm_button" class="box-body">
+                                <div class="row text-center">
+                                    <div class="col-sm-6 col-sm-offset-3 col-md-12 col-md-offset-0">
+                                        <button class="btn btn-primary btn-block btn-lg" type="submit">設定</button>
+                                    </div>
                                 </div>
-                            </div>
-                        </div><!-- /.box-body -->
-                    </div><!-- /.box -->
+                            </div><!-- /.box-body -->
+                        </div><!-- /.box -->
+                    </div>
                 </div>
             </div><!-- /.col -->
     </form>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/customer_agreement.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/customer_agreement.twig
@@ -55,8 +55,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </div><!-- /.box-body -->
                     </div><!-- /.box -->
                 </div>
-                <div id="common_box" class="col-md-3">
-                    <div class="col_inner" id="aside_column">
+                <div class="col_inner" id="aside_column">
+                    <div id="common_box" class="col-md-3">
                         <div id="common_button_box" class="box no-header">
                             <div id="common_button_box__body" class="box-body">
                                 <div class="row">

--- a/src/Eccube/Resource/template/admin/Setting/Shop/customer_agreement.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/customer_agreement.twig
@@ -29,9 +29,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% form_theme form 'Form/bootstrap_3_horizontal_layout.html.twig' %}
 
 {% block main %}
+    <div class="row" id="aside_wrap">
         <form role="form" name="form1" id="form1" method="post">
             {{ form_widget(form._token) }}
-            <div class="row" id="aside_wrap">
                 <div id="detail_wrap" class="col-md-9">
                     <div id="detail_box" class="box form-horizontal">
                         <div id="detail_box__header" class="box-header">
@@ -55,8 +55,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </div><!-- /.box-body -->
                     </div><!-- /.box -->
                 </div>
-                <div class="col_inner" id="aside_column">
-                    <div id="common_box" class="col-md-3">
+                <div class="col-md-3" id="aside_column">
+                    <div id="common_box" class="col_inner">
                         <div id="common_button_box" class="box no-header">
                             <div id="common_button_box__body" class="box-body">
                                 <div class="row">
@@ -77,8 +77,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             </div>
 
         <div class="btn-area">
-        </div>
         </form>
+    </div>
 {% endblock %}
 
 

--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
@@ -40,9 +40,9 @@ $(function(){
 {% endblock javascript %}
 
 {% block main %}
+<div class="row" id="aside_wrap">
     <form role="form" class="form-horizontal" name="form1" id="form1" method="post" action="">
         {{ form_widget(form._token) }}
-        <div class="row" id="aside_wrap">
             <div id="detail_wrap" class="col-md-9">
                 <div id="delivery_info_box" class="box">
                     <div id="delivery_info_box__header" class="box-header">
@@ -162,10 +162,7 @@ $(function(){
                     </div>
                 </div>
             </div><!-- /.col -->
-
-
-
-        </div>
     </form>
+</div>
 
 {% endblock %}

--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
@@ -141,8 +141,8 @@ $(function(){
 
             </div><!-- /.col -->
 
-            <div id="common_box" class="col-md-3">
-                <div class="col_inner" id="aside_column">
+            <div class="col_inner" id="aside_column">
+                <div id="common_box" class="col-md-3">
                     <div id="common_button_box" class="box no-header">
                         <div id="common_button_box__body" class="box-body">
                             <div id="common_button_box__insert_button" class="row text-center">

--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
@@ -140,9 +140,8 @@ $(function(){
                 </div>
 
             </div><!-- /.col -->
-
-            <div class="col_inner" id="aside_column">
-                <div id="common_box" class="col-md-3">
+            <div class="col-md-3" id="aside_column">
+                <div id="common_box" class="col_inner">
                     <div id="common_button_box" class="box no-header">
                         <div id="common_button_box__body" class="box-body">
                             <div id="common_button_box__insert_button" class="row text-center">

--- a/src/Eccube/Resource/template/admin/Setting/Shop/tradelaw.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/tradelaw.twig
@@ -42,9 +42,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 {% block main %}
 
+<div class="row" id="aside_wrap">
 <form name="tradelaw_form" role="form" id="tradelaw_form" method="post" action="{{ url('admin_setting_shop_tradelaw') }}">
     {{ form_widget(form._token) }}
-    <div class="row" id="aside_wrap">
         <div id="detail_wrap" class="col-md-9">
             <div id="detail_box" class="box form-horizontal">
                 <div id="detail_box__header" class="box-header">
@@ -126,8 +126,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 </div><!-- /.box-body -->
             </div><!-- /.box -->
         </div>
-        <div class="col_inner" id="aside_column">
-            <div id="common_box" class="col-md-3">
+        <div class="col-md-3" id="aside_column">
+            <div id="common_box" class="col_inner">
                 <div id="common_button_box" class="box no-header">
                     <div id="common_button_box__body" class="box-body">
                         <div  class="row">
@@ -145,9 +145,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 </div><!-- /.box -->
             </div>
         </div><!-- /.col -->
+</form>
     </div>
 
 
-</form>
 
 {% endblock %}

--- a/src/Eccube/Resource/template/admin/Setting/Shop/tradelaw.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/tradelaw.twig
@@ -126,8 +126,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 </div><!-- /.box-body -->
             </div><!-- /.box -->
         </div>
-        <div id="common_box" class="col-md-3">
-            <div class="col_inner" id="aside_column">
+        <div class="col_inner" id="aside_column">
+            <div id="common_box" class="col-md-3">
                 <div id="common_button_box" class="box no-header">
                     <div id="common_button_box__body" class="box-body">
                         <div  class="row">

--- a/src/Eccube/Resource/template/admin/Setting/System/authority.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/authority.twig
@@ -59,9 +59,9 @@ $(function() {
 {% endblock javascript %}
 
 {% block main %}
+<div class="row" id="aside_wrap">
     <form name="form1" method="post" action="{{ url('admin_setting_system_authority') }}">
     {{ form_widget(form._token) }}
-    <div class="row" id="aside_wrap">
         <div id="authority_wrap" class="col-md-9">
             <div id="authority_list_box" class="box">
                 <div id="authority_list_box__header" class="box-header">
@@ -135,6 +135,6 @@ $(function() {
                 </div><!-- /.box -->
             </div>
         </div><!-- /.col -->
-    </div>
     </form>
+</div>
 {% endblock %}

--- a/src/Eccube/Resource/template/admin/Setting/System/masterdata.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/masterdata.twig
@@ -106,8 +106,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             </div><!-- /.box-body -->
         </div>
 
-        <div id="common_box" class="col-md-3">
-            <div class="col_inner" id="aside_column">
+        <div class="col_inner" id="aside_column">
+            <div id="common_box" class="col-md-3">
                 <div id="common_button_box" class="box no-header">
                     <div id="common_button_box__body" class="box-body">
                         <div id="common_button_box__insert_button"  class="row text-center">

--- a/src/Eccube/Resource/template/admin/Setting/System/masterdata.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/masterdata.twig
@@ -29,8 +29,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 {% block main %}
 <form id="form1" name="form1" method="post" action="{{ url('admin_setting_system_masterdata') }}">
+<div class="row">
     {{ form_widget(form._token) }}
-    <div class="row">
         <div id="master_edit" class="col-md-12">
             <div id="master_edit_box" class="box">
                 <div id="master_edit_box__header" class="box-header">
@@ -64,10 +64,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 </form>
 
 {% if form2.data is not empty %}
+<div class="row" id="aside_wrap">
 <form id="form2" name="form2" method="post" action="{{ url('admin_setting_system_masterdata_edit') }}">
     {{ form_widget(form2.masterdata_name) }}
     {{ form_widget(form2._token) }}
-    <div class="row" id="aside_wrap">
         <div id="result_list_box" class="col-md-9">
             <div id="result_list_box__body" class="box">
                 <div id="result_list_box__header" class="box-header">
@@ -106,8 +106,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             </div><!-- /.box-body -->
         </div>
 
-        <div class="col_inner" id="aside_column">
-            <div id="common_box" class="col-md-3">
+        <div class="col-md-3" id="aside_column">
+            <div id="common_box" class="col_inner">
                 <div id="common_button_box" class="box no-header">
                     <div id="common_button_box__body" class="box-body">
                         <div id="common_button_box__insert_button"  class="row text-center">
@@ -119,7 +119,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 </div><!-- /.box -->
             </div>
         </div><!-- /.col --> 
-    </div>
 </form>
+</div>
 {% endif %}
 {% endblock %}

--- a/src/Eccube/Resource/template/admin/Setting/System/member_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/member_edit.twig
@@ -66,8 +66,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
         </div><!-- /.col -->
         
-        <div id="common_box" class="col-md-3">
-            <div class="col_inner" id="aside_column">
+        <div class="col_inner" id="aside_column">
+            <div id="common_box" class="col-md-3">
                 <div id="common_button_box" class="box no-header">
                     <div id="common_button_box__body" class="box-body">
                         <div id="common_button_box__button_area" class="row text-center">

--- a/src/Eccube/Resource/template/admin/Setting/System/member_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/member_edit.twig
@@ -66,8 +66,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
         </div><!-- /.col -->
         
-        <div class="col_inner" id="aside_column">
-            <div id="common_box" class="col-md-3">
+        <div class="col-md-3" id="aside_column">
+            <div id="common_box" class="col_inner">
                 <div id="common_button_box" class="box no-header">
                     <div id="common_button_box__body" class="box-body">
                         <div id="common_button_box__button_area" class="row text-center">

--- a/src/Eccube/Resource/template/admin/Setting/System/security.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/security.twig
@@ -29,9 +29,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% form_theme form 'Form/bootstrap_3_horizontal_layout.html.twig' %}
 
 {% block main %}
+<div class="row" id="aside_wrap">
     <form method="post" action="{{ url('admin_setting_system_security') }}">
     {{ form_widget(form._token) }}
-    <div class="row" id="aside_wrap">
         <div  id="security_wrap" class="col-md-9">
             <div id="security_box" class="box">
                 <div id="security_box__header" class="box-header">
@@ -98,6 +98,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 </div><!-- /.box -->
             </div>
         </div><!-- /.col --> 
-    </div>
     </form>
+</div>
 {% endblock %}

--- a/src/Eccube/Resource/template/admin/Store/authentication_setting.twig
+++ b/src/Eccube/Resource/template/admin/Store/authentication_setting.twig
@@ -50,8 +50,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             </div><!-- /.box -->
         </div><!-- /.col -->
 
-        <div class="col-md-3">
-            <div class="col_inner" id="aside_column">
+        <div class="col-md-3" id="aside_column">
+            <div id="common_box" class="col_inner">
                 <div class="box no-header">
                     <div class="box-body">
                         <div class="row text-center">

--- a/src/Eccube/Resource/template/admin/Store/plugin_install.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_install.twig
@@ -50,8 +50,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             </div><!-- /.box-body -->
         </div><!-- /.box -->
     </div><!-- /.col -->
-    <div class="col-md-3">
-        <div class="col_inner" id="aside_column">
+    <div class="col-md-3" id="aside_column">
+        <div id="common_box" class="col_inner">
             <div class="box no-header">
                 <div class="box-body">
                     <div class="row text-center">

--- a/src/Eccube/Resource/template/admin/Store/template.twig
+++ b/src/Eccube/Resource/template/admin/Store/template.twig
@@ -87,8 +87,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 </div>
             </div><!-- /.box -->
         </div>
-        <div class="col-md-3">
-            <div class="col_inner" id="aside_column">
+        <div class="col-md-3" id="aside_column">
+            <div id="common_box" class="col_inner">
                 <div class="box no-header">
                     <div class="box-body">
                         <div class="row text-center">

--- a/src/Eccube/Resource/template/admin/Store/template_add.twig
+++ b/src/Eccube/Resource/template/admin/Store/template_add.twig
@@ -64,8 +64,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 </div><!-- /.box-body -->
             </div><!-- /.box -->
         </div><!-- /.col -->
-        <div class="col-md-3">
-            <div class="col_inner" id="aside_column">
+        <div class="col-md-3" id="aside_column">
+            <div id="common_box" class="col_inner">
                 <div class="box no-header">
                     <div class="box-body">
                         <div class="row text-center">

--- a/src/Eccube/Resource/template/admin/change_password.twig
+++ b/src/Eccube/Resource/template/admin/change_password.twig
@@ -51,8 +51,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         </div><!-- /.box -->
     </div><!-- /.col -->
 
-    <div class="col_inner" id="aside_column">
-        <div id="common_box" class="col-md-3">
+    <div class="col-md-3" id="aside_column">
+        <div id="common_box" class="col_inner">
             <div id="common_button_box" class="box no-header">
                 <div id="common_button_box__body" class="box-body">
                     <div id="common_button_box__button_area" class="row text-center">

--- a/src/Eccube/Resource/template/admin/change_password.twig
+++ b/src/Eccube/Resource/template/admin/change_password.twig
@@ -51,8 +51,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         </div><!-- /.box -->
     </div><!-- /.col -->
 
-    <div id="common_box" class="col-md-3">
-        <div class="col_inner" id="aside_column">
+    <div class="col_inner" id="aside_column">
+        <div id="common_box" class="col-md-3">
             <div id="common_button_box" class="box no-header">
                 <div id="common_button_box__body" class="box-body">
                     <div id="common_button_box__button_area" class="row text-center">


### PR DESCRIPTION
mac, safariにて、商品登録等の登録系画面の右側にある「登録」ボタンが、画面スクロール時追従しない。
https://github.com/EC-CUBE/ec-cube/issues/2016

対応について
タグ表示順番直しました

【画面リスト】
■コンテンツ管理　・　ブロック編集
https://ec-cube.local/admin/content/block/10/edit

■コンテンツ管理　・　ファイル管理
https://ec-cube.local/admin/content/file_manager

■コンテンツ管理　・　レイアウト管理
https://ec-cube.local/admin/content/layout/1/edit

■コンテンツ管理　・　新着情報管理
https://ec-cube.local/admin/content/news/new

■コンテンツ管理　・　ページ管理
https://ec-cube.local/admin/content/page/1/edit

■会員管理　・　会員登録・編集
https://ec-cube.local/admin/customer/new
https://ec-cube.local/admin/customer/1/edit

■商品管理　・　商品登録
https://ec-cube.local/admin/product/product/new

■ショップ設定　・　利用規約管理
https://ec-cube.local/admin/setting/shop/customer_agreement

■ショップ設定　・　配送先管理
https://ec-cube.local/admin/setting/shop/delivery/new

■ショップ設定　・　メール管理
https://ec-cube.local/admin/setting/shop/mail

■基本情報設定　・　SHOPマスター
https://ec-cube.local/admin/setting/shop

■ショップ設定　・　特定商取引法管理
https://ec-cube.local/admin/setting/shop/tradelaw

■システム設定　・　権限管理
https://ec-cube.local/admin/setting/system/authority

■システム設定　・　マスターデータ管理
https://ec-cube.local/admin/setting/system/masterdata/Eccube-Entity-Master-Pref/edit

■システム設定　・　メンバー管理
https://ec-cube.local/admin/setting/system/member/new

■システム設定　・　セキュリティ管理
https://ec-cube.local/admin/setting/system/security

■システム設定　・　パスワード変更
https://ec-cube.local/admin/change_password




