### PR TITLE
ルーティング関連の修正

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -319,6 +319,17 @@ class Application extends \Silex\Application
             return new ChainUrlGenerator($generators, $app['request_context']);
         });
 
+        // Route CollectionにEC-CUBEで定義したルーティングを追加(debug tool barに出力するため)
+        $this->extend('routes', function ($routes, $app) {
+            $routes->addCollection($app['eccube.router.extend']->getRouteCollection());
+            foreach ($app['eccube.routers.plugin'] as $router) {
+                $routes->addCollection($router->getRouteCollection());
+            };
+            $routes->addCollection($app['eccube.router.origin']->getRouteCollection());
+
+            return $routes;
+        });
+
         // init http cache
         $this->initCacheRequest();
 

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -319,10 +319,6 @@ class Application extends \Silex\Application
             return new ChainUrlGenerator($generators, $app['request_context']);
         });
 
-        // TODO この設定が正しいか要確認
-        $this->extend('routes_factory', function ($routes, $app ) {
-            return $this['sensio_framework_extra.routing.loader.annot_dir']->load($this['config']['root_dir'].'/src/Eccube/Controller');
-        });
         // init http cache
         $this->initCacheRequest();
 

--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -42,9 +42,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
- * TODO 管理画面のルーティングは動的に行う.おそらくコントローラのディレクトリをフロント/管理で分ける必要がある
- *
- * @Route("/admin/order")
+ * @Route("/{_admin}/order")
  */
 class EditController extends AbstractController
 {

--- a/src/Eccube/Controller/Admin/Shipping/EditController.php
+++ b/src/Eccube/Controller/Admin/Shipping/EditController.php
@@ -25,8 +25,7 @@ use Eccube\Form\Type\Admin\ShipmentItemType;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
- * // FIXME UrlGenerator で {_admin} を認識しない問題あり
- * @Route("/admin/shipping")
+ * @Route("/{_admin}/shipping")
  */
 class EditController
 {

--- a/src/Eccube/Controller/Admin/Shipping/ShippingController.php
+++ b/src/Eccube/Controller/Admin/Shipping/ShippingController.php
@@ -24,8 +24,7 @@ use Eccube\Form\Type\Admin\ShipmentItemType;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
- * // FIXME UrlGenerator で {_admin} を認識しない問題あり
- * @Route("/admin/shipping")
+ * @Route("/{_admin}/shipping")
  */
 class ShippingController
 {

--- a/src/Eccube/ControllerProvider/AdminControllerProvider.php
+++ b/src/Eccube/ControllerProvider/AdminControllerProvider.php
@@ -95,8 +95,8 @@ class AdminControllerProvider implements ControllerProviderInterface
         // order
         $c->match('/order', '\Eccube\Controller\Admin\Order\OrderController::index')->bind('admin_order');
         $c->match('/order/page/{page_no}', '\Eccube\Controller\Admin\Order\OrderController::index')->assert('page_no', '\d+')->bind('admin_order_page');
-        $c->match('/order/new', '\Eccube\Controller\Admin\Order\EditController::index')->bind('admin_order_new');
-        $c->match('/order/{id}/edit', '\Eccube\Controller\Admin\Order\EditController::index')->assert('id', '\d+')->bind('admin_order_edit');
+        //$c->match('/order/new', '\Eccube\Controller\Admin\Order\EditController::index')->bind('admin_order_new');
+        //$c->match('/order/{id}/edit', '\Eccube\Controller\Admin\Order\EditController::index')->assert('id', '\d+')->bind('admin_order_edit');
         $c->delete('/order/{id}/delete', '\Eccube\Controller\Admin\Order\OrderController::delete')->assert('id', '\d+')->bind('admin_order_delete');
         $c->match('/order/export/order', '\Eccube\Controller\Admin\Order\OrderController::exportOrder')->bind('admin_order_export_order');
         $c->match('/order/export/shipping', '\Eccube\Controller\Admin\Order\OrderController::exportShipping')->bind('admin_order_export_shipping');

--- a/src/Eccube/Routing/EccubeRouter.php
+++ b/src/Eccube/Routing/EccubeRouter.php
@@ -42,6 +42,13 @@ class EccubeRouter extends Router
             ]
         );
 
+        $collection->addDefaults(
+            [
+                '_admin' => $this->adminPrefix,
+                '_user_data' => $this->userDataPrefix,
+            ]
+        );
+
         return $collection;
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

ルーティング関連の修正
- url_generatorで管理画面のルーティングが取得できない問題を修正
- src以下のアノテーションが読めない問題を修正
- デバッグツールバーにアノテーションのルーティングが表示されるように修正

Router:Debugコマンドの修正
- アノテーションのルーティングを出力するように修正
- コントローラクラスを表示するように修正

## 方針(Policy)

-

## 実装に関する補足(Appendix)

### url_generatorで管理画面のルーティングが取得できない問題を修正

```
$app->url("admin_test")
```
など、アノテーションで追加したルーティングを指定すると例外が発生する問題を修正しました。

### src以下のアノテーションが読めない問題を修正

src以下のコントローラにアノテーションでルーティングを定義しても認識されない問題を修正しました。また、デバッグツールバーにも検索対象のルーティング一覧が表示されるように修正しています。

## テスト（Test)

-

## 相談（Discussion）

-

