### PR TITLE
[管理画面ページレイアウト編集]全ページ=ONのブロックの移動が、プレビューに反映されるよう修正

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -363,7 +363,7 @@ class Application extends ApplicationTrait
                 // フロント画面
                 $request = $event->getRequest();
                 $route = $request->attributes->get('_route');
-
+                $page = $route;
                 // ユーザ作成画面
                 if ($route === 'user_data') {
                     $params = $request->attributes->get('_route_params');
@@ -376,7 +376,7 @@ class Application extends ApplicationTrait
                 try {
                     $DeviceType = $app['eccube.repository.master.device_type']
                         ->find(\Eccube\Entity\Master\DeviceType::DEVICE_TYPE_PC);
-                    $PageLayout = $app['eccube.repository.page_layout']->getByUrl($DeviceType, $route);
+                    $PageLayout = $app['eccube.repository.page_layout']->getByUrl($DeviceType, $route, $page);
                 } catch (\Doctrine\ORM\NoResultException $e) {
                     $PageLayout = $app['eccube.repository.page_layout']->newPageLayout($DeviceType);
                 }

--- a/src/Eccube/Controller/Admin/Content/LayoutController.php
+++ b/src/Eccube/Controller/Admin/Content/LayoutController.php
@@ -38,6 +38,15 @@ class LayoutController
         $DeviceType = $app['eccube.repository.master.device_type']
             ->find(\Eccube\Entity\Master\DeviceType::DEVICE_TYPE_PC);
 
+        $PreviewBlockPositions = $app['orm.em']->getRepository('Eccube\Entity\BlockPosition')
+            ->findBy(array(
+                'page_id' => 0,
+            ));
+        foreach ($PreviewBlockPositions as $BlockPosition) {
+            $app['orm.em']->remove($BlockPosition);
+        }
+        $app['orm.em']->flush();
+
         // 編集対象ページ
         /* @var $TargetPageLayout \Eccube\Entity\PageLayout */
         $TargetPageLayout = $app['eccube.repository.page_layout']->get($DeviceType, $id);
@@ -89,7 +98,7 @@ class LayoutController
         $listForm->get('layout')->setData($TargetPageLayout);
 
         $form = $builder->getForm();
-//dump( $request->request->all() );exit;
+
         if ('POST' === $request->getMethod()) {
             $form->handleRequest($request);
 
@@ -125,8 +134,8 @@ class LayoutController
                                 'anywhere' => 1,
                                 'block_id' => $data['id_' . $i],
                             ));
-                        //Only for TOP page
-                        if ( $TargetPageLayout != 1) {
+                        //exist and not preview model
+                        if (( count($Other) > 0)&&($id)) {
                             continue;
                         }
                     }

--- a/src/Eccube/Controller/Admin/Content/LayoutController.php
+++ b/src/Eccube/Controller/Admin/Content/LayoutController.php
@@ -89,7 +89,7 @@ class LayoutController
         $listForm->get('layout')->setData($TargetPageLayout);
 
         $form = $builder->getForm();
-
+//dump( $request->request->all() );exit;
         if ('POST' === $request->getMethod()) {
             $form->handleRequest($request);
 
@@ -118,13 +118,15 @@ class LayoutController
                     }
                     // 他のページに anywhere が存在する場合は INSERT しない
                     $anywhere = (isset($data['anywhere_' . $i]) && $data['anywhere_' . $i] == 1) ? 1 : 0;
+
                     if (isset($data['anywhere_' . $i]) && $data['anywhere_' . $i] == 1) {
                         $Other = $app['orm.em']->getRepository('Eccube\Entity\BlockPosition')
                             ->findBy(array(
                                 'anywhere' => 1,
                                 'block_id' => $data['id_' . $i],
                             ));
-                        if (count($Other) > 0) {
+                        //Only for TOP page
+                        if ( $TargetPageLayout != 1) {
                             continue;
                         }
                     }
@@ -143,9 +145,9 @@ class LayoutController
                         ->setBlock($Block)
                         ->setPageLayout($TargetPageLayout)
                         ->setAnywhere($anywhere);
-                    if ($id == 0) {
-                        $BlockPosition->setAnywhere(0);
-                    }
+//                    if ($id == 0) {
+//                        $BlockPosition->setAnywhere(0);
+//                    }
                     $TargetPageLayout->addBlockPosition($BlockPosition);
                     $app['orm.em']->persist($BlockPosition);
                 }

--- a/src/Eccube/Controller/Admin/Content/LayoutController.php
+++ b/src/Eccube/Controller/Admin/Content/LayoutController.php
@@ -38,7 +38,7 @@ class LayoutController
         $DeviceType = $app['eccube.repository.master.device_type']
             ->find(\Eccube\Entity\Master\DeviceType::DEVICE_TYPE_PC);
 
-        $PreviewBlockPositions = $app['orm.em']->getRepository('Eccube\Entity\BlockPosition')
+        $PreviewBlockPositions = $app['eccube.repository.block_position']
             ->findBy(array(
                 'page_id' => 0,
             ));

--- a/src/Eccube/Controller/Admin/Content/LayoutController.php
+++ b/src/Eccube/Controller/Admin/Content/LayoutController.php
@@ -154,9 +154,7 @@ class LayoutController
                         ->setBlock($Block)
                         ->setPageLayout($TargetPageLayout)
                         ->setAnywhere($anywhere);
