### PR TITLE
リポジトリで組み立てているQueryBuilderをカスタマイズする機構を実装

### DIFF
--- a/app/Acme/Entity/AdminProductListCustomizer.php
+++ b/app/Acme/Entity/AdminProductListCustomizer.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace Acme\Entity;
+
+
+use Eccube\Annotation\QueryExtension;
+use Eccube\Doctrine\Query\OrderByClause;
+use Eccube\Doctrine\Query\OrderByCustomizer;
+use Eccube\Repository\ProductRepository;
+
+/**
+ * @QueryExtension(ProductRepository::QUERY_KEY_SEARCH_ADMIN)
+ */
+class AdminProductListCustomizer extends OrderByCustomizer
+{
+    /**
+     * 常に商品IDでソートする。
+     *
+     * @param array $params
+     * @param $queryKey
+     * @return OrderByClause[]
+     */
+    protected function createStatements($params, $queryKey)
+    {
+        return [new OrderByClause('p.id')];
+    }
+}

--- a/src/Eccube/Annotation/QueryExtension.php
+++ b/src/Eccube/Annotation/QueryExtension.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Eccube\Annotation;
+use Doctrine\Common\Annotations\Annotation\Target;
+use Doctrine\ORM\Mapping\Annotation;
+
+/**
+ * @Annotation
+ * @Target("CLASS")
+ */
+final class QueryExtension implements Annotation
+{
+    /**
+     * @var array
+     */
+    public $value;
+}

--- a/src/Eccube/Doctrine/Query/JoinClause.php
+++ b/src/Eccube/Doctrine/Query/JoinClause.php
@@ -1,0 +1,188 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Doctrine\Query;
+
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * JOIN句を組み立てるクラス
+ */
+class JoinClause
+{
+
+    private $join;
+
+    private $alias;
+
+    private $conditionType;
+
+    private $condition;
+
+    private $indexBy;
+
+    private $leftJoin = false;
+
+    /**
+     * @var JoinClauseWhereCustomizer $whereCustomizer
+     */
+    private $whereCustomizer;
+
+    /**
+     * @var JoinClauseOrderByCustomizer $orderByCustomizer
+     */
+    private $orderByCustomizer;
+
+    /**
+     * JoinClause constructor.
+     * @param $leftJoin
+     * @param $join
+     * @param $alias
+     * @param $conditionType
+     * @param $condition
+     * @param $indexBy
+     */
+    private function __construct($leftJoin, $join, $alias, $conditionType = null, $condition = null, $indexBy = null)
+    {
+        $this->leftJoin = $leftJoin;
+        $this->join = $join;
+        $this->alias = $alias;
+        $this->conditionType = $conditionType;
+        $this->condition = $condition;
+        $this->indexBy = $indexBy;
+        $this->whereCustomizer = new JoinClauseWhereCustomizer();
+        $this->orderByCustomizer = new JoinClauseOrderByCustomizer();
+    }
+
+    /**
+     * INNER JOIN用のファクトリメソッド。
+     *
+     * @see QueryBuilder::innerJoin()
+     * @param $join
+     * @param $alias
+     * @param $conditionType
+     * @param $condition
+     * @param $indexBy
+     * @return JoinClause
+     */
+    public static function innerJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
+    {
+        return new JoinClause(false, $join, $alias, $conditionType, $condition, $indexBy);
+    }
+
+    /**
+     * LEFT JOIN用のファクトリメソッド。
+     *
+     * @see QueryBuilder::leftJoin()
+     * @param $join
+     * @param $alias
+     * @param $conditionType
+     * @param $condition
+     * @param $indexBy
+     * @return JoinClause
+     */
+    public static function leftJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
+    {
+        return new JoinClause(true, $join, $alias, $conditionType, $condition, $indexBy);
+    }
+
+    /**
+     * WHERE句を追加します。
+     *
+     * @param WhereClause $whereClause
+     * @return $this
+     */
+    public function addWhere(WhereClause $whereClause)
+    {
+        $this->whereCustomizer->add($whereClause);
+        return $this;
+    }
+
+    /**
+     * ORDER BY句を追加します。
+     * @param OrderByClause $orderByClause
+     * @return $this
+     */
+    public function addOrderBy(OrderByClause $orderByClause)
+    {
+        $this->orderByCustomizer->add($orderByClause);
+        return $this;
+    }
+
+    public function build(QueryBuilder $builder) {
+        if ($this->leftJoin) {
+            $builder->leftJoin($this->join, $this->alias, $this->conditionType, $this->condition, $this->indexBy);
+        } else {
+            $builder->innerJoin($this->join, $this->alias, $this->conditionType, $this->condition, $this->indexBy);
+        }
+        $this->whereCustomizer->customize($builder, null, '');
+        $this->orderByCustomizer->customize($builder, null, '');
+    }
+}
+
+class JoinClauseWhereCustomizer extends WhereCustomizer
+{
+    /**
+     * @var WhereClause[]
+     */
+    private $whereClauses = [];
+
+    public function add(WhereClause $whereClause)
+    {
+        $this->whereClauses[] = $whereClause;
+    }
+
+    /**
+     * @param array $params
+     * @param $queryKey
+     * @return WhereClause[]
+     */
+    protected function createStatements($params, $queryKey)
+    {
+        return $this->whereClauses;
+    }
+}
+
+class JoinClauseOrderByCustomizer extends OrderByCustomizer
+{
+    /**
+     * @var OrderByClause[]
+     */
+    private $orderByClauses = [];
+
+    public function add(OrderByClause $orderByClause)
+    {
+        $this->orderByClauses[] = $orderByClause;
+    }
+
+    /**
+     * @param array $params
+     * @param $queryKey
+     * @return OrderByClause[]
+     */
+    protected function createStatements($params, $queryKey)
+    {
+        return $this->orderByClauses;
+    }
+}

