### PR TITLE
日時データ型の対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ install:
 
 before_script:
   - CODENAME=$(lsb_release -c -s)
+  - if [[ $DB = 'mysql' ]]; then mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql; fi
   - if [[ $PHP_SAPI != 'phpdbg' ]] || [[ $CODENAME = 'trusty' ]]; then phpenv config-rm xdebug.ini ; fi
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer self-update || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ install:
 
 before_script:
   - CODENAME=$(lsb_release -c -s)
-  - if [[ $DB = 'mysql' ]]; then mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql; fi
   - if [[ $PHP_SAPI != 'phpdbg' ]] || [[ $CODENAME = 'trusty' ]]; then phpenv config-rm xdebug.ini ; fi
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer self-update || true

--- a/src/Eccube/Doctrine/DBAL/Types/UTCDateTimeTzType.php
+++ b/src/Eccube/Doctrine/DBAL/Types/UTCDateTimeTzType.php
@@ -26,8 +26,9 @@ namespace Eccube\Doctrine\DBAL\Types;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\DateTimeTzType;
 
-class UTCDateTimeType extends DateTimeType
+class UTCDateTimeTzType extends DateTimeTzType
 {
     /**
      * UTCのタイムゾーン
@@ -65,7 +66,7 @@ class UTCDateTimeType extends DateTimeType
         }
 
         $converted = \DateTime::createFromFormat(
-            $platform->getDateTimeFormatString(),
+            $platform->getDateTimeTzFormatString(),
             $value,
             self::getUtcTimeZone()
         );
@@ -74,7 +75,7 @@ class UTCDateTimeType extends DateTimeType
             throw ConversionException::conversionFailedFormat(
                 $value,
                 $this->getName(),
-                $platform->getDateTimeFormatString()
+                $platform->getDateTimeTzFormatString()
             );
         }
 

--- a/src/Eccube/Doctrine/EventSubscriber/InitSubscriber.php
+++ b/src/Eccube/Doctrine/EventSubscriber/InitSubscriber.php
@@ -25,21 +25,16 @@
 namespace Eccube\Doctrine\EventSubscriber;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
-use Doctrine\ORM\Events;
+use Doctrine\DBAL\Event\ConnectionEventArgs;
+use Doctrine\DBAL\Events;
 use Eccube\Application;
 
-class TimeZoneSubscriber implements EventSubscriber
+class InitSubscriber implements EventSubscriber
 {
     /**
      * @var Application
      */
     protected $app;
-
-    /**
-     * @var
-     */
-    protected static $timezone;
 
     /**
      * @param Application $app
@@ -49,29 +44,26 @@ class TimeZoneSubscriber implements EventSubscriber
         $this->app = $app;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getSubscribedEvents()
     {
-        return array(
-            Events::postLoad,
-        );
+        return array(Events::postConnect);
     }
 
-    public function postLoad(LifecycleEventArgs $args)
+    /**
+     * @param ConnectionEventArgs $args
+     */
+    public function postConnect(ConnectionEventArgs $args)
     {
-        $entity = $args->getObject();
-
-        $refl = new \ReflectionObject($entity);
-        foreach ($refl->getProperties() as $prop) {
-            if (!$prop->isStatic()) {
-                $prop->setAccessible(true);
-                $value = $prop->getValue($entity);
-                if (!is_null($value) && $value instanceof \DateTime) {
-                    $timezone = is_null(self::$timezone)
-                        ? self::$timezone = new \DateTimeZone($this->app['config']['timezone'])
-                        : self::$timezone;
-                    $value->setTimezone($timezone);
-                }
-            }
+        $db = $args->getConnection();
+        $platform = $args->getDatabasePlatform()->getName();
+        
+        if ($platform === 'mysql') {
+            $db->executeQuery("SET SESSION time_zone = 'UTC'");
+        } elseif ($platform === 'postgresql') {
+            $db->executeQuery("SET TIME ZONE 'UTC'");
         }
     }
 }

--- a/src/Eccube/Doctrine/EventSubscriber/InitSubscriber.php
+++ b/src/Eccube/Doctrine/EventSubscriber/InitSubscriber.php
@@ -61,7 +61,7 @@ class InitSubscriber implements EventSubscriber
         $platform = $args->getDatabasePlatform()->getName();
         
         if ($platform === 'mysql') {
-            $db->executeQuery("SET SESSION time_zone = 'UTC'");
+            $db->executeQuery("SET SESSION time_zone = '+00:00'");
         } elseif ($platform === 'postgresql') {
             $db->executeQuery("SET TIME ZONE 'UTC'");
         }

--- a/src/Eccube/Entity/AuthorityRole.php
+++ b/src/Eccube/Entity/AuthorityRole.php
@@ -34,14 +34,14 @@ class AuthorityRole extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/BaseInfo.php
+++ b/src/Eccube/Entity/BaseInfo.php
@@ -197,7 +197,7 @@ class BaseInfo extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/Block.php
+++ b/src/Eccube/Entity/Block.php
@@ -60,14 +60,14 @@ class Block extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/Category.php
+++ b/src/Eccube/Entity/Category.php
@@ -190,14 +190,14 @@ class Category extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/ClassCategory.php
+++ b/src/Eccube/Entity/ClassCategory.php
@@ -78,14 +78,14 @@ class ClassCategory extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/ClassName.php
+++ b/src/Eccube/Entity/ClassName.php
@@ -78,14 +78,14 @@ class ClassName extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/Csv.php
+++ b/src/Eccube/Entity/Csv.php
@@ -69,14 +69,14 @@ class Csv extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/Customer.php
+++ b/src/Eccube/Entity/Customer.php
@@ -172,7 +172,7 @@ class Customer extends \Eccube\Entity\AbstractEntity implements UserInterface
     /**
      * @var \DateTime|null
      *
-     * @ORM\Column(name="birth", type="datetime", nullable=true)
+     * @ORM\Column(name="birth", type="datetimetz", nullable=true)
      */
     private $birth;
 
@@ -200,14 +200,14 @@ class Customer extends \Eccube\Entity\AbstractEntity implements UserInterface
     /**
      * @var \DateTime|null
      *
-     * @ORM\Column(name="first_buy_date", type="datetime", nullable=true)
+     * @ORM\Column(name="first_buy_date", type="datetimetz", nullable=true)
      */
     private $first_buy_date;
 
     /**
      * @var \DateTime|null
      *
-     * @ORM\Column(name="last_buy_date", type="datetime", nullable=true)
+     * @ORM\Column(name="last_buy_date", type="datetimetz", nullable=true)
      */
     private $last_buy_date;
 
@@ -242,7 +242,7 @@ class Customer extends \Eccube\Entity\AbstractEntity implements UserInterface
     /**
      * @var \DateTime|null
      *
-     * @ORM\Column(name="reset_expire", type="datetime", nullable=true)
+     * @ORM\Column(name="reset_expire", type="datetimetz", nullable=true)
      */
     private $reset_expire;
 
@@ -256,14 +256,14 @@ class Customer extends \Eccube\Entity\AbstractEntity implements UserInterface
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/CustomerAddress.php
+++ b/src/Eccube/Entity/CustomerAddress.php
@@ -240,14 +240,14 @@ class CustomerAddress extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/CustomerFavoriteProduct.php
+++ b/src/Eccube/Entity/CustomerFavoriteProduct.php
@@ -56,14 +56,14 @@ class CustomerFavoriteProduct extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/Delivery.php
+++ b/src/Eccube/Entity/Delivery.php
@@ -98,14 +98,14 @@ class Delivery extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/Help.php
+++ b/src/Eccube/Entity/Help.php
@@ -230,14 +230,14 @@ class Help extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/Layout.php
+++ b/src/Eccube/Entity/Layout.php
@@ -94,14 +94,14 @@ class Layout extends AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/MailHistory.php
+++ b/src/Eccube/Entity/MailHistory.php
@@ -57,7 +57,7 @@ class MailHistory extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime|null
      *
-     * @ORM\Column(name="send_date", type="datetime", nullable=true)
+     * @ORM\Column(name="send_date", type="datetimetz", nullable=true)
      */
     private $send_date;
 

--- a/src/Eccube/Entity/MailTemplate.php
+++ b/src/Eccube/Entity/MailTemplate.php
@@ -99,14 +99,14 @@ class MailTemplate extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/Member.php
+++ b/src/Eccube/Entity/Member.php
@@ -140,21 +140,21 @@ class Member extends \Eccube\Entity\AbstractEntity implements UserInterface
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 
     /**
      * @var \DateTime|null
      *
-     * @ORM\Column(name="login_date", type="datetime", nullable=true)
+     * @ORM\Column(name="login_date", type="datetimetz", nullable=true)
      */
     private $login_date;
 

--- a/src/Eccube/Entity/News.php
+++ b/src/Eccube/Entity/News.php
@@ -57,7 +57,7 @@ class News extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime|null
      *
-     * @ORM\Column(name="news_date", type="datetime", nullable=true)
+     * @ORM\Column(name="news_date", type="datetimetz", nullable=true)
      */
     private $date;
 
@@ -113,14 +113,14 @@ class News extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -302,7 +302,7 @@ class Order extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime|null
      *
-     * @ORM\Column(name="order_birth", type="datetime", nullable=true)
+     * @ORM\Column(name="order_birth", type="datetimetz", nullable=true)
      */
     private $birth;
 
@@ -372,35 +372,35 @@ class Order extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 
     /**
      * @var \DateTime|null
      *
-     * @ORM\Column(name="order_date", type="datetime", nullable=true)
+     * @ORM\Column(name="order_date", type="datetimetz", nullable=true)
      */
     private $order_date;
 
     /**
      * @var \DateTime|null
      *
-     * @ORM\Column(name="commit_date", type="datetime", nullable=true)
+     * @ORM\Column(name="commit_date", type="datetimetz", nullable=true)
      */
     private $commit_date;
 
     /**
      * @var \DateTime|null
      *
-     * @ORM\Column(name="payment_date", type="datetime", nullable=true)
+     * @ORM\Column(name="payment_date", type="datetimetz", nullable=true)
      */
     private $payment_date;
 

--- a/src/Eccube/Entity/PageLayout.php
+++ b/src/Eccube/Entity/PageLayout.php
@@ -339,14 +339,14 @@ class PageLayout extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/Payment.php
+++ b/src/Eccube/Entity/Payment.php
@@ -134,14 +134,14 @@ class Payment extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/Plugin.php
+++ b/src/Eccube/Entity/Plugin.php
@@ -98,14 +98,14 @@ class Plugin extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/PluginEventHandler.php
+++ b/src/Eccube/Entity/PluginEventHandler.php
@@ -108,14 +108,14 @@ class PluginEventHandler extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -518,14 +518,14 @@ class Product extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/ProductClass.php
+++ b/src/Eccube/Entity/ProductClass.php
@@ -247,14 +247,14 @@ class ProductClass extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/ProductImage.php
+++ b/src/Eccube/Entity/ProductImage.php
@@ -49,7 +49,7 @@ class ProductImage extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 

--- a/src/Eccube/Entity/ProductStock.php
+++ b/src/Eccube/Entity/ProductStock.php
@@ -60,14 +60,14 @@ class ProductStock extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/ProductTag.php
+++ b/src/Eccube/Entity/ProductTag.php
@@ -41,7 +41,7 @@ class ProductTag extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 

--- a/src/Eccube/Entity/Shipping.php
+++ b/src/Eccube/Entity/Shipping.php
@@ -177,7 +177,7 @@ class Shipping extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime|null
      *
-     * @ORM\Column(name="shipping_delivery_date", type="datetime", nullable=true)
+     * @ORM\Column(name="shipping_delivery_date", type="datetimetz", nullable=true)
      */
     private $shipping_delivery_date;
 
@@ -191,7 +191,7 @@ class Shipping extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime|null
      *
-     * @ORM\Column(name="shipping_commit_date", type="datetime", nullable=true)
+     * @ORM\Column(name="shipping_commit_date", type="datetimetz", nullable=true)
      */
     private $shipping_commit_date;
 
@@ -212,14 +212,14 @@ class Shipping extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/TaxRule.php
+++ b/src/Eccube/Entity/TaxRule.php
@@ -106,7 +106,7 @@ class TaxRule extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="apply_date", type="datetime")
+     * @ORM\Column(name="apply_date", type="datetimetz")
      */
     private $apply_date;
 
