### PR TITLE
SQLフィルターの実装

### DIFF
--- a/app/Acme/Entity/SecretProductFilter.php
+++ b/app/Acme/Entity/SecretProductFilter.php
@@ -1,0 +1,69 @@
+<?php
+
+
+namespace Acme\Entity;
+
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Filter\SQLFilter;
+use Eccube\Doctrine\Filter\ConditionalSQLFilter;
+use Eccube\Entity\Product;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * 【秘密の商品】という商品名は商品詳細画面のURLを知っているユーザだけがアクセスできるようにするSQLフィルター
+ */
+class SecretProductFilter extends SQLFilter implements ConditionalSQLFilter
+{
+
+    /**
+     * SQLフィルターを適用するか判定
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param \Eccube\Application $app
+     * @return bool
+     */
+    public static function isApplicable($request, $app)
+    {
+        $route = $request->attributes->get('_route');
+
+        // 管理者に対しては常にフィルターを掛けない
+        if ($app->isGranted('ROLE_ADMIN')) {
+            return false;
+        }
+
+        // 商品詳細画面
+        else if ($route === 'product_detail') {
+            // ログインユーザに対してはフィルターを掛けない
+            if ($app->isGranted('ROLE_USER')) {
+                return false;
+            }
+
+            // 秘密の商品である場合はログインが必須
+            $params = $request->attributes->get('_route_params');
+            $Product = $app['eccube.repository.product']->get($params['id']);
+            if ($Product && strpos($Product->getName(), '【秘密の商品】') === 0) {
+                throw  new AccessDeniedException();
+            }
+
+            return false;
+        }
+        return true;
+
+    }
+
+    /**
+     * Gets the SQL query part to add to a query.
+     *
+     * @param ClassMetaData $targetEntity
+     * @param string $targetTableAlias
+     *
+     * @return string The constraint SQL if there is available, empty string otherwise.
+     */
+    public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
+    {
+        if ($targetEntity->reflClass->getName() === Product::class) {
+            return $targetTableAlias.".name NOT LIKE '【秘密の商品】%'";
+        }
+        return '';
+    }
+}

--- a/src/Eccube/Doctrine/Filter/ConditionalSQLFilter.php
+++ b/src/Eccube/Doctrine/Filter/ConditionalSQLFilter.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Doctrine\Filter;
+
+
+use Eccube\Application;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * 条件によって検索結果をフィルタリングするための抽象クラス。
+ */
+interface ConditionalSQLFilter
+{
+    /**
+     * フィルタを適用するかどうかを判定します
+     * @param Request $request リクエスト
+     * @param Application $app アプリケーションコンテキスト
+     * @return boolean フィルタを適用する場合はtrue
+     * @throws AccessDeniedException
+     */
+    public static function isApplicable($request, $app);
+}

--- a/src/Eccube/Doctrine/Filter/SQLFilterConfigurator.php
+++ b/src/Eccube/Doctrine/Filter/SQLFilterConfigurator.php
@@ -1,0 +1,74 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Doctrine\Filter;
+
+
+use Doctrine\ORM\Configuration;
+use Eccube\Application;
+use Psr\Log\InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * SQLFilterを設定するクラス
+ */
+class SQLFilterConfigurator
+{
+
+    /**
+     * @var Application $app
+     */
+    private $app;
+
+    /**
+     * @var Configuration $config
+     */
+    private $config;
+
+    function __construct(Application $app)
+    {
+        $this->app = $app;
+        $this->config = $app['orm.em']->getConfiguration();
+    }
+
+    /**
+     * @param $filterClassName|string フィルタークラス名
+     */
+    public function addFilter($filterClassName)
+    {
+        $interfaces = class_implements($filterClassName);
+        if (array_search(ConditionalSQLFilter::class, $interfaces) == false) {
+            throw new InvalidArgumentException("$filterClassName should implement ".ConditionalSQLFilter::class);
+        }
+        $this->config->addFilter($filterClassName, $filterClassName);
+        $this->app->before(function (Request $request, Application $app) use ($filterClassName) {
+            $enable = call_user_func($filterClassName.'::isApplicable', $request, $app);
+            if ($enable) {
+                $filters = $this->app['orm.em']->getFilters();
+                $filters->enable($filterClassName);
+                /** @var ConditionalSQLFilter $filter */
+                $filters->getFilter($filterClassName);
+            }
+        });
+    }
+}

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -431,6 +431,10 @@ class EccubeServiceProvider implements ServiceProviderInterface, EventListenerPr
 
             return $types;
         });
