### PR TITLE
パスワード変更フローにおいて、管理者にパスワードが送信されるのは不適切なため、管理者にはメールが送信されないように変更。

### DIFF
--- a/src/Eccube/Resource/template/default/Form/form_layout.twig
+++ b/src/Eccube/Resource/template/default/Form/form_layout.twig
@@ -240,7 +240,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 {%- block zip_widget -%}
     {%- if freeze -%}
-        〒&nbsp;{{ form_widget(form[form.vars.zip01_name]) }}&nbsp;-&nbsp;{{- form_widget(form[form.vars.zip02_name]) }}
+        {%- if freeze_display_text -%}〒&nbsp;{%- endif -%}{{ form_widget(form[form.vars.zip01_name]) }}{%- if freeze_display_text -%}&nbsp;-&nbsp;{%- endif -%}{{- form_widget(form[form.vars.zip02_name]) }}
     {%- else -%}
         〒{{- form_widget(form[form.vars.zip01_name], {'id': 'zip01', 'attr': {'style': 'ime-mode: disabled;', 'pattern': '\\d*'}}) }}-{{- form_widget(form[form.vars.zip02_name], {'id': 'zip02', 'attr': {'style': 'ime-mode: disabled;', 'pattern': '\\d*'}}) }} <span class="question-circle"><svg class="cb cb-question"><use xlink:href="#cb-question" /></svg></span> <a href="http://www.post.japanpost.jp/zipcode/" target="_blank">郵便番号検索</a>
         {%- for child in form %}

--- a/src/Eccube/Service/MailService.php
+++ b/src/Eccube/Service/MailService.php
@@ -376,7 +376,6 @@ class MailService
             ->setSubject('[' . $this->BaseInfo->getShopName() . '] パスワード変更のご確認')
             ->setFrom(array($this->BaseInfo->getEmail01() => $this->BaseInfo->getShopName()))
             ->setTo(array($Customer->getEmail()))
-            ->setBcc($this->BaseInfo->getEmail01())
             ->setReplyTo($this->BaseInfo->getEmail03())
             ->setReturnPath($this->BaseInfo->getEmail04())
             ->setBody($body);
@@ -417,7 +416,6 @@ class MailService
             ->setSubject('[' . $this->BaseInfo->getShopName() . '] パスワード変更のお知らせ')
             ->setFrom(array($this->BaseInfo->getEmail01() => $this->BaseInfo->getShopName()))
             ->setTo(array($Customer->getEmail()))
-            ->setBcc($this->BaseInfo->getEmail01())
             ->setReplyTo($this->BaseInfo->getEmail03())
             ->setReturnPath($this->BaseInfo->getEmail04())
             ->setBody($body);


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ PullRequestの目的
フロント画面からパスワード再発行の手順でパスワードを再発行すると、BCCで管理者にも同じメールが送信されてしまいセキュリティの面で問題がある。
+ 関連するIssue番号など
https://github.com/EC-CUBE/ec-cube/issues/2180

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外し内容
ユーザのパスワードの平文を管理者が見えてはいけないというセキュリティポリシー

## 実装に関する補足(Appendix)
+ コードだけではわかりづらい点ななど実装するにあたって、レビューアに追加で伝えておきたいこと
BCCのメールを飛ばないようにしただけです。

## テスト（Test)
+ テストを行っている範囲などレビューアーが安心できるような情報
ローカルでテスト済み

## 相談（Discussion）
+ 相談したいことや意見をもとめたいこと
よろしくお願いいたします。


