### PR TITLE
複数配送のお届け先追加時に、デフォルトの配送先の選択がリセットされないように対応

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -801,6 +801,25 @@ class ShoppingController extends AbstractController
             );
             $app['eccube.event.dispatcher']->dispatch(EccubeEvents::FRONT_SHOPPING_SHIPPING_EDIT_COMPLETE, $event);
 
+            //非会員場合はお届け情報は追加する
+            if (!$app->isGranted('IS_AUTHENTICATED_FULLY')) {
+                // Sessionから住所を取得する
+                $customerAddresses = $app['session']->get($this->sessionCustomerAddressKey);
+                $customerAddresses = unserialize($customerAddresses);
+                $hasAddress = false;
+                // 既に住所あった場合は有フラグを立てる
+                foreach($customerAddresses as $idx => $address){
+                    if($Shipping->hasCustomerAddress($address)){
+                        $hasAddress = true;
+                        break;
+                    }
+                }
+                // 登録されてない住所は追加する
+                if($hasAddress === false){
+                    $customerAddresses[] = $CustomerAddress;
+                    $app['session']->set($this->sessionCustomerAddressKey, serialize($customerAddresses));
+                }
+            }
             log_info('お届け先追加処理完了', array('id' => $Order->getId(), 'shipping' => $id));
             return $app->redirect($app->url('shopping'));
         }

--- a/src/Eccube/Entity/Shipping.php
+++ b/src/Eccube/Entity/Shipping.php
@@ -240,6 +240,66 @@ class Shipping extends \Eccube\Entity\AbstractEntity
     }
 
     /**
+     * CustomerAddress 設定されているチェック.
+     *
+     * @param \Eccube\Entity\CustomerAddress $CustomerAddress
+     * @return Boolean
+     */
+    public function hasCustomerAddress(CustomerAddress $CustomerAddress)
+    {
+        if($this->getName01() != $CustomerAddress->getName01()){
+            return false;
+        }
+        if($this->getName02() != $CustomerAddress->getName02()){
+            return false;
+        }
+        if($this->getKana01() != $CustomerAddress->getKana01()){
+            return false;
+        }
+        if($this->getKana02() != $CustomerAddress->getKana02()){
+            return false;
+        }
+        if($this->getCompanyName() != $CustomerAddress->getCompanyName()){
+            return false;
+        }
+        if($this->getTel01() != $CustomerAddress->getTel01()){
+            return false;
+        }
+        if($this->getTel02() != $CustomerAddress->getTel02()){
+            return false;
+        }
+        if($this->getTel03() != $CustomerAddress->getTel03()){
+            return false;
+        }
+        if($this->getFax01() != $CustomerAddress->getFax01()){
+            return false;
+        }
+        if($this->getFax02() != $CustomerAddress->getFax02()){
+            return false;
+        }
+        if($this->getFax03() != $CustomerAddress->getFax03()){
+            return false;
+        }
+        if($this->getZip01() != $CustomerAddress->getZip01()){
+            return false;
+        }
+        if($this->getZip02() != $CustomerAddress->getZip02()){
+            return false;
+        }
+        if($this->getZipCode() != $CustomerAddress->getZip01() . $CustomerAddress->getZip02()){
+            return false;
+        }
+        if($this->getAddr01() != $CustomerAddress->getAddr01()){
+            return false;
+        }
+        if($this->getAddr02() != $CustomerAddress->getAddr02()){
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * 個人情報をクリア.
      *
      * @return \Eccube\Entity\Shipping

--- a/src/Eccube/Resource/template/default/Shopping/shipping.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping.twig
@@ -43,7 +43,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div id="list_box__list_body_inner" class="tbody">
                             {% for CustomerAddress in Customer.CustomerAddresses %}
                             <div id="list_box__item--{{ CustomerAddress.id }}" class="addr_box tr">
-                            <div id="list_box__id--{{ CustomerAddress.id }}" class="icon_radio td"><input type="radio" id="address{{ CustomerAddress.id }}" class="no-style" name="address" value="{{ CustomerAddress.id }}" /></div>
+                            <div id="list_box__id--{{ CustomerAddress.id }}" class="icon_radio td"><input type="radio" {% if CustomerAddress.id == addressId %}checked="checked"{% endif %} id="address{{ CustomerAddress.id }}" class="no-style" name="address" value="{{ CustomerAddress.id }}" /></div>
                             <div id="list_box__address_area--{{ CustomerAddress.id }}" class="column td">
                                 <label for="address{{ CustomerAddress.id }}">
                                     <p id="list_box__address--{{ CustomerAddress.id }}" class="address">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
複数配送のお届け先追加時に、デフォルトの配送先の選択がリセットされる
https://github.com/EC-CUBE/ec-cube/issues/1590
と
https://github.com/EC-CUBE/ec-cube/issues/1617
と
https://github.com/EC-CUBE/ec-cube/issues/2200

## 方針(Policy)
フロント側購入フロー、テンプレート、「複数配送を有効にする」

## 実装に関する補足(Appendix)

> いくつかの配送先が登録されていたとして、
> 注文者がカートから、
> A：配送先を変更しようとした際の編集画面と、
> B：複数配送先を追加指定したい場合の、追加設定の画面とで、
> デフォルトの住所選択がリセットされています。
> 
> Aのケースでは、ラジオボタンが全て未選択になります。こちらはこれでも問題ないかもしれませんが、
> Bのケースの場合は、追加指定使用とした場合の、元の住所もリセットされてしまうようで、
> 一見気づきにくいです。

AとBの対応しました

## テスト（Test)
すでにあります

## 相談（Discussion）
ShippingとCustomerAddress確認のためにいかのメソッドを追加しました
https://github.com/trebla-on/ec-cube/blob/35cf29ed0636bd79144e7c643c0df058af34de7c/src/Eccube/Entity/Shipping.php#L248-L300
すべての項目同じ場合はそのCustomerAddressはデフォルトとして使います


