### PR TITLE
UnitTest:テスト用ダミー商品作成時に、販売制限数が必ず1以上になるように修正。

### DIFF
--- a/tests/Eccube/Tests/Web/Admin/Product/AbstractProductCommonTestCase.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/AbstractProductCommonTestCase.php
@@ -85,7 +85,7 @@ abstract class AbstractProductCommonTestCase extends AbstractAdminWebTestCase
             ->setCode('test code')
             ->setStock(100)
             ->setStockUnlimited(Constant::DISABLED)
-            ->setSaleLimit($this->faker->randomNumber(2))
+            ->setSaleLimit($this->faker->randomNumber(2) + 1)
             ->setPrice01($this->faker->randomNumber(4))
             ->setPrice02($this->faker->randomNumber(4))
             ->setDeliveryFee($this->faker->randomNumber(4))

--- a/tests/Eccube/Tests/Web/Admin/Product/AbstractProductCommonTestCase.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/AbstractProductCommonTestCase.php
@@ -85,7 +85,7 @@ abstract class AbstractProductCommonTestCase extends AbstractAdminWebTestCase
             ->setCode('test code')
             ->setStock(100)
             ->setStockUnlimited(Constant::DISABLED)
-            ->setSaleLimit($this->faker->randomNumber(2) + 1)
+            ->setSaleLimit($this->faker->numberBetween(1, 99))
             ->setPrice01($this->faker->randomNumber(4))
             ->setPrice02($this->faker->randomNumber(4))
             ->setDeliveryFee($this->faker->randomNumber(4))


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
UnitTest
- 販売制限数に「0」が設定された時に、エラーになってテスト失敗するのを修正。
- SQLiteのテストがNGになっていたのを修正。

## 方針(Policy)
テストコードのみの修正です。

## 実装に関する補足(Appendix)
なし

## テスト（Test)
Unitテストが通ることを確認しました。

## 相談（Discussion）
なし