### PR TITLE
会員マスタの検索条件のセッション保持方法を変更

### DIFF
--- a/src/Eccube/Service/CsvExportService.php
+++ b/src/Eccube/Service/CsvExportService.php
@@ -381,12 +381,13 @@ class CsvExportService
     public function getCustomerQueryBuilder(Request $request)
     {
         $session = $request->getSession();
-        if ($session->has('eccube.admin.customer.search')) {
-            $searchData = $session->get('eccube.admin.customer.search');
-            $this->findDeserializeObjects($searchData);
-        } else {
-            $searchData = array();
-        }
+        $viewData = $session->get('eccube.admin.customer.search', array());
+
+        $app = \Eccube\Application::getInstance();
+        $searchForm = $app['form.factory']
+            ->create('admin_search_customer', null, array('csrf_protection' => true));
+
+        $searchData = \Eccube\FormUtil::submitAndGetData($searchForm, $viewData);
 
         // 会員データのクエリビルダを構築.
         $qb = $this->customerRepository

--- a/src/Eccube/Service/CsvExportService.php
+++ b/src/Eccube/Service/CsvExportService.php
@@ -387,7 +387,7 @@ class CsvExportService
         $searchForm = $app['form.factory']
             ->create('admin_search_customer', null, array('csrf_protection' => true));
 
-        $searchData = \Eccube\FormUtil::submitAndGetData($searchForm, $viewData);
+        $searchData = \Eccube\Util\FormUtil::submitAndGetData($searchForm, $viewData);
 
         // 会員データのクエリビルダを構築.
         $qb = $this->customerRepository

--- a/src/Eccube/Util/FormUtil.php
+++ b/src/Eccube/Util/FormUtil.php
@@ -44,6 +44,13 @@ class FormUtil
         return $viewData;
     }
 
+    /**
+     * formオブジェクトにviewdataをsubmitし, マッピングした結果を返す.
+     *
+     * @param FormInterface $form
+     * @param $viewData
+     * @return mixed
+     */
     public static function submitAndGetData(FormInterface $form, $viewData)
     {
         $form->submit($viewData);

--- a/src/Eccube/Util/FormUtil.php
+++ b/src/Eccube/Util/FormUtil.php
@@ -37,8 +37,14 @@ class FormUtil
     public static function getViewData(FormInterface $form)
     {
         $viewData = array();
-        foreach ($form->all() as $key => $value) {
-            $viewData[$key] = $value->getViewData();
+        $forms = $form->all();
+
+        if (empty($forms)) {
+            return $form->getViewData();
+        }
+
+        foreach ($forms as $key => $value) {
+            $viewData[$key] = self::getViewData($value);
         }
 
         return $viewData;

--- a/src/Eccube/Util/FormUtil.php
+++ b/src/Eccube/Util/FormUtil.php
@@ -44,7 +44,12 @@ class FormUtil
         }
 
         foreach ($forms as $key => $value) {
-            $viewData[$key] = self::getViewData($value);
+            // choice typeは各選択肢もFormとして扱われるため再帰しない.
+            if ($value->getConfig()->hasOption('choices')) {
+                $viewData[$key] = $value->getViewData();
+            } else {
+                $viewData[$key] = self::getViewData($value);
+            }
         }
 
         return $viewData;

--- a/src/Eccube/Util/FormUtil.php
+++ b/src/Eccube/Util/FormUtil.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Util;
+
+
+use Symfony\Component\Form\FormInterface;
+
+class FormUtil
+{
+    /**
+     * formオブジェクトからviewDataを取得する.
+     *
+     * @param FormInterface $form
+     * @return array
+     */
+    public static function getViewData(FormInterface $form)
+    {
+        $viewData = array();
+        foreach ($form->all() as $key => $value) {
+            $viewData[$key] = $value->getViewData();
+        }
+
+        return $viewData;
+    }
+
+    public static function submitAndGetData(FormInterface $form, $viewData)
+    {
+        $form->submit($viewData);
+
+        return $form->getData();
+    }
+}

--- a/tests/Eccube/Tests/Util/FormUtilTest.php
+++ b/tests/Eccube/Tests/Util/FormUtilTest.php
@@ -94,4 +94,58 @@ class FormUtilTest extends EccubeTestCase
         $viewData = FormUtil::getViewData($form);
         $this->assertEquals($formData, $viewData);
     }
+
+    /**
+     * choice typeのテスト
+     */
+    public function testChoiceType()
+    {
+        $formData = array(
+            'sex' => '1',
+        );
+
+        $form = $this->app['form.factory']
+            ->createBuilder(
+                'form',
+                null,
+                array(
+                    'csrf_protection' => false,
+                )
+            )
+            ->add('sex', 'sex')
+            ->getForm();
+
+        $form->submit($formData);
+        $viewData = FormUtil::getViewData($form);
+        $this->assertEquals($formData, $viewData);
+    }
+
+
+    /**
+     * choice type(multiple)のテスト
+     */
+    public function testChoiceTypeMultiple()
+    {
+        $formData = array(
+            'sex' => array('1', '2')
+        );
+
+        $form = $this->app['form.factory']
+            ->createBuilder(
+                'form',
+                null,
+                array(
+                    'csrf_protection' => false,
+                )
+            )
+            ->add('sex', 'sex', array(
+                'multiple' => true,
+            ))
+            ->getForm();
+
+        $form->submit($formData);
+        $viewData = FormUtil::getViewData($form);
+        $this->assertEquals($formData, $viewData);
+    }
+
 }

