### PR TITLE
商品在庫が無い場合でも、商品詳細画面に「お気に入りに追加」ボタンを表示する対応

### DIFF
--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -228,24 +228,24 @@ $(function(){
                                     <ul id="detail_cart_box__insert_button" class="row">
                                         <li class="col-xs-12 col-sm-8"><button type="submit" id="add-cart" class="btn btn-primary btn-block prevention-btn prevention-mask">カートに入れる</button></li>
                                     </ul>
-                                    {% if BaseInfo.option_favorite_product == 1 %}
-                                    <ul id="detail_cart_box__favorite_button" class="row">
-                                        {% if is_favorite == false %}
-                                            <li class="col-xs-12 col-sm-8"><button type="submit" id="favorite" class="btn btn-info btn-block prevention-btn prevention-mask">お気に入りに追加</button></li>
-                                        {% else %}
-                                            <li class="col-xs-12 col-sm-8"><button type="submit" id="favorite" class="btn btn-info btn-block" disabled="disabled">お気に入りに追加済みです</button></li>
-                                        {% endif %}
-                                    </ul>
-                                    {% endif %}
-                                </div>
                             {% else %}
                                 {# 在庫がない場合は品切れボタンのみ表示 #}
                                 <div id="detail_cart_box__button_area" class="btn_area">
                                     <ul class="row">
                                         <li class="col-xs-12 col-sm-8"><button type="button" class="btn btn-default btn-block" disabled="disabled">ただいま品切れ中です</button></li>
                                     </ul>
-                                </div>
-                            {% endif %}
+                            {% endif %} {#End stock find#}
+                                    {#Favorite product button#}
+                                    {% if BaseInfo.option_favorite_product == 1 %}
+                                        <ul id="detail_cart_box__favorite_button" class="row">
+                                            {% if is_favorite == false %}
+                                                <li class="col-xs-12 col-sm-8"><button type="submit" id="favorite" class="btn btn-info btn-block prevention-btn prevention-mask">お気に入りに追加</button></li>
+                                            {% else %}
+                                                <li class="col-xs-12 col-sm-8"><button type="submit" id="favorite" class="btn btn-info btn-block" disabled="disabled">お気に入りに追加済みです</button></li>
+                                            {% endif %}
+                                        </ul>
+                                    {% endif %}
+                                </div> {#End div#detail_cart_box__button_area #}
                         </div>
                         <!--▲買い物かご-->
                         {{ form_rest(form) }}

--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -228,13 +228,6 @@ $(function(){
                                     <ul id="detail_cart_box__insert_button" class="row">
                                         <li class="col-xs-12 col-sm-8"><button type="submit" id="add-cart" class="btn btn-primary btn-block prevention-btn prevention-mask">カートに入れる</button></li>
                                     </ul>
-                            {% else %}
-                                {# 在庫がない場合は品切れボタンのみ表示 #}
-                                <div id="detail_cart_box__button_area" class="btn_area">
-                                    <ul class="row">
-                                        <li class="col-xs-12 col-sm-8"><button type="button" class="btn btn-default btn-block" disabled="disabled">ただいま品切れ中です</button></li>
-                                    </ul>
-                            {% endif %} {#End stock find#}
                                     {#Favorite product button#}
                                     {% if BaseInfo.option_favorite_product == 1 %}
                                         <ul id="detail_cart_box__favorite_button" class="row">
@@ -246,6 +239,24 @@ $(function(){
                                         </ul>
                                     {% endif %}
                                 </div> {#End div#detail_cart_box__button_area #}
+                            {% else %}
+                                {# 在庫がない場合は品切れボタンを表示 #}
+                                <div id="detail_cart_box__button_area" class="btn_area">
+                                    <ul class="row">
+                                        <li class="col-xs-12 col-sm-8"><button type="button" class="btn btn-default btn-block" disabled="disabled">ただいま品切れ中です</button></li>
+                                    </ul>
+                                    {#Favorite product button#}
+                                    {% if BaseInfo.option_favorite_product == 1 %}
+                                        <ul id="detail_cart_box__favorite_button" class="row">
+                                            {% if is_favorite == false %}
+                                                <li class="col-xs-12 col-sm-8"><button type="submit" id="favorite" class="btn btn-info btn-block prevention-btn prevention-mask">お気に入りに追加</button></li>
+                                            {% else %}
+                                                <li class="col-xs-12 col-sm-8"><button type="submit" id="favorite" class="btn btn-info btn-block" disabled="disabled">お気に入りに追加済みです</button></li>
+                                            {% endif %}
+                                        </ul>
+                                    {% endif %}
+                                </div> {#End div#detail_cart_box__button_area #}
+                            {% endif %} {#End stock find#}
                         </div>
                         <!--▲買い物かご-->
                         {{ form_rest(form) }}

--- a/tests/Eccube/Tests/Web/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/ProductControllerTest.php
@@ -84,7 +84,7 @@ class ProductControllerTest extends AbstractWebTestCase
         /** @var $client Client */
         $client = $this->client;
         /** @var $crawler Crawler */
-        $crawler = $client->request('POST', $this->app->url('product_detail', array('id' => $id)));
+        $crawler = $client->request('GET', $this->app->url('product_detail', array('id' => $id)));
 
         $this->assertTrue($client->getResponse()->isSuccessful());
 
@@ -123,7 +123,7 @@ class ProductControllerTest extends AbstractWebTestCase
         /** @var $client Client */
         $client = $this->client;
         /** @var $crawler Crawler */
-        $crawler = $client->request('POST', $this->app->url('product_detail', array('id' => $id)));
+        $crawler = $client->request('GET', $this->app->url('product_detail', array('id' => $id)));
 
         $this->assertTrue($client->getResponse()->isSuccessful());
 

--- a/tests/Eccube/Tests/Web/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/ProductControllerTest.php
@@ -25,6 +25,9 @@
 namespace Eccube\Tests\Web;
 
 use Eccube\Common\Constant;
+use Eccube\Entity\ProductClass;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpKernel\Client;
 
 class ProductControllerTest extends AbstractWebTestCase
 {
@@ -56,4 +59,43 @@ class ProductControllerTest extends AbstractWebTestCase
         $this->assertTrue($client->getResponse()->isSuccessful());
     }
 
+    /**
+     * Test product can add favorite when out of stock.
+     *
+     * @link https://github.com/EC-CUBE/ec-cube/issues/1637
+     */
+    public function testProductFavoriteAddWhenOutOfStock()
+    {
+        // お気に入り商品機能を有効化
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $BaseInfo->setOptionFavoriteProduct(Constant::ENABLED);
+        $Product = $this->createProduct('Product no stock', 1);
+        /** @var $ProductClass ProductClass */
+        $ProductClass = $Product->getProductClasses()->first();
+        $ProductClass->setStockUnlimited(Constant::DISABLED);
+        $ProductClass->setStock(0);
+        $ProductStock = $ProductClass->getProductStock();
+        $ProductStock->setStock(0);
+        $this->app['orm.em']->flush();
+        $id = $Product->getId();
+        $user = $this->createCustomer();
+        $this->loginTo($user);
+
+        /** @var $client Client */
+        $client = $this->client;
+        /** @var $crawler Crawler */
+        $crawler = $client->request('POST',
+            $this->app->url('product_detail', array('id' => $id))
+        );
+
+        $this->assertTrue($client->getResponse()->isSuccessful());
+
+        $favoriteForm = $crawler->selectButton('お気に入りに追加')->form();
+        $favoriteForm['mode'] = 'add_favorite';
+
+        $client->submit($favoriteForm);
+        $crawler = $client->followRedirect();
+
+        $this->assertContains('お気に入りに追加済みです', $crawler->filter('#detail_cart_box')->html());
+    }
 }


### PR DESCRIPTION
fix #1637
Fixed :  商品在庫が無い場合、商品詳細画面に「お気に入りに追加」ボタンが表示されない