### PR TITLE
商品CSVアップロード時に商品画像に空文字が設定されていれば登録対象外とするように修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -686,7 +686,7 @@ class CsvImportController
                 $fileName = Str::trimAll($image);
                 if (!empty($fileName)) {
                     $ProductImage = new ProductImage();
-                    $ProductImage->setFileName(Str::trimAll($image));
+                    $ProductImage->setFileName($fileName);
                     $ProductImage->setProduct($Product);
                     $ProductImage->setRank($rank);
 

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -683,14 +683,17 @@ class CsvImportController
             $rank = 1;
             foreach ($images as $image) {
 
-                $ProductImage = new ProductImage();
-                $ProductImage->setFileName(Str::trimAll($image));
-                $ProductImage->setProduct($Product);
-                $ProductImage->setRank($rank);
+                $fileName = Str::trimAll($image);
+                if (!empty($fileName)) {
+                    $ProductImage = new ProductImage();
+                    $ProductImage->setFileName(Str::trimAll($image));
+                    $ProductImage->setProduct($Product);
+                    $ProductImage->setRank($rank);
 
-                $Product->addProductImage($ProductImage);
-                $rank++;
-                $this->em->persist($ProductImage);
+                    $Product->addProductImage($ProductImage);
+                    $rank++;
+                    $this->em->persist($ProductImage);
+                }
             }
         }
     }

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -416,8 +416,10 @@ class ProductController extends AbstractController
                     $app['orm.em']->persist($Product);
 
                     // 削除
-                    $fs = new Filesystem();
-                    $fs->remove($app['config']['image_save_realdir'] . '/' . $delete_image);
+                    if (!empty($delete_image)) {
+                        $fs = new Filesystem();
+                        $fs->remove($app['config']['image_save_realdir'].'/'.$delete_image);
+                    }
                 }
                 $app['orm.em']->persist($Product);
                 $app['orm.em']->flush();
@@ -576,8 +578,10 @@ class ProductController extends AbstractController
                 // 画像ファイルの削除(commit後に削除させる)
                 foreach ($deleteImages as $deleteImage) {
                     try {
-                        $fs = new Filesystem();
-                        $fs->remove($app['config']['image_save_realdir'] . '/' . $deleteImage);
+                        if (!empty($deleteImage)) {
+                            $fs = new Filesystem();
+                            $fs->remove($app['config']['image_save_realdir'].'/'.$deleteImage);
+                        }
                     } catch (\Exception $e) {
                         // エラーが発生しても無視する
                     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#2160 
管理画面「商品CSV登録」にて、「商品画像」の列の先頭や末尾にカンマがある等場合にfile_nameが空のProductImageエンティティが生成される対応

## 方針(Policy)
商品画像名がセットされていなければ対象外とし、ProductImageエンティティが生成されないように修正
