### PR TITLE
複数配送時のインデックスの参照先に誤りがあったため修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -94,7 +94,7 @@ $(function() {
 
         var data = $(this).data();
         shipment_idx = data.idx;
-        
+
         shipmentItem_idx = 0;
         for(i = 0; i < shipping_details_count.length; i++) { 
             if (shipping_details_count[i].idx == shipment_idx) {
@@ -517,7 +517,7 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
             {% endif %}
             {% for shippingForm in form.Shippings %}
             {% set shippingIndex = loop.index0 %}
-            <div id="shipping_info_box--{{ shippingIndex }}" class="box accordion">
+            <div id="shipping_info_box--{{ shippingForm.vars.name }}" class="box accordion">
                 <div id="shipping_info_box__toggle--{{ shippingIndex }}" class="box-header toggle active">
                     <h3 class="box-title">お届け先情報{% if form.Shippings|length > 1 %}({{ loop.index }}){% endif %}<svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg></h3>
                 </div><!-- /.box-header -->
@@ -525,11 +525,11 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                     <div id="shipping_info_list--{{ shippingIndex }}" class="order_list">
                         <div class="btn_area">
                             <ul id="shipping_info_list__menu--{{ shippingIndex }}">
-                                <li><a class="btn btn-default copyCustomerToShippingButton" data-idx="{{ shippingIndex }}">注文者情報をコピー</a></li>
+                                <li><a class="btn btn-default copyCustomerToShippingButton" data-idx="{{ shippingForm.vars.name }}">注文者情報をコピー</a></li>
                                 {% if BaseInfo.optionMultipleShipping %}
-                                <li><a class="btn btn-default" data-toggle="modal" data-target="#searchProductModal" data-idx="{{ shippingIndex }}">商品の追加</a></li>
+                                <li><a class="btn btn-default" data-toggle="modal" data-target="#searchProductModal" data-idx="{{ shippingForm.vars.name }}">商品の追加</a></li>
                                 {% if form.Shippings|length > 1 %}
-                                    <li><button type="button" class="btn btn-default delete_delivery" data-idx="{{ shippingIndex }}">お届け先情報を削除</button></li>
+                                    <li><button type="button" class="btn btn-default delete_delivery" data-idx="{{ shippingForm.vars.name }}">お届け先情報を削除</button></li>
                                 {% endif %}
                                 {% endif %}
                             </ul>
@@ -537,7 +537,7 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
 
                         {% if BaseInfo.optionMultipleShipping %}
                         <div class="tableish"
-                             id="shipment_item_list{{ shippingIndex }}"
+                             id="shipment_item_list{{ shippingForm.vars.name }}"
                              data-prototype="
                              {% filter escape %}
                                      {{ include('Order/shipment_item_prototype.twig', { 'shipmentItemForm': shippingForm.ShipmentItems.vars.prototype }) }}

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -516,8 +516,8 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
             <div id="shipping_info__button_new"><button type="submit" class="btn btn-default" name="mode" value="add_delivery">お届け先を新規追加</button></div>
             {% endif %}
             {% for shippingForm in form.Shippings %}
-            {% set shippingIndex = loop.index0 %}
-            <div id="shipping_info_box--{{ shippingForm.vars.name }}" class="box accordion">
+            {% set shippingIndex = shippingForm.vars.name %}
+            <div id="shipping_info_box--{{ shippingIndex }}" class="box accordion">
                 <div id="shipping_info_box__toggle--{{ shippingIndex }}" class="box-header toggle active">
                     <h3 class="box-title">お届け先情報{% if form.Shippings|length > 1 %}({{ loop.index }}){% endif %}<svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg></h3>
                 </div><!-- /.box-header -->
@@ -525,11 +525,11 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                     <div id="shipping_info_list--{{ shippingIndex }}" class="order_list">
                         <div class="btn_area">
                             <ul id="shipping_info_list__menu--{{ shippingIndex }}">
-                                <li><a class="btn btn-default copyCustomerToShippingButton" data-idx="{{ shippingForm.vars.name }}">注文者情報をコピー</a></li>
+                                <li><a class="btn btn-default copyCustomerToShippingButton" data-idx="{{ shippingIndex }}">注文者情報をコピー</a></li>
                                 {% if BaseInfo.optionMultipleShipping %}
-                                <li><a class="btn btn-default" data-toggle="modal" data-target="#searchProductModal" data-idx="{{ shippingForm.vars.name }}">商品の追加</a></li>
+                                <li><a class="btn btn-default" data-toggle="modal" data-target="#searchProductModal" data-idx="{{ shippingIndex }}">商品の追加</a></li>
                                 {% if form.Shippings|length > 1 %}
-                                    <li><button type="button" class="btn btn-default delete_delivery" data-idx="{{ shippingForm.vars.name }}">お届け先情報を削除</button></li>
+                                    <li><button type="button" class="btn btn-default delete_delivery" data-idx="{{ shippingIndex }}">お届け先情報を削除</button></li>
                                 {% endif %}
                                 {% endif %}
                             </ul>
@@ -537,7 +537,7 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
 
                         {% if BaseInfo.optionMultipleShipping %}
                         <div class="tableish"
-                             id="shipment_item_list{{ shippingForm.vars.name }}"
+                             id="shipment_item_list{{ shippingIndex }}"
                              data-prototype="
                              {% filter escape %}
                                      {{ include('Order/shipment_item_prototype.twig', { 'shipmentItemForm': shippingForm.ShipmentItems.vars.prototype }) }}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#2053
この対応で複数配送時にお届け先削除が可能になっているが、
お届け先の追加、削除、追加を繰り返して商品の追加を行うとエラーが発生したため参照先を修正。