### PR TITLE
管理画面にてサーバ側のチェックにて入力エラー発生時、エラー箇所へジャンプさせる対応 #1929

### DIFF
--- a/html/template/admin/assets/js/function.js
+++ b/html/template/admin/assets/js/function.js
@@ -219,9 +219,11 @@ $(function () {
         $('body').append($form); // Firefox requires form to be on the page to allow submission
         $form.submit();
     });
+});
 
-    // Scroll to error message if have
-    $(window).load(function() {
+// Scroll to error message if have
+$(window).load(function() {
+    $(function () {
         var el = $(".errormsg");
         if (el.length) {
             // Open panel when has error
@@ -235,16 +237,16 @@ $(function () {
                 $('html, body').scrollTop(errorOffset - errorMargin);
             }, 400);
         }
-    });
 
-    function openPanel(el) {
-        var accordion = el.parents('div.accordion');
-        if (accordion) {
-            var toggle = accordion.find('div.toggle');
-            if (!toggle.hasClass('active')) {
-                toggle.addClass('active');
-                accordion.find('div.accpanel').toggle('fast');
+        function openPanel(el) {
+            var accordion = el.parents('div.accordion');
+            if (accordion) {
+                var toggle = accordion.find('div.toggle');
+                if (!toggle.hasClass('active')) {
+                    toggle.addClass('active');
+                    accordion.find('div.accpanel').toggle('fast');
+                }
             }
         }
-    }
+    });
 });

--- a/html/template/admin/assets/js/function.js
+++ b/html/template/admin/assets/js/function.js
@@ -223,30 +223,25 @@ $(function () {
 
 // Scroll to error message if have
 $(window).load(function() {
-    $(function () {
-        var el = $(".errormsg");
-        if (el.length) {
-            // Open panel when has error
-            openPanel(el.first());
-            // Waiting for other js and css completed before scroll to error message.
-            setTimeout(function () {
-                var errorOffset = el.first().offset().top;
-                var screenHeight = $(window).height();
-                var errorMargin = parseInt(screenHeight/10) + $('header').outerHeight();
+    var el = $(".errormsg");
+    if (el.length) {
+        // Open panel when has error
+        openPanel(el.first());
+        var errorOffset = el.first().offset().top;
+        var screenHeight = $(window).height();
+        var errorMargin = parseInt(screenHeight/10) + $('header').outerHeight();
 
-                $('html, body').scrollTop(errorOffset - errorMargin);
-            }, 400);
-        }
+        $('html, body').scrollTop(errorOffset - errorMargin);
+    }
 
-        function openPanel(el) {
-            var accordion = el.parents('div.accordion');
-            if (accordion) {
-                var toggle = accordion.find('div.toggle');
-                if (!toggle.hasClass('active')) {
-                    toggle.addClass('active');
-                    accordion.find('div.accpanel').toggle('fast');
-                }
+    function openPanel(el) {
+        var accordion = el.parents('div.accordion');
+        if (accordion) {
+            var toggle = accordion.find('div.toggle');
+            if (!toggle.hasClass('active')) {
+                toggle.addClass('active');
+                accordion.find('div.accpanel').toggle('fast');
             }
         }
-    });
+    }
 });

--- a/html/template/admin/assets/js/function.js
+++ b/html/template/admin/assets/js/function.js
@@ -224,6 +224,8 @@ $(function () {
     $(window).load(function() {
         var el = $(".errormsg");
         if (el.length) {
+            // Open panel when has error
+            openPanel(el.first());
             setTimeout(function () {
                 var errorOffset = el.first().offset().top;
                 var screenHeight = $(window).height();
@@ -233,4 +235,15 @@ $(function () {
             }, 400);
         }
     });
+
+    function openPanel(el) {
+        var accordion = el.parents('div.accordion');
+        if (accordion) {
+            var toggle = accordion.find('div.toggle');
+            if (!toggle.hasClass('active')) {
+                toggle.addClass('active');
+                accordion.find('div.accpanel').toggle('fast');
+            }
+        }
+    }
 });

--- a/html/template/admin/assets/js/function.js
+++ b/html/template/admin/assets/js/function.js
@@ -3,12 +3,9 @@
  */
 
 jQuery(document).ready(function ($) {
-
     /*
      * Brake point Check
      */
-
-
     $(window).on('load , resize', function () {
         $('body').removeClass('pc_view md_view sp_view');
         if (window.innerWidth < 768) {
@@ -222,4 +219,18 @@ $(function () {
         $('body').append($form); // Firefox requires form to be on the page to allow submission
         $form.submit();
     });
+
+
+    // scroll to error message if have
+    var el = $(".errormsg");
+    if (el.length) {
+        var body = $('html, body');
+        var offsetError = el.first().offset().top;
+        var screenHeight = $(window).height();
+        var errorMargin = parseInt(screenHeight/10) + $('header').outerHeight();
+
+        $(body).stop().animate({
+            scrollTop: offsetError - errorMargin
+        }, 500);
+    }
 });

--- a/html/template/admin/assets/js/function.js
+++ b/html/template/admin/assets/js/function.js
@@ -220,12 +220,13 @@ $(function () {
         $form.submit();
     });
 
-    // scroll to error message if have
+    // Scroll to error message if have
     $(window).load(function() {
         var el = $(".errormsg");
         if (el.length) {
             // Open panel when has error
             openPanel(el.first());
+            // Waiting for other js and css completed before scroll to error message.
             setTimeout(function () {
                 var errorOffset = el.first().offset().top;
                 var screenHeight = $(window).height();

--- a/html/template/admin/assets/js/function.js
+++ b/html/template/admin/assets/js/function.js
@@ -220,17 +220,17 @@ $(function () {
         $form.submit();
     });
 
-
     // scroll to error message if have
-    var el = $(".errormsg");
-    if (el.length) {
-        var body = $('html, body');
-        var offsetError = el.first().offset().top;
-        var screenHeight = $(window).height();
-        var errorMargin = parseInt(screenHeight/10) + $('header').outerHeight();
+    $(window).load(function() {
+        var el = $(".errormsg");
+        if (el.length) {
+            setTimeout(function () {
+                var errorOffset = el.first().offset().top;
+                var screenHeight = $(window).height();
+                var errorMargin = parseInt(screenHeight/10) + $('header').outerHeight();
 
-        $(body).stop().animate({
-            scrollTop: offsetError - errorMargin
-        }, 500);
-    }
+                $('html, body').scrollTop(errorOffset - errorMargin);
+            }, 400);
+        }
+    });
 });

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -34,14 +34,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 <script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
 <script>
 $(function() {
-    // scroll to error message if have
-    var el = $('.errormsg');
-    if (el.length) {
-        $('html, body').animate({
-            scrollTop: (el.first().offset().top - 200)
-        }, 500);
-    }
-
     $('#zip-search').click(function() {
         AjaxZip3.zip2addr('order[zip][zip01]', 'order[zip][zip02]', 'order[address][pref]', 'order[address][addr01]');
     });

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -34,6 +34,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 <script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
 <script>
 $(function() {
+    // scroll to error message if have
+    var el = $('.errormsg');
+    if (el.length) {
+        $('html, body').animate({
+            scrollTop: (el.first().offset().top - 200)
+        }, 500);
+    }
+
     $('#zip-search').click(function() {
         AjaxZip3.zip2addr('order[zip][zip01]', 'order[zip][zip02]', 'order[address][pref]', 'order[address][addr01]');
     });


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ PullRequestの目的: https://github.com/EC-CUBE/ec-cube/issues/1929

## 方針(Policy)


## 実装に関する補足(Appendix)
+ when have error input, after loading, delay 0.4s to scroll to error input

## テスト（Test)
### 確認画面
商品登録
受注登録
会員登録
新着情報管理
ファイル管理
ページ作成
ブロック作成
ショップマスター
特定商取引
支払い方法設定
配送方法設定
税率設定
メンバー管理
セキュリティ管理
マスターデータ管理
テンプレートアップロード
認証キー設定
### 検証端末
windows7 + chrome：前述の全ケースを確認
windows7 + firefox：受注登録画面の1ケースのみ確認
windows7 + IE11：受注登録画面の1ケースのみ確認
ipad mini + safari：受注登録画面の1ケースのみ確認
iPhone + safari：受注登録画面の1ケースのみ確認
Android (Simulator)：受注登録画面の1ケースのみ確認

## 相談（Discussion）




