### PR TITLE
path.ymlで絶対パスを使用しないように変更

### DIFF
--- a/eccube_install.php
+++ b/eccube_install.php
@@ -476,7 +476,7 @@ function getPathConfig()
     $ADMIN_ROUTE = getenv('ADMIN_ROUTE');
     $TEMPLATE_CODE = 'default';
     $USER_DATA_ROUTE = 'user_data';
-    $ROOT_DIR = realpath(__DIR__);
+    $ROOT_DIR = '%ROOT_DIR%';
     $ROOT_URLPATH = getenv('ROOT_URLPATH');
     $ROOT_PUBLIC_URLPATH = $ROOT_URLPATH.RELATIVE_PUBLIC_DIR_PATH;
 

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -900,8 +900,7 @@ class Application extends \Silex\Application
         if (!file_exists($config_php)) {
             $config_yml = $ymlPath.'/'.$config_name.'.yml';
             if (file_exists($config_yml)) {
-                $ymlContent = str_replace('%ROOT_DIR%', realpath(__DIR__.'/../../'), file_get_contents($config_yml));
-                $config = Yaml::parse($ymlContent);
+                $config = Yaml::parse(file_get_contents($config_yml));
                 $config = empty($config) ? array() : $config;
                 if (isset($this['output_config_php']) && $this['output_config_php']) {
                     file_put_contents($config_php, sprintf('<?php return %s', var_export($config, true)).';');
@@ -910,6 +909,12 @@ class Application extends \Silex\Application
         } else {
             $config = require $config_php;
         }
+
+        // `%ROOT_DIR%`を絶対パスに変換
+        $rootDir = realpath(__DIR__.'/../../');
+        array_walk($config, function(&$value) use ($rootDir) {
+            $value = str_replace('%ROOT_DIR%', $rootDir, $value);
+        });
 
         $config_dist = array();
         $config_php_dist = $distPath.'/'.$config_name.'.dist.php';

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -900,7 +900,8 @@ class Application extends \Silex\Application
         if (!file_exists($config_php)) {
             $config_yml = $ymlPath.'/'.$config_name.'.yml';
             if (file_exists($config_yml)) {
-                $config = Yaml::parse(file_get_contents($config_yml));
+                $ymlContent = str_replace('%ROOT_DIR%', realpath(__DIR__.'/../../'), file_get_contents($config_yml));
+                $config = Yaml::parse($ymlContent);
                 $config = empty($config) ? array() : $config;
                 if (isset($this['output_config_php']) && $this['output_config_php']) {
                     file_put_contents($config_php, sprintf('<?php return %s', var_export($config, true)).';');

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -848,7 +848,7 @@ class InstallController
         $ADMIN_ROUTE = $data['admin_dir'];
         $TEMPLATE_CODE = 'default';
         $USER_DATA_ROUTE = 'user_data';
-        $ROOT_DIR = realpath(__DIR__ . '/../../../../');
+        $ROOT_DIR = '%ROOT_DIR%';
         $ROOT_URLPATH = $request->getBasePath();
         $ROOT_PUBLIC_URLPATH = $ROOT_URLPATH . RELATIVE_PUBLIC_DIR_PATH;
 


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
関連 #864 

## 方針(Policy)
+ `%ROOT_DIR%`が内部的に絶対パスとして変換されるように実装