--- a/tests/Eccube/Tests/Util/FormUtilTest.php
+++ b/tests/Eccube/Tests/Util/FormUtilTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Eccube\Tests\Util;
+
+use Eccube\Tests\EccubeTestCase;
+use Eccube\Util\FormUtil;
+
+class FormUtilTest extends EccubeTestCase
+{
+    protected $form;
+
+    protected $formData = array(
+        'pref' => '28',
+        'name' => 'パーコレータ',
+        'date' => '2017-02-01'
+    );
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->form = $this->app['form.factory']
+            ->createBuilder(
+                'form',
+                null,
+                array(
+                    'csrf_protection' => false,
+                )
+            )
+            ->add('pref', 'pref')
+            ->add('name', 'text')
+            ->add('date', 'date', array(
+                'label' => '受注日(FROM)',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'empty_value' => array('year' => '----', 'month' => '--', 'day' => '--'),
+            ))
+            ->getForm();
+    }
+
+    public function testGetViewData()
+    {
+        $this->form->submit($this->formData);
+
+        $viewData = FormUtil::getViewData($this->form);
+
+        // POSTしたデータと同じになるはず.
+        $this->assertEquals($this->formData, $viewData);
+    }
+
+    public function testSubmitAndGetData()
+    {
+        $data = FormUtil::submitAndGetData($this->form, $this->formData);
+
+        // formはsubmitされている.
+        $this->assertTrue($this->form->isSubmitted());
+
+        // prefはPrefエンティティに変換されている.
+        $this->assertInstanceOf('\Eccube\Entity\Master\Pref', $data['pref']);
+        $this->assertEquals(28, $data['pref']->getId());
+        $this->assertEquals('兵庫県', $data['pref']->getName());
+
+        // dateはDateTimeに変換されている.
+        $this->assertInstanceOf('\DateTime', $data['date']);
+    }
+}

--- a/tests/Eccube/Tests/Util/FormUtilTest.php
+++ b/tests/Eccube/Tests/Util/FormUtilTest.php
@@ -65,4 +65,33 @@ class FormUtilTest extends EccubeTestCase
         // dateはDateTimeに変換されている.
         $this->assertInstanceOf('\DateTime', $data['date']);
     }
+
+    /**
+     * AddressTypeなど, 子要素をもつFormTypeのテスト.
+     */
+    public function testNestedFormType()
+    {
+        $formData = array(
+            'address' => array(
+                'pref' => '27',
+                'addr01' => '北区',
+                'addr02' => '梅田'
+            )
+        );
+
+        $form = $this->app['form.factory']
+            ->createBuilder(
+                'form',
+                null,
+                array(
+                    'csrf_protection' => false,
+                )
+            )
+            ->add('address', 'address')
+            ->getForm();
+
+        $form->submit($formData);
+        $viewData = FormUtil::getViewData($form);
+        $this->assertEquals($formData, $viewData);
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#2112 の対応

## 方針(Policy)

entityをセッションに保持するのは推奨されていない
entityではなく、postされたデータをセッションに保持し、利用時に復元するように修正

参考
http://qiita.com/tarokamikaze/items/b6cb73be0294fe6b14c1#14ajax%E7%94%A8%E3%81%AE-api-%E4%BD%9C%E3%82%8A%E3%81%9F%E3%81%84

## 実装に関する補足(Appendix)

- 受注検索、商品検索も同様に対応する必要がある

## テスト（Test)

## 相談（Discussion）



