### PR TITLE
YubinBango を使用するよう変更

### DIFF
--- a/src/Eccube/Form/Type/AddressType.php
+++ b/src/Eccube/Form/Type/AddressType.php
@@ -98,16 +98,18 @@ class AddressType extends AbstractType
         $resolver->setDefaults(array(
             'options' => array(),
             'help' => 'form.contact.address.help',
-            'pref_options' => array('constraints' => array()),
+            'pref_options' => array('constraints' => array(), 'attr' => array('class' => ' p-region-id')),
             'addr01_options' => array(
                 'constraints' => array(
                     new Assert\Length(array('max' => $this->config['address1_len'])),
                 ),
+                'attr' => array('class' => 'p-locality'),
             ),
             'addr02_options' => array(
                 'constraints' => array(
                     new Assert\Length(array('max' => $this->config['address2_len'])),
                 ),
+                'attr' => array('class' => 'p-street-address'),
             ),
             'pref_name' => 'pref',
             'addr01_name' => 'addr01',

--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -85,6 +85,7 @@ class OrderType extends AbstractType
                     'constraints' => array(
                         new Assert\NotBlank(),
                     ),
+                    'attr' => array('class' => 'p-postal-code'),
                 ),
             ))
             ->add('address', 'address', array(
@@ -93,6 +94,7 @@ class OrderType extends AbstractType
                     'constraints' => array(
                         new Assert\NotBlank(),
                     ),
+                    'attr' => array('class' => 'p-region-id'),
                 ),
                 'addr01_options' => array(
                     'constraints' => array(
@@ -101,6 +103,7 @@ class OrderType extends AbstractType
                             'max' => $config['mtext_len'],
                         )),
                     ),
+                    'attr' => array('class' => 'p-locality'),
                 ),
                 'addr02_options' => array(
                     'required' => false,
@@ -110,6 +113,7 @@ class OrderType extends AbstractType
                             'max' => $config['mtext_len'],
                         )),
                     ),
+                    'attr' => array('class' => 'p-street-address'),
                 ),
             ))
             ->add('email', 'email', array(

--- a/src/Eccube/Form/Type/Admin/ShippingType.php
+++ b/src/Eccube/Form/Type/Admin/ShippingType.php
@@ -85,6 +85,7 @@ class ShippingType extends AbstractType
                     'constraints' => array(
                         new Assert\NotBlank(),
                     ),
+                    'attr' => array('class' => 'p-postal-code'),
                 ),
             ))
             ->add('address', 'address', array(
@@ -93,6 +94,7 @@ class ShippingType extends AbstractType
                     'constraints' => array(
                         new Assert\NotBlank(),
                     ),
+                    'attr' => array('class' => 'p-region-id'),
                 ),
                 'addr01_options' => array(
                     'constraints' => array(
@@ -101,6 +103,7 @@ class ShippingType extends AbstractType
                             'max' => $config['mtext_len'],
                         )),
                     ),
+                    'attr' => array('class' => 'p-locality'),
                 ),
                 'addr02_options' => array(
                     'required' => false,
@@ -110,6 +113,7 @@ class ShippingType extends AbstractType
                             'max' => $config['mtext_len'],
                         )),
                     ),
