### PR TITLE
非会員購入のテストを修正

### DIFF
--- a/src/Eccube/Controller/Mypage/DeliveryController.php
+++ b/src/Eccube/Controller/Mypage/DeliveryController.php
@@ -78,7 +78,7 @@ class DeliveryController extends AbstractController
         // 正しい遷移かをチェック
         $allowdParents = array(
             $app->url('mypage_delivery'),
-            $app->url('shopping_delivery'),
+            $app->url('shopping_redirect_to'),
         );
 
         // 遷移が正しくない場合、デフォルトであるマイページの配送先追加の画面を設定する

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -169,7 +169,7 @@ class ShoppingController extends AbstractController
      * 購入処理
      *
      * @Method("POST")
-     * @Route("/shopping/confirm", name="shopping/confirm")
+     * @Route("/confirm", name="shopping/confirm")
      */
     public function confirm(Application $app, Request $request)
     {

--- a/src/Eccube/ControllerProvider/FrontControllerProvider.php
+++ b/src/Eccube/ControllerProvider/FrontControllerProvider.php
@@ -111,8 +111,8 @@ class FrontControllerProvider implements ControllerProviderInterface
         $c->match('/shopping/redirect', '\Eccube\Controller\ShoppingController::redirectTo')->bind('shopping_redirect_to');
         //$c->match('/shopping/confirm', '\Eccube\Controller\ShoppingController::confirm')->bind('shopping_confirm');
         // $c->match('/shopping/delivery', '\Eccube\Controller\ShoppingController::delivery')->bind('shopping_delivery');
-        $c->match('/shopping/payment', '\Eccube\Controller\ShoppingController::payment')->bind('shopping_payment');
-        $c->match('/shopping/shipping_change/{id}', '\Eccube\Controller\ShoppingController::shippingChange')->assert('id', '\d+')->bind('shopping_shipping_change');
+        //$c->match('/shopping/payment', '\Eccube\Controller\ShoppingController::payment')->bind('shopping_payment');
+        //$c->match('/shopping/shipping_change/{id}', '\Eccube\Controller\ShoppingController::shippingChange')->assert('id', '\d+')->bind('shopping_shipping_change');
         $c->match('/shopping/shipping/{id}', '\Eccube\Controller\ShoppingController::shipping')->assert('id', '\d+')->bind('shopping_shipping');
         $c->match('/shopping/shipping_edit_change/{id}', '\Eccube\Controller\ShoppingController::shippingEditChange')->assert('id', '\d+')->bind('shopping_shipping_edit_change');
         $c->match('/shopping/shipping_edit/{id}', '\Eccube\Controller\ShoppingController::shippingEdit')->assert('id', '\d+')->bind('shopping_shipping_edit');

--- a/src/Eccube/Resource/template/default/Shopping/index.twig
+++ b/src/Eccube/Resource/template/default/Shopping/index.twig
@@ -300,7 +300,7 @@ $(function() {
                                 {{ form_widget(form.Shippings[idx].DeliveryTime, {'attr': {'class': 'form-control'}}) }}
                             </div>
                             {% if is_granted('ROLE_USER') %}
-                            <p id="shopping_confirm_box__edit_button--{{ idx }}" class="btn_edit"><a href="{{ url('shopping_shipping_change', {'id': shipping.id}) }}" class="btn btn-default btn-sm btn-shipping" data-id="{{ shipping.id }}">変更</a></p>
+                            <p id="shopping_confirm_box__edit_button--{{ idx }}" class="btn_edit"><a href="{{ url('shopping_shipping', {'id': shipping.id}) }}" class="btn btn-default btn-sm btn-shipping" data-id="{{ shipping.id }}">変更</a></p>
                             {% else %}
                             <p id="shopping_confirm_box__edit_button--{{ idx }}" class="btn_edit"><a href="{{ url('shopping_shipping_edit_change', {'id': shipping.id}) }}" class="btn btn-default btn-sm btn-shipping-edit" data-id="{{ shipping.id }}">変更</a></p>
                             {% endif %}

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -122,6 +122,13 @@ class ShoppingService
         $Customer = $nonMember['customer'];
         $Customer->setPref($this->app['eccube.repository.master.pref']->find($nonMember['pref']));
 
+        foreach ($Customer->getCustomerAddresses() as $CustomerAddress) {
+            $Pref = $CustomerAddress->getPref();
+            if ($Pref) {
+                $CustomerAddress->setPref($this->app['eccube.repository.master.pref']->find($Pref->getId()));
+            }
+        }
+
         return $Customer;
 
     }

--- a/tests/Eccube/Tests/Plugin/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Plugin/Web/ShoppingControllerTest.php
@@ -128,12 +128,12 @@ class ShoppingControllerTest extends AbstractWebTestCase
         );
 
         // 完了画面
-        $crawler = $this->scenarioComplete($client, $this->app->path('shopping_confirm'));
+        $crawler = $this->scenarioComplete($client, $this->app->path('shopping/confirm'));
         $this->assertTrue($client->getResponse()->isRedirect($this->app->url('shopping_complete')));
 
         $hookpoins = array_merge($hookpoins,
             array(
-                EccubeEvents::FRONT_SHOPPING_CONFIRM_INITIALIZE,
+                EccubeEvents::FRONT_SHOPPING_INDEX_INITIALIZE,
                 EccubeEvents::SERVICE_SHOPPING_ORDER_STATUS,
                 EccubeEvents::FRONT_SHOPPING_CONFIRM_PROCESSING,
                 EccubeEvents::MAIL_ORDER,
@@ -172,14 +172,14 @@ class ShoppingControllerTest extends AbstractWebTestCase
         // お届け先指定画面
         $crawler = $client->request(
             'POST',
-            $this->app->path('shopping_delivery')
+            $this->app->path('shopping_redirect_to')
         );
 
         $this->assertTrue($client->getResponse()->isSuccessful());
 
         $hookpoins = array_merge($hookpoins,
             array(
-                EccubeEvents::FRONT_SHOPPING_DELIVERY_INITIALIZE,
+                EccubeEvents::FRONT_SHOPPING_INDEX_INITIALIZE,
             )
         );
         $this->verifyOutputString($hookpoins);
@@ -214,16 +214,16 @@ class ShoppingControllerTest extends AbstractWebTestCase
         // お届け先指定画面
         $crawler = $client->request(
             'POST',
-            $this->app->path('shopping_delivery'),
+            $this->app->path('shopping_redirect_to'),
             array(
-                'shopping' => array(
-                    'shippings' => array(
+                '_shopping_order' => array(
+                    'Shippings' => array(
                         0 => array(
-                            'delivery' => 1,
-                            'deliveryTime' => 1
+                            'Delivery' => 1,
+                            'DeliveryTime' => 1
                         ),
                     ),
-                    'payment' => 1,
+                    'Payment' => 1,
                     'message' => $faker->text(),
                     '_token' => 'dummy'
                 )
@@ -234,8 +234,7 @@ class ShoppingControllerTest extends AbstractWebTestCase
 
         $hookpoins = array_merge($hookpoins,
             array(
-                EccubeEvents::FRONT_SHOPPING_DELIVERY_INITIALIZE,
-                EccubeEvents::FRONT_SHOPPING_DELIVERY_COMPLETE,
+                EccubeEvents::FRONT_SHOPPING_INDEX_INITIALIZE,
             )
         );
         $this->verifyOutputString($hookpoins);
@@ -269,7 +268,7 @@ class ShoppingControllerTest extends AbstractWebTestCase
         // お届け先指定
         $crawler = $client->request(
             'POST',
-            $this->app->path('shopping_delivery'),
+            $this->app->path('shopping_redirect_to'),
             array(
                 'shopping' => array(
                     'shippings' => array(
@@ -287,7 +286,7 @@ class ShoppingControllerTest extends AbstractWebTestCase
 
         $hookpoins = array_merge($hookpoins,
             array(
-                EccubeEvents::FRONT_SHOPPING_DELIVERY_INITIALIZE,
+                EccubeEvents::FRONT_SHOPPING_INDEX_INITIALIZE,
             )
         );
         $this->verifyOutputString($hookpoins);
@@ -322,16 +321,16 @@ class ShoppingControllerTest extends AbstractWebTestCase
         // 支払い方法選択
         $crawler = $client->request(
             'POST',
-            $this->app->path('shopping_payment'),
+            $this->app->path('shopping_redirect_to'),
             array(
-                'shopping' => array(
-                    'shippings' => array(
+                '_shopping_order' => array(
+                    'Shippings' => array(
                         0 => array(
-                            'delivery' => 1,
-                            'deliveryTime' => 1
+                            'Delivery' => 1,
+                            'DeliveryTime' => 1
                         ),
                     ),
-                    'payment' => 1,
+                    'Payment' => 1,
                     'message' => $faker->text(),
                     '_token' => 'dummy'
                 )
@@ -342,8 +341,7 @@ class ShoppingControllerTest extends AbstractWebTestCase
 
         $hookpoins = array_merge($hookpoins,
             array(
-                EccubeEvents::FRONT_SHOPPING_PAYMENT_INITIALIZE,
-                EccubeEvents::FRONT_SHOPPING_PAYMENT_COMPLETE,
+                EccubeEvents::FRONT_SHOPPING_INDEX_INITIALIZE,
             )
         );
         $this->verifyOutputString($hookpoins);
@@ -378,16 +376,16 @@ class ShoppingControllerTest extends AbstractWebTestCase
         // 支払い方法選択
         $crawler = $client->request(
             'POST',
-            $this->app->path('shopping_payment'),
+            $this->app->path('shopping_redirect_to'),
             array(
-                'shopping' => array(
-                    'shippings' => array(
+                '_shopping_order' => array(
+                    'Shippings' => array(
                         0 => array(
-                            'delivery' => 1,
-                            'deliveryTime' => 1
+                            'Delivery' => 1,
+                            'DeliveryTime' => 1
                         ),
                     ),
-                    'payment' => 100, // payment=100 は無効な値
+                    'Payment' => 100, // payment=100 は無効な値
                     'message' => $faker->text(),
                     '_token' => 'dummy'
                 )
@@ -396,7 +394,7 @@ class ShoppingControllerTest extends AbstractWebTestCase
 
         $hookpoins = array_merge($hookpoins,
             array(
-                EccubeEvents::FRONT_SHOPPING_PAYMENT_INITIALIZE,
+                EccubeEvents::FRONT_SHOPPING_INDEX_INITIALIZE,
             )
         );
         $this->verifyOutputString($hookpoins);
@@ -425,17 +423,12 @@ class ShoppingControllerTest extends AbstractWebTestCase
         $hookpoins = array_merge($hookpoins,
             array(
                 EccubeEvents::FRONT_SHOPPING_INDEX_INITIALIZE,
-                EccubeEvents::FRONT_SHOPPING_SHIPPING_CHANGE_INITIALIZE,
             )
         );
 
         // お届け先指定画面
         $shipping_url = $crawler->filter('a.btn-shipping')->attr('href');
         $crawler = $this->scenarioComplete($client, $shipping_url);
-
-        // /shipping/shipping_change/<id> から /shipping/shipping/<id> へリダイレクト
-        $shipping_url = str_replace('shipping_change', 'shipping', $shipping_url);
-        $this->assertTrue($client->getResponse()->isRedirect($shipping_url));
 
         $this->verifyOutputString($hookpoins);
     }
@@ -463,7 +456,6 @@ class ShoppingControllerTest extends AbstractWebTestCase
         $hookpoins = array_merge($hookpoins,
             array(
                 EccubeEvents::FRONT_SHOPPING_INDEX_INITIALIZE,
-                EccubeEvents::FRONT_SHOPPING_SHIPPING_CHANGE_INITIALIZE,
             )
         );
 
@@ -513,7 +505,6 @@ class ShoppingControllerTest extends AbstractWebTestCase
         $hookpoins = array_merge($hookpoins,
             array(
                 EccubeEvents::FRONT_SHOPPING_INDEX_INITIALIZE,
-                EccubeEvents::FRONT_SHOPPING_SHIPPING_CHANGE_INITIALIZE,
                 EccubeEvents::FRONT_SHOPPING_SHIPPING_EDIT_INITIALIZE,
 
             )
@@ -576,11 +567,11 @@ class ShoppingControllerTest extends AbstractWebTestCase
         );
 
         // ご注文完了
-        $this->scenarioComplete($client, $this->app->path('shopping_confirm'));
+        $this->scenarioComplete($client, $this->app->path('shopping/confirm'));
 
         $hookpoins = array_merge($hookpoins,
             array(
-                EccubeEvents::FRONT_SHOPPING_CONFIRM_INITIALIZE,
+                EccubeEvents::FRONT_SHOPPING_INDEX_INITIALIZE,
                 EccubeEvents::SERVICE_SHOPPING_ORDER_STATUS,
                 EccubeEvents::FRONT_SHOPPING_CONFIRM_PROCESSING,
                 EccubeEvents::MAIL_ORDER,
@@ -657,16 +648,16 @@ class ShoppingControllerTest extends AbstractWebTestCase
         $crawler = $client->request(
             'POST',
             $confirm_url,
-            array('shopping' =>
+            array('_shopping_order' =>
                   array(
-                      'shippings' =>
+                      'Shippings' =>
                       array(0 =>
                             array(
-                                'delivery' => 1,
-                                'deliveryTime' => 1
+                                'Delivery' => 1,
+                                'DeliveryTime' => 1
                             ),
                       ),
-                      'payment' => 1,
+                      'Payment' => 1,
                       'message' => $faker->text(),
                       '_token' => 'dummy'
                   )

--- a/tests/Eccube/Tests/Web/AbstractShoppingControllerTestCase.php
+++ b/tests/Eccube/Tests/Web/AbstractShoppingControllerTestCase.php
@@ -89,8 +89,8 @@ abstract class AbstractShoppingControllerTestCase extends AbstractWebTestCase
         if (count($shippings) < 1) {
             $shippings = array(
                 array(
-                    'delivery' => 1,
-                    'deliveryTime' => 1
+                    'Delivery' => 1,
+                    'DeliveryTime' => 1
                 ),
             );
         }
@@ -98,10 +98,10 @@ abstract class AbstractShoppingControllerTestCase extends AbstractWebTestCase
         $crawler = $client->request(
             'POST',
             $confirm_url,
-            array('shopping' =>
+            array('_shopping_order' =>
                   array(
-                      'shippings' => $shippings,
-                      'payment' => 3,
+                      'Shippings' => $shippings,
+                      'Payment' => 3,
                       'message' => $faker->text(),
                       '_token' => 'dummy'
                   )

--- a/tests/Eccube/Tests/Web/CartValidationTest.php
+++ b/tests/Eccube/Tests/Web/CartValidationTest.php
@@ -2079,14 +2079,13 @@ class CartValidationTest extends AbstractWebTestCase
         // change payment
         $paymentForm = array(
             '_token' => 'dummy',
-            'payment' => 4,
+            'Payment' => 4,
             'message' => $this->getFaker()->paragraph,
-            'shippings' => array(
-                array('delivery' => 1,),
+            'Shippings' => array(
+                array('Delivery' => 1,),
             ),
         );
-        $client->request('POST', $this->app->url('shopping_payment'), array('shopping' => $paymentForm));
-        $client->followRedirect();
+        $client->request('POST', $this->app->url('shopping_redirect_to'), array('_shopping_order' => $paymentForm));
         $crawler = $client->followRedirect();
 
         // THEN
@@ -2138,14 +2137,13 @@ class CartValidationTest extends AbstractWebTestCase
         // change payment
         $paymentForm = array(
             '_token' => 'dummy',
-            'payment' => 4, // change payment
+            'Payment' => 4, // change payment
             'message' => $this->getFaker()->paragraph,
-            'shippings' => array(
-                array('delivery' => 1,),
+            'Shippings' => array(
+                array('Delivery' => 1,),
             ),
         );
-        $client->request('POST', $this->app->url('shopping_payment'), array('shopping' => $paymentForm));
-        $client->followRedirect();
+        $client->request('POST', $this->app->url('shopping_redirect_to'), array('_shopping_order' => $paymentForm));
         $crawler = $client->followRedirect();
 
         // THEN
@@ -2198,14 +2196,13 @@ class CartValidationTest extends AbstractWebTestCase
         // change payment
         $paymentForm = array(
             '_token' => 'dummy',
-            'payment' => 4, // change payment
+            'Payment' => 4, // change payment
             'message' => $this->getFaker()->paragraph,
-            'shippings' => array(
-                array('delivery' => 1,),
+            'Shippings' => array(
+                array('Delivery' => 1,),
             ),
         );
-        $client->request('POST', $this->app->url('shopping_payment'), array('shopping' => $paymentForm));
-        $client->followRedirect();
+        $client->request('POST', $this->app->url('shopping_redirect_to'), array('_shopping_order' => $paymentForm));
         $crawler = $client->followRedirect();
 
         // THEN
@@ -2256,13 +2253,13 @@ class CartValidationTest extends AbstractWebTestCase
         // change payment
         $paymentForm = array(
             '_token' => 'dummy',
-            'payment' => 4, // change payment
+            'Payment' => 4, // change payment
             'message' => $this->getFaker()->paragraph,
-            'shippings' => array(
-                array('delivery' => 1,),
+            'Shippings' => array(
+                array('Delivery' => 1,),
             ),
         );
-        $client->request('POST', $this->app->url('shopping_payment'), array('shopping' => $paymentForm));
+        $client->request('POST', $this->app->url('shopping_redirect_to'), array('_shopping_order' => $paymentForm));
 
         // only one redirect (shopping 1)
         $crawler = $client->followRedirect();
@@ -2317,13 +2314,13 @@ class CartValidationTest extends AbstractWebTestCase
         // change payment
         $paymentForm = array(
             '_token' => 'dummy',
-            'payment' => 4, // change payment
+            'Payment' => 4, // change payment
             'message' => $this->getFaker()->paragraph,
-            'shippings' => array(
-                array('delivery' => 1,),
+            'Shippings' => array(
+                array('Delivery' => 1,),
             ),
         );
-        $client->request('POST', $this->app->url('shopping_payment'), array('shopping' => $paymentForm));
+        $client->request('POST', $this->app->url('shopping_redirect_to'), array('_shopping_order' => $paymentForm));
 
         // only one redirect (shopping 1)
         $crawler = $client->followRedirect();
@@ -2866,19 +2863,19 @@ class CartValidationTest extends AbstractWebTestCase
     {
         $faker = $this->getFaker();
         if (strlen($confirmUrl) == 0) {
-            $confirmUrl = $this->app->url('shopping_confirm');
+            $confirmUrl = $this->app->url('shopping/confirm');
         }
 
         if (count($arrShopping) == 0) {
             $arrShopping = array(
-                'shippings' =>
+                'Shippings' =>
                     array(
                         array(
-                            'delivery' => 1,
-                            'deliveryTime' => 1
+                            'Delivery' => 1,
+                            'DeliveryTime' => 1
                         ),
                     ),
-                'payment' => 3,
+                'Payment' => 3,
                 'message' => $faker->text(),
                 '_token' => 'dummy',
             );
@@ -2886,7 +2883,7 @@ class CartValidationTest extends AbstractWebTestCase
         $crawler = $client->request(
             'POST',
             $confirmUrl,
-            array('shopping' => $arrShopping)
+            array('_shopping_order' => $arrShopping)
         );
 
         return $crawler;

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -82,7 +82,7 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
         $this->verify();
 
         // 完了画面
-        $crawler = $this->scenarioComplete($client, $this->app->path('shopping_confirm'));
+        $crawler = $this->scenarioComplete($client, $this->app->path('shopping/confirm'));
         $this->assertTrue($client->getResponse()->isRedirect($this->app->url('shopping_complete')));
 
         $BaseInfo = $this->app['eccube.repository.base_info']->get();
@@ -154,14 +154,14 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
             'POST',
             $this->app->path('shopping_redirect_to'),
             array(
-                'shopping' => array(
-                    'shippings' => array(
+                '_shopping_order' => array(
+                    'Shippings' => array(
                         0 => array(
-                            'delivery' => 1,
-                            'deliveryTime' => 1
+                            'Delivery' => 1,
+                            'DeliveryTime' => 1
                         ),
                     ),
-                    'payment' => 1,
+                    'Payment' => 1,
                     'message' => $faker->text(),
                     '_token' => 'dummy'
                 ),
@@ -232,14 +232,14 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
             'POST',
             $this->app->path('shopping_redirect_to'),
             array(
-                'shopping' => array(
-                    'shippings' => array(
+                '_shopping_order' => array(
+                    'Shippings' => array(
                         0 => array(
-                            'delivery' => 1,
-                            'deliveryTime' => 1
+                            'Delivery' => 1,
+                            'DeliveryTime' => 1
                         ),
                     ),
-                    'payment' => 1,
+                    'Payment' => 1,
                     'message' => $faker->text(),
                     '_token' => 'dummy'
                 ),
@@ -306,9 +306,7 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
         $shipping_url = $crawler->filter('a.btn-shipping')->attr('href');
         $crawler = $this->scenarioComplete($client, $shipping_url);
 
-        // /shipping/shipping_change/<id> から /shipping/shipping/<id> へリダイレクト
-        $shipping_url = str_replace('shipping_change', 'shipping', $shipping_url);
-        $this->assertTrue($client->getResponse()->isRedirect($shipping_url));
+        $this->assertTrue($client->getResponse()->isSuccessful());
     }
 
     /**
@@ -406,7 +404,7 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
         $this->assertTrue($client->getResponse()->isRedirect($this->app->url('shopping')));
 
         // ご注文完了
-        $this->scenarioComplete($client, $this->app->path('shopping_confirm'));
+        $this->scenarioComplete($client, $this->app->path('shopping/confirm'));
 
         $BaseInfo = $this->app['eccube.repository.base_info']->get();
         $Messages = $this->getMailCatcherMessages();

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
@@ -124,17 +124,17 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
         // 完了画面
         $crawler = $this->scenarioComplete(
             $client,
-            $this->app->path('shopping_confirm'),
+            $this->app->path('shopping/confirm'),
             array(
                 // 配送先1
                 array(
-                    'delivery' => 1,
-                    'deliveryTime' => 1
+                    'Delivery' => 1,
+                    'DeliveryTime' => 1
                 ),
                 // 配送先2
                 array(
-                    'delivery' => 1,
-                    'deliveryTime' => 1
+                    'Delivery' => 1,
+                    'DeliveryTime' => 1
                 )
             )
         );


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#2162

- ShiopingとPrefでエンティティの不整合が発生していた問題を修正(※)
- ルーティングの変更点を追随
- 重複しているテストケースを削除

(※)非会員購入時に、以下のマッピングエラーが発生しする問題に対応
```
Doctrine\ORM\ORMInvalidArgumentException: A new entity was found through the relationship 'Eccube\Entity\Shipping#Pref' that was not configured to cascade persist operations for entity: 
ç§‹ç”°çœŒ. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist  this association in the mapping for example @ManyToOne(..,cascade={"persist"}).
```

## 備考

修正箇所が重複するため, #2164 の続きで修正しています。
#2164 の後にマージお願いします。
