### PR TITLE
新たなmetaタグを追加できるようにする

### DIFF
--- a/src/Eccube/Entity/PageLayout.php
+++ b/src/Eccube/Entity/PageLayout.php
@@ -249,6 +249,11 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
      * @var string
      */
     private $meta_robots;
+    
+    /**
+     * @var string
+     */
+    private $meta_tags;
 
     /**
      * @var \Doctrine\Common\Collections\Collection
@@ -541,6 +546,29 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     public function getMetaRobots()
     {
         return $this->meta_robots;
+    }
+    
+    /**
+     * Set meta_tags
+     *
+     * @param string $metaTags
+     * @return PageLayout
+     */
+    public function setMetaTags($metaTags)
+    {
+        $this->meta_tags = $metaTags;
+
+        return $this;
+    }
+
+    /**
+     * Get meta_tags
+     *
+     * @return string
+     */
+    public function getMetaTags()
+    {
+        return $this->meta_tags;
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/MainEditType.php
+++ b/src/Eccube/Form/Type/Admin/MainEditType.php
@@ -127,10 +127,12 @@ class MainEditType extends AbstractType
                 )
             ))->add('meta_tags', 'textarea', array(
                 'label' => '追加metaタグ',
-                'attr' => array(
-                    'placeholder' => '複数のmetaタグを入力可能',
-                ),
-                'required' => false
+                'required' => false,
+                'constraints' => array(
+                    new Assert\Length(array(
+                        'max' => $app['config']['lltext_len'],
+                    ))
+                )
             ))
             ->add('DeviceType', 'entity', array(
                 'class' => 'Eccube\Entity\Master\DeviceType',

--- a/src/Eccube/Form/Type/Admin/MainEditType.php
+++ b/src/Eccube/Form/Type/Admin/MainEditType.php
@@ -128,7 +128,7 @@ class MainEditType extends AbstractType
             ))->add('meta_tags', 'textarea', array(
                 'label' => '追加metaタグ',
                 'attr' => array(
-                    'placeholder' => '(例)：<meta name="copyright" content="著作権を入力してください" /><meta name="classification" content="webページのジャンルを入力してください" />',
+                    'placeholder' => '複数のmetaタグを入力可能',
                 ),
                 'required' => false
             ))

--- a/src/Eccube/Form/Type/Admin/MainEditType.php
+++ b/src/Eccube/Form/Type/Admin/MainEditType.php
@@ -128,10 +128,7 @@ class MainEditType extends AbstractType
             ))->add('meta_tags', 'textarea', array(
                 'label' => 'フリーエリア',
                 'attr' => array(
-                    'placeholder' => '複数のメタタグを記述することが可能です                           
-(例)                                                                                    
-<meta name="copyright" content="著作権を入力してください" />                                          
-<meta name="classification" content="webページのジャンルを入力してください" />',
+                    'placeholder' => '(例)：<meta name="copyright" content="著作権を入力してください" /><meta name="classification" content="webページのジャンルを入力してください" />',
                 ),
                 'required' => false,
                 'constraints' => array(

--- a/src/Eccube/Form/Type/Admin/MainEditType.php
+++ b/src/Eccube/Form/Type/Admin/MainEditType.php
@@ -126,16 +126,11 @@ class MainEditType extends AbstractType
                     ))
                 )
             ))->add('meta_tags', 'textarea', array(
-                'label' => 'フリーエリア',
+                'label' => '追加metaタグ',
                 'attr' => array(
                     'placeholder' => '(例)：<meta name="copyright" content="著作権を入力してください" /><meta name="classification" content="webページのジャンルを入力してください" />',
                 ),
-                'required' => false,
-                'constraints' => array(
-                    new Assert\Length(array(
-                        'max' => $app['config']['mutext_len'],
-                    ))
-                )
+                'required' => false
             ))
             ->add('DeviceType', 'entity', array(
                 'class' => 'Eccube\Entity\Master\DeviceType',

--- a/src/Eccube/Form/Type/Admin/MainEditType.php
+++ b/src/Eccube/Form/Type/Admin/MainEditType.php
@@ -125,6 +125,20 @@ class MainEditType extends AbstractType
                         'max' => $app['config']['stext_len'],
                     ))
                 )
