### PR TITLE
購入完了後に、ゲスト購入用のセッション情報を破棄するように仕様変更

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -322,8 +322,12 @@ class ShoppingController extends AbstractController
             return $event->getResponse();
         }
 
-        // 受注IDセッションを削除
+        // 受注に関連するセッションを削除
         $app['session']->remove($this->sessionOrderKey);
+        $app['session']->remove($this->sessionMultipleKey);
+        // 非会員用セッション情報を空の配列で上書きする(プラグイン互換性保持のために削除はしない)
+        $app['session']->set($this->sessionKey, array());
+        $app['session']->set($this->sessionCustomerAddressKey, array());
 
         log_info('購入処理完了', array($orderId));
 

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -113,6 +113,9 @@ class ShoppingService
         if (is_null($nonMember)) {
             return null;
         }
+        if (!array_key_exists('customer', $nonMember) || !array_key_exists('pref', $nonMember)) {
+            return null;
+        }
 
         $Customer = $nonMember['customer'];
         $Customer->setPref($this->app['eccube.repository.master.pref']->find($nonMember['pref']));


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
ゲスト購入時のセキュリティ強化です。
購入完了後にゲスト購入用のセッション情報を破棄するように仕様変更します。 

## 方針(Policy)
購入完了後に、ゲストが繰り返し購入する場合は、
配送先などを都度入力する必要がでてきますが、利便性よりセキュリティを優先します。

## 実装に関する補足(Appendix)
プラグインの互換性維持のため、
セッションを削除するのではなく、空のデータで上書きします。

## テスト（Test)
・購入完了後に、セッション内に情報が残っていないことを確認。
・EC-CUBEペイメント決済プラグインの動作確認済み。

## 相談（Discussion）
なし


