### PR TITLE
配送方法が異なる商品がカートに存在する場合、共通の支払い方法のみが表示されるよう修正

### DIFF
--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -1000,25 +1000,27 @@ class ShoppingService
      */
     public function getFormPayments($deliveries, Order $Order)
     {
-
         $productTypes = $this->orderService->getProductTypes($Order);
 
         if ($this->BaseInfo->getOptionMultipleShipping() == Constant::ENABLED && count($productTypes) > 1) {
             // 複数配送時の支払方法
-
             $payments = $this->app['eccube.repository.payment']->findAllowedPayments($deliveries);
         } else {
-
             // 配送業者をセット
             $shippings = $Order->getShippings();
-            $Shipping = $shippings[0];
-            $payments = $this->app['eccube.repository.payment']->findPayments($Shipping->getDelivery(), true);
-
+            $payments = array();
+            foreach ($shippings as $Shipping) {
+                $paymentsShip = $this->app['eccube.repository.payment']->findPayments($Shipping->getDelivery(), true);
+                if (!$payments) {
+                    $payments = $paymentsShip;
+                } else {
+                    $payments = array_intersect($payments, $paymentsShip);
+                }
+            }
         }
         $payments = $this->getPayments($payments, $Order->getSubTotal());
 
         return $payments;
-
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 配送方法が異なる商品がカートにある場合に、片方の配送方法でしか利用できない支払い方法が表示されている
+ #2211 

## 方針(Policy)
+ Union all payments for each shipping

## 実装に関する補足(Appendix)

## テスト（Test)
- One shipping
   - Single product
   - Multi product with multi class
   - Multi product with single class
- Multi shipping
   - Single product with one shipping method
   - Multi product with one shipping method
   - Multi product with multi shipping method

## 相談（Discussion）
+ **Note:** When combined delivery as the payments method are empty, the system will fail and the customer can not proceed with the purchase.
+ Need to fix it in another issue.



