### PR TITLE
支払上限金額を超えているとお支払方法が表示されない対応

### DIFF
--- a/src/Eccube/Resource/template/default/Shopping/index.twig
+++ b/src/Eccube/Resource/template/default/Shopping/index.twig
@@ -298,6 +298,9 @@ $(function() {
                     <div id="payment_list" class="column">
                         <div id="payment_list__body" class="form-group">
                             <ul id="payment_list__list" class="payment_list">
+                            {% if form.payment is empty %}
+                                <p class="errormsg text-danger">合計金額に対して可能な支払い方法がありません。<br>{{ BaseInfo.email02 }}にお問い合わせ下さい。</p>
+                            {% endif %}
                             {% for key, child in form.payment %}
                             <li>
                                 {{ form_widget(child, {'attr': {'class': 'payment' }}) }}

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -285,6 +285,35 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
     }
 
     /**
+     * 購入確認画面
+     */
+    public function testPaymentEmpty()
+    {
+        $faker = $this->getFaker();
+        $Customer = $this->logIn();
+        $client = $this->client;
+
+        // カート画面
+        $this->scenarioCartIn($client);
+
+        // 支払い方法のMINとMAXルール変更
+        $PaymentColl = $this->app['eccube.repository.payment']->findAll();
+        foreach($PaymentColl as $Payment){
+                $Payment->setRuleMin(0);
+                $Payment->setRuleMax(0);
+        }
+        // 確認画面
+        $crawler = $this->scenarioConfirm($client);
+
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $email02 = $BaseInfo->getEmail02();
+        $this->assertTrue($client->getResponse()->isSuccessful());
+        $this->expected = '合計金額に対して可能な支払い方法がありません。' . $email02 . 'にお問い合わせ下さい。';
+        $this->actual = $crawler->filter('p.errormsg')->text();
+        $this->verify();
+    }
+
+    /**
      * 購入確認画面→お届け先の設定
      */
     public function testShippingChangeWithPost()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
支払上限金額を超えているとお支払方法が表示されない
https://github.com/EC-CUBE/ec-cube/issues/2101

## 方針(Policy)
支払方法ない場合は以下のエラーメッセージ表示します
```
合計金額に対して可能な支払い方法がありません。
base_info.email02にお問い合わせ下さい。

```

## 実装に関する補足(Appendix)


## テスト（Test)
支払方法一個でもない場合テストケースを追加しました

## 相談（Discussion）