+                    'attr' => array('class' => 'p-street-address'),
                 ),
             ))
             ->add('tel', 'tel', array(

--- a/src/Eccube/Form/Type/ZipType.php
+++ b/src/Eccube/Form/Type/ZipType.php
@@ -91,7 +91,7 @@ class ZipType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'options' => array('constraints' => array()),
+            'options' => array('constraints' => array(), 'attr' => array('class' => 'p-postal-code')),
             'zip01_options' => array(
                 'constraints' => array(
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')),

--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -32,19 +32,13 @@
 {% form_theme form 'Form/bootstrap_3_horizontal_layout.html.twig' %}
 
 {% block javascript %}
-<script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
-<script>
-    $(function() {
-        $('#zip-search').click(function() {
-            AjaxZip3.zip2addr('admin_customer[zip][zip01]', 'admin_customer[zip][zip02]', 'admin_customer[address][pref]', 'admin_customer[address][addr01]');
-        });
-    });
-</script>
+    <script src="//yubinbango.github.io/yubinbango/yubinbango.js" charset="UTF-8"></script>
 {% endblock javascript %}
 
 {% block main %}
 <div class="row" id="aside_wrap">
-    <form name="customer_form" role="form" id="customer_form" method="post" action="{%- if Customer.id %}{{ url('admin_customer_edit', { id : Customer.id }) }}{% else %}{{ url('admin_customer_new') }}{% endif -%}">
+    <form name="customer_form" role="form" id="customer_form" method="post" action="{%- if Customer.id %}{{ url('admin_customer_edit', { id : Customer.id }) }}{% else %}{{ url('admin_customer_new') }}{% endif -%}" novalidate class="h-adr">
+        <span class="p-country-name" style="display:none;">Japan</span>
         {{ form_widget(form._token) }}
         <div id="detail_wrap" class="col-md-9">
             <div id="detail_box" class="box accordion">
@@ -96,7 +90,6 @@
                                 {{ form_errors(form.zip) }}
                                 {{ form_errors(form.zip.zip01) }}
                                 {{ form_errors(form.zip.zip02) }}
-                                <span><button type="button" id="zip-search" class="btn btn-default btn-sm">郵便番号から自動入力</button></span>
                             </div>
                         </div>
                         {# 住所：都道府県 #}

--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -37,7 +37,7 @@
 
 {% block main %}
 <div class="row" id="aside_wrap">
-    <form name="customer_form" role="form" id="customer_form" method="post" action="{%- if Customer.id %}{{ url('admin_customer_edit', { id : Customer.id }) }}{% else %}{{ url('admin_customer_new') }}{% endif -%}" novalidate class="h-adr">
+    <form name="customer_form" role="form" id="customer_form" method="post" action="{%- if Customer.id %}{{ url('admin_customer_edit', { id : Customer.id }) }}{% else %}{{ url('admin_customer_new') }}{% endif -%}" class="h-adr">
         <span class="p-country-name" style="display:none;">Japan</span>
         {{ form_widget(form._token) }}
         <div id="detail_wrap" class="col-md-9">

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -31,13 +31,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% form_theme searchProductModalForm 'Form/bootstrap_3_horizontal_layout.html.twig' %}
 
 {% block javascript %}
-<script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
-<script>
+    <script src="//yubinbango.github.io/yubinbango/yubinbango.js" charset="UTF-8"></script>
+    <script>
 $(function() {
-    $('#zip-search').click(function() {
-        AjaxZip3.zip2addr('order[zip][zip01]', 'order[zip][zip02]', 'order[address][pref]', 'order[address][addr01]');
-    });
-
     // 注文者情報をコピー
     $('.copyCustomerToShippingButton').on('click', function() {
         var data = $(this).data();
@@ -96,12 +92,12 @@ $(function() {
         shipment_idx = data.idx;
 
         shipmentItem_idx = 0;
-        for(i = 0; i < shipping_details_count.length; i++) { 
+        for(i = 0; i < shipping_details_count.length; i++) {
             if (shipping_details_count[i].idx == shipment_idx) {
                 shipmentItem_idx = shipping_details_count[i].cnt;
             }
         }
-        
+
         $.ajax({
             type: 'POST',
             dataType: 'html',
@@ -129,7 +125,7 @@ $(function() {
         {% set maxIndex = max(form.OrderDetails|keys) + 1 %}
     {% endif %}
     order_details_count = '{{ maxIndex }}';
-    
+
     var shipping_details_count = [];
     {% if BaseInfo.optionMultipleShipping %}
         {% for shippingKey, shippingForm in form.Shippings %}
@@ -155,14 +151,14 @@ $(function() {
 
         onChangeOrderDetailCount(order_details_count);
     });
-    
+
     $(".delete_delivery").on("click", function(){
        var data = $(this).data();
        $("#shipping_info_box--" + data.idx ).remove();
        document.form1.modal.value = "calc";
        document.form1.submit();
     });
-    
+
     $(".delete_shipping_product").on("click", function(){
        var data = $(this).data();
        var idKey = "order_Shippings_"+ data.idx.replace("--","_ShipmentItems_") +"_quantity";
@@ -219,7 +215,8 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
 
 {% block main %}
 <div class="row" id="aside_wrap">
-    <form name="form1" method="post" action="?">
+    <form name="form1" method="post" action="?" class="h-adr">
+        <span class="p-country-name" style="display:none;">Japan</span>
     <input type="hidden" name="modal" value="">
     {{ form_widget(form._token) }}
         <div id="detail_wrap" class="col-md-12">
@@ -292,7 +289,6 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                                 〒{{ form_widget(form.zip.zip01) }}-{{ form_widget(form.zip.zip02) }}
                                 {{ form_errors(form.zip.zip01) }}
                                 {{ form_errors(form.zip.zip02) }}
-                                <span><button type="button" id="zip-search" class="btn btn-default btn-sm">郵便番号から自動入力</button></span>
                             </div>
                         </div>
                         {# 住所：都道府県 #}

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -215,8 +215,7 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
 
 {% block main %}
 <div class="row" id="aside_wrap">
-    <form name="form1" method="post" action="?" class="h-adr">
-        <span class="p-country-name" style="display:none;">Japan</span>
+    <form name="form1" method="post" action="?">
     <input type="hidden" name="modal" value="">
     {{ form_widget(form._token) }}
         <div id="detail_wrap" class="col-md-12">
@@ -242,7 +241,8 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                     </div><!-- /.box-body -->
                 </div><!-- /.box -->
             </div>
-            <div id="customer_info_box"  class="box accordion">
+            <div id="customer_info_box"  class="box accordion h-adr">
+                <span class="p-country-name" style="display:none;">Japan</span>
                 <div id="customer_info_box__toggle" class="box-header toggle active">
                     <h3 class="box-title">注文者情報<svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg></h3>
                 </div><!-- /.box-header -->
@@ -602,7 +602,8 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                         {% endif %}
 
                         <hr>
-                        <div id="shipment_item_detail--{{ shippingIndex }}" class="form-horizontal">
+                        <div id="shipment_item_detail--{{ shippingIndex }}" class="form-horizontal h-adr">
+                            <span class="p-country-name" style="display:none;">Japan</span>
                             <div id="shipment_item_detail__name--{{ shippingIndex }}" class="form-group">
                                 {{ form_label(shippingForm.name) }}
                                 <div class="col-sm-9 col-lg-10 input_name form-inline">

--- a/src/Eccube/Resource/template/admin/Setting/Shop/shop_master.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/shop_master.twig
@@ -31,21 +31,15 @@
 {% form_theme form 'Form/bootstrap_3_horizontal_layout.html.twig' %}
 
 {% block javascript %}
-<script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
-<script>
-$(function() {
-    $('#zip-search').click(function(event) {
-        AjaxZip3.zip2addr('shop_master[zip][zip01]', 'shop_master[zip][zip02]', 'shop_master[address][pref]', 'shop_master[address][addr01]');
-    });
-});
-</script>
+    <script src="//yubinbango.github.io/yubinbango/yubinbango.js" charset="UTF-8"></script>
 {% endblock javascript %}
 
 
 {% block main %}
 
     <div class="row" id="aside_wrap">
-        <form name="form1" role="form" class="form-horizontal" id="point_form" method="post" action="">
+        <form name="form1" role="form" class="form-horizontal h-adr" id="point_form" method="post" action="">
+            <span class="p-country-name" style="display:none;">Japan</span>
         {{ form_widget(form._token) }}
 
             <div id="detail_wrap" class="col-md-9">
@@ -68,7 +62,6 @@ $(function() {
                                 〒{{ form_widget(form.zip.zip01) }}-{{ form_widget(form.zip.zip02) }}
                                 {{ form_errors(form.zip.zip01) }}
                                 {{ form_errors(form.zip.zip02) }}
-                                <span><button type="button" id="zip-search" class="btn btn-default btn-sm">郵便番号から自動入力</button></span>
                             </div>
                         </div>
                         {# 住所：都道府県 #}

--- a/src/Eccube/Resource/template/admin/Setting/Shop/tradelaw.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/tradelaw.twig
@@ -30,20 +30,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% form_theme form 'Form/bootstrap_3_horizontal_layout.html.twig' %}
 
 {% block javascript %}
-<script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
-<script>
-    $(function() {
-        $('#zip-search').click(function(event) {
-            AjaxZip3.zip2addr('tradelaw[law_zip][law_zip01]', 'tradelaw[law_zip][law_zip02]', 'tradelaw[law_address][law_pref]', 'tradelaw[law_address][law_addr01]');
-        });
-    });
-</script>
+    <script src="//yubinbango.github.io/yubinbango/yubinbango.js" charset="UTF-8"></script>
 {% endblock javascript %}
 
 {% block main %}
 
 <div class="row" id="aside_wrap">
-<form name="tradelaw_form" role="form" id="tradelaw_form" method="post" action="{{ url('admin_setting_shop_tradelaw') }}">
+<form name="tradelaw_form" role="form" id="tradelaw_form" method="post" action="{{ url('admin_setting_shop_tradelaw') }}" class="h-adr">
+    <span class="p-country-name" style="display:none;">Japan</span>
     {{ form_widget(form._token) }}
         <div id="detail_wrap" class="col-md-9">
             <div id="detail_box" class="box form-horizontal">
@@ -61,7 +55,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             〒{{ form_widget(form.law_zip.law_zip01) }}-{{ form_widget(form.law_zip.law_zip02) }}
                             {{ form_errors(form.law_zip.law_zip01) }}
                             {{ form_errors(form.law_zip.law_zip02) }}
-                            <span><button type="button" id="zip-search" class="btn btn-default btn-sm">郵便番号から自動入力</button></span>
                         </div>
                     </div>
 

--- a/src/Eccube/Resource/template/default/Contact/index.twig
+++ b/src/Eccube/Resource/template/default/Contact/index.twig
@@ -22,18 +22,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% extends 'default_frame.twig' %}
 
 {% block javascript %}
-<script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
-<script>
-    $(function() {
-        $('#zip-search').click(function() {
-            AjaxZip3.zip2addr('contact[zip][zip01]', 'contact[zip][zip02]', 'contact[address][pref]', 'contact[address][addr01]');
-        });
-    });
-</script>
+    <script src="//yubinbango.github.io/yubinbango/yubinbango.js" charset="UTF-8"></script>
 {% endblock javascript %}
 
 {% block main %}
-
 <div id="contents" class="main_only">
     <div class="container-fluid inner no-padding">
         <div id="main">
@@ -45,7 +37,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <p>内容によっては回答をさしあげるのにお時間をいただくこともございます。<br/>
                             また、休業日は翌営業日以降の対応となりますのでご了承ください。</p>
 
-                        <form name="form1" id="form1" method="post" action="{{ url('contact') }}">
+                        <form name="form1" id="form1" method="post" action="{{ url('contact') }}" class="h-adr">
+                            <span class="p-country-name" style="display:none;">Japan</span>
                             {{ form_widget(form._token) }}
                             <div id="top_box__body_inner" class="dl_table">
                                 <dl id="top_box__name">

--- a/src/Eccube/Resource/template/default/Entry/index.twig
+++ b/src/Eccube/Resource/template/default/Entry/index.twig
@@ -24,14 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% set body_class = 'registration_page' %}
 
 {% block javascript %}
-<script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
-<script>
-    $(function() {
-        $('#zip-search').click(function() {
-            AjaxZip3.zip2addr('entry[zip][zip01]', 'entry[zip][zip02]', 'entry[address][pref]', 'entry[address][addr01]');
-        });
-    });
-</script>
+    <script src="//yubinbango.github.io/yubinbango/yubinbango.js" charset="UTF-8"></script>
 {% endblock javascript %}
 
 {% block main %}
@@ -39,7 +32,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 <div id="top_wrap" class="container-fluid">
     <div id="top_box" class="row">
         <div id="top_box__body" class="col-md-10 col-md-offset-1">
-            <form method="post" action="{{ url('entry') }}">
+            <form method="post" action="{{ url('entry') }}" novalidate class="h-adr">
+                <span class="p-country-name" style="display:none;">Japan</span>
                 {{ form_widget(form._token) }}
                 <div id="top_box__body_inner" class="dl_table">
                     <dl id="top_box__name">

--- a/src/Eccube/Resource/template/default/Entry/index.twig
+++ b/src/Eccube/Resource/template/default/Entry/index.twig
@@ -32,7 +32,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 <div id="top_wrap" class="container-fluid">
     <div id="top_box" class="row">
         <div id="top_box__body" class="col-md-10 col-md-offset-1">
-            <form method="post" action="{{ url('entry') }}" novalidate class="h-adr">
+            <form method="post" action="{{ url('entry') }}" class="h-adr">
                 <span class="p-country-name" style="display:none;">Japan</span>
                 {{ form_widget(form._token) }}
                 <div id="top_box__body_inner" class="dl_table">

--- a/src/Eccube/Resource/template/default/Form/form_layout.twig
+++ b/src/Eccube/Resource/template/default/Form/form_layout.twig
@@ -248,7 +248,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         {%- for child in form %}
             {{- form_errors(child) -}}
         {% endfor -%}
-        <div class="zip-search"><button type="button" id="zip-search" class="btn btn-default btn-sm">郵便番号から自動入力</button></div>
     {%- endif -%}
 {%- endblock zip_widget -%}
 

--- a/src/Eccube/Resource/template/default/Mypage/change.twig
+++ b/src/Eccube/Resource/template/default/Mypage/change.twig
@@ -26,14 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% set mypageno = 'change' %}
 
 {% block javascript %}
-<script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
-<script>
-    $(function() {
-        $('#zip-search').click(function() {
-            AjaxZip3.zip2addr('entry[zip][zip01]', 'entry[zip][zip02]', 'entry[address][pref]', 'entry[address][addr01]');
-        });
-    });
-</script>
+    <script src="//yubinbango.github.io/yubinbango/yubinbango.js" charset="UTF-8"></script>
 {% endblock javascript %}
 
 {% block main %}
@@ -42,7 +35,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     {% include 'Mypage/navi.twig' %}
     <div id="detail_box" class="row">
         <div id="detail_box__body" class="col-md-10 col-md-offset-1">
-            <form method="post" action="{{ url('mypage_change') }}">
+            <form method="post" action="{{ url('mypage_change') }}" class="h-adr">
+                <span class="p-country-name" style="display:none;">Japan</span>
                 {{ form_widget(form._token) }}
                 <div id="detail_box__body_inner" class="dl_table">
                     <dl id="detail_box__name">

--- a/src/Eccube/Resource/template/default/Mypage/delivery_edit.twig
+++ b/src/Eccube/Resource/template/default/Mypage/delivery_edit.twig
@@ -26,14 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% set body_class = 'mypage' %}
 
 {% block javascript %}
-<script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
-<script>
-$(function() {
-    $('#zip-search').click(function() {
-        AjaxZip3.zip2addr('customer_address[zip][zip01]', 'customer_address[zip][zip02]', 'customer_address[address][pref]', 'customer_address[address][addr01]');
-    });
-});
-</script>
+    <script src="//yubinbango.github.io/yubinbango/yubinbango.js" charset="UTF-8"></script>
 {% endblock javascript %}
 
 {% block main %}
@@ -44,7 +37,8 @@ $(function() {
 
         <div id="detail_box" class="row">
             <div id="detail_box__body" class="col-sm-10 col-sm-offset-1">
-                <form role="form" action="" method="post">
+                <form role="form" action="" method="post" class="h-adr">
+                    <span class="p-country-name" style="display:none;">Japan</span>
                     {{ form_widget(form._token) }}
                     <div id="detail_box__body_inner" class="dl_table">
 

--- a/src/Eccube/Resource/template/default/Shopping/nonmember.twig
+++ b/src/Eccube/Resource/template/default/Shopping/nonmember.twig
@@ -24,14 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% set body_class = 'cart_page' %}
 
 {% block javascript %}
-<script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
-<script>
-    $(function() {
-        $('#zip-search').click(function() {
-            AjaxZip3.zip2addr('nonmember[zip][zip01]', 'nonmember[zip][zip02]', 'nonmember[address][pref]', 'nonmember[address][addr01]');
-        });
-    });
-</script>
+    <script src="//yubinbango.github.io/yubinbango/yubinbango.js" charset="UTF-8"></script>
 {% endblock javascript %}
 
 {% block main %}
@@ -47,7 +40,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     <li><span class="flow_number">4</span><br>完了</li>
                 </ul>
             </div>
-            <form method="post" action="{{ url('shopping_nonmember') }}">
+            <form method="post" action="{{ url('shopping_nonmember') }}" class="h-adr">
+                <span class="p-country-name" style="display:none;">Japan</span>
                 {{ form_widget(form._token) }}
                 <div id="detail_box__body" class="dl_table">
                     <dl id="detail_box__name">

--- a/src/Eccube/Resource/template/default/Shopping/shipping_edit.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping_edit.twig
@@ -28,21 +28,15 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% endif %}
 
 {% block javascript %}
-    <script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
-    <script>
-        $(function() {
-            $('#zip-search').click(function() {
-                AjaxZip3.zip2addr('shopping_shipping[zip][zip01]', 'shopping_shipping[zip][zip02]', 'shopping_shipping[address][pref]', 'shopping_shipping[address][addr01]');
-            });
-        });
-    </script>
+    <script src="//yubinbango.github.io/yubinbango/yubinbango.js" charset="UTF-8"></script>
 {% endblock javascript %}
 
 {% block main %}
     <h1 class="page-heading">お届け先の{% if is_granted('ROLE_USER') %}追加{% else %}変更{% endif %}</h1>
     <div id="detail_wrap" class="container-fluid">
         <div id="detail_box" class="row">
-            <form method="post" action="{{ url('shopping_shipping_edit', {'id': shippingId}) }}">
+            <form method="post" action="{{ url('shopping_shipping_edit', {'id': shippingId}) }}" class="h-adr">
+                <span class="p-country-name" style="display:none;">Japan</span>
                 {{ form_widget(form._token) }}
                 <div id="detail_box__body" class="col-sm-10 col-sm-offset-1">
                     <div id="detail_box__body_inner" class="dl_table">

--- a/src/Eccube/Resource/template/default/Shopping/shipping_multiple_edit.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping_multiple_edit.twig
@@ -24,21 +24,15 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% set body_class = 'cart_page' %}
 
 {% block javascript %}
-    <script src="//ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
-    <script>
-        $(function() {
-            $('#zip-search').click(function() {
-                AjaxZip3.zip2addr('shopping_shipping[zip][zip01]', 'shopping_shipping[zip][zip02]', 'shopping_shipping[address][pref]', 'shopping_shipping[address][addr01]');
-            });
-        });
-    </script>
+    <script src="//yubinbango.github.io/yubinbango/yubinbango.js" charset="UTF-8"></script>
 {% endblock javascript %}
 
 {% block main %}
     <h1 class="page-heading">お届け先の追加</h1>
     <div id="detail_wrap" class="container-fluid">
         <div id="detail_box" class="row">
-            <form method="post" action="{{ url('shopping_shipping_multiple_edit') }}">
+            <form method="post" action="{{ url('shopping_shipping_multiple_edit') }}" class="h-adr">
+                <span class="p-country-name" style="display:none;">Japan</span>
                 {{ form_widget(form._token) }}
                 <div id="detail_box__body" class="col-sm-10 col-sm-offset-1">
                     <div id="detail_box__body_inner" class="dl_table">


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ ajaxzip3 の README より 新規の設置には yubinbangoライブラリの使用をオススメしています。 とのことなので。

## 方針(Policy)
+ see also https://github.com/yubinbango/yubinbango

## 実装に関する補足(Appendix)
Effect:

Form Type:
1. AddressType.php
2. ZipType.php
3. OrderType.php

Admin:
1. Customer/edit.twig
2. Order/edit.twig
3. Setting/Shop/shop_master.twig
4. Setting/Shop/tradelaw.twig

Front (default template):
1. Contact/index.twig
2. Entry/index.twig
3. Form/form_layout.twig
4. Mypage/change.twig
5. Mypage/delivery_edit.twig
6. Shopping/nonmember.twig
7. Shopping/shipping_edit.twig
8. Shopping/shipping_multiple_edit.twig

## テスト（Test)

1. IE 11
2. FF
3. Chrome
4. Simulation (mobile)

## 相談（Discussion）
問題タイトル :  複数住所ケースでエラーがあります。
詳細内容：
バークエンド・システムの受注登録画面では：
・注文者情報で 郵便番号を入力して自動的に住所が表示されます: OK
・お届け先情報で 郵便番号を入力して自動的に住所が表示されません: NG。理由：この欄でYubinbangoライブラリを適用できません。ページ同じで重複するクラス名にはYubinbangoライブラリを適用できません。ページ同じで重複するクラス名のときパーション3.1とパーション3.0.15でYubinbangoライブラリを適用できません。

