### PR TITLE
freeze_display_textで郵便番号の「〒」「-」、電話番号の「-」を消えるようにする

### DIFF
--- a/src/Eccube/Resource/template/default/Form/form_layout.twig
+++ b/src/Eccube/Resource/template/default/Form/form_layout.twig
@@ -240,7 +240,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 {%- block zip_widget -%}
     {%- if freeze -%}
-        〒&nbsp;{{ form_widget(form[form.vars.zip01_name]) }}&nbsp;-&nbsp;{{- form_widget(form[form.vars.zip02_name]) }}
+        {%- if freeze_display_text -%}〒&nbsp;{%- endif -%}{{ form_widget(form[form.vars.zip01_name]) }}{%- if freeze_display_text -%}&nbsp;-&nbsp;{%- endif -%}{{- form_widget(form[form.vars.zip02_name]) }}
     {%- else -%}
         〒{{- form_widget(form[form.vars.zip01_name], {'id': 'zip01', 'attr': {'style': 'ime-mode: disabled;', 'pattern': '\\d*'}}) }}-{{- form_widget(form[form.vars.zip02_name], {'id': 'zip02', 'attr': {'style': 'ime-mode: disabled;', 'pattern': '\\d*'}}) }} <span class="question-circle"><svg class="cb cb-question"><use xlink:href="#cb-question" /></svg></span> <a href="http://www.post.japanpost.jp/zipcode/" target="_blank">郵便番号検索</a>
         {%- for child in form %}

--- a/src/Eccube/Resource/template/default/Form/form_layout.twig
+++ b/src/Eccube/Resource/template/default/Form/form_layout.twig
@@ -216,8 +216,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     {%- for child in form %}
         {{- form_widget(child, {'type': 'tel', 'attr': {'style': 'ime-mode: disabled;'}}) -}}
         {%- if freeze -%}
-            {%- if child.vars.value is not empty -%}
-                {%- if loop.last == false%}&nbsp;-&nbsp;{% endif -%}
+            {%- if freeze_display_text -%}
+                {%- if child.vars.value is not empty -%}
+                    {%- if loop.last == false%}&nbsp;-&nbsp;{% endif -%}
+                {%- endif -%}
             {%- endif -%}
         {%- else -%}
             {%- if loop.last == false%}&nbsp;-&nbsp;{% endif -%}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ PullRequestの目的
```
$builder->setAttribute('freeze', true);
$builder->setAttribute('freeze_display_text', false);
```
で郵便番号の「〒」と「-」を非表示にする。
+ 関連するIssue番号など
https://github.com/EC-CUBE/ec-cube/issues/2183

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外し内容

## 実装に関する補足(Appendix)
+ コードだけではわかりづらい点ななど実装するにあたって、レビューアに追加で伝えておきたいこと

## テスト（Test)
+ テストを行っている範囲などレビューアーが安心できるような情報
案件にて実稼働中

## 相談（Discussion）
+ 相談したいことや意見をもとめたいこと



