### PR TITLE
受注データの更新を行った時に、会員の最終購入日が更新されないようにする

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -50,10 +50,13 @@ class EditController extends AbstractController
 
         $TargetOrder = null;
         $OriginOrder = null;
+        $isNewOrder = false;
 
         if (is_null($id)) {
             // 空のエンティティを作成.
             $TargetOrder = $this->newOrder($app);
+            $isNewOrder = true;
+
         } else {
             $TargetOrder = $app['eccube.repository.order']->find($id);
             if (is_null($TargetOrder)) {
@@ -246,7 +249,7 @@ class EditController extends AbstractController
 
                         if ($Customer) {
                             // 会員の場合、購入回数、購入金額などを更新
-                            $app['eccube.repository.customer']->updateBuyData($app, $Customer, $TargetOrder->getOrderStatus()->getId());
+                            $app['eccube.repository.customer']->updateBuyData($app, $Customer, $isNewOrder);
                         }
 
                         $event = new EventArgs(

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -169,7 +169,7 @@ class OrderController extends AbstractController
         $Customer = $Order->getCustomer();
         if ($Customer) {
             // 会員の場合、購入回数、購入金額などを更新
-            $app['eccube.repository.customer']->updateBuyData($app, $Customer, $Order->getOrderStatus()->getId());
+            $app['eccube.repository.customer']->updateBuyData($app, $Customer);
         }
 
         $event = new EventArgs(

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -447,14 +447,6 @@ class CustomerRepository extends EntityRepository implements UserProviderInterfa
                 $Customer->setFirstBuyDate($now);
             }
 
-            if ($orderStatusId == $app['config']['order_cancel'] ||
-                    $orderStatusId == $app['config']['order_pending'] ||
-                    $orderStatusId == $app['config']['order_processing']) {
-                // キャンセル、決済処理中、購入処理中は購入時間は更新しない
-            } else {
-                $Customer->setLastBuyDate($now);
-            }
-
             $Customer->setBuyTimes($data['buy_times']);
             $Customer->setBuyTotal($data['buy_total']);
 

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -422,9 +422,9 @@ class CustomerRepository extends EntityRepository implements UserProviderInterfa
      *
      * @param $app
      * @param  Customer $Customer
-     * @param  $orderStatusId
+     * @param  $isNewOrder
      */
-    public function updateBuyData($app, Customer $Customer, $orderStatusId)
+    public function updateBuyData($app, Customer $Customer, $isNewOrder = false)
     {
         // 会員の場合、初回購入時間・購入時間・購入回数・購入金額を更新
 
@@ -445,6 +445,10 @@ class CustomerRepository extends EntityRepository implements UserProviderInterfa
             $firstBuyDate = $Customer->getFirstBuyDate();
             if (empty($firstBuyDate)) {
                 $Customer->setFirstBuyDate($now);
+            }
+
+            if($isNewOrder) {
+                $Customer->setLastBuyDate($now);
             }
 
             $Customer->setBuyTimes($data['buy_times']);

--- a/tests/Eccube/Tests/Repository/CustomerRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/CustomerRepositoryTest.php
@@ -203,7 +203,7 @@ class CustomerRepositoryTest extends EccubeTestCase
         $this->app['orm.em']->flush();
 
         $this->actual = 1;
-        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer, $this->app['config']['order_new']);
+        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer);
         $this->expected = $this->Customer->getBuyTimes();
         $this->verify();
 
@@ -215,7 +215,7 @@ class CustomerRepositoryTest extends EccubeTestCase
         $this->app['orm.em']->flush();
 
         $this->actual = 0;
-        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer, $this->app['config']['order_cancel']);
+        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer);
         $this->expected = $this->Customer->getBuyTimes();
         $this->verify();
 

--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -100,6 +100,26 @@ class EditControllerTest extends AbstractEditControllerTestCase
         $this->verify();
     }
 
+    public function testNotUpdateLastBuyDate()
+    {
+        $Customer = $this->createCustomer();
+        $Order = $this->createOrder($Customer);
+        $formData = $this->createFormData($Customer, $this->Product);
+        $this->client->request(
+            'POST',
+            $this->app->url('admin_order_edit', array('id' => $Order->getId())),
+            array(
+                'order' => $formData,
+                'mode' => 'register'
+            )
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_order_edit', array('id' => $Order->getId()))));
+        $EditedCustomer = $this->app['eccube.repository.customer']->find($Customer->getId());
+        $this->expected = $Customer->getLastBuyDate();
+        $this->actual = $EditedCustomer->getLastBuyDate();
+        $this->verify();
+    }
+
     public function testSearchCustomer()
     {
         $crawler = $this->client->request(


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
  受注データの更新を行うと会員の最終購入日が更新されてしまう
#2238 

## テスト（Test)
テストしたケースは以下のようになります。

１．受注検索して、一つ選択して、受注画面を開いて、何にせずに登録する 　＝＞CUSTOMERの最終購入日を変更なし。

２．受注検索して、一つ選択して、受注画面を開いて、金額を変更します。 　＝＞CUSTOMERの最終購入日を変更なし。

3．受注検索して、一つ選択して、受注画面を開いて、受注ステータス（新規受付＝＞キャンセルなど）を変更します。 　＝＞CUSTOMERの最終購入日を変更なし。

4．新しい受注を作成します。 　＝＞CUSTOMERの最終購入日を変更なし。

5．フロントを新しい商品を買い物する。 　＝＞CUSTOMERの最終購入日を変更する




