### PR TITLE
カート追加処理の実装例

### DIFF
--- a/src/Eccube/Controller/CartController.php
+++ b/src/Eccube/Controller/CartController.php
@@ -345,6 +345,140 @@ class CartController extends AbstractController
     }
 
     /**
+     * カートに入っている商品の個数を1増やす.
+     *
+     * @param Application $app
+     * @param Request $request
+     * @param $cart_no
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     */
+    public function upCartNo(Application $app, Request $request, $cart_no)
+    {
+        $this->isTokenValid($app);
+
+        // FRONT_CART_UP_INITIALIZE
+        $event = new EventArgs(
+            array(
+                'cart_no' => $cart_no,
+            ),
+            $request
+        );
+        $app['eccube.event.dispatcher']->dispatch(EccubeEvents::FRONT_CART_UP_CART_NO_INITIALIZE, $event);
+
+        try {
+
+            log_info('カート加算処理開始', array('cart_no' => $cart_no));
+
+            $cart_no = $event->getArgument('cart_no');
+
+            $app['eccube.service.cart']->upCartNoQuantity($cart_no)->save();
+
+            // FRONT_CART_UP_COMPLETE
+            $event = new EventArgs(
+                array(
+                    'cart_no' => $cart_no,
+                ),
+                $request
+            );
+            $app['eccube.event.dispatcher']->dispatch(EccubeEvents::FRONT_CART_UP_CART_NO_COMPLETE, $event);
+
+            if ($event->hasResponse()) {
+                return $event->getResponse();
+            }
+
+            log_info('カート加算処理完了', array('cart_no' => $cart_no));
+
+        } catch (CartException $e) {
+
+            log_info('カート加算エラー', array($e->getMessage()));
+
+            // FRONT_CART_UP_EXCEPTION
+            $event = new EventArgs(
+                array(
+                    'exception' => $e,
+                ),
+                $request
+            );
+            $app['eccube.event.dispatcher']->dispatch(EccubeEvents::FRONT_CART_UP_CART_NO_EXCEPTION, $event);
+
+            if ($event->hasResponse()) {
+                return $event->getResponse();
+            }
+
+            $app->addRequestError($e->getMessage());
+        }
+
+        return $app->redirect($app->url('cart'));
+    }
+
+    /**
+     * カートに入っている商品の個数を1減らす.
+     *
+     * @param Application $app
+     * @param Request $request
+     * @param $cart_no
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     */
+    public function downCartNo(Application $app, Request $request, $cart_no)
+    {
+        $this->isTokenValid($app);
+
+        // FRONT_CART_DOWN_INITIALIZE
+        $event = new EventArgs(
+            array(
+                'cart_no' => $cart_no,
+            ),
+            $request
+        );
+        $app['eccube.event.dispatcher']->dispatch(EccubeEvents::FRONT_CART_DOWN_CART_NO_INITIALIZE, $event);
+
+        try {
+
+            log_info('カート減算処理開始', array('cart_no' => $cart_no));
+
+            $cart_no = $event->getArgument('cart_no');
+
+            $app['eccube.service.cart']->downCartNoQuantity($cart_no)->save();
+
+            // FRONT_CART_DOWN_COMPLETE
+            $event = new EventArgs(
+                array(
+                    'cart_no' => $cart_no,
+                ),
+                $request
+            );
+            $app['eccube.event.dispatcher']->dispatch(EccubeEvents::FRONT_CART_DOWN_CART_NO_COMPLETE, $event);
+
+            if ($event->hasResponse()) {
+                return $event->getResponse();
+            }
+
+            log_info('カート減算処理完了', array('cart_no' => $cart_no));
+
+        } catch (CartException $e) {
+
+            log_info('カート減算エラー', array($e->getMessage()));
+
+            // FRONT_CART_DOWN_EXCEPTION
+            $event = new EventArgs(
+                array(
+                    'exception' => $e,
+                ),
+                $request
+            );
+            $app['eccube.event.dispatcher']->dispatch(EccubeEvents::FRONT_CART_DOWN_CART_NO_EXCEPTION, $event);
+
+            if ($event->hasResponse()) {
+                return $event->getResponse();
+            }
+
+            $app->addRequestError($e->getMessage());
+        }
+
+        return $app->redirect($app->url('cart'));
+    }
+
+    /**
      * カートに入っている商品を削除する.
      *
      * @param Application $app

--- a/src/Eccube/Controller/Mypage/MypageController.php
+++ b/src/Eccube/Controller/Mypage/MypageController.php
@@ -204,7 +204,21 @@ class MypageController extends AbstractController
             try {
                 if ($OrderDetail->getProduct() &&
                     $OrderDetail->getProductClass()) {
-                    $app['eccube.service.cart']->addProduct($OrderDetail->getProductClass()->getId(), $OrderDetail->getQuantity())->save();
+                    $CartItem = $app['eccube.service.cart']->generateCartItem($OrderDetail->getProductClass());
+                    $CartItem->setQuantity($OrderDetail->getQuantity());
+
+                    $event = new EventArgs(
+                        array(
+                            'Order' => $Order,
+                            'OrderDetail' => $OrderDetail,
+                            'Customer' => $Customer,
+                            'CartItem' => $CartItem,
+                        ),
+                        $request
+                    );
+                    $app['eccube.event.dispatcher']->dispatch(EccubeEvents::FRONT_MYPAGE_MYPAGE_ORDER_ADD_CART, $event);
+
+                    $app['eccube.service.cart']->addCartItem($CartItem)->save();
                 } else {
                     log_info($app->trans('cart.product.delete'), array($id));
                     $app->addRequestError('cart.product.delete');

--- a/src/Eccube/ControllerProvider/FrontControllerProvider.php
+++ b/src/Eccube/ControllerProvider/FrontControllerProvider.php
@@ -54,6 +54,7 @@ class FrontControllerProvider implements ControllerProviderInterface
         // setquantity deprecated since 3.0.0, to be removed in 3.1
         $c->put('/cart/setQuantity/{productClassId}/{quantity}', '\Eccube\Controller\CartController::setQuantity')->bind('cart_set_quantity')->assert('productClassId', '\d+')->assert('quantity', '\d+');
         $c->put('/cart/remove/{productClassId}', '\Eccube\Controller\CartController::remove')->bind('cart_remove')->assert('productClassId', '\d+');
+        $c->put('/cart/remove/cart_no/{cart_no}', '\Eccube\Controller\CartController::removeCartNo')->bind('cart_remove_cart_no')->assert('cart_no', '\d+');
         $c->match('/cart/buystep', '\Eccube\Controller\CartController::buystep')->bind('cart_buystep');
 
         // contact

--- a/src/Eccube/ControllerProvider/FrontControllerProvider.php
+++ b/src/Eccube/ControllerProvider/FrontControllerProvider.php
@@ -50,7 +50,9 @@ class FrontControllerProvider implements ControllerProviderInterface
         $c->match('/cart', '\Eccube\Controller\CartController::index')->bind('cart');
         $c->post('/cart/add', '\Eccube\Controller\CartController::add')->bind('cart_add');
         $c->put('/cart/up/{productClassId}', '\Eccube\Controller\CartController::up')->bind('cart_up')->assert('productClassId', '\d+');
+        $c->put('/cart/up/cart_no/{cart_no}', '\Eccube\Controller\CartController::upCartNo')->bind('cart_up_cart_no')->assert('cart_no', '\d+');
         $c->put('/cart/down/{productClassId}', '\Eccube\Controller\CartController::down')->bind('cart_down')->assert('productClassId', '\d+');
+        $c->put('/cart/down/cart_no/{cart_no}', '\Eccube\Controller\CartController::downCartNo')->bind('cart_down_cart_no')->assert('cart_no', '\d+');
         // setquantity deprecated since 3.0.0, to be removed in 3.1
         $c->put('/cart/setQuantity/{productClassId}/{quantity}', '\Eccube\Controller\CartController::setQuantity')->bind('cart_set_quantity')->assert('productClassId', '\d+')->assert('quantity', '\d+');
         $c->put('/cart/remove/{productClassId}', '\Eccube\Controller\CartController::remove')->bind('cart_remove')->assert('productClassId', '\d+');

--- a/src/Eccube/Entity/Cart.php
+++ b/src/Eccube/Entity/Cart.php
@@ -153,23 +153,6 @@ class Cart extends \Eccube\Entity\AbstractEntity
     }
 
     /**
-     * カート商品を削除する
-     *
-     * @param CartItem $CartItem カート商品 (同じインスタンスである必要はない)
-     * @param \Eccube\Service\CartCompareService $compareService
-     * @return $this
-     */
-    public function removeCartItemByCartItem(CartItem $CartItem, $compareService)
-    {
-        $TargetCartItem = $compareService->getExistsCartItem($CartItem);
-        if ($TargetCartItem) {
-            $this->CartItems->removeElement($TargetCartItem);
-        }
-
-        return $this;
-    }
-
-    /**
      * @return \Eccube\Entity\Cart
      */
     public function clearCartItems()

