### PR TITLE
heroku button の3.1対応

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: $(composer config bin-dir)/heroku-php-apache2 html/
+web: $(composer config bin-dir)/heroku-php-apache2

--- a/composer.json
+++ b/composer.json
@@ -95,8 +95,7 @@
     },
     "scripts": {
         "compile": [
-            "php eccube_install.php pgsql none --skip-createdb -V",
-            "sed -i -e \"s|${PWD}|/app|\" ${PWD}/app/config/eccube/path.yml"
+            "php eccube_install.php pgsql none --skip-createdb -V"
         ]
     },
     "config": {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

heroku buttonが動作していなかったので修正

## 実装に関する補足(Appendix)

- ドキュメントルートの指定にhtmlディレクトリが不要になったので削除
- path.ymlが相対パスになったため、デプロイ時の書き換え処理を削除

