### PR TITLE
会員の合計購入金額、回数の集計のテストコードの追加

### DIFF
--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -507,8 +507,6 @@ class OrderRepository extends EntityRepository
             ->andWhere('o.OrderStatus in (:OrderStatuses)')
             ->setParameter('Customer', $Customer)
             ->setParameter('OrderStatuses', $OrderStatuses)
-            ->groupBy('o.id')
-            ->orderBy('o.id', 'ASC')
             ->getQuery()
             ->getResult();
 

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -507,6 +507,7 @@ class OrderRepository extends EntityRepository
             ->andWhere('o.OrderStatus in (:OrderStatuses)')
             ->setParameter('Customer', $Customer)
             ->setParameter('OrderStatuses', $OrderStatuses)
+            ->groupBy('o.Customer')
             ->getQuery()
             ->getResult();
 

--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -90,6 +90,14 @@ class EditControllerTest extends AbstractEditControllerTestCase
         $this->expected = $formData['name']['name01'];
         $this->actual = $EditedOrder->getName01();
         $this->verify();
+
+        // 顧客の購入回数と購入金額確認
+        $this->expected =  $EditedOrder->getTotalPrice();
+        $this->actual = $EditedOrder->getCustomer()->getBuyTotal();
+        $this->verify();
+        $this->expected = 1;
+        $this->actual = $EditedOrder->getCustomer()->getBuyTimes();
+        $this->verify();
     }
 
     public function testSearchCustomer()
@@ -110,6 +118,56 @@ class EditControllerTest extends AbstractEditControllerTestCase
 
         $this->expected = $this->Customer->getName01().$this->Customer->getName02().'('.$this->Customer->getKana01().$this->Customer->getKana02().')';
         $this->actual = $Result[0]['name'];
+        $this->verify();
+    }
+
+    public function testOrderCustomerInfo()
+    {
+        $Customer = $this->createCustomer();
+        $Order = $this->createOrder($Customer);
+
+        $formData = $this->createFormData($Customer, $this->Product);
+        $this->client->request(
+            'POST',
+            $this->app->url('admin_order_edit', array('id' => $Order->getId())),
+            array(
+                'order' => $formData,
+                'mode' => 'register'
+            )
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_order_edit', array('id' => $Order->getId()))));
+
+        $EditedOrder = $this->app['eccube.repository.order']->find($Order->getId());
+
+        // 顧客の購入回数と購入金額確認
+        $totalPrice = $EditedOrder->getTotalPrice();
+        $this->expected = $totalPrice ;
+        $this->actual = $EditedOrder->getCustomer()->getBuyTotal();
+        $this->verify();
+        $this->expected = 1;
+        $this->actual = $EditedOrder->getCustomer()->getBuyTimes();
+        $this->verify();
+
+        $Order = $this->createOrder($Customer);
+        $formData = $this->createFormData($Customer, $this->Product);
+        $this->client->request(
+            'POST',
+            $this->app->url('admin_order_edit', array('id' => $Order->getId())),
+            array(
+                'order' => $formData,
+                'mode' => 'register'
+            )
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_order_edit', array('id' => $Order->getId()))));
+
+        $EditedOrder = $this->app['eccube.repository.order']->find($Order->getId());
+
+        // 顧客の購入回数と購入金額確認
+        $this->expected =  $totalPrice + $EditedOrder->getTotalPrice();
+        $this->actual = $EditedOrder->getCustomer()->getBuyTotal();
+        $this->verify();
+        $this->expected = 2;
+        $this->actual = $EditedOrder->getCustomer()->getBuyTimes();
         $this->verify();
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
[管理画面]受注編集すると、購入者の会員の合計購入回数に「１」がセットされてしまう
https://github.com/EC-CUBE/ec-cube/issues/2218

## 方針(Policy)
受注情報取得する時修正しました。

## 実装に関する補足(Appendix)

## テスト（Test)
管理画面受注編集の時「購入回数」と「購入金額」テストケース追加

## 相談（Discussion）



