### PR TITLE
auto_renderオプションが正しく判定できていなかったので修正

### DIFF
--- a/src/Eccube/Form/Extension/DoctrineOrmExtension.php
+++ b/src/Eccube/Form/Extension/DoctrineOrmExtension.php
@@ -82,7 +82,7 @@ class DoctrineOrmExtension extends AbstractTypeExtension
                     if ($anno) {
                         $options = is_null($anno->options) ? [] : $anno->options;
                         $options['eccube_form_options'] = [
-                            'auto_render' => $anno->auto_render,
+                            'auto_render' => (true === $anno->auto_render),
                             'form_theme' => $anno->form_theme,
                         ];
                         if (!isset($form[$prop->getName()])) {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#2427 の修正不備。
auto_renderのオプションを指定しなかった場合、値がnullになり、twig側で判定できていなかったので修正