--- a/src/Eccube/Doctrine/Query/JoinCustomizer.php
+++ b/src/Eccube/Doctrine/Query/JoinCustomizer.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\Doctrine\Query;
+
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * JOIN句をカスタマイズするクラス。
+ *
+ * @package Eccube\Doctrine\Query
+ */
+abstract class JoinCustomizer implements QueryCustomizer
+{
+
+    /**
+     * @param QueryBuilder $builder
+     * @param array $params
+     * @param string $queryKey
+     */
+    public final function customize(QueryBuilder $builder, $params, $queryKey)
+    {
+        foreach ($this->createStatements($params, $queryKey) as $joinClause) {
+            $joinClause->build($builder);
+        }
+    }
+
+    /**
+     * 追加するJOIN句を組み立てます。
+     * このメソッドの戻り値が、元のクエリのJOIN句に追加されます。
+     *
+     * @param array $params
+     * @param $queryKey
+     * @return JoinClause[]
+     */
+    public abstract function createStatements($params, $queryKey);
+
+}

--- a/src/Eccube/Doctrine/Query/OrderByClause.php
+++ b/src/Eccube/Doctrine/Query/OrderByClause.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Doctrine\Query;
+
+
+/**
+ * ORDER BY句を組み立てるクラス。
+ *
+ * @package Eccube\Doctrine\Query
+ */
+class OrderByClause
+{
+
+    private $sort;
+    private $order;
+
+    /**
+     * OrderByClause constructor.
+     * @param $sort
+     * @param string $order
+     */
+    function __construct($sort, $order = 'asc')
+    {
+        $this->sort = $sort;
+        $this->order = $order;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSort()
+    {
+        return $this->sort;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrder()
+    {
+        return $this->order;
+    }
+}

--- a/src/Eccube/Doctrine/Query/OrderByCustomizer.php
+++ b/src/Eccube/Doctrine/Query/OrderByCustomizer.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Doctrine\Query;
+
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * ORDER BY句をカスタマイズするクラス。
+ *
+ * @package Eccube\Doctrine\Query
+ */
+abstract class OrderByCustomizer implements QueryCustomizer
+{
+
+    /**
+     * @param QueryBuilder $builder
+     * @param array $params
+     * @param string $queryKey
+     */
+    public final function customize(QueryBuilder $builder, $params, $queryKey)
+    {
+        foreach ($this->createStatements($params, $queryKey) as $index=>$orderByClause) {
+            if ($index === 0) {
+                $builder->orderBy($orderByClause->getSort(), $orderByClause->getOrder());
+            } else {
+                $builder->addOrderBy($orderByClause->getSort(), $orderByClause->getOrder());
+            }
+        }
+    }
+
+    /**
+     * 変更するORDER BY句を組み立てます。
+     * このメソッドの戻り値で、元のクエリのORDER BY句が上書きされます。
+     *
+     * @param array $params
+     * @param $queryKey
+     * @return OrderByClause[]
+     */
+    protected abstract function createStatements($params, $queryKey);
+}

--- a/src/Eccube/Doctrine/Query/Queries.php
+++ b/src/Eccube/Doctrine/Query/Queries.php
@@ -1,0 +1,42 @@
+<?php
+
+
+namespace Eccube\Doctrine\Query;
+
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\QueryBuilder;
+use Eccube\Annotation\QueryExtension;
+use Psr\Log\InvalidArgumentException;
+
+class Queries
+{
+
+    private $customizers = [];
+
+    public function addCustomizer(QueryCustomizer $customizer) {
+        if (!$customizer) {
+            throw new InvalidArgumentException('Customizer should not be null.');
+        }
+        $reader = new AnnotationReader();
+        $rc = new \ReflectionClass($customizer);
+        $anno = $reader->getClassAnnotation($rc, QueryExtension::class);
+        if (!$anno) {
+            throw new InvalidArgumentException(get_class($customizer).' doesn\'t have any '.QueryExtension::class.' annotation.');
+        }
+        foreach ($anno->value as $queryKey) {
+            $this->customizers[$queryKey][] = $customizer;
+        }
+    }
+
+    public function customize($queryKey, QueryBuilder $builder, $params)
+    {
+        if (isset($this->customizers[$queryKey])) {
+            /* @var QueryCustomizer $customizer */
+            foreach ($this->customizers[$queryKey] as $customizer) {
+                $customizer->customize($builder, $params, $queryKey);
+            }
+        }
+        return $builder;
+    }
+}

--- a/src/Eccube/Doctrine/Query/QueryCustomizer.php
+++ b/src/Eccube/Doctrine/Query/QueryCustomizer.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Doctrine\Query;
+
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * クエリをカスタマイズするインターフェイス。
+ *
+ * @package Eccube\Doctrine\Query
+ */
+interface QueryCustomizer
+{
+
+    /**
+     * クエリをカスタマイズします。
+     *
+     * @param QueryBuilder $builder
+     * @param array $params
+     * @param string $queryKey
+     */
+    public function customize(QueryBuilder $builder, $params, $queryKey);
+}

--- a/src/Eccube/Doctrine/Query/WhereClause.php
+++ b/src/Eccube/Doctrine/Query/WhereClause.php
@@ -1,0 +1,305 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Doctrine\Query;
+
+
+use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * WHERE句を組み立てるクラス。
+ *
+ * @package Eccube\Doctrine\Query
+ */
+class WhereClause
+{
+
+    private $expr;
+
+    /**
+     * @var array
+     */
+    private $params;
+
+    /**
+     * WhereClause constructor.
+     * @param $expr
+     * @param array $params
+     */
+    private function __construct($expr, $params = null)
+    {
+        $this->expr = $expr;
+        $this->params = $params;
+    }
+
+    private static function newWhereClause($expr, $x, $y)
+    {
+        if ($y) {
+            if (is_array($y)) {
+                return new WhereClause($expr, $y);
+            } else {
+                return new WhereClause($expr, [$x => $y]);
+            }
+        }
+        return new WhereClause($expr);
+    }
+
+    /**
+     * =条件式のファクトリメソッド。
+     *
+     * Example:
+     *      WhereClause::eq('name', ':Name', 'hoge')
+     *      WhereClause::eq('name', ':Name', ['Name' => 'hoge'])
+     *
+     * @param $x
+     * @param $y
+     * @param $param
+     * @return WhereClause
+     */
+    public static function eq($x, $y, $param)
+    {
+        return self::newWhereClause(self::expr()->eq($x, $y), $y, $param);
+    }
+
+    /**
+     * <>条件式のファクトリメソッド。
+     *
+     * Example:
+     *      WhereClause::neq('name', ':Name', 'hoge')
+     *      WhereClause::neq('name', ':Name', ['Name' => 'hoge'])
+     *
+     * @param $x
+     * @param $y
+     * @param $param
+     * @return WhereClause
+     */
+    public static function neq($x, $y, $param)
+    {
+        return self::newWhereClause(self::expr()->neq($x, $y), $y, $param);
+    }
+
+    /**
+     * IS NULL条件式のファクトリメソッド。
+     *
+     * Example:
+     *      WhereClause::isNull('name')
+     *
+     * @param $x
+     * @return WhereClause
+     */
+    public static function isNull($x)
+    {
+        return new WhereClause(self::expr()->isNull($x));
+    }
+
+    /**
+     * IS NOT NULL条件式のファクトリメソッド。
+     *
+     * Example:
+     *      WhereClause::isNotNull('name')
+     *
+     * @param $x
+     * @return WhereClause
+     */
+    public static function isNotNull($x)
+    {
+        return new WhereClause(self::expr()->isNotNull($x));
+    }
+
+    /**
+     * LIKE演算子のファクトリメソッド。
+     *
+     * Example:
+     *      WhereClause::like('name', ':Name', '%hoge')
+     *      WhereClause::like('name', ':Name', ['Name' => '%hoge'])
+     *
+     * @param $x
+     * @param $y
+     * @param $param
+     * @return WhereClause
+     */
+    public static function like($x, $y, $param)
+    {
+        return self::newWhereClause(self::expr()->like($x, $y), $y, $param);
+    }
+
+    /**
+     * NOT LIKE演算子のファクトリメソッド。
+     *
+     * Example:
+     *      WhereClause::notLike('name', ':Name', '%hoge')
+     *      WhereClause::notLike('name', ':Name', ['Name' => '%hoge'])
+     *
+     * @param $x
+     * @param $y
+     * @param $param
+     * @return WhereClause
+     */
+    public static function notLike($x, $y, $param)
+    {
+        return self::newWhereClause(self::expr()->notLike($x, $y), $y, $param);
+    }
+
+    /**
+     * IN演算子のファクトリメソッド。
+     *
+     * Example:
+     *      WhereClause::in('name', ':Names', ['foo', 'bar'])
+     *      WhereClause::in('name', ':Names', ['Names' => ['foo', 'bar']])
+     *
+     * @param $x
+     * @param $y
+     * @param $param
+     * @return WhereClause
+     */
+    public static function in($x, $y, $param)
+    {
+        return new WhereClause(self::expr()->in($x, $y), self::isMap($param) ? $param : [$y => $param]);
+    }
+
+    private static function isMap($arrayOrMap)
+    {
+        return array_values($arrayOrMap) !== $arrayOrMap;
+    }
+
+    /**
+     * NOT IN演算子のファクトリメソッド。
+     *
+     * Example:
+     *      WhereClause::notIn('name', ':Names', ['foo', 'bar'])
+     *      WhereClause::notIn('name', ':Names', ['Names' => ['foo', 'bar']])
+     *
+     * @param $x
+     * @param $y
+     * @param $param
+     * @return WhereClause
+     */
+    public static function notIn($x, $y, $param)
+    {
+        return new WhereClause(self::expr()->notIn($x, $y), self::isMap($param) ? $param : [$y => $param]);
+    }
+
+    /**
+     * BETWEEN演算子のファクトリメソッド。
+     *
+     * Example:
+     *      WhereClause::between('price', ':PriceMin', ':PriceMax', [1000, 2000])
+     *      WhereClause::between('price', ':PriceMin', ':PriceMax', ['PriceMin' => 1000, 'PriceMax' => 2000])
+     *
+     * @param $var
+     * @param $x
+     * @param $y
+     * @param $params
+     * @return WhereClause
+     */
+    public static function between($var, $x, $y, $params)
+    {
+        return new WhereClause(self::expr()->between($var, $x, $y), self::isMap($params) ? $params : [$x => $params[0], $y => $params[1]]);
+    }
+
+    /**
+     * >演算子のファクトリメソッド。
+     *
+     * Example:
+     *      WhereClause::gt('price', ':Price', 1000)
+     *      WhereClause::gt('price', ':Price', ['Price' => 1000])
+     *
+     * @param $x
+     * @param $y
+     * @param $param
+     * @return WhereClause
+     */
+    public static function gt($x, $y, $param)
+    {
+        return self::newWhereClause(self::expr()->gt($x, $y), $y, $param);
+    }
+
+    /**
+     * >=演算子のファクトリメソッド。
+     *
+     * Example:
+     *      WhereClause::gte('price', ':Price', 1000)
+     *      WhereClause::gte('price', ':Price', ['Price' => 1000])
+     *
+     * @param $x
+     * @param $y
+     * @param $param
+     * @return WhereClause
+     */
+    public static function gte($x, $y, $param)
+    {
+        return self::newWhereClause(self::expr()->gte($x, $y), $y, $param);
+    }
+
+    /**
+     * <演算子のファクトリメソッド。
+     *
+     * Example:
+     *      WhereClause::lt('price', ':Price', 1000)
+     *      WhereClause::lt('price', ':Price', ['Price' => 1000])
+     *
+     * @param $x
+     * @param $y
+     * @param $param
+     * @return WhereClause
+     */
+    public static function lt($x, $y, $param)
+    {
+        return self::newWhereClause(self::expr()->lt($x, $y), $y, $param);
+    }
+
+    /**
+     * <=演算子のファクトリメソッド。
+     *
+     * Example:
+     *      WhereClause::lte('price', ':Price', 1000)
+     *      WhereClause::lte('price', ':Price', ['Price' => 1000])
+     *
+     * @param $x
+     * @param $y
+     * @param $param
+     * @return WhereClause
+     */
+    public static function lte($x, $y, $param)
+    {
+        return self::newWhereClause(self::expr()->lte($x, $y), $y, $param);
+    }
+
+    /**
+     * @return Expr
+     */
+    private static function expr()
+    {
+        return new Expr();
+    }
+
+    public function build(QueryBuilder $builder) {
+        $builder->andWhere($this->expr);
+        if ($this->params) {
+            foreach ($this->params as $key=>$param) {
+                $builder->setParameter($key, $param);
+            }
+        }
+    }
+}

--- a/src/Eccube/Doctrine/Query/WhereCustomizer.php
+++ b/src/Eccube/Doctrine/Query/WhereCustomizer.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace Eccube\Doctrine\Query;
+
+
+use Doctrine\ORM\QueryBuilder;
+
+abstract class WhereCustomizer implements QueryCustomizer
+{
+
+    /**
+     * @param QueryBuilder $builder
+     * @param array $params
+     * @param string $queryKey
+     */
+    public final function customize(QueryBuilder $builder, $params, $queryKey)
+    {
+        foreach ($this->createStatements($params, $queryKey) as $whereClause) {
+            $whereClause->build($builder);
+        }
+    }
+
+    /**
+     * @param array $params
+     * @param $queryKey
+     * @return WhereClause[]
+     */
+    protected abstract function createStatements($params, $queryKey);
+}

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -42,6 +42,9 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  */
 class CustomerRepository extends EntityRepository implements UserProviderInterface
 {
+
+    const QUERY_KEY_SEARCH = '\Eccube\Repository\CustomerRepository_SEARCH';
+
     protected $app;
 
     public function setApplication($app)
@@ -288,7 +291,7 @@ class CustomerRepository extends EntityRepository implements UserProviderInterfa
         // Order By
         $qb->addOrderBy('c.update_date', 'DESC');
 
-        return $qb;
+        return $this->app['eccube.queries']->customize(self::QUERY_KEY_SEARCH, $qb, $searchData);
     }
 
     /**

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -36,6 +36,10 @@ use Eccube\Util\Str;
  */
 class OrderRepository extends EntityRepository
 {
+    const QUERY_KEY_SEARCH = '\Eccube\Repository\OrderRepository_SEARCH';
+    const QUERY_KEY_SEARCH_ADMIN = '\Eccube\Repository\OrderRepository_SEARCH_ADMIN';
+    const QUERY_KEY_SEARCH_BY_CUSTOMER = '\Eccube\Repository\OrderRepository_SEARCH_BY_CUSTOMER';
+
     protected $app;
 
     public function setApplication($app)
@@ -244,7 +248,7 @@ class OrderRepository extends EntityRepository
         // Order By
         $qb->addOrderBy('o.update_date', 'DESC');
 
-        return $qb;
+        return $this->app['eccube.queries']->customize(self::QUERY_KEY_SEARCH, $qb, $searchData);
     }
 
 
@@ -439,7 +443,7 @@ class OrderRepository extends EntityRepository
         $qb->orderBy('o.update_date', 'DESC');
         $qb->addorderBy('o.id', 'DESC');
 
-        return $qb;
+        return $this->app['eccube.queries']->customize(self::QUERY_KEY_SEARCH_ADMIN, $qb, $searchData);
     }
 
 
@@ -456,7 +460,7 @@ class OrderRepository extends EntityRepository
         // Order By
         $qb->addOrderBy('o.id', 'DESC');
 
-        return $qb;
+        return $this->app['eccube.queries']->customize(self::QUERY_KEY_SEARCH_BY_CUSTOMER, $qb, ['customer' => $Customer]);
     }
 
     /**

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -39,6 +39,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class ProductRepository extends EntityRepository
 {
 
+    const QUERY_KEY_SEARCH = '\Eccube\Repository\ProductRepository_SEARCH';
+    const QUERY_KEY_SEARCH_ADMIN = '\Eccube\Repository\ProductRepository_SEARCH_ADMIN';
+    const QUERY_KEY_GET_FAVORITE = '\Eccube\Repository\ProductRepository_GET_FAVORITE';
+
     /**
      * @var \Eccube\Application
      */
