### PR TITLE
デバイスによってテンプレートを切り替える実装

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -407,12 +407,25 @@ class Application extends \Silex\Application
                 $paths[] = __DIR__.'/../../app/Plugin';
                 $cacheDir =  __DIR__.'/../../app/cache/twig/admin';
             } else {
-                if (file_exists($app['config']['template_realdir'])) {
-                    $paths[] = $app['config']['template_realdir'];
+                switch ($app['mobile_detect.device_type']) {
+                    case \Eccube\Entity\Master\DeviceType::DEVICE_TYPE_SP:
+                        // TODO 構成を要検討
+                        if (file_exists(__DIR__.'/../../app/template/smartphone')) {
+                            $paths[] = __DIR__.'/../../app/template/smartphone';
+                        }
+                        $paths[] = __DIR__.'/Resource/template/smartphone';
+                        $paths[] = __DIR__.'/../../app/Plugin';
+                        $cacheDir =  __DIR__.'/../../app/cache/twig/smartphone';
+                        // $cacheDir =  __DIR__.'/../../app/cache/twig/'.$app['config']['template_code'];
+                    default:
+                    case \Eccube\Entity\Master\DeviceType::DEVICE_TYPE_PC:
+                        if (file_exists($app['config']['template_realdir'])) {
+                            $paths[] = $app['config']['template_realdir'];
+                        }
+                        $paths[] = $app['config']['template_default_realdir'];
+                        $paths[] = __DIR__.'/../../app/Plugin';
+                        $cacheDir =  __DIR__.'/../../app/cache/twig/'.$app['config']['template_code'];
                 }
-                $paths[] = $app['config']['template_default_realdir'];
-                $paths[] = __DIR__.'/../../app/Plugin';
-                $cacheDir =  __DIR__.'/../../app/cache/twig/'.$app['config']['template_code'];
             }
             $app['twig']->setCache($app['debug'] ? null : $cacheDir);
             $app['twig.loader']->addLoader(new \Twig_Loader_Filesystem($paths));

--- a/src/Eccube/Entity/Master/DeviceType.php
+++ b/src/Eccube/Entity/Master/DeviceType.php
@@ -31,6 +31,7 @@ class DeviceType extends \Eccube\Entity\AbstractEntity
 {
     const DEVICE_TYPE_MB = 1;
     const DEVICE_TYPE_SP = 2;
+    // const DEVICE_TYPE_TABLET = 3;
     const DEVICE_TYPE_PC = 10;
     const DEVICE_TYPE_ADMIN = 99;
 

--- a/src/Eccube/Resource/template/smartphone/Block/cart.twig
+++ b/src/Eccube/Resource/template/smartphone/Block/cart.twig
@@ -1,0 +1,88 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+<div id="cart_area">
+    <p class="clearfix cart-trigger"><a href="#cart">
+            <svg class="cb cb-shopping-cart">
+                <use xlink:href="#cb-shopping-cart"/>
+            </svg>
+            <span class="badge">{{ Cart.total_quantity }}</span>
+            <svg class="cb cb-close">
+                <use xlink:href="#cb-close"/>
+            </svg>
+        </a>
+        <span class="cart_price pc">合計 <span class="price">{{ Cart.total_price|price }}</span></span></p>
+    <div id="cart" class="cart">
+        <div class="inner">
+            {% for error in app.session.flashbag.get('eccube.front.cart.error')  %}
+                <div class="message">
+                    <p class="errormsg bg-danger">
+                        <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>{{ error|trans|nl2br }}
+                    </p>
+                </div>
+            {% endfor %}
+            {% for CartItem in Cart.CartItems %}
+                {% set ProductClass = CartItem.Object %}
+                {% set Product = ProductClass.Product %}
+                <div class="item_box clearfix">
+                    <div class="item_photo"><img
+                                src="{{ app.config.image_save_urlpath }}/{{ Product.MainListImage|no_image_product }}"
+                                alt="{{ Product.name }}"></div>
+                    <dl class="item_detail">
+                        <dt class="item_name">{{ Product.name }}</dt>
+                        <dd class="item_pattern small">
+                            {%- if ProductClass.ClassCategory1 -%}
+                                {{ ProductClass.ClassCategory1.ClassName }}：{{ ProductClass.ClassCategory1 }}
+                                {%- if ProductClass.ClassCategory2 -%}
+                                    <br>{{ ProductClass.ClassCategory2.ClassName }}：{{ ProductClass.ClassCategory2 }}
+                                {%- endif -%}
+                            {%- endif -%}
+                        </dd>
+                        <dd class="item_price">{{ CartItem.price|price }}<span class="small">税込</span></dd>
+                        <dd class="item_quantity form-group form-inline">数量：{{ CartItem.quantity }}</dd>
+                    </dl>
+                </div><!--/item_box-->
+                <p class="cart_price sp">合計 <span class="price">{{ Cart.total_price|price }}</span></p>
+            {% endfor %}
+            {% if Cart.CartItems|length > 0 %}
+
+                <div class="btn_area">
+                    <ul>
+                        <li>
+                            <a href="{{ url('cart') }}" class="btn btn-primary">カートへ進む</a>
+                        </li>
+                        <li>
+                            <button type="button" class="btn btn-default btn-sm cart-trigger">キャンセル</button>
+                        </li>
+                    </ul>
+                </div>
+            {% else %}
+                <div class="btn_area">
+                    <div class="message">
+                        <p class="errormsg bg-danger" style="margin-bottom: 20px;">
+                            現在カート内に<br>商品はございません。
+                        </p>
+                    </div>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/src/Eccube/Resource/template/smartphone/Block/category.twig
+++ b/src/Eccube/Resource/template/smartphone/Block/category.twig
@@ -1,0 +1,43 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% macro tree(Category) %}
+    <li>
+        <a href="{{ url('product_list') }}?category_id={{ Category.id }}">
+            {{ Category.name }}
+        </a>
+        {% if Category.children|length > 0 %}
+            <ul>
+            {% for ChildCategory in Category.children %}
+                    {{ _self.tree(ChildCategory) }}
+            {% endfor %}
+            </ul>
+        {% endif %}
+    </li>
+{% endmacro %}
+
+<nav id="category" class="drawer_block pc">
+    <ul class="category-nav">
+    {% for Category in Categories %}
+        {{ _self.tree(Category) }}
+    {% endfor %}
+    </ul> <!-- category-nav -->
+</nav>

--- a/src/Eccube/Resource/template/smartphone/Block/footer.twig
+++ b/src/Eccube/Resource/template/smartphone/Block/footer.twig
@@ -1,0 +1,36 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+<div class="container-fluid inner">
+    <ul>
+        <li><a href="{{ url('help_about') }}">当サイトについて</a></li>
+        <li><a href="{{ url('help_privacy') }}">プライバシーポリシー</a></li>
+        <li><a href="{{ url('help_tradelaw') }}">特定商取引法に基づく表記</a></li>
+        <li><a href="{{ url('contact') }}">お問い合わせ</a></li>
+    </ul>
+    <div class="footer_logo_area">
+        <p class="logo"><a href="{{ url('homepage') }}">{{ BaseInfo.shop_name }}</a></p>
+        <p class="copyright">
+            <small>copyright (c) {{ BaseInfo.shop_name }} all rights reserved.</small>
+        </p>
+    </div>
+</div>
+

--- a/src/Eccube/Resource/template/smartphone/Block/free.twig
+++ b/src/Eccube/Resource/template/smartphone/Block/free.twig
@@ -1,0 +1,30 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+<div class="col-sm-3 txt_bnr_area">
+    <div class="txt_bnr">
+        {%- if BaseInfo.delivery_free_amount -%}
+            <strong>{{ BaseInfo.delivery_free_amount|number_format }}円以上の購入で<br><strong>配送料無料</strong></strong><br>一部地域は除く
+        {%- else -%}
+            <strong>0円以上の購入で<br><strong>配送料無料</strong></strong><br>一部地域は除く
+        {%- endif -%}
+    </div>
+</div>

--- a/src/Eccube/Resource/template/smartphone/Block/garally.twig
+++ b/src/Eccube/Resource/template/smartphone/Block/garally.twig
@@ -1,0 +1,37 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+<div class="item_gallery">
+    <ul class="row">
+        <li class="col-sm-2 col-xs-4"><a href="#" class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img10.jpg"></a></li>
+        <li class="col-sm-2 col-xs-4"><a href="#" class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img11.jpg"></a></li>
+        <li class="col-sm-2 col-xs-4"><a href="#" class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img12.jpg"></a></li>
+        <li class="col-sm-2 col-xs-4"><a href="#" class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img13.jpg"></a></li>
+        <li class="col-sm-2 col-xs-4"><a href="#" class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img14.jpg"></a></li>
+        <li class="col-sm-2 col-xs-4"><a href="#" class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img15.jpg"></a></li>
+        <li class="col-sm-2 col-xs-4"><a href="#" class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img16.jpg"></a></li>
+        <li class="col-sm-2 col-xs-4"><a href="#" class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img17.jpg"></a></li>
+        <li class="col-sm-2 col-xs-4"><a href="#" class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img18.jpg"></a></li>
+        <li class="col-sm-2 col-xs-4"><a href="#" class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img19.jpg"></a></li>
+        <li class="col-sm-2 col-xs-4"><a href="#" class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img20.jpg"></a></li>
+        <li class="col-sm-2 col-xs-4"><a href="#" class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img21.jpg"></a></li>
+    </ul>
+</div>

--- a/src/Eccube/Resource/template/smartphone/Block/login.twig
+++ b/src/Eccube/Resource/template/smartphone/Block/login.twig
@@ -1,0 +1,58 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% if is_granted('ROLE_USER') %}
+    <div id="member" class="member drawer_block pc">
+        <ul class="member_link">
+            <li>
+                <a href="{{ url('mypage') }}">
+                    <svg class="cb cb-user-circle"><use xlink:href="#cb-user-circle" /></svg>マイページ
+                </a>
+            </li>
+            {% if BaseInfo.option_favorite_product == 1 %}
+                <li><a href="{{ url('mypage_favorite') }}"><svg class="cb cb-heart-circle"><use xlink:href="#cb-heart-circle"></use></svg>お気に入り</a></li>
+            {% endif %}
+            <li>
+                <a href="{{ url('logout') }}">
+                    <svg class="cb cb-lock-circle"><use xlink:href="#cb-lock-circle" /></svg>ログアウト
+                </a>
+            </li>
+        </ul>
+    </div>
+{% else %}
+    <div id="member" class="member drawer_block pc">
+        <ul class="member_link">
+            <li>
+                <a href="{{ url('entry') }}">
+                    <svg class="cb cb-user-circle"><use xlink:href="#cb-user-circle" /></svg>新規会員登録
+                </a>
+            </li>
+            {% if BaseInfo.option_favorite_product == 1 %}
+                <li><a href="{{ url('mypage_favorite') }}"><svg class="cb cb-heart-circle"><use xlink:href="#cb-heart-circle"></use></svg>お気に入り</a></li>
+            {% endif %}
+            <li>
+                <a href="{{ url('mypage_login') }}">
+                    <svg class="cb cb-lock-circle"><use xlink:href="#cb-lock-circle" /></svg>ログイン
+                </a>
+            </li>
+        </ul>
+    </div>
+{% endif %}

--- a/src/Eccube/Resource/template/smartphone/Block/logo.twig
+++ b/src/Eccube/Resource/template/smartphone/Block/logo.twig
@@ -1,0 +1,25 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+             <div class="header_logo_area">
+                <p class="copy">くらしを楽しむライフスタイルグッズ</p>
+                <h1 class="header_logo"><a href="{{ url('homepage') }}">{{ BaseInfo.shop_name }}</a></h1>
+            </div>

--- a/src/Eccube/Resource/template/smartphone/Block/logo.twig
+++ b/src/Eccube/Resource/template/smartphone/Block/logo.twig
@@ -20,6 +20,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #}
              <div class="header_logo_area">
-                <p class="copy">くらしを楽しむライフスタイルグッズ</p>
+                <p class="copy">スマートフォンで閲覧いただいております。</p>
                 <h1 class="header_logo"><a href="{{ url('homepage') }}">{{ BaseInfo.shop_name }}</a></h1>
             </div>

--- a/src/Eccube/Resource/template/smartphone/Block/new_product.twig
+++ b/src/Eccube/Resource/template/smartphone/Block/new_product.twig
@@ -1,0 +1,134 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+<div id="contents_top">
+<div id="item_list">
+    <div class="row">
+        <div class="col-sm-6 col-xs-12">
+            <div class="row no-padding">
+                <div class="col-xs-6">
+                    <div class="img img_right"><a href="#"><img src="{{ app.config.front_urlpath }}/img/top/img01.jpg"></a></div>
+                </div>
+                <div class="col-xs-6">
+                    <div class="img"><a href="#"><img src="{{ app.config.front_urlpath }}/img/top/img02.jpg"></a></div>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-6 col-xs-12 comment_area">
+            <div class="txt_center">
+                <h4>新入荷商品特集</h4>
+                <h5>この季節にぴったりな商品をご用意しました</h5>
+                <p>さわやかな日差しが過ごしやすい季節。心地よいくらしのための、お部屋のアクセントになるおすすめのファブリックやグッズをご紹介します。</p>
+                <p><a class="btn btn-success" href="{{ url('product_list') }}">商品一覧へ<svg class="cb cb-angle-right"><use xlink:href="#cb-angle-right" /></svg></a></p>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-4 col-xs-12">
+            <div class="pickup_item">
+                <a href="#">
+                    <div class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img03.jpg"></div>
+                    <dl>
+                        <dt class="item_name text-warning">お気に入りのエスプレッソタイム</dt>
+                        <dd class="item_comment">コーヒータイムを上質な時間にしてくれる、口当たりのよさとデザイン性を兼ね備えたエスプレッソカップを集めました・・・</dd>
+                        <dd class="more_link text-warning">read more</dd>
+                    </dl>
+                </a>
+            </div>
+        </div>
+        <div class="col-sm-4 col-xs-12">
+            <div class="pickup_item">
+                <a href="#">
+                    <div class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img04.jpg"></div>
+                    <dl>
+                        <dt class="item_name text-warning">アウトドアにおすすめのアイテム</dt>
+                        <dd class="item_comment">カジュアルすぎない感じがちょうどよい、大人のためのアウトドアマガジンから、バイヤーおすすめのアイテムをセレクト・・・</dd>
+                        <dd class="more_link text-warning">read more</dd>
+                    </dl>
+                </a>
+            </div>
+        </div>
+        <div class="col-sm-4 col-xs-12">
+            <div class="pickup_item">
+                <a href="#">
+                    <div class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img05.jpg"></div>
+                    <dl>
+                        <dt class="item_name text-warning">フランス製のデッドストック</dt>
+                        <dd class="item_comment">60～70年代のフランス製のデッドストックの器を集めました。絶妙な色合いと、独特の優しい風合いをお楽しみいただけ・・・</dd>
+                        <dd class="more_link text-warning">read more</dd>
+                    </dl>
+                </a>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-3 col-xs-6">
+            <div class="pickup_item">
+                <a href="#">
+                    <div class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img06.jpg"></div>
+                    <p class="item_comment text-warning">木彫りのぬくもりがあたたかいアニマルオブジェ</p>
+                    <dl>
+                        <dt class="item_name">オブジェ（ふくろう）</dt>
+                        <dd class="item_price">\ 1,785</dd>
+                    </dl>
+                </a>
+            </div>
+        </div>
+        <div class="col-sm-3 col-xs-6">
+            <div class="pickup_item">
+                <a href="#">
+                    <div class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img07.jpg"></div>
+                    <p class="item_comment text-warning">青色が美しい職人が仕上げた吹きガラス</p>
+                    <dl>
+                        <dt class="item_name">ガラス瓶</dt>
+                        <dd class="item_price special_price">\ 1,785</dd>
+                    </dl>
+                </a>
+            </div>
+        </div>
+        <div class="col-sm-3 col-xs-6">
+            <div class="pickup_item">
+                <a href="#">
+                    <div class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img08.jpg"></div>
+                    <p class="item_comment text-warning">いつかは持ちたい。一生モノの銀製カトラリー</p>
+                    <dl>
+                        <dt class="item_name">シルバーカトラリー</dt>
+                        <dd class="item_price">\ 1,785</dd>
+                    </dl>
+                </a>
+            </div>
+        </div>
+        <div class="col-sm-3 col-xs-6">
+            <div class="pickup_item">
+                <a href="#">
+                    <div class="item_photo"><img src="{{ app.config.front_urlpath }}/img/top/img09.jpg"></div>
+                    <p class="item_comment text-warning">こだわりのシルクスクリーンプリントがポイント</p>
+                    <dl>
+                        <dt class="item_name">フォトクッションカバー</dt>
+                        <dd class="item_price">\ 1,785</dd>
+                    </dl>
+                </a>
+            </div>
+        </div>
+    </div>
+    
+</div>
+</div>

