### PR TITLE
規格1のみ商品で在庫がなければ(品切れ中)を表示させるように修正

### DIFF
--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -24,8 +24,9 @@
 
 namespace Eccube\Entity;
 
-use Eccube\Common\Constant;
 use Doctrine\Common\Collections\ArrayCollection;
+use Eccube\Common\Constant;
+
 /**
  * Product
  */
@@ -100,7 +101,7 @@ class Product extends \Eccube\Entity\AbstractEntity
                 if ($ProductClass->getClassCategory1()) {
                     $classCategoryId1 = $ProductClass->getClassCategory1()->getId();
                     if (!empty($classCategoryId1)) {
-                        $this->classCategories1[$ProductClass->getClassCategory1()->getId()] = $ProductClass->getClassCategory1()->getName();
+                        $this->classCategories1[$ProductClass->getClassCategory1()->getId()] = $ProductClass->getClassCategory1()->getName() . ($ProductClass->getStockFind() ? '' : ' (品切れ中)');
                         if ($ProductClass->getClassCategory2()) {
                             $this->classCategories2[$ProductClass->getClassCategory1()->getId()][$ProductClass->getClassCategory2()->getId()] = $ProductClass->getClassCategory2()->getName();
                         }


### PR DESCRIPTION
規格1のみの商品の場合、在庫切れの規格に `(品切れ中)` が表示されていなかったため、
プルダウンに `(品切れ中)` を表示させるように修正