### PR TITLE
#2238 会員の初回・最終購入日を、購入回数と同様に受注データから取得する

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -235,7 +235,7 @@ class EditController extends AbstractController
 
                         if ($Customer) {
                             // 会員の場合、購入回数、購入金額などを更新
-                            $app['eccube.repository.customer']->updateBuyData($app, $Customer, $TargetOrder->getOrderStatus()->getId());
+                            $app['eccube.repository.customer']->updateBuyData($app, $Customer);
                         }
 
                         $event = new EventArgs(

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -209,7 +209,7 @@ class OrderController extends AbstractController
         $Customer = $Order->getCustomer();
         if ($Customer) {
             // 会員の場合、購入回数、購入金額などを更新
-            $app['eccube.repository.customer']->updateBuyData($app, $Customer, $Order->getOrderStatus()->getId());
+            $app['eccube.repository.customer']->updateBuyData($app, $Customer);
         }
 
         $event = new EventArgs(

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -439,25 +439,10 @@ class CustomerRepository extends EntityRepository implements UserProviderInterfa
 
         if (!empty($result)) {
             $data = $result[0];
-
-            $now = new \DateTime();
-
-            $firstBuyDate = $Customer->getFirstBuyDate();
-            if (empty($firstBuyDate)) {
-                $Customer->setFirstBuyDate($now);
-            }
-
-            if ($orderStatusId == $app['config']['order_cancel'] ||
-                    $orderStatusId == $app['config']['order_pending'] ||
-                    $orderStatusId == $app['config']['order_processing']) {
-                // キャンセル、決済処理中、購入処理中は購入時間は更新しない
-            } else {
-                $Customer->setLastBuyDate($now);
-            }
-
+            $Customer->setFirstBuyDate(new \DateTime($data['min_order_date']));
+            $Customer->setLastBuyDate(new \DateTime($data['max_order_date']));
             $Customer->setBuyTimes($data['buy_times']);
             $Customer->setBuyTotal($data['buy_total']);
-
         } else {
             // 受注データが存在しなければ初期化
             $Customer->setFirstBuyDate(null);

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -422,9 +422,8 @@ class CustomerRepository extends EntityRepository implements UserProviderInterfa
      *
      * @param $app
      * @param  Customer $Customer
-     * @param  $orderStatusId
      */
-    public function updateBuyData($app, Customer $Customer, $orderStatusId)
+    public function updateBuyData($app, Customer $Customer)
     {
         // 会員の場合、初回購入時間・購入時間・購入回数・購入金額を更新
 

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -502,7 +502,7 @@ class OrderRepository extends EntityRepository
     public function getCustomerCount(\Eccube\Entity\Customer $Customer, array $OrderStatuses)
     {
         $result = $this->createQueryBuilder('o')
-            ->select('COUNT(o.id) AS buy_times, SUM(o.total)  AS buy_total, min(o.order_date) AS min_order_date, max(o.order_date)  AS max_order_date')
+            ->select('COUNT(o.id) AS buy_times, SUM(o.total) AS buy_total, min(o.order_date) AS min_order_date, max(o.order_date) AS max_order_date')
             ->where('o.Customer = :Customer')
             ->andWhere('o.OrderStatus in (:OrderStatuses)')
             ->setParameter('Customer', $Customer)

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -502,7 +502,7 @@ class OrderRepository extends EntityRepository
     public function getCustomerCount(\Eccube\Entity\Customer $Customer, array $OrderStatuses)
     {
         $result = $this->createQueryBuilder('o')
-            ->select('COUNT(o.id) AS buy_times, SUM(o.total)  AS buy_total')
+            ->select('COUNT(o.id) AS buy_times, SUM(o.total)  AS buy_total, min(o.order_date) AS min_order_date, max(o.order_date)  AS max_order_date')
             ->where('o.Customer = :Customer')
             ->andWhere('o.OrderStatus in (:OrderStatuses)')
             ->setParameter('Customer', $Customer)
@@ -513,4 +513,5 @@ class OrderRepository extends EntityRepository
 
         return $result;
     }
+
 }

--- a/tests/Eccube/Tests/Repository/CustomerRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/CustomerRepositoryTest.php
@@ -203,7 +203,7 @@ class CustomerRepositoryTest extends EccubeTestCase
         $this->app['orm.em']->flush();
 
         $this->actual = 1;
-        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer, $this->app['config']['order_new']);
+        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer);
         $this->expected = $this->Customer->getBuyTimes();
         $this->verify();
 
@@ -215,7 +215,7 @@ class CustomerRepositoryTest extends EccubeTestCase
         $this->app['orm.em']->flush();
 
         $this->actual = 0;
-        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer, $this->app['config']['order_cancel']);
+        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer);
         $this->expected = $this->Customer->getBuyTimes();
         $this->verify();
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#2238 

## 方針(Policy)
会員の購入回数と購入金額は、管理画面での受注データ更新の度に集計・更新されているため、
その仕様に合わせて初回・最終購入日も更新するようにする。

## テスト（Test)
管理画面からの受注データ作成・更新・削除を確認しました。





