### PR TITLE
カート画面で「購入金額上限」「販売制限」のエラーが同時発生した時に、エラーメッセージに商品名が表示されない問題対応

### DIFF
--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -500,7 +500,14 @@ class CartService
         $this->errors[] = $error;
         $this->session->getFlashBag()->add('eccube.front.request.error', $error);
         if (!is_null($productName)) {
-            $this->session->getFlashBag()->add('eccube.front.request.product', $productName);
+            // 追加されているエラーのキーを取得する
+            $cnt = $this->session->getFlashBag()->peek('eccube.front.request.error');
+            end($cnt);
+            $key = key($cnt);
+            // エラーと同じキー商品名を設定する
+            $tmpBag = $this->session->getFlashBag()->get('eccube.front.request.product');
+            $tmpBag[$key] = $productName;
+            $this->session->getFlashBag()->set('eccube.front.request.product', $tmpBag);
         }
 
         return $this;


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
カート画面で「購入金額上限」「販売制限」のエラーが同時発生した時に、エラーメッセージに商品名が表示されない
https://github.com/EC-CUBE/ec-cube/issues/2216

## 実装に関する補足(Appendix)
テンプレートの中にエラーメッセージと商品名メッセージ取得する時キーで商品名マッチングしてますので商品名追加する時キーはエラーと同じするように修正しました

## テスト（Test)
カート画面で「金額の上限」と「販売制限」エラーあった時エラーメッセージの中に商品名表示するテストケース追加

## 相談（Discussion）




