### PR TITLE
非会員購入のテスト修正

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -79,7 +79,7 @@ class ShoppingController extends AbstractController
     /**
      * 購入画面表示
      *
-     * @Route("/", name="shopping")
+     * @Route("", name="shopping")
      * @Template("Shopping/index.twig")
      *
      * @param Application $app
@@ -169,7 +169,7 @@ class ShoppingController extends AbstractController
      * 購入処理
      *
      * @Method("POST")
-     * @Route("/shopping/confirm", name="shopping/confirm")
+     * @Route("/confirm", name="shopping/confirm")
      */
     public function confirm(Application $app, Request $request)
     {

--- a/src/Eccube/Form/Type/Shopping/OrderType.php
+++ b/src/Eccube/Form/Type/Shopping/OrderType.php
@@ -135,8 +135,9 @@ class OrderType extends AbstractType
             function (FormEvent $event) {
                 /** @var Order $Order */
                 $Order = $event->getData();
-                $Order->setPaymentMethod($Order->getPayment()->getMethod());
-                $Order->setCharge($Order->getPayment()->getCharge());
+                $Payment = $Order->getPayment();
+                $Order->setPaymentMethod($Payment ? $Payment->getMethod() : null);
+                $Order->setCharge($Payment ? $Payment->getCharge() : null);
             }
         );
     }

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -122,6 +122,13 @@ class ShoppingService
         $Customer = $nonMember['customer'];
         $Customer->setPref($this->app['eccube.repository.master.pref']->find($nonMember['pref']));
 
+        foreach ($Customer->getCustomerAddresses() as $CustomerAddress) {
+            $Pref = $CustomerAddress->getPref();
+            if ($Pref) {
+                $CustomerAddress->setPref($this->app['eccube.repository.master.pref']->find($Pref->getId()));
+            }
+        }
+
         return $Customer;
 
     }

--- a/tests/Eccube/Tests/Web/AbstractShoppingControllerTestCase.php
+++ b/tests/Eccube/Tests/Web/AbstractShoppingControllerTestCase.php
@@ -89,8 +89,8 @@ abstract class AbstractShoppingControllerTestCase extends AbstractWebTestCase
         if (count($shippings) < 1) {
             $shippings = array(
                 array(
-                    'delivery' => 1,
-                    'deliveryTime' => 1
+                    'Delivery' => 1,
+                    'shipping_delivery_date' => null
                 ),
             );
         }
@@ -98,10 +98,10 @@ abstract class AbstractShoppingControllerTestCase extends AbstractWebTestCase
         $crawler = $client->request(
             'POST',
             $confirm_url,
-            array('shopping' =>
+            array('_shopping_order' =>
                   array(
-                      'shippings' => $shippings,
-                      'payment' => 3,
+                      'Shippings' => $shippings,
+                      'Payment' => 3,
                       'message' => $faker->text(),
                       '_token' => 'dummy'
                   )

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
@@ -95,7 +95,7 @@ class ShoppingControllerWithNonmemberTest extends AbstractShoppingControllerTest
         $this->actual = $crawler->filter('h1.page-heading')->text();
         $this->verify();
 
-        $this->scenarioComplete($client, $this->app->path('shopping_confirm'));
+        $this->scenarioComplete($client, $this->app->path('shopping/confirm'));
 
         $this->assertTrue($client->getResponse()->isRedirect($this->app->url('shopping_complete')));
 


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)

#2162

ShiopingとPrefでエンティティの不整合が発生していた問題を修正しました。

```
Doctrine\ORM\ORMInvalidArgumentException: A new entity was found through the relationship 'Eccube\Entity\Shipping#Pref' that was not configured to cascade persist operations for entity: 
ç§‹ç”°çœŒ. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist  this association in the mapping for example @ManyToOne(..,cascade={"persist"}).
```