@@ -156,7 +160,7 @@ class ProductRepository extends EntityRepository
                 ->addOrderBy('p.id', 'DESC');
         }
 
-        return $qb;
+        return $this->app['eccube.queries']->customize(self::QUERY_KEY_SEARCH, $qb, $searchData);
     }
 
     /**
@@ -270,7 +274,7 @@ class ProductRepository extends EntityRepository
         $qb
             ->orderBy('p.update_date', 'DESC');
 
-        return $qb;
+        return $this->app['eccube.queries']->customize(self::QUERY_KEY_SEARCH_ADMIN, $qb, $searchData);
     }
 
     /**
@@ -292,6 +296,6 @@ class ProductRepository extends EntityRepository
         // XXX Paginater を使用した場合に PostgreSQL で正しくソートできない
         $qb->addOrderBy('cfp.create_date', 'DESC');
 
-        return $qb;
+        return $this->app['eccube.queries']->customize(self::QUERY_KEY_GET_FAVORITE, $qb, ['customer' => $Customer]);
     }
 }

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -204,7 +204,9 @@ class EccubeServiceProvider implements ServiceProviderInterface, EventListenerPr
             return $CategoryRepository;
         };
         $app['eccube.repository.customer'] = function () use ($app) {
-            return $app['orm.em']->getRepository('Eccube\Entity\Customer');
+            $customerRepository = $app['orm.em']->getRepository('Eccube\Entity\Customer');
+            $customerRepository->setApplication($app);
+            return $customerRepository;
         };
         $app['eccube.repository.news'] = function () use ($app) {
             return $app['orm.em']->getRepository('Eccube\Entity\News');
@@ -478,6 +480,11 @@ class EccubeServiceProvider implements ServiceProviderInterface, EventListenerPr
             return $types;
         });
         $app['eccube.entity.event.dispatcher']->addEventListener(new \Acme\Entity\SoldOutEventListener());
+        $app['eccube.queries'] = function () {
+            return new \Eccube\Doctrine\Query\Queries();
+        };
+        // TODO QueryCustomizerの追加方法は要検討
+        $app['eccube.queries']->addCustomizer(new \Acme\Entity\AdminProductListCustomizer());
     }
 
     public function subscribe(Container $app, EventDispatcherInterface $dispatcher)

--- a/tests/Eccube/Tests/Doctrine/Query/JoinClauseTest.php
+++ b/tests/Eccube/Tests/Doctrine/Query/JoinClauseTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Eccube\Tests\Doctrine\Query;
+
+use Doctrine\ORM\Query\Parameter;
+use Doctrine\ORM\QueryBuilder;
+use Eccube\Doctrine\Query\JoinClause;
+use Eccube\Doctrine\Query\OrderByClause;
+use Eccube\Doctrine\Query\WhereClause;
+use Eccube\Tests\EccubeTestCase;
+
+class JoinClauseTest extends EccubeTestCase
+{
+    public function testInnerJoin()
+    {
+        $clause = JoinClause::innerJoin('p.ProductCategories', 'pct');
+        self::assertEquals('INNER JOIN p.ProductCategories pct', $this->asString($clause));
+    }
+
+    public function testLeftJoin()
+    {
+        $clause = JoinClause::leftJoin('p.ProductCategories', 'pct');
+        self::assertEquals('LEFT JOIN p.ProductCategories pct', $this->asString($clause));
+    }
+
+    public function testInnerJoinFull()
+    {
+        $clause = JoinClause::innerJoin('p.ProductCategories', 'pct', 'ON', 'pct.rank = 1', 'categoryId');
+        self::assertEquals('INNER JOIN p.ProductCategories pct INDEX BY categoryId ON pct.rank = 1', $this->asString($clause));
+    }
+
+    public function testLeftJoinFull()
+    {
+        $clause = JoinClause::leftJoin('p.ProductCategories', 'pct', 'ON', 'pct.rank = 1', 'categoryId');
+        self::assertEquals('LEFT JOIN p.ProductCategories pct INDEX BY categoryId ON pct.rank = 1', $this->asString($clause));
+    }
+
+    public function testWithWhere()
+    {
+        $clause = JoinClause::leftJoin('p.ProductCategories', 'pct')
+            ->addWhere(WhereClause::eq('p.name', ':Name', 'hoge'))
+            ->addWhere(WhereClause::eq('pct.rank', ':Rank', 1));
+        self::assertEquals('LEFT JOIN p.ProductCategories pct WHERE p.name = :Name AND pct.rank = :Rank', $this->asString($clause));
+        self::assertEquals([new Parameter('Name', 'hoge'), new Parameter('Rank', 1)], $this->getParams($clause));
+    }
+
+    public function testWithOrderBy()
+    {
+        $clause = JoinClause::leftJoin('p.ProductCategories', 'pct')
+            ->addOrderBy(new OrderByClause('pct.rank', 'desc'))
+            ->addOrderBy(new OrderByClause('pct.categoryId'));
+        self::assertEquals('LEFT JOIN p.ProductCategories pct ORDER BY pct.rank desc, pct.categoryId asc', $this->asString($clause));
+    }
+
+    private function asString(JoinClause $clause)
+    {
+        $builder = $this->queryBuilder();
+        $clause->build($builder);
+        return preg_replace('/^SELECT p FROM Product p /', '', $builder->getDQL());
+    }
+
+    private function getParams(JoinClause $clause)
+    {
+        $builder = $this->queryBuilder();
+        $clause->build($builder);
+        return $builder->getParameters()->toArray();
+    }
+
+    /**
+     * @return QueryBuilder
+     */
+    private function queryBuilder()
+    {
+        return $this->app['orm.em']->createQueryBuilder()
+            ->select('p')->from('Product', 'p');
+    }
+
+}

