### PR TITLE
購入確認画面のページレイアウトレコードを追加

### DIFF
--- a/src/Eccube/Resource/doctrine/migration/Version20170222120000.php
+++ b/src/Eccube/Resource/doctrine/migration/Version20170222120000.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\ORM\EntityManager;
+use Eccube\Entity\PageLayout;
+
+class Version20170222120000 extends AbstractMigration
+{
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $app = \Eccube\Application::getInstance();
+        /** @var EntityManager $em */
+        $em = $app["orm.em"];
+
+        $DeviceType = $app['eccube.repository.master.device_type']->find(10);
+
+        $PageLayout = new PageLayout();
+        $PageLayout
+            ->setDeviceType($DeviceType)
+            ->setName('商品購入/確認')
+            ->setUrl('shopping_confirm')
+            ->setFileName('Shopping/confirm')
+            ->setEditFlg(2)
+            ->setMetaRobots('noindex');
+        $em->persist($PageLayout);
+
+        $em->flush();
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+
+    }
+}

--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -296,6 +296,13 @@ class EditControllerTest extends AbstractEditControllerTestCase
             $tax = (int) $this->app['eccube.service.tax_rule']->calcTax($orderDetail['price'], $orderDetail['tax_rate'], $orderDetail['tax_rule']);
             $totalTax += $tax * $formDataForEdit['OrderDetails'][$indx]['quantity'];
         }
+        
+        // Multi用項目を削除
+        foreach($formDataForEdit['Shippings'] as $key => $node){
+            if(isset($node['ShipmentItems'])){
+                unset($formDataForEdit['Shippings'][$key]['ShipmentItems']);
+            }
+        }
 
         // 管理画面で受注編集する
         $this->client->request(
@@ -305,6 +312,7 @@ class EditControllerTest extends AbstractEditControllerTestCase
             )
         );
         $EditedOrderafterEdit = $this->app['eccube.repository.order']->find($Order->getId());
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_order_edit', array('id' => $Order->getId()))));
 
         //確認する「トータル税金」
         $this->expected = $totalTax;
@@ -331,6 +339,7 @@ class EditControllerTest extends AbstractEditControllerTestCase
 
         $savedOderId = preg_replace('/.*\/admin\/order\/(\d+)\/edit/', '$1', $url);
         $SavedOrder = $this->app['eccube.repository.order']->find($savedOderId);
+        $this->assertTrue($this->client->getResponse()->isRedirect($url));
 
         $this->expected = $this->Customer->getSex();
         $this->actual = $SavedOrder->getSex();

--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -296,13 +296,6 @@ class EditControllerTest extends AbstractEditControllerTestCase
             $tax = (int) $this->app['eccube.service.tax_rule']->calcTax($orderDetail['price'], $orderDetail['tax_rate'], $orderDetail['tax_rule']);
             $totalTax += $tax * $formDataForEdit['OrderDetails'][$indx]['quantity'];
         }
-        
-        // Multi用項目を削除
-        foreach($formDataForEdit['Shippings'] as $key => $node){
-            if(isset($node['ShipmentItems'])){
-                unset($formDataForEdit['Shippings'][$key]['ShipmentItems']);
-            }
-        }
 
         // 管理画面で受注編集する
         $this->client->request(
@@ -312,7 +305,6 @@ class EditControllerTest extends AbstractEditControllerTestCase
             )
         );
         $EditedOrderafterEdit = $this->app['eccube.repository.order']->find($Order->getId());
-        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_order_edit', array('id' => $Order->getId()))));
 
         //確認する「トータル税金」
         $this->expected = $totalTax;
@@ -339,7 +331,6 @@ class EditControllerTest extends AbstractEditControllerTestCase
 
         $savedOderId = preg_replace('/.*\/admin\/order\/(\d+)\/edit/', '$1', $url);
         $SavedOrder = $this->app['eccube.repository.order']->find($savedOderId);
-        $this->assertTrue($this->client->getResponse()->isRedirect($url));
 
         $this->expected = $this->Customer->getSex();
         $this->actual = $SavedOrder->getSex();

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -245,6 +245,55 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
     }
 
     /**
+     * 購入確認画面→支払い方法失敗する、レイアウトヘッダーとフッター確認
+     */
+    public function testOrtderConfirmLayout()
+    {
+        $faker = $this->getFaker();
+        $Customer = $this->logIn();
+        $client = $this->client;
+
+        // カート画面
+        $this->scenarioCartIn($client);
+
+        // 確認画面
+        $crawler = $this->scenarioConfirm($client);
+
+        // 支払い方法選択
+        $crawler = $client->request(
+            'POST',
+            $this->app->path('shopping_payment'),
+            array(
+                'shopping' => array(
+                    'shippings' => array(
+                        0 => array(
+                            'delivery' => 1,
+                            'deliveryTime' => 1
+                        ),
+                    ),
+                    'payment' => 0,
+                    'message' => $faker->text(),
+                    '_token' => 'dummy'
+                )
+            )
+        );
+        // レイアウトヘッダーの部分確認
+        $this->expected = 'header';
+        $this->actual = $crawler->filter('header')->attr('id');
+        $this->verify();
+
+        // レイアウトフッターの部分確認
+        $this->expected = 'footer';
+        $this->actual = $crawler->filter('footer')->attr('id');
+        $this->verify();
+
+        // 確認画面で支払方法エラー表示する確認
+        $this->expected = '有効な値ではありません。';
+        $this->actual = $crawler->filter('P.errormsg')->text();
+        $this->verify();
+    }
+
+    /**
      * 購入確認画面→支払い方法選択(エラー)
      */
     public function testPaymentWithError()


### PR DESCRIPTION
注文確定時バリデーションエラーが発生した場合、ヘッダー等が消えてしまう。
https://github.com/EC-CUBE/ec-cube/issues/2063

dtb_page_layoutテーブルにshopping_confirmレーコドを追加する