@@ -120,14 +120,14 @@ class TaxRule extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/src/Eccube/Entity/Template.php
+++ b/src/Eccube/Entity/Template.php
@@ -83,14 +83,14 @@ class Template extends \Eccube\Entity\AbstractEntity
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="create_date", type="datetime")
+     * @ORM\Column(name="create_date", type="datetimetz")
      */
     private $create_date;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="update_date", type="datetime")
+     * @ORM\Column(name="update_date", type="datetimetz")
      */
     private $update_date;
 

--- a/tests/Eccube/Tests/Doctrine/TimeZone/TimeZoneTest.php
+++ b/tests/Eccube/Tests/Doctrine/TimeZone/TimeZoneTest.php
@@ -12,7 +12,7 @@ class TimeZoneTest extends EccubeTestCase
         parent::setUp();
 
         // 2000-01-01 00:00:00 +09 (jst)
-        // 1999-12-31 03:00:00 +00 (utc)
+        // 1999-12-31 15:00:00 +00 (utc)
         // の日時データを登録
         $sql = "
             insert into dtb_product (

--- a/tests/Eccube/Tests/Doctrine/TimeZone/TimeZoneTest.php
+++ b/tests/Eccube/Tests/Doctrine/TimeZone/TimeZoneTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Eccube\Tests\Doctrine;
+
+use Eccube\Entity\Product;
+use Eccube\Tests\EccubeTestCase;
+
+class TimeZoneTest extends EccubeTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        // 2000-01-01 00:00:00 +09 (jst)
+        // 1999-12-31 03:00:00 +00 (utc)
+        // の日時データを登録
+        $sql = "
+            insert into dtb_product (
+                product_id,
+                name,
+                create_date,
+                update_date,
+                discriminator_type)
+            values(
+                999,
+                '商品名',
+                '1999-12-31 15:00:00',
+                '1999-12-31 15:00:00',
+                'product');";
+
+        /** @var \Eccube\Application $app */
+        $app = $this->app;
+        $app['db']->exec($sql);
+    }
+
+    public function testOrmFind()
+    {
+        /** @var \Eccube\Application $app */
+        $app = $this->app;
+
+        $product = $app['eccube.repository.product']->find(999);
+
+        // jstに変換されて取得されるはず.
+        $expected = '2000-01-01 00:00:00';
+        $actual = $product->getCreateDate()->format('Y-m-d H:i:s');
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * ORMで、2000-01-01 00:00:00(jst)を登録した場合のテスト.
+     *
+     * ORMでfindすると、 2000-01-01 00:00:00(jst) が取得できる.
+     * データベース上では1999-12-31 15:00:00(utc)で登録されている.
+     */
+    public function testOrmPersist()
+    {
+        /** @var \Eccube\Application $app */
+        $app = $this->app;
+
+        $product = new Product();
+        $product->setName('商品名');
+
+        $app['orm.em']->persist($product);
+        $app['orm.em']->flush($product);
+
+        // jstでcreate dateを登録
+        $timezone = new \DateTimeZone($app['config']['timezone']);
+        $createDate = new \DateTime('2000-01-01 00:00:00', $timezone);
+
+        $product->setCreateDate($createDate);
+        $app['orm.em']->flush($product);
+
+        // emtity managerの管理対象からはずす
+        $app['orm.em']->detach($product);
+
+        $id = $product->getId();
+
+        // jstに変換されて取得できるはず
+        $product = $app['eccube.repository.product']->find($id);
+        $expected = '2000-01-01 00:00:00';
+        $actual = $product->getCreateDate()->format('Y-m-d H:i:s');
+
+        $this->assertEquals($expected, $actual);
+
+        $sql = 'select product_id, create_date from dtb_product where product_id = ?';
+        $stmt = $app['db']->executeQuery($sql, [$id]);
+        $product = $stmt->fetch();
+
+        // utcで登録されているはず
+        $expected = '1999-12-31 15:00:00';
+        $actual = new \DateTime($product['create_date'], new \DateTimeZone('UTC'));
+
+        $this->assertEquals($expected, $actual->format('Y-m-d H:i:s'));
+    }
+
+    public function testDbalSelect()
+    {
+        /** @var \Eccube\Application $app */
+        $app = $this->app;
+
+        $sql = 'select create_date from dtb_product where product_id = 999';
+        $stmt = $app['db']->executeQuery($sql);
+        $product = $stmt->fetch();
+
+        // dbalでselectした場合, utc時刻をそのまま取得
+        $expected = '1999-12-31 15:00:00';
+        $actual = new \DateTime($product['create_date'], new \DateTimeZone('UTC'));
+
+        $this->assertEquals($expected, $actual->format('Y-m-d H:i:s'));
+
+        // convertToPHPValueでjst時刻に変換可能
+        $timezone = new \DateTimeZone($app['config']['timezone']);
+        $expected = new \DateTime('2000-01-01 00:00:00', $timezone);
+        $actual = $app['db']->convertToPHPValue($product['create_date'], 'datetimetz');
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testDbalInsert()
+    {
+        /** @var \Eccube\Application $app */
+        $app = $this->app;
+
+        // jstで登録
+        $timezone = new \DateTimeZone($app['config']['timezone']);
+        $createDate = new \DateTime('2000-01-01 00:00:00', $timezone);
+        $updateDate = new \DateTime('2000-01-01 00:00:00', $timezone);
+
+        $app['db']->insert('dtb_product', [
+            'product_id' => 9999,
+            'name' => '商品名',
+            'create_date' => $createDate,
+            'update_date' => $updateDate,
+            'discriminator_type' => 'product'
+        ], [
+            'update_date' => 'datetimetz',
+            'create_date' => 'datetimetz',
+        ]);
+
+        $sql = 'select product_id, create_date from dtb_product where product_id = 9999';
+        $stmt = $app['db']->executeQuery($sql);
+        $product = $stmt->fetch();
+
+        // utcに変換されて登録されている
+        $expected = '1999-12-31 15:00:00';
+        $actual = new \DateTime($product['create_date'], new \DateTimeZone('UTC'));
+
+        $this->assertEquals($expected, $actual->format('Y-m-d H:i:s'));
+    }
+
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#1199 の対応

## 方針(Policy)

### mysql
- mysqlのdatetimeはタイムゾーン情報を持っていない。
- ormから投入するデータは、全てUTCに変換して保存する
  - select時はアプリ側のtimezoneに変換する
  - insert時はUTCに変換してinsert
- 接続時に、`SET time_zone = 'UTC'`する
  - dbalで直接sqlを実行した場合を想定
  - current_timestampやnowした時に、UTCで検索/更新するため
- 参考
  - http://tmtms.hatenablog.com/entry/2015/08/22/mysql-timezone
  - http://qiita.com/ytyng/items/031828e723bf1eadf436

### postgresql
- timestamp with timezoneを使う
  - 内部的にはUTC時刻で表現される
- ormから投入するデータは、全てUTCに変換して保存する
  - select時はアプリ側のtimezoneに変換する
  - insert時はUTCに変換してinsert
- 接続時に、`Set timezone TO 'UTC`する
  - dbalで直接sqlを実行した場合を想定
  - current_timestampやnowした時に、UTCで検索/更新するため
- 参考
  - http://qiita.com/mikakane/items/4885af02986ab812a12f 

## 実装に関する補足(Appendix)

~~~mysqlの場合、タイムゾーンテーブルがロードされていないと、以下のエラーが発生します。~~~
~~~`SQLSTATE[HY000]: General error: 1298 Unknown or incorrect time zone: 'UTC'`~~~

~~~https://dev.mysql.com/doc/refman/5.6/ja/mysql-tzinfo-to-sql.html~~~

https://github.com/EC-CUBE/ec-cube/pull/2308/commits/91d82f00f4121eed39eb1f5dec944917f2853005 で対応

## テスト（Test)

https://github.com/EC-CUBE/ec-cube/pull/2308/commits/a9e66fd878f08813b83101ab1208919ae455f272 にselect/insertのテストコードを追加

## 相談（Discussion）
