### PR TITLE
インストール時に、Proxy設定を出力する処理の変更

### DIFF
--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -174,7 +174,7 @@ class InstallController
 
                 // ロードバランサー、プロキシサーバ設定
                 $sessionData['trusted_proxies_connection_only'] = (bool)$config['trusted_proxies_connection_only'];
-                $trustedProxies = $config['admin_allow_host'];
+                $trustedProxies = $config['trusted_proxies'];
                 if (count($trustedProxies) > 0) {
                     $sessionData['trusted_proxies'] = Str::convertLineFeed(implode("\n", $trustedProxies));
                 }

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -691,8 +691,8 @@ class InstallController
             $adminTrustedProxies = array('127.0.0.1/8', '::1');
         }
 
-        $target = array('${AUTH_MAGIC}', '${SHOP_NAME}', '${ECCUBE_INSTALL}', '${FORCE_SSL}', '${TRUSTED_PROXIES_CONNECTION_ONLY}');
-        $replace = array($auth_magic, $data['shop_name'], '0', $data['admin_force_ssl'], $data['trusted_proxies_connection_only']);
+        $target = array('${AUTH_MAGIC}', '${SHOP_NAME}', '${ECCUBE_INSTALL}', '${FORCE_SSL}');
+        $replace = array($auth_magic, $data['shop_name'], '0', $data['admin_force_ssl']);
 
         $fs = new Filesystem();
         $content = str_replace(
@@ -702,6 +702,7 @@ class InstallController
 
         $config = Yaml::parse(file_get_contents($config_file));
         $config['admin_allow_host'] = $adminAllowHosts;
+        $config['trusted_proxies_connection_only'] = $data['trusted_proxies_connection_only'];
         $config['trusted_proxies'] = $adminTrustedProxies;
         $yml = Yaml::dump($config);
         file_put_contents($config_file, $yml);

--- a/src/Eccube/Resource/config/config.yml.dist
+++ b/src/Eccube/Resource/config/config.yml.dist
@@ -3,12 +3,10 @@ password_hash_algos: sha256
 shop_name: ${SHOP_NAME}
 force_ssl: ${FORCE_SSL}
 admin_allow_host:
-trusted_proxies_connection_only: ${TRUSTED_PROXIES_CONNECTION_ONLY}
-trusted_proxies:
 cookie_lifetime: 0
 cookie_name: eccube
 locale: ja
 timezone: Asia/Tokyo
 pageinrange: false
-trusted_proxies_connection_only: ${TRUSTED_PROXIES_CONNECTION_ONLY}
-trusted_proxies:
+trusted_proxies_connection_only: false
+trusted_proxies: {  }

--- a/src/Eccube/Resource/doctrine/migration/Version20170217184500.php
+++ b/src/Eccube/Resource/doctrine/migration/Version20170217184500.php
@@ -26,7 +26,7 @@ class Version20170217184500 extends AbstractMigration
 
         // キーが未定義の場合は初期値を設定する
         if (!array_key_exists('trusted_proxies_connection_only', $config)) {
-            $appendConfig['trusted_proxies_connection_only'] = 0;
+            $appendConfig['trusted_proxies_connection_only'] = false;
         }
         if (!array_key_exists('trusted_proxies', $config)) {
             $appendConfig['trusted_proxies'] = array();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
インストール時に、Proxy設定を出力する処理の変更。
(Proxy設定は3.0.14で追加したパラメータ)

- 文字列置き換えを行う必要は無いので、置き換え利用しないようにしました。
- 再インストール時に、Proxy一覧を読み込めない不具合があったので修正しました。

## 方針(Policy)
- eccube_install.php/eccube_install.shでインストールした時には、config.yml.distのままでよい。

## 実装に関する補足(Appendix)
なし

## テスト（Test)
trusted_proxies_connection_only :ON/OFF
trusted_proxies :入力あり/なし
の組み合わせ4通りでインストールして、config.ymlへの出力結果を確認。

eccube_install.php/eccube_install.shでインストールして、config.ymlへの出力結果を確認。

## 相談（Discussion）
なし


