### PR TITLE
[商品登録]画像アップロードをシーケンシャル（同期）にアップロードする修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -129,6 +129,7 @@ $(function() {
     $('#{{ form.product_image.vars.id }}').fileupload({
         url: "{{ url('admin_product_image_add') }}",
         type: "post",
+        sequentialUploads: true,
         dataType: 'json',
         done: function (e, data) {
             $('#progress').hide();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
https://github.com/EC-CUBE/ec-cube/issues/2276

## 相談（Discussion）
商品画像アップロードスクリプトに「sequentialUploads: true」を追加しましたが対応はなってないみたいです
画像アップロードはシーケンシャルなりましたがファイルの選択順ではないです、ブラウザーの仕様になってます
選択するフォルダーの表示順でアップロードするです。
例：フォルダーの表示順
image_1.jpg
image_2.jpg
image_3.jpg
image_4.jpg
image_5.jpg
コントロールキー押して「image_5.jpg」と「image_3.jpg」を選択し、アップロード順番は
こんな順番になります
「image_3.jpg」
「image_5.jpg」
色んなブラウザ確認しましたがいつも同じルールです。

別の方法でできると思って色んな所調べましたが選択順はブラウザーの仕様になります、
フォルダーのなかで画像表示順変更したらアップロード順かわります。


