### PR TITLE
MySQLの半角全角共通検索を無効化

### DIFF
--- a/src/Eccube/Doctrine/ORM/Query/Normalize.php
+++ b/src/Eccube/Doctrine/ORM/Query/Normalize.php
@@ -52,7 +52,7 @@ class Normalize extends FunctionNode
                 $sql = sprintf("LOWER(TRANSLATE(%s, '%s', '%s'))", $this->string->dispatch($sqlWalker), self::FROM, self::TO);
                 break;
             case 'pdo_mysql':
-                $sql = sprintf('%s COLLATE utf8_unicode_ci', $this->string->dispatch($sqlWalker));
+                $sql = $this->string->dispatch($sqlWalker);
                 break;
             default:
                 $sql = sprintf('LOWER(%s)', $this->string->dispatch($sqlWalker));


### PR DESCRIPTION
取り急ぎ #2051 の対応 (無効化しただけで、根本的な解決ではありません)