### PR TITLE
商品規格1のみ設定されている商品で、規格選択時の価格表示変更が機能してない

### DIFF
--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -40,6 +40,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     fnSetClassCategories(
             document.form1, {{ form.classcategory_id2.vars.value|json_encode|raw }}
     );
+    {% elseif form.classcategory_id1 is defined %}
+          eccube.checkStock(document.form1, {{ Product.id }}, {{ form.classcategory_id1.vars.value|json_encode|raw }}, null);
     {% endif %}
 </script>
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

https://xoops.ec-cube.net/modules/newbb/viewtopic.php?topic_id=19046&forum=8&post_id=82184#forumpost82184

## 再現手順(Procedure)

商品規格1のみ設定している場合、規格を選択して数量を「0」にしてカートに入れると、販売価格が選択している規格の価格に変更されない。

【例】
300円〜500円
　↓　規格を選択する
400円
　↓　エラーリロード
300円〜500円

## 対応方法

商品テンプレートの中に規格２ないとき規格１をチェックして、バリュー設定されている時に価格表示変える

## 備考


