### PR TITLE
Entityイベントの実装

### DIFF
--- a/app/Acme/Entity/SoldOutEventListener.php
+++ b/app/Acme/Entity/SoldOutEventListener.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace Acme\Entity;
+
+
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Eccube\Entity\Event\Annotations\PreUpdate;
+use Eccube\Entity\Event\EntityEventListener;
+use Eccube\Entity\ProductStock;
+
+/**
+ * @PreUpdate("Eccube\Entity\ProductStock")
+ */
+class SoldOutEventListener implements EntityEventListener
+{
+    public function execute(LifecycleEventArgs $eventArgs)
+    {
+        /** @var PreUpdateEventArgs $eventArgs */
+        if ($eventArgs->hasChangedField('stock')) {
+            /** @var ProductStock $ProductStock */
+            $ProductStock = $eventArgs->getEntity();
+
+            // 変更前の在庫数
+            $prevStock = $eventArgs->getOldValue('stock');
+            // 変更後の在庫数
+            $currentStock = $ProductStock->getStock();
+
+            // 在庫数が0になった場合は売り切れ
+            if ($currentStock == 0 && $prevStock != 0) {
+                // TODO 管理者にメール送信
+            }
+        }
+    }
+}

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -31,6 +31,7 @@ use Eccube\Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Eccube\EventListener\TransactionListener;
 use Eccube\Plugin\ConfigManager as PluginConfigManager;
 use Eccube\Routing\EccubeRouter;
+use Eccube\ServiceProvider\EntityEventServiceProvider;
 use Eccube\ServiceProvider\MobileDetectServiceProvider;
 use Sergiors\Silex\Provider\AnnotationsServiceProvider;
 use Sergiors\Silex\Provider\DoctrineCacheServiceProvider;
