### PR TITLE
Event for include template

### DIFF
--- a/src/Eccube/Twig/Extension/EccubeExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeExtension.php
@@ -262,7 +262,7 @@ class EccubeExtension extends \Twig_Extension
     {
         return Str::timeAgo($date);
     }
-    
+
     /**
      * Name of this extension
      *
@@ -272,6 +272,7 @@ class EccubeExtension extends \Twig_Extension
     {
         return array(
             new Twig_TokenParser_Include($this->app),
+            new Twig_TokenParser_Extends($this->app),
         );
     }
 }

--- a/src/Eccube/Twig/Extension/EccubeExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeExtension.php
@@ -262,5 +262,16 @@ class EccubeExtension extends \Twig_Extension
     {
         return Str::timeAgo($date);
     }
-
+    
+    /**
+     * Name of this extension
+     *
+     * @return string
+     */
+    public function getTokenParsers()
+    {
+        return array(
+            new Twig_TokenParser_Include($this->app),
+        );
+    }
 }

--- a/src/Eccube/Twig/Extension/Twig_TokenParser_Include.php
+++ b/src/Eccube/Twig/Extension/Twig_TokenParser_Include.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Twig\Extension;
+
+use \Twig_Token;
+use \Twig_Node_Include;
+use Eccube\Event\TemplateEvent;
+use Monolog\Logger;
+
+class Twig_TokenParser_Include extends \Twig_TokenParser
+{
+    public function __construct($app)
+    {
+        $this->app = $app;
+    }
+    public function parse(Twig_Token $token)
+    {   
+        $expr = $this->parser->getExpressionParser()->parseExpression();
+
+        list($variables, $only, $ignoreMissing) = $this->parseArguments();
+        
+        // Begin create event for include
+        $view = $expr->getAttribute('value');
+        $source = $this->app['twig']->getLoader()->getSource($view);
+
+        $event = new TemplateEvent($view, $source);
+        $eventName = $view;
+        if ($this->app->isAdminRequest()) {
+            // 管理画面の場合、event名に「Admin/」を付ける
+            $eventName = 'Admin/' . $view;
+        }
+        $this->app['monolog']->debug('Template Event Name : ' . $eventName);
+
+        $this->app['eccube.event.dispatcher']->dispatch($eventName, $event);
+        // Begin create event for include
+
+        return new Twig_Node_Include($expr, $variables, $only, $ignoreMissing, $token->getLine(), $this->getTag());
+    }
+
+    protected function parseArguments()
+    {
+        $stream = $this->parser->getStream();
+
+        $ignoreMissing = false;
+        if ($stream->nextIf(Twig_Token::NAME_TYPE, 'ignore')) {
+            $stream->expect(Twig_Token::NAME_TYPE, 'missing');
+
+            $ignoreMissing = true;
+        }
+
+        $variables = null;
+        if ($stream->nextIf(Twig_Token::NAME_TYPE, 'with')) {
+            $variables = $this->parser->getExpressionParser()->parseExpression();
+        }
+
+        $only = false;
+        if ($stream->nextIf(Twig_Token::NAME_TYPE, 'only')) {
+            $only = true;
+        }
+
+        $stream->expect(Twig_Token::BLOCK_END_TYPE);
+
+        return array($variables, $only, $ignoreMissing);
+    }
+
+    public function getTag()
+    {
+        return 'include';
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
以下の問題を発生しています。
プラグインを書くとき現在のECCUBEシステムが「render sub template」イベントを取得できませんでした。理由：現在のアルゴリズムがURLリンクを使用しています。

・例えば1:
プラグインGMOで、MYPAGEにメニューを追加したいとき13イベントを追加して必要です。（下に備考1で13イベントの詳細内容を参考してください。）

・例えば2:
プラグインABCで、MYPAGEにメニューを追加したいとき「同時に二つのプラグインが見えない」問題を発生します。理由：MYPAGEにメニューを追加のために現在のアルゴリズムがURLリンクを使用しています。

・画像１：「ご注文履歴」リンクをクリックするとき「GMOとPluginABC」二つのプラグインが表示されます。
![image](https://user-images.githubusercontent.com/29972415/28363228-e37ef5ee-6ca9-11e7-8607-0ef880ca8056.png)

・画像２：「GMO」リンクをクリックするときPluginABCのプラグインが表示されません。
![image](https://user-images.githubusercontent.com/29972415/28363234-ec0dbccc-6ca9-11e7-9d3c-1f826a5bc53c.png)

## 方針(Policy)
・提案ソリューション：
「render sub template」イベントを取得のために新しいアルゴリズムを使用します。

・詳細内容：
Mypage/navi.twig:
- [onRenderMypageBefore, NORMAL]

/**
     * @param TemplateEvent $event
     */
    public function onMypageNaviRender(TemplateEvent $event)

## 実装に関する補足(Appendix)
新しいアルゴリズムと現在のアルゴリズムを比べます。
・現在のアルゴリズム
- 13イベントを取得して必要です。
- 「sub template」イベントを取得できません。
- HTMLにrenderする後にイベントを取得できます。 (下に備考2で「onRenderMypageBefore」関数を参考してください。)

・新しいアルゴリズム
-  13イベントじゃなくて1イベントだけを取得して必要です。
- 「sub template」イベントを取得できます。
- HTMLにrenderする前にイベントを取得できます。 (twigファイル)

※備考 1: 
13 イベント:
#Mypage events
eccube.event.render.mypage.before:
    - [onRenderMypageBefore, NORMAL]
eccube.event.render.mypage_change.before:
    - [onRenderMypageBefore, NORMAL]
eccube.event.render.mypage_change_complete.before:
    - [onRenderMypageBefore, NORMAL]
eccube.event.render.mypage_delivery.before:
    - [onRenderMypageBefore, NORMAL]
eccube.event.render.mypage_delivery_new.before:
    - [onRenderMypageBefore, NORMAL]
eccube.event.render.mypage_delivery_edit.before:
    - [onRenderMypageBefore, NORMAL]
eccube.event.render.mypage_favorite.before:
    - [onRenderMypageBefore, NORMAL]
eccube.event.render.mypage_history.before:
    - [onRenderMypageBefore, NORMAL]
eccube.event.render.mypage_mail_view.before:
    - [onRenderMypageBefore, NORMAL]
eccube.event.render.mypage_order.before:
    - [onRenderMypageBefore, NORMAL]
eccube.event.render.mypage_withdraw.before:
    - [onRenderMypageBefore, NORMAL]
eccube.event.render.gmo_mypage_subscription_orders.before:
    - [onRenderMypageBefore, NORMAL]
eccube.event.render.gmo_mypage_change_card.before:
    - [onRenderMypageBefore, NORMAL]

※備考2: 
onRenderMypageBefore:

/**
     * Add sub menu link to change card page on menu in my page
     */
    public function onRenderMypageBefore(FilterResponseEvent $event) 
