### PR TITLE
テストケースにリダイレクトチェックのAssertを追加

### DIFF
--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -285,7 +285,6 @@ class EditControllerTest extends AbstractEditControllerTestCase
         $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_order_edit', array('id' => $Order->getId()))));
 
         $EditedOrder = $this->app['eccube.repository.order']->find($Order->getId());
-
         $formDataForEdit = $this->createFormDataForEdit($EditedOrder);
 
         //税金計算
@@ -297,6 +296,13 @@ class EditControllerTest extends AbstractEditControllerTestCase
             $totalTax += $tax * $formDataForEdit['OrderDetails'][$indx]['quantity'];
         }
 
+        // Multi用項目を削除
+        foreach($formDataForEdit['Shippings'] as $key => $node){
+            if(isset($node['ShipmentItems'])){
+                unset($formDataForEdit['Shippings'][$key]['ShipmentItems']);
+            }
+        }
+
         // 管理画面で受注編集する
         $this->client->request(
             'POST', $this->app->url('admin_order_edit', array('id' => $Order->getId())), array(
@@ -304,6 +310,8 @@ class EditControllerTest extends AbstractEditControllerTestCase
             'mode' => 'register'
             )
         );
+
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_order_edit', array('id' => $Order->getId()))));
         $EditedOrderafterEdit = $this->app['eccube.repository.order']->find($Order->getId());
 
         //確認する「トータル税金」
@@ -328,6 +336,7 @@ class EditControllerTest extends AbstractEditControllerTestCase
         );
 
         $url = $crawler->filter('a')->text();
+        $this->assertTrue($this->client->getResponse()->isRedirect($url));
 
         $savedOderId = preg_replace('/.*\/admin\/order\/(\d+)\/edit/', '$1', $url);
         $SavedOrder = $this->app['eccube.repository.order']->find($savedOderId);


### PR DESCRIPTION
テストケースでバリデーションエラーを捕捉していない
#1772

修正内容
受注登録、編集の後にフォームの入力値は更新した後画面で確認する。
現在はリダイレクトチャックありましたがデータ内容なかったので追加しました。
こちらの対応方法あってるかどうかわかりませんのでご確認お願いします。

古いPRこちら　 https://github.com/EC-CUBE/ec-cube/pull/2064
