### PR TITLE
#2249 商品複製時に個別税率もコピーするように修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -644,6 +644,13 @@ class ProductController extends AbstractController
                     $CopyStock->setProductClass($Class);
                     $app['orm.em']->persist($CopyStock);
 
+                    $TaxRule = $Class->getTaxRule();
+                    if ($TaxRule) {
+                        $CopyTaxRule = clone $TaxRule;
+                        $CopyTaxRule->setProductClass($Class);
+                        $CopyTaxRule->setProduct($CopyProduct);
+                        $app['orm.em']->persist($CopyTaxRule);
+                    }
                     $app['orm.em']->persist($Class);
                 }
                 $Images = $CopyProduct->getProductImage();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#2249

## テスト（Test)
個別税率が設定されている商品を複製し、フロント側に反映されることを確認しました。
個別税率未設定の商品を複製できることを確認しました。

