### PR TITLE
テストケースでバリデーションエラーを捕捉していない

### DIFF
--- a/src/Eccube/Common/Constant.php
+++ b/src/Eccube/Common/Constant.php
@@ -28,7 +28,7 @@ class Constant {
     /**
      * EC-CUBE VERSION.
      */
-    const VERSION = '3.0.12-p1';
+    const VERSION = '3.0.13';
 
     /**
      * Enable value.

--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -285,8 +285,6 @@ class EditControllerTest extends AbstractEditControllerTestCase
         $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_order_edit', array('id' => $Order->getId()))));
 
         $EditedOrder = $this->app['eccube.repository.order']->find($Order->getId());
-        $this->client->request('GET', $this->app->url('admin_order_edit', array('id' => $Order->getId())));
-
         $formDataForEdit = $this->createFormDataForEdit($EditedOrder);
 
         //税金計算


### PR DESCRIPTION
テストケースでバリデーションエラーを捕捉していない
https://github.com/EC-CUBE/ec-cube/issues/1772

修正内容
受注登録、編集の後にフォームの入力値は更新した後画面で確認する。
現在はリダイレクトチャックありましたがデータ内容なかったので追加しました。
こちらの対応方法あってるかどうかわかりませんのでご確認お願いします。