### PR TITLE
お問い合わせ確認ページ：タイトルのオーバーライドはtwig内で行うように変更

### DIFF
--- a/src/Eccube/Controller/ContactController.php
+++ b/src/Eccube/Controller/ContactController.php
@@ -81,11 +81,9 @@ class ContactController
                     $builder->setAttribute('freeze', true);
                     $form = $builder->getForm();
                     $form->handleRequest($request);
-                    $title = 'お問い合わせ(確認ページ)';
 
                     return $app->render('Contact/confirm.twig', array(
                         'form' => $form->createView(),
-                        'title' => $title,
                     ));
 
                 case 'complete':

--- a/src/Eccube/Resource/template/default/Contact/confirm.twig
+++ b/src/Eccube/Resource/template/default/Contact/confirm.twig
@@ -21,6 +21,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #}
 {% extends 'default_frame.twig' %}
 
+{# ページのタイトルを上書きして設定する #}
+{% set title = 'お問い合わせ(確認ページ)' %}
+
 {% block main %}
 <div id="contents" class="main_only">
     <div id="confirm_wrap" class="container-fluid inner no-padding">


### PR DESCRIPTION
Controllerのphpコードでオーバーライドしていましたが、
デザインカスタマイズ時に...

- 変更箇所の特定が難しい
- 本体のphpコードを変更しないといけない

という理由のため、twigコード内でタイトルのオーバーライドを行うように変更しました。