### PR TITLE
商品規格画面で「商品登録に戻る」ボタン追加

### DIFF
--- a/src/Eccube/Resource/template/admin/Product/product_class.twig
+++ b/src/Eccube/Resource/template/admin/Product/product_class.twig
@@ -309,7 +309,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         <input id="mode" type="hidden" name="mode">
         <button type="submit" class="btn btn-primary btn-lg btn-block" name="mode" value="update">更新</button>
 {% endif %}
-        <p><a href="{{ url('admin_product_page', { page_no : app.session.get('eccube.admin.product.search.page_no')|default('1') } ) }}?resume=1">前のページに戻る</a></p>
+        <p><a href="{{ url('admin_product_product_edit', {id : Product.id}) }}">商品登録に戻る</a></p>
     </div>
 </div>
 </form>

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductClassControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductClassControllerTest.php
@@ -54,6 +54,14 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
 
         // Then
         $this->assertTrue($this->client->getResponse()->isRedirect($redirectUrl));
+
+        // 商品登録画面に移動する確認
+        $crawler = $this->client->followRedirect();
+        $csvExportUrl = $crawler->filter('div#edit_box__footer div p a')->selectLink('商品登録に戻る')->link()->getUri();
+
+        $crawler = $this->client->request('GET', $csvExportUrl);
+        $panelName = $crawler->filter('div#main h1 span')->text();
+        $this->assertContains('商品登録', $panelName);
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
https://github.com/EC-CUBE/ec-cube/issues/2245
商品規格登録ページから商品登録ページに戻りたい

## 方針(Policy)
条件なしでいつも商品編集画面に移動する
「商品登録に戻る」ボタンを追加
遷移先は、商品編集画面（admin/product/product/〇〇〇/edit）。

## テスト（Test)
- ボタンあり確認
- リンククリックすると商品編集画面に移動する確認

