### PR TITLE
カバレッジレポート作成時のエラーを修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ php:
   - 7.0
   - 7.1
 
+dist: precise
+
 matrix:
   fast_finish: true
   include:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,6 +26,7 @@
           <exclude>
             <directory suffix=".php">./src/Eccube/Resource</directory>
             <directory suffix=".php">./src/Eccube/Command/PluginCommand/Resource</directory>
+            <directory suffix=".php">./src/Eccube/Command/GeneratorCommand/generatortemplate</directory>
           </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ カバレッジレポート作成時にエラーにプラグインジェネレータのテンプレートを読み込んでエラーになっていたので、除外するように設定

## その他
#2433 を先に取り込んでください。

