### PR TITLE
パスワード再発行時に、EC-CUBEが自動生成した初期パスワードが、管理者は送信されないように修正

### DIFF
--- a/src/Eccube/Service/MailService.php
+++ b/src/Eccube/Service/MailService.php
@@ -376,7 +376,6 @@ class MailService
             ->setSubject('[' . $this->BaseInfo->getShopName() . '] パスワード変更のご確認')
             ->setFrom(array($this->BaseInfo->getEmail01() => $this->BaseInfo->getShopName()))
             ->setTo(array($Customer->getEmail()))
-            ->setBcc($this->BaseInfo->getEmail01())
             ->setReplyTo($this->BaseInfo->getEmail03())
             ->setReturnPath($this->BaseInfo->getEmail04())
             ->setBody($body);
@@ -417,7 +416,6 @@ class MailService
             ->setSubject('[' . $this->BaseInfo->getShopName() . '] パスワード変更のお知らせ')
             ->setFrom(array($this->BaseInfo->getEmail01() => $this->BaseInfo->getShopName()))
             ->setTo(array($Customer->getEmail()))
-            ->setBcc($this->BaseInfo->getEmail01())
             ->setReplyTo($this->BaseInfo->getEmail03())
             ->setReturnPath($this->BaseInfo->getEmail04())
             ->setBody($body);

--- a/tests/Eccube/Tests/Service/MailServiceTest.php
+++ b/tests/Eccube/Tests/Service/MailServiceTest.php
@@ -347,9 +347,7 @@ class MailServiceTest extends AbstractServiceTestCase
         $this->expected = 'Reply-To: '.$this->BaseInfo->getEmail03();
         $this->verifyRegExp($Message, 'Reply-Toは'.$this->BaseInfo->getEmail03().'ではありません');
 
-        $BccMessage = $this->getMessage($Messages[1]->id);
-        $this->expected = 'Bcc: '.$this->BaseInfo->getEmail01();
-        $this->verifyRegExp($BccMessage, 'BCC');
+        $this->assertLessThanOrEqual(1, count($Messages), 'Bccメールは送信しない');
     }
 
     public function testSendPasswordResetCompleteMail()
@@ -372,9 +370,7 @@ class MailServiceTest extends AbstractServiceTestCase
         $this->expected = 'Reply-To: '.$this->BaseInfo->getEmail03();
         $this->verifyRegExp($Message, 'Reply-Toは'.$this->BaseInfo->getEmail03().'ではありません');
 
-        $BccMessage = $this->getMessage($Messages[1]->id);
-        $this->expected = 'Bcc: '.$this->BaseInfo->getEmail01();
-        $this->verifyRegExp($BccMessage, 'BCC');
+        $this->assertLessThanOrEqual(1, count($Messages), 'Bccメールは送信しない');
     }
 
     protected function getMessages()


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ PullRequestの目的
フロント画面からパスワード再発行の手順でパスワードを再発行すると、BCCで管理者にも同じメールが送信されてしまいセキュリティの面で問題がある。
+ 関連するIssue番号など
https://github.com/EC-CUBE/ec-cube/issues/2180

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外し内容
ユーザのパスワードの平文を管理者が見えてはいけないというセキュリティポリシー

## 実装に関する補足(Appendix)
+ コードだけではわかりづらい点ななど実装するにあたって、レビューアに追加で伝えておきたいこと
BCCのメールを飛ばないようにしただけです。

## テスト（Test)
+ テストを行っている範囲などレビューアーが安心できるような情報
ローカルでテスト済み

## 相談（Discussion）
+ 相談したいことや意見をもとめたいこと
以下のプルリクは不要な改修まで入ってしまっていますのでこちらを採用していただけますでしょうか。
https://github.com/EC-CUBE/ec-cube/pull/2181
