### PR TITLE
Fix ignore catch when has warning.

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -35,7 +35,10 @@ if (php_sapi_name() === 'cli-server' && is_file($filename)) {
     return false;
 }
 
-\Symfony\Component\Debug\ErrorHandler::register();
+$errorHandler = \Symfony\Component\Debug\ErrorHandler::register();
+//@deprecated since 3.0.0, to be considered in 3.1 .
+$errorLevel = E_ALL & ~E_NOTICE & ~E_USER_NOTICE & ~E_WARNING & E_USER_WARNING & ~E_STRICT & ~E_DEPRECATED & ~E_USER_DEPRECATED;
+$errorHandler->throwAt($errorLevel, true);
 \Eccube\Exception\EccubeExceptionHandler::register(false);
 
 // output_config_php = true に設定することで、Config Yaml ファイルを元に Config PHP ファイルが出力されます。


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
https://github.com/EC-CUBE/ec-cube/pull/1928
上記PRについて、NOTICE、WARNING、DEPRECATEDは除くように対応をしました。

## テスト（Test)
1. Warning => OK
2. Fate/Critical => error page
3. DB connect error => error page
4. Install => OK
5. Info => OK

## 相談（Discussion）
+ When the system has a warning, the log will not be written!