@@ -523,6 +524,7 @@ class Application extends \Silex\Application
 
     public function initDoctrine()
     {
+        $this->register(new EntityEventServiceProvider());
         $this->register(new \Silex\Provider\DoctrineServiceProvider(), array(
             'dbs.options' => array(
                 'default' => $this['config']['database']

--- a/src/Eccube/Entity/Event/Annotations/EntityEvent.php
+++ b/src/Eccube/Entity/Event/Annotations/EntityEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Eccube\Entity\Event\Annotations;
+
+/**
+ * @Annotation
+ * @Target("CLASS")
+ */
+class EntityEvent
+{
+    /**
+     * 対象にするEntityクラス
+     * @var array
+     */
+    public $value;
+}

--- a/src/Eccube/Entity/Event/Annotations/LoadClassMetadata.php
+++ b/src/Eccube/Entity/Event/Annotations/LoadClassMetadata.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Entity\Event\Annotations;
+
+
+use Doctrine\ORM\Events;
+
+/**
+ * @Annotation
+ * @TargetEvent(Events::loadClassMetadata)
+ */
+final class LoadClassMetadata extends EntityEvent
+{
+}

--- a/src/Eccube/Entity/Event/Annotations/OnClassMetadataNotFound.php
+++ b/src/Eccube/Entity/Event/Annotations/OnClassMetadataNotFound.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Entity\Event\Annotations;
+
+
+use Doctrine\ORM\Events;
+
+/**
+ * @Annotation
+ * @TargetEvent(Events::onClassMetadataNotFound)
+ */
+final class OnClassMetadataNotFound extends EntityEvent
+{
+}

--- a/src/Eccube/Entity/Event/Annotations/OnClear.php
+++ b/src/Eccube/Entity/Event/Annotations/OnClear.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Entity\Event\Annotations;
+
+
+use Doctrine\ORM\Events;
+
+/**
+ * @Annotation
+ * @TargetEvent(Events::onClear)
+ */
+final class OnClear extends EntityEvent
+{
+}

--- a/src/Eccube/Entity/Event/Annotations/OnFlush.php
+++ b/src/Eccube/Entity/Event/Annotations/OnFlush.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Entity\Event\Annotations;
+
+
+use Doctrine\ORM\Events;
+
+/**
+ * @Annotation
+ * @TargetEvent(Events::onFlush)
+ */
+final class OnFlush extends EntityEvent
+{
+}

--- a/src/Eccube/Entity/Event/Annotations/PostFlush.php
+++ b/src/Eccube/Entity/Event/Annotations/PostFlush.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Entity\Event\Annotations;
+
+
+use Doctrine\ORM\Events;
+
+/**
+ * @Annotation
+ * @TargetEvent(Events::postFlush)
+ */
+final class PostFlush extends EntityEvent
+{
+}

--- a/src/Eccube/Entity/Event/Annotations/PostLoad.php
+++ b/src/Eccube/Entity/Event/Annotations/PostLoad.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Entity\Event\Annotations;
+
+
+use Doctrine\ORM\Events;
+
+/**
+ * @Annotation
+ * @TargetEvent(Events::postLoad)
+ */
+final class PostLoad extends EntityEvent
+{
+}

--- a/src/Eccube/Entity/Event/Annotations/PostPersist.php
+++ b/src/Eccube/Entity/Event/Annotations/PostPersist.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Entity\Event\Annotations;
+
+
+use Doctrine\ORM\Events;
+
+/**
+ * @Annotation
+ * @TargetEvent(Events::postPersist)
+ */
+final class PostPersist extends EntityEvent
+{
+}

--- a/src/Eccube/Entity/Event/Annotations/PostRemove.php
+++ b/src/Eccube/Entity/Event/Annotations/PostRemove.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Entity\Event\Annotations;
+
+
+use Doctrine\ORM\Events;
+
+/**
+ * @Annotation
+ * @TargetEvent(Events::postRemove)
+ */
+final class PostRemove extends EntityEvent
+{
+}

--- a/src/Eccube/Entity/Event/Annotations/PostUpdate.php
+++ b/src/Eccube/Entity/Event/Annotations/PostUpdate.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Entity\Event\Annotations;
+
+
+use Doctrine\ORM\Events;
+
+/**
+ * @Annotation
+ * @TargetEvent(Events::postUpdate)
+ */
+final class PostUpdate extends EntityEvent
+{
+}

--- a/src/Eccube/Entity/Event/Annotations/PrePersist.php
+++ b/src/Eccube/Entity/Event/Annotations/PrePersist.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Entity\Event\Annotations;
+
+
+use Doctrine\ORM\Events;
+
+/**
+ * @Annotation
+ * @TargetEvent(Events::prePersist)
+ */
+final class PrePersist extends EntityEvent
+{
+}

--- a/src/Eccube/Entity/Event/Annotations/PreRemove.php
+++ b/src/Eccube/Entity/Event/Annotations/PreRemove.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Entity\Event\Annotations;
+
+
+use Doctrine\ORM\Events;
+
+/**
+ * @Annotation
+ * @TargetEvent(Events::preRemove)
+ */
+final class PreRemove extends EntityEvent
+{
+}

--- a/src/Eccube/Entity/Event/Annotations/PreUpdate.php
+++ b/src/Eccube/Entity/Event/Annotations/PreUpdate.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Entity\Event\Annotations;
+
+
+use Doctrine\ORM\Events;
+
+/**
+ * @Annotation
+ * @TargetEvent(Events::preUpdate)
+ */
+final class PreUpdate extends EntityEvent
+{
+}

--- a/src/Eccube/Entity/Event/Annotations/TargetEvent.php
+++ b/src/Eccube/Entity/Event/Annotations/TargetEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace Eccube\Entity\Event\Annotations;
+
+/**
+ * @Annotation
+ * @Target("CLASS")
+ */
+final class TargetEvent
+{
+    /**
+     * @var string
+     */
+    public $value;
+}

--- a/src/Eccube/Entity/Event/EntityEventDispatcher.php
+++ b/src/Eccube/Entity/Event/EntityEventDispatcher.php
@@ -1,0 +1,142 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Entity\Event;
+
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Events;
+use Eccube\Entity\Event\Annotations\TargetEntity;
+use Eccube\Entity\Event\Annotations\TargetEvent;
+
+class EntityEventDispatcher
+{
+
+    private $eventListeners = [];
+
+    private $entityManager;
+
+    function __construct(EntityManager $em)
+    {
+        AnnotationRegistry::registerAutoloadNamespace('Eccube\Entity\Event\Annotations', __DIR__.'/../../..');
+        $this->entityManager = $em;
+    }
+
+    public function addEventListener(EntityEventListener $listener)
+    {
+        $reader = new AnnotationReader();
+        $rc = new \ReflectionClass($listener);
+        $annotations = $reader->getClassAnnotations($rc);
+        foreach ($annotations as $ann) {
+            $eventAnn = $reader->getClassAnnotation(new \ReflectionClass($ann), TargetEvent::class);
+            if ($eventAnn) {
+                if (!isset($this->eventListeners[$eventAnn->value])) {
+                    $this->entityManager->getEventManager()->addEventListener($eventAnn->value, $this);
+                }
+                foreach ($ann->value as $targetClass) {
+                    $this->eventListeners[$eventAnn->value][$targetClass][] = $listener;
+                }
+            }
+        }
+    }
+
+    public function preRemove(LifecycleEventArgs $eventArgs)
+    {
+        $this->handle(Events::preRemove, $eventArgs);
+    }
+
+    public function postRemove(LifecycleEventArgs $eventArgs)
+    {
+        $this->handle(Events::postRemove, $eventArgs);
+    }
+
+    public function prePersist(LifecycleEventArgs $eventArgs)
+    {
+        $this->handle(Events::prePersist, $eventArgs);
+    }
+
+    public function postPersist(LifecycleEventArgs $eventArgs)
+    {
+        $this->handle(Events::postPersist, $eventArgs);
+    }
+
+    public function preUpdate(LifecycleEventArgs $eventArgs)
+    {
+        $this->handle(Events::preUpdate, $eventArgs);
+    }
+
+    public function postUpdate(LifecycleEventArgs $eventArgs)
+    {
+        $this->handle(Events::postUpdate, $eventArgs);
+    }
+
+    public function postLoad(LifecycleEventArgs $eventArgs)
+    {
+        $this->handle(Events::postLoad, $eventArgs);
+    }
+
+    public function loadClassMetadata(LifecycleEventArgs $eventArgs)
+    {
+        $this->handle(Events::loadClassMetadata, $eventArgs);
+    }
+
+    public function onClassMetadataNotFound(LifecycleEventArgs $eventArgs)
+    {
+        $this->handle(Events::onClassMetadataNotFound, $eventArgs);
+    }
+
+    public function onFlush(LifecycleEventArgs $eventArgs)
+    {
+        $this->handle(Events::onFlush, $eventArgs);
+    }
+
+    public function postFlush(LifecycleEventArgs $eventArgs)
+    {
+        $this->handle(Events::postFlush, $eventArgs);
+    }
+
+    public function onClear(LifecycleEventArgs $eventArgs)
+    {
+        $this->handle(Events::onClear, $eventArgs);
+    }
+
+    private function handle($eventName, LifecycleEventArgs $eventArgs)
+    {
+        $listeners = $this->getEventListeners($eventName);
+        $entityClass = get_class($eventArgs->getEntity());
+        if (isset($listeners[$entityClass])) {
+            array_walk($listeners[$entityClass], function(EntityEventListener $listener) use ($eventArgs) {
+                $listener->execute($eventArgs);
+            });
+        }
+    }
+
+    public function getEventListeners($targetEvent)
+    {
+        return isset($this->eventListeners[$targetEvent]) ? $this->eventListeners[$targetEvent] : [];
+    }
+}

--- a/src/Eccube/Entity/Event/EntityEventListener.php
+++ b/src/Eccube/Entity/Event/EntityEventListener.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Entity\Event;
+
+
+use Doctrine\ORM\Event\LifecycleEventArgs;
+
+interface EntityEventListener
+{
+    public function execute(LifecycleEventArgs $eventArgs);
+}

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -431,6 +431,7 @@ class EccubeServiceProvider implements ServiceProviderInterface, EventListenerPr
 
             return $types;
         });
+        $app['eccube.entity.event.dispatcher']->addEventListener(new \Acme\Entity\SoldOutEventListener());
     }
 
     public function subscribe(Container $app, EventDispatcherInterface $dispatcher)

--- a/src/Eccube/ServiceProvider/EntityEventServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EntityEventServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace Eccube\ServiceProvider;
+
+
+use Eccube\Entity\Event\EntityEventDispatcher;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+class EntityEventServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * Registers services on the given container.
+     *
+     * This method should only be used to configure services and parameters.
+     * It should not get services.
+     *
+     * @param Container $pimple A container instance
+     */
+    public function register(Container $container)
+    {
+        $container['eccube.entity.event.dispatcher'] = function($container) {
+            return new EntityEventDispatcher($container['orm.em']);
+        };
+    }
+}

