### PR TITLE
【受注管理】メール通知履歴を印刷可能なレイアウトに変更

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/mail.twig
+++ b/src/Eccube/Resource/template/admin/Order/mail.twig
@@ -164,7 +164,7 @@ $(function() {
     <div class="modal-content">
       <div class="modal-body">
       </div>
-      <div class="modal-footer">
+      <div class="modal-footer hidden-print">
         <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
       </div>
     </div>

--- a/src/Eccube/Resource/template/admin/Order/mail_view.twig
+++ b/src/Eccube/Resource/template/admin/Order/mail_view.twig
@@ -20,17 +20,12 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #}
 <style media="print" type="text/css">
-    #mailModal {
+    .modal-open .modal {
         position: absolute;
         display: block;
-        width: auto;
-        height: auto;
         overflow: visible;
     }
-    #main {
-        visibility:hidden;
-    }
-    #mailModal .modal-footer {
+    .modal-open #main {
         visibility:hidden;
     }
 </style>

--- a/src/Eccube/Resource/template/admin/Order/mail_view.twig
+++ b/src/Eccube/Resource/template/admin/Order/mail_view.twig
@@ -19,6 +19,19 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #}
+<style media="print" type="text/css">
+    #mailModal {
+        position: absolute;
+        display: block;
+        width: auto;
+        height: auto;
+        overflow: visible;
+    }
+    #main {
+        visibility:hidden;
+    }
+</style>
+
 <strong>{{ subject }}</strong>
 <br><br>
 <small>{{ body|raw|nl2br }}</small>

--- a/src/Eccube/Resource/template/admin/Order/mail_view.twig
+++ b/src/Eccube/Resource/template/admin/Order/mail_view.twig
@@ -30,6 +30,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     #main {
         visibility:hidden;
     }
+    #mailModal .modal-footer {
+        visibility:hidden;
+    }
 </style>
 
 <strong>{{ subject }}</strong>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ Print preview a mail modal.
+ #2188 

## 方針(Policy)
+ When printing e-mail notification history is displayed, the modal part covers the back management screen.	
+ Expected: When printing is selected while modal display is performed, only modal is printed.

## 実装に関する補足(Appendix)
+ Compatible with PHP: 5.3-7
+ Compatible with Mysql and Pgsql.
+ Compatible with Chrome lastest, firefox lastest, ie >= 11

## テスト（Test)
+ Chrome lastest, firefox lastest, ie 11

## 相談（Discussion）