### PR TITLE
vendorに同梱しているphpunitを利用するように変更

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_script:
 
 script: # PHP7 + precise のテストは実行されない
   - if [[ $PHP_SAPI = 'phpdbg' ]] && [[ $CODENAME = 'trusty' ]]; then phpdbg -qrr ./vendor/bin/phpunit --coverage-clover=coverage.clover ; fi
-  - if [[ $PHP_SAPI != 'phpdbg' ]]; then phpunit ; fi
+  - if [[ $PHP_SAPI != 'phpdbg' ]]; then ./vendor/bin/phpunit ; fi
 
 after_script:
   - if [[ $PHP_SAPI = 'phpdbg' ]]; then wget https://scrutinizer-ci.com/ocular.phar ; fi


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
Travis-ciのphpunitがバージョンアップし、PHP7以上でないと利用できなくなったため。
vendorに同梱しているphpunitを利用する。

## 方針(Policy)
概要の通り

## 実装に関する補足(Appendix)
なし

## テスト（Test)
Travis-ciのテストが全てグリーンになりました。

## 相談（Discussion）
なし



