### PR TITLE
IIS環境でfaviconが表示するように対応

### DIFF
--- a/html/web.config
+++ b/html/web.config
@@ -11,6 +11,9 @@
         </rule>
         <rule name="Force simple error message for requests for non-existent favicon.ico" stopProcessing="true">
           <match url="favicon\.ico" />
+          <conditions>
+              <add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />
+          </conditions>
           <action type="CustomResponse" statusCode="404" subStatusCode="1" statusReason="File Not Found" statusDescription="The requested file favicon.ico was not found" />
         </rule>
         <!-- Rewrite URLs of the form 'x' to the form 'index.php/x'. -->

--- a/web.config.sample
+++ b/web.config.sample
@@ -11,6 +11,9 @@
         </rule>
         <rule name="Force simple error message for requests for non-existent favicon.ico" stopProcessing="true">
           <match url="favicon\.ico" />
+          <conditions>
+              <add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />
+          </conditions>
           <action type="CustomResponse" statusCode="404" subStatusCode="1" statusReason="File Not Found" statusDescription="The requested file favicon.ico was not found" />
         </rule>
         <!-- Rewrite URLs of the form 'x' to the form 'index.php/x'. -->


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
IIS環境でfaviconが表示されない
https://github.com/EC-CUBE/ec-cube/issues/2054

問題：IIS設定ファイルの中にfaviconのmatchルールありましたがコンディションなかったのでいつも404エラー出ました
対応：ファイルがないチェック時404エラー出るようにコンディションを追加しました


## テスト（Test)
サーバー：　IIS 7
ブラウザー：ie11,FF,Chrome OKでした

## 相談（Discussion）



