### PR TITLE
Fix issue #2125 マイページ_ご注文履歴詳細_配送情報_配送方法で、配送料金の参照データが違う

### DIFF
--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -167,7 +167,7 @@ $(function(){
                             {{ Shipping.tel01 }}-{{ Shipping.tel02 }}-{{ Shipping.tel03 }}
                         </p>
                         <p id="shipping_list__delivery--{{ Shipping.id }}">
-                            配送方法：　{{ Shipping.shipping_delivery_name }}{{ Shipping.delivery_fee ? '（＋' ~ Shipping.delivery_fee.fee|price ~ '）' : '' }}<br>
+                            配送方法：　{{ Shipping.shipping_delivery_name }}{{ Shipping.shipping_delivery_fee ? '（＋' ~ Shipping.shipping_delivery_fee|price ~ '）' : '' }}<br>
                             お届け日：　{{ Shipping.shipping_delivery_date|date_format|default('指定なし') }}<br>
                             お届け時間：　{{ Shipping.shipping_delivery_time|default('指定なし') }}
                         </p>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ Fix issue #2125
　マイページ_ご注文履歴詳細_配送情報_配送方法で表示する配送料金について、
　配送方法による規定料金(Shipping.delivery_fee.fee)から
　決済時に確定した配送料金(Shipping.shipping_delivery_fee)に修正する。
　購入金額による無料送料が適用された場合などに齟齬が生じるため。

## 方針(Policy)
+ 特になし

## 実装に関する補足(Appendix)
+ 特になし

## テスト（Test)
+ Shipping.shipping_delivery_fee値による表示確認
　1)NULL,0 ... 表示なし
　2)1〜999999999 ... （＋¥ 1）〜（＋¥ 9,999,999,999）

## 相談（Discussion）
+ 特になし