+        $app['eccube.sql.filter.configurator'] = function() use ($app) {
+            return new \Eccube\Doctrine\Filter\SQLFilterConfigurator($app);
+        };
+        $app['eccube.sql.filter.configurator']->addFilter(\Acme\Entity\SecretProductFilter::class);
     }
 
     public function subscribe(Container $app, EventDispatcherInterface $dispatcher)

--- a/tests/Eccube/Tests/Web/SecretProductFilterTest.php
+++ b/tests/Eccube/Tests/Web/SecretProductFilterTest.php
@@ -1,0 +1,92 @@
+<?php
+
+
+namespace Eccube\Tests\Web;
+
+
+use Symfony\Component\HttpKernel\Client;
+
+class SecretProductFilterTest extends AbstractWebTestCase
+{
+
+    public function testGuestCannotSeeDetailPageOfSecretProduct()
+    {
+        $Product = $this->createProduct('テスト');
+
+        /** @var Client $client */
+        $client = $this->client;
+        $client->request('POST',
+            $this->app->url('product_detail', array('id' => $Product->getId()))
+        );
+        $this->assertTrue($client->getResponse()->isSuccessful());
+    }
+
+    public function testCustomerCanSeeDetailPageOfSecretProduct()
+    {
+        $this->loginTo($this->createCustomer());
+        $Product = $this->createProduct('テスト');
+
+        /** @var Client $client */
+        $client = $this->client;
+        $client->request('POST',
+            $this->app->url('product_detail', array('id' => $Product->getId()))
+        );
+        $this->assertTrue($client->getResponse()->isSuccessful());
+    }
+
+    public function testGuestCanSeeDetailPageOfPublicProduct()
+    {
+        $Product = $this->createProduct('【秘密の商品】テスト');
+
+        /** @var Client $client */
+        $client = $this->client;
+        $client->request('POST',
+            $this->app->url('product_detail', array('id' => $Product->getId()))
+        );
+        $this->assertFalse($client->getResponse()->isSuccessful());
+    }
+
+    public function testCustomerCanSeeDetailPageOfPublicProduct()
+    {
+        $this->loginTo($this->createCustomer());
+        $Product = $this->createProduct('【秘密の商品】テスト');
+
+        /** @var Client $client */
+        $client = $this->client;
+        $client->request('POST',
+            $this->app->url('product_detail', array('id' => $Product->getId()))
+        );
+        $this->assertTrue($client->getResponse()->isSuccessful());
+    }
+
+    public function testGuestCannotSeeSecretProductInProductList()
+    {
+        $this->createProduct('【秘密の商品】テスト');
+        $client = $this->client;
+        $crawler = $client->request('GET', $this->app->url('product_list'));
+        $this->assertNotContains('【秘密の商品】', $crawler->html());
+    }
+
+    public function testCustomerCannotSeeSecretProductInProductList()
+    {
+        $this->loginTo($this->createCustomer());
+        $this->createProduct('【秘密の商品】テスト');
+        $client = $this->client;
+        $crawler = $client->request('GET', $this->app->url('product_list'));
+        $this->assertNotContains('【秘密の商品】', $crawler->html());
+    }
+
+    public function testAdminCanSeeSecretProductInAdminProductList()
+    {
+        $this->loginTo($this->createMember());
+        $Product = $this->createProduct('【秘密の商品】テスト');
+        $client = $this->client;
+        $crawler = $client->request('POST',
+            $this->app->url('admin_product'),
+            array('admin_search_product' => array(
+                '_token' => 'dummy',
+                'id' => $Product->getId()))
+        );
+        $this->assertContains('【秘密の商品】テスト', $crawler->html());
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 関連 #1984
+ 条件によって適用されるSQLフィルターの実装

## 方針(Policy)
+ Doctrineの[SQLFilter](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/filters.html)を拡張

## テスト（Test)
+ テストケース
    + `tests/Eccube/Tests/Web/SecretProductFilterTest.php`
+ サンプル実装
    + `app/Acme/Entity/SecretProductFilter.php`

## 相談（Discussion）
+ 実現したかったのは、SQLフィルターを適用するかどうかの判定とフィルタリング処理を1つのクラスで実装できる
+ Doctrine側でSQLFilterのインスタンス化を行うため、どうしてもDoctrineのSQLFilterクラスの継承とstaticなメソッドを実装する形になってしまう。



