### PR TITLE
"さくらのレンタルサーバ"でSSLのリダイレクトループを回避するコードを.htaccessにコメント追記

### DIFF
--- a/.htaccess.sample
+++ b/.htaccess.sample
@@ -17,6 +17,10 @@ DirectoryIndex index.php index.html .ht
     RewriteCond %{HTTP:Authorization} ^(.*)
     RewriteRule ^(.*) - [E=HTTP_AUTHORIZATION:%1]
 
+    # さくらのレンタルサーバでサイトへのアクセスをSSL経由に制限する場合の対応
+    # RewriteCond %{HTTP:x-sakura-forwarded-for} !^$
+    # RewriteRule ^(.*) - [E=HTTPS:on]
+
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !^(.*)\.(gif|png|jpe?g|css|ico|js|svg)$ [NC]
     RewriteRule ^(.*)$ index.php [QSA,L]

--- a/html/.htaccess
+++ b/html/.htaccess
@@ -12,6 +12,10 @@ allow from all
     RewriteCond %{HTTP:Authorization} ^(.*)
     RewriteRule ^(.*) - [E=HTTP_AUTHORIZATION:%1]
 
+    # さくらのレンタルサーバでサイトへのアクセスをSSL経由に制限する場合の対応
+    # RewriteCond %{HTTP:x-sakura-forwarded-for} !^$
+    # RewriteRule ^(.*) - [E=HTTPS:on]
+
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !^(.*)\.(gif|png|jpe?g|css|ico|js|svg)$ [NC]


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#1357  で、SSL強制した場合のリダイレクトループを解消する対応を行いましたが、
「さくらのレンタルサーバ」でSNI SSLを利用した場合に、必要なHTTPヘッダフィールドが取得できずリダイレクトループが発生してしまう。

## 方針(Policy)
SSL接続時には`x-sakura-forwarded-for`というHTTPヘッダフィールドが付加されるので、
そのHTTPヘッダフィールドが見つかった場合は、HTTPS接続だと判断するようにします。

## 実装に関する補足(Appendix)
本体コードの変更を避けるため、.htaccessで解消する方法を選びました。

※本体コードの変更する場合、Application.phpに以下のようなコードを追加することになります。
```
$request = Request::getInstance();
if ($request->headers->has('HTTP_X_SAKURA_FORWARDED_FOR')) {
    $request->server->set('HTTPS', 'on');
}
```

## テスト（Test)
「さくらのレンタルサーバ」で、SSL制限ONにした場合に、リダイレクトループ発生することを確認。
今回追加した.htaccessのコードを有効にして、現象解決していることを確認OK。

## 相談（Discussion）
とくになし



