### PR TITLE
受注商品追加フォームテンプレートのadd_cart拡張部分修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/search_product.twig
+++ b/src/Eccube/Resource/template/admin/Order/search_product.twig
@@ -212,15 +212,17 @@
                             {% endif %}
                         {% endif %}
                     </td>
-                    <div class="extra-form">
-                        {% for f in form.getIterator %}
-                            {% if f.vars.name matches '[^plg*]' %}
-                                {{ form_label(f) }}
-                                {{ form_widget(f) }}
-                                {{ form_errors(f) }}
-                            {% endif %}
-                        {% endfor %}
-                    </div>
+                    <td>
+                        <div class="extra-form">
+                            {% for f in form.getIterator %}
+                                {% if f.vars.name matches '[^plg*]' %}
+                                    {{ form_label(f) }}
+                                    {{ form_widget(f) }}
+                                    {{ form_errors(f) }}
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                    </td>
                     <td class="text-right">
                         <button onclick="fnAddOrderDetail($(this).parent().parent(), {{ Product.id }})" type="button" class="btn btn-default btn-sm" name="mode" value="modal">
                             決定


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#2247 
+ 対象：受注編集画面 商品追加フォームのテンプレート
+ プラグインからのadd_cartフォーム拡張部分(plgで始まるサブフォーム)が送信されないためテンプレート修正


## 方針
+ テーブル内でtdに囲まれていなかったため囲みました