### PR TITLE
[受注編集]"お届け日"、"数量"の入力箇所上部に変更前の値を表示する。

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -28,7 +28,9 @@ use Eccube\Application;
 use Eccube\Common\Constant;
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\Master\DeviceType;
+use Eccube\Entity\OrderDetail;
 use Eccube\Entity\ShipmentItem;
+use Eccube\Entity\Shipping;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
 use Symfony\Component\Form\FormError;
@@ -67,15 +69,24 @@ class EditController extends AbstractController
         // 編集前のお届け先のアイテム情報を保持
         $OriginalShipmentItems = new ArrayCollection();
 
+        // Save previous value before calculate
+        $arrOldOrder = array();
+
+        /** @var $OrderDetail OrderDetail*/
         foreach ($TargetOrder->getOrderDetails() as $OrderDetail) {
             $OriginalOrderDetails->add($OrderDetail);
+            $arrOldOrder['OrderDetails'][]['quantity'] = $OrderDetail->getQuantity();
         }
 
         // 編集前の情報を保持
-        foreach ($TargetOrder->getShippings() as $tmpOriginalShippings) {
+        /** @var $tmpOriginalShippings Shipping*/
+        foreach ($TargetOrder->getShippings() as $key => $tmpOriginalShippings) {
+            $arrOldOrder['Shippings'][$key]['shipping_delivery_date'] = $tmpOriginalShippings->getShippingDeliveryDate();
+            /** @var $tmpOriginalShipmentItem ShipmentItem*/
             foreach ($tmpOriginalShippings->getShipmentItems() as $tmpOriginalShipmentItem) {
                 // アイテム情報
                 $OriginalShipmentItems->add($tmpOriginalShipmentItem);
+                $arrOldOrder['Shippings'][$key]['ShipmentItems'][]['quantity'] = $tmpOriginalShipmentItem->getQuantity();
             }
             // お届け先情報
             $OriginalShippings->add($tmpOriginalShippings);
@@ -331,6 +342,7 @@ class EditController extends AbstractController
             'Order' => $TargetOrder,
             'id' => $id,
             'shippingDeliveryTimes' => $app['serializer']->serialize($times, 'json'),
+            'arrOldOrder' => $arrOldOrder,
         ));
     }
 

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -421,6 +421,9 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                                             </div>
                                             <div class="col-md-4 col-lg-3 form-group form-inline text-right">
                                                 <span id="product_info_list__quantity--{{ loop.index }}" class="item_quantity">
+                                                    {% if arrOldOrder.OrderDetails[loop.index0] is defined %}
+                                                        {{ arrOldOrder.OrderDetails[loop.index0].quantity }}<br/>
+                                                    {% endif %}
                                                     {% if BaseInfo.optionMultipleShipping %}
                                                         数量：{{ form_widget(orderDetailForm.quantity, {'read_only': 'readonly'}) }}
                                                     {% else %}
@@ -579,6 +582,9 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                                         </div>
                                         <div id="shipment_item__quantity--{{ shippingIndex }}--{{ shippingItemkey }}" class="col-md-4 col-lg-3 form-group form-inline text-right">
                                             <span class="item_quantity">
+                                                {% if arrOldOrder.Shippings[shippingIndex].ShipmentItems[loop.index0] is defined %}
+                                                    {{ arrOldOrder.Shippings[shippingIndex].ShipmentItems[loop.index0].quantity }}<br/>
+                                                {% endif %}
                                                 数量：{{ form_widget(shipmentItemForm.quantity, {'attr': {'class': 'shipment_quantity'}}) }}
                                                 {{ form_errors(shipmentItemForm.quantity) }}
                                             </span>
@@ -696,6 +702,11 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                             <div id="shipment_item_detail__shipping_delivery_date--{{ shippingIndex }}" class="form-group">
                                 {{ form_label(shippingForm.shipping_delivery_date) }}
                                 <div class="col-sm-9 col-lg-10">
+                                    {% if arrOldOrder.Shippings[shippingIndex].shipping_delivery_date is not empty %}
+                                        {{ arrOldOrder.Shippings[shippingIndex].shipping_delivery_date|date('Y-m-d') }}<br/>
+                                    {% else %}
+                                        指定なし
+                                    {% endif %}
                                     {{ form_widget(shippingForm.shipping_delivery_date) }}
                                     {{ form_errors(shippingForm.shipping_delivery_date) }}
                                 </div>

--- a/tests/Eccube/Tests/Web/Admin/Order/AbstractEditControllerTestCase.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/AbstractEditControllerTestCase.php
@@ -169,9 +169,10 @@ abstract class AbstractEditControllerTestCase extends AbstractAdminWebTestCase
             );
 
             if ($Shippings->getShippingDeliveryDate() instanceof \DateTime) {
-                $shippingDeliveryDate['year'] = $Shippings->getShippingDeliveryDate()->format('Y');
-                $shippingDeliveryDate['month'] = $Shippings->getShippingDeliveryDate()->format('n');
-                $shippingDeliveryDate['day'] = $Shippings->getShippingDeliveryDate()->format('d');
+                $dateShipping = $Shippings->getShippingDeliveryDate();
+                $shippingDeliveryDate['year'] = $dateShipping->format('Y');
+                $shippingDeliveryDate['month'] = $dateShipping->format('n');
+                $shippingDeliveryDate['day'] = $dateShipping->format('j');
             }
             $shipmentItems = array();
             /** @var \Eccube\Entity\ShipmentItem $ShipmentItem */


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ When there is an error, it will display the delivery date and quantity before the change.

## 方針(Policy)
+ Displays the old value before the change when it was an error.

## 実装に関する補足(Appendix)

## テスト（Test)
+ With one product.
+ Many products.									
+ Multi shipping with one product.									
+ Multiple shipping with multiple products.									
+ When you create order.
+ When you edit order.

## 相談（Discussion）
**This problem will be solved in another issue**
+ **Problem exist**: Clone function of `doctrine relationships` are not implemented. (order/order detail/ shipping/ shipment item). Therefore, when creating a clone of a object, the relationships of the object will fail.
+ Example: When creating a clone of an orders, the orders detail will not create and it still holds the relationship with database. It makes the code more complicated, confusing and cumbersome.
 * https://github.com/EC-CUBE/ec-cube/blob/master/src/Eccube/Controller/Admin/Order/EditController.php#L63
 * https://github.com/EC-CUBE/ec-cube/blob/master/src/Eccube/Controller/Admin/Order/EditController.php#L71
 * https://github.com/EC-CUBE/ec-cube/blob/master/src/Eccube/Controller/Admin/Order/EditController.php#L78
 * https://github.com/EC-CUBE/ec-cube/blob/master/src/Eccube/Controller/Admin/Order/EditController.php#L81