### PR TITLE
[管理_規格編集]フォームエラー発生時、エラーメッセージが表示されない対応

### DIFF
--- a/src/Eccube/Resource/template/admin/Product/class_category.twig
+++ b/src/Eccube/Resource/template/admin/Product/class_category.twig
@@ -93,6 +93,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 {{ form_widget(form._token) }}
                                 {{ form_widget(form.name, {attr: {placeholder: '分類名を入力'}}) }}
                                 <button class="btn btn-default btn-sm" type="submit">分類作成</button>
+                                {{ form_errors(form.name) }}
                             </div>
                         </div>
                         <div class="extra-form">

--- a/src/Eccube/Resource/template/admin/Product/class_name.twig
+++ b/src/Eccube/Resource/template/admin/Product/class_name.twig
@@ -87,8 +87,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             <div class="col-md-12 form-inline">
                                 {{ form_widget(form._token) }}
                                 {{ form_widget(form.name, {attr: {placeholder: '規格名を入力'}}) }}
-                                {{ form_errors(form.name) }}
                                 <button class="btn btn-default btn-sm" type="submit">規格作成</button>
+                                {{ form_errors(form.name) }}
                             </div>
                         </div>
                         <div class="extra-form">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
管理画面の規格編集画面でフォームエラーあっても表示されないです
https://github.com/EC-CUBE/ec-cube/issues/2372

修正について
１．商品管理・規格編集（/product/class_category/）画面でエラーメッセージ追加
２．商品管理・規格編集（/product/class_name）画面でエラーメッセージ表示場所変更（規格作成ボタンの後）

## 方針(Policy)
特にないです

## 相談（Discussion）
エラーメッセージ表示場所は規格作成ボタンの後にしました、前入れるとエラーあった場合はボタンがしたになる