### PR TITLE
顧客検索と受注検索のPerPageをSESSIONに保存（商品検索と同じ対応）

### DIFF
--- a/src/Eccube/Controller/Admin/Customer/CustomerController.php
+++ b/src/Eccube/Controller/Admin/Customer/CustomerController.php
@@ -57,7 +57,22 @@ class CustomerController extends AbstractController
         $active = false;
 
         $pageMaxis = $app['eccube.repository.master.page_max']->findAll();
-        $page_count = $app['config']['default_page_count'];
+
+        // 表示件数は順番で取得する、1.SESSION 2.設定ファイル
+        $page_count = $session->get('eccube.admin.customer.search.page_count', $app['config']['default_page_count']);
+
+        $page_count_param = $request->get('page_count');
+        // 表示件数はURLパラメターから取得する
+        if($page_count_param && is_numeric($page_count_param)){
+            foreach($pageMaxis as $pageMax){
+                if($page_count_param == $pageMax->getName()){
+                    $page_count = $pageMax->getName();
+                    // 表示件数入力値正し場合はSESSIONに保存する
+                    $session->set('eccube.admin.customer.search.page_count', $page_count);
+                    break;
+                }
+            }
+        }
 
         if ('POST' === $request->getMethod()) {
 
@@ -95,6 +110,7 @@ class CustomerController extends AbstractController
                 // sessionを削除
                 $session->remove('eccube.admin.customer.search');
                 $session->remove('eccube.admin.customer.search.page_no');
+                $session->remove('eccube.admin.customer.search.page_count');
             } else {
                 // pagingなどの処理
                 if (is_null($page_no)) {

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -57,7 +57,23 @@ class OrderController extends AbstractController
 
         $disps = $app['eccube.repository.master.disp']->findAll();
         $pageMaxis = $app['eccube.repository.master.page_max']->findAll();
-        $page_count = $app['config']['default_page_count'];
+
+        // 表示件数は順番で取得する、1.SESSION 2.設定ファイル
+        $page_count = $session->get('eccube.admin.order.search.page_count', $app['config']['default_page_count']);
+
+        $page_count_param = $request->get('page_count');
+        // 表示件数はURLパラメターから取得する
+        if($page_count_param && is_numeric($page_count_param)){
+            foreach($pageMaxis as $pageMax){
+                if($page_count_param == $pageMax->getName()){
+                    $page_count = $pageMax->getName();
+                    // 表示件数入力値正し場合はSESSIONに保存する
+                    $session->set('eccube.admin.order.search.page_count', $page_count);
+                    break;
+                }
+            }
+        }
+
         $active = false;
 
         if ('POST' === $request->getMethod()) {
@@ -93,6 +109,7 @@ class OrderController extends AbstractController
                 // sessionを削除
                 $session->remove('eccube.admin.order.search');
                 $session->remove('eccube.admin.order.search.page_no');
+                $session->remove('eccube.admin.order.search.page_count');
             } else {
                 // pagingなどの処理
                 $searchData = $session->get('eccube.admin.order.search');


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
顧客検索結果の画面でPerPageを変更して（20件）、その後顧客編集へ移動して、戻った後にPerPageが前選択したもの（20件）表示するように修正
※受注検索同じ修正

備考：同じ動きは商品検索前からなってます

## 方針(Policy)
特になありません、
