### PR TITLE
ご注文内容のご確認画面でお届け先の変更ボタン押しても画面移動しない対応

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -546,11 +546,11 @@ class ShoppingController extends AbstractController
         if ($form->isSubmitted()) {
             // お届け先変更の時フォームバーリデトしない
             // お問い合わせ内容を保存する
-                $data = $form->getData();
-                $message = $data['message'];
-                $Order->setMessage($message);
-                // 受注情報を更新
-                $app['orm.em']->flush();
+            $data = $form->getData();
+            $message = $data['message'];
+            $Order->setMessage($message);
+            // 受注情報を更新
+            $app['orm.em']->flush();
             // お届け先設定一覧へリダイレクト
             return $app->redirect($app->url('shopping_shipping', array('id' => $id)));
         }

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -543,13 +543,14 @@ class ShoppingController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
-            $data = $form->getData();
-            $message = $data['message'];
-            $Order->setMessage($message);
-            // 受注情報を更新
-            $app['orm.em']->flush();
-
+        if ($form->isSubmitted()) {
+            // お届け先変更の時フォームバーリデトしない
+            // お問い合わせ内容を保存する
+                $data = $form->getData();
+                $message = $data['message'];
+                $Order->setMessage($message);
+                // 受注情報を更新
+                $app['orm.em']->flush();
             // お届け先設定一覧へリダイレクト
             return $app->redirect($app->url('shopping_shipping', array('id' => $id)));
         }
@@ -678,7 +679,9 @@ class ShoppingController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
+        if ($form->isSubmitted()) {
+            // お届け先変更の時フォームバーリデトしない
+            // お問い合わせ内容を保存する
             $data = $form->getData();
             $message = $data['message'];
             $Order->setMessage($message);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
ご注文内容のご確認画面でお届け先の変更ボタン押しても画面移動しない対応
https://github.com/EC-CUBE/ec-cube/issues/2233

お届け編集移動する時お問合せバリデートしないようにロッジク追加

## テスト（Test)
お問合せ内容にエラーなるように桁数を設定して、お届け変更して、確認画面でお問合せ内容残ってる確認する（会員とゲスト）