--- a/tests/Eccube/Tests/Doctrine/Query/JoinCustomizerTest.php
+++ b/tests/Eccube/Tests/Doctrine/Query/JoinCustomizerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Eccube\Tests\Doctrine\Query;
+
+use Doctrine\ORM\QueryBuilder;
+use Eccube\Doctrine\Query\JoinClause;
+use Eccube\Doctrine\Query\JoinCustomizer;
+use Eccube\Tests\EccubeTestCase;
+
+class JoinCustomizerTest extends EccubeTestCase
+{
+    public function testCustomize()
+    {
+        $builder = $this->createQueryBuilder();
+        $customizer = new JoinCustomizerTest_Customizer(function() { return []; });
+        $customizer->customize($builder, null, '');
+        self::assertEquals($builder->getDQL(), 'SELECT p FROM Product p');
+    }
+
+    public function testCustomizeInnerJoin()
+    {
+        $builder = $this->createQueryBuilder();
+        $customizer = new JoinCustomizerTest_Customizer(function() { return [
+            JoinClause::innerJoin('p.ProductCategories', 'pct')
+        ]; });
+        $customizer->customize($builder, null, '');
+        self::assertEquals($builder->getDQL(), 'SELECT p FROM Product p INNER JOIN p.ProductCategories pct');
+    }
+
+    public function testCustomizeMultiInnerJoin()
+    {
+        $builder = $this->createQueryBuilder();
+        $customizer = new JoinCustomizerTest_Customizer(function() { return [
+            JoinClause::innerJoin('p.ProductCategories', 'pct'),
+            JoinClause::innerJoin('pct.Category', 'c')
+        ]; });
+        $customizer->customize($builder, null, '');
+        self::assertEquals($builder->getDQL(), 'SELECT p FROM Product p INNER JOIN p.ProductCategories pct INNER JOIN pct.Category c');
+    }
+
+    /**
+     * @return QueryBuilder
+     */
+    private function createQueryBuilder()
+    {
+        return $this->app['orm.em']->createQueryBuilder()
+            ->select('p')
+            ->from('Product', 'p');
+    }
+}
+
+class JoinCustomizerTest_Customizer extends JoinCustomizer
+{
+
+    private $callback;
+
+    function __construct($callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * @param array $params
+     * @param $queryKey
+     * @return JoinClause[]
+     */
+    public function createStatements($params, $queryKey)
+    {
+        $callback = $this->callback;
+        return $callback($params);
+    }
+}

--- a/tests/Eccube/Tests/Doctrine/Query/OrderByCustomizerTest.php
+++ b/tests/Eccube/Tests/Doctrine/Query/OrderByCustomizerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+
+namespace Eccube\Tests\Doctrine\Query;
+
+
+use Doctrine\ORM\QueryBuilder;
+use Eccube\Doctrine\Query\OrderByClause;
+use Eccube\Doctrine\Query\OrderByCustomizer;
+use Eccube\Tests\EccubeTestCase;
+
+class OrderByCustomizerTest extends EccubeTestCase
+{
+
+    public function testCustomizeNop()
+    {
+        $builder = $this->createQueryBuilder();
+        $customizer = new OrderByCustomizerTest_Customizer(function() { return []; });
+        $customizer->customize($builder, null, '');
+
+        self::assertEquals('SELECT p FROM Product p', $builder->getDQL());
+    }
+
+    public function testCustomizeNop_Should_not_Override()
+    {
+        $builder = $this->createQueryBuilder()
+            ->orderBy('name', 'desc');
+        $customizer = new OrderByCustomizerTest_Customizer(function() { return []; });
+        $customizer->customize($builder, null, '');
+
+        self::assertEquals('SELECT p FROM Product p ORDER BY name desc', $builder->getDQL());
+    }
+
+    public function testCustomize_Override()
+    {
+        $builder = $this->createQueryBuilder()
+            ->orderBy('name', 'desc');
+        $customizer = new OrderByCustomizerTest_Customizer(function() { return [
+            new OrderByClause('productId')
+        ]; });
+        $customizer->customize($builder, null, '');
+
+        self::assertEquals('SELECT p FROM Product p ORDER BY productId asc', $builder->getDQL());
+    }
+
+    public function testCustomize_Override_with_multi_clause()
+    {
+        $builder = $this->createQueryBuilder()
+            ->orderBy('name', 'desc');
+        $customizer = new OrderByCustomizerTest_Customizer(function() { return [
+            new OrderByClause('productId'),
+            new OrderByClause('name', 'desc')
+        ]; });
+        $customizer->customize($builder, null, '');
+
+        self::assertEquals('SELECT p FROM Product p ORDER BY productId asc, name desc', $builder->getDQL());
+    }
+
+    /**
+     * @return QueryBuilder
+     */
+    private function createQueryBuilder()
+    {
+        return $this->app['orm.em']->createQueryBuilder()
+            ->select('p')
+            ->from('Product', 'p');
+    }
+}
+
+class OrderByCustomizerTest_Customizer extends OrderByCustomizer
+{
+
+    /**
+     * @var callable $closure
+     */
+    private $closure;
+
+    function __construct($closure)
+    {
+        $this->closure = $closure;
+    }
+
+    /**
+     * @param array $params
+     * @param $queryKey
+     * @return OrderByClause[]
+     */
+    public function createStatements($params, $queryKey)
+    {
+        $callback = $this->closure;
+        return $callback($params);
+    }
+}

--- a/tests/Eccube/Tests/Doctrine/Query/QueriesTest.php
+++ b/tests/Eccube/Tests/Doctrine/Query/QueriesTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Eccube\Tests\Doctrine\Query;
+
+use Doctrine\ORM\QueryBuilder;
+use Eccube\Annotation\QueryExtension;
+use Eccube\Doctrine\Query\Queries;
+use Eccube\Doctrine\Query\QueryCustomizer;
+use Eccube\Tests\EccubeTestCase;
+use Psr\Log\InvalidArgumentException;
+
+class QueriesTest extends EccubeTestCase
+{
+
+    public function testCustomizerShouldBeCalled()
+    {
+        $customizer = new QueriesTest_Customizer();
+        $queries = new Queries();
+        $queries->addCustomizer($customizer);
+
+        $queries->customize(QueriesTest::class, $this->queryBuilder(), null);
+
+        self::assertTrue($customizer->customized);
+    }
+
+    public function testCustomizerShouldNotBeCalled()
+    {
+        $customizer = new QueriesTest_Customizer();
+        $queries = new Queries();
+        $queries->addCustomizer($customizer);
+
+        $queries->customize('Dummy', $this->queryBuilder(), null);
+
+        self::assertFalse($customizer->customized);
+    }
+
+    public function testAddCustomizerWithoutAnnotation()
+    {
+        $customizer = new QueriesTest_CustomizerWithoutAnnotation();
+        $queries = new Queries();
+
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $queries->addCustomizer($customizer);
+    }
+
+    /**
+     * @return QueryBuilder
+     */
+    private function queryBuilder()
+    {
+        return $this->app['orm.em']->createQueryBuilder()
+            ->select('p')->from('Product', 'p');
+    }
+
+}
+
+/**
+ * @QueryExtension(QueriesTest::class)
+ */
+class QueriesTest_Customizer implements QueryCustomizer
+{
+
+    public $customized = false;
+
+    public function customize(QueryBuilder $builder, $params, $queryKey)
+    {
+        $this->customized = true;
+    }
+}
+
+class QueriesTest_CustomizerWithoutAnnotation implements QueryCustomizer
+{
+    public function customize(QueryBuilder $builder, $params, $queryKey) {}
+}

--- a/tests/Eccube/Tests/Doctrine/Query/WhereClauseTest.php
+++ b/tests/Eccube/Tests/Doctrine/Query/WhereClauseTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Eccube\Tests\Doctrine\Query;
+
+use Doctrine\ORM\Query\Parameter;
+use Doctrine\ORM\QueryBuilder;
+use Eccube\Doctrine\Query\WhereClause;
+use Eccube\Tests\EccubeTestCase;
+
+class WhereClauseTest extends EccubeTestCase
+{
+    public function testEq()
+    {
+        $actual = WhereClause::eq('name', ':Name', 'foo');
+        self::assertEquals('name = :Name', $this->asString($actual));
+        self::assertEquals([new Parameter('Name', 'foo')], $this->getParams($actual));
+    }
+
+    public function testEqWithMapParam()
+    {
+        $actual = WhereClause::eq('name', ':Name', ['Name' => 'foo']);
+        self::assertEquals('name = :Name', $this->asString($actual));
+        self::assertEquals([new Parameter('Name', 'foo')], $this->getParams($actual));
+    }
+
+    public function testNeq()
+    {
+        $actual = WhereClause::neq('name', ':Name', 'foo');
+        self::assertEquals('name <> :Name', $this->asString($actual));
+        self::assertEquals([new Parameter('Name', 'foo')], $this->getParams($actual));
+    }
+
+    public function testIsNull()
+    {
+        $actual = WhereClause::isNull('name');
+        self::assertEquals('name IS NULL', $this->asString($actual));
+        self::assertEquals([], $this->getParams($actual));
+    }
+
+    public function testIsNotNull()
+    {
+        $actual = WhereClause::isNotNull('name');
+        self::assertEquals('name IS NOT NULL', $this->asString($actual));
+        self::assertEquals([], $this->getParams($actual));
+    }
+
+    public function testLike()
+    {
+        $actual = WhereClause::like('name', ':Name', '%hoge');
+        self::assertEquals('name LIKE :Name', $this->asString($actual));
+        self::assertEquals([new Parameter('Name', '%hoge')], $this->getParams($actual));
+    }
+
+    public function testNotLike()
+    {
+        $actual = WhereClause::notLike('name', ':Name', '%hoge');
+        self::assertEquals('name NOT LIKE :Name', $this->asString($actual));
+        self::assertEquals([new Parameter('Name', '%hoge')], $this->getParams($actual));
+    }
+
+    public function testIn()
+    {
+        $actual = WhereClause::in('name', ':Names', ['foo', 'bar']);
+        self::assertEquals('name IN(:Names)', $this->asString($actual));
+        self::assertEquals([new Parameter('Names', ['foo', 'bar'])], $this->getParams($actual));
+    }
+
+    public function testInWithMap()
+    {
+        $actual = WhereClause::in('name', ':Names', ['Names' => ['foo', 'bar']]);
+        self::assertEquals('name IN(:Names)', $this->asString($actual));
+        self::assertEquals([new Parameter('Names', ['foo', 'bar'])], $this->getParams($actual));
+    }
+
+    public function testNotIn()
+    {
+        $actual = WhereClause::notIn('name', ':Names', ['foo', 'bar']);
+        self::assertEquals('name NOT IN(:Names)', $this->asString($actual));
+        self::assertEquals([new Parameter('Names', ['foo', 'bar'])], $this->getParams($actual));
+    }
+
+    public function testNotInWithMap()
+    {
+        $actual = WhereClause::notIn('name', ':Names', ['Names' => ['foo', 'bar']]);
+        self::assertEquals('name NOT IN(:Names)', $this->asString($actual));
+        self::assertEquals([new Parameter('Names', ['foo', 'bar'])], $this->getParams($actual));
+    }
+
+    public function testBetween()
+    {
+        $actual = WhereClause::between('price', ':Min', ':Max', [1000, 2000]);
+        self::assertEquals('price BETWEEN :Min AND :Max', $this->asString($actual));
+        self::assertEquals([new Parameter('Min', 1000), new Parameter('Max', 2000)], $this->getParams($actual));
+    }
+
+    public function testBetweenWithMap()
+    {
+        $actual = WhereClause::between('price', ':Min', ':Max', ['Min' => 1000, 'Max' => 2000]);
+        self::assertEquals('price BETWEEN :Min AND :Max', $this->asString($actual));
+        self::assertEquals([new Parameter('Min', 1000), new Parameter('Max', 2000)], $this->getParams($actual));
+    }
+
+    public function testGt()
+    {
+        $actual = WhereClause::gt('price', ':Price', 1000);
+        self::assertEquals('price > :Price', $this->asString($actual));
+        self::assertEquals([new Parameter('Price', 1000)], $this->getParams($actual));
+    }
+
+    public function testGtWithMap()
+    {
+        $actual = WhereClause::gt('price', ':Price', ['Price' => 1000]);
+        self::assertEquals('price > :Price', $this->asString($actual));
+        self::assertEquals([new Parameter('Price', 1000)], $this->getParams($actual));
+    }
+
+    public function testGte()
+    {
+        $actual = WhereClause::gte('price', ':Price', 1000);
+        self::assertEquals('price >= :Price', $this->asString($actual));
+        self::assertEquals([new Parameter('Price', 1000)], $this->getParams($actual));
+    }
+
+    public function testGteWithMap()
+    {
+        $actual = WhereClause::gte('price', ':Price', ['Price' => 1000]);
+        self::assertEquals('price >= :Price', $this->asString($actual));
+        self::assertEquals([new Parameter('Price', 1000)], $this->getParams($actual));
+    }
+
+    public function testLt()
+    {
+        $actual = WhereClause::lt('price', ':Price', 1000);
+        self::assertEquals('price < :Price', $this->asString($actual));
+        self::assertEquals([new Parameter('Price', 1000)], $this->getParams($actual));
+    }
+
+    public function testLtWithMap()
+    {
+        $actual = WhereClause::lt('price', ':Price', ['Price' => 1000]);
+        self::assertEquals('price < :Price', $this->asString($actual));
+        self::assertEquals([new Parameter('Price', 1000)], $this->getParams($actual));
+    }
+
+    public function testLte()
+    {
+        $actual = WhereClause::lte('price', ':Price', 1000);
+        self::assertEquals('price <= :Price', $this->asString($actual));
+        self::assertEquals([new Parameter('Price', 1000)], $this->getParams($actual));
+    }
+
+    public function testLteWithMap()
+    {
+        $actual = WhereClause::lte('price', ':Price', ['Price' => 1000]);
+        self::assertEquals('price <= :Price', $this->asString($actual));
+        self::assertEquals([new Parameter('Price', 1000)], $this->getParams($actual));
+    }
+
+    /*
+     * Helper methods.
+     */
+
+    private function asString(WhereClause $clause)
+    {
+        /** @var QueryBuilder $builder */
+        $builder = $this->app['orm.em']->createQueryBuilder();
+        $clause->build($builder);
+        return preg_replace('/^SELECT WHERE /', '', $builder->getDQL());
+    }
+
+    private function getParams(WhereClause $clause)
+    {
+        /** @var QueryBuilder $builder */
+        $builder = $this->app['orm.em']->createQueryBuilder();
+        $clause->build($builder);
+        return $builder->getParameters()->toArray();
+    }
+}

--- a/tests/Eccube/Tests/Doctrine/Query/WhereCustomizerTest.php
+++ b/tests/Eccube/Tests/Doctrine/Query/WhereCustomizerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Eccube\Tests\Doctrine\Query;
+
+use Doctrine\ORM\QueryBuilder;
+use Eccube\Doctrine\Query\WhereClause;
+use Eccube\Doctrine\Query\WhereCustomizer;
+use Eccube\Tests\EccubeTestCase;
+
+class WhereCustomizerTest extends EccubeTestCase
+{
+
+    public function testCustomizeNOP()
+    {
+        $builder = $this->createQueryBuilder();
+        $customizer = new WhereCustomizerTest_Customizer(function() { return []; });
+        $customizer->customize($builder, null, '');
+
+        self::assertEquals('SELECT p FROM Product p', $builder->getDQL());
+    }
+
+    public function testCustomizeAddWhereClause()
+    {
+        $builder = $this->createQueryBuilder();
+        $customizer = new WhereCustomizerTest_Customizer(function() { return [WhereClause::eq('name', ':Name', 'hoge')]; });
+        $customizer->customize($builder, null, '');
+
+        self::assertEquals('SELECT p FROM Product p WHERE name = :Name', $builder->getDQL());
+    }
+
+    public function testCustomizeAddMultipleWhereClause()
+    {
+        $builder = $this->createQueryBuilder();
+        $customizer = new WhereCustomizerTest_Customizer(function() { return [
+            WhereClause::eq('name', ':Name', 'hoge'),
+            WhereClause::eq('delFlg', ':DelFlg', 0)
+        ]; });
+        $customizer->customize($builder, null, '');
+
+        self::assertEquals('SELECT p FROM Product p WHERE name = :Name AND delFlg = :DelFlg', $builder->getDQL());
+    }
+
+    /**
+     * @return QueryBuilder
+     */
+    private function createQueryBuilder()
+    {
+        return $this->app['orm.em']->createQueryBuilder()
+            ->select('p')
+            ->from('Product', 'p');
+    }
+}
+
+class WhereCustomizerTest_Customizer extends WhereCustomizer
+{
+    /**
+     * @var callable $callback
+     */
+    private $callback;
+
+    function __construct($callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * @param array $params
+     * @param $queryKey
+     * @return WhereClause[]
+     */
+    protected function createStatements($params, $queryKey)
+    {
+        $callback = $this->callback;
+        return $callback($params);
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ リポジトリで組み立てているQueryBuilderに対してソート順や検索条件をカスタマイズできる機構を追加

### 実装例
```php:AdminProductListCustomizer.php
/**
 * @QueryExtension(ProductRepository::QUERY_KEY_SEARCH_ADMIN)
 */
class AdminProductListCustomizer extends OrderByCustomizer
{
    /**
     * 常に商品IDでソートする。
     *
     * @param array $params
     * @return OrderByClause[]
     */
    protected function createStatements($params)
    {
        return [new OrderByClause('p.id')];
    }
}
```

## 方針(Policy)
+ カスタマイズするためのインターフェイスとしては以下を提供

|インターフェイス/クラス|概要|
|---|---|
|QueryCustomizer|QueryBuilderを自由に変更|
|OrderByCustomizer|ソート順を変更する|
|WhereCustomizer|検索条件を追加する|
|JoinCustomizer|結合するテーブルを追加する|


## テスト（Test)
+ 管理画面の商品マスターのソート順を商品IDに固定するサンプル
    + Acme\Entity\AdminProductListCustomizer

## 相談（Discussion）
+ QueryExtensionアノテーションに指定するキーを各リポジトリで定義しておくのか、どこかにまとめて定義したほうがいいのかどうか。