### PR TITLE
UTF-8のCSVがUTF-8として認識されない不具合を修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -640,7 +640,7 @@ class CsvImportController
             }
         } else {
             // アップロードされたファイルがUTF-8以外は文字コード変換を行う
-            $encode = Str::characterEncoding(substr($file, 0, 6));
+            $encode = Str::characterEncoding(substr($file, 0, 8));
             if ($encode != 'UTF-8') {
                 $file = mb_convert_encoding($file, 'UTF-8', $encode);
             }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
substr($file, 0, 6)だと変なとこで切られて文字化ける。mb_substr()だと大丈夫だけど細かく検証してないのでとりあえずコレで

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）



