### PR TITLE
受注編集画面で変更前の値を表示する対応

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -75,7 +75,7 @@ class EditController extends AbstractController
         /** @var $OrderDetail OrderDetail*/
         foreach ($TargetOrder->getOrderDetails() as $OrderDetail) {
             $OriginalOrderDetails->add($OrderDetail);
-            $arrOldOrder['OrderDetails'][]['quantity'] = $OrderDetail->getQuantity();
+            $arrOldOrder['OrderDetails'][$OrderDetail->getId()]['quantity'] = $OrderDetail->getQuantity();
         }
 
         // 編集前の情報を保持
@@ -86,7 +86,7 @@ class EditController extends AbstractController
             foreach ($tmpOriginalShippings->getShipmentItems() as $tmpOriginalShipmentItem) {
                 // アイテム情報
                 $OriginalShipmentItems->add($tmpOriginalShipmentItem);
-                $arrOldOrder['Shippings'][$key]['ShipmentItems'][]['quantity'] = $tmpOriginalShipmentItem->getQuantity();
+                $arrOldOrder['Shippings'][$key]['ShipmentItems'][$tmpOriginalShipmentItem->getId()]['quantity'] = $tmpOriginalShipmentItem->getQuantity();
             }
             // お届け先情報
             $OriginalShippings->add($tmpOriginalShippings);

--- a/src/Eccube/Form/Type/Admin/OrderDetailType.php
+++ b/src/Eccube/Form/Type/Admin/OrderDetailType.php
@@ -49,6 +49,10 @@ class OrderDetailType extends AbstractType
         $config = $this->app['config'];
 
         $builder
+            ->add('id', 'hidden', array(
+                'required' => false,
+                'mapped' => false
+            ))
             ->add('new', 'hidden', array(
                 'required' => false,
                 'mapped' => false,

--- a/src/Eccube/Form/Type/Admin/ShipmentItemType.php
+++ b/src/Eccube/Form/Type/Admin/ShipmentItemType.php
@@ -49,6 +49,10 @@ class ShipmentItemType extends AbstractType
         $config = $this->app['config'];
 
         $builder
+            ->add('id', 'hidden', array(
+                'required' => false,
+                'mapped' => false
+            ))
             ->add('new', 'hidden', array(
                 'required' => false,
                 'mapped' => false,

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -423,12 +423,14 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                                                 <span id="product_info_list__quantity--{{ loop.index }}" class="item_quantity">
                                                     {% set detail_id = orderDetailForm.vars.value.id %}
                                                     {% if arrOldOrder.OrderDetails[detail_id] is defined %}
-                                                        {{ arrOldOrder.OrderDetails[detail_id].quantity }}<br/>
+                                                        {% set prev_quantity = arrOldOrder.OrderDetails[detail_id].quantity ~ ' ' %}
+                                                    {% else %}
+                                                        {% set prev_quantity = '' %}
                                                     {% endif %}
                                                     {% if BaseInfo.optionMultipleShipping %}
-                                                        数量：{{ form_widget(orderDetailForm.quantity, {'read_only': 'readonly'}) }}
+                                                        数量：{{ prev_quantity }}{{ form_widget(orderDetailForm.quantity, {'read_only': 'readonly'}) }}
                                                     {% else %}
-                                                        数量：{{ form_widget(orderDetailForm.quantity) }}
+                                                        数量：{{ prev_quantity }}{{ form_widget(orderDetailForm.quantity) }}
                                                     {% endif %}
                                                     {{ form_errors(orderDetailForm.quantity) }}
                                                 </span>
@@ -585,9 +587,11 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                                             <span class="item_quantity">
                                                 {% set item_id = shipmentItemForm.vars.value.id %}
                                                 {% if arrOldOrder.Shippings[shippingIndex].ShipmentItems[item_id] is defined %}
-                                                    {{ arrOldOrder.Shippings[shippingIndex].ShipmentItems[item_id].quantity }}<br/>
+                                                    {% set prev_quantity = arrOldOrder.Shippings[shippingIndex].ShipmentItems[item_id].quantity ~ ' ' %}
+                                                {% else %}
+                                                    {% set prev_quantity = '' %}
                                                 {% endif %}
-                                                数量：{{ form_widget(shipmentItemForm.quantity, {'attr': {'class': 'shipment_quantity'}}) }}
+                                                数量：{{ prev_quantity }}{{ form_widget(shipmentItemForm.quantity, {'attr': {'class': 'shipment_quantity'}}) }}
                                                 {{ form_errors(shipmentItemForm.quantity) }}
                                             </span>
                                         </div>

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -421,8 +421,9 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                                             </div>
                                             <div class="col-md-4 col-lg-3 form-group form-inline text-right">
                                                 <span id="product_info_list__quantity--{{ loop.index }}" class="item_quantity">
-                                                    {% if arrOldOrder.OrderDetails[loop.index0] is defined %}
-                                                        {{ arrOldOrder.OrderDetails[loop.index0].quantity }}<br/>
+                                                    {% set detail_id = orderDetailForm.vars.value.id %}
+                                                    {% if arrOldOrder.OrderDetails[detail_id] is defined %}
+                                                        {{ arrOldOrder.OrderDetails[detail_id].quantity }}<br/>
                                                     {% endif %}
                                                     {% if BaseInfo.optionMultipleShipping %}
                                                         数量：{{ form_widget(orderDetailForm.quantity, {'read_only': 'readonly'}) }}
@@ -582,8 +583,9 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                                         </div>
                                         <div id="shipment_item__quantity--{{ shippingIndex }}--{{ shippingItemkey }}" class="col-md-4 col-lg-3 form-group form-inline text-right">
                                             <span class="item_quantity">
-                                                {% if arrOldOrder.Shippings[shippingIndex].ShipmentItems[loop.index0] is defined %}
-                                                    {{ arrOldOrder.Shippings[shippingIndex].ShipmentItems[loop.index0].quantity }}<br/>
+                                                {% set item_id = shipmentItemForm.vars.value.id %}
+                                                {% if arrOldOrder.Shippings[shippingIndex].ShipmentItems[item_id] is defined %}
+                                                    {{ arrOldOrder.Shippings[shippingIndex].ShipmentItems[item_id].quantity }}<br/>
                                                 {% endif %}
                                                 数量：{{ form_widget(shipmentItemForm.quantity, {'attr': {'class': 'shipment_quantity'}}) }}
                                                 {{ form_errors(shipmentItemForm.quantity) }}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
受注編集画面で変更前の値を表示する対応
https://github.com/EC-CUBE/ec-cube/pull/2278


■問題：古い数量関連する時レコードキー使ってないみたい
https://github.com/EC-CUBE/ec-cube/blob/master/src/Eccube/Controller/Admin/Order/EditController.php#L78
https://github.com/EC-CUBE/ec-cube/blob/master/src/Eccube/Controller/Admin/Order/EditController.php#L89

■再現
１．注文する（三つ商品、数量は3，2，1）
△受注登録の時　　
   商品A　3個
   商品B　2個
  　商品C　1個

２．受注編集の時一番上の商品削除する
３．新規商品追加する
４．計算結果の更新押すと古い数量表示になる。

△受注編集
　　　　　　　　表示　｜　本当のバリュー
   商品B　3個　　｜　　2個
   商品C　2個　　｜　　1個
  　商品D　1個　　｜　　

■対応方法
dtb_shipment_item.idを使って判断する