--- a/src/Eccube/Resource/template/smartphone/Block/news.twig
+++ b/src/Eccube/Resource/template/smartphone/Block/news.twig
@@ -1,0 +1,72 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+<script type="text/javascript">
+$(function(){
+    $(".newslist").each(function(){
+        var listLenght = $(this).find("dl").length;
+        if(listLenght>5){
+            $(this).find("dl:gt(4)").each(function(){$(this).hide();});
+            $(this).append('<a id="news_readmore">» もっと見る</a>');
+            var dispNum = 5;
+            $(this).find("#news_readmore").click(function(){
+                dispNum +=5;
+                $(this).parent().find("dl:lt("+dispNum+")").show(400);
+                if (dispNum>=listLenght) {
+                    $(this).hide();
+                }
+            })
+        }
+    });
+});
+</script>
+<div class="col-sm-9 news_contents">
+    <div id="news_area">
+        <h2 class="heading01">新着情報</h2>
+        <div class="accordion">
+            <div class="newslist">
+
+                {% for News in NewsList %}
+                <dl>
+                    <dt>
+                        <span class="date">{{ News.date|date("Y/m/d") }}</span>
+                        <span class="news_title">
+                            {{ News.title }}
+                        </span>
+                        {% if News.comment or News.url %}
+                        <span class="angle-circle"><svg class="cb cb-angle-down"><use xlink:href="#cb-angle-down" /></svg></span>
+                        {% endif %}
+                    </dt>
+                    {% if News.comment or News.url %}
+                    <dd>{{ News.comment|raw|nl2br}}
+                        {% if News.url %}<br>
+                        <a href="{{ News.url }}" {% if News.link_method == '1' %}target="_blank"{% endif %}>
+                        詳しくはこちら
+                        </a>{% endif %}
+                    </dd>
+                    {% endif %}
+                </dl>
+                {% endfor %}
+
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Eccube/Resource/template/smartphone/Block/search_product.twig
+++ b/src/Eccube/Resource/template/smartphone/Block/search_product.twig
@@ -1,0 +1,43 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+<div class="drawer_block pc header_bottom_area">
+    <div id="search" class="search">
+        <form method="get" id="searchform" action="{{ path('product_list') }}">
+            <div class="search_inner">
+                {{ form_widget(form.category_id) }}
+                <div class="input_search clearfix">
+                    {{ form_widget(form.name, {'attr': { 'placeholder' : "キーワードを入力" }} ) }}
+                    <button type="submit" class="bt_search"><svg class="cb cb-search"><use xlink:href="#cb-search" /></svg></button>
+                </div>
+            </div>
+            <div class="extra-form">
+                {% for f in form.getIterator %}
+                    {% if f.vars.name matches '[^plg*]' %}
+                        {{ form_label(f) }}
+                        {{ form_widget(f) }}
+                        {{ form_errors(f) }}
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/Eccube/Resource/template/smartphone/Cart/index.twig
+++ b/src/Eccube/Resource/template/smartphone/Cart/index.twig
@@ -1,0 +1,195 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'cart_page' %}
+
+{% block main %}
+    <h1 class="page-heading">ショッピングカート</h1>
+    <div id="cart" class="container-fluid">
+        <div id="cart_box" class="row">
+            <div id="cart_box__body" class="col-md-10 col-md-offset-1">
+                {% if is_granted('ROLE_USER') %}
+                <div id="cart_box__flow_state" class="flowline step3">
+                {% else %}
+                <div id="cart_box__flow_state" class="flowline step4">
+                {% endif %}
+                    <ul id="cart_box__flow_state_list" class="clearfix">
+                        <li class="active"><span class="flow_number">1</span><br>カートの商品</li>
+                    {% if is_granted('ROLE_USER') %}
+                        <li><span class="flow_number">2</span><br>ご注文内容確認</li>
+                        <li><span class="flow_number">3</span><br>完了</li>
+                    {% else %}
+                        <li><span class="flow_number">2</span><br>お客様情報</li>
+                        <li><span class="flow_number">3</span><br>ご注文内容確認</li>
+                        <li><span class="flow_number">4</span><br>完了</li>
+                    {% endif %}
+                    </ul>
+                </div>
+
+                {% set productStr = app.session.flashbag.get('eccube.front.request.product') %}
+                {% for error in app.session.flashbag.get('eccube.front.request.error')  %}
+                    {% set idx = loop.index0 %}
+                    {% if productStr[idx] is defined %}
+                    <div id="cart_box__message--{{ loop.index }}" class="message">
+                        <p class="errormsg bg-danger">
+                            <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>
+                            {{ error|trans({'%product%':productStr[idx]})|nl2br }}
+                        </p>
+                    </div>
+                    {% else %}
+                    <div id="cart_box__message--{{ loop.index }}" class="message">
+                        <p class="errormsg bg-danger">
+                            <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>{{ error|trans|nl2br }}
+                        </p>
+                    </div>
+                    {% endif %}
+                {% endfor %}
+                {% for error in app.session.flashbag.get('eccube.front.cart.error')  %}
+                    <div id="cart_box__message_error--{{ loop.index }}" class="message">
+                        <p class="errormsg bg-danger">
+                            <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>{{ error|trans|nl2br }}
+                        </p>
+                    </div>
+                {% endfor %}
+
+                {% if Cart.CartItems|length > 0 %}
+                <form name="form" id="form_cart" method="post" action="{{ url('cart') }}">
+                    <p id="cart_item__info" class="message">
+                        商品の合計金額は「<strong>{{ Cart.total_price|price }}</strong>」です。
+                        {% if BaseInfo.delivery_free_amount and BaseInfo.delivery_free_quantity %}
+                            <br />
+                            {% if is_delivery_free %}
+                                現在送料無料です。
+                            {% else %}
+                                あと「<strong>{{ least|price }}</strong>」または「<strong>{{ quantity|number_format }}個</strong>」のお買い上げで<strong class="text-primary">送料無料</strong>になります。
+                            {% endif %}
+                        {% elseif BaseInfo.delivery_free_amount %}
+                            <br />
+                            {% if is_delivery_free %}
+                                現在送料無料です。
+                            {% else %}
+                                あと「<strong>{{ least|price }}</strong>」のお買い上げで<strong class="text-primary">送料無料</strong>になります。
+                            {% endif %}
+                        {% elseif BaseInfo.delivery_free_quantity %}
+                            <br />
+                            {% if is_delivery_free %}
+                                現在送料無料です。
+                            {% else %}
+                                あと「<strong>{{ quantity|number_format }}個</strong>」のお買い上げで<strong class="text-primary">送料無料</strong>になります。
+                            {% endif %}
+                        {% endif %}
+                    </p>
+                    <div id="cart_item_list" class="cart_item table">
+                        <div class="thead">
+                            <ol id="cart_item_list__header">
+                                <li id="cart_item_list__header_cart_remove">削除</li>
+                                <li id="cart_item_list__header_product_detail">商品内容</li>
+                                <li id="cart_item_list__header_total">数量</li>
+                                <li id="cart_item_list__header_sub_total">小計</li>
+                            </ol>
+                        </div>
+                        <div id="cart_item_list__body" class="tbody">
+
+                            {% for CartItem in Cart.CartItems %}
+                                {% set ProductClass = CartItem.Object %}
+                                {% set Product = ProductClass.Product %}
+
+                                <div id="cart_item_list__item" class="item_box tr">
+                                    <div id="cart_item_list__cart_remove" class="icon_edit td">
+                                        <a href="{{ url('cart_remove', {'productClassId': ProductClass.id }) }}" {{ csrf_token_for_anchor() }} data-method="put" data-message="カートから商品を削除してもよろしいですか?">
+                                            <svg class="cb cb-close"><use xlink:href="#cb-close" /></svg>
+                                        </a>
+                                    </div>
+                                    <div class="td table">
+                                        <div id="cart_item_list__product_image" class="item_photo">
+                                            <a  target="_blank" href="{{ url('product_detail', {id : Product.id} ) }}">
+                                                <img src="{{ app.config.image_save_urlpath }}/{{ Product.MainListImage|no_image_product }}" alt="{{ Product.name }}" />
+                                            </a>
+                                        </div>
+                                        <dl class="item_detail">
+                                            <dt id="cart_item_list__product_detail" class="item_name text-default">
+                                                <a target="_blank" href="{{ url('product_detail', {id : Product.id} ) }}">{{ Product.name }}</a>
+                                            </dt>
+                                            <dd id="cart_item_list__class_category" class="item_pattern small">
+                                                {% if ProductClass.ClassCategory1 and ProductClass.ClassCategory1.id %}
+                                                    {{ ProductClass.ClassCategory1.ClassName }}：{{ ProductClass.ClassCategory1 }}
+                                                {% endif %}
+                                                {% if ProductClass.ClassCategory2 and ProductClass.ClassCategory2.id %}
+                                                    <br>{{ ProductClass.ClassCategory2.ClassName }}：{{ ProductClass.ClassCategory2 }}
+                                                {% endif %}
+                                            </dd>
+                                            <dd id="cart_item_list__item_price" class="item_price">￥{{ CartItem.price|number_format }}</dd>
+                                            <dd id="cart_item_list__item_subtotal" class="item_subtotal">小計：￥{{ CartItem.total_price|number_format }}</dd>
+                                        </dl>
+                                    </div>
+                                    <div id="cart_item_list__quantity" class="item_quantity td">
+                                        {{ CartItem.quantity|number_format }}
+                                        <ul id="cart_item_list__quantity_edit">
+                                            <li>
+                                                {% if CartItem.quantity > 1 %}
+                                                    <a id="cart_item_list__down" href="{{ url('cart_down', {'productClassId': ProductClass.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false"><svg class="cb cb-minus"><use xlink:href="#cb-minus" /></svg></a>
+                                                {% else %}
+                                                    <span><svg class="cb cb-minus"><use xlink:href="#cb-minus" /></svg></span>
+                                                {% endif %}
+                                            </li>
+                                            <li>
+                                                <a id="cart_item_list__up" href="{{ url('cart_up', {'productClassId': ProductClass.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false"><svg class="cb cb-plus"><use xlink:href="#cb-plus" /></svg></a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                    <div id="cart_item_list__subtotal" class="item_subtotal td">￥{{ CartItem.total_price|number_format }}</div>
+                                </div><!--/item_box-->
+                            {% endfor %}
+
+                        </div>
+                    </div><!--/cart_item-->
+                    <div class="total_box">
+                        <dl id="total_box__total_price" class="total_price">
+                            <dt>合計：</dt>
+                            <dd class="text-primary">￥{{ Cart.total_price|number_format }}</dd>
+                        </dl>
+                        <div id="total_box__user_action_menu" class="btn_group">
+
+                            <p id="total_box__next_button" >
+                                <a href="{{ path('cart_buystep') }}" class="btn btn-primary btn-block">レジに進む</a>
+                            </p>
+                            <p id="total_box__top_button">
+                                <a  href="{{ url('top') }}" class="btn btn-info btn-block">お買い物を続ける</a>
+                            </p>
+                        </div>
+                    </div>
+
+                </form>
+                {% else %}
+                <div id="cart_box__message" class="message">
+                    <p class="errormsg bg-danger">
+                        <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>現在カート内に商品はございません。
+                    </p>
+                </div>
+                {% endif %}
+
+            </div><!-- /.col -->
+        </div><!-- /.row -->
+
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Contact/complete.twig
+++ b/src/Eccube/Resource/template/smartphone/Contact/complete.twig
@@ -1,0 +1,46 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block main %}
+<h1 class="page-heading">お問い合わせ完了</h1>
+
+<div id="complete_wrap" class="container-fluid">
+    <div id="deliveradd_input" class="row">
+        <div id="complete_box" class="col-sm-10 col-sm-offset-1">
+            <div id="complete_box__body" class="complete_message">
+                <h2 id="complete_box__header_message">お問い合わせ内容の送信が完了いたしました。</h2>
+                <p id="complete_box__message">
+                万一、ご回答メールが届かない場合は、トラブルの可能性もありますので<br />
+                大変お手数ではございますがもう一度お問い合わせいただくか、お電話にてお問い合わせください。<br />
+                今後ともご愛顧賜りますようよろしくお願い申し上げます。
+                </p>
+            </div>
+            <div id="complete_box__footer" class="row no-padding">
+                <div id="complete_box__top_button" class="btn_group col-sm-offset-4 col-sm-4">
+                    <p><a href="{{ url('index') }}" class="btn btn-info btn-block">トップページへ</a></p>
+                </div>
+            </div>
+        </div><!-- /.col -->
+    </div><!-- /.row -->
+</div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Contact/confirm.twig
+++ b/src/Eccube/Resource/template/smartphone/Contact/confirm.twig
@@ -1,0 +1,101 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block main %}
+<div id="contents" class="main_only">
+    <div id="confirm_wrap" class="container-fluid inner no-padding">
+        <div id="main">
+            <h1 class="page-heading">お問い合わせ</h1>
+
+            <div id="confirm_inner" class="container-fluid">
+                <div id="confirm_box" class="row">
+                    <div id="confirm_box__body" class="col-md-10 col-md-offset-1">
+                        <p>内容によっては回答をさしあげるのにお時間をいただくこともございます。<br />
+                            また、休業日は翌営業日以降の対応となりますのでご了承ください。</p>
+
+                        <form name="form1" id="form1" method="post" action="?">
+                            {{ form_widget(form._token) }}
+                            <div id="confirm_box__body_inner" class="dl_table">
+                                <dl id="confirm_box__name">
+                                    <dt>{{ form_label(form.name) }}</dt>
+                                    <dd class="form-group">
+                                        {{ form_widget(form.name.name01) }}
+                                        {{ form_widget(form.name.name02) }}
+                                    </dd>
+                                </dl>
+                                <dl id="confirm_box__kana">
+                                    <dt>{{ form_label(form.kana) }}</dt>
+                                    <dd class="form-group">
+                                        {{ form_widget(form.kana.kana01) }}
+                                        {{ form_widget(form.kana.kana02) }}
+                                    </dd>
+                                </dl>
+                                <dl id="confirm_box__address">
+                                    <dt>{{ form_label(form.address) }}</dt>
+                                    <dd>
+                                        <div class="form-group">
+                                            {{ form_widget(form.zip) }}<br />
+                                            {{ form_widget(form.address) }}
+                                        </div>
+                                    </dd>
+                                </dl>
+                                <dl id="confirm_box__tel">
+                                    <dt>{{ form_label(form.tel) }}</dt>
+                                    <dd>
+                                        <div class="form-group">
+                                            {{ form_widget(form.tel) }}
+                                        </div>
+                                    </dd>
+                                </dl>
+                                <dl id="confirm_box__email">
+                                    <dt>{{ form_label(form.email) }}</dt>
+                                    <dd>
+                                        <div class="form-group">
+                                            {{ form_widget(form.email) }}
+                                        </div>
+                                    </dd>
+                                </dl>
+                                <dl id="confirm_box__contents">
+                                    <dt>{{ form_label(form.contents) }}</dt>
+                                    <dd>
+                                        <div class="column">
+                                            {{ form_widget(form.contents) }}
+                                        </div>
+                                    </dd>
+                                </dl>
+                            </div>
+                            <div id="confirm_box__footer" class="row no-padding">
+                                <div id="confirm_box__button_menu" class="btn_group col-sm-offset-4 col-sm-4">
+                                    <p id="confirm_box__confirm_button"><button type="submit" class="btn btn-primary btn-block" name="mode" value="complete">送信をする</button></p>
+                                    <p id="confirm_box__back_button"><button type="submit" class="btn btn-info btn-block" name="mode" value="back">戻る</button></p>
+                                </div>
+                            </div>
+                        </form>
+                    </div><!-- /.col -->
+                </div><!-- /.row -->
+            </div>
+
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Contact/index.twig
+++ b/src/Eccube/Resource/template/smartphone/Contact/index.twig
@@ -1,0 +1,131 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block javascript %}
+<script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
+<script>
+    $(function() {
+        $('#zip-search').click(function() {
+            AjaxZip3.zip2addr('contact[zip][zip01]', 'contact[zip][zip02]', 'contact[address][pref]', 'contact[address][addr01]');
+        });
+    });
+</script>
+{% endblock javascript %}
+
+{% block main %}
+
+<div id="contents" class="main_only">
+    <div class="container-fluid inner no-padding">
+        <div id="main">
+            <h1 class="page-heading">お問い合わせ</h1>
+
+            <div id="top_wrap" class="container-fluid">
+                <div id="top_box" class="row">
+                    <div id="top_box__body" class="col-md-10 col-md-offset-1">
+                        <p>内容によっては回答をさしあげるのにお時間をいただくこともございます。<br/>
+                            また、休業日は翌営業日以降の対応となりますのでご了承ください。</p>
+
+                        <form name="form1" id="form1" method="post" action="{{ url('contact') }}">
+                            {{ form_widget(form._token) }}
+                            <div id="top_box__body_inner" class="dl_table">
+                                <dl id="top_box__name">
+                                    <dt>{{ form_label(form.name) }}</dt>
+                                    <dd class="form-group input_name">
+                                        {{ form_widget(form.name.name01) }}
+                                        {{ form_widget(form.name.name02) }}
+                                        {{ form_errors(form.name.name01) }}
+                                        {{ form_errors(form.name.name02) }}
+                                    </dd>
+                                </dl>
+                                <dl id="top_box__kana">
+                                    <dt>{{ form_label(form.kana) }}</dt>
+                                    <dd class="form-group input_name">
+                                        {{ form_widget(form.kana.kana01) }}
+                                        {{ form_widget(form.kana.kana02) }}
+                                        {{ form_errors(form.kana.kana01) }}
+                                        {{ form_errors(form.kana.kana02) }}
+                                    </dd>
+                                </dl>
+                                <dl id="top_box__address_detail">
+                                    <dt>{{ form_label(form.address) }}</dt>
+                                    <dd>
+                                        <div id="top_box__zip" class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
+                                        <div id="top_box__address" class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
+                                            {{ form_widget(form.address) }}
+                                            {{ form_errors(form.address) }}
+                                        </div>
+                                    </dd>
+                                </dl>
+                                <dl id="top_box__tel">
+                                    <dt>{{ form_label(form.tel) }}</dt>
+                                    <dd>
+                                        <div class="form-inline form-group input_tel">
+                                            {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
+                                            {{ form_errors(form.tel) }}
+                                        </div>
+                                    </dd>
+                                </dl>
+                                <dl id="top_box__email">
+                                    <dt>{{ form_label(form.email) }}</dt>
+                                    <dd>
+                                        <div class="form-group">
+                                            {{ form_widget(form.email) }}
+                                            {{ form_errors(form.email) }}
+                                        </div>
+                                    </dd>
+                                </dl>
+                                <dl id="top_box__contents">
+                                    <dt>{{ form_label(form.contents) }}</dt>
+                                    <dd>
+                                        <div class="column">
+                                            {{ form_widget(form.contents) }}
+                                            {{ form_errors(form.contents) }}
+                                        </div>
+                                    </dd>
+                                </dl>
+                            </div>
+                            <input id="top_box__hidden_mode" type="hidden" name="mode" value="confirm">
+                            {% for f in form %}
+                                {% if f.vars.name matches '[^plg*]' %}
+                                    <div class="extra-form dl_table">
+                                        {{ form_row(f) }}
+                                    </div>
+                                {% endif %}
+                            {% endfor %}
+                            <div id="top_box__footer" class="row no-padding">
+                                <div id="top_box__confirm_button" class="btn_group col-sm-offset-4 col-sm-4">
+                                    <p><button type="submit" class="btn btn-primary btn-block">確認ページへ</button></p>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                    <!-- /.col -->
+                </div>
+                <!-- /.row -->
+            </div>
+
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Entry/activate.twig
+++ b/src/Eccube/Resource/template/smartphone/Entry/activate.twig
@@ -1,0 +1,48 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'registration_page' %}
+
+{% block main %}
+    <h1 class="page-heading">新規会員登録（完了）</h1>
+    <div id="activate_box" class="container-fluid">
+        <div id="deliveradd_input" class="row">
+            <div id="activate_box__body" class="col-sm-10 col-sm-offset-1">
+                <div id="activate_box__message" class="complete_message">
+                    <h2 class="heading01">本登録が完了いたしました。</h2>
+                    <p>それではショッピングをお楽しみください。</p>
+                    <p>今後ともご愛顧賜りますようよろしくお願い申し上げます。</p>
+                </div>
+                <div id="activate_box__footer" class="row no-padding">
+                    <div id="activate_box__button_menu" class="btn_group col-sm-offset-4 col-sm-4">
+                        <p id="activate_box__top_button" >
+                            <a href="{{ url('index') }}" class="btn btn-info btn-block">トップページへ</a>
+                        </p>
+                    </div>
+                </div>
+
+            </div><!-- /.col -->
+        </div><!-- /.row -->
+
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Entry/complete.twig
+++ b/src/Eccube/Resource/template/smartphone/Entry/complete.twig
@@ -1,0 +1,49 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'registration_page' %}
+
+{% block main %}
+    <h1 class="page-heading">新規会員登録（完了）</h1>
+    <div id="complete_box" class="container-fluid">
+        <div id="deliveradd_input" class="row">
+            <div id="complete_box__body" class="col-sm-10 col-sm-offset-1">
+                <div id="complete_box__message" class="complete_message">
+                    <h2 class="heading01">会員登録ありがとうございます</h2>
+                    <p id="complete_box__attention">
+                        現在<span class="attention">仮会員</span>の状態です。<br />
+                        ご入力いただいたメールアドレス宛てに、ご連絡が届いておりますので、<br />本会員登録になった上でお買い物をお楽しみください。<br />
+                        今後ともご愛顧賜りますようよろしくお願い申し上げます。
+                    </p>
+                </div>
+                <div id="complete_box__footer" class="row no-padding">
+                    <div id="complete_box__button_menu" class="btn_group col-sm-offset-4 col-sm-4">
+                        <p id="complete_box__top_button">
+                            <a href="{{ url('index') }}" class="btn btn-info btn-block">トップページへ</a>
+                        </p>
+                    </div>
+                </div>
+            </div><!-- /.col -->
+        </div><!-- /.row -->
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Entry/confirm.twig
+++ b/src/Eccube/Resource/template/smartphone/Entry/confirm.twig
@@ -1,0 +1,147 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'registration_page' %}
+
+{% block main %}
+    <h1 class="page-heading">新規会員登録確認</h1>
+    <div id="confirm_wrap" class="container-fluid">
+        <div id="confirm_box" class="row">
+            <div id="confirm_box__body" class="col-md-10 col-md-offset-1">
+                <p id="confirm_box__message">下記の内容で送信してもよろしいでしょうか？<br/>よろしければ、一番下の「会員登録をする」ボタンをクリックしてください。</p>
+
+                <form method="post" action="{{ url('entry') }}">
+                    {{ form_widget(form._token) }}
+                    <div id="confirm_box__body_inner" class="dl_table">
+                        <dl id="confirm_box__name">
+                            <dt>{{ form_label(form.name) }}</dt>
+                            <dd class="form-group input_name">
+                                {{ form_widget(form.name.name01, { attr : { placeholder: '姓' }}) }}
+                                {{ form_widget(form.name.name02, { attr : { placeholder: '名' }}) }}
+                            </dd>
+                        </dl>
+                        <dl id="confirm_box__kana">
+                            <dt>{{ form_label(form.kana) }}</dt>
+                            <dd class="form-group input_name">
+                                {{ form_widget(form.kana.kana01, { attr : { placeholder: 'セイ' }}) }}
+                                {{ form_widget(form.kana.kana02, { attr : { placeholder: 'メイ' }}) }}
+                            </dd>
+                        </dl>
+                        <dl id="confirm_box__company_name">
+                            <dt>{{ form_label(form.company_name) }}</dt>
+                            <dd class="form-group input_name">
+                                {{ form_widget(form.company_name) }}
+                            </dd>
+                        </dl>
+                        <dl id="confirm_box__address_detail">
+                            <dt>{{ form_label(form.address) }}</dt>
+                            <dd>
+                                <div id="confirm_box__zip" class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
+                                <div id="confirm_box__address" class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
+                                    {{ form_widget(form.address) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl id="confirm_box__tel">
+                            <dt>{{ form_label(form.tel) }}</dt>
+                            <dd>
+                                <div class="form-inline form-group input_tel">
+                                    {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl id="confirm_box__fax">
+                            <dt>{{ form_label(form.fax) }}</dt>
+                            <dd>
+                                <div class="form-inline form-group input_tel">
+                                    {{ form_widget(form.fax, {attr : {class : 'short'}}) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl id="confirm_box__email">
+                            <dt>{{ form_label(form.email) }}</dt>
+                            <dd>
+                                <div class="form-group">
+                                    {{ form_widget(form.email.first) }}
+                                    {{ form_widget(form.email.second, {freeze_display_text: false}) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl id="confirm_box__password">
+                            <dt>{{ form_label(form.password) }}</dt>
+                            <dd>
+                                <div class="form-group">
+                                    ********
+                                    {{ form_widget(form.password.first, {freeze_display_text: false}) }}
+                                    {{ form_widget(form.password.second, {freeze_display_text: false}) }}
+                                </div>
+                            </dd>
+                        </dl>
+                    </div>
+                    <div class="dl_table not_required">
+                        <dl id="confirm_box__birth">
+                            <dt>{{ form_label(form.birth) }}</dt>
+                            <dd>
+                                <div class="form-group form-inline">
+                                    {{ form_widget(form.birth) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl id="confirm_box__sex">
+                            <dt>{{ form_label(form.sex) }}</dt>
+                            <dd>
+                                <div class="form-group form-inline">
+                                    {{ form_widget(form.sex) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl id="confirm_box__job">
+                            <dt>{{ form_label(form.job) }}</dt>
+                            <dd>
+                                <div class="form-group form-inline">
+                                    {{ form_widget(form.job) }}
+                                </div>
+                            </dd>
+                        </dl>
+                    </div>
+
+                    <div id="confirm_box__footer" class="row no-padding">
+                        <div id="confirm_box__button_menu" class="btn_group col-sm-offset-4 col-sm-4">
+                            <p id="confirm_box__insert_button">
+                                <button type="submit" class="btn btn-primary btn-block" name="mode" value="complete">
+                                    会員登録をする
+                                </button>
+                            </p>
+                            <p id="confirm_box__back_button">
+                                <button type="submit" class="btn btn-info btn-block" name="mode" value="back">戻る
+                                </button>
+                            </p>
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <!-- /.col -->
+        </div>
+        <!-- /.row -->
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Entry/index.twig
+++ b/src/Eccube/Resource/template/smartphone/Entry/index.twig
@@ -1,0 +1,175 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'registration_page' %}
+
+{% block javascript %}
+<script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
+<script>
+    $(function() {
+        $('#zip-search').click(function() {
+            AjaxZip3.zip2addr('entry[zip][zip01]', 'entry[zip][zip02]', 'entry[address][pref]', 'entry[address][addr01]');
+        });
+    });
+</script>
+{% endblock javascript %}
+
+{% block main %}
+<h1 class="page-heading">新規会員登録</h1>
+<div id="top_wrap" class="container-fluid">
+    <div id="top_box" class="row">
+        <div id="top_box__body" class="col-md-10 col-md-offset-1">
+            <form method="post" action="{{ url('entry') }}">
+                {{ form_widget(form._token) }}
+                <div id="top_box__body_inner" class="dl_table">
+                    <dl id="top_box__name">
+                        <dt>{{ form_label(form.name) }}</dt>
+                        <dd class="form-group input_name">
+                            {{ form_widget(form.name.name01) }}
+                            {{ form_widget(form.name.name02) }}
+                            {{ form_errors(form.name.name01) }}
+                            {{ form_errors(form.name.name02) }}
+                        </dd>
+                    </dl>
+                    <dl id="top_box__kana">
+                        <dt>{{ form_label(form.kana) }}</dt>
+                        <dd class="form-group input_name">
+                            {{ form_widget(form.kana.kana01) }}
+                            {{ form_widget(form.kana.kana02) }}
+                            {{ form_errors(form.kana.kana01) }}
+                            {{ form_errors(form.kana.kana02) }}
+                        </dd>
+                    </dl>
+                    <dl id="top_box__company_name">
+                        <dt>{{ form_label(form.company_name) }}</dt>
+                        <dd class="form-group input_name">
+                            {{ form_widget(form.company_name) }}
+                            {{ form_errors(form.company_name) }}
+                        </dd>
+                    </dl>
+                    <dl id="top_box__address_detail">
+                        <dt>{{ form_label(form.address) }}</dt>
+                        <dd>
+                            <div id="top_box__zip" class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
+                            <div id="top_box__address" class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
+                                {{ form_widget(form.address) }}
+                                {{ form_errors(form.address) }}
+                            </div>
+                        </dd>
+                    </dl>
+                    <dl id="top_box__tel">
+                        <dt>{{ form_label(form.tel) }}</dt>
+                        <dd>
+                            <div class="form-inline form-group input_tel">
+                                {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
+                                {{ form_errors(form.tel) }}
+                            </div>
+                        </dd>
+                    </dl>
+                    <dl id="top_box__fax">
+                        <dt>{{ form_label(form.fax) }}</dt>
+                        <dd>
+                            <div class="form-inline form-group input_tel">
+                                {{ form_widget(form.fax, {attr : {class : 'short'}}) }}
+                                {{ form_errors(form.fax) }}
+                            </div>
+                        </dd>
+                    </dl>
+                    <dl id="top_box__email">
+                        <dt>{{ form_label(form.email) }}</dt>
+                        <dd>
+                            {% for emailField in form.email %}
+                            <div class="form-group {% if emailField.vars.errors is not empty %}has-error{% endif %}">
+                                {{ form_widget(emailField) }}
+                                {{ form_errors(emailField) }}
+                            </div>
+                            {% endfor %}
+                        </dd>
+                    </dl>
+                    <dl id="top_box__password">
+                        <dt>{{ form_label(form.password) }}</dt>
+                        <dd>
+                            {% for passwordField in form.password %}
+                            <div class="form-group {% if passwordField.vars.errors is not empty %}has-error{% endif %}">
+                                {{ form_widget(passwordField, { type : 'password' }) }}
+                                {{ form_errors(passwordField) }}
+                            </div>
+                            {% endfor %}
+                        </dd>
+                    </dl>
+                </div>
+                <div id="top_box__birth" class="dl_table not_required">
+                    <dl>
+                        <dt>{{ form_label(form.birth) }}</dt>
+                        <dd>
+                            <div class="form-group form-inline">
+                                {{ form_widget(form.birth) }}
+                                {{ form_errors(form.birth) }}
+                            </div>
+                        </dd>
+                    </dl>
+                    <dl>
+                        <dt id="top_box__sex">{{ form_label(form.sex) }}</dt>
+                        <dd>
+                            <div class="form-group form-inline">
+                                {{ form_widget(form.sex) }}
+                                {{ form_errors(form.sex) }}
+                            </div>
+                        </dd>
+                    </dl>
+                    <dl id="top_box__job">
+                        <dt>{{ form_label(form.job) }}</dt>
+                        <dd>
+                            <div class="form-group form-inline">
+                                {{ form_widget(form.job) }}
+                                {{ form_errors(form.job) }}
+                            </div>
+                        </dd>
+                    </dl>
+                </div>
+                {% for f in form %}
+                    {% if f.vars.name matches '[^plg*]' %}
+                        <div class="extra-form dl_table">
+                            {{ form_row(f) }}
+                        </div>
+                    {% endif %}
+                {% endfor %}
+                <input id="top_box__hidden_mode" type="hidden" name="mode" value="confirm">
+                <p id="top_box__agreement" class="form_terms_link"><a href="{{ url('help_agreement') }}" target="_blank">利用規約</a>に同意してお進みください
+                </p>
+
+                <div id="top_box__footer" class="row no-padding">
+                    <div id="top_box__button_menu" class="btn_group col-sm-offset-4 col-sm-4">
+                        <p>
+                            <button type="submit" class="btn btn-primary btn-block">同意する</button>
+                        </p>
+                        <p><a href="{{ url('index') }}" class="btn btn-info btn-block">同意しない</a></p>
+                    </div>
+                </div>
+            </form>
+        </div>
+        <!-- /.col -->
+    </div>
+    <!-- /.row -->
+</div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Forgot/complete.twig
+++ b/src/Eccube/Resource/template/smartphone/Forgot/complete.twig
@@ -1,0 +1,48 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block main %}
+    <div id="contents" class="main_only">
+        <div class="container-fluid inner no-padding">
+            <div id="main">
+                <h1 class="page-heading">パスワード発行メールの送信 完了</h1>
+                <div id="complete_wrap" class="container-fluid">
+                    <div id="complete_box" class="row">
+                        <div id="complete_box__body" class="col-md-10 col-md-offset-1">
+                            <div id="complete_box__message" class="complete_message">
+                                <h2>パスワード再発行メールの送信が完了しました。</h2>
+                                <p>ご登録メールアドレスにパスワードを再発行するためのメールを送信いたしました。<br/>
+                            メールの内容をご確認いただきますよう、お願いいたします。</p>
+                                <p>※メールが届かない場合はメールアドレスをご確認の上、再度お試しください。</p>
+                            </div>
+                        </div><!-- /.col -->
+                    </div><!-- /.row -->
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}
+
+

--- a/src/Eccube/Resource/template/smartphone/Forgot/index.twig
+++ b/src/Eccube/Resource/template/smartphone/Forgot/index.twig
@@ -1,0 +1,70 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block main %}
+    <div id="contents" class="main_only">
+        <div class="container-fluid inner no-padding">
+            <div id="main">
+                <h1 class="page-heading">パスワードの再発行</h1>
+                <div id="top_wrap" class="container-fluid">
+                    <div id="top_box" class="row">
+                        <div id="top_box__body" class="col-md-10 col-md-offset-1">
+                            <p>ご登録時のメールアドレスを入力して「次へ」ボタンをクリックしてください。</p>
+                            <p>※新しくパスワードを発行いたしますので、お忘れになったパスワードはご利用できなくなります。</p>
+                            <form name="form1" id="form1" method="post" action="{{ url('forgot') }}">
+                                {{ form_widget(form._token) }}
+                                <div id="top_box__body_inner" class="dl_table">
+                                    <dl id="top_box__login_email">
+                                        <dt>{{ form_label(form.login_email) }}</dt>
+                                        <dd>
+                                            <div class="form-group">
+                                                {{ form_widget(form.login_email) }}
+                                                {{ form_errors(form.login_email) }}
+                                            </div>
+                                        </dd>
+                                    </dl>
+                                </div>
+                                {% for f in form %}
+                                    {% if f.vars.name matches '[^plg*]' %}
+                                        <div class="extra-form dl_table">
+                                            {{ form_row(f) }}
+                                        </div>
+                                    {% endif %}
+                                {% endfor %}
+                                <div id="top_box__footer" class="row no-padding">
+                                <div id="top_box__next_button" class="btn_group col-sm-offset-4 col-sm-4">
+                                    <p><button type="submit" class="btn btn-primary btn-block">次のページへ</button></p>
+                                </div>
+                                </div>
+                            </form>
+                        </div><!-- /.col -->
+                    </div><!-- /.row -->
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}
+
+

--- a/src/Eccube/Resource/template/smartphone/Forgot/reset.twig
+++ b/src/Eccube/Resource/template/smartphone/Forgot/reset.twig
@@ -1,0 +1,46 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block main %}
+
+    <div id="contents" class="main_only">
+        <div id="reset_wrap" class="container-fluid inner no-padding">
+            <div id="main">
+                <h1 class="page-heading">パスワード変更(完了ページ)</h1>
+                <div id="reset_box" class="container-fluid">
+                    <div id="reset_box__body" class="row">
+                        <div id="reset_box__message" class="col-md-10 col-md-offset-1">
+                            <h2>新しいパスワードが送信されました。</h2>
+                            <p>新しいパスワード送り致しましたので、メールをご確認ください。</p>
+                            <p>今後ともご愛顧賜りますようよろしくお願い申し上げます。</p>
+                        </div><!-- /.col -->
+                    </div><!-- /.row -->
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}
+
+

--- a/src/Eccube/Resource/template/smartphone/Form/form_div_layout.twig
+++ b/src/Eccube/Resource/template/smartphone/Form/form_div_layout.twig
@@ -1,0 +1,22 @@
+{%- extends 'form_div_layout.html.twig' -%}
+
+{% block form_errors %}
+    {% if errors|length > 0 %}
+        {% for error in errors %}
+            <p class="errormsg text-danger">{{ error.message|trans }}</p>
+        {% endfor %}
+    {% endif -%}
+{% endblock %}
+
+{% block form_label %}
+    {{ parent() }}
+    {% if required %}<span class="required">必須</span>{% endif %}
+{% endblock %}
+
+{% block choice_widget %}
+    {% if type is defined and type == 'hidden' %}
+        {{ block('form_widget_simple') }}
+    {% else %}
+        {{ parent() }}
+    {% endif %}
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Form/form_layout.twig
+++ b/src/Eccube/Resource/template/smartphone/Form/form_layout.twig
@@ -1,0 +1,278 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{%- extends 'bootstrap_3_layout.html.twig' -%}
+
+{%- block form_widget_compound -%}
+    {%- if form.vars.freeze_display_text is defined and form.vars.freeze_display_text -%}
+        <div class="dl_table" {{ block('widget_container_attributes') }}>
+            {%- if form.parent is empty and errors|length > 0 -%}
+                    {{- form_errors(form) -}}
+            {%- endif -%}
+            {{- block('form_rows') -}}
+            {{- form_rest(form) -}}
+        </div>
+    {%- else -%}
+        {{- block('form_rows') -}}
+        {{- form_rest(form) -}}
+    {%- endif -%}
+{%- endblock form_widget_compound -%}
+
+{% block form_row -%}
+    {%- if form.vars.freeze_display_text is defined and form.vars.freeze_display_text -%}
+    {% set attr = attr|merge({class: attr.class|default('')}) %}
+    <dl>
+        <dt>{{ form_label(form) }}</dt>
+        <dd class="form-group{% if not valid %} has-error{% endif %}{% if 'middle' in attr.class %} input_name{% endif %}{% if 'short' in attr.class %} input_tel{% endif %}{% if 'zip' in attr.class %} input_zip{% endif %}">
+            {{ form_widget(form) }}
+            {{ form_errors(form) }}
+        </dd>
+    </dl>
+    {%- else -%}
+        {{- form_errors(form) -}}
+        {{- form_widget(form) -}}
+    {%- endif -%}
+{%- endblock form_row %}
+
+{% block form_errors -%}
+    {% if errors|length > 0 -%}
+        {% if form.parent %}
+            {%- for error in errors -%}
+                {%- if freeze_display_text -%}
+                    <p class="errormsg text-danger">{{ error.message |trans }}</p>
+                {%- endif %}
+            {%- endfor -%}
+        {%- endif %}
+    {%- endif %}
+{%- endblock form_errors %}
+
+{# Widgets #}
+
+{%- block form_widget -%}
+    {{- parent() -}}
+    {%- if freeze is defined and freeze == false -%}
+        {%- if help is defined and help is not empty -%}
+            <p class="mini"><span class="attention">{{ help|trans({}, translation_domain) }}</span></p>
+        {%- endif -%}
+    {%- endif -%}
+{%- endblock form_widget -%}
+
+{%- block form_widget_simple -%}
+    {%- if freeze is defined and freeze -%}
+        {%- set type = 'hidden' -%}
+        {%- if freeze_display_text is defined and freeze_display_text -%}
+            {{- value|default('')|nl2br -}}
+        {%- endif -%}
+    {%- endif -%}
+    {{- parent() -}}
+{%- endblock form_widget_simple -%}
+
+{%- block hidden_row -%}
+    {%- if freeze_display_text is defined and freeze_display_text -%}
+        <div style="display: none">
+            {{- form_widget(form) -}}
+        </div>
+    {%- else -%}
+        {{- form_widget(form) -}}
+    {%- endif -%}
+{%- endblock hidden_row -%}
+
+{%- block textarea_widget -%}
+    {%- if freeze is defined and freeze -%}
+        {{- block('form_widget_simple') -}}
+    {%- else -%}
+        {{- parent() -}}
+        {%- if help is defined and help is not empty -%}
+            <p class="mini"><span class="attention">{{ help|trans({}, translation_domain) }}</span></p>
+        {%- endif -%}
+    {%- endif -%}
+{%- endblock textarea_widget -%}
+
+{%- block choice_widget_collapsed -%}
+    {% if freeze is defined and freeze %}
+        {% set flag = false %}
+        {% for choice in choices %}
+            {% if choice is selectedchoice(value) %}
+                {%- if freeze_display_text is defined and freeze_display_text -%}
+                    {{ choice.label|trans({}, translation_domain) }}
+                {% endif %}
+                <input type="hidden" value="{{ choice.value }}" {{ block('widget_attributes') }} />
+                {% set flag = true %}
+            {% endif %}
+        {% endfor %}
+        {% if flag == false %}<input type="hidden" value="" {{ block('widget_attributes') }} />{% endif %}
+    {%- else -%}
+        {{- parent() -}}
+    {%- endif -%}
+{%- endblock choice_widget_collapsed -%}
+
+
+{%- block choice_widget_expanded -%}
+    {% if freeze is defined and freeze %}
+        {%- if freeze_display_text is defined and freeze_display_text -%}
+            {% if is_object(form.vars.data) %}
+                {{ form.vars.data.name|default(form.vars.data) }}
+            {% else %}
+                {% for choice in choices %}
+                    {% if form.vars.data|format is same as (choice.value|format) %}
+                        {{ choice.label }}
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
+        {%- endif -%}
+        <input type="hidden" value="{{ form.vars.data.id|default(form.vars.data) }}" {{ block('widget_attributes') }} />
+    {%- else -%}
+        {{- parent() -}}
+    {%- endif -%}
+{%- endblock choice_widget_expanded -%}
+
+
+{%- block checkbox_widget -%}
+    {%- if freeze is defined and freeze -%}
+        {%- if checked -%}
+            {%- if freeze_display_text is defined and freeze_display_text -%}
+                {{ block('form_label') }}
+            {%- endif -%}
+            <input type="hidden" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %} />
+        {%- endif -%}
+    {%- else -%}
+        {{- parent() -}}
+    {%- endif -%}
+{%- endblock checkbox_widget -%}
+
+{%- block radio_widget -%}
+    {%- if freeze is defined and freeze -%}
+        {%- if checked -%}
+            {%- if freeze_display_text is defined and freeze_display_text -%}
+                {{ block('form_label') }}
+            {%- endif -%}
+            <input type="hidden" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %} />
+        {%- endif -%}
+    {%- else -%}
+        {{- parent() -}}
+    {%- endif -%}
+{%- endblock radio_widget -%}
+
+
+{%- block password_widget -%}
+    {%- if freeze is defined and freeze -%}
+        <input type="hidden" {{ block('widget_attributes') }} value="{{ form.vars.data }}" />
+        {%- else -%}
+        {{- parent() -}}
+    {%- endif -%}
+{%- endblock password_widget -%}
+
+
+{%- block date_widget -%}
+    {%- if freeze is defined and freeze -%}
+    {%- for child in form %}
+            {%- if child.vars.value is not empty -%}
+            {{ form_widget(child) }}
+            {%- if loop.last == false%}/{% endif -%}
+            {%- endif -%}
+    {% endfor -%}
+    {%- else -%}
+        {{- parent() -}}
+    {%- endif -%}
+{%- endblock date_widget -%}
+
+
+{# EC-CUBE Widget #}
+
+
+
+{%- block name_widget -%}
+    {%- for child in form %}
+        {%- if freeze is defined and freeze -%}
+            {{ form_widget(child) }}
+        {%- else -%}
+            {{ form_widget(child) -}}
+        {%- endif -%}
+    {% endfor -%}
+    {%- for child in form %}
+        {{- form_errors(child) -}}
+    {% endfor -%}
+{%- endblock name_widget -%}
+
+{%- block tel_widget -%}
+    {%- for child in form %}
+        {{- form_widget(child, {'type': 'tel', 'attr': {'style': 'ime-mode: disabled;'}}) -}}
+        {%- if freeze is defined and freeze -%}
+            {%- if child.vars.value is not empty -%}
+                {%- if loop.last == false%}&nbsp;-&nbsp;{% endif -%}
+            {%- endif -%}
+        {%- else -%}
+            {%- if loop.last == false%}&nbsp;-&nbsp;{% endif -%}
+        {%- endif -%}
+    {% endfor -%}
+    {%- for child in form %}
+        {{- form_errors(child) -}}
+    {% endfor -%}
+{%- endblock tel_widget -%}
+
+{%- block fax_widget -%}
+    {%- for child in form %}
+        {{- form_widget(child, {'attr': {'style': 'ime-mode: disabled;'}}) -}}
+        {%- if loop.last == false%}&nbsp;-&nbsp;{% endif -%}
+    {% endfor -%}
+    {%- for child in form %}
+        {{- form_errors(child) -}}
+    {% endfor -%}
+{%- endblock fax_widget -%}
+
+{%- block zip_widget -%}
+    {%- if freeze is defined and freeze -%}
+        〒&nbsp;{{ form_widget(form[form.vars.zip01_name]) }}&nbsp;-&nbsp;{{- form_widget(form[form.vars.zip02_name]) }}
+    {%- else -%}
+        〒{{- form_widget(form[form.vars.zip01_name], {'id': 'zip01', 'attr': {'style': 'ime-mode: disabled;', 'pattern': '\\d*'}}) }}-{{- form_widget(form[form.vars.zip02_name], {'id': 'zip02', 'attr': {'style': 'ime-mode: disabled;', 'pattern': '\\d*'}}) }} <span class="question-circle"><svg class="cb cb-question"><use xlink:href="#cb-question" /></svg></span> <a href="http://www.post.japanpost.jp/zipcode/" target="_blank">郵便番号検索</a>
+        {%- for child in form %}
+            {{- form_errors(child) -}}
+        {% endfor -%}
+        <div class="zip-search"><button type="button" id="zip-search" class="btn btn-default btn-sm">郵便番号から自動入力</button></div>
+    {%- endif -%}
+{%- endblock zip_widget -%}
+
+{%- block address_widget -%}
+    <div class="form-inline form-group input_zip">
+    {{- form_widget(form[form.vars.pref_name], {'id': 'pref'}) -}}
+    </div>
+    {%- if freeze is defined and freeze -%}
+        {{- form_widget(form[form.vars.addr01_name]) -}}
+        {{- form_widget(form[form.vars.addr02_name]) -}}
+    {%- else -%}
+        <div class="form-group">
+            {{- form_widget(form[form.vars.addr01_name], {'id': 'addr01', 'attr': {'style': 'ime-mode: active;', 'placeholder': 'form.address1.help' }}) -}}<br />
+        </div>
+        <div class="form-group">
+            {{- form_widget(form[form.vars.addr02_name], {'id': 'addr02', 'attr': {'style': 'ime-mode: active;', 'placeholder': 'form.address2.help'}}) -}}<br />
+        </div>
+        {%- for child in form %}
+            {{- form_errors(child) -}}
+        {% endfor -%}
+    {%- endif -%}
+{%- endblock address_widget -%}
+
+{%- block form_label -%}
+    {{- parent() -}}
+    {%- if not freeze -%}
+        {%- if required -%}<span class="required">必須</span>{%- endif -%}
+    {%- endif -%}
+{%- endblock -%}

--- a/src/Eccube/Resource/template/smartphone/Help/about.twig
+++ b/src/Eccube/Resource/template/smartphone/Help/about.twig
@@ -1,0 +1,133 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+
+{% block javascript %}
+{% if BaseInfo.latitude is not null and BaseInfo.longitude is not null %}
+<script src="//maps.googleapis.com/maps/api/js?sensor=false"></script>
+<script>
+$(function() {
+    $("#maps").css({
+        'margin-top': '15px',
+        'margin-left': 'auto',
+        'margin-right': 'auto',
+        'width': '98%',
+        'height': '300px'
+    });
+    var lat = {{ BaseInfo.latitude|escape('js') }};
+    var lng = {{ BaseInfo.longitude|escape('js') }};
+    if (lat && lng) {
+        var latlng = new google.maps.LatLng(lat, lng);
+        var mapOptions = {
+            zoom: 15,
+            center: latlng,
+            mapTypeId: google.maps.MapTypeId.ROADMAP
+        };
+        var map = new google.maps.Map($("#maps").get(0), mapOptions);
+        var marker = new google.maps.Marker({map: map, position: latlng});
+    } else {
+        $("#maps").remove();
+    }
+});
+</script>
+{% endif %}
+{% endblock javascript %}
+
+{% block main %}
+    <div id="contents" class="main_only">
+        <div class="container-fluid inner no-padding">
+            <div id="main">
+                <h1 class="page-heading">当サイトについて</h1>
+                <div id="help_about" class="container-fluid">
+                    <div id="help_about_box" class="row">
+                        <div id="help_about_box__body" class="col-md-10 col-md-offset-1">
+                            <div id="help_about_box__body_innner" class="dl_table">
+                                {% if BaseInfo.shop_name is defined %}
+                                    <dl id="help_about_box__shop_name">
+                                        <dt>店名</dt>
+                                        <dd>{{ BaseInfo.shop_name }}</dd>
+                                    </dl>
+                                {% endif %}
+
+                                {% if BaseInfo.company_name is defined %}
+                                <dl id="help_about_box__company_name">
+                                    <dt>会社名</dt>
+                                    <dd>{{ BaseInfo.company_name }}</dd>
+                                </dl>
+                                {% endif %}
+
+                                {% if BaseInfo.zip01 is defined %}
+                                <dl id="help_about_box__zip">
+                                    <dt>所在地</dt>
+                                    <dd>〒{{ BaseInfo.zip01 }}-{{ BaseInfo.zip02 }}<br />
+                                        {{ BaseInfo.pref }}{{ BaseInfo.addr01 }}{{ BaseInfo.addr02 }}
+                                    </dd>
+                                </dl>
+                                {% endif %}
+
+                                {% if BaseInfo.tel01 is defined %}
+                                    <dl id="help_about_box__tel">
+                                        <dt>電話番号</dt>
+                                        <dd>{{ BaseInfo.tel01 }}-{{ BaseInfo.tel02 }}-{{ BaseInfo.tel03 }}</dd>
+                                    </dl>
+                                {% endif %}
+
+                                {% if BaseInfo.fax01 is defined %}
+                                    <dl id="help_about_box__fax">
+                                        <dt>FAX番号</dt>
+                                        <dd>{{ BaseInfo.fax01 }}-{{ BaseInfo.fax02 }}-{{ BaseInfo.fax03 }}</dd>
+                                    </dl>
+                                {% endif %}
+
+                                {% if BaseInfo.business_hour is defined %}
+                                    <dl id="help_about_box__business_hour">
+                                        <dt>営業時間</dt>
+                                        <dd>{{ BaseInfo.business_hour }}</dd>
+                                    </dl>
+                                {% endif %}
+
+                                {% if BaseInfo.good_traded is defined %}
+                                    <dl id="help_about_box__good_traded">
+                                        <dt>取扱商品</dt>
+                                        <dd>{{ BaseInfo.good_traded|nl2br }}</dd>
+                                    </dl>
+                                {% endif %}
+
+                                {% if BaseInfo.message is defined %}
+                                    <dl id="help_about_box__message">
+                                        <dt>メッセージ</dt>
+                                        <dd>{{ BaseInfo.message|nl2br }}</dd>
+                                    </dl>
+                                {% endif %}
+                            </div>
+
+                            <div id="maps"></div>
+
+                        </div><!-- /.col -->
+                    </div><!-- /.row -->
+
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Help/agreement.twig
+++ b/src/Eccube/Resource/template/smartphone/Help/agreement.twig
@@ -1,0 +1,44 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block main %}
+
+    <div id="contents" class="main_only">
+        <div id="agreement_wrap" class="container-fluid inner no-padding">
+            <div id="main">
+                <h1 class="page-heading">利用規約</h1>
+                <div id="agreement_box__body" class="container-fluid">
+                    <div id="agreement_box__customer_agreement" class="row">
+                        <div class="col-md-10 col-md-offset-1">
+                            {% if help is not null %}
+                            {{ help.customerAgreement|raw|nl2br }}
+                            {% endif %}
+                        </div><!-- /.col -->
+                    </div><!-- /.row -->
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Help/guide.twig
+++ b/src/Eccube/Resource/template/smartphone/Help/guide.twig
@@ -1,0 +1,41 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block main %}
+    <div id="contents" class="main_only">
+        <div id="guide_wrap" class="container-fluid inner no-padding">
+            <div id="main">
+                <h1 class="page-heading">ご利用ガイド</h1>
+                <div id="guide_box__body"  class="container-fluid">
+                    <div id="guide_box__body_inner" class="row">
+                        <div id="guide_box__body_item" class="col-md-10 col-md-offset-1">
+
+
+                        </div><!-- /.col -->
+                    </div><!-- /.row -->
+
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Help/privacy.twig
+++ b/src/Eccube/Resource/template/smartphone/Help/privacy.twig
@@ -1,0 +1,48 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block main %}
+    <div id="contents" class="main_only">
+        <div id="privacy_wrap" class="container-fluid inner no-padding">
+            <div id="main">
+                <h1 class="page-heading">プライバシーポリシー</h1>
+                <div id="privacy_box" class="container-fluid">
+                    <div id="privacy_box__body" class="row">
+                        <div id="privacy_box__body_inner" class="col-md-10 col-md-offset-1">
+                            <p id="privacy_box__declaration">
+                                {% if BaseInfo.company_name is not null %}
+                                    {{ BaseInfo.company_name }}は、
+                                {% endif %}
+                                個人情報保護の重要性に鑑み、「個人情報の保護に関する法律」及び本プライバシーポリシーを遵守し、お客さまのプライバシー保護に努めます。
+                            </p>
+                            <br />
+                            <h3 id="privacy_box__lead_header">個人情報の定義</h3>
+                            <p id="privacy_box__lead">お客さま個人に関する情報(以下「個人情報」といいます)であって、お客さまのお名前、住所、電話番号など当該お客さま個人を識別することができる情報をさします。他の情報と組み合わせて照合することにより個人を識別することができる情報も含まれます。</p>
+                        </div><!-- /.col -->
+                    </div><!-- /.row -->
+
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Help/tradelaw.twig
+++ b/src/Eccube/Resource/template/smartphone/Help/tradelaw.twig
@@ -1,0 +1,134 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block main %}
+<div id="contents" class="main_only">
+    <div class="container-fluid inner no-padding">
+        <div id="main">
+            <h1 class="page-heading">特定商取引法に基づく表記</h1>
+            <div id="tradelaw_wrap" class="container-fluid">
+                <div class="row">
+                    <div id="tradelaw_box" class="col-md-10 col-md-offset-1">
+                        <div id="tradelaw__body" class="dl_table">
+
+                            {% if help.law_company is defined %}
+                            <dl id="tradelaw__law_company">
+                                <dt>販売業者</dt>
+                                <dd>{{ help.law_company }}</dd>
+                            </dl>
+                            {% endif %}
+
+                            {% if help.law_manager is defined %}
+                            <dl id="tradelaw__law_manager">
+                                <dt>運営責任者</dt>
+                                <dd>{{ help.law_manager }}</dd>
+                            </dl>
+                            {% endif %}
+
+                            {% if help.law_zip01 is defined %}
+                            <dl id="tradelaw__zip">
+                                <dt>住所</dt>
+                                <dd>〒{{ help.law_zip01 }}-{{ help.law_zip02 }}<br />
+                                    {{ help.law_pref|default('') }}{{ help.law_addr01 }}{{ help.law_addr02 }}
+                                </dd>
+                            </dl>
+                            {% endif %}
+
+                            {% if help.law_tel01 is defined %}
+                            <dl id="tradelaw__tel">
+                                <dt>電話番号</dt>
+                                <dd>{{ help.law_tel01 }}-{{ help.law_tel02 }}-{{ help.law_tel03 }}</dd>
+                            </dl>
+                            {% endif %}
+
+                            {% if help.law_fax01 is defined and help.law_fax01 is not empty %}
+                            <dl id="tradelaw__fax">
+                                <dt>FAX番号</dt>
+                                <dd>{{ help.law_fax01 }}-{{ help.law_fax02 }}-{{ help.law_fax03 }}</dd>
+                            </dl>
+                            {% endif %}
+
+                            {% if help.law_email is defined %}
+                            <dl id="tradelaw__email">
+                                <dt>メールアドレス</dt>
+                                <dd><a href="mailto:{{ help.law_email }}">{{ help.law_email }}</a></dd>
+                            </dl>
+                            {% endif %}
+
+                            {% if help.law_url is defined %}
+                            <dl id="tradelaw__law_url">
+                                <dt>URL</dt>
+                                <dd><a href="{{ help.law_url }}">{{ help.law_url }}</a></dd>
+                            </dl>
+                            {% endif %}
+
+                            {% if help.law_term01 is defined %}
+                            <dl id="tradelaw__law_term01">
+                                <dt>商品以外の必要代金</dt>
+                                <dd>{{ help.law_term01|nl2br }}</dd>
+                            </dl>
+                            {% endif %}
+
+                            {% if help.law_term02 is defined %}
+                            <dl id="tradelaw__law_term02">
+                                <dt>注文方法</dt>
+                                <dd>{{ help.law_term02|nl2br }}</dd>
+                            </dl>
+                            {% endif %}
+
+                            {% if help.law_term03 is defined %}
+                            <dl id="tradelaw__law_term03">
+                                <dt>支払方法</dt>
+                                <dd>{{ help.law_term03|nl2br }}</dd>
+                            </dl>
+                            {% endif %}
+
+                            {% if help.law_term04 is defined %}
+                            <dl id="tradelaw__law_term04">
+                                <dt>支払期限</dt>
+                                <dd>{{ help.law_term04|nl2br }}</dd>
+                            </dl>
+                            {% endif %}
+
+                            {% if help.law_term05 is defined %}
+                            <dl id="tradelaw__law_term05">
+                                <dt>引渡し時期</dt>
+                                <dd>{{ help.law_term05|nl2br }}</dd>
+                            </dl>
+                            {% endif %}
+
+                            {% if help.law_term06 is defined %}
+                            <dl id="tradelaw__law_term06">
+                                <dt>返品・交換について</dt>
+                                <dd>{{ help.law_term06|nl2br }}</dd>
+                            </dl>
+                            {% endif %}
+                        </div>
+                    </div><!-- /.col -->
+                </div><!-- /.row -->
+
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Mail/contact_mail.twig
+++ b/src/Eccube/Resource/template/smartphone/Mail/contact_mail.twig
@@ -1,0 +1,48 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+　※本メールは自動配信メールです。
+　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
+　最適にご覧になれます。
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+　※本メールは、
+　{{ BaseInfo.shop_name }}よりお問い合わせされた方に
+　お送りしています。
+　もしお心当たりが無い場合は、
+　その旨 {# 問い合わせ受付メール #}{{ BaseInfo.email02 }} まで
+　ご連絡いただければ幸いです。
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+{{ data.name01 }} {{ data.name02 }} 様
+
+以下のお問い合わせを受付致しました。
+確認次第ご連絡いたしますので、少々お待ちください。
+
+■お名前　：{{ data.name01 }} {{ data.name02 }}{% if data.kana01 or data.kana02 %} ({{ data.kana01 }} {{ data.kana02 }}){% endif %} 様
+■郵便番号：{% if data.zip01 and data.zip02 %}〒{{ data.zip01 }} - {{ data.zip02 }}{% endif %}
+
+■住所　　：{% if data.pref.name is defined %} {{ data.pref.name }}{% endif %}{{ data.addr01 }}{{ data.addr02 }}
+■電話番号：{{ data.tel01 }} - {{ data.tel02 }} - {{ data.tel03 }}
+■メールアドレス：{{ data.email }}
+■お問い合わせの内容
+
+{{ data.contents }}

--- a/src/Eccube/Resource/template/smartphone/Mail/customer_withdraw_mail.twig
+++ b/src/Eccube/Resource/template/smartphone/Mail/customer_withdraw_mail.twig
@@ -1,0 +1,42 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+　※本メールは自動配信メールです。
+　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
+　最適にご覧になれます。
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+　※本メールは、
+{{ BaseInfo.shop_name }}より退会手続きを希望された方に
+　お送りしています。
+　もしお心当たりが無い場合は、
+　その旨 {# 問い合わせ受付メール #}{{ BaseInfo.email02 }} まで
+　ご連絡いただければ幸いです。
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+{{ Customer.name01 }} {{ Customer.name02 }} 様
+
+{{ BaseInfo.shop_name }}でございます。
+
+退会手続きが完了いたしました。
+{{ BaseInfo.shop_name }}をご利用いただき誠にありがとうございました。
+
+またのご利用を心よりお待ち申し上げます。

--- a/src/Eccube/Resource/template/smartphone/Mail/entry_complete.twig
+++ b/src/Eccube/Resource/template/smartphone/Mail/entry_complete.twig
@@ -1,0 +1,45 @@
+{#
+ This file is part of EC-CUBE
+
+ Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+ http://www.lockon.co.jp/
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ #}
+　
+　※本メールは自動配信メールです。
+　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
+　最適にご覧になれます。
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+　※本メールは、
+　{{ BaseInfo.shop_name }}より会員登録を希望された方に
+　お送りしています。
+　もしお心当たりが無い場合は、
+　その旨 {{ BaseInfo.email02 }} まで
+　ご連絡いただければ幸いです。
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+{{ Customer.name01 }} {{ Customer.name02 }} 様
+
+{{ BaseInfo.shop_name }}でございます。
+
+この度は会員登録依頼をいただきましてまことに有り難うございます。
+
+本会員登録が完了いたしました。
+ショッピングをお楽しみくださいませ。
+
+今後ともどうぞ{{ BaseInfo.shop_name }}をよろしくお願い申し上げます。

--- a/src/Eccube/Resource/template/smartphone/Mail/entry_confirm.twig
+++ b/src/Eccube/Resource/template/smartphone/Mail/entry_confirm.twig
@@ -1,0 +1,53 @@
+{#
+ This file is part of EC-CUBE
+
+ Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+ http://www.lockon.co.jp/
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ #}
+　※本メールは自動配信メールです。
+　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
+　最適にご覧になれます。
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+　※本メールは、
+　{{ BaseInfo.shop_name }}より会員登録を希望された方に
+　お送りしています。
+　もしお心当たりが無い場合はこのままこのメールを破棄していただ
+　ければ会員登録はなされません。
+　またその旨 {{ BaseInfo.email02 }} まで
+　ご連絡いただければ幸いです。
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+{{ Customer.name01 }} {{ Customer.name02 }} 様
+
+{{ BaseInfo.shop_name }}でございます。
+
+この度は会員登録依頼をいただきまして、有り難うございます。
+
+現在は仮登録の状態です。
+　　　~~~~~~
+本会員登録を完了するには下記URLにアクセスしてください。
+※入力されたお客様の情報はSSL暗号化通信により保護されます。
+
+{{ activateUrl }}
+
+上記URLにて本会員登録が完了いたしましたら改めてご登録内容ご確認
+メールをお送り致します。
+
+
+

--- a/src/Eccube/Resource/template/smartphone/Mail/forgot_mail.twig
+++ b/src/Eccube/Resource/template/smartphone/Mail/forgot_mail.twig
@@ -1,0 +1,42 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+　※本メールは自動配信メールです。
+　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
+　最適にご覧になれます。
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+　※本メールは、
+{{ BaseInfo.shop_name }}よりパスワード再発行手続きを希望された方に
+　お送りしています。
+　もしお心当たりが無い場合は、
+　その旨 {# 問い合わせ受付メール #}{{ BaseInfo.email02 }} まで
+　ご連絡いただければ幸いです。
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+パスワードを変更するには下記URLにアクセスしてください。
+※入力されたお客様の情報はSSL暗号化通信により保護されます。
+※URLの有効期限は{{ app.config.customer_reset_expire }}分以内です。有効期限を過ぎますとURLは無効となりますので、その場合、もう一度最初から手続きを行ってください。
+
+{{ reset_url }}
+
+上記URLにてパスワードを変更が完了いたしましたら
+改めてご登録内容のご確認メールをお送り致します。

--- a/src/Eccube/Resource/template/smartphone/Mail/order.twig
+++ b/src/Eccube/Resource/template/smartphone/Mail/order.twig
@@ -1,0 +1,110 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{{ Order.name01 }} {{ Order.name02 }} 様
+
+{{ header }}
+
+************************************************
+　ご請求金額
+************************************************
+
+ご注文番号：{{ Order.id }}
+お支払い合計：{{ Order.payment_total|price}}
+お支払い方法：{{ Order.payment_method }}
+メッセージ：{{ Order.message }}
+
+
+************************************************
+　ご注文商品明細
+************************************************
+
+{% for OrderDetail in Order.OrderDetails %}
+商品コード: {{ OrderDetail.product_code }}
+商品名: {{ OrderDetail.product_name }}  {{ OrderDetail.classcategory_name1 }}  {{ OrderDetail.classcategory_name2 }}
+単価： {{ calc_inc_tax(OrderDetail.price, OrderDetail.tax_rate, OrderDetail.tax_rule)|price }}
+数量： {{ OrderDetail.quantity|number_format }}
+
+{% endfor %}
+
+-------------------------------------------------
+小　計 {{ Order.subtotal|price }}{% if Order.tax > 0 %}(うち消費税 {{ Order.tax|price }}){% endif %}
+
+手数料 {{ Order.charge|price }}
+送　料 {{ Order.delivery_fee_total|price}}
+{% if Order.discount > 0 %}
+値引き {{ (0 - Order.discount)|price}}
+{% endif %}
+============================================
+合　計 {{ Order.payment_total|price }}
+
+************************************************
+　ご注文者情報
+************************************************
+お名前　：{{ Order.name01 }} {{ Order.name02 }} 様
+フリガナ：{{ Order.kana01 }} {{ Order.kana02 }} 様
+{% if Order.company_name %}
+会社名　：{{ Order.company_name }}
+{% endif %}
+{% if app.config.form_country_enable %}
+国　　　：{{ Order.Country }}
+ZIPCODE ：{{ Order.zip_code }}
+{% endif %}
+郵便番号：〒{{ Order.zip01 }}-{{ Order.zip02 }}
+住所　　：{{ Order.Pref.name }}{{ Order.addr01 }}{{ Order.addr02 }}
+電話番号：{{ Order.tel01 }}-{{ Order.tel02 }}-{{ Order.tel03 }}
+FAX番号 ：{{ Order.fax01 }}-{{ Order.fax02 }}-{{ Order.fax03 }}
+
+メールアドレス：{{ Order.email }}
+
+************************************************
+　配送情報
+************************************************
+
+{%  for Shipping in Order.Shippings %}
+◎お届け先{% if Order.multiple %}{{ loop.index }}{% endif %}
+
+お名前　：{{ Shipping.name01 }} {{ Shipping.name02 }} 様
+フリガナ：{{ Shipping.kana01 }} {{ Shipping.kana02 }} 様
+{% if Shipping.company_name %}
+会社名　：{{ Shipping.company_name }}
+{% endif %}
+{% if app.config.form_country_enable %}
+    　国　　　：{{ Shipping.Country.name }}
+    　ZIPCODE ：{{ Shipping.zip_code }}
+{% endif %}
+郵便番号：〒{{ Shipping.zip01 }}-{{ Shipping.zip02 }}
+住所　　：{{ Shipping.Pref.name }}{{ Shipping.addr01 }}{{ Shipping.addr02 }}
+電話番号：{{ Shipping.tel01 }}-{{ Shipping.tel02 }}-{{ Shipping.tel03 }}
+FAX番号 ：{{ Shipping.fax01 }}-{{ Shipping.fax02 }}-{{ Shipping.fax03 }}
+
+お届け日：{{ Shipping.shipping_delivery_date is empty ? '指定なし' : Shipping.shipping_delivery_date|date_format }}
+お届け時間：{{ Shipping.shipping_delivery_time|default('指定なし') }}
+
+{%  for ShipmentItem in Shipping.ShipmentItems %}
+商品コード: {{ ShipmentItem.product_code }}
+商品名: {{ ShipmentItem.product_name }}  {{ ShipmentItem.classcategory_name1 }}  {{ ShipmentItem.classcategory_name2 }}
+数量：{{ ShipmentItem.quantity|number_format }}
+
+{% endfor %}
+{% endfor %}
+
+{{ footer }}

--- a/src/Eccube/Resource/template/smartphone/Mail/reset_complete_mail.twig
+++ b/src/Eccube/Resource/template/smartphone/Mail/reset_complete_mail.twig
@@ -1,0 +1,39 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+　※本メールは自動配信メールです。
+　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
+　最適にご覧になれます。
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+　※本メールは、
+{{ BaseInfo.shop_name }}よりパスワード再発行手続きを希望された方に
+　お送りしています。
+　もしお心当たりが無い場合は、
+　その旨 {# 問い合わせ受付メール #}{{ BaseInfo.email02 }} まで
+　ご連絡いただければ幸いです。
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+パスワードを変更いたしました。
+
+新しいパスワード：{{ password }}
+
+このパスワードは一時的なものですので、お早めにご変更下さい。

--- a/src/Eccube/Resource/template/smartphone/Mypage/change.twig
+++ b/src/Eccube/Resource/template/smartphone/Mypage/change.twig
@@ -1,0 +1,174 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'mypage' %}
+
+{% set mypageno = 'change' %}
+
+{% block javascript %}
+<script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
+<script>
+    $(function() {
+        $('#zip-search').click(function() {
+            AjaxZip3.zip2addr('entry[zip][zip01]', 'entry[zip][zip02]', 'entry[address][pref]', 'entry[address][addr01]');
+        });
+    });
+</script>
+{% endblock javascript %}
+
+{% block main %}
+<h1 class="page-heading">マイページ/会員情報編集</h1>
+<div id="detail_wrap" class="container-fluid">
+    {% include 'Mypage/navi.twig' %}
+    <div id="detail_box" class="row">
+        <div id="detail_box__body" class="col-md-10 col-md-offset-1">
+            <form method="post" action="{{ url('mypage_change') }}">
+                {{ form_widget(form._token) }}
+                <div id="detail_box__body_inner" class="dl_table">
+                    <dl id="detail_box__name">
+                        <dt>{{ form_label(form.name) }}</dt>
+                        <dd class="form-group input_name">
+                            {{ form_widget(form.name.name01) }}
+                            {{ form_widget(form.name.name02) }}
+                            {{ form_errors(form.name.name01) }}
+                            {{ form_errors(form.name.name02) }}
+                        </dd>
+                    </dl>
+                    <dl id="detail_box__kana">
+                        <dt>{{ form_label(form.kana) }}</dt>
+                        <dd class="form-group input_name">
+                            {{ form_widget(form.kana.kana01) }}
+                            {{ form_widget(form.kana.kana02) }}
+                            {{ form_errors(form.kana.kana01) }}
+                            {{ form_errors(form.kana.kana02) }}
+                        </dd>
+                    </dl>
+                    <dl id="detail_box__company_name">
+                        <dt>{{ form_label(form.company_name) }}</dt>
+                        <dd class="form-group input_name">
+                            {{ form_widget(form.company_name) }}
+                            {{ form_errors(form.company_name) }}
+                        </dd>
+                    </dl>
+                    <dl id="detail_box__address_detail">
+                        <dt>{{ form_label(form.address) }}</dt>
+                        <dd>
+                            <div id="detail_box__zip" class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
+                            <div id="detail_box__address" class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
+                                {{ form_widget(form.address) }}
+                                {{ form_errors(form.address) }}
+                            </div>
+                        </dd>
+                    </dl>
+                    <dl id="detail_box__tel">
+                        <dt>{{ form_label(form.tel) }}</dt>
+                        <dd>
+                            <div class="form-inline form-group input_tel">
+                                {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
+                                {{ form_errors(form.tel) }}
+                            </div>
+                        </dd>
+                    </dl>
+                    <dl id="detail_box__fax">
+                        <dt>{{ form_label(form.fax) }}</dt>
+                        <dd>
+                            <div class="form-inline form-group input_tel">
+                                {{ form_widget(form.fax, {attr : {class : 'short'}}) }}
+                                {{ form_errors(form.fax) }}
+                            </div>
+                        </dd>
+                    </dl>
+                    <dl id="detail_box__email">
+                        <dt>{{ form_label(form.email) }}</dt>
+                        <dd>
+                            {% for emailField in form.email %}
+                            <div class="form-group {% if emailField.vars.errors is not empty %}has-error{% endif %}">
+                                {{ form_widget(emailField) }}
+                                {{ form_errors(emailField) }}
+                            </div>
+                            {% endfor %}
+                        </dd>
+                    </dl>
+                    <dl id="detail_box__password">
+                        <dt>{{ form_label(form.password) }}</dt>
+                        <dd>
+                            {% for passwordField in form.password %}
+                            <div class="form-group {% if passwordField.vars.errors is not empty %}has-error{% endif %}">
+                                {{ form_widget(passwordField, { type : 'password' }) }}
+                                {{ form_errors(passwordField) }}
+                            </div>
+                            {% endfor %}
+                        </dd>
+                    </dl>
+                </div>
+                <div class="dl_table not_required">
+                    <dl id="detail_box__birth">
+                        <dt>{{ form_label(form.birth) }}</dt>
+                        <dd>
+                            <div class="form-group form-inline">
+                                {{ form_widget(form.birth) }}
+                                {{ form_errors(form.birth) }}
+                            </div>
+                        </dd>
+                    </dl>
+                    <dl id="detail_box__sex">
+                        <dt>{{ form_label(form.sex) }}</dt>
+                        <dd>
+                            <div class="form-group form-inline">
+                                {{ form_widget(form.sex) }}
+                                {{ form_errors(form.sex) }}
+                            </div>
+                        </dd>
+                    </dl>
+                    <dl id="detail_box__job">
+                        <dt>{{ form_label(form.job) }}</dt>
+                        <dd>
+                            <div class="form-group form-inline">
+                                {{ form_widget(form.job) }}
+                                {{ form_errors(form.job) }}
+                            </div>
+                        </dd>
+                    </dl>
+                </div>
+                {% for f in form %}
+                    {% if f.vars.name matches '[^plg*]' %}
+                        <div class="extra-form dl_table">
+                            {{ form_row(f) }}
+                        </div>
+                    {% endif %}
+                {% endfor %}
+                <div id="detail_box__edit_button" class="row no-padding">
+                    <div class="btn_group col-sm-offset-4 col-sm-4">
+                        <p>
+                            <button type="submit" class="btn btn-info btn-block">変更する</button>
+                        </p>
+                    </div>
+                </div>
+            </form>
+        </div>
+        <!-- /.col -->
+    </div>
+    <!-- /.row -->
+
+</div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Mypage/change_complete.twig
+++ b/src/Eccube/Resource/template/smartphone/Mypage/change_complete.twig
@@ -1,0 +1,50 @@
+{#
+ This file is part of EC-CUBE
+
+ Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+ http://www.lockon.co.jp/
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ #}
+{% extends 'default_frame.twig' %}
+
+{% set mypageno = 'change' %}
+
+{% set body_class = 'mypage' %}
+
+{% block main %}
+    <h1 class="page-heading">マイページ/会員情報編集(完了)</h1>
+    <div id="complete_wrap" class="container-fluid">
+    {% include 'Mypage/navi.twig' %}
+        <div id="deliveradd_input" class="row">
+            <div id="complete_box__body" class="col-sm-10 col-sm-offset-1">
+                <div id="complete_box__message"class="complete_message">
+                    <h2 class="heading01">会員登録内容の変更が完了いたしました</h2>
+                    <p>今後ともご愛顧賜りますようよろしくお願い申し上げます。</p>
+                </div>
+                <div id="complete_box__top_button" class="row no-padding">
+                    <div class="btn_group col-sm-offset-4 col-sm-4">
+                        <p>
+                            <a href="{{ url('index') }}" class="btn btn-info btn-block">トップページへ</a>
+                        </p>
+                    </div>
+                </div>
+
+            </div><!-- /.col -->
+        </div><!-- /.row -->
+
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Mypage/delivery.twig
+++ b/src/Eccube/Resource/template/smartphone/Mypage/delivery.twig
@@ -1,0 +1,89 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set mypageno = 'delivery' %}
+
+{% set body_class = 'mypage' %}
+
+{% block main %}
+    <h1 class="page-heading">マイページ/お届け先編集</h1>
+    <div id="delivery_wrap" class="container-fluid">
+
+        {{ include('Mypage/navi.twig') }}
+
+        <div id="delivery_list_box" class="row">
+            <div id="delivery_list_box__body" class="col-md-12">
+                <p id="delivery_list_box__customer_addresses" class="intro"><strong>{{ Customer.CustomerAddresses|length }}件</strong>のお届け先があります。</p>
+                    <div id="deliveradd_select" class="row">
+                        <div id="delivery_list_box__body_inner" class="col-sm-10 col-sm-offset-1">
+                            <p id="delivery_box__new_button">
+                            {% if Customer.CustomerAddresses|length < app.config.deliv_addr_max %}
+                                <a href="{{ url('mypage_delivery_new') }}">
+                                    <button class="btn btn-default btn-sm">新規お届け先を追加する</button>
+                                </a>
+                            {% else %}
+                                <span id="delivery_box__deliv_addr_max" class="text-danger">お届け先登録の上限の{{ app.config.deliv_addr_max }}件に達しています。お届け先を入力したい場合は、削除か変更を行ってください</span>
+                            {% endif %}
+                            </p>
+
+                            {% if Customer.CustomerAddresses|length > 0 %}
+                            <div id="delivery_address_list" class="table address_table">
+                                <div id="delivery_address_list__list" class="tbody">
+
+                                    {% for CustomerAddress in Customer.CustomerAddresses %}
+                                        <div id="delivery_address_list__item--{{ CustomerAddress.id }}" class="addr_box tr">
+                                            <div id="delivery_address_list__delete--{{ CustomerAddress.id }}" class="icon_edit td">
+                                            {% if Customer.CustomerAddresses|length != 1 %}
+                                                <a href="{{ url('mypage_delivery_delete', { id : CustomerAddress.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete">
+                                                    <svg class="cb cb-close"><use xlink:href="#cb-close" /></svg>
+                                                </a>
+                                            {% endif %}
+                                            </div>
+                                            <div id="delivery_address_list__address--{{ CustomerAddress.id }}" class="column is-edit td">
+                                                <label for="address01">
+                                                <p id="delivery_address_list__address_detail--{{ CustomerAddress.id }}" class="address">
+                                                    {{ CustomerAddress.name01 }}&nbsp;{{ CustomerAddress.name02 }}<br>
+                                                    〒{{ CustomerAddress.zip01 }}-{{ CustomerAddress.zip02 }}　{{ CustomerAddress.Pref }}{{ CustomerAddress.addr01 }}{{ CustomerAddress.addr02 }}<br>
+                                                    {{ CustomerAddress.tel01 }}-{{ CustomerAddress.tel02 }}-{{ CustomerAddress.tel03 }}</p>
+                                                </label>
+                                                <p id="delivery_address_list__edit_button--{{ CustomerAddress.id }}" class="btn_edit">
+                                                    <a href="{{ url('mypage_delivery_edit', { id : CustomerAddress.id }) }}">
+                                                        <button class="btn btn-default btn-sm">変更</button>
+                                                    </a>
+                                                </p>
+                                            </div>
+                                        </div><!--/addr_box-->
+                                    {% endfor %}
+
+                                </div>
+                            </div><!--/table-->
+                            {% endif %}
+
+                        </div>
+                    </div><!-- /.row -->
+
+            </div><!-- /.col -->
+        </div><!-- /.row -->
+
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Mypage/delivery_edit.twig
+++ b/src/Eccube/Resource/template/smartphone/Mypage/delivery_edit.twig
@@ -1,0 +1,128 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set mypageno = 'delivery' %}
+
+{% set body_class = 'mypage' %}
+
+{% block javascript %}
+<script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
+<script>
+$(function() {
+    $('#zip-search').click(function() {
+        AjaxZip3.zip2addr('customer_address[zip][zip01]', 'customer_address[zip][zip02]', 'customer_address[address][pref]', 'customer_address[address][addr01]');
+    });
+});
+</script>
+{% endblock javascript %}
+
+{% block main %}
+    <h1 class="page-heading">マイページ/お届け先編集</h1>
+    <div id="detail_wrap" class="container-fluid">
+
+        {{ include('Mypage/navi.twig') }}
+
+        <div id="detail_box" class="row">
+            <div id="detail_box__body" class="col-sm-10 col-sm-offset-1">
+                <form role="form" action="" method="post">
+                    {{ form_widget(form._token) }}
+                    <div id="detail_box__body_inner" class="dl_table">
+
+                        <dl id="detail_box__name">
+                            <dt>{{ form_label(form.name) }}</dt>
+                            <dd class="form-group input_name">
+                                {{ form_widget(form.name.name01, { attr : { placeholder: '姓' }}) }}
+                                {{ form_widget(form.name.name02, { attr : { placeholder: '名' }}) }}
+                                {{ form_errors(form.name.name01) }}
+                                {{ form_errors(form.name.name02) }}
+                            </dd>
+                        </dl>
+                        <dl id="detail_box__kana">
+                            <dt>{{ form_label(form.kana) }}</dt>
+                            <dd class="form-group input_name">
+                                {{ form_widget(form.kana.kana01, { attr : { placeholder: 'セイ' }}) }}
+                                {{ form_widget(form.kana.kana02, { attr : { placeholder: 'メイ' }}) }}
+                                {{ form_errors(form.kana.kana01) }}
+                                {{ form_errors(form.kana.kana02) }}
+                            </dd>
+                        </dl>
+                        <dl id="detail_box__company_name">
+                            <dt>{{ form_label(form.company_name) }}</dt>
+                            <dd class="form-group input_name">
+                                {{ form_widget(form.company_name) }}
+                                {{ form_errors(form.company_name) }}
+                            </dd>
+                        </dl>
+
+                        <dl id="detail_box__address">
+                            <dt>{{ form_label(form.address) }}</dt>
+                            <dd>
+                                <div id="detail_box__zip" class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
+                                <div id="detail_box__address" class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
+                                    {{ form_widget(form.address) }}
+                                    {{ form_errors(form.address) }}
+                                </div>
+                            </dd>
+                        </dl>
+
+                        <dl id="detail_box__tel">
+                            <dt>{{ form_label(form.tel) }}</dt>
+                            <dd>
+                                <div class="form-inline form-group input_tel">
+                                    {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
+                                    {{ form_errors(form.tel) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl id="detail_box__fax">
+                            <dt>{{ form_label(form.fax) }}</dt>
+                            <dd>
+                                <div class="form-inline form-group input_tel">
+                                    {{ form_widget(form.fax, {attr : {class : 'short'}}) }}
+                                    {{ form_errors(form.fax) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        {% for f in form.getIterator %}
+                            {% if f.vars.name matches '[^plg*]' %}
+                                {{ form_row(f) }}
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                    <div id="detail_box__insert_button" class="row no-padding">
+                        <div class="btn_group col-sm-offset-4 col-sm-4">
+                            <p>
+                                <button type="submit" class="btn btn-info btn-block prevention-btn prevention-mask">
+                                    登録する
+                                </button>
+                            </p>
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <!-- /.col -->
+        </div>
+        <!-- /.row -->
+
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Mypage/favorite.twig
+++ b/src/Eccube/Resource/template/smartphone/Mypage/favorite.twig
@@ -1,0 +1,78 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set mypageno = 'favorite' %}
+
+{% set body_class = 'mypage' %}
+
+{% block main %}
+    <h1 class="page-heading">マイページ/お気に入り一覧</h1>
+    <div id="favorite_wrap" class="container-fluid">
+
+        {% include 'Mypage/navi.twig' %}
+
+        <div id="favorite_list_box" class="row">
+            <div id="favorite_list_box__body" class="col-md-12">
+            {% if pagination.totalItemCount > 0 %}
+                <p id="favorite_lst__total_item_count" class="intro"><strong>{{ pagination.totalItemCount }}件</strong>のお気に入りがあります。</p>
+                <div id="item_list">
+                    <div id="favorite_list__list" class="row no-padding">
+                        {% for FavoriteProduct in pagination %}
+                        {% set Product = FavoriteProduct.Product %}
+                        <div id="favorite__list--{{ Product.id }}" class="col-sm-3 col-xs-6">
+                            <div id="favorite_list__item--{{ Product.id }}" class="product_item">
+                                <a href="{{ url('product_detail', {'id': Product.id}) }}">
+                                    <div id="favorite_list__image--{{ Product.id }}" class="item_photo">
+                                        <img src="{{ app.config.image_save_urlpath }}/{{ Product.main_list_image|no_image_product }}" alt="{{ Product.name }}"/>
+                                    </div>
+                                </a>
+                                <a href="{{ url('mypage_favorite_delete', { id : Product.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete">
+                                    <button type="button" class="btn_circle"><svg class="cb cb-close"><use xlink:href="#cb-close"></use></svg></button>
+                                </a>
+                                <a href="{{ url('product_detail', {'id': Product.id}) }}">
+                                    <dl id="favorite_list__detail--{{ Product.id }}">
+                                        <dt id="favorite_list__name--{{ Product.id }}" class="item_name" style="height: 22px;"> {{ Product.name }}</dt>
+                                        <dd id="favorite_list__price02_inc_tax--{{ Product.id }}" class="item_price">
+                                            {% if Product.price02_inc_tax_min == Product.price02_inc_tax_max %}
+                                                {{ Product.price02_inc_tax_min|price }}
+                                            {% else %}
+                                                {{ Product.price02_inc_tax_min|price }}～{{ Product.price02_inc_tax_max|price }}
+                                            {% endif %}
+                                        </dd>
+                                    </dl>
+                                </a>
+                            </div>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
+                <div id="favorite_list__pagination" class="paging">
+                    {% include "pagination.twig" with {'pages': pagination.paginationData} %}
+                </div>
+            {% else %}
+                <p id="favorite_list__not_found_message" class="intro">お気に入りが登録されていません。</p>
+            {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Mypage/history.twig
+++ b/src/Eccube/Resource/template/smartphone/Mypage/history.twig
@@ -1,0 +1,259 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set mypageno = 'index' %}
+
+{% set body_class = 'mypage' %}
+
+{% block javascript %}
+<script>
+$(function(){
+    $(".title").on("click", function(){
+        $(this).next().slideToggle();
+    });
+    $(".close").on("click", function(){
+        $(this).parent().slideToggle();
+    });
+});
+</script>
+{% endblock %}
+{% block main %}
+    <h1 class="page-heading">マイページ/ご注文履歴詳細</h1>
+    <div id="detail_wrap" class="container-fluid">
+
+        {% include 'Mypage/navi.twig' %}
+
+        <div id="detail_box" class="row">
+            <div id="detail_box__body" class="col-md-12">
+                <dl id="detail_box__body_inner" class="order_detail">
+                    <dt id="detail_box__create_date">ご注文日時：</dt>
+                    <dd>{{ Order.create_date|date("Y/m/d H:i:s") }}</dd>
+                    <dt id="detail_box__id">ご注文番号：</dt>
+                    <dd>{{ Order.id }}</dd>
+                    {% if BaseInfo.option_mypage_order_status_display %}
+                        <dt id="detail_box__customer_order_status">ご注文状況：</dt>
+                        <dd>{{ Order.CustomerOrderStatus }}</dd>
+                    {% endif %}
+                </dl>
+            </div>
+        </div>
+
+        <div id="shopping_confirm" class="row">
+            <div id="confirm_main" class="col-sm-8">
+                <div id="detail_list_box__body" class="cart_item table">
+                    <div id="detail_list_box__list" class="tbody">
+                        {% set remessage = '' %}
+                        {% for OrderDetail in Order.OrderDetails %}
+                            <div id="detail_list__item_box--{{ OrderDetail.id }}" class="item_box tr">
+                                <div id="detail_list__item--{{ OrderDetail.id }}" class="td table">
+                                    <div id="detail_list__image--{{ OrderDetail.id }}" class="item_photo">
+                                        {% if OrderDetail.Product is null %}
+                                            <img src="{{ app.config.image_save_urlpath }}/{{ ''|no_image_product }}" />
+                                        {% else %}
+                                            {% if OrderDetail.enable %}
+                                                <a href="{{ url('product_detail', { id : OrderDetail.Product.id } ) }}">
+                                                    <img src="{{ app.config.image_save_urlpath }}/{{ OrderDetail.product.MainListImage|no_image_product }}" />
+                                                </a>
+                                            {% else %}
+                                                <img src="{{ app.config.image_save_urlpath }}/{{ ''|no_image_product }}" />
+                                            {% endif %}
+                                        {% endif %}
+                                    </div>
+                                    <dl id="detail_list__item_detail--{{ OrderDetail.id }}" class="item_detail">
+                                        <dt id="detail_list__product_name--{{ OrderDetail.id }}" class="item_name text-default">
+                                            {% if OrderDetail.Product is null %}
+                                                {{ OrderDetail.product_name }}
+                                            {% else %}
+                                                {% if OrderDetail.enable %}
+                                                    <a href="{{ url('product_detail', {'id': OrderDetail.Product.id}) }}">
+                                                        {{ OrderDetail.product_name }}
+                                                    </a>
+                                                {% else %}
+                                                    {{ OrderDetail.product_name }}
+                                                {% endif %}
+                                            {% endif %}
+                                        </dt>
+                                        <dd id="detail_list__classcategory_name--{{ OrderDetail.id }}" class="item_pattern small">
+                                            {% if OrderDetail.classcategory_name1 is not empty %}
+                                                {{ OrderDetail.classcategory_name1 }}
+                                            {% endif %}
+                                            {% if OrderDetail.classcategory_name2 is not empty %}
+                                                / {{ OrderDetail.classcategory_name2 }}
+                                            {% endif %}
+                                        </dd>
+                                        <dd id="detail_list__price_inc_tax--{{ OrderDetail.id }}" class="item_price">
+                                            {{ OrderDetail.price_inc_tax|price }} × {{ OrderDetail.quantity|number_format }}
+                                        </dd>
+                                        <dd id="detail_list__total_price--{{ OrderDetail.id }}" class="item_subtotal">
+                                            小計：{{ OrderDetail.total_price|price }}
+                                        </dd>
+                                        {% if OrderDetail.product and OrderDetail.price_inc_tax != OrderDetail.productClass.price02IncTax %}
+                                            <dd id="detail_list__price02_inc_tax--{{ OrderDetail.id }}" class="text-danger">
+                                                <strong>【現在価格】{{ OrderDetail.productClass.price02IncTax|price }}</strong>
+                                            </dd>
+                                            {% set remessage = true %}
+                                        {% endif %}
+                                    </dl>
+                                </div>
+                            </div><!--/item_box-->
+                        {% endfor %}
+                    </div>
+                </div><!--/cart_item-->
+
+                <h2 class="heading02">配送情報</h2>
+                {% set OrderDetail = Order.OrderDetails.0 %}
+                {% for Shipping in Order.Shippings %}
+                    <div id="shipping_list--{{ Shipping.id }}" class="column is-edit">
+                        <h3>お届け先{% if Order.multiple %}({{ loop.index }}){% endif %}</h3>
+                        <div id="shipping_list__body--{{ Shipping.id }}" class="cart_item table">
+                            <div id="shipping_list__list--{{ Shipping.id }}" class="tbody">
+                                {% for shipmentItem in Shipping.shipmentItems %}
+                                    <div id="shipping_list__shipment--{{ Shipping.id }}_{{ shipmentItem.product.id }}" class="item_box tr">
+                                        <div id="shipping_list__shipment_item--{{ Shipping.id }}_{{ shipmentItem.product.id }}" class="td table">
+                                            <div id="shipping_list__shipment_image--{{ Shipping.id }}_{{ shipmentItem.product.id }}" class="item_photo">
+                                                {% if shipmentItem.product is null %}
+                                                    <img src="{{ app.config.image_save_urlpath }}/{{ ''|no_image_product }}" />
+                                                {% else %}
+                                                    {% if shipmentItem.product.enable %}
+                                                        <img src="{{ app.config.image_save_urlpath }}/{{ shipmentItem.product.MainListImage|no_image_product }}" alt="{{ shipmentItem.productName }}" />
+                                                    {% else %}
+                                                        <img src="{{ app.config.image_save_urlpath }}/{{ ''|no_image_product }}" />
+                                                    {% endif %}
+                                                {% endif %}
+                                            </div>
+                                            <dl id="shipping_list__shipment_detail--{{ Shipping.id }}_{{ shipmentItem.product.id }}" class="item_detail">
+                                                <dt id="shipping_list__shipment_product_name--{{ Shipping.id }}_{{ shipmentItem.product.id }}" class="item_name text-default">
+                                                    {{ shipmentItem.productName }} ×{{ shipmentItem.quantity }}
+                                                </dt>
+                                                <dd id="shipping_list__shipment_class_category--{{ Shipping.id }}_{{ shipmentItem.product.id }}" class="item_pattern small">
+                                                    {% if shipmentItem.productClass.classCategory1 %}
+                                                        {{ shipmentItem.productClass.classCategory1.className }}：{{ shipmentItem.productClass.classCategory1 }}
+                                                    {% endif %}
+                                                    {% if shipmentItem.productClass.classCategory2 %}
+                                                        <br>{{ shipmentItem.productClass.classCategory2.className }}：{{ shipmentItem.productClass.classCategory2 }}
+                                                    {% endif %}
+                                                </dd>
+                                            </dl>
+                                        </div>
+                                    </div><!--/item_box-->
+                                {% endfor %}
+                            </div>
+                        </div>
+
+                        <p id="shipping_list__address--{{ Shipping.id }}" class="address">
+                            {{ Shipping.name01 }}&nbsp;{{ Shipping.name02 }}&nbsp;
+                            ({{ Shipping.kana01 }}&nbsp;{{ Shipping.kana02 }})&nbsp;様<br>
+                            〒{{ Shipping.zip01 }}-{{ Shipping.zip02 }}　{{ Shipping.Pref }}{{ Shipping.addr01 }}{{ Shipping.addr02 }}<br>
+                            {{ Shipping.tel01 }}-{{ Shipping.tel02 }}-{{ Shipping.tel03 }}
+                        </p>
+                        <p id="shipping_list__delivery--{{ Shipping.id }}">
+                            配送方法：　{{ Shipping.shipping_delivery_name }}{{ Shipping.shipping_delivery_fee ? '（＋' ~ Shipping.shipping_delivery_fee|price ~ '）' : '' }}<br>
+                            お届け日：　{{ Shipping.shipping_delivery_date|date_format|default('指定なし') }}<br>
+                            お届け時間：　{{ Shipping.shipping_delivery_time|default('指定なし') }}
+                        </p>
+                    </div>
+                    {% if loop.last == false%}<hr>{% endif %}
+                {% endfor %}
+                <h2 class="heading02">お支払方法</h2>
+                <div id="detail_box__payment_method" class="column">
+                    <p>
+                        支払方法： {{ Order.PaymentMethod }}
+                    </p>
+                </div>
+                <h2 class="heading02">お問い合わせ</h2>
+                <div id="detail_box__message" class="column">
+                    <p>
+                        {{ Order.message|default('記載なし')|nl2br }}
+                    </p>
+                </div>
+
+                <h2 class="heading02">メール配信履歴一覧</h2>
+                <div id="mail_list" class="column mail_list">
+                    {% for MailHistory in Order.MailHistories %}
+                        <dl id="mail_list__item--{{ loop.index }}">
+                            <dt id="mail_list__send_date--{{ loop.index }}">
+                                <span class="date">{{ MailHistory.send_date|date("Y/m/d H:i:s") }}</span>
+                            </dt>
+                            <dd id="mail_list__subject--{{ loop.index }}">
+                                <span class="title">
+                                    <a data-toggle="modal" data-target="#myModal{{ loop.index }}">{{ MailHistory.subject }}</a>
+                                </span>
+                                <p id="mail_list__mail_body--{{ loop.index }}" style="display: none;">
+                                    {{ MailHistory.mail_body|nl2br }}<br>
+                                    <span class="close"><a>閉じる</a></span>
+                                </p>
+                            </dd>
+                        </dl>
+                    {% else %}
+                        メール履歴がありません。
+                    {% endfor %}
+                </div>
+            </div><!-- /.col -->
+
+            <div id="confirm_side" class="col-sm-4">
+                <div id="summary_box" class="total_box">
+                    <dl id="summary_box__subtotal">
+                        <dt>小計</dt>
+                        <dd>{{ Order.subtotal|price }}</dd>
+                    </dl>
+                    <dl id="summary_box__charge">
+                        <dt>手数料</dt>
+                        <dd>{{ Order.charge|price }}</dd>
+                    </dl>
+                    <dl id="summary_box__delivery_fee_total">
+                        <dt>送料合計</dt>
+                        <dd>{{ Order.delivery_fee_total|price }}</dd>
+                    </dl>
+                    {% if Order.discount > 0 %}
+                        <dl id="summary_box__discount">
+                            <dt>値引き</dt>
+                            <dd>
+                                &minus;{{ Order.discount|price }}
+                            </dd>
+                        </dl>
+                    {% endif %}
+
+                    <div id="summary_box__summary" class="total_amount">
+                        <p id="summary_box__payment_total" class="total_price">
+                            合計 <strong class="text-primary">{{ Order.payment_total|price }}<span class="small">税込</span></strong>
+                        </p>
+                        <p id="summary_box__reorder_button">
+                            <a href="{{ url('mypage_order', {'id': Order.id }) }}" class="btn btn-primary btn-block" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">再注文する</a>
+                        </p>
+                    </div>
+                    {% if remessage %}
+                        <p id="summary_box__message" class="text-danger">
+                            <strong>※金額が変更されている商品があるため、再注文時はご注意ください。</strong>
+                        </p>
+                    {% endif %}
+                </div>
+            </div>
+        </div><!-- /.row -->
+
+        <div id="detail_box__top_button" class="row">
+            <div class="col-sm-4 col-sm-offset-4">
+                <a href="{{ url('mypage') }}" class="btn btn-default btn-sm">戻る</a>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Mypage/index.twig
+++ b/src/Eccube/Resource/template/smartphone/Mypage/index.twig
@@ -1,0 +1,100 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set mypageno = 'index' %}
+
+{% set body_class = 'mypage' %}
+
+{% block main %}
+    <h1 class="page-heading">マイページ/ご注文履歴</h1>
+    <div id="history_wrap" class="container-fluid">
+
+        {% include 'Mypage/navi.twig' %}
+
+        <div id="history_list" class="row">
+            <div id="history_list__body" class="col-md-12">
+
+                {% if pagination.totalItemCount > 0 %}
+                    <p id="history_list__total_count" class="intro"><strong>{{ pagination.totalItemCount }}件</strong>の履歴があります。</p>
+
+                    {% for Order in pagination %}
+                        <div id="history_list__item--{{ Order.id }}" class="historylist_column row">
+                            <div id="history_list__item_info--{{ Order.id }}" class="col-sm-4">
+                                <h3 id="history_list__order_date--{{ Order.id }}" class="order_date">{{ Order.order_date|date("Y/m/d H:i:s") }}</h3>
+                                <dl id="history_list__order_detail--{{ Order.id }}" class="order_detail">
+                                    <dt id="history_list__header_order_id--{{ Order.id }}">ご注文番号：</dt>
+                                    <dd id="history_list__order_id--{{ Order.id }}">{{ Order.id }}</dd>
+                                    {% if BaseInfo.option_mypage_order_status_display %}
+                                        <dt id="history_list__header_order_status--{{ Order.id }}">ご注文状況：</dt>
+                                        <dd id="history_list__order_status--{{ Order.id }}">{{ Order.CustomerOrderStatus }}</dd>
+                                    {% endif %}
+                                </dl>
+                                <p id="history_list__detail_button--{{ Order.id }}"><a class="btn btn-default btn-sm" href="{{ url('mypage_history', {'id': Order.id}) }}">詳細を見る</a></p>
+                            </div>
+                            <div id="history_detail_list--{{ Order.id }}" class="col-sm-8">
+                                {% for OrderDetail in Order.OrderDetails %}
+                                    <div id="history_detail_list__body--{{ Order.id }}_{{ OrderDetail.id }}" class="item_box table">
+                                        <div id="history_detail_list__body_inner--{{ Order.id }}_{{ OrderDetail.id }}" class="tbody">
+                                            <div id="history_detail_list__item--{{ Order.id }}_{{ OrderDetail.id }}" class="tr">
+                                                <div id="history_detail_list__image--{{ Order.id }}_{{ OrderDetail.id }}" class="item_photo td">
+                                                    {% if OrderDetail.Product is null %}
+                                                        <img src="{{ app.config.image_save_urlpath }}/{{ '' | no_image_product }}" />
+                                                    {% else %}
+                                                        {% if OrderDetail.enable %}
+                                                            <img src="{{ app.config.image_save_urlpath }}/{{ OrderDetail.product.MainListImage|no_image_product }}">
+                                                        {% else %}
+                                                            <img src="{{ app.config.image_save_urlpath }}/{{ ''|no_image_product }}" />
+                                                        {% endif %}
+                                                    {% endif %}
+                                                </div>
+                                                <dl id="history_detail_list__item_info--{{ Order.id }}_{{ OrderDetail.id }}" class="item_detail td">
+                                                    <dt id="history_detail_list__product_name--{{ Order.id }}_{{ OrderDetail.id }}" class="item_name">{{ OrderDetail.product_name }}</dt>
+                                                    <dd id="history_detail_list__category_name--{{ Order.id }}_{{ OrderDetail.id }}" class="item_pattern small">
+                                                        {% if OrderDetail.class_category_name1 is not empty %}
+                                                            {{ OrderDetail.class_category_name1 }}
+                                                        {% endif %}
+                                                        {% if OrderDetail.class_category_name1 is not empty %}
+                                                            / {{ OrderDetail.class_category_name2 }}
+                                                        {% endif %}
+                                                    </dd>
+                                                    <dd id="history_detail_list__price--{{ Order.id }}_{{ OrderDetail.id }}" class="item_price">{{ OrderDetail.price_inc_tax|price }} ×{{ OrderDetail.quantity }}</dd>
+                                                </dl>
+                                            </div>
+                                        </div>
+                                    </div><!--/item_box-->
+                                {% endfor %}
+                            </div>
+                        </div><!--/historylist_column-->
+                    {% endfor %}
+
+                    {% include "pagination.twig" with {'pages': pagination.paginationData} %}
+
+                {% else %}
+                    <p id="history_list__not_result_message" class="intro">ご注文履歴がありません。</p>
+                {% endif %}
+
+            </div><!-- /.col -->
+        </div><!-- /.row -->
+
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Mypage/login.twig
+++ b/src/Eccube/Resource/template/smartphone/Mypage/login.twig
@@ -1,0 +1,82 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'mypage' %}
+
+{% block main %}
+    <h1 class="page-heading">ログイン</h1>
+    <div class="container-fluid">
+        <form name="login_mypage" id="login_mypage" method="post" action="{{ url('login_check') }}" onsubmit="return eccube.checkLoginFormInputted('login_mypage')">
+            {% if app.session.flashBag.has('eccube.login.target.path') %}
+                {% for targetPath in app.session.flashBag.get('eccube.login.target.path') %}
+                    <input type="hidden" name="_target_path" value="{{ targetPath }}" />
+                {% endfor %}
+            {% endif %}
+            <div id="login_box" class="row">
+                <div id="mypage_login_wrap" class="col-sm-8 col-sm-offset-2">
+                    <div id="mypage_login_box" class="column">
+
+                        <div id="mypage_login_box__body" class="column_inner clearfix">
+                            <div class="icon"><svg class="cb cb-user-circle"><use xlink:href="#cb-user-circle" /></svg></div>
+                            <div id="mypage_login_box__login_email" class="form-group">
+                                {{ form_widget(form.login_email, {'attr': {'style' : 'ime-mode: disabled;', 'placeholder' : 'メールアドレス', 'autofocus': true}}) }}
+                            </div>
+                            <div id="mypage_login_box__login_pass" class="form-group">
+                                {{ form_widget(form.login_pass,  {'attr': {'placeholder' : 'パスワード' }}) }}
+                                {% if BaseInfo.option_remember_me %}
+                                    {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
+                                        <input id="mypage_login_box__login_memory" type="hidden" name="login_memory" value="1">
+                                    {% else %}
+                                        {{ form_widget(form.login_memory) }}
+                                    {% endif %}
+                                {% endif %}
+                            </div>
+                            <div class="extra-form form-group">
+                                {% for f in form.getIterator %}
+                                    {% if f.vars.name matches '[^plg*]' %}
+                                        {{ form_label(f) }}
+                                        {{ form_widget(f) }}
+                                        {{ form_errors(f) }}
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                            {% if error %}
+                            <div id="mypage_login_box__error_message" class="form-group">
+                                <span class="text-danger">{{ error|trans|raw }}</span>
+                            </div>
+                            {% endif %}
+                            <div id="mypage_login__login_button" class="btn_area">
+                                <p><button type="submit" class="btn btn-info btn-block btn-lg">ログイン</button></p>
+                                <ul id="mypage_login__login_menu" >
+                                    <li><a href="{{ url('forgot') }}">ログイン情報をお忘れですか？</a></li>
+                                    <li><a href="{{ url('entry') }}">新規会員登録</a></li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div><!-- /.col -->
+            </div><!-- /.row -->
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
+        </form>
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Mypage/navi.twig
+++ b/src/Eccube/Resource/template/smartphone/Mypage/navi.twig
@@ -1,0 +1,38 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% set favorite = BaseInfo.option_favorite_product %}
+<nav id="navi_list_box" class="local_nav {% if favorite == 1 %}favorite{% endif %}">
+    <ul id="navi_list">
+        <li class="{% if mypageno|default('') == 'index' %}active{% endif %}"><a href="{{ url('mypage') }}">ご注文履歴</a></li>
+        {% if favorite == 1 %}
+        <li class="{% if mypageno|default('') == 'favorite' %}active{% endif %}"><a href="{{ url('mypage_favorite') }}">お気に入り一覧</a></li>
+        {% endif %}
+        <li class="{% if mypageno|default('') == 'change' %}active{% endif %}"><a href="{{ url('mypage_change') }}">会員情報編集</a></li>
+        <li class="{% if mypageno|default('') == 'delivery' %}active{% endif %}"><a href="{{ url('mypage_delivery') }}">お届け先編集</a></li>
+        <li class="{% if mypageno|default('') == 'withdraw' %}active{% endif %}"><a href="{{ url('mypage_withdraw') }}">退会手続き</a></li>
+    </ul>
+</nav>
+<div id="welcome_message" class="message">
+    <p>
+        ようこそ ／ {{ app.user.name01 }} {{ app.user.name02 }} 様
+    </p>
+</div>

--- a/src/Eccube/Resource/template/smartphone/Mypage/withdraw.twig
+++ b/src/Eccube/Resource/template/smartphone/Mypage/withdraw.twig
@@ -1,0 +1,59 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set mypageno = 'withdraw' %}
+
+{% set body_class = 'mypage' %}
+
+{% block main %}
+<h1 class="page-heading">マイページ/退会手続き</h1>
+<div id="withdraw_wrap" class="container-fluid">
+    {% include 'Mypage/navi.twig' %}
+    <div id="withdraw_box" class="unsubscribe_box">
+        <form method="post" action="{{ url('mypage_withdraw') }}">
+        {{ form_widget(form._token) }}
+        <div id="withdraw_box__body" class="row no-padding">
+            <div id="withdraw_box__body_inner" class="col-sm-6 col-sm-offset-3">
+                    <div class="icon"><svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg></div>
+                    <h3>退会手続きの前にご確認ください</h3>
+                    <p>会員を退会された場合には、現在保存されている購入履歴やお届け先等の情報は、すべて削除されますがよろしいでしょうか？</p>
+            </div>
+        </div>
+        <div class="row">
+            {% for f in form %}
+                {% if f.vars.name matches '[^plg*]' %}
+                    <div class="extra-form dl_table">
+                        {{ form_row(f) }}
+                    </div>
+                {% endif %}
+            {% endfor %}
+        </div>
+        <div id="withdraw_box__confirm_button" class="row">
+            <div class="btn_group col-sm-offset-4 col-sm-4">
+                <p><button type="submit" class="btn btn-info btn-block" name="mode" value="confirm">会員退会手続きへ</button></p>
+            </div>
+        </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Mypage/withdraw_complete.twig
+++ b/src/Eccube/Resource/template/smartphone/Mypage/withdraw_complete.twig
@@ -1,0 +1,47 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set mypageno = 'withdraw' %}
+
+{% set body_class = 'mypage' %}
+
+{% block main %}
+<h1 class="page-heading">マイページ/退会手続き</h1>
+<div id="complete_wrap" class="container-fluid">
+    <div id="complete_box" class="unsubscribe_box">
+        <div id="complete_box__body" class="row no-padding">
+            <div id="complete_box__message" class="col-sm-6 col-sm-offset-3">
+                    <h3>退会が完了いたしました</h3>
+                    <p>ご利用いただき誠にありがとうございました。<br>
+                    またのご来店をお待ちしております。</p>
+            </div>
+        </div>
+        <div id="complete_box__top_button" class="row">
+            <div class="btn_group col-sm-offset-4 col-sm-4">
+                <p><a href="{{ url('homepage') }}" class="btn btn-info btn-block">トップページへ</a></p>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Mypage/withdraw_confirm.twig
+++ b/src/Eccube/Resource/template/smartphone/Mypage/withdraw_confirm.twig
@@ -1,0 +1,51 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set mypageno = 'withdraw' %}
+
+{% set body_class = 'mypage' %}
+
+{% block main %}
+<h1 class="page-heading">マイページ/退会手続き</h1>
+<div id="confirm_wrap" class="container-fluid">
+    {% include 'Mypage/navi.twig' %}
+    <div id="confirm_box" class="unsubscribe_box">
+        <div id="confirm_box__body" class="row no-padding">
+            <div id="confirm_box__message" class="col-sm-6 col-sm-offset-3">
+                    <div class="icon"><svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg></div>
+                    <h3>退会手続きを実行してもよろしいでしょうか？</h3>
+                    <p>退会手続きが完了した時点で、現在保存されている購入履歴やお届け先等の情報は、すべて削除されますのでご注意ください。</p>
+            </div>
+        </div>
+        <form method="post" action="{{ url('mypage_withdraw') }}">
+            {{ form_widget(form._token) }}
+                <div id="confirm_box__footer" class="row">
+                    <div id="confirm_box__complete_button" class="btn_group col-sm-offset-4 col-sm-4">
+                        <p><a href="{{ url('mypage') }}" class="btn btn-info btn-block">いいえ、退会しません</a></p>
+                        <p><button type="submit" class="btn btn-default btn-block" name="mode" value="complete">はい、退会します</button></p>
+                    </div>
+                </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Product/detail.twig
+++ b/src/Eccube/Resource/template/smartphone/Product/detail.twig
@@ -1,0 +1,285 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'product_page' %}
+
+{% block javascript %}
+<script>
+    eccube.classCategories = {{ Product.class_categories|json_encode|raw }};
+
+    // 規格2に選択肢を割り当てる。
+    function fnSetClassCategories(form, classcat_id2_selected) {
+        var $form = $(form);
+        var product_id = $form.find('input[name=product_id]').val();
+        var $sele1 = $form.find('select[name=classcategory_id1]');
+        var $sele2 = $form.find('select[name=classcategory_id2]');
+        eccube.setClassCategories($form, product_id, $sele1, $sele2, classcat_id2_selected);
+    }
+
+    {% if form.classcategory_id2 is defined %}
+    fnSetClassCategories(
+            document.form1, {{ form.classcategory_id2.vars.value|json_encode|raw }}
+    );
+    {% endif %}
+</script>
+
+<script>
+$(function(){
+    $('.carousel').slick({
+        infinite: false,
+        speed: 300,
+        prevArrow:'<button type="button" class="slick-prev"><span class="angle-circle"><svg class="cb cb-angle-right"><use xlink:href="#cb-angle-right" /></svg></span></button>',
+        nextArrow:'<button type="button" class="slick-next"><span class="angle-circle"><svg class="cb cb-angle-right"><use xlink:href="#cb-angle-right" /></svg></span></button>',
+        slidesToShow: 4,
+        slidesToScroll: 4,
+        responsive: [
+            {
+                breakpoint: 768,
+                settings: {
+                    slidesToShow: 3,
+                    slidesToScroll: 3
+                }
+            }
+        ]
+    });
+
+    $('.slides').slick({
+        dots: true,
+        arrows: false,
+        speed: 300,
+        customPaging: function(slider, i) {
+            return '<button class="thumbnail">' + $(slider.$slides[i]).find('img').prop('outerHTML') + '</button>';
+        }
+    });
+
+    $('#favorite').click(function() {
+        $('#mode').val('add_favorite');
+    });
+
+    $('#add-cart').click(function() {
+        $('#mode').val('add_cart');
+    });
+
+    // bfcache無効化
+    $(window).bind('pageshow', function(event) {
+        if (event.originalEvent.persisted) {
+            location.reload(true);
+        }
+    });
+});
+</script>
+
+{% endblock %}
+
+{% block main %}
+    {# todo ブロック化}
+    <div id="topicpath" class="row">
+        {% for ProductCategory in Product.ProductCategories %}
+        <ol>
+            <li><a href="{{ url('product_list') }}">全商品</a></li>
+            {% for Category in ProductCategory.Category.path %}
+                <li><a href="{{ url('product_list') }}?category_id={{ Category.id }}">{{ Category.name }}</a></li>
+            {% endfor %}
+            <li>{{ Product.name }}</li>
+        </ol>
+        {% endfor %}
+    </div>
+    #}
+
+    <!-- ▼item_detail▼ -->
+    <div id="item_detail">
+        <div id="detail_wrap" class="row">
+            <!--★画像★-->
+            <div id="item_photo_area" class="col-sm-6">
+                <div id="detail_image_box__slides" class="slides">
+                    {% if Product.ProductImage|length > 0 %}
+                        {% for ProductImage in Product.ProductImage %}
+                        <div id="detail_image_box__item--{{ loop.index }}"><img src="{{ app.config.image_save_urlpath }}/{{ ProductImage|no_image_product }}"/></div>
+                        {% endfor %}
+                    {% else %}
+                        <div id="detail_image_box__item"><img src="{{ app.config.image_save_urlpath }}/{{ ''|no_image_product }}"/></div>
+                    {% endif %}
+                </div>
+            </div>
+
+            <section id="item_detail_area" class="col-sm-6">
+
+                <!--★商品名★-->
+                <h3 id="detail_description_box__name" class="item_name">{{ Product.name }}</h3>
+                <div id="detail_description_box__body" class="item_detail">
+
+                    {% if Product.ProductTag is not empty %}
+                        <!--▼商品タグ-->
+                        <div id="product_tag_box" class="product_tag">
+                            {% for ProductTag in Product.ProductTag %}
+                                <span id="product_tag_box__product_tag--{{ ProductTag.Tag.id }}" class="product_tag_list">{{ ProductTag.Tag }}</span>
+                            {% endfor %}
+                        </div>
+                        <hr>
+                        <!--▲商品タグ-->
+                    {% endif %}
+
+                    <!--★通常価格★-->
+                    {% if Product.hasProductClass -%}
+                        {% if Product.getPrice01Min is not null and Product.getPrice01IncTaxMin == Product.getPrice01IncTaxMax %}
+                        <p id="detail_description_box__class_normal_price" class="normal_price"> 通常価格：<span class="price01_default">{{ Product.getPrice01IncTaxMin|price }}</span> <span class="small">税込</span></p>
+                        {% elseif Product.getPrice01Min is not null and Product.getPrice01Max is not null %}
+                        <p id="detail_description_box__class_normal_range_price" class="normal_price"> 通常価格：<span class="price01_default">{{ Product.getPrice01IncTaxMin|price }} ～ {{ Product.getPrice01IncTaxMax|price }}</span> <span class="small">税込</span></p>
+                        {% endif %}
+                    {% else -%}
+                        {% if Product.getPrice01Max is not null %}
+                        <p id="detail_description_box__normal_price" class="normal_price"> 通常価格：<span class="price01_default">{{ Product.getPrice01IncTaxMin|price }}</span> <span class="small">税込</span></p>
+                        {% endif %}
+                    {% endif -%}
+
+                    <!--★販売価格★-->
+                    {% if Product.hasProductClass -%}
+                        {% if Product.getPrice02IncTaxMin == Product.getPrice02IncTaxMax %}
+                        <p id="detail_description_box__class_sale_price" class="sale_price text-primary"> <span class="price02_default">{{ Product.getPrice02IncTaxMin|price }}</span> <span class="small">税込</span></p>
+                        {% else %}
+                        <p id="detail_description_box__class_range_sale_price" class="sale_price text-primary"> <span class="price02_default">{{ Product.getPrice02IncTaxMin|price }} ～ {{  Product.getPrice02IncTaxMax|price }}</span> <span class="small">税込</span></p>
+                        {% endif %}
+                    {% else -%}
+                        <p id="detail_description_box__sale_price" class="sale_price text-primary"> <span class="price02_default">{{ Product.getPrice02IncTaxMin|price }}</span> <span class="small">税込</span></p>
+                    {% endif -%}
+
+                    <!--▼商品コード-->
+                    <p id="detail_description_box__item_range_code" class="item_code">商品コード： <span id="item_code_default">
+                        {{ Product.code_min }}
+                        {% if Product.code_min != Product.code_max %} ～ {{ Product.code_max }}{% endif %}
+                        </span> </p>
+                    <!--▲商品コード-->
+
+                    <!-- ▼関連カテゴリ▼ -->
+                    <div id="relative_category_box" class="relative_cat">
+                        <p>関連カテゴリ</p>
+                          {% for ProductCategory in Product.ProductCategories %}
+                        <ol id="relative_category_box__relative_category--{{ ProductCategory.product_id }}_{{ loop.index }}">
+                            {% for Category in ProductCategory.Category.path %}
+                            <li><a id="relative_category_box__relative_category--{{ ProductCategory.product_id }}_{{ loop.parent.loop.index }}_{{ Category.id }}" href="{{ url('product_list') }}?category_id={{ Category.id }}">{{ Category.name }}</a></li>
+                            {% endfor %}
+                        </ol>
+                        {% endfor %}
+                    </div>
+                    <!-- ▲関連カテゴリ▲ -->
+
+                    <form action="?" method="post" id="form1" name="form1">
+                        <!--▼買い物かご-->
+                        <div id="detail_cart_box" class="cart_area">
+                            {% if Product.stock_find %}
+
+                                {# 規格 #}
+                                {% if form.classcategory_id1 is defined %}
+                                <ul id="detail_cart_box__cart_class_category_id" class="classcategory_list">
+                                    {# 規格1 #}
+                                    <li>
+                                        {{ form_widget(form.classcategory_id1) }}
+                                        {{ form_errors(form.classcategory_id1) }}
+                                    </li>
+                                    {# 規格2 #}
+                                    {% if form.classcategory_id2 is defined %}
+                                        <li>
+                                            {{ form_widget(form.classcategory_id2) }}
+                                            {{ form_errors(form.classcategory_id2) }}
+                                        </li>
+                                     {% endif %}
+                                </ul>
+                                {% endif %}
+
+                                {# 数量 #}
+                                <dl id="detail_cart_box__cart_quantity" class="quantity">
+                                    <dt>数量</dt>
+                                    <dd>
+                                        {{ form_widget(form.quantity) }}
+                                        {{ form_errors(form.quantity) }}
+                                    </dd>
+                                </dl>
+
+                                <div class="extra-form">
+                                    {% for f in form.getIterator %}
+                                        {% if f.vars.name matches '[^plg*]' %}
+                                            {{ form_row(f) }}
+                                        {% endif %}
+                                    {% endfor %}
+                                </div>
+
+                                {# カートボタン #}
+                                <div id="detail_cart_box__button_area" class="btn_area">
+                                    <ul id="detail_cart_box__insert_button" class="row">
+                                        <li class="col-xs-12 col-sm-8"><button type="submit" id="add-cart" class="btn btn-primary btn-block prevention-btn prevention-mask">カートに入れる</button></li>
+                                    </ul>
+                                    {#Favorite product button#}
+                                    {% if BaseInfo.option_favorite_product == 1 %}
+                                        <ul id="detail_cart_box__favorite_button" class="row">
+                                            {% if is_favorite == false %}
+                                                <li class="col-xs-12 col-sm-8"><button type="submit" id="favorite" class="btn btn-info btn-block prevention-btn prevention-mask">お気に入りに追加</button></li>
+                                            {% else %}
+                                                <li class="col-xs-12 col-sm-8"><button type="submit" id="favorite" class="btn btn-info btn-block" disabled="disabled">お気に入りに追加済みです</button></li>
+                                            {% endif %}
+                                        </ul>
+                                    {% endif %}
+                                </div> {#End div#detail_cart_box__button_area #}
+                            {% else %}
+                                {# 在庫がない場合は品切れボタンを表示 #}
+                                <div id="detail_cart_box__button_area" class="btn_area">
+                                    <ul class="row">
+                                        <li class="col-xs-12 col-sm-8"><button type="button" class="btn btn-default btn-block" disabled="disabled">ただいま品切れ中です</button></li>
+                                    </ul>
+                                    {#Favorite product button#}
+                                    {% if BaseInfo.option_favorite_product == 1 %}
+                                        <ul id="detail_cart_box__favorite_button" class="row">
+                                            {% if is_favorite == false %}
+                                                <li class="col-xs-12 col-sm-8"><button type="submit" id="favorite" class="btn btn-info btn-block prevention-btn prevention-mask">お気に入りに追加</button></li>
+                                            {% else %}
+                                                <li class="col-xs-12 col-sm-8"><button type="submit" id="favorite" class="btn btn-info btn-block" disabled="disabled">お気に入りに追加済みです</button></li>
+                                            {% endif %}
+                                        </ul>
+                                    {% endif %}
+                                </div> {#End div#detail_cart_box__button_area #}
+                            {% endif %} {#End stock find#}
+                        </div>
+                        <!--▲買い物かご-->
+                        {{ form_rest(form) }}
+                    </form>
+
+                    <!--★商品説明★-->
+                    <p id="detail_not_stock_box__description_detail" class="item_comment">{{ Product.description_detail|raw|nl2br }}</p>
+
+                </div>
+                <!-- /.item_detail -->
+
+            </section>
+            <!--詳細ここまで-->
+        </div>
+
+        {# フリーエリア #}
+        {% if Product.freearea %}
+        <div id="sub_area" class="row">
+            <div class="col-sm-10 col-sm-offset-1">
+                <div id="detail_free_box__freearea" class="freearea">{{ include(template_from_string(Product.freearea)) }}</div>
+            </div>
+        </div>
+        {% endif %}
+    </div>
+    <!-- ▲item_detail▲ -->
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Product/list.twig
+++ b/src/Eccube/Resource/template/smartphone/Product/list.twig
@@ -1,0 +1,149 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'product_page' %}
+
+{% block javascript %}
+    <script>
+        // 並び順を変更
+        function fnChangeOrderBy(orderby) {
+            eccube.setValue('orderby', orderby);
+            eccube.setValue('pageno', 1);
+            eccube.submitForm();
+        }
+
+        // 表示件数を変更
+        function fnChangeDispNumber(dispNumber) {
+            eccube.setValue('disp_number', dispNumber);
+            eccube.setValue('pageno', 1);
+            eccube.submitForm();
+        }
+        // 商品表示BOXの高さを揃える
+        $(window).load(function() {
+            $('.product_item').matchHeight();
+        });
+    </script>
+{% endblock %}
+
+{% block main %}
+    {% if search_form.category_id.vars.errors|length == 0 %}
+    <form name="form1" id="form1" method="get" action="?">
+        {{ form_widget(search_form) }}
+    </form>
+    <!-- ▼topicpath▼ -->
+    <div id="topicpath" class="row">
+        <ol id="list_header_menu">
+            <li><a href="{{ url('product_list') }}">全商品</a></li>
+            {% if Category is not null %}
+                {% for Path in Category.path %}
+                    <li><a href="{{ url('product_list') }}?category_id={{ Path.id }}">{{ Path.name }}</a></li>
+                {% endfor %}
+            {% endif %}
+            {% if search_form.vars.value.name %}
+            <li>「{{ search_form.vars.value.name }}」の検索結果</li>
+            {% endif %}
+        </ol>
+    </div>
+    <!-- ▲topicpath▲ -->
+    <div id="result_info_box" class="row">
+        <form name="page_navi_top" id="page_navi_top" action="?">
+            {% if pagination.totalItemCount > 0 %}
+                <p id="result_info_box__item_count" class="intro col-sm-6"><strong><span id="productscount">{{ pagination.totalItemCount }}</span>件</strong>の商品がみつかりました。
+                </p>
+
+                <div id="result_info_box__menu_box" class="col-sm-6 no-padding">
+                    <ul id="result_info_box__menu" class="pagenumberarea clearfix">
+                        <li id="result_info_box__disp_menu">
+                            {{ form_widget(disp_number_form, {'id': '', 'attr': {'onchange': "javascript:fnChangeDispNumber(this.value);"}}) }}
+                        </li>
+                        <li id="result_info_box__order_menu">
+                            {{ form_widget(order_by_form, {'id': '', 'attr': {'onchange': "javascript:fnChangeOrderBy(this.value);"}}) }}
+                        </li>
+                    </ul>
+                </div>
+
+                {% for f in disp_number_form.getIterator %}
+                    {% if f.vars.name matches '[^plg*]' %}
+                        {{ form_label(f) }}
+                        {{ form_widget(f) }}
+                        {{ form_errors(f) }}
+                    {% endif %}
+                {% endfor %}
+
+                {% for f in order_by_form.getIterator %}
+                    {% if f.vars.name matches '[^plg*]' %}
+                        {{ form_label(f) }}
+                        {{ form_widget(f) }}
+                        {{ form_errors(f) }}
+                    {% endif %}
+                {% endfor %}
+            {% else %}
+                <p id="result_info_box__item_count" class="intro col-sm-6"><strong style="display: none;"><span id="productscount">{{ pagination.totalItemCount }}</span>件</strong>お探しの商品は見つかりませんでした。</p>
+            {% endif %}
+        </form>
+    </div>
+
+    <!-- ▼item_list▼ -->
+    <div id="item_list">
+        <div class="row no-padding">
+            {% for Product in pagination %}
+                <div id="result_list_box--{{ Product.id }}" class="col-sm-3 col-xs-6">
+                    <div id="result_list__item--{{ Product.id }}" class="product_item">
+                        <a href="{{ url('product_detail', {'id': Product.id}) }}">
+                            <div id="result_list__image--{{ Product.id }}" class="item_photo">
+                                <img src="{{ app.config.image_save_urlpath }}/{{ Product.main_list_image|no_image_product }}">
+                            </div>
+                            <dl id="result_list__detail--{{ Product.id }}">
+                                <dt id="result_list__name--{{ Product.id }}" class="item_name">{{ Product.name }}</dt>
+                                {% if Product.description_list %}
+                                    <dd id="result_list__description_list--{{ Product.id }}" class="item_comment">{{ Product.description_list|raw|nl2br }}</dd>
+                                {% endif %}
+                                {% if Product.hasProductClass %}
+                                    {% if Product.getPrice02Min == Product.getPrice02Max %}
+                                    <dd id="result_list__price02_inc_tax--{{ Product.id }}" class="item_price">
+                                        {{ Product.getPrice02IncTaxMin|price }}
+                                    </dd>
+                                    {% else %}
+                                    <dd id="result_list__price02_inc_tax--{{ Product.id }}" class="item_price">
+                                        {{ Product.getPrice02IncTaxMin|price }} ～ {{ Product.getPrice02IncTaxMax|price }}
+                                    </dd>
+                                    {% endif %}
+                                {% else %}
+                                    <dd id="result_list__price02_inc_tax--{{ Product.id }}" class="item_price">{{ Product.getPrice02IncTaxMin|price }}</dd>
+                                {% endif %}
+                            </dl>
+                        </a>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+
+    </div>
+    <!-- ▲item_list▲ -->
+    {% if pagination.totalItemCount > 0 %}
+        {% include "pagination.twig" with { 'pages' : pagination.paginationData } %}
+    {% endif %}
+    {% else %}
+        <p class="errormsg text-danger">ご指定のカテゴリは存在しません。</p>
+    {% endif %}
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Shopping/complete.twig
+++ b/src/Eccube/Resource/template/smartphone/Shopping/complete.twig
@@ -1,0 +1,72 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'cart_page' %}
+
+{% block main %}
+    <h1 class="page-heading">ご注文完了</h1>
+    <div id="complete_wrap" class="container-fluid">
+        <div id="complete_flow_box" class="row">
+            <div id="complete_flow_box__body" class="col-md-12">
+                {% if is_granted('ROLE_USER') %}
+                <div id="complete_flow_box__flow_state" class="flowline step3">
+                {% else %}
+                <div id="complete_flow_box__flow_state" class="flowline step4">
+                {% endif %}
+                    <ul id="complete_flow_box__flow_state_list" class="clearfix">
+                        <li><span class="flow_number">1</span><br>カートの商品</li>
+                    {% if is_granted('ROLE_USER') %}
+                        <li><span class="flow_number">2</span><br>ご注文内容確認</li>
+                        <li class="active"><span class="flow_number">3</span><br>完了</li>
+                    {% else %}
+                        <li><span class="flow_number">2</span><br>お客様情報</li>
+                        <li><span class="flow_number">3</span><br>ご注文内容確認</li>
+                        <li class="active"><span class="flow_number">4</span><br>完了</li>
+                    {% endif %}
+                    </ul>
+                </div>
+            </div><!-- /.col -->
+        </div><!-- /.row -->
+
+
+        <div id="deliveradd_input" class="row">
+            <div id="deliveradd_input_box" class="col-sm-10 col-sm-offset-1">
+                <div id="deliveradd_input_box__message" class="complete_message">
+                    <h2 class="heading01">ご注文ありがとうございました</h2>
+                    <p>ただいま、ご注文の確認メールをお送りさせていただきました。<br />
+                        万一、ご確認メールが届かない場合は、トラブルの可能性もありますので大変お手数ではございますがもう一度お問い合わせいただくか、お電話にてお問い合わせくださいませ。<br />
+                        今後ともご愛顧賜りますようよろしくお願い申し上げます。</p>
+                </div>
+                <div id="deliveradd_input_box__top_button" class="row no-padding">
+                    <div class="btn_group col-sm-offset-4 col-sm-4">
+                        <p>
+                            <a href="{{ url('homepage') }}" class="btn btn-info btn-block">トップページへ</a>
+                        </p>
+                    </div>
+                </div>
+
+            </div><!-- /.col -->
+        </div><!-- /.row -->
+
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Shopping/index.twig
+++ b/src/Eccube/Resource/template/smartphone/Shopping/index.twig
@@ -1,0 +1,374 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% form_theme form 'Form/form_div_layout.twig' %}
+
+{% block javascript %}
+<script>
+$(function() {
+
+    $('.delivery').on('change', function() {
+        $('#shopping_order_mode').val('delivery');
+        $('#shopping-form').attr('action', '{{ url("shopping_redirect_to") }}').submit();
+    });
+
+    $('.payment').on('change', function() {
+        $('#shopping_order_mode').val('payment');
+        $('#shopping-form').attr('action', '{{ url("shopping_redirect_to") }}').submit();
+    });
+
+    $('.btn-shipping').click(function() {
+        $('#shopping_order_mode').val('shipping_change');
+        $('#shopping_order_param').val($(this).data('id'));
+        $('#shopping-form').attr('action', '{{ url("shopping_redirect_to") }}').submit();
+
+        $('#shopping-form').attr('action', '{{ url("shopping/confirm") }}');
+        $('#shopping_order_mode').val('');
+        $('#shopping_order_param').val('');
+        return false;
+    });
+
+    $('.btn-shipping-edit').click(function() {
+        $('#shopping_order_mode').val('shipping_edit_change');
+        $('#shopping_order_param').val($(this).data('id'));
+        $('#shopping-form').attr('action', '{{ url("shopping_redirect_to") }}').submit();
+
+        $('#shopping-form').attr('action', '{{ url("shopping/confirm") }}');
+        $('#shopping_order_mode').val('');
+        $('#shopping_order_param').val('');
+        return false;
+    });
+
+    $('.btn-shipping-multiple').click(function() {
+        $('#shopping_order_mode').val('shipping_multiple_change');
+        $('#shopping-form').attr('action', '{{ url("shopping_redirect_to") }}').submit();
+
+        $('#shopping-form').attr('action', '{{ url("shopping/confirm") }}');
+        $('#shopping_order_mode').val('');
+        $('#shopping_order_param').val('');
+        return false;
+    });
+
+    {% if is_granted('ROLE_USER') == false %}
+        var ref = [];
+        var name = [];
+        var input = [];
+        var customerin = [];
+
+        $('#customer').click(function() {
+            // ref = $('.customer-name01');
+            var edit = $('.customer-edit');
+            var hidden = $('.customer-in');
+
+            $(edit).each(function(index) {
+                ref[index] = $(this);
+            });
+            $(hidden).each(function(index) {
+                customerin[index] = $(this);
+            });
+            $(ref).each(function(index) {
+                name[index] = $(this).text();
+            });
+            $(name).each(function(index) {
+                input[index] = $('<input id="edit' + index + '" type="text" />').val(name[index]);
+            });
+            $(input).each(function(index) {
+                ref[index].empty().append(input[index]);
+            });
+
+            $('#customer').prop("disabled", true);
+            $('.mod-button').show();
+        });
+
+        $('#customer-ok').click(function() {
+            $(ref).each(function(index) {
+                var nameAfter = input[index].val();
+                ref[index].empty().text(nameAfter);
+                customerin[index].val(nameAfter);
+                input[index].remove();
+            });
+
+            var postData = {};
+            $('.customer-in').each(function() {
+                postData[$(this).attr('name')] = $(this).val();
+            });
+
+            $.ajax({
+                url: "{{ url('shopping_customer') }}",
+                type: 'POST',
+                data: postData,
+                dataType: 'json',
+            }).done(function(){
+            }).fail(function(){
+                alert('更新に失敗しました。入力内容を確認してください。');
+                $(ref).each(function(index) {
+                    ref[index].empty().text(name[index]);
+                    input[index].remove();
+                });
+            });
+
+            $('#customer').prop("disabled", false);
+            $('.mod-button').hide();
+        });
+
+        $('#customer-cancel').click(function() {
+            $(ref).each(function(index) {
+                ref[index].empty().text(name[index]);
+                input[index].remove();
+            });
+
+            $('#customer').prop("disabled", false);
+            $('.mod-button').hide();
+        });
+    {% endif %}
+
+});
+</script>
+{% endblock javascript %}
+
+{% block main %}
+    <h1 class="page-heading">ご注文内容のご確認</h1>
+    <div id="confirm_wrap" class="container-fluid">
+        <div id="confirm_flow_box" class="row">
+            <div id="confirm_flow_box__body" class="col-md-12">
+                {% if is_granted('ROLE_USER') %}
+                <div id="confirm_flow_box__flow_state" class="flowline step3">
+                {% else %}
+                <div id="confirm_flow_box__flow_state" class="flowline step4">
+                {% endif %}
+                    <ul id="confirm_flow_box__flow_state_list" class="clearfix">
+                    <li><span class="flow_number">1</span><br>カートの商品</li>
+                    {% if is_granted('ROLE_USER') %}
+                        <li class="active"><span class="flow_number">2</span><br>ご注文内容確認</li>
+                        <li><span class="flow_number">3</span><br>完了</li>
+                    {% else %}
+                        <li><span class="flow_number">2</span><br>お客様情報</li>
+                        <li class="active"><span class="flow_number">3</span><br>ご注文内容確認</li>
+                        <li><span class="flow_number">4</span><br>完了</li>
+                    {% endif %}
+                    </ul>
+                </div>
+                {% for error in app.session.flashbag.get('eccube.front.error')  %}
+                    <div id="confirm_flow_box__message" class="message">
+                        <p class="errormsg bg-danger">
+                            <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>{{ error|trans|nl2br }}
+                        </p>
+                    </div>
+                {% endfor %}
+                    {% set productStr = app.session.flashbag.get('eccube.front.request.product') %}
+                    {% for error in app.session.flashbag.get('eccube.front.request.error')  %}
+                        {% set idx = loop.index0 %}
+                        {% if productStr[idx] is defined %}
+                            <div id="cart_box__message--{{ loop.index }}" class="message">
+                                <p class="errormsg bg-danger">
+                                    <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>
+                                    {{ error|trans({'%product%':productStr[idx]})|nl2br }}
+                                </p>
+                            </div>
+                        {% else %}
+                            <div id="confirm_flow_box__message--{{ loop.index }}" class="message">
+                                <p class="errormsg bg-danger">
+                                    <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>{{ error|trans|nl2br }}
+                                </p>
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+            </div><!-- /.col -->
+        </div><!-- /.row -->
+        <form id="shopping-form" method="post" action="{{ url('shopping/confirm') }}">
+            {{ form_widget(form._token) }}
+            {{ form_widget(form.mode) }}
+            {{ form_widget(form.param) }}
+            <div id="shopping_confirm" class="row">
+                <div id="confirm_main" class="col-sm-8">
+                    <div id="cart_box" class="cart_item table">
+                        <div id="cart_box_list" class="tbody">
+                            {% for orderDetail in Order.orderDetails %}
+                            <div id="cart_box_list__item_box--{{ loop.index }}" class="item_box tr">
+                                <div id="cart_box_list__item--{{ loop.index }}" class="td table">
+                                    <div id="cart_box_list__photo--{{ loop.index }}" class="item_photo">{# TODO 暫定 #}{% if orderDetail.productName != '送料' %}<img src="{{ app.config.image_save_urlpath }}/{{ orderDetail.product is null ? null : orderDetail.product.MainListImage|no_image_product }}" alt="{{ orderDetail.productName }}" />{% endif %}</div>
+                                    <dl id="cart_box_list__detail--{{ loop.index }}" class="item_detail">
+                                        <dt id="cart_box_list__name--{{ loop.index }}" class="item_name text-default">{{ orderDetail.productName }}</dt>
+                                        <dd id="cart_box_list__class_category--{{ loop.index }}" class="item_pattern small">
+                                            {% if orderDetail.productClass is not null and orderDetail.productClass.classCategory1 %}
+                                                {{ orderDetail.productClass.classCategory1.className }}：{{ orderDetail.productClass.classCategory1 }}
+                                            {% endif %}
+                                            {% if orderDetail.productClass is not null and orderDetail.productClass.classCategory2 %}
+                                                <br>{{ orderDetail.productClass.classCategory2.className }}：{{ orderDetail.productClass.classCategory2 }}
+                                            {% endif %}
+                                        </dd>
+                                        <dd id="cart_box_list__price--{{ loop.index }}" class="item_price">{{ orderDetail.priceIncTax|price }} × {{ orderDetail.quantity|number_format }}</dd>
+                                        <dd id="cart_box_list__subtotal--{{ loop.index }}" class="item_subtotal">小計：{{ orderDetail.totalPrice|price }}</dd>
+                                    </dl>
+                                </div>
+                            </div><!--/item_box-->
+                            {% endfor %}
+                        </div>
+                    </div><!--/cart_item-->
+                    <p><a id="confirm_box__quantity_edit_button" href="{{ url('cart') }}" class="btn btn-default btn-sm">数量を変更または削除する</a></p>
+                    <h2 class="heading02">お客様情報</h2>
+                    <div id="customer_detail_box" class="column is-edit">
+                        <p id="customer_detail_box__customer_address" class="address"><span class="customer-edit customer-name01">{{ Order.name01 }}</span> <span class="customer-edit customer-name02">{{ Order.name02 }}</span> 様<br>
+                        〒<span class="customer-edit customer-zip01">{{ Order.zip01 }}</span>-<span class="customer-edit customer-zip02">{{ Order.zip02 }}</span> <span class="customer-edit customer-pref">{{ Order.pref }}</span><span class="customer-edit customer-addr01">{{ Order.addr01 }}</span><span class="customer-edit customer-addr02">{{ Order.addr02 }}</span><br>
+                        <span class="customer-edit customer-tel01">{{ Order.tel01 }}</span>-<span class="customer-edit customer-tel02">{{ Order.tel02 }}</span>-<span class="customer-edit customer-tel03">{{ Order.tel03 }}</span></p>
+                        {% if is_granted('ROLE_USER') == false %}
+                            <div class="customer-edit customer-email">{{ Order.email }}</div>
+                            <div class="customer-edit customer-company_name">{{ Order.companyName }}</div>
+                            <div class="mod-button" style="display:none;">
+                                <span id="customer-ok"><button type="button" class="btn btn-default btn-sm">OK</button></span>
+                                <span id="customer-cancel"><button type="button" class="btn btn-default btn-sm">キャンセル</button></span>
+                            </div>
+                            <p class="btn_edit"><button type="button" id="customer" class="btn btn-default btn-sm">変更</button></p>
+                            <input type="hidden" id="customer-name01" class="customer-in" name="customer_name01" value="{{ Order.name01 }}">
+                            <input type="hidden" id="customer-name02" class="customer-in" name="customer_name02" value="{{ Order.name02 }}">
+                            <input type="hidden" id="customer-zip01" class="customer-in" name="customer_zip01" value="{{ Order.zip01 }}">
+                            <input type="hidden" id="customer-zip02" class="customer-in" name="customer_zip02" value="{{ Order.zip02 }}">
+                            <input type="hidden" id="customer-pref" class="customer-in" name="customer_pref" value="{{ Order.pref }}">
+                            <input type="hidden" id="customer-addr01" class="customer-in" name="customer_addr01" value="{{ Order.addr01 }}">
+                            <input type="hidden" id="customer-addr02" class="customer-in" name="customer_addr02" value="{{ Order.addr02 }}">
+                            <input type="hidden" id="customer-tel01" class="customer-in" name="customer_tel01" value="{{ Order.tel01 }}">
+                            <input type="hidden" id="customer-tel02" class="customer-in" name="customer_tel02" value="{{ Order.tel02 }}">
+                            <input type="hidden" id="customer-tel03" class="customer-in" name="customer_tel03" value="{{ Order.tel03 }}">
+                            <input type="hidden" id="customer-email" class="customer-in" name="customer_email" value="{{ Order.email }}">
+                            <input type="hidden" id="customer-company-name" class="customer-in" name="customer_company_name" value="{{ Order.companyName }}">
+                        {% endif %}
+                    </div>
+
+                    <h2 class="heading02">配送情報</h2>
+                    {% for shipping in Order.shippings %}
+                        {% set idx = loop.index0 %}
+                        <div id="shipping_confirm_box--{{ idx }}" class="column is-edit">
+                            <h3>お届け先{% if Order.multiple %}({{ loop.index }}){% endif %}</h3>
+                            <div id="shipping_confirm_box__body--{{ idx }}" class="cart_item table">
+                                <div id="shipping_confirm_box__list--{{ idx }}" class="tbody">
+                                {% for shipmentItem in shipping.shipmentItems %}
+                                    <div id="shipping_confirm_box__item--{{ idx }}_{{ shipmentItem.id }}" class="item_box tr">
+                                        <div id="shipping_box__body_inner--{{ idx }}_{{ shipmentItem.id }}" class="td table">
+                                            <div id="shipping_box__photo--{{ idx }}_{{ shipmentItem.id }}" class="item_photo"><img src="{{ app.config.image_save_urlpath }}/{{ shipmentItem.product.MainListImage|no_image_product }}" alt="{{ shipmentItem.productName }}" /></div>
+                                            <dl id="shipping_box__detail--{{ idx }}_{{ shipmentItem.id }}" class="item_detail">
+                                                <dt id="shipping_box__name--{{ idx }}_{{ shipmentItem.id }}" class="item_name text-default">{{ shipmentItem.productName }}</dt>
+                                                <dd id="shipping_box__class_category--{{ idx }}_{{ shipmentItem.id }}" class="item_pattern small">
+                                                    {% if shipmentItem.productClass.classCategory1 %}
+                                                        {{ shipmentItem.productClass.classCategory1.className }}：{{ shipmentItem.productClass.classCategory1 }}
+                                                    {% endif %}
+                                                    {% if shipmentItem.productClass.classCategory2 %}
+                                                        <br>{{ shipmentItem.productClass.classCategory2.className }}：{{ shipmentItem.productClass.classCategory2 }}
+                                                    {% endif %}
+                                                </dd>
+                                                <dd id="shipping_box__price--{{ idx }}_{{ shipmentItem.id }}" class="item_price">{{ shipmentItem.priceIncTax|price }} × {{ shipmentItem.quantity|number_format }}</dd>
+                                                <dd id="shipping_box__subtotal--{{ idx }}_{{ shipmentItem.id }}" class="item_subtotal">小計：{{ shipmentItem.totalPrice|price }}</dd>
+                                            </dl>
+                                        </div>
+                                    </div><!--/item_box-->
+                                {% endfor %}
+                                </div>
+                            </div>
+
+                            <p id="shopping_confirm_box__shipping_address_detail--{{ idx }}" class="address">{{ shipping.name01 }} {{ shipping.name02 }} 様<br>
+                            〒{{ shipping.zip01 }}-{{ shipping.zip02 }} {{ shipping.pref }}{{ shipping.addr01 }}{{ shipping.addr02 }}<br>
+                            {{ shipping.tel01 }}-{{ shipping.tel02 }}-{{ shipping.tel03 }}</p>
+                            <div id="shopping_confirm_box__shipping_delivery--{{ idx }}" class="form-inline form-group">
+                                <label>配送方法</label>
+                                {{ form_widget(form.Shippings[idx].Delivery, {'attr': {'class': 'delivery form-control'}}) }}
+                                {{ form_errors(form.Shippings[idx].Delivery) }}
+                            </div>
+
+                            <div id="shopping_confirm_box__shipping_delivery_date_time--{{ idx }}" class="form-inline form-group">
+                                <label>お届け日</label>
+                                {{ form_widget(form.Shippings[idx].shipping_delivery_date, {'attr': {'class': 'form-control'}}) }}<br class="sp">
+                                <label>お届け時間</label>
+                                {{ form_widget(form.Shippings[idx].DeliveryTime, {'attr': {'class': 'form-control'}}) }}
+                            </div>
+                            {% if is_granted('ROLE_USER') %}
+                            <p id="shopping_confirm_box__edit_button--{{ idx }}" class="btn_edit"><a href="{{ url('shopping_shipping', {'id': shipping.id}) }}" class="btn btn-default btn-sm btn-shipping" data-id="{{ shipping.id }}">変更</a></p>
+                            {% else %}
+                            <p id="shopping_confirm_box__edit_button--{{ idx }}" class="btn_edit"><a href="{{ url('shopping_shipping_edit_change', {'id': shipping.id}) }}" class="btn btn-default btn-sm btn-shipping-edit" data-id="{{ shipping.id }}">変更</a></p>
+                            {% endif %}
+                        </div>
+                        {% if loop.last == false%}<hr>{% endif %}
+                    {% endfor %}
+                    {% if BaseInfo.optionMultipleShipping %}
+                        <hr>
+                        <div><a id="shopping_confirm_box__button_edit_multiple"  href="{{ url('shopping_shipping_multiple_change') }}" class="btn btn-default btn-sm btn-shipping-multiple">お届け先を追加する</a></div>
+                    {% endif %}
+
+                    <h2 class="heading02">お支払方法</h2>
+                    <div id="payment_list" class="column">
+                        <div id="payment_list__body" class="form-group">
+                            <ul id="payment_list__list" class="payment_list">
+                            {% for key, child in form.Payment %}
+                            <li>
+                                {{ form_label(child, null, { 'widget' : form_widget(child, {'attr': {'class': 'payment' }}) }) }}
+                                {% if form.Payment.vars.choices[key].data.payment_image is not null %}
+                                <img src="{{ app.config.image_save_urlpath }}/{{ form.payment.vars.choices[key].data.payment_image }}">
+                                {% endif %}
+                            </li>
+                            {% endfor %}
+                            {{ form_errors(form.Payment) }}
+                            </ul>
+                        </div>
+                    </div>
+                    <h2 class="heading02">お問い合わせ欄</h2>
+                    <div id="contact_message" class="column">
+                        {{ form_widget(form.message, {'attr': {'class': 'form-control', 'placeholder': 'お問い合わせ事項がございましたら、こちらにご入力ください。(3000文字まで)', 'rows': '6'}}) }}
+                        {{ form_errors(form.message) }}
+                    </div>
+                    <div class="extra-form column">
+                        {% for f in form.getIterator %}
+                            {% if f.vars.name matches '[^plg*]' %}
+                                {{ form_row(f) }}
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                </div><!-- /.col -->
+
+                <div id="confirm_side" class="col-sm-4">
+                    <div id="summary_box__total_box" class="total_box">
+                        <dl id="summary_box__subtotal">
+                            <dt>小計</dt>
+                            <dd class="text-primary">{{ Order.subtotal|price }}</dd>
+                        </dl>
+                        <dl id="summary_box__quantity_price">
+                            <dt>内手数料</dt>
+                            <dd>{{ Order.charge|price }}</dd>
+                        </dl>
+                        <dl id="summary_box__shipping_price">
+                            <dt>内送料</dt>
+                            <dd>{{ Order.deliveryFeeTotal|price }}</dd>
+                        </dl>
+                        {% if Order.discount > 0 %}
+                        <dl id="summary_box__discount_price">
+                            <dt>内値引き</dt>
+                            <dd>{{ (0 - Order.discount)|price}}</dd>
+                        </dl>
+                        {% endif %}
+                        <div id="summary_box__result" class="total_amount">
+                            <p id="summary_box__total_amount" class="total_price">合計 <strong class="text-primary">{{ Order.total|price }}<span class="small">税込</span></strong></p>
+                            <p id="summary_box__confirm_button"><button id="order-button" type="submit" class="btn btn-primary btn-block prevention-btn prevention-mask">注文する</button></p>
+                        </div>
+                    </div>
+                </div>
+            </div><!-- /.row -->
+        </form>
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Shopping/login.twig
+++ b/src/Eccube/Resource/template/smartphone/Shopping/login.twig
@@ -1,0 +1,97 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'cart_page' %}
+
+{% block main %}
+
+    <h1 class="page-heading">ログイン</h1>
+    <div id="login_wrap" class="container-fluid">
+        <form method="post" action="{{ url('login_check') }}">
+            <input type="hidden" name="_target_path" value="shopping" />
+            <input type="hidden" name="_failure_path" value="shopping_login" />
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
+
+            <div id="login_box" class="login_cart row">
+                {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
+                <div id="customer_box" class="col-sm-8 col-sm-offset-2" style="height: 330px;">
+                {% else %}
+                <div id="customer_box" class="col-sm-8" style="height: 330px;">
+                {% endif %}
+                    <div id="customer_box__body" class="column">
+                        <div id="customer_box__body_inner" class="column_inner clearfix">
+                            <div class="icon"><svg class="cb cb-user-circle"><use xlink:href="#cb-user-circle"></use></svg></div>
+                            <div id="customer_box__login_email" class="form-group">
+                                {{ form_widget(form.login_email, {attr: {'style' : 'ime-mode: disabled;', placeholder: 'メールアドレス', 'autofocus': true}}) }} <br class="sp">
+                            </div>
+                            <div id="customer_box__login_pass" class="form-group">
+                                {{ form_widget(form.login_pass, {attr: {placeholder: 'パスワード'}}) }}
+                                {% if BaseInfo.option_remember_me %}
+                                    {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
+                                        <input type="hidden" name="login_memory" value="1">
+                                    {% else %}
+                                        {{ form_widget(form.login_memory) }}
+                                    {% endif %}
+                                {% endif %}
+                            </div>
+                            <div class="extra-form form-group">
+                                {% for f in form.getIterator %}
+                                    {% if f.vars.name matches '[^plg*]' %}
+                                        {{ form_row(f) }}
+                                        {{ form_widget(f) }}
+                                        {{ form_errors(f) }}
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                            {% if error %}
+                                <div id="customer_box__error_message" class="form-group">
+                                    <span class="text-danger">{{ error|trans|raw }}</span>
+                                </div>
+                            {% endif %}
+                            <div id="customer_box__login_button" class="btn_area">
+                                <p><button type="submit" class="btn btn-info btn-block btn-lg">ログイン</button></p>
+                                <ul id="customer_box__login_menu">
+                                <li><a href="{{ url('forgot') }}">ログイン情報をお忘れですか？</a></li>
+                                <li><a href="{{ url('entry') }}">新規会員登録</a></li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div><!-- /.col -->
+
+                {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
+                {% else %}
+                <div id="guest_box" class="col-sm-4" style="height: 330px;">
+                    <div id="guest_box__body" class="column">
+                        <div id="guest_box__body_inner" class="column_inner">
+                            <p id="guest_box__message" class="message">会員登録をせずに購入手続きをされたい方は、下記よりお進みください。
+                            <p id="guest_box__confirm_button" class="btn_area">
+                                <a href="{{ url('shopping_nonmember') }}" class="btn btn-info btn-block btn-lg">ゲスト購入</a></p>
+                        </div>
+                    </div>
+                </div><!-- /.col -->
+                {% endif %}
+            </div><!-- /.row -->
+        </form>
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Shopping/nonmember.twig
+++ b/src/Eccube/Resource/template/smartphone/Shopping/nonmember.twig
@@ -1,0 +1,130 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'cart_page' %}
+
+{% block javascript %}
+<script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
+<script>
+    $(function() {
+        $('#zip-search').click(function() {
+            AjaxZip3.zip2addr('nonmember[zip][zip01]', 'nonmember[zip][zip02]', 'nonmember[address][pref]', 'nonmember[address][addr01]');
+        });
+    });
+</script>
+{% endblock javascript %}
+
+{% block main %}
+<h1 class="page-heading">お客様情報の入力</h1>
+<div id="detail_wrap" class="container-fluid">
+    <div id="detail_box__body" class="row">
+        <div id="detail_box__body_inner" class="col-md-10 col-md-offset-1">
+            <div id="detail_flow_box__flow_state" class="flowline step4">
+                <ul id="detail_flow_box___flow_state_list"  class="clearfix">
+                    <li><span class="flow_number">1</span><br>カートの商品</li>
+                    <li class="active"><span class="flow_number">2</span><br>お客様情報</li>
+                    <li><span class="flow_number">3</span><br>ご注文内容確認</li>
+                    <li><span class="flow_number">4</span><br>完了</li>
+                </ul>
+            </div>
+            <form method="post" action="{{ url('shopping_nonmember') }}">
+                {{ form_widget(form._token) }}
+                <div id="detail_box__body" class="dl_table">
+                    <dl id="detail_box__name">
+                        <dt>{{ form_label(form.name) }}</dt>
+                        <dd class="form-group input_name">
+                            {{ form_widget(form.name.name01) }}
+                            {{ form_widget(form.name.name02) }}
+                            {{ form_errors(form.name.name01) }}
+                            {{ form_errors(form.name.name02) }}
+                        </dd>
+                    </dl>
+                    <dl id="detail_box__kana">
+                        <dt>{{ form_label(form.kana) }}</dt>
+                        <dd class="form-group input_name">
+                            {{ form_widget(form.kana.kana01) }}
+                            {{ form_widget(form.kana.kana02) }}
+                            {{ form_errors(form.kana.kana01) }}
+                            {{ form_errors(form.kana.kana02) }}
+                        </dd>
+                    </dl>
+                    <dl id="detail_box__company_name">
+                        <dt>{{ form_label(form.company_name) }}</dt>
+                        <dd class="form-group input_name">
+                            {{ form_widget(form.company_name) }}
+                            {{ form_errors(form.company_name) }}
+                        </dd>
+                    </dl>
+                    <dl id="detail_box__address">
+                        <dt>{{ form_label(form.address) }}</dt>
+                        <dd>
+                            <div id="detail_box__zip" class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
+                            <div id="detail_box__address" class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
+                                {{ form_widget(form.address) }}
+                                {{ form_errors(form.address) }}
+                            </div>
+                        </dd>
+                    </dl>
+                    <dl id="detail_box__tel">
+                        <dt>{{ form_label(form.tel) }}</dt>
+                        <dd>
+                            <div class="form-inline form-group input_tel">
+                                {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
+                                {{ form_errors(form.tel) }}
+                            </div>
+                        </dd>
+                    </dl>
+                    <dl id="detail_box__email">
+                        <dt>{{ form_label(form.email) }}</dt>
+                        <dd>
+                            <div class="form-group {% if form.email.first.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.email.first) }}</div>
+                            <div class="form-group {% if form.email.second.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.email.second, {attr: {placeholder: '確認のためもう一度入力してください'}}) }}
+                                {{ form_errors(form.email.first) }}
+                                {{ form_errors(form.email.second) }}
+                            </div>
+                        </dd>
+                    </dl>
+                </div>
+                {% for f in form %}
+                    {% if f.vars.name matches '[^plg*]' %}
+                        <div class="extra-form dl_table">
+                            {{ form_row(f) }}
+                        </div>
+                    {% endif %}
+                {% endfor %}
+                <div id="detail_box__footer" class="row no-padding">
+                    <div id="detail_box__button_menu" class="btn_group col-sm-offset-4 col-sm-4">
+                        <p id="detail_box__next_button">
+                            <button type="submit" class="btn btn-primary btn-block">次へ</button>
+                        </p>
+                        <p id="detail_box__back_button"><a href="{{ url('cart') }}" class="btn btn-info btn-block">戻る</a></p>
+                    </div>
+                </div>
+            </form>
+        </div>
+        <!-- /.col -->
+    </div>
+    <!-- /.row -->
+
+</div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Shopping/shipping.twig
+++ b/src/Eccube/Resource/template/smartphone/Shopping/shipping.twig
@@ -1,0 +1,74 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block main %}
+    <h1 class="page-heading">お届け先の指定</h1>
+    <div id="deliver_wrap" class="container-fluid">
+        <form method="post" action="{{ url('shopping_shipping', {'id': shippingId}) }}">
+            <div id="deliveradd_select" class="row">
+                <div id="list_box__body" class="col-sm-10 col-sm-offset-1">
+                    <p id="list_box__add_button">
+                    {% if Customer.CustomerAddresses|length < app.config.deliv_addr_max %}
+                        <a href="{{ url('shopping_shipping_edit', {'id': shippingId}) }}" class="btn btn-default btn-sm">新規お届け先を追加する</a>
+                    {% else %}
+                        <span id="list_box__deliv_addr_max_message" class="text-danger">お届け先登録上限の{{ app.config.deliv_addr_max }}件に達しています。お届け先を入力したい場合は、削除か変更を行ってください</span>
+                    {% endif %}
+                    </p>
+                    {% if error %}
+                        <p id="list_box__deliv_addr_alert" class="text-danger">お届け先を指定してください。</p>
+                    {% endif %}
+
+                    {% if Customer.CustomerAddresses|length > 0 %}
+                     <div id="list_box__list_body" class="table address_table">
+                        <div id="list_box__list_body_inner" class="tbody">
+                            {% for CustomerAddress in Customer.CustomerAddresses %}
+                            <div id="list_box__item--{{ CustomerAddress.id }}" class="addr_box tr">
+                            <div id="list_box__id--{{ CustomerAddress.id }}" class="icon_radio td"><input type="radio" id="address{{ CustomerAddress.id }}" class="no-style" name="address" value="{{ CustomerAddress.id }}" /></div>
+                            <div id="list_box__address_area--{{ CustomerAddress.id }}" class="column td">
+                                <label for="address{{ CustomerAddress.id }}">
+                                    <p id="list_box__address--{{ CustomerAddress.id }}" class="address">
+                                        {{ CustomerAddress.name01 }}&nbsp;{{ CustomerAddress.name02 }}<br>
+                                        〒{{ CustomerAddress.zip01 }}-{{ CustomerAddress.zip02 }} {{ CustomerAddress.Pref }}{{ CustomerAddress.addr01 }}{{ CustomerAddress.addr02 }}<br>
+                                        {{ CustomerAddress.tel01 }}-{{ CustomerAddress.tel02 }}-{{ CustomerAddress.tel03 }}
+                                    </p>
+                                </label>
+                            </div>
+                            </div>
+                            {% endfor %}
+                            </div>
+                        </div><!--/table-->
+                        {% endif %}
+
+                    <div id="list_box__button_menu" class="row no-padding">
+                        <div class="btn_group col-sm-offset-4 col-sm-4">
+                            <p id="list_box__confirm_button"><button type="submit" class="btn btn-primary btn-block">選択したお届け先に送る</button></p>
+                            <p id="list_box__back_button"><a href="{{ url('shopping') }}" class="btn btn-info btn-block">戻る</a></p>
+                        </div>
+                    </div>
+
+                </div>
+            </div><!-- /.row -->
+        </form>
+
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Shopping/shipping_edit.twig
+++ b/src/Eccube/Resource/template/smartphone/Shopping/shipping_edit.twig
@@ -1,0 +1,127 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'cart_page' %}
+{#ログイン状態によって、表示内容を切替#}
+{% if is_granted('ROLE_USER') is empty %}
+    {% set title = '商品購入/お届け先の変更' %}
+{% endif %}
+
+{% block javascript %}
+    <script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
+    <script>
+        $(function() {
+            $('#zip-search').click(function() {
+                AjaxZip3.zip2addr('shopping_shipping[zip][zip01]', 'shopping_shipping[zip][zip02]', 'shopping_shipping[address][pref]', 'shopping_shipping[address][addr01]');
+            });
+        });
+    </script>
+{% endblock javascript %}
+
+{% block main %}
+    <h1 class="page-heading">お届け先の{% if is_granted('ROLE_USER') %}追加{% else %}変更{% endif %}</h1>
+    <div id="detail_wrap" class="container-fluid">
+        <div id="detail_box" class="row">
+            <form method="post" action="{{ url('shopping_shipping_edit', {'id': shippingId}) }}">
+                {{ form_widget(form._token) }}
+                <div id="detail_box__body" class="col-sm-10 col-sm-offset-1">
+                    <div id="detail_box__body_inner" class="dl_table">
+                        <dl id="detail_box__name">
+                            <dt>{{ form_label(form.name) }}</dt>
+                            <dd class="form-group input_name">
+                                {{ form_widget(form.name.name01) }}
+                                {{ form_widget(form.name.name02) }}
+                                {{ form_errors(form.name.name01) }}
+                                {{ form_errors(form.name.name02) }}
+                            </dd>
+                        </dl>
+                        <dl id="detail_box__kana">
+                            <dt>{{ form_label(form.kana) }}</dt>
+                            <dd class="form-group input_name">
+                                {{ form_widget(form.kana.kana01) }}
+                                {{ form_widget(form.kana.kana02) }}
+                                {{ form_errors(form.kana.kana01) }}
+                                {{ form_errors(form.kana.kana02) }}
+                            </dd>
+                        </dl>
+                        <dl id="detail_box__company_name">
+                            <dt>{{ form_label(form.company_name) }}</dt>
+                            <dd class="form-group input_name">
+                                {{ form_widget(form.company_name) }}
+                                {{ form_errors(form.company_name) }}
+                            </dd>
+                        </dl>
+                        <dl id="detail_box__address">
+                            <dt>{{ form_label(form.address) }}</dt>
+                            <dd>
+                                <div id="detail_box__zip"
+                                     class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
+                                <div id="detail_box__pref"
+                                     class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
+                                    {{ form_widget(form.address) }}
+                                    {{ form_errors(form.address) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl id="detail_box__tel">
+                            <dt>{{ form_label(form.tel) }}</dt>
+                            <dd>
+                                <div class="form-inline form-group input_tel">
+                                    {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
+                                    {{ form_errors(form.tel) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl id="detail_box__fax">
+                            <dt>{{ form_label(form.fax) }}</dt>
+                            <dd>
+                                <div class="form-inline form-group input_tel">
+                                    {{ form_widget(form.fax, {attr : {class : 'short'}}) }}
+                                    {{ form_errors(form.fax) }}
+                                </div>
+                            </dd>
+                        </dl>
+                    </div>
+                    {% for f in form %}
+                        {% if f.vars.name matches '[^plg*]' %}
+                            <div class="extra-form dl_table">
+                                {{ form_row(f) }}
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                    <div id="detail_box_footer" class="row no-padding">
+                        <div id="detail_box__button_menu" class="btn_group col-sm-offset-4 col-sm-4">
+                            <p id="detail_box__insert_button">
+                                <button type="submit" class="btn btn-primary btn-block prevention-btn prevention-mask">
+                                    登録する
+                                </button>
+                            </p>
+                            <p id="detail_box__back_button"><a href="{{ url('shopping') }}"
+                                                               class="btn btn-info btn-block">戻る</a></p>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Shopping/shipping_multiple.twig
+++ b/src/Eccube/Resource/template/smartphone/Shopping/shipping_multiple.twig
@@ -1,0 +1,188 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% block javascript %}
+<script>
+$(function() {
+    $('.add').click(function() {
+        var data = $(this).data();
+        var idx = data.idx;
+        var item = $('#item' + idx);
+        var row = $('#item' + idx + '-0');
+        var addrow = $(row).clone();
+
+        // 行のID設定
+        var i = 0;
+        $('#item' + idx).find('.shipping_item').each(function() {
+            $(this).attr('id', 'item' + idx + '-' + i);
+            i++;
+        });
+        $(addrow).attr('id', 'item' + idx + '-' + i);
+
+        // お届け先設定
+        i = 0;
+        $('#item' + idx).find('select').each(function() {
+            $(this).attr('name', 'form[shipping_multiple][' + idx + '][shipping][' + i + '][customer_address]');
+            i++;
+        });
+        $(addrow).find('select').attr('name', 'form[shipping_multiple][' + idx + '][shipping][' + i + '][customer_address]');
+
+        // 数量設定
+        i = 0;
+        $('#item' + idx).find('input').each(function() {
+            $(this).attr('name', 'form[shipping_multiple][' + idx + '][shipping][' + i + '][quantity]');
+            i++;
+        });
+        $(addrow).find('input').attr('name', 'form[shipping_multiple][' + idx + '][shipping][' + i + '][quantity]');
+
+        // 削除ボタン設定
+        i = 0;
+        $('#item' + idx).find('button').each(function() {
+            $(this).attr('data-itemidx', idx + '-' + i);
+            $(this).data('itemidx', idx + '-' + i);
+            if (i != 0) {
+                // 1行目以外の削除ボタンを表示
+                $(this).removeAttr('style');
+            }
+            i++;
+        });
+        $(addrow).find('button').attr('data-itemidx', idx + '-' + i);
+        $(addrow).find('button').data('itemidx', idx + '-' + i);
+        $(addrow).find('button').removeAttr('style');
+
+        $(item).append($(addrow));
+    });
+
+    $(document).on('click', '.delete', function() {
+        var data = $(this).data();
+        $('#item' + data.itemidx).remove();
+    });
+
+});
+</script>
+{% endblock javascript %}
+
+{% block main %}
+    <h1 class="page-heading">お届け先の複数指定</h1>
+    <div id="multiple_wrap" class="container-fluid">
+        <form id="shipping-multiple-form" method="post" action="{{ url('shopping_shipping_multiple') }}">
+            {{ form_widget(form._token) }}
+            <div id="multiple_list_box" class="row">
+                <div id="multiple_list_box__body" class="col-sm-10 col-sm-offset-1">
+                    <p class="message">各商品のお届け先を選択してください。(※数量の合計は、カゴの中の数量と合わせてください。)</p>
+
+                    {% for error in errors %}
+                        <div class="text-danger">{{ error.message }}</div>
+                    {% endfor %}
+
+                    {% if is_granted('ROLE_USER') %}
+                    {% else %}
+                        <p><a href="{{ url('shopping_shipping_multiple_edit') }}" class="btn btn-default btn-sm">新規お届け先を追加する</a></p>
+                    {% endif %}
+
+                    {% for shipmentItem in shipmentItems %}
+                        {% set idx = loop.index0 %}
+                        {% set itemvalue = 0 %}
+                        <hr>
+                        <div id="multiple_list__item_box--{{ idx }}" class="cart_item table shipping_multiple_table">
+                            <div id="multiple_list__item_box__body--{{ idx }}" class="tbody">
+                                <div id="multiple_list__item_box_body_inner--{{ idx }}" class="item_box tr">
+                                    <div id="multiple_list__item--{{ idx }}" class="td table">
+                                        <div id="multiple_list__image--{{ idx }}" class="item_photo"><img src="{{ app.config.image_save_urlpath }}/{{ shipmentItem.product.MainListImage|no_image_product }}" alt="{{ shipmentItem.productName }}"/></div>
+                                        <dl id="multiple_list__item_detail--{{ idx }}" class="item_detail">
+                                            <dt id="multiple_list__product_name--{{ idx }}" class="item_name text-default">
+                                                <strong>{{ shipmentItem.productName }}</strong></dt>
+                                            <dd id="multiple_list__product_class_category--{{ idx }}" class="item_pattern small">
+                                                <p>
+                                                    {% if shipmentItem.productClass.classCategory1 %}
+                                                        {{ shipmentItem.productClass.classCategory1.className }}：{{ shipmentItem.productClass.classCategory1 }}
+                                                        <br>
+                                                    {% endif %}
+                                                    {% if shipmentItem.productClass.classCategory2 %}
+                                                        {{ shipmentItem.productClass.classCategory2.className }}：{{ shipmentItem.productClass.classCategory2 }}
+                                                        <br>
+                                                    {% endif %}
+                                                </p>
+                                            </dd>
+                                            <dd id="multiple_list__total_price--{{ idx }}">小計：{{ shipmentItem.totalPrice|price }}</dd>
+                                            {% for key, value in compItemQuantities %}
+                                                {% if shipmentItem.productClass.id == key %}
+                                                    <dd id="multiple_list__value--{{ idx }}_{{ key }}">数量：{{ value }}</dd>
+                                                    {% set itemvalue = value %}
+                                                {% endif %}
+                                            {% endfor %}
+                                        </dl>
+                                    </div>
+                                </div>
+                                <!--/item_box-->
+                            </div>
+                        </div><!--/cart_item-->
+
+                        <div id="item{{ idx }}">
+                            {% for shipping in form.shipping_multiple[idx].shipping %}
+                                <div id="item{{ idx }}-{{ loop.index0 }}" class="shipping_item item{{ idx }} form-inline" style="margin-bottom: 5px;">
+                                    <div id="multiple_list__shipping_address--{{ idx }}_{{ loop.index0 }}" class="form-group">
+                                        <label>お届け先</label>
+                                        {{ form_widget(shipping.customer_address, {'attr': {'class': 'shipping'}}) }}
+                                        {{ form_errors(shipping.customer_address) }}
+                                    </div>
+                                    <div id="multiple_list__shipping_quantity--{{ idx }}_{{ loop.index0 }}" class="form-group">
+                                        <label>数量</label>
+                                        {% for key, value in compItemQuantities %}
+                                            {% if shipmentItem.productClass.id == key %}
+                                                {% set quantity = shipping.quantity.vars.value ?: value %}
+                                                {{ form_widget(shipping.quantity, {'attr': {'class': 'quantity'}, 'value': quantity}) }}
+                                                {{ form_errors(shipping.quantity) }}
+                                            {% endif %}
+                                        {% endfor %}
+                                    </div>
+                                    <button id="button__delete--{{ idx }}_{{ loop.index0 }}" type="button" class="btn btn-default btn-sm delete" data-itemidx="{{ idx }}-{{ loop.index0 }}" style="{% if loop.index0 == 0 %}display: none;{% endif %}">削除</button>
+                                </div>
+                            {% endfor %}
+                        </div>
+                        <p id="multiple_list__add_button">
+                            <button id="button__add" type="button" class="btn btn-default btn-sm add" data-idx="{{ idx }}">お届け先追加</button>
+                        </p>
+                    {% endfor %}
+                    <div class="extra-form">
+                        {% for f in form %}
+                            {% if f.vars.name matches '[^plg*]' %}
+                                {{ form_row(f) }}
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                    <div id="multiple_list__footer" class="row no-padding">
+                        <div id="multiple_list__button_menu" class="btn_group col-sm-offset-4 col-sm-4">
+                            <p id="multiple_list__confirm_button">
+                                <button id="button__confirm" type="submit" class="btn btn-primary btn-block">選択したお届け先に送る</button>
+                            </p>
+                            <p id="multiple_list__back_button"><a href="{{ url('shopping') }}" class="btn btn-info btn-block">戻る</a></p>
+                        </div>
+                    </div>
+
+                </div>
+            </div><!-- /.row -->
+        </form>
+    </div>
+
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Shopping/shipping_multiple_edit.twig
+++ b/src/Eccube/Resource/template/smartphone/Shopping/shipping_multiple_edit.twig
@@ -1,0 +1,121 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'cart_page' %}
+
+{% block javascript %}
+    <script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
+    <script>
+        $(function() {
+            $('#zip-search').click(function() {
+                AjaxZip3.zip2addr('shopping_shipping[zip][zip01]', 'shopping_shipping[zip][zip02]', 'shopping_shipping[address][pref]', 'shopping_shipping[address][addr01]');
+            });
+        });
+    </script>
+{% endblock javascript %}
+
+{% block main %}
+    <h1 class="page-heading">お届け先の追加</h1>
+    <div id="detail_wrap" class="container-fluid">
+        <div id="detail_box" class="row">
+            <form method="post" action="{{ url('shopping_shipping_multiple_edit') }}">
+                {{ form_widget(form._token) }}
+                <div id="detail_box__body" class="col-sm-10 col-sm-offset-1">
+                    <div id="detail_box__body_inner" class="dl_table">
+                        <dl>
+                            <dt id="detail_box__name">{{ form_label(form.name) }}</dt>
+                            <dd class="form-group input_name">
+                                {{ form_widget(form.name.name01) }}
+                                {{ form_widget(form.name.name02) }}
+                                {{ form_errors(form.name.name01) }}
+                                {{ form_errors(form.name.name02) }}
+                            </dd>
+                        </dl>
+                        <dl id="detail_box__kana">
+                            <dt>{{ form_label(form.kana) }}</dt>
+                            <dd class="form-group input_name">
+                                {{ form_widget(form.kana.kana01) }}
+                                {{ form_widget(form.kana.kana02) }}
+                                {{ form_errors(form.kana.kana01) }}
+                                {{ form_errors(form.kana.kana02) }}
+                            </dd>
+                        </dl>
+                        <dl id="detail_box__company_name">
+                            <dt>{{ form_label(form.company_name) }}</dt>
+                            <dd class="form-group input_name">
+                                {{ form_widget(form.company_name) }}
+                                {{ form_errors(form.company_name) }}
+                            </dd>
+                        </dl>
+                        <dl id="detail_box__address">
+                            <dt>{{ form_label(form.address) }}</dt>
+                            <dd>
+                                <div id="detail_box__zip"
+                                     class="form-group form-inline input_zip {% if form.zip.zip01.vars.errors is not empty or form.zip.zip02.vars.errors is not empty %}has-error{% endif %}">{{ form_widget(form.zip) }}</div>
+                                <div id="detail_box__pref"
+                                     class="{% if form.address.pref.vars.errors is not empty or form.address.addr01.vars.errors is not empty or form.address.addr02.vars.errors is not empty %}has-error{% endif %}">
+                                    {{ form_widget(form.address) }}
+                                    {{ form_errors(form.address) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl id="detail_box__tel">
+                            <dt>{{ form_label(form.tel) }}</dt>
+                            <dd>
+                                <div class="form-inline form-group input_tel">
+                                    {{ form_widget(form.tel, {attr : {class : 'short'}}) }}
+                                    {{ form_errors(form.tel) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl id="detail_box__fax">
+                            <dt>{{ form_label(form.fax) }}</dt>
+                            <dd>
+                                <div class="form-inline form-group input_tel">
+                                    {{ form_widget(form.fax, {attr : {class : 'short'}}) }}
+                                    {{ form_errors(form.fax) }}
+                                </div>
+                            </dd>
+                        </dl>
+                    </div>
+                    {% for f in form %}
+                        {% if f.vars.name matches '[^plg*]' %}
+                            <div class="extra-form dl_table">
+                                {{ form_row(f) }}
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                    <div id="detail_box__button_menu" class="row no-padding">
+                        <div class="btn_group col-sm-offset-4 col-sm-4">
+                            <p id="detail_box__insert_button">
+                                <button type="submit" class="btn btn-primary btn-block">登録する</button>
+                            </p>
+                            <p id="detail_box__back_button"><a href="{{ url('shopping_shipping_multiple') }}"
+                                                               class="btn btn-info btn-block">戻る</a></p>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/Shopping/shopping_error.twig
+++ b/src/Eccube/Resource/template/smartphone/Shopping/shopping_error.twig
@@ -1,0 +1,51 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'cart_page' %}
+
+{% block main %}
+    <h1 class="page-heading">購入エラー</h1>
+    <div id="error_wrap" class="container-fluid">
+        <div id="error_box" class="row">
+            <div id="error_box__body" class="col-sm-10 col-sm-offset-1">
+                {% for error in app.session.flashbag.get('eccube.front.error')  %}
+                <div id="error_box__error_message-{{ loop.index }}" class="message">
+                    {{ error|trans|nl2br }}
+                </div>
+                {% endfor %}
+                <div id="error_box__footer" class="row no-padding">
+                    <div id="error_box__button_menu" class="btn_group col-sm-offset-4 col-sm-4">
+                        <p id="error_box__top_button">
+                            <a href="{{ url('homepage') }}" class="btn btn-info btn-block">トップページへ</a>
+                        </p>
+                        <p id="error_box__back_button">
+                            <a href="{{ url('cart') }}" class="btn btn-info btn-block">カートに戻る</a>
+                        </p>
+                    </div>
+                </div>
+
+            </div><!-- /.col -->
+        </div><!-- /.row -->
+
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/block.twig
+++ b/src/Eccube/Resource/template/smartphone/block.twig
@@ -1,0 +1,34 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% for Block in Blocks %}
+    <!-- ▼{{ Block.name }} -->
+    {% if Block.logic_flg %}
+        {% if app.config.http_cache.enabled %}
+            {{ render_esi(path('block_' ~ Block.file_name)) }}
+        {% else %}
+            {{ render(path('block_' ~ Block.file_name)) }}
+        {% endif %}
+    {% else %}
+        {{ include('Block/' ~ Block.file_name~ '.twig', ignore_missing = true) }}
+    {% endif %}
+    <!-- ▲{{ Block.name }} -->
+{% endfor %}

--- a/src/Eccube/Resource/template/smartphone/default_frame.twig
+++ b/src/Eccube/Resource/template/smartphone/default_frame.twig
@@ -1,0 +1,181 @@
+<!doctype html>
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>{{ BaseInfo.shop_name }}{% if subtitle is defined and subtitle is not empty %} / {{ subtitle }}{% elseif title is defined and title is not empty %} / {{ title }}{% endif %}</title>
+{% if PageLayout.author is not empty %}
+    <meta name="author" content="{{ PageLayout.author }}">
+{% endif %}
+{% if PageLayout.description is not empty %}
+    <meta name="description" content="{{ PageLayout.description }}">
+{% endif %}
+{% if PageLayout.keyword is not empty %}
+    <meta name="keywords" content="{{ PageLayout.keyword }}">
+{% endif %}
+{% if PageLayout.meta_robots is not empty %}
+    <meta name="robots" content="{{ PageLayout.meta_robots }}">
+{% endif %}
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="icon" href="{{ app.config.front_urlpath }}/img/common/favicon.ico">
+<link rel="stylesheet" href="{{ app.config.front_urlpath }}/css/style.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}">
+<link rel="stylesheet" href="{{ app.config.front_urlpath }}/css/slick.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}">
+<link rel="stylesheet" href="{{ app.config.front_urlpath }}/css/default.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}">
+<!-- for original theme CSS -->
+{% block stylesheet %}{% endblock %}
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+<script>window.jQuery || document.write('<script src="{{ app.config.front_urlpath }}/js/vendor/jquery-1.11.3.min.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"><\/script>')</script>
+
+{# ▼Head COLUMN #}
+{% if PageLayout.Head %}
+    {# ▼上ナビ #}
+    {{ include('block.twig', {'Blocks': PageLayout.Head}) }}
+    {# ▲上ナビ #}
+{% endif %}
+{# ▲Head COLUMN #}
+
+</head>
+<body id="page_{{ app.request_stack.currentrequest.get('_route') }}" class="{{ body_class|default('other_page') }}">
+<div id="wrapper">
+    <header id="header">
+        <div class="container-fluid inner">
+            {# ▼HeaderInternal COLUMN #}
+            {% if PageLayout.Header %}
+                {# ▼上ナビ #}
+                {{ include('block.twig', {'Blocks': PageLayout.Header}) }}
+                {# ▲上ナビ #}
+            {% endif %}
+            {# ▲HeaderInternal COLUMN #}
+            <p id="btn_menu"><a class="nav-trigger" href="#nav">Menu<span></span></a></p>
+        </div>
+    </header>
+
+    <div id="contents" class="{{ PageLayout.theme }}">
+
+        <div id="contents_top">
+            {# ▼TOP COLUMN #}
+            {% if PageLayout.ContentsTop %}
+                {# ▼上ナビ #}
+                {{ include('block.twig', {'Blocks': PageLayout.ContentsTop}) }}
+                {# ▲上ナビ #}
+            {% endif %}
+            {# ▲TOP COLUMN #}
+        </div>
+
+        <div class="container-fluid inner">
+            {# ▼LEFT COLUMN #}
+            {% if PageLayout.SideLeft %}
+                <div id="side_left" class="side">
+                    {# ▼左ナビ #}
+                    {{ include('block.twig', {'Blocks': PageLayout.SideLeft}) }}
+                    {# ▲左ナビ #}
+                </div>
+            {% endif %}
+            {# ▲LEFT COLUMN #}
+
+            <div id="main">
+                {# ▼メイン上部 #}
+                {% if PageLayout.MainTop %}
+                    <div id="main_top">
+                        {{ include('block.twig', {'Blocks': PageLayout.MainTop}) }}
+                    </div>
+                {% endif %}
+                {# ▲メイン上部 #}
+
+                <div id="main_middle">
+                    {% block main %}{% endblock %}
+                </div>
+
+                {# ▼メイン下部 #}
+                {% if PageLayout.MainBottom %}
+                    <div id="main_bottom">
+                        {{ include('block.twig', {'Blocks': PageLayout.MainBottom}) }}
+                    </div>
+                {% endif %}
+                {# ▲メイン下部 #}
+            </div>
+
+            {# ▼RIGHT COLUMN #}
+            {% if PageLayout.SideRight %}
+                <div id="side_right" class="side">
+                    {# ▼右ナビ #}
+                    {{ include('block.twig', {'Blocks': PageLayout.SideRight}) }}
+                    {# ▲右ナビ #}
+                </div>
+            {% endif %}
+            {# ▲RIGHT COLUMN #}
+
+            {# ▼BOTTOM COLUMN #}
+            {% if PageLayout.ContentsBottom %}
+                <div id="contents_bottom">
+                    {# ▼下ナビ #}
+                    {{ include('block.twig', {'Blocks': PageLayout.ContentsBottom}) }}
+                    {# ▲下ナビ #}
+                </div>
+            {% endif %}
+            {# ▲BOTTOM COLUMN #}
+
+        </div>
+
+        <footer id="footer">
+            {# ▼Footer COLUMN#}
+            {% if PageLayout.Footer %}
+                {# ▼上ナビ #}
+                {{ include('block.twig', {'Blocks': PageLayout.Footer}) }}
+                {# ▲上ナビ #}
+            {% endif %}
+            {# ▲Footer COLUMN#}
+
+        </footer>
+
+    </div>
+
+    <div id="drawer" class="drawer sp">
+    </div>
+
+</div>
+
+<div class="overlay"></div>
+
+<script src="{{ app.config.front_urlpath }}/js/vendor/bootstrap.custom.min.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
+<script src="{{ app.config.front_urlpath }}/js/vendor/slick.min.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
+<script src="{{ app.config.front_urlpath }}/js/function.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
+<script src="{{ app.config.front_urlpath }}/js/eccube.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
+<script>
+$(function () {
+    $('#drawer').append($('.drawer_block').clone(true).children());
+    $.ajax({
+        url: '{{ app.config.front_urlpath }}/img/common/svg.html',
+        type: 'GET',
+        dataType: 'html',
+    }).done(function(data){
+        $('body').prepend(data);
+    }).fail(function(data){
+    });
+});
+</script>
+{% block javascript %}{% endblock %}
+</body>
+</html>

--- a/src/Eccube/Resource/template/smartphone/error.twig
+++ b/src/Eccube/Resource/template/smartphone/error.twig
@@ -1,0 +1,77 @@
+<!doctype html>
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+<html lang="ja">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>{{ error_title }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="{{ app.config.front_urlpath }}/img/common/favicon.ico">
+    <link rel="stylesheet" href="{{ app.config.front_urlpath }}/css/style.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}">
+    <link rel="stylesheet" href="{{ app.config.front_urlpath }}/css/default.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"><!-- for original theme CSS -->
+
+</head>
+<body>
+<div id="wrapper" class="error_page">
+    <div id="contents" class="theme_main_only">
+        <div class="container-fluid inner">
+            <div id="main">
+                <div id="default_error_wrap" class="container-fluid">
+                    <div id="default_error_box" class="message_box">
+                        <div id="default_error_box__body" class="row no-padding">
+                            <div id="default_error__message" class="col-sm-6 col-sm-offset-3">
+                                <div class="icon"><svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg></div>
+                                <h1>{{ error_title }}</h1>
+                                <p>{{ error_message }}</p>
+                            </div>
+                        </div>
+                        <div id="default_error__footer" class="row">
+                            <div id="default_error__top_button" class="btn_group col-sm-offset-4 col-sm-4">
+                                <a href="{{ url('homepage') }}"><p><button type="button" class="btn btn-info btn-block">トップページへ</button></p></a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+<script>window.jQuery || document.write('<script src="{{ app.config.front_urlpath }}/js/vendor/jquery-1.11.3.min.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"><\/script>')</script>
+<script src="{{ app.config.front_urlpath }}/js/function.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
+<script>
+    $(function () {
+        $.ajax({
+            url: '{{ app.config.front_urlpath }}/img/common/svg.html',
+            type: 'GET',
+            dataType: 'html',
+        }).done(function(data){
+            $('body').prepend(data);
+        }).fail(function(data){
+        });
+    });
+</script>
+
+</body>
+</html>

--- a/src/Eccube/Resource/template/smartphone/index.twig
+++ b/src/Eccube/Resource/template/smartphone/index.twig
@@ -1,0 +1,55 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'front_page' %}
+
+{% block javascript %}
+<script>
+$(function(){
+    $('.main_visual').slick({
+        dots: true,
+        arrows: false,
+        autoplay: true,
+        speed: 300
+    });
+});
+</script>
+{% endblock %}
+
+{% block main %}
+    <div class="row">
+       <div class="col-sm-12">
+            <div class="main_visual">
+                <div class="item">
+                  <img src="{{ app.config.front_urlpath }}/img/top/mv01.jpg">
+                </div>
+                <div class="item">
+                  <img src="{{ app.config.front_urlpath }}/img/top/mv02.jpg">
+                </div>
+                <div class="item">
+                  <img src="{{ app.config.front_urlpath }}/img/top/mv03.jpg">
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/smartphone/pagination.twig
+++ b/src/Eccube/Resource/template/smartphone/pagination.twig
@@ -1,0 +1,81 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% if app.config.pageinrange  is defined %}
+    {% set pageinrange  = app.config.pageinrange %}
+{% else  %}
+    {% set pageinrange  = false %}
+{% endif %}
+
+{% if pages.pageCount > 1 %}
+<div id="pagination_wrap" class="pagination">
+    <ul>
+
+        {% if pageinrange and pages.firstPageInRange != 1 %}
+            {# 最初へリンクを表示 #}
+            <li class="pagenation__item-first">
+                <a href="{{ path(app.request_stack.currentrequest.attributes.get('_route'), app.request_stack.currentrequest.query.all|merge({'pageno': pages.first})) }}"
+                   aria-label="First"><span aria-hidden="true">最初へ</span></a>
+            </li>
+        {% endif %}
+
+        {% if pages.previous is defined %}
+            <li class="pagenation__item-previous">
+                <a href="{{ path(app.request_stack.currentrequest.attributes.get('_route'), app.request_stack.currentrequest.query.all|merge({'pageno': pages.previous})) }}"
+                   aria-label="Previous"><span aria-hidden="true">前へ</span></a>
+            </li>
+        {% endif %}
+
+        {% if pageinrange and pages.firstPageInRange != 1 %}
+            {# 1ページリンクが表示されない場合、「...」を表示 #}
+            <li>...</li>
+        {% endif %}
+
+        {% for page in pages.pagesInRange %}
+            {% if page == pages.current %}
+                <li class="pagenation__item active"><a href="{{ path(app.request_stack.currentrequest.attributes.get('_route'), app.request_stack.currentrequest.query.all|merge({'pageno': page})) }}"> {{ page }} </a></li>
+            {% else %}
+                <li class="pagenation__item"><a href="{{ path(app.request_stack.currentrequest.attributes.get('_route'), app.request_stack.currentrequest.query.all|merge({'pageno': page})) }}"> {{ page }} </a></li>
+            {% endif %}
+        {% endfor %}
+
+        {% if pageinrange and pages.last != pages.lastPageInRange %}
+            {# 最終ページリンクが表示されない場合、「...」を表示 #}
+            <li>...</li>
+        {% endif %}
+
+        {% if pages.next is defined %}
+            <li class="pagenation__item-next">
+                <a href="{{ path(app.request_stack.currentrequest.attributes.get('_route'), app.request_stack.currentrequest.query.all|merge({'pageno': pages.next})) }}"
+                   aria-label="Next"><span aria-hidden="true">次へ</span></a>
+            </li>
+        {% endif %}
+
+        {% if pageinrange and pages.last != pages.lastPageInRange %}
+            {# 最後へリンクを表示 #}
+            <li class="pagenation__item-last">
+                <a href="{{ path(app.request_stack.currentrequest.attributes.get('_route'), app.request_stack.currentrequest.query.all|merge({'pageno': pages.last})) }}"
+                   aria-label="Last"><span aria-hidden="true">最後へ</span></a>
+            </li>
+        {% endif %}
+    </ul>
+</div>
+{% endif %}

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -179,12 +179,7 @@ class ShoppingService
         $Order = $this->getNewOrder($Customer);
         $Order->setPreOrderId($preOrderId);
 
-        // device type
-        if ($this->app['mobile_detect']->isMobile()) {
-            $DeviceType = $this->app['eccube.repository.master.device_type']->find(DeviceType::DEVICE_TYPE_SP);
-        } else {
-            $DeviceType = $this->app['eccube.repository.master.device_type']->find(DeviceType::DEVICE_TYPE_PC);
-        }
+        $DeviceType = $this->app['eccube.repository.master.device_type']->find($this->app['mobile_detect.device_type']);
         $Order->setDeviceType($DeviceType);
 
         $this->em->persist($Order);

--- a/src/Eccube/ServiceProvider/MobileDetectServiceProvider.php
+++ b/src/Eccube/ServiceProvider/MobileDetectServiceProvider.php
@@ -1,25 +1,27 @@
 <?php
-/*
-* This file is part of MobileDetectServiceProvider.
-*
-* (c) Lhassan Baazzi <baazzilhassan@gmail.com>
-*
-* For the full copyright and license information, please view the LICENSE
-* file that was distributed with this source code.
-*/
+
 namespace Eccube\ServiceProvider;
 
 use Pimple\ServiceProviderInterface;
 use Pimple\Container;
+
 /**
  * @see https://github.com/jbinfo/MobileDetectServiceProvider/pull/4
  */
 class MobileDetectServiceProvider implements ServiceProviderInterface
 {
-    public function register(Container $container)
+    public function register(Container $app)
     {
-        $container['mobile_detect'] = function($c) {
+        $app['mobile_detect'] = function($app) {
             return new \Mobile_Detect();
+        };
+
+        $app['mobile_detect.device_type'] = function ($app) {
+            if ($app['mobile_detect']->isMobile()) {
+                return \Eccube\Entity\Master\DeviceType::DEVICE_TYPE_SP;
+            } else {
+                return \Eccube\Entity\Master\DeviceType::DEVICE_TYPE_PC;
+            }
         };
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ UA を判定して、テンプレートを切り替える実装
+ #2266 

## 方針(Policy)
+ Twig のロードパスを切り替えるのみ
+ MobileDetectServiceProvider にて、判定用のコンテナを生成

## 実装に関する補足(Appendix)
+ `template_realdir` や、 `template_code` の扱いは考慮していない
+ スマートフォン用のテンプレートは、 PC 用を単純にコピーしたのみ

## テスト（Test)
+ スマートフォンでアクセスすると、ヘッダに **スマートフォンで閲覧いただいております。** と表示されます

## 相談（Discussion）
+ `template_realdir` や、 `template_code` の扱いを要検討

