### PR TITLE
セキュリティ設定＞IP制限の文字長が短い

### DIFF
--- a/src/Eccube/Form/Type/Admin/SecurityType.php
+++ b/src/Eccube/Form/Type/Admin/SecurityType.php
@@ -62,7 +62,7 @@ class SecurityType extends AbstractType
                 'required' => false,
                 'label' => 'IP制限',
                 'constraints' => array(
-                    new Assert\Length(array('max' => $this->config['mtext_len'])),
+                    new Assert\Length(array('max' => $this->config['ltext_len'])),
                 ),
             ))
             ->add('force_ssl', 'checkbox', array(

--- a/src/Eccube/Form/Type/Admin/SecurityType.php
+++ b/src/Eccube/Form/Type/Admin/SecurityType.php
@@ -62,7 +62,7 @@ class SecurityType extends AbstractType
                 'required' => false,
                 'label' => 'IP制限',
                 'constraints' => array(
-                    new Assert\Length(array('max' => $this->config['stext_len'])),
+                    new Assert\Length(array('max' => $this->config['mtext_len'])),
                 ),
             ))
             ->add('force_ssl', 'checkbox', array(

--- a/tests/Eccube/Tests/Form/Type/Admin/SecurityTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SecurityTypeTest.php
@@ -76,4 +76,10 @@ class SecurityTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->assertFalse($this->form->isValid());
     }
 
+    public function testValidAdminAllowHost_MaxLength()
+    {
+        $this->formData['admin_allow_host'] = str_repeat("127.0.0.1\n", 100);
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
 }

--- a/tests/Eccube/Tests/Form/Type/Admin/SecurityTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SecurityTypeTest.php
@@ -76,9 +76,12 @@ class SecurityTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->assertFalse($this->form->isValid());
     }
 
+    /**
+     * Over ltext_len = 3000
+     */
     public function testValidAdminAllowHost_MaxLength()
     {
-        $this->formData['admin_allow_host'] = str_repeat("127.0.0.1\n", 100);
+        $this->formData['admin_allow_host'] = str_repeat("127.0.0.1\n", 1000);
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ This PR to fix: #2414 

## 方針(Policy)
+ 文字長が50文字(stextlen)のため、IPアドレスを数個登録すると上限に達してしまう
+ ltext_len



