### PR TITLE
商品ごとの送料設定無効時は、商品ごとに設定されている送料を反映しないように修正

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -395,7 +395,7 @@ class ShoppingController extends AbstractController
                     ));
 
                     // 商品ごとの配送料合計
-                    if (!is_null($BaseInfo->getOptionProductDeliveryFee())) {
+                    if ($BaseInfo->getOptionProductDeliveryFee() === Constant::ENABLED) {
                         $productDeliveryFeeTotal += $app['eccube.service.shopping']->getProductDeliveryFee($Shipping);
                     }
 

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -558,7 +558,7 @@ class ShoppingService
 
         // 商品ごとの配送料合計
         $productDeliveryFeeTotal = 0;
-        if (!is_null($this->BaseInfo->getOptionProductDeliveryFee())) {
+        if ($this->BaseInfo->getOptionProductDeliveryFee() === Constant::ENABLED) {
             $productDeliveryFeeTotal = $ProductClass->getDeliveryFee() * $quantity;
         }
 
@@ -671,7 +671,7 @@ class ShoppingService
 
         // 商品ごとの配送料合計
         $productDeliveryFeeTotal = 0;
-        if (!is_null($this->BaseInfo->getOptionProductDeliveryFee())) {
+        if ($this->BaseInfo->getOptionProductDeliveryFee() === Constant::ENABLED) {
             $productDeliveryFeeTotal += $this->getProductDeliveryFee($Shipping);
         }
 
@@ -828,7 +828,7 @@ class ShoppingService
             $Shipping->setDeliveryFee($deliveryFee);
             // 商品ごとの配送料合計
             $productDeliveryFeeTotal = 0;
-            if (!is_null($this->BaseInfo->getOptionProductDeliveryFee())) {
+            if ($this->BaseInfo->getOptionProductDeliveryFee() === Constant::ENABLED) {
                 $productDeliveryFeeTotal += $this->getProductDeliveryFee($Shipping);
             }
             $Shipping->setShippingDeliveryFee($deliveryFee->getFee() + $productDeliveryFeeTotal);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#2252

## テスト（Test)
フロントにて、商品別送料が反映されることを確認後、商品別送料設定を無効にして送料を再計算し、商品別送料が反映されないことを確認しました。