+            ))->add('meta_tags', 'textarea', array(
+                'label' => 'フリーエリア',
+                'attr' => array(
+                    'placeholder' => '複数のメタタグを記述することが可能です                           
+(例)                                                                                    
+<meta name="copyright" content="著作権を入力してください" />                                          
+<meta name="classification" content="webページのジャンルを入力してください" />',
+                ),
+                'required' => false,
+                'constraints' => array(
+                    new Assert\Length(array(
+                        'max' => $app['config']['mutext_len'],
+                    ))
+                )
             ))
             ->add('DeviceType', 'entity', array(
                 'class' => 'Eccube\Entity\Master\DeviceType',

--- a/src/Eccube/Resource/config/constant.yml.dist
+++ b/src/Eccube/Resource/config/constant.yml.dist
@@ -127,6 +127,7 @@ module_dir: downloads/module/
 module_realdir: /PATH/TO/WEB_ROOT/data/downloads/module/
 mtext_len: 200
 multiple_urlpath: /shopping/multiple.php
+mutext_len: 300
 mypage_delivaddr_urlpath: /mypage/delivery.php
 mypage_order_status_disp_flag: true
 navi_pmax: 4

--- a/src/Eccube/Resource/config/constant.yml.dist
+++ b/src/Eccube/Resource/config/constant.yml.dist
@@ -127,7 +127,6 @@ module_dir: downloads/module/
 module_realdir: /PATH/TO/WEB_ROOT/data/downloads/module/
 mtext_len: 200
 multiple_urlpath: /shopping/multiple.php
-mutext_len: 300
 mypage_delivaddr_urlpath: /mypage/delivery.php
 mypage_order_status_disp_flag: true
 navi_pmax: 4

--- a/src/Eccube/Resource/doctrine/Eccube.Entity.PageLayout.dcm.yml
+++ b/src/Eccube/Resource/doctrine/Eccube.Entity.PageLayout.dcm.yml
@@ -53,6 +53,9 @@ Eccube\Entity\PageLayout:
         meta_robots:
             type: text
             nullable: true
+        meta_tags:
+            type: text
+            nullable: true
     oneToMany:
         BlockPositions:
             targetEntity: Eccube\Entity\BlockPosition

--- a/src/Eccube/Resource/doctrine/migration/Version20170224150000.php
+++ b/src/Eccube/Resource/doctrine/migration/Version20170224150000.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170224150000 extends AbstractMigration
+{
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $t = $schema->getTable('dtb_page_layout');
+        if (!$t->hasColumn('meta_tags')) {
+            $t->addColumn('meta_tags', 'text', array('NotNull' => false));
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+    }
+}

--- a/src/Eccube/Resource/template/admin/Content/page_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/page_edit.twig
@@ -107,7 +107,7 @@
                         {{ form_row(form.description) }}
                         {{ form_row(form.keyword) }}
                         {{ form_row(form.meta_robots) }}
-                        {{ form_row(form.meta_tags) }}
+                        {{ form_row(form.meta_tags, { attr : { placeholder : '複数のmetaタグを入力可能'}}) }}
                     </div>
                 </div>
 

--- a/src/Eccube/Resource/template/admin/Content/page_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/page_edit.twig
@@ -107,6 +107,7 @@
                         {{ form_row(form.description) }}
                         {{ form_row(form.keyword) }}
                         {{ form_row(form.meta_robots) }}
+                        {{ form_row(form.meta_tags) }}
                     </div>
                 </div>
 

--- a/src/Eccube/Resource/template/default/default_frame.twig
+++ b/src/Eccube/Resource/template/default/default_frame.twig
@@ -39,7 +39,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% endif %}
 <meta name="viewport" content="width=device-width, initial-scale=1">
 {% if PageLayout.meta_tags is not empty %}
-    {{ PageLayout.meta_tags }}
+    {{ PageLayout.meta_tags|raw }}
 {% endif %}
 {% block meta_tags %}{% endblock %}
 <link rel="icon" href="{{ app.config.front_urlpath }}/img/common/favicon.ico">

--- a/src/Eccube/Resource/template/default/default_frame.twig
+++ b/src/Eccube/Resource/template/default/default_frame.twig
@@ -38,6 +38,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     <meta name="robots" content="{{ PageLayout.meta_robots }}">
 {% endif %}
 <meta name="viewport" content="width=device-width, initial-scale=1">
+{% block meta_tags %}
+    {% if PageLayout.meta_tags is not empty %}
+        {{ PageLayout.meta_tags }}
+    {% endif %}
+{% endblock %}
 <link rel="icon" href="{{ app.config.front_urlpath }}/img/common/favicon.ico">
 <link rel="stylesheet" href="{{ app.config.front_urlpath }}/css/style.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}">
 <link rel="stylesheet" href="{{ app.config.front_urlpath }}/css/slick.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}">

--- a/src/Eccube/Resource/template/default/default_frame.twig
+++ b/src/Eccube/Resource/template/default/default_frame.twig
@@ -38,11 +38,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     <meta name="robots" content="{{ PageLayout.meta_robots }}">
 {% endif %}
 <meta name="viewport" content="width=device-width, initial-scale=1">
-{% block meta_tags %}
-    {% if PageLayout.meta_tags is not empty %}
-        {{ PageLayout.meta_tags }}
-    {% endif %}
-{% endblock %}
+{% if PageLayout.meta_tags is not empty %}
+    {{ PageLayout.meta_tags }}
+{% endif %}
+{% block meta_tags %}{% endblock %}
 <link rel="icon" href="{{ app.config.front_urlpath }}/img/common/favicon.ico">
 <link rel="stylesheet" href="{{ app.config.front_urlpath }}/css/style.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}">
 <link rel="stylesheet" href="{{ app.config.front_urlpath }}/css/slick.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}">

--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -629,6 +629,7 @@ class Generator {
             ->setDescription($faker->word)
             ->setKeyword($faker->word)
             ->setMetaRobots($faker->word)
+            ->setMetaTags('<meta name="meta_tags_test" content="' . str_replace('\'', '', $faker->word) . '" />')
         ;
         $this->app['orm.em']->persist($PageLayout);
         $this->app['orm.em']->flush($PageLayout);

--- a/tests/Eccube/Tests/Form/Type/Admin/MainEditTestType.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/MainEditTestType.php
@@ -41,6 +41,7 @@ class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         'description' => '',
         'keyword' => '',
         'meta_robots' => '',
+        'meta_tags' => '',
         'DeviceType' => '10',
     );
 
@@ -251,4 +252,19 @@ class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
+    
+    public function testValidMetaTags_Blank()
+    {
+        $this->formData['meta_tags'] = '';
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testInValidMetaTags_FreeLength()
+    {
+        $this->formData['meta_tags'] = '<meta name="meta_tags_test" content="test" />';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+    
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
新たなmetaタグを追加できるようにする
https://github.com/EC-CUBE/ec-cube/issues/2128

## 方針(Policy)
 enhancement >> 3.0.14

## 実装に関する補足(Appendix)
+ コードだけではわかりづらい点ななど実装するにあたって、レビューアに追加で伝えておきたいこと

## テスト（Test)
西郷で作ります

## 相談（Discussion）
質問
1．Blockについて
>>{% block meta_tags %}{% endblock %} を追加し、個別のtwigファイルからmeta_tagsタグを追加できるようにするか、
どこでmeta_tagsファイルを作ったらいいですか？
私はこちらに追加しました
https://github.com/trebla-on/ec-cube/blob/40ce97c7a9a121fdcd7c368d848efdd731775f26/src/Eccube/Resource/template/default/default_frame.twig#L41-L45

2．300文字の設定はこちらに追加しました、大丈夫ですか？
https://github.com/trebla-on/ec-cube/blob/40ce97c7a9a121fdcd7c368d848efdd731775f26/src/Eccube/Resource/config/constant.yml.dist#L130

3．placeholderについて
placeholderの内容は改行、<br>タグは不可ですので表示は改行なしになります、大丈夫ですか？
https://github.com/trebla-on/ec-cube/blob/40ce97c7a9a121fdcd7c368d848efdd731775f26/src/Eccube/Form/Type/Admin/MainEditType.php#L131-L135