--- a/src/Eccube/Entity/Cart.php
+++ b/src/Eccube/Entity/Cart.php
@@ -91,21 +91,17 @@ class Cart extends \Eccube\Entity\AbstractEntity
 
     /**
      * @param  \Eccube\Entity\CartItem $AddCartItem
+     * @param  \Eccube\Service\CartCompareService $compareService
      * @return \Eccube\Entity\Cart
      */
-    public function setCartItem(\Eccube\Entity\CartItem $AddCartItem)
+    public function setCartItem(\Eccube\Entity\CartItem $AddCartItem, $compareService)
     {
-        $find = false;
-        foreach ($this->CartItems as $CartItem) {
-            if ($CartItem->getClassName() === $AddCartItem->getClassName() && $CartItem->getClassId() === $AddCartItem->getClassId()) {
-                $find = true;
-                $CartItem
-                    ->setPrice($AddCartItem->getPrice())
-                    ->setQuantity($AddCartItem->getQuantity());
-            }
-        }
-
-        if (!$find) {
+        $CartItem = $compareService->getExistsCartItem($AddCartItem);
+        if ($CartItem) {
+            $CartItem
+                ->setPrice($AddCartItem->getPrice())
+                ->setQuantity($AddCartItem->getQuantity());
+        } else {
             $this->addCartItem($AddCartItem);
         }
 

--- a/src/Eccube/Entity/Cart.php
+++ b/src/Eccube/Entity/Cart.php
@@ -147,6 +147,23 @@ class Cart extends \Eccube\Entity\AbstractEntity
     }
 
     /**
+     * カート商品を削除する
+     *
+     * @param CartItem $CartItem カート商品 (同じインスタンスである必要はない)
+     * @param \Eccube\Service\CartCompareService $compareService
+     * @return $this
+     */
+    public function removeCartItemByCartItem(CartItem $CartItem, $compareService)
+    {
+        $TargetCartItem = $compareService->getExistsCartItem($CartItem);
+        if ($TargetCartItem) {
+            $this->CartItems->removeElement($TargetCartItem);
+        }
+
+        return $this;
+    }
+
+    /**
      * @return \Eccube\Entity\Cart
      */
     public function clearCartItems()

--- a/src/Eccube/Entity/Cart.php
+++ b/src/Eccube/Entity/Cart.php
@@ -153,6 +153,23 @@ class Cart extends \Eccube\Entity\AbstractEntity
     }
 
     /**
+     * カート商品をcart_noから削除する
+     *
+     * @param int $cart_no
+     * @return $this
+     */
+    public function removeCartItemByCartNo($cart_no)
+    {
+        $this->CartItems->map(function ($CartItem) use ($cart_no) {
+            if ($CartItem->getCartNo() == $cart_no) {
+                $this->CartItems->removeElement($CartItem);
+            }
+        });
+
+        return $this;
+    }
+
+    /**
      * @return \Eccube\Entity\Cart
      */
     public function clearCartItems()

--- a/src/Eccube/Entity/Cart.php
+++ b/src/Eccube/Entity/Cart.php
@@ -42,6 +42,11 @@ class Cart extends \Eccube\Entity\AbstractEntity
     private $pre_order_id = null;
 
     /**
+     * @var int
+     */
+    private $current_cart_no = 0;
+
+    /**
      * @var array
      */
     private $Payments = array();
