### PR TITLE
メール内容表示崩れ対応（左INDENT）

### DIFF
--- a/src/Eccube/Resource/template/default/Mail/customer_withdraw_mail.twig
+++ b/src/Eccube/Resource/template/default/Mail/customer_withdraw_mail.twig
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 　※本メールは、
-{{ BaseInfo.shop_name }}より退会手続きを希望された方に
+  {{ BaseInfo.shop_name }}より退会手続きを希望された方に
 　お送りしています。
 　もしお心当たりが無い場合は、
 　その旨 {# 問い合わせ受付メール #}{{ BaseInfo.email02 }} まで

--- a/src/Eccube/Resource/template/default/Mail/forgot_mail.twig
+++ b/src/Eccube/Resource/template/default/Mail/forgot_mail.twig
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 　※本メールは、
-{{ BaseInfo.shop_name }}よりパスワード再発行手続きを希望された方に
+  {{ BaseInfo.shop_name }}よりパスワード再発行手続きを希望された方に
 　お送りしています。
 　もしお心当たりが無い場合は、
 　その旨 {# 問い合わせ受付メール #}{{ BaseInfo.email02 }} まで

--- a/src/Eccube/Resource/template/default/Mail/reset_complete_mail.twig
+++ b/src/Eccube/Resource/template/default/Mail/reset_complete_mail.twig
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 　※本メールは、
-{{ BaseInfo.shop_name }}よりパスワード再発行手続きを希望された方に
+  {{ BaseInfo.shop_name }}よりパスワード再発行手続きを希望された方に
 　お送りしています。
 　もしお心当たりが無い場合は、
 　その旨 {# 問い合わせ受付メール #}{{ BaseInfo.email02 }} まで


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
ref:https://github.com/EC-CUBE/ec-cube/issues/2386

■問題
　以下のメールBODYの中に文言の左INDENTは正しくないです
　　―　customer_withdraw_mail.twig
  ―　forgot_mail.twig
  ―　reset_complete_mail.twig
　　例：〇〇〇〇->サイト名
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
　※本メールは、
〇〇〇〇よりパスワード再発行手続きを希望された方に
　お送りしています。
　もしお心当たりが無い場合は、
　その旨 dziulka@kdl.co.jp まで
　ご連絡いただければ幸いです。
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
  正し表示はこちらです
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
　※本メールは、
　〇〇〇〇よりパスワード再発行手続きを希望された方に
　お送りしています。
　もしお心当たりが無い場合は、
　その旨 dziulka@kdl.co.jp まで
　ご連絡いただければ幸いです。
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
  
■対応方法実装
　テンプレート修正（左に2桁空白追加）


