### PR TITLE
[WIP]商品個別税率の場合は、共通の課税規則を利用するように変更。

### DIFF
--- a/src/Eccube/Repository/TaxRuleRepository.php
+++ b/src/Eccube/Repository/TaxRuleRepository.php
@@ -203,9 +203,20 @@ class TaxRuleRepository extends EntityRepository
         });
 
         if (!empty($TaxRules)) {
-            $this->rules[$cacheKey] = $TaxRules[0];
+            $TaxRule = $TaxRules[0];
 
-            return $TaxRules[0];
+            // 商品個別税率の場合は、共通税率設定の課税規則を適用して返却
+            $RelatedProduct = $TaxRule->getProduct();
+            if (!empty($RelatedProduct)) {
+                $CommonTaxRule = $this->getByRule();
+                $CommonCalcRule = $CommonTaxRule->getCalcRule();
+                $TaxRule->setCalcRule($CommonCalcRule);
+            }
+
+            // キャッシュに保存
+            $this->rules[$cacheKey] = $TaxRule;
+
+            return $TaxRule;
         } else {
             throw new NoResultException();
         }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 個別税率を設定した商品は、課税規則が常に「四捨五入」で計算されている #2114

## 方針(Policy)
+ 商品に個別税率がある場合の計算も、`税率設定>共通税率設定`の課税規則(四捨五入/切り上げ/切り捨て)に連動するように変更。

## 実装に関する補足(Appendix)
+ dtb_tax_ruleのレコードを書き換えるのではなく、税率設定の取得時に書き換えるアプローチで、変更箇所を少なくしました。

## テスト（Test)
+ これからやります＆テストコード書きます（まだWIP）

## 相談（Discussion）
+ もっといい方法あればアドバイスいただきたいです。



