### PR TITLE
eccube_install.shで、MySQL使用時にパスワードの空白除去を最初に行う

### DIFF
--- a/eccube_install.sh
+++ b/eccube_install.sh
@@ -92,6 +92,7 @@ case "${DBTYPE}" in
 ;;
 "mysql" )
     #-- DB Seting MySQL
+    DBPASS=`echo $DBPASS | tr -d " "`
     MYSQL=mysql
     ROOTUSER=root
     ROOTPASS=${DBPASS}
@@ -219,7 +220,6 @@ case "${DBTYPE}" in
     get_optional_sql | ${PSQL} -U ${DBUSER} -q ${DBNAME} || exit 1
 ;;
 "mysql" )
-    DBPASS=`echo $DBPASS | tr -d " "`
     if [ -n ${DBPASS} ]; then
         PASSOPT="--password=$DBPASS"
         CONFIGPASS=$DBPASS


### PR DESCRIPTION
```
DBPASS=`echo $DBPASS | tr -d " "`
``` 

で空白除去を行っていますが、この処理の前に database.yml を出力しており、そちらでは空白除去前のパスワードが設定されるため、パスワードの差異が発生します。これを回避するための修正です。

```
DBPASS=" " sh eccube_install.sh mysql
```

のようにした場合に再現ができます。