### PR TITLE
受注管理の電話番号検索が入力フォーマットと実際の検索仕様がズレてる

### DIFF
--- a/src/Eccube/Form/Type/Admin/SearchOrderType.php
+++ b/src/Eccube/Form/Type/Admin/SearchOrderType.php
@@ -71,7 +71,7 @@ class SearchOrderType extends AbstractType
                 'required' => false,
                 'constraints' => array(
                     new Assert\Regex(array(
-                        'pattern' => "/^[\d-]+$/u",
+                        'pattern' => "/^[\d]+$/u",
                         'message' => 'form.type.admin.nottelstyle',
                     )),
                 ),

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -41,7 +41,7 @@ form.type.name.firstname.nothasspace: お名前(名)にスペース、タブ、�
 form.type.name.lastname.nothasspace: お名前(性)にスペース、タブ、改行は含めないで下さい。
 form.type.customer.company.nothasspace: 会社名にスペース、タブ、改行は含めないで下さい。
 
-form.type.admin.nottelstyle: 電話番号は半角数字かハイフンのみを入力してください。。
+form.type.admin.nottelstyle: 電話番号は半角数字のみを入力してください。。
 form.type.admin.notkanastyle: お名前(フリガナ)はカタカナで入力してください。
 
 form.type.select.notselect: 入力されていません。


### PR DESCRIPTION
ハイフンはいるとヒットしないけど、ハイフンの入力を許可してる。