-//                    if ($id == 0) {
-//                        $BlockPosition->setAnywhere(0);
-//                    }
+
                     $TargetPageLayout->addBlockPosition($BlockPosition);
                     $app['orm.em']->persist($BlockPosition);
                 }

--- a/src/Eccube/Repository/PageLayoutRepository.php
+++ b/src/Eccube/Repository/PageLayoutRepository.php
@@ -116,7 +116,7 @@ class PageLayoutRepository extends EntityRepository
 
     }
 
-    public function getByUrl(DeviceType $DeviceType, $url)
+    public function getByUrl(DeviceType $DeviceType, $url, $page)
     {
         $options = $this->app['config']['doctrine_cache'];
         $lifetime = $options['result_cache']['lifetime'];
@@ -138,9 +138,9 @@ class PageLayoutRepository extends EntityRepository
             ))
             ->getSingleResult();
 
-        if($url == 'preview')
+        if(($url == 'preview')&&($page == 'homepage')) {
             return $ownResult;
-
+        }
         $qb = $this->createQueryBuilder('p')
             ->select('p, bp, b')
             ->leftJoin('p.BlockPositions', 'bp', 'WITH', 'p.id = bp.page_id')

--- a/src/Eccube/Repository/PageLayoutRepository.php
+++ b/src/Eccube/Repository/PageLayoutRepository.php
@@ -138,6 +138,9 @@ class PageLayoutRepository extends EntityRepository
             ))
             ->getSingleResult();
 
+        if($url == 'preview')
+            return $ownResult;
+
         $qb = $this->createQueryBuilder('p')
             ->select('p, bp, b')
             ->leftJoin('p.BlockPositions', 'bp', 'WITH', 'p.id = bp.page_id')

--- a/src/Eccube/Repository/PageLayoutRepository.php
+++ b/src/Eccube/Repository/PageLayoutRepository.php
@@ -138,9 +138,10 @@ class PageLayoutRepository extends EntityRepository
             ))
             ->getSingleResult();
 
-        if(($url == 'preview')&&($page == 'homepage')) {
+        if(count($ownResult->getBlockPositions()) && ($url == 'preview') && ($page == 'homepage')) {
             return $ownResult;
         }
+
         $qb = $this->createQueryBuilder('p')
             ->select('p, bp, b')
             ->leftJoin('p.BlockPositions', 'bp', 'WITH', 'p.id = bp.page_id')

--- a/src/Eccube/Repository/PageLayoutRepository.php
+++ b/src/Eccube/Repository/PageLayoutRepository.php
@@ -116,7 +116,7 @@ class PageLayoutRepository extends EntityRepository
 
     }
 
-    public function getByUrl(DeviceType $DeviceType, $url, $page)
+    public function getByUrl(DeviceType $DeviceType, $url, $page = null)
     {
         $options = $this->app['config']['doctrine_cache'];
         $lifetime = $options['result_cache']['lifetime'];

--- a/src/Eccube/Repository/PageLayoutRepository.php
+++ b/src/Eccube/Repository/PageLayoutRepository.php
@@ -155,11 +155,17 @@ class PageLayoutRepository extends EntityRepository
             ->getResult();
 
         $OwnBlockPosition = $ownResult->getBlockPositions();
+        $OwnBlockPositionIds = array();
+        foreach ($OwnBlockPosition as $BlockPosition) {
+            $OwnBlockPositionIds[] =  $BlockPosition->getBlockId();
+        }
+
         foreach ($anyResults as $anyResult) {
             $BlockPositions = $anyResult->getBlockPositions();
             foreach ($BlockPositions as $BlockPosition) {
-                if (!$OwnBlockPosition->contains($BlockPosition)) {
+                if (!in_array($BlockPosition->getBlockId(), $OwnBlockPositionIds)) {
                     $ownResult->addBlockPosition($BlockPosition);
+                    $OwnBlockPositionIds[] = $BlockPosition->getBlockId();
                 }
             }
         }

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -208,6 +208,9 @@ class EccubeServiceProvider implements ServiceProviderInterface
 
             return $blockRepository;
         });
+        $app['eccube.repository.block_position'] = $app->share(function () use ($app) {
+            return $app['orm.em']->getRepository('Eccube\Entity\BlockPosition');
+        });
         $app['eccube.repository.order'] = $app->share(function () use ($app) {
             $orderRepository = $app['orm.em']->getRepository('Eccube\Entity\Order');
             $orderRepository->setApplication($app);


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ PullRequestの目的、関連するIssue番号など
   - #2207
   - Preview mode can arrange block as design
   - Avoid duplicate blocks in preview mode
   - Can remove block(all page) in preview mode
 
## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外し内容
  - Not affect to real mode

## 実装に関する補足(Appendix)
+ Still problem : can not arrange block between blocks ( all page ) in other sub page 

## テスト（Test)
+ Arrange block in TOP page 
+ Remove block ( all page ) in TOP page 
+ Checking duplicate any block 
- Arrange block between blocks( all page ) at sub page ( * case ERROR ) 

## 相談（Discussion）