@@ -96,9 +101,9 @@ class Cart extends \Eccube\Entity\AbstractEntity
      */
     public function setCartItem(\Eccube\Entity\CartItem $AddCartItem, $compareService)
     {
-        $CartItem = $compareService->getExistsCartItem($AddCartItem);
-        if ($CartItem) {
-            $CartItem
+        $ExistsCartItem = $compareService->getExistsCartItem($AddCartItem);
+        if ($ExistsCartItem) {
+            $ExistsCartItem
                 ->setPrice($AddCartItem->getPrice())
                 ->setQuantity($AddCartItem->getQuantity());
         } else {
@@ -114,6 +119,7 @@ class Cart extends \Eccube\Entity\AbstractEntity
      */
     public function addCartItem(CartItem $CartItem)
     {
+        $CartItem->setCartNo($this->getNextCartNo());
         $this->CartItems[] = $CartItem;
 
         return $this;
@@ -241,4 +247,8 @@ class Cart extends \Eccube\Entity\AbstractEntity
         return $this;
     }
 
+    public function getNextCartNo()
+    {
+        return $this->current_cart_no++;
+    }
 }

--- a/src/Eccube/Entity/CartItem.php
+++ b/src/Eccube/Entity/CartItem.php
@@ -26,7 +26,7 @@ namespace Eccube\Entity;
 
 class CartItem extends \Eccube\Entity\AbstractEntity
 {
-
+    private $cart_no;
     private $class_name;
     private $class_id;
     private $price;
@@ -39,7 +39,26 @@ class CartItem extends \Eccube\Entity\AbstractEntity
 
     public function __sleep()
     {
-        return array('class_name', 'class_id', 'price', 'quantity');
+        return array('cart_no', 'class_name', 'class_id', 'price', 'quantity');
+    }
+
+    /**
+     * @param int $cart_no
+     * @return CartItem
+     */
+    public function setCartNo($cart_no)
+    {
+        $this->cart_no = $cart_no;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCartNo()
+    {
+        return $this->cart_no;
     }
 
     /**

--- a/src/Eccube/Event/EccubeEvents.php
+++ b/src/Eccube/Event/EccubeEvents.php
@@ -433,6 +433,7 @@ final class EccubeEvents
 
     // order
     const FRONT_MYPAGE_MYPAGE_ORDER_INITIALIZE = 'front.mypage.mypage.order.initialize';
+    const FRONT_MYPAGE_MYPAGE_ORDER_ADD_CART = 'front.mypage.mypage.order.add_cart';
     const FRONT_MYPAGE_MYPAGE_ORDER_COMPLETE = 'front.mypage.mypage.order.complete';
 
     // favorite

--- a/src/Eccube/Event/EccubeEvents.php
+++ b/src/Eccube/Event/EccubeEvents.php
@@ -517,6 +517,7 @@ final class EccubeEvents
     // detail
     const FRONT_PRODUCT_DETAIL_INITIALIZE = 'front.product.detail.initialize';
     const FRONT_PRODUCT_DETAIL_FAVORITE = 'front.product.detail.favorite';
+    const FRONT_PRODUCT_DETAIL_ADD_CART = 'front.product.detail.add_cart';
     const FRONT_PRODUCT_DETAIL_COMPLETE = 'front.product.detail.complete';
 
 

--- a/src/Eccube/Event/EccubeEvents.php
+++ b/src/Eccube/Event/EccubeEvents.php
@@ -474,6 +474,10 @@ final class EccubeEvents
     const FRONT_CART_REMOVE_INITIALIZE = 'front.cart.remove.initialize';
     const FRONT_CART_REMOVE_COMPLETE = 'front.cart.remove.complete';
 
+    // remove_cart_no
+    const FRONT_CART_REMOVE_CART_NO_INITIALIZE = 'front.cart.remove_cart_no.initialize';
+    const FRONT_CART_REMOVE_CART_NO_COMPLETE = 'front.cart.remove_cart_no.complete';
+
     // buystep
     const FRONT_CART_BUYSTEP_INITIALIZE = 'front.cart.buystep.initialize';
     const FRONT_CART_BUYSTEP_COMPLETE = 'front.cart.buystep.complete';

--- a/src/Eccube/Event/EccubeEvents.php
+++ b/src/Eccube/Event/EccubeEvents.php
@@ -474,6 +474,16 @@ final class EccubeEvents
     const FRONT_CART_REMOVE_INITIALIZE = 'front.cart.remove.initialize';
     const FRONT_CART_REMOVE_COMPLETE = 'front.cart.remove.complete';
 
+    // up_cart_no
+    const FRONT_CART_UP_CART_NO_INITIALIZE = 'front.cart.up_cart_no.initialize';
+    const FRONT_CART_UP_CART_NO_COMPLETE = 'front.cart.up_cart_no.complete';
+    const FRONT_CART_UP_CART_NO_EXCEPTION = 'front.cart.up_cart_no.exception';
+
+    // down_cart_no
+    const FRONT_CART_DOWN_CART_NO_INITIALIZE = 'front.cart.down_cart_no.initialize';
+    const FRONT_CART_DOWN_CART_NO_COMPLETE = 'front.cart.down_cart_no.complete';
+    const FRONT_CART_DOWN_CART_NO_EXCEPTION = 'front.cart.down_cart_no.exception';
+
     // remove_cart_no
     const FRONT_CART_REMOVE_CART_NO_INITIALIZE = 'front.cart.remove_cart_no.initialize';
     const FRONT_CART_REMOVE_CART_NO_COMPLETE = 'front.cart.remove_cart_no.complete';

--- a/src/Eccube/Resource/template/default/Cart/index.twig
+++ b/src/Eccube/Resource/template/default/Cart/index.twig
@@ -147,13 +147,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                         <ul id="cart_item_list__quantity_edit">
                                             <li>
                                                 {% if CartItem.quantity > 1 %}
-                                                    <a id="cart_item_list__down" href="{{ url('cart_down', {'productClassId': ProductClass.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false"><svg class="cb cb-minus"><use xlink:href="#cb-minus" /></svg></a>
+                                                    <a id="cart_item_list__down" href="{{ url('cart_down_cart_no', {'cart_no': CartItem.cart_no}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false"><svg class="cb cb-minus"><use xlink:href="#cb-minus" /></svg></a>
                                                 {% else %}
                                                     <span><svg class="cb cb-minus"><use xlink:href="#cb-minus" /></svg></span>
                                                 {% endif %}
                                             </li>
                                             <li>
-                                                <a id="cart_item_list__up" href="{{ url('cart_up', {'productClassId': ProductClass.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false"><svg class="cb cb-plus"><use xlink:href="#cb-plus" /></svg></a>
+                                                <a id="cart_item_list__up" href="{{ url('cart_up_cart_no', {'cart_no': CartItem.cart_no}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false"><svg class="cb cb-plus"><use xlink:href="#cb-plus" /></svg></a>
                                             </li>
                                         </ul>
                                     </div>

--- a/src/Eccube/Resource/template/default/Cart/index.twig
+++ b/src/Eccube/Resource/template/default/Cart/index.twig
@@ -116,7 +116,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
                                 <div id="cart_item_list__item" class="item_box tr">
                                     <div id="cart_item_list__cart_remove" class="icon_edit td">
-                                        <a href="{{ url('cart_remove', {'productClassId': ProductClass.id }) }}" {{ csrf_token_for_anchor() }} data-method="put" data-message="カートから商品を削除してもよろしいですか?">
+                                        <a href="{{ url('cart_remove_cart_no', {'cart_no': CartItem.cart_no }) }}" {{ csrf_token_for_anchor() }} data-method="put" data-message="カートから商品を削除してもよろしいですか?">
                                             <svg class="cb cb-close"><use xlink:href="#cb-close" /></svg>
                                         </a>
                                     </div>

--- a/src/Eccube/Service/CartComparator/CompareContext.php
+++ b/src/Eccube/Service/CartComparator/CompareContext.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Eccube\Service\CartComparator;
+
+class CompareContext
+{
+    /** @var \Doctrine\Common\Collections\ArrayCollection */
+    protected $compareStrategies;
+
+    function __construct()
+    {
+        $this->compareStrategies = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+
+    /**
+     * @param $CartItem1
+     * @param $CartItem2
+     * @return bool
+     */
+    public function compare($CartItem1, $CartItem2)
+    {
+        $result = !$this->compareStrategies->isEmpty();
+
+        /** @var \Eccube\Service\CartComparator\Strategy\CartComparatorStrategyInterface $strategy */
+        foreach ($this->compareStrategies as $strategy) {
+            $result = $result && $strategy->compare($CartItem1, $CartItem2);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param Strategy\CartComparatorStrategyInterface $strategy
+     * @return $this
+     */
+    public function addStrategy(\Eccube\Service\CartComparator\Strategy\CartComparatorStrategyInterface $strategy)
+    {
+        $this->compareStrategies->add($strategy);
+
+        return $this;
+    }
+
+    /**
+     * @return \Doctrine\Common\Collections\ArrayCollection
+     */
+    public function getStrategies()
+    {
+        return $this->compareStrategies;
+    }
+}

--- a/src/Eccube/Service/CartComparator/Strategy/CartComparatorStrategyInterface.php
+++ b/src/Eccube/Service/CartComparator/Strategy/CartComparatorStrategyInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Eccube\Service\CartComparator\Strategy;
+
+interface CartComparatorStrategyInterface
+{
+    /**
+     * @param \Eccube\Entity\CartItem $CartItem1
+     * @param \Eccube\Entity\CartItem $CartItem2
+     * @return \Eccube\Entity\CartItem
+     */
+    public function compare($CartItem1, $CartItem2);
+}

--- a/src/Eccube/Service/CartComparator/Strategy/ProductClassStrategy.php
+++ b/src/Eccube/Service/CartComparator/Strategy/ProductClassStrategy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Eccube\Service\CartComparator\Strategy;
+
+class ProductClassStrategy implements CartComparatorStrategyInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function compare($CartItem1, $CartItem2)
+    {
+        return
+            $CartItem1->getClassId() == $CartItem2->getClassId() &&
+            $CartItem1->getClassName() == $CartItem2->getClassName();
+    }
+}

--- a/src/Eccube/Service/CartCompareService.php
+++ b/src/Eccube/Service/CartCompareService.php
@@ -40,6 +40,18 @@ class CartCompareService
     }
 
     /**
+     * CompareContext::compare()のエイリアス
+     *
+     * @param \Eccube\Entity\CartItem $CartItem1
+     * @param \Eccube\Entity\CartItem $CartItem2
+     * @return bool
+     */
+    public function compare($CartItem1, $CartItem2)
+    {
+        return $this->context->compare($CartItem1, $CartItem2);
+    }
+
+    /**
      * カート内商品と比較し、既に存在する商品を取得する
      *
      * @param \Eccube\Entity\CartItem $CartItem

--- a/src/Eccube/Service/CartCompareService.php
+++ b/src/Eccube/Service/CartCompareService.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Eccube\Service;
+
+use Eccube\Entity\Cart;
+
+class CartCompareService
+{
+    /** @var Cart  */
+    protected $Cart;
+
+    /** @var \Eccube\Service\CartComparator\CompareContext */
+    protected $context;
+
+    /**
+     * @param $Cart
+     */
+    public function __construct($Cart)
+    {
+        $this->Cart = $Cart;
+    }
+
+    /**
+     * @param \Eccube\Service\CartComparator\CompareContext $context
+     * @return $this
+     */
+    public function setContext($context)
+    {
+        $this->context = $context;
+
+        return $this;
+    }
+
+    /**
+     * @return \Eccube\Service\CartComparator\CompareContext
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
+    /**
+     * カート内商品と比較し、既に存在する商品を取得する
+     *
+     * @param \Eccube\Entity\CartItem $CartItem
+     * @return \Eccube\Entity\CartItem|null 存在しない場合はnull
+     */
+    public function getExistsCartItem($CartItem)
+    {
+        $result = null;
+
+        foreach ($this->Cart->getCartItems() as $CompareCartItem) {
+            if ($this->context->compare($CartItem, $CompareCartItem)) {
+                $result = $CompareCartItem;
+                break;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -709,6 +709,37 @@ class CartService
     }
 
     /**
+     * @param int $cart_no
+     * @return \Eccube\Service\CartService
+     */
+    public function upCartNoQuantity($cart_no)
+    {
+        $CartItem = $this->getCart()->getCartItemByCartNo($cart_no);
+        if ($CartItem) {
+            $this->setCartItemQuantity($CartItem, $CartItem->getQuantity() + 1);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param int $cart_no
+     * @return \Eccube\Service\CartService
+     */
+    public function downCartNoQuantity($cart_no)
+    {
+        $CartItem = $this->getCart()->getCartItemByCartNo($cart_no);
+        if ($CartItem) {
+            $quantity = $CartItem->getQuantity() - 1;
+            if ($quantity > 0) {
+                $this->setCartItemQuantity($CartItem, $quantity);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * @return array
      */
     public function getProductTypes()

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -311,7 +311,7 @@ class CartService
                 ->setPrice($ProductClass->getPrice02IncTax())
                 ->setQuantity($quantity);
 
-            $this->cart->setCartItem($CartItem);
+            $this->cart->setCartItem($CartItem, $this->generateCartCompareService());
         }
 
         return $this;
@@ -444,7 +444,7 @@ class CartService
                     if ((0 < $quantity) && ($CartItem->getQuantity() != $quantity)) {
                         // 個数が異なれば更新
                         $CartItem->setQuantity($quantity);
-                        $this->cart->setCartItem($CartItem);
+                        $this->cart->setCartItem($CartItem, $this->generateCartCompareService());
                     }
                 }
 
@@ -712,4 +712,11 @@ class CartService
         return $quantity;
     }
 
+    /**
+     * @return \Eccube\Service\CartCompareService
+     */
+    public function generateCartCompareService()
+    {
+        return $this->app['eccube.service.cart.compare']($this->getCart());
+    }
 }

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -54,6 +54,19 @@ class EccubeServiceProvider implements ServiceProviderInterface, EventListenerPr
         $app['eccube.service.cart'] = function () use ($app) {
             return new \Eccube\Service\CartService($app);
         };
+        $app['eccube.service.cart.compare'] = $app->protect(function ($Cart) use ($app) {
+            $service = new \Eccube\Service\CartCompareService($Cart);
+            $service->setContext($app['eccube.cart.comparator.context']);
+            return $service;
+        });
+        $app['eccube.cart.comparator.context'] = function () use ($app) {
+            $context = new \Eccube\Service\CartComparator\CompareContext();
+            $context->addStrategy($app['eccube.cart.comparator.strategy.product_class']);
+            return $context;
+        };
+        $app['eccube.cart.comparator.strategy.product_class'] = function () {
+            return new \Eccube\Service\CartComparator\Strategy\ProductClassStrategy();
+        };
         $app['eccube.service.order'] = function () use ($app) {
             return new \Eccube\Service\OrderService($app);
         };

--- a/tests/Eccube/Tests/Service/CartComparator/Strategy/FalseStrategy.php
+++ b/tests/Eccube/Tests/Service/CartComparator/Strategy/FalseStrategy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Eccube\Tests\Service\CartComparator\Strategy;
+
+use Eccube\Service\CartComparator\Strategy\CartComparatorStrategyInterface;
+
+class FalseStrategy implements CartComparatorStrategyInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function compare($CartItem1, $CartItem2)
+    {
+        return false;
+    }
+}

--- a/tests/Eccube/Tests/Service/CartCompareServiceTest.php
+++ b/tests/Eccube/Tests/Service/CartCompareServiceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Eccube\Tests\Service;
+
+class CartCompareServiceTest extends AbstractServiceTestCase
+{
+    /** @var \Eccube\Service\CartService */
+    protected $cartService;
+
+    /** @var \Eccube\Service\CartCompareService */
+    protected $compareService;
+
+    /** @var \Eccube\Entity\Product */
+    protected $Product;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->cartService = $this->app['eccube.service.cart'];
+        $this->compareService = $this->cartService->generateCartCompareService();
+        $this->Product = $this->createProduct();
+    }
+
+    public function testGetExistsCartItem_exists()
+    {
+        $ProductClasses = $this->Product->getProductClasses();
+        $CartItem1 = $this->cartService->generateCartItem($ProductClasses[0]);
+        $CartItem2 = $this->cartService->generateCartItem($ProductClasses[1]);
+        $this->cartService->addCartItem($CartItem1);
+        $this->cartService->addCartItem($CartItem2);
+
+        $SearchCartItem = clone $CartItem2;
+        $this->assertEquals($CartItem2, $this->compareService->getExistsCartItem($SearchCartItem));
+    }
+
+    public function testGetExistsCartItem_notExists()
+    {
+        $ProductClasses = $this->Product->getProductClasses();
+        $CartItem1 = $this->cartService->generateCartItem($ProductClasses[0]);
+        $CartItem2 = $this->cartService->generateCartItem($ProductClasses[1]);
+        $this->cartService->addCartItem($CartItem1);
+        $this->cartService->addCartItem($CartItem2);
+
+        $CartItem3 = $this->cartService->generateCartItem($ProductClasses[2]);
+
+        $SearchCartItem = clone $CartItem3;
+        $this->assertNull($this->compareService->getExistsCartItem($SearchCartItem));
+    }
+
+    public function testCompare_equal()
+    {
+        $ProductClasses = $this->Product->getProductClasses();
+        $CartItem1 = $this->cartService->generateCartItem($ProductClasses[0]);
+        $CartItem2 = $this->cartService->generateCartItem($ProductClasses[1]);
+        $SearchCartItem1 = clone $CartItem1;
+        $SearchCartItem2 = clone $CartItem2;
+
+        $this->assertTrue($this->compareService->compare($CartItem1, $SearchCartItem1));
+        $this->assertTrue($this->compareService->compare($CartItem2, $SearchCartItem2));
+    }
+
+    public function testCompare_notEqual()
+    {
+        $ProductClasses = $this->Product->getProductClasses();
+        $CartItem1 = $this->cartService->generateCartItem($ProductClasses[0]);
+        $CartItem2 = $this->cartService->generateCartItem($ProductClasses[1]);
+        $SearchCartItem1 = clone $CartItem1;
+        $SearchCartItem2 = clone $CartItem2;
+
+        $this->assertFalse($this->compareService->compare($CartItem1, $SearchCartItem2));
+        $this->assertFalse($this->compareService->compare($CartItem2, $SearchCartItem1));
+    }
+}

--- a/tests/Eccube/Tests/Service/CartServiceTest.php
+++ b/tests/Eccube/Tests/Service/CartServiceTest.php
@@ -498,13 +498,6 @@ class CartServiceTest extends AbstractServiceTestCase
         } catch (\Eccube\Exception\CartException $e) {
             $this->assertTrue(true);
         }
-
-        try {
-            $this->app['eccube.service.cart']->generateCartItem('a');
-            $this->fail();
-        } catch (\Eccube\Exception\CartException $e) {
-            $this->assertTrue(true);
-        }
     }
 
     public function testAddCartItem_ProductClassEntity()

--- a/tests/Eccube/Tests/Service/CartServiceTest.php
+++ b/tests/Eccube/Tests/Service/CartServiceTest.php
@@ -50,12 +50,11 @@ class CartServiceTest extends AbstractServiceTestCase
     }
 
     /**
-     * 必ず別カート商品と判定するストラテジーを追加
+     * 同じ商品規格のカート商品を複数セットできるよう変更
      */
-    protected function addFalseStrategy()
+    protected function setProductClassDuplicable()
     {
-        $strategy = new \Eccube\Tests\Service\CartComparator\Strategy\FalseStrategy();
-        $this->app['eccube.cart.comparator.context']->addStrategy($strategy);
+        $this->app['eccube.cart.comparator.context']->getStrategies()->clear();
     }
 
     public function testUnlock()
@@ -553,7 +552,7 @@ class CartServiceTest extends AbstractServiceTestCase
 
     public function testAddCartItem_duplicateProductClass()
     {
-        $this->addFalseStrategy();
+        $this->setProductClassDuplicable();
         /** @var \Eccube\Service\CartService $cartService */
         $cartService = $this->app['eccube.service.cart'];
 
@@ -663,7 +662,7 @@ class CartServiceTest extends AbstractServiceTestCase
 
     public function testSetCartItemQuantityWithOverStock_duplicateProductClass()
     {
-        $this->addFalseStrategy();
+        $this->setProductClassDuplicable();
         /** @var \Eccube\Service\CartService $cartService */
         $cartService = $this->app['eccube.service.cart'];
 
@@ -719,7 +718,7 @@ class CartServiceTest extends AbstractServiceTestCase
 
     public function testSetCartItemQuantityWithOverSaleLimit_duplicateProductClass()
     {
-        $this->addFalseStrategy();
+        $this->setProductClassDuplicable();
         /** @var \Eccube\Service\CartService $cartService */
         $cartService = $this->app['eccube.service.cart'];
 
@@ -845,7 +844,7 @@ class CartServiceTest extends AbstractServiceTestCase
 
     public function testRemoveCartNo_duplicateProductClass()
     {
-        $this->addFalseStrategy();
+        $this->setProductClassDuplicable();
         /** @var \Eccube\Service\CartService $cartService */
         $cartService = $this->app['eccube.service.cart'];
         $CartItems = $cartService->getCart()->getCartItems();

--- a/tests/Eccube/Tests/Service/CartServiceTest.php
+++ b/tests/Eccube/Tests/Service/CartServiceTest.php
@@ -470,4 +470,250 @@ class CartServiceTest extends AbstractServiceTestCase
         $this->actual = count($ProductTypes);
         $this->verify();
     }
+
+    public function testGenerateCartItem()
+    {
+        $ProductClasses = $this->Product->getProductClasses();
+        $ProductClass = $ProductClasses[0];
+
+        $CartItem = $this->app['eccube.service.cart']->generateCartItem($ProductClass);
+        $this->assertInstanceOf('Eccube\Entity\CartItem', $CartItem);
+
+        $CartItem = $this->app['eccube.service.cart']->generateCartItem($ProductClass->getId());
+        $this->assertInstanceOf('Eccube\Entity\CartItem', $CartItem);
+    }
+
+    public function testGenerateCartItem_invalidArgument()
+    {
+        try {
+            $this->app['eccube.service.cart']->generateCartItem(null);
+            $this->fail();
+        } catch (\Exception $e) {
+            $this->assertTrue(true);
+        }
+
+        try {
+            $this->app['eccube.service.cart']->generateCartItem($this->Product);
+            $this->fail();
+        } catch (\Eccube\Exception\CartException $e) {
+            $this->assertTrue(true);
+        }
+
+        try {
+            $this->app['eccube.service.cart']->generateCartItem('a');
+            $this->fail();
+        } catch (\Eccube\Exception\CartException $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    public function testAddCartItem_ProductClassEntity()
+    {
+        /** @var \Eccube\Service\CartService $cartService */
+        $cartService = $this->app['eccube.service.cart'];
+
+        $CartItem = $cartService->generateCartItem(1);
+        $cartService->addCartItem($CartItem);
+        $CartItems = $cartService->getCart()->getCartItems();
+
+        $this->assertEquals('Eccube\Entity\ProductClass', $CartItems[0]->getClassName());
+        $this->assertEquals(1, $CartItems[0]->getClassId());
+    }
+
+    public function testAddCartItem_Quantity()
+    {
+        /** @var \Eccube\Service\CartService $cartService */
+        $cartService = $this->app['eccube.service.cart'];
+        $this->assertCount(0, $cartService->getCart()->getCartItems());
+
+        $CartItem = $cartService->generateCartItem(1);
+        $cartService->addCartItem($CartItem);
+        $this->assertEquals(1, $cartService->getCartItemQuantity($CartItem));
+
+        $cartService->clear();
+
+        $CartItem = $cartService->generateCartItem(10);
+        $CartItem->setQuantity(6);
+        $cartService->addCartItem($CartItem);
+        $this->assertEquals(5, $cartService->getCartItemQuantity($CartItem));
+
+        $cartService->clear();
+
+        $CartItem = $cartService->generateCartItem(10);
+        $CloneCartItem = clone $CartItem;
+        $CartItem->setQuantity(101);
+        $cartService->addCartItem($CartItem);
+        $this->assertEquals(5, $cartService->getCartItemQuantity($CloneCartItem));
+    }
+
+    public function testSetCartItemQuantityWithObject()
+    {
+        /** @var \Eccube\Service\CartService $cartService */
+        $cartService = $this->app['eccube.service.cart'];
+
+        $ProductClasses = $this->Product->getProductClasses();
+        $CartItem = $this->app['eccube.service.cart']->generateCartItem($ProductClasses[0]);
+        $cartService
+            ->setCartItemQuantity($CartItem, 1)
+            ->save();
+
+        $Cart = $this->app['session']->get('cart');
+        $CartItems = $Cart->getCartItems();
+
+        $this->assertCount(1, $CartItems);
+    }
+
+    public function testSetCartItemQuantityWithProductHide()
+    {
+        /** @var \Eccube\Service\CartService $cartService */
+        $cartService = $this->app['eccube.service.cart'];
+
+        $Disp = $this->app['eccube.repository.master.disp']->find(\Eccube\Entity\Master\Disp::DISPLAY_HIDE);
+        $this->Product->setStatus($Disp);
+        $this->app['orm.em']->flush();
+
+        try {
+            $ProductClasses = $this->Product->getProductClasses();
+            $ProductClass = $ProductClasses[0];
+            $CartItem = $cartService->generateCartItem($ProductClass);
+            $cartService
+                ->setCartItemQuantity($CartItem, 1)
+                ->save();
+            $this->fail();
+        } catch (CartException $e) {
+            $this->expected = 'cart.product.not.status';
+            $this->actual = $e->getMessage();
+        }
+        $this->verify();
+    }
+
+    public function testSetCartItemQuantityWithOverPrice()
+    {
+        /** @var \Eccube\Service\CartService $cartService */
+        $cartService = $this->app['eccube.service.cart'];
+
+        $ProductClasses = $this->Product->getProductClasses();
+        $ProductClass = $ProductClasses[0];
+        $ProductClass->setPrice02($this->app['config']['max_total_fee']);
+        $this->app['orm.em']->flush();
+
+        try {
+            $CartItem = $cartService->generateCartItem($ProductClass);
+            $cartService->setCartItemQuantity($CartItem, 2)->save();
+        } catch (CartException $e) {
+            $this->actual = $cartService->getError();
+            $this->expected = 'cart.over.price_limit';
+        }
+
+        $this->verify();
+    }
+
+    public function testSetCartItemQuantityWithOverStock()
+    {
+        /** @var \Eccube\Service\CartService $cartService */
+        $cartService = $this->app['eccube.service.cart'];
+
+        $ProductClasses = $this->Product->getProductClasses();
+        $ProductClass = $ProductClasses[0];
+        $ProductClass->setStockUnlimited(0);
+        $ProductClass->setStock(10);
+        $this->app['orm.em']->flush();
+
+        $CartItem = $cartService->generateCartItem($ProductClass);
+        $cartService->setCartItemQuantity($CartItem, 20)->save();
+
+        $this->actual = $cartService->getErrors();
+        $this->expected = array('cart.over.stock');
+        $this->verify();
+    }
+
+    public function testSetCartItemQuantityWithOverSaleLimit()
+    {
+        /** @var \Eccube\Service\CartService $cartService */
+        $cartService = $this->app['eccube.service.cart'];
+
+        $ProductClasses = $this->Product->getProductClasses();
+        /** @var \Eccube\Entity\ProductClass $ProductClass */
+        $ProductClass = $ProductClasses[0];
+        $ProductClass
+            ->setStockUnlimited(0)
+            ->setStock(10)
+            ->setSaleLimit(5);
+        $this->app['orm.em']->flush();
+
+        $CartItem = $cartService->generateCartItem($ProductClass);
+        $cartService->setCartItemQuantity($CartItem, 7)->save();
+
+        $this->actual = $cartService->getErrors();
+        $this->expected = array('cart.over.sale_limit');
+        $this->verify();
+    }
+
+    public function testSetCartItemQuantityWithMultipleProductType()
+    {
+        /** @var \Eccube\Service\CartService $cartService */
+        $cartService = $this->app['eccube.service.cart'];
+
+        // カート投入
+        $ProductClasses1 = $this->Product->getProductClasses();
+        $ProductClasses2 = $this->Product2->getProductClasses();
+
+        try {
+            $cartService
+                ->addCartItem($cartService->generateCartItem($ProductClasses1[0]))
+                ->save();
+            $cartService
+                ->addCartItem($cartService->generateCartItem($ProductClasses2[0]))
+                ->save();
+            $this->fail();
+        } catch (CartException $e) {
+            $this->actual = $e->getMessage();
+        }
+        $this->expected = 'cart.product.type.kind';
+        $this->verify('複数配送OFFの場合は複数商品種別のカート投入はエラー');
+    }
+
+    public function testSetCartItemQuantityWithMultipleShipping()
+    {
+        /** @var \Eccube\Service\CartService $cartService */
+        $cartService = $this->app['eccube.service.cart'];
+
+        // 複数配送対応としておく
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $BaseInfo->setOptionMultipleShipping(Constant::ENABLED);
+
+        // product_class_id = 2 の ProductType を 2 に変更
+        $ProductClass = $this->app['orm.em']
+            ->getRepository('Eccube\Entity\ProductClass')
+            ->find(2);
+        $ProductClass->setProductType($this->ProductType2);
+
+        // ProductType 1 と 2 で, 共通する支払い方法を削除しておく
+        $PaymentOption = $this
+            ->app['orm.em']
+            ->getRepository('\Eccube\Entity\PaymentOption')
+            ->findOneBy(
+                array(
+                    'delivery_id' => 1,
+                    'payment_id' => 3
+                )
+            );
+        $this->assertNotNull($PaymentOption);
+        $this->app['orm.em']->remove($PaymentOption);
+        $this->app['orm.em']->flush();
+
+        // カート投入
+        try {
+            // XXX createProduct() で生成した商品を使いたいが,
+            // createProduct() で生成すると CartService::getCart()->getCartItem() で
+            // 商品が取得できないため, 初期設定商品を使用する
+            $cartService->setCartItemQuantity($cartService->generateCartItem(1), 1);
+            $cartService->setCartItemQuantity($cartService->generateCartItem(2), 1);
+            $this->fail();
+        } catch (CartException $e) {
+            $this->actual = $e->getMessage();
+        }
+        $this->expected = 'cart.product.payment.kind';
+        $this->verify('複数配送ONの場合は支払い方法の異なるカート投入はエラー');
+    }
 }

--- a/tests/Eccube/Tests/Service/CartServiceTest.php
+++ b/tests/Eccube/Tests/Service/CartServiceTest.php
@@ -479,8 +479,18 @@ class CartServiceTest extends AbstractServiceTestCase
         $CartItem = $this->app['eccube.service.cart']->generateCartItem($ProductClass);
         $this->assertInstanceOf('Eccube\Entity\CartItem', $CartItem);
 
+        $this->assertEquals($ProductClass, $CartItem->getObject());
+        $this->assertEquals($ProductClass->getId(), $CartItem->getClassId());
+        $this->assertEquals($ProductClass->getPrice02IncTax(), $CartItem->getPrice());
+        $this->assertEquals(1, $CartItem->getQuantity());
+
         $CartItem = $this->app['eccube.service.cart']->generateCartItem($ProductClass->getId());
         $this->assertInstanceOf('Eccube\Entity\CartItem', $CartItem);
+
+        $this->assertEquals($ProductClass, $CartItem->getObject());
+        $this->assertEquals($ProductClass->getId(), $CartItem->getClassId());
+        $this->assertEquals($ProductClass->getPrice02IncTax(), $CartItem->getPrice());
+        $this->assertEquals(1, $CartItem->getQuantity());
     }
 
     public function testGenerateCartItem_invalidArgument()
@@ -489,13 +499,6 @@ class CartServiceTest extends AbstractServiceTestCase
             $this->app['eccube.service.cart']->generateCartItem(null);
             $this->fail();
         } catch (\Exception $e) {
-            $this->assertTrue(true);
-        }
-
-        try {
-            $this->app['eccube.service.cart']->generateCartItem($this->Product);
-            $this->fail();
-        } catch (\Eccube\Exception\CartException $e) {
             $this->assertTrue(true);
         }
     }

--- a/tests/Eccube/Tests/Service/CartServiceTest.php
+++ b/tests/Eccube/Tests/Service/CartServiceTest.php
@@ -915,4 +915,47 @@ class CartServiceTest extends AbstractServiceTestCase
         $this->actual = count($cartService->getCart()->getPayments());
         $this->verify('設定されている支払い方法は' . $this->expected . '種類');
     }
+
+    public function testUpCartNoQuantity()
+    {
+        /** @var \Eccube\Service\CartService $cartService */
+        $cartService = $this->app['eccube.service.cart'];
+
+        $CartItem = $cartService->generateCartItem(1);
+        $cartService->setCartItemQuantity($CartItem, 1);
+        $cart_no = $CartItem->getCartNo();
+
+        $cartService->upCartNoQuantity($cart_no);
+        $quantity = $cartService->getCartItemQuantity($CartItem);
+        $this->assertEquals(2, $quantity);
+    }
+
+    public function testDownCartNoQuantity()
+    {
+        /** @var \Eccube\Service\CartService $cartService */
+        $cartService = $this->app['eccube.service.cart'];
+
+        $CartItem = $cartService->generateCartItem(1);
+        $cartService->setCartItemQuantity($CartItem, 2);
+        $cart_no = $CartItem->getCartNo();
+
+        $cartService->downCartNoQuantity($cart_no);
+        $quantity = $cartService->getCartItemQuantity($CartItem);
+        $this->assertEquals(1, $quantity);
+    }
+
+    public function testDownCartNoQuantity_NotRemove()
+    {
+        /** @var \Eccube\Service\CartService $cartService */
+        $cartService = $this->app['eccube.service.cart'];
+
+        $CartItem = $cartService->generateCartItem(1);
+        $cartService->setCartItemQuantity($CartItem, 1);
+        $cart_no = $CartItem->getCartNo();
+
+        $cartService->downCartNoQuantity($cart_no);
+        $quantity = $cartService->getCartItemQuantity($CartItem);
+        $this->assertEquals(1, $quantity);
+        $this->assertCount(1, $cartService->getCart()->getCartItems());
+    }
 }

--- a/tests/Eccube/Tests/Web/CartControllerTest.php
+++ b/tests/Eccube/Tests/Web/CartControllerTest.php
@@ -63,4 +63,10 @@ class CartControllerTest extends AbstractWebTestCase
         $this->client->request('PUT', '/cart/remove/1');
         $this->assertTrue($this->client->getResponse()->isRedirection());
     }
