### PR TITLE
受注管理、出荷管理で登録できなかったのを修正

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -29,6 +29,8 @@ use Eccube\Common\Constant;
 use Eccube\Entity\Customer;
 use Eccube\Entity\CustomerAddress;
 use Eccube\Entity\Master\OrderItemType;
+use Eccube\Entity\Master\TaxType;
+use Eccube\Entity\Master\TaxDisplayType;
 use Eccube\Entity\ShipmentItem;
 use Eccube\Entity\Shipping;
 use Eccube\Event\EccubeEvents;

--- a/src/Eccube/Entity/ShipmentItem.php
+++ b/src/Eccube/Entity/ShipmentItem.php
@@ -26,6 +26,7 @@ namespace Eccube\Entity;
 
 use Eccube\Util\EntityUtil;
 use Eccube\Entity\Master\OrderItemType;
+use Eccube\Entity\Master\TaxDisplayType;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -69,6 +70,21 @@ class ShipmentItem extends \Eccube\Entity\AbstractEntity
      */
     public function getTotalPrice()
     {
+        $TaxDisplayType = $this->getTaxDisplayType();
+        if (is_object($TaxDisplayType)) {
+            switch ($TaxDisplayType->getId()) {
+                // 税込価格
+                case TaxDisplayType::INCLUDED:
+                    $this->setPriceIncTax($this->getPrice());
+                    break;
+                    // 税別価格の場合は税額を加算する
+                case TaxDisplayType::EXCLUDED:
+                    // TODO 課税規則を考慮する
+                    $this->setPriceIncTax($this->getPrice() + $this->getPrice() * $this->getTaxRate() / 100);
+                    break;
+            }
+        }
+
         return $this->getPriceIncTax() * $this->getQuantity();
     }
 

