### PR TITLE
Entity/Product.phpのドキュメンテーションコメントを修正

### DIFF
--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -125,7 +125,7 @@ class Product extends \Eccube\Entity\AbstractEntity
     /**
      * Get ClassName1
      *
-     * @return bool
+     * @return string
      */
     public function getClassName1()
     {
@@ -137,7 +137,7 @@ class Product extends \Eccube\Entity\AbstractEntity
     /**
      * Get ClassName2
      *
-     * @return bool
+     * @return string
      */
     public function getClassName2()
     {
@@ -149,7 +149,7 @@ class Product extends \Eccube\Entity\AbstractEntity
     /**
      * Get getClassCategories1
      *
-     * @return bool
+     * @return array
      */
     public function getClassCategories1()
     {
@@ -161,7 +161,7 @@ class Product extends \Eccube\Entity\AbstractEntity
     /**
      * Get getClassCategories2
      *
-     * @return bool
+     * @return array
      */
     public function getClassCategories2($class_category1)
     {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
Entity/Product.phpのドキュメンテーションコメントが間違っていたので修正
修正個所は以下の関数の戻り値
+ getClassName1()
+ getClassName2()
+ getClassCategories1()
+ getClassCategories2()

## 方針(Policy)
なし

## 実装に関する補足(Appendix)
なし

## テスト（Test)
開発中の環境で商品詳細画面を表示してエラーなし

## 相談（Discussion）
なし