+
+    public function testRoutingCartRemoveCartNo()
+    {
+        $this->client->request('PUT', '/cart/remove/cart_no/1');
+        $this->assertTrue($this->client->getResponse()->isRedirection());
+    }
 }

--- a/tests/Eccube/Tests/Web/CartControllerTest.php
+++ b/tests/Eccube/Tests/Web/CartControllerTest.php
@@ -69,4 +69,16 @@ class CartControllerTest extends AbstractWebTestCase
         $this->client->request('PUT', '/cart/remove/cart_no/1');
         $this->assertTrue($this->client->getResponse()->isRedirection());
     }
+
+    public function testRoutingCartUpCartNo()
+    {
+        $this->client->request('PUT', '/cart/up/cart_no/1');
+        $this->assertTrue($this->client->getResponse()->isRedirection());
+    }
+
+    public function testRoutingCartDownCartNo()
+    {
+        $this->client->request('PUT', '/cart/down/cart_no/1');
+        $this->assertTrue($this->client->getResponse()->isRedirection());
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#2219  について自分でも手を動かしてみようと思い、商品詳細画面のカート追加部分のみ実験的に実装。

余力があれば開発を続けますが、通常業務もあるため完成まで漕ぎ着けられるかどうか不明。

どなたかが引き取って拡張するようならそれでも構いません。

## 方針(Policy)

+ 現状では商品規格IDが実質上のカートのIDとなっている。同じ商品規格でも異なるオプションなら別のカートとして追加したいケースに対応。

+ カートに追加する処理では、商品規格IDではなくCartItemエンティティを渡す。追加対象のCartItemとカート内のCartItemを比較する判定を追加可能。

## 課題

+ ~~同じ商品規格が複数カートに入った際の、在庫や購入制限を考慮する必要がある。~~ 対応済み

+ ~~削除時等に利用するカートのIDを、商品規格ID以外に変更する必要がある。2系のcart_noのような方式で、現在値をセッションに保持するのがいいと思われる。~~ 対応済み

+ 単価計算についても、同様の実装で拡張可能だと好ましい。

+ OrderDetailやShipmentItemでも共通の処理を利用することを考慮すると、CartItem/OrderDetail/ShipmentItemに```CartItemTrait```的なものを設定した方がいいのでは。

## 実装に関する補足(Appendix)

+ 利用例 https://github.com/izayoi256/ec-cube/tree/issue/2219_option

  - CartItemにオプションフィールドを追加し、オプションの入力内容で比較する判定を実装してあります。

  - 商品詳細画面でカートに追加時、「オプション入力」の内容も考慮してカート追加処理が行なわれます。

  - ~~※ 実装してあるのはカート追加処理までで、削除等は未対応です。~~ フロント側は対応済み

## テスト（Test)

+ 新規実装分は一通りテスト追加済み。

## 相談（Discussion）

nanasessさんの実装を真似てはいますが、恥ずかしながら初めてデザインパターンに触れるため、何か変な箇所があればご指摘下さい。