### PR TITLE
#1354 管理画面から送信する受注メール送信履歴の登録方法修正

### DIFF
--- a/src/Eccube/Controller/Admin/Order/MailController.php
+++ b/src/Eccube/Controller/Admin/Order/MailController.php
@@ -121,17 +121,16 @@ class MailController
                     case 'complete':
 
                         $data = $form->getData();
-                        $body = $this->createBody($app, $data['header'], $data['footer'], $Order);
 
                         // メール送信
-                        $app['eccube.service.mail']->sendAdminOrderMail($Order, $data);
+                        $message = $app['eccube.service.mail']->sendAdminOrderMail($Order, $data);
 
                         // 送信履歴を保存.
                         $MailTemplate = $form->get('template')->getData();
                         $MailHistory = new MailHistory();
                         $MailHistory
-                            ->setSubject($data['subject'])
-                            ->setMailBody($body)
+                            ->setSubject($message->getSubject())
+                            ->setMailBody($message->getBody())
                             ->setMailTemplate($MailTemplate)
                             ->setSendDate(new \DateTime())
                             ->setOrder($Order);
@@ -301,17 +300,16 @@ class MailController
 
                             $Order = $app['eccube.repository.order']->find($value);
 
-                            $body = $this->createBody($app, $data['header'], $data['footer'], $Order);
 
                             // メール送信
-                            $app['eccube.service.mail']->sendAdminOrderMail($Order, $data);
+                            $message = $app['eccube.service.mail']->sendAdminOrderMail($Order, $data);
 
                             // 送信履歴を保存.
                             $MailTemplate = $form->get('template')->getData();
                             $MailHistory = new MailHistory();
                             $MailHistory
-                                ->setSubject($data['subject'])
-                                ->setMailBody($body)
+                                ->setSubject($message->getSubject())
+                                ->setMailBody($message->getBody())
                                 ->setMailTemplate($MailTemplate)
                                 ->setSendDate(new \DateTime())
                                 ->setOrder($Order);

--- a/src/Eccube/Service/MailService.php
+++ b/src/Eccube/Service/MailService.php
@@ -355,7 +355,7 @@ class MailService
 
         log_info('受注管理通知メール送信完了', array('count' => $count));
 
-        return $count;
+        return $message;
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#1354 

- 管理画面から送信したメール送信履歴のタイトルに店舗名が入らないことに対する修正（実際に送信したメールのタイトルには店舗名入っていますが、保存される履歴には入っていなかった）

- 実際に送信したデータを履歴に登録せず再生成しているため、'mail.admin.order'に対するイベントでメール内容が修正されて実際の送信内容との齟齬が生まれる可能性がある

## 方針(Policy)

メールデータを再生成して履歴へ登録するのではなく、実際に送信したメールから件名・本文を取得して登録する


