### PR TITLE
メンバー削除後に例外ならないように対応

### DIFF
--- a/src/Eccube/Entity/AuthorityRole.php
+++ b/src/Eccube/Entity/AuthorityRole.php
@@ -3,6 +3,7 @@
 namespace Eccube\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Eccube\Util\EntityUtil;
 
 /**
  * AuthorityRole
@@ -162,6 +163,9 @@ class AuthorityRole extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 }

--- a/src/Eccube/Entity/Category.php
+++ b/src/Eccube/Entity/Category.php
@@ -26,6 +26,7 @@ namespace Eccube\Entity;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Mapping as ORM;
+use Eccube\Util\EntityUtil;
 
 /**
  * Category
@@ -465,6 +466,9 @@ class Category extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 }

--- a/src/Eccube/Entity/ClassCategory.php
+++ b/src/Eccube/Entity/ClassCategory.php
@@ -24,6 +24,8 @@
 
 namespace Eccube\Entity;
 
+use Eccube\Util\EntityUtil;
+
 /**
  * ClassCategory
  */
@@ -245,6 +247,9 @@ class ClassCategory extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 }

--- a/src/Eccube/Entity/ClassName.php
+++ b/src/Eccube/Entity/ClassName.php
@@ -24,6 +24,8 @@
 
 namespace Eccube\Entity;
 
+use Eccube\Util\EntityUtil;
+
 /**
  * ClassName
  */
@@ -263,6 +265,9 @@ class ClassName extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 }

--- a/src/Eccube/Entity/Csv.php
+++ b/src/Eccube/Entity/Csv.php
@@ -3,6 +3,7 @@
 namespace Eccube\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Eccube\Util\EntityUtil;
 
 /**
  * Csv
@@ -302,6 +303,9 @@ class Csv extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 }

--- a/src/Eccube/Entity/Delivery.php
+++ b/src/Eccube/Entity/Delivery.php
@@ -23,6 +23,7 @@
 
 
 namespace Eccube\Entity;
+use Eccube\Util\EntityUtil;
 
 /**
  * Delivery
@@ -401,6 +402,9 @@ class Delivery extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 

--- a/src/Eccube/Entity/MailHistory.php
+++ b/src/Eccube/Entity/MailHistory.php
@@ -23,6 +23,7 @@
 
 
 namespace Eccube\Entity;
+use Eccube\Util\EntityUtil;
 
 /**
  * MailHistory
@@ -217,6 +218,9 @@ class MailHistory extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 }

--- a/src/Eccube/Entity/MailTemplate.php
+++ b/src/Eccube/Entity/MailTemplate.php
@@ -25,6 +25,7 @@
 namespace Eccube\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Eccube\Util\EntityUtil;
 
 /**
  * MailTemplate
@@ -304,6 +305,9 @@ class MailTemplate extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 }

--- a/src/Eccube/Entity/Member.php
+++ b/src/Eccube/Entity/Member.php
@@ -27,6 +27,7 @@ namespace Eccube\Entity;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Eccube\Util\EntityUtil;
 
 /**
  * Member
@@ -379,6 +380,9 @@ class Member extends \Eccube\Entity\AbstractEntity implements UserInterface
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 

--- a/src/Eccube/Entity/News.php
+++ b/src/Eccube/Entity/News.php
@@ -24,6 +24,8 @@
 
 namespace Eccube\Entity;
 
+use Eccube\Util\EntityUtil;
+
 /**
  * News
  */
@@ -357,6 +359,9 @@ class News extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 }

--- a/src/Eccube/Entity/Payment.php
+++ b/src/Eccube/Entity/Payment.php
@@ -24,6 +24,8 @@
 
 namespace Eccube\Entity;
 
+use Eccube\Util\EntityUtil;
+
 /**
  * Payment
  */
@@ -283,6 +285,9 @@ class Payment extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 

--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -26,6 +26,8 @@ namespace Eccube\Entity;
 
 use Eccube\Common\Constant;
 use Doctrine\Common\Collections\ArrayCollection;
+use Eccube\Util\EntityUtil;
+
 /**
  * Product
  */
@@ -903,6 +905,9 @@ class Product extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 

--- a/src/Eccube/Entity/ProductClass.php
+++ b/src/Eccube/Entity/ProductClass.php
@@ -24,6 +24,8 @@
 
 namespace Eccube\Entity;
 
+use Eccube\Util\EntityUtil;
+
 /**
  * ProductClass
  */
@@ -639,6 +641,9 @@ class ProductClass extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
     /**

--- a/src/Eccube/Entity/ProductImage.php
+++ b/src/Eccube/Entity/ProductImage.php
@@ -3,6 +3,7 @@
 namespace Eccube\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Eccube\Util\EntityUtil;
 
 /**
  * ProductImage
@@ -170,6 +171,9 @@ class ProductImage extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 }

--- a/src/Eccube/Entity/ProductStock.php
+++ b/src/Eccube/Entity/ProductStock.php
@@ -3,6 +3,7 @@
 namespace Eccube\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Eccube\Util\EntityUtil;
 
 /**
  * ProductStock
@@ -166,6 +167,9 @@ class ProductStock extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
     /**

--- a/src/Eccube/Entity/ProductTag.php
+++ b/src/Eccube/Entity/ProductTag.php
@@ -3,6 +3,8 @@
 namespace Eccube\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Eccube\Util\EntityUtil;
+
 
 /**
  * ProductTag
@@ -134,6 +136,9 @@ class ProductTag extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 

--- a/src/Eccube/Entity/TaxRule.php
+++ b/src/Eccube/Entity/TaxRule.php
@@ -24,6 +24,9 @@
 
 namespace Eccube\Entity;
 
+use Eccube\Util\EntityUtil;
+
+
 /**
  * TaxRule
  */
@@ -306,6 +309,9 @@ class TaxRule extends \Eccube\Entity\AbstractEntity
      */
     public function getCreator()
     {
+        if (EntityUtil::isEmpty($this->Creator)) {
+            return null;
+        }
         return $this->Creator;
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
インストール時に登録されるサンプル商品の作成者(Member)が論理削除されている
https://github.com/EC-CUBE/ec-cube/issues/847

## 方針(Policy)
$Entity->getCreator()呼び出すあとに[ IS NULL]チェックが必要です

## 実装に関する補足(Appendix)
特になし

## テスト（Test)
なし


