### PR TITLE
1ページ内でid属性が重複する可能性があるため修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Product/csv_category.twig
+++ b/src/Eccube/Resource/template/admin/Product/csv_category.twig
@@ -80,7 +80,7 @@ $(function() {
                             {{ form_errors(form.import_file) }}
                         </div>
                         {% for error in errors %}
-                            <div id="upload_box__error" class="text-danger">{{ error.message }}</div>
+                            <div id="upload_box__error--{{ loop.index }}" class="text-danger">{{ error.message }}</div>
                         {% endfor %}
                     </div>
                     <div id="spinner"></div>

--- a/src/Eccube/Resource/template/admin/Product/csv_product.twig
+++ b/src/Eccube/Resource/template/admin/Product/csv_product.twig
@@ -80,7 +80,7 @@ $(function() {
                             {{ form_errors(form.import_file) }}
                         </div>
                         {% for error in errors %}
-                            <div id="upload_file_box__upload_error" class="text-danger">{{ error.message }}</div>
+                            <div id="upload_file_box__upload_error--{{ loop.index }}" class="text-danger">{{ error.message }}</div>
                         {% endfor %}
                     </div>
                     <div id="spinner"></div>

--- a/src/Eccube/Resource/template/admin/Store/unregisterd_plugin_table.twig
+++ b/src/Eccube/Resource/template/admin/Store/unregisterd_plugin_table.twig
@@ -28,7 +28,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             </thead>
             <tbody>
             {% for Plugin in Plugins %}
-                <form id="{{ Plugin.name }}" name="{{ Plugin.name }}" method="post" action="">
+                <form id="{{ Plugin.code }}" name="{{ Plugin.name }}" method="post" action="">
                     <tr class="{% if Plugin.enable == 0 %}active{% endif %}">
                         {% if Plugin.name is defined %}
                             <td class="tp">

--- a/src/Eccube/Resource/template/default/Cart/index.twig
+++ b/src/Eccube/Resource/template/default/Cart/index.twig
@@ -114,23 +114,23 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 {% set ProductClass = CartItem.Object %}
                                 {% set Product = ProductClass.Product %}
 
-                                <div id="cart_item_list__item" class="item_box tr">
-                                    <div id="cart_item_list__cart_remove" class="icon_edit td">
+                                <div id="cart_item_list__item--{{ ProductClass.id }}" class="item_box tr">
+                                    <div id="cart_item_list__cart_remove--{{ ProductClass.id }}" class="icon_edit td">
                                         <a href="{{ url('cart_remove', {'productClassId': ProductClass.id }) }}" {{ csrf_token_for_anchor() }} data-method="put" data-message="カートから商品を削除してもよろしいですか?">
                                             <svg class="cb cb-close"><use xlink:href="#cb-close" /></svg>
                                         </a>
                                     </div>
                                     <div class="td table">
-                                        <div id="cart_item_list__product_image" class="item_photo">
+                                        <div id="cart_item_list__product_image--{{ ProductClass.id }}" class="item_photo">
                                             <a  target="_blank" href="{{ url('product_detail', {id : Product.id} ) }}">
                                                 <img src="{{ app.config.image_save_urlpath }}/{{ Product.MainListImage|no_image_product }}" alt="{{ Product.name }}" />
                                             </a>
                                         </div>
                                         <dl class="item_detail">
-                                            <dt id="cart_item_list__product_detail" class="item_name text-default">
+                                            <dt id="cart_item_list__product_detail--{{ ProductClass.id }}" class="item_name text-default">
                                                 <a target="_blank" href="{{ url('product_detail', {id : Product.id} ) }}">{{ Product.name }}</a>
                                             </dt>
-                                            <dd id="cart_item_list__class_category" class="item_pattern small">
+                                            <dd id="cart_item_list__class_category--{{ ProductClass.id }}" class="item_pattern small">
                                                 {% if ProductClass.ClassCategory1 and ProductClass.ClassCategory1.id %}
                                                     {{ ProductClass.ClassCategory1.ClassName }}：{{ ProductClass.ClassCategory1 }}
                                                 {% endif %}
@@ -138,26 +138,26 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                     <br>{{ ProductClass.ClassCategory2.ClassName }}：{{ ProductClass.ClassCategory2 }}
                                                 {% endif %}
                                             </dd>
-                                            <dd id="cart_item_list__item_price" class="item_price">￥{{ CartItem.price|number_format }}</dd>
-                                            <dd id="cart_item_list__item_subtotal" class="item_subtotal">小計：￥{{ CartItem.total_price|number_format }}</dd>
+                                            <dd id="cart_item_list__item_price--{{ ProductClass.id }}" class="item_price">￥{{ CartItem.price|number_format }}</dd>
+                                            <dd id="cart_item_list__item_subtotal--{{ ProductClass.id }}" class="item_subtotal">小計：￥{{ CartItem.total_price|number_format }}</dd>
                                         </dl>
                                     </div>
-                                    <div id="cart_item_list__quantity" class="item_quantity td">
+                                    <div id="cart_item_list__quantity--{{ ProductClass.id }}" class="item_quantity td">
                                         {{ CartItem.quantity|number_format }}
-                                        <ul id="cart_item_list__quantity_edit">
+                                        <ul id="cart_item_list__quantity_edit--{{ ProductClass.id }}">
                                             <li>
                                                 {% if CartItem.quantity > 1 %}
-                                                    <a id="cart_item_list__down" href="{{ url('cart_down', {'productClassId': ProductClass.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false"><svg class="cb cb-minus"><use xlink:href="#cb-minus" /></svg></a>
+                                                    <a id="cart_item_list__down--{{ ProductClass.id }}" href="{{ url('cart_down', {'productClassId': ProductClass.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false"><svg class="cb cb-minus"><use xlink:href="#cb-minus" /></svg></a>
                                                 {% else %}
                                                     <span><svg class="cb cb-minus"><use xlink:href="#cb-minus" /></svg></span>
                                                 {% endif %}
                                             </li>
                                             <li>
-                                                <a id="cart_item_list__up" href="{{ url('cart_up', {'productClassId': ProductClass.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false"><svg class="cb cb-plus"><use xlink:href="#cb-plus" /></svg></a>
+                                                <a id="cart_item_list__up--{{ ProductClass.id }}" href="{{ url('cart_up', {'productClassId': ProductClass.id}) }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false"><svg class="cb cb-plus"><use xlink:href="#cb-plus" /></svg></a>
                                             </li>
                                         </ul>
                                     </div>
-                                    <div id="cart_item_list__subtotal" class="item_subtotal td">￥{{ CartItem.total_price|number_format }}</div>
+                                    <div id="cart_item_list__subtotal--{{ ProductClass.id }}" class="item_subtotal td">￥{{ CartItem.total_price|number_format }}</div>
                                 </div><!--/item_box-->
                             {% endfor %}
 

--- a/src/Eccube/Resource/template/default/Shopping/index.twig
+++ b/src/Eccube/Resource/template/default/Shopping/index.twig
@@ -153,7 +153,7 @@ $(function() {
                     </ul>
                 </div>
                 {% for error in app.session.flashbag.get('eccube.front.error')  %}
-                    <div id="confirm_flow_box__message" class="message">
+                    <div id="confirm_flow_box__message--{{ loop.index }}" class="message">
                         <p class="errormsg bg-danger">
                             <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>{{ error|trans|nl2br }}
                         </p>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
* 1ページ内で`id`属性値が重複する可能性がある部分を修正

## 方針(Policy)
* 他のページと同様に、`{{ loop.index }}`の付与または一意なIDなどを付与するように修正

## テスト（Test)
* カートに複数商品を投入し、`id`属性値がかぶらないことを確認しました
* カートに商品を投入し、`id`属性値に規格IDが設定されていることを確認しました
* 購入確認画面のエラーメッセージは通常の方法では発生させられないため検証はできませんでした
* 未登録プラグインを複数登録して`id`属性値に`{{ loop.index }}`が付与されることを確認しました
* 商品CSV登録画面でエラーの発生するCSVファイルをアップロードして`id`属性値に`{{ loop.index }}`が付与されることを確認しました
* 商品CSVファイルは以下を使用しました
```
商品ID,公開ステータス(ID),商品名,ショップ用メモ欄,商品説明(一覧),商品説明(詳細),検索ワード,フリーエリア,商品削除フラグ,商品画像,商品カテゴリ(ID),タグ(ID),商品種別(ID),規格分類1(ID),規格分類2(ID),発送日目安(ID),商品コード,在庫数,在庫数無制限フラグ,販売制限数,通常価格,販売価格,送料,商品規格削除フラグ
,,,,,,,,,,,,,,,,,,,,,,,
```
* カテゴリCSV登録画面でエラーの発生するCSVファイルをアップロードして`id`属性値に`{{ loop.index }}`が付与されることを確認しました
* カテゴリCSVは商品とは異なり、エラーが発生すると中断してしまうため複数の検証はできませんでした
* カテゴリCSVファイルは以下を使用しました
```
カテゴリID,カテゴリ名,親カテゴリID
,,
```