--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -170,7 +170,6 @@ class OrderType extends AbstractType
                 'scale' => 0,
                 'grouping' => true,
                 'constraints' => array(
-                    new Assert\NotBlank(),
                     new Assert\Length(array(
                         'max' => $config['int_len'],
                     )),
@@ -182,7 +181,6 @@ class OrderType extends AbstractType
                 'scale' => 0,
                 'grouping' => true,
                 'constraints' => array(
-                    new Assert\NotBlank(),
                     new Assert\Length(array(
                         'max' => $config['int_len'],
                     )),
@@ -194,7 +192,6 @@ class OrderType extends AbstractType
                 'scale' => 0,
                 'grouping' => true,
                 'constraints' => array(
-                    new Assert\NotBlank(),
                     new Assert\Length(array(
                         'max' => $config['int_len'],
                     )),

--- a/src/Eccube/Form/Type/Admin/ShipmentItemType.php
+++ b/src/Eccube/Form/Type/Admin/ShipmentItemType.php
@@ -144,7 +144,7 @@ class ShipmentItemType extends AbstractType
 
         $app = $this->app;
         // XXX price を priceIncTax にセットし直す
-        // どこか一箇所にまとめたい
+        // ShipmentItem::getTotalPrice でもやっているので、どこか一箇所にまとめたい
         $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) use ($app) {
                 /** @var \Eccube\Entity\ShipmentItem $ShipmentItem */
                 $ShipmentItem = $event->getData();

--- a/src/Eccube/Service/Calculator/Strategy/ShippingStrategy.php
+++ b/src/Eccube/Service/Calculator/Strategy/ShippingStrategy.php
@@ -3,6 +3,8 @@ namespace Eccube\Service\Calculator\Strategy;
 
 use Eccube\Application;
 use Eccube\Entity\Master\OrderItemType;
+use Eccube\Entity\Master\TaxType;
+use Eccube\Entity\Master\TaxDisplayType;
 use Eccube\Entity\Order;
 use Eccube\Entity\ShipmentItem;
 use Eccube\Entity\Shipping;
@@ -24,6 +26,9 @@ class ShippingStrategy implements CalculateStrategyInterface
     {
         // 送料の受注明細区分
         $DeliveryFeeType = $this->app['eccube.repository.master.order_item_type']->find(OrderItemType::DELIVERY_FEE);
+        // TODO
+        $TaxExclude = $this->app['orm.em']->getRepository(TaxDisplayType::class)->find(TaxDisplayType::EXCLUDED);
+        $Taxion = $this->app['orm.em']->getRepository(TaxType::class)->find(TaxType::TAXATION);
 
         // 配送ごとに送料の明細を作成
         foreach ($this->Order->getShippings() as $Shipping) {
@@ -37,7 +42,9 @@ class ShippingStrategy implements CalculateStrategyInterface
                     ->setTaxRate(0)
                     ->setQuantity(1)
                     ->setOrderItemType($DeliveryFeeType)
-                    ->setShipping($Shipping);
+                    ->setShipping($Shipping)
+                    ->setTaxDisplayType($TaxExclude)
+                    ->setTaxType($Taxion);
                 $ShipmentItems->append($ShipmentItem);
                 $Shipping->addShipmentItem($ShipmentItem);
             }

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -28,6 +28,7 @@ use Doctrine\ORM\EntityManager;
 use Eccube\Common\Constant;
 use Eccube\Entity\CartItem;
 use Eccube\Entity\Master\Disp;
+use Eccube\Entity\Master\OrderItemType;
 use Eccube\Entity\ProductClass;
 use Eccube\Exception\CartException;
 use Symfony\Component\HttpFoundation\Session\Session;

--- a/src/Eccube/Service/OrderHelper.php
+++ b/src/Eccube/Service/OrderHelper.php
@@ -10,6 +10,8 @@ use Eccube\Entity\CartItem;
 use Eccube\Entity\Customer;
 use Eccube\Entity\CustomerAddress;
 use Eccube\Entity\Master\OrderItemType;
+use Eccube\Entity\Master\TaxType;
+use Eccube\Entity\Master\TaxDisplayType;
 use Eccube\Entity\Order;
 use Eccube\Entity\OrderDetail;
 use Eccube\Entity\ShipmentItem;
@@ -154,8 +156,11 @@ class OrderHelper
     private function createShipmentItemsFromCartItems($CartItems)
     {
         $ProductItemType = $this->orderItemTypeRepository->find(OrderItemType::PRODUCT);
+        // TODO
+        $TaxExclude = $this->em->getRepository(TaxDisplayType::class)->find(TaxDisplayType::EXCLUDED);
+        $Taxion = $this->em->getRepository(TaxType::class)->find(TaxType::TAXATION);
 
-        return array_map(function($item) use ($ProductItemType) {
+        return array_map(function($item) use ($ProductItemType, $TaxExclude, $Taxion) {
             /* @var $item CartItem */
             /* @var $ProductClass \Eccube\Entity\ProductClass */
             $ProductClass = $item->getObject();
@@ -173,7 +178,9 @@ class OrderHelper
                 ->setQuantity($item->getQuantity())
                 ->setTaxRule($TaxRule->getId())
                 ->setTaxRate($TaxRule->getTaxRate())
-                ->setOrderItemType($ProductItemType);
+                ->setOrderItemType($ProductItemType)
+                ->setTaxDisplayType($TaxExclude)
+                ->setTaxType($Taxion);
 
             $ClassCategory1 = $ProductClass->getClassCategory1();
             if (!is_null($ClassCategory1)) {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 管理画面からの新規登録時、注文明細の登録ができなかったのを修正
+ フロント側からの注文時、税率等の各種属性が ShipmentItem にセットされなかったのを修正

## 方針(Policy)
+ alpha2 の不具合修正

## 実装に関する補足(Appendix)
+ 冗長な処理がいくつか残っています

## テスト（Test)
+ とり急ぎ動作するよう修正

## 相談（Discussion）
+ OrderType の 値引、送料、手数料の属性は不要かも



