### PR TITLE
商品の新着順取得時のorderBy条件にidを追加（テストケースのみ）

### DIFF
--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
@@ -303,4 +303,50 @@ class ProductRepositoryGetQueryBuilderBySearchDataTest extends AbstractProductRe
         $this->actual = count($this->Results);
         $this->verify();
     }
+
+    public function test300ProductsList()
+    {
+        $tables = array(
+            'dtb_product_image',
+            'dtb_product_stock',
+            'dtb_product_class',
+            'dtb_product_category',
+            'dtb_product'
+        );
+        $this->deleteAllRows($tables);
+        $productList = array();
+        for ($i = 1; $i <= 300; $i++) {
+            $classNo = mt_rand(1, 3);
+            $productName = 'BIG商品-' . $i;
+            $this->createProduct($productName, $classNo);
+            $productList[] = $productName;
+        }
+        $productList = array_reverse($productList);
+
+        // 商品作成時間同じにする
+        $QueryBuilder = $this->app['orm.em']->createQueryBuilder();
+        $QueryBuilder->update('Eccube\Entity\Product','p');
+        $QueryBuilder->set('p.create_date',':createDate');
+        $QueryBuilder->setParameter(':createDate',new \DateTime());
+        $QueryBuilder->getQuery()->execute();
+
+        // 新着順
+        $ProductListOrderBy = $this->app['orm.em']->getRepository('\Eccube\Entity\Master\ProductListOrderBy')->find(2);
+        $this->searchData = array(
+            'name' => 'BIG商品-',
+            'orderby' => $ProductListOrderBy
+        );
+
+        $this->scenario();
+        $this->expected = array();
+        foreach($productList as $productName){
+            $this->expected[] = $productName;
+        }
+
+        $this->actual = array();
+        foreach($this->Results as $row){
+            $this->actual[] = $row->getName();
+        }
+        $this->verify();
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
商品の新着順取得時のorderBy条件にidを追加
https://github.com/EC-CUBE/ec-cube/pull/2290

データ件数を300件でテストケースです