### PR TITLE
管理画面・支払方法管理（登録）（編集）画面でバリデートエラーあった場合はアップロードした画像を消えないように対応

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/Shop/PaymentController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/PaymentController.php
@@ -76,6 +76,8 @@ class PaymentController extends AbstractController
 
         $form = $builder->getForm();
 
+        // 既に画像保存されてる場合は取得する
+        $oldPaymentImage = $Payment->getPaymentImage();
         $form->setData($Payment);
 
         // 登録ボタン押下
@@ -123,6 +125,7 @@ class PaymentController extends AbstractController
             'form' => $form->createView(),
             'payment_id' => $id,
             'Payment' => $Payment,
+            'oldPaymentImage' => $oldPaymentImage,
         ));
     }
 

--- a/src/Eccube/Resource/template/admin/Setting/Shop/payment_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/payment_edit.twig
@@ -66,9 +66,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             + '</svg>'
             + '</a>'
             + '</li>';
-    if ($("#{{ form.payment_image.vars.id }}").val() != "") {
+    var payment_image = $("#{{ form.payment_image.vars.id }}").val();
+    if (payment_image != "") {
         var filename = $("#{{ form.payment_image.vars.id }}").val();
-        var path = '{{ app.config.image_save_urlpath }}/' + filename;
+        if(payment_image == "{{ oldPaymentImage }}") {
+            var path = '{{ app.config.image_save_urlpath }}/' + filename;
+        } else {
+            var path = '{{ app.config.image_temp_urlpath }}/' + filename;
+        }
         var $img = $(proto_img.replace(/__path__/g, path));
         $("#{{ form.payment_image.vars.id }}").val(filename);
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
■問題
管理画面・支払方法管理（登録）（編集）画面でバーリデトエラーあった場合はアップロードした画像が消える
■再現
１．支払方法登録・編集画面で必要な値入力する
２．画像アップロードする
３．利用条件（TO）値に10桁数字入れる（バーリデトエラーなるために）
４．「登録」ボタン押す、フォーム内容表示しますが画像が消えてる。
■対応方法実装
　—　コントローラでDBに画像名ある場合はビューに渡す
　—　ビューで画像パス設定するロッジク変更
　　　　　image_save_urlpath　<---既にある画像
　　　　　image_temp_urlpath　<---新規画像
