### PR TITLE
WIP[管理画面]商品検索画面の「表示件数」と「すべて/公開/非公開/在庫なし」を同時に使用できるように対応

### DIFF
--- a/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
@@ -125,6 +125,29 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $this->expected = '検索結果 ' . $cnt . ' 件 が該当しました';
         $this->actual = $crawler->filter('h3.box-title')->text();
         $this->verify();
+
+        // デフォルトのの表示件数確認テスト
+        $this->expected = '10件';
+        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        $this->verify();
+
+        // 表示件数20件テスト
+        $crawler = $this->client->request('GET', $this->app->url('admin_product_page', array('page_no' => 1)), array('page_count' => 20));
+        $this->expected = '20件';
+        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        $this->verify();
+
+        // 表示件数入力値は正しくない場合はデフォルトのの表示件数になるテスト
+        $crawler = $this->client->request('GET', $this->app->url('admin_product_page', array('page_no' => 1)), array('page_count' => 999999));
+        $this->expected = '20件';
+        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        $this->verify();
+
+        // 表示件数はSESSIONから取得するテスト
+        $crawler = $this->client->request('GET', $this->app->url('admin_product_page', array('page_no' => 1)), array('status' => 1));
+        $this->expected = '20件';
+        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        $this->verify();
     }
 
     public function testProductSearchByName()
@@ -148,6 +171,29 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $this->expected = '検索結果 1 件 が該当しました';
         $this->actual = $crawler->filter('h3.box-title')->text();
         $this->verify();
+
+        // デフォルトのの表示件数確認テスト
+        $this->expected = '10件';
+        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        $this->verify();
+
+        // 表示件数20件テスト
+        $crawler = $this->client->request('GET', $this->app->url('admin_product_page', array('page_no' => 1)), array('page_count' => 40));
+        $this->expected = '40件';
+        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        $this->verify();
+
+        // 表示件数入力値は正しくない場合はデフォルトのの表示件数になるテスト
+        $crawler = $this->client->request('GET', $this->app->url('admin_product_page', array('page_no' => 1)), array('page_count' => 999999));
+        $this->expected = '40件';
+        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        $this->verify();
+
+        // 表示件数はSESSIONから取得するテスト
+        $crawler = $this->client->request('GET', $this->app->url('admin_product_page', array('page_no' => 1)), array('status' => 1));
+        $this->expected = '40件';
+        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        $this->verify();
     }
 
     public function testProductSearchById()
@@ -168,6 +214,29 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $crawler = $this->client->request('POST', $this->app->url('admin_product'), $post);
         $this->expected = '検索結果 1 件 が該当しました';
         $this->actual = $crawler->filter('h3.box-title')->text();
+        $this->verify();
+
+        // デフォルトのの表示件数確認テスト
+        $this->expected = '10件';
+        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        $this->verify();
+
+        // 表示件数20件テスト
+        $crawler = $this->client->request('GET', $this->app->url('admin_product_page', array('page_no' => 1)), array('page_count' => 30));
+        $this->expected = '30件';
+        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        $this->verify();
+
+        // 表示件数入力値は正しくない場合はデフォルトのの表示件数になるテスト
+        $crawler = $this->client->request('GET', $this->app->url('admin_product_page', array('page_no' => 1)), array('page_count' => 999999));
+        $this->expected = '30件';
+        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        $this->verify();
+
+        // 表示件数はSESSIONから取得するテスト
+        $crawler = $this->client->request('GET', $this->app->url('admin_product_page', array('page_no' => 1)), array('status' => 1));
+        $this->expected = '30件';
+        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
         $this->verify();
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
[管理画面]商品検索画面の「表示件数」と「すべて/公開/非公開/在庫なし」を同時に使用できるように変更
https://github.com/EC-CUBE/ec-cube/issues/2138

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)
追加しました、
１．デフォルトの設定確認
２．入力値から設定なる確認
３．正しくない入力値場合はデフォルトの設定なる確認
４．入力値ない場合はSESSIONから取得する確認

## 相談（Discussion）