--- a/tests/Eccube/Tests/Entity/Event/EntityEventDispatcherTest.php
+++ b/tests/Eccube/Tests/Entity/Event/EntityEventDispatcherTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Eccube\Tests\Entity\Event;
+
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Events;
+use Eccube\Entity\Customer;
+use Eccube\Entity\Event\Annotations\PrePersist;
+use Eccube\Entity\Event\Annotations\PreUpdate;
+use Eccube\Entity\Event\Annotations\TargetEntity;
+use Eccube\Entity\Event\EntityEventDispatcher;
+use Eccube\Entity\Event\EntityEventListener;
+use Eccube\Entity\Product;
+use Eccube\Tests\EccubeTestCase;
+
+class EntityEventDispatcherTest extends EccubeTestCase
+{
+
+    /**
+     * @test
+     */
+    public function addEventListener()
+    {
+        $dispatcher = new EntityEventDispatcher($this->app['orm.em']);
+        $listener = new EntityEventDispatcherTest_SimpleEventListener();
+        $dispatcher->addEventListener($listener);
+        $actualListeners = $dispatcher->getEventListeners(Events::preUpdate);
+        self::assertTrue(in_array($listener, $actualListeners[Product::class]));
+    }
+
+    /**
+     * @test
+     */
+    public function addEventListener_with_multi_entity_listener()
+    {
+        $dispatcher = new EntityEventDispatcher($this->app['orm.em']);
+        $listener = new EntityEventDispatcherTest_MultiEntityEventListener();
+        $dispatcher->addEventListener($listener);
+        $actualListeners = $dispatcher->getEventListeners(Events::preUpdate);
+        self::assertTrue(in_array($listener, $actualListeners[Product::class]));
+        self::assertTrue(in_array($listener, $actualListeners[Customer::class]));
+    }
+
+    /**
+     * @test
+     */
+    public function eventListenerShouldBeCalled()
+    {
+        $listener = new EntityEventDispatcherTest_ProductPersistListener();
+        $this->app['eccube.entity.event.dispatcher']->addEventListener($listener);
+        $product = $this->createProduct();
+        $this->app['orm.em']->flush($product);
+        self::assertTrue($listener->executed);
+    }
+
+    /**
+     * @test
+     */
+    public function eventListenerShouldNotBeCalled()
+    {
+        $listener = new EntityEventDispatcherTest_ProductPersistListener();
+        $this->app['eccube.entity.event.dispatcher']->addEventListener($listener);
+        $customer = $this->createCustomer();
+        $this->app['orm.em']->flush($customer);
+        self::assertFalse($listener->executed);
+    }
+}
+
+/**
+ * @PreUpdate("Eccube\Entity\Product")
+ */
+class EntityEventDispatcherTest_SimpleEventListener implements EntityEventListener
+{
+    public function execute(LifecycleEventArgs $eventArgs) {}
+}
+
+/**
+ * @PreUpdate({"Eccube\Entity\Product", "Eccube\Entity\Customer"})
+ */
+class EntityEventDispatcherTest_MultiEntityEventListener implements EntityEventListener
+{
+    public function execute(LifecycleEventArgs $eventArgs) {}
+}
+
+/**
+ * @PrePersist("Eccube\Entity\Product")
+ */
+class EntityEventDispatcherTest_ProductPersistListener implements EntityEventListener
+{
+
+    public $executed = false;
+
+    public function execute(LifecycleEventArgs $eventArgs)
+    {
+        $this->executed = true;
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ https://github.com/EC-CUBE/ec-cube/issues/1984
+ Entityの登録や更新時などのライフサイクルイベント時に、プラグイン側で処理を実装できる仕組みを追加

### 実装例(Productエンティティが更新されたときに処理を実行)
```
/**
 * @PreUpdate("Eccube\Entity\Product")
 */
class MyProductUpdateListener implements EntityEventListener
{
    public function execute(LifecycleEventArgs $eventArgs)
    {
        // 商品情報が更新されたときの処理を実装
    }
}
```

## 方針(Policy)
+ Doctrineの[ライフサイクルイベント](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/events.html#reference-events-lifecycle-events)をベースに実装

## 実装に関する補足(Appendix)
+ イベントリスナーを登録する方法については要検討
    + 現時点での実装では各ServiceProviderでリスナーを追加しているが、最終的にはアノテーションをみて自動登録されるようにしたい

## テスト（Test)
+ テストケース
    + EntityEventDispatcherTest.php
+ サンプル実装
    + app/Acme/Entity/SoldOutEventListener.php

## 相談（Discussion）
+ アノテーション等の名前空間(Eccube\Entity\Event\Annotations)は適切か？

