### PR TITLE
プラグイン等から CalculateStrategy を追加できるよう修正

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -1242,6 +1242,9 @@ class ShoppingController extends AbstractController
     public function calculateOrder(Application $app, Request $request)
     {
         $Order = $app['request_scope']->get('Order');
+
+        $app['eccube.calculate.strategies']->setOrder($Order);
+
         // 構築したOrderを集計する.
         $app['eccube.service.calculate']($Order, $Order->getCustomer())->calculate();
         return new Response();

--- a/src/Eccube/Service/Calculator/CalculateContext.php
+++ b/src/Eccube/Service/Calculator/CalculateContext.php
@@ -48,7 +48,7 @@ class CalculateContext
         return $Order;
     }
 
-    public function setCalculateStrategies(\Doctrine\Common\Collections\ArrayCollection $strategies)
+    public function setCalculateStrategies(\Eccube\Service\Calculator\CalculateStrategyCollection $strategies)
     {
         $this->CalculateStrategies = $strategies;
     }

--- a/src/Eccube/Service/Calculator/CalculateStrategyCollection.php
+++ b/src/Eccube/Service/Calculator/CalculateStrategyCollection.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Eccube\Service\Calculator;
+
+use Eccube\Application;
+use Eccube\Entity\Order;
+use Eccube\Service\Calculator\CalculateStrategyInterface;
+class CalculateStrategyCollection extends \Doctrine\Common\Collections\ArrayCollection
+{
+    protected $app;
+    protected $Order;
+
+    public function setApplication(Application $app) {
+        $this->app = $app;
+    }
+
+    public function setOrder(Order $Order) {
+        $this->Order = $Order;
+        // TODO DI の定義で宣言的にセットしたい
+        foreach ($this as $Strategy) {
+            $Strategy->setOrder($this->Order);
+        }
+    }
+
+    public function add($Strategy)
+    {
+        // TODO 本当は取り出すときにインスタンス化したい
+        $Strategy->setApplication($this->app);
+        return parent::add($Strategy);
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ プラグイン等から CalculateStrategy を追加できるよう修正
+ 以下のように追加可能
```php
$app['eccube.calculate.strategies']->setOrder($Order);
$app['eccube.calculate.strategies']->add(new \Eccube\Service\Calculator\Strategy\DiscountStrategy($Order));
```

## 方針(Policy)
+ とり急ぎ動作するように暫定対応

## 相談（Discussion）
+ Order をいたるところでセットしているが、もう少し自動的にセットされるようにしたい



