### PR TITLE
電話番号の各要素のフォーム名をoptionで指定した場合にエラー判定がおかしいバグの修正

### DIFF
--- a/src/Eccube/Form/Type/TelType.php
+++ b/src/Eccube/Form/Type/TelType.php
@@ -56,7 +56,7 @@ class TelType extends AbstractType
         if (!isset($options['options']['error_bubbling'])) {
             $options['options']['error_bubbling'] = $options['error_bubbling'];
         }
-        // nameは呼び出しもので定義したものを使う
+        // nameは呼び出しもとで定義したものを使う
         if (empty($options['tel01_name'])) {
             $options['tel01_name'] = $builder->getName().'01';
         }
@@ -77,21 +77,21 @@ class TelType extends AbstractType
         $builder->setAttribute('tel02_name', $options['tel02_name']);
         $builder->setAttribute('tel03_name', $options['tel03_name']);
         // todo 変
-        $builder->addEventListener(FormEvents::POST_BIND, function ($event) use ($builder) {
+        $builder->addEventListener(FormEvents::POST_BIND, function ($event) use ($builder, $options) {
             $form = $event->getForm();
             $count = 0;
-            if ($form[$builder->getName().'01']->getData() != '') {
+            if ($form[$options['tel01_name']]->getData() != '') {
                 $count++;
             }
-            if ($form[$builder->getName().'02']->getData() != '') {
+            if ($form[$options['tel02_name']]->getData() != '') {
                 $count++;
             }
-            if ($form[$builder->getName().'03']->getData() != '') {
+            if ($form[$options['tel03_name']]->getData() != '') {
                 $count++;
             }
             if ($count != 0 && $count != 3) {
                 // todo メッセージをymlに入れる
-                $form[$builder->getName().'01']->addError(new FormError('全て入力してください。'));
+                $form[$options['tel01_name']]->addError(new FormError('全て入力してください。'));
             }
         });
     }


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ optionで指定したフォーム名がaddEventListenerのエラーチェックで使用されていない

## 実装に関する補足(Appendix)
+ optionでサブフォーム名を指定できるようになっているので、エラーチェックもそのフォーム名を利用する




