### PR TITLE
.htaccess、web.configの除外する拡張子にmapを追加

### DIFF
--- a/.htaccess.sample
+++ b/.htaccess.sample
@@ -22,6 +22,6 @@ DirectoryIndex index.php index.html .ht
     # RewriteRule ^(.*) - [E=HTTPS:on]
 
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_FILENAME} !^(.*)\.(gif|png|jpe?g|css|ico|js|svg)$ [NC]
+    RewriteCond %{REQUEST_FILENAME} !^(.*)\.(gif|png|jpe?g|css|ico|js|svg|map)$ [NC]
     RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>

--- a/html/.htaccess
+++ b/html/.htaccess
@@ -18,6 +18,6 @@ allow from all
 
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_FILENAME} !^(.*)\.(gif|png|jpe?g|css|ico|js|svg)$ [NC]
+    RewriteCond %{REQUEST_FILENAME} !^(.*)\.(gif|png|jpe?g|css|ico|js|svg|map)$ [NC]
     RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>

--- a/html/web.config
+++ b/html/web.config
@@ -22,7 +22,7 @@
           <conditions>
             <add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />
             <add input="{REQUEST_FILENAME}" matchType="IsDirectory" ignoreCase="false" negate="true" />
-            <add input="{URL}" pattern="^(.*)\.(gif|png|jpe?g|css|ico|js|svg)$" ignoreCase="false" negate="true" />
+            <add input="{URL}" pattern="^(.*)\.(gif|png|jpe?g|css|ico|js|svg|map)$" ignoreCase="false" negate="true" />
           </conditions>
           <action type="Rewrite" url="index.php/{R:1}" appendQueryString="true" />
         </rule>

--- a/web.config.sample
+++ b/web.config.sample
@@ -22,7 +22,7 @@
           <conditions>
             <add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />
             <add input="{REQUEST_FILENAME}" matchType="IsDirectory" ignoreCase="false" negate="true" />
-            <add input="{URL}" pattern="^(.*)\.(gif|png|jpe?g|css|ico|js|svg)$" ignoreCase="false" negate="true" />
+            <add input="{URL}" pattern="^(.*)\.(gif|png|jpe?g|css|ico|js|svg|map)$" ignoreCase="false" negate="true" />
           </conditions>
           <action type="Rewrite" url="index.php/{R:1}" appendQueryString="true" />
         </rule>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
.htaccess、web.configの除外する拡張子にmapが含まれていなかったため、無視するように追加