### PR TITLE
Travis CIでPHP5.3のテストをできるように修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ php:
   - 7.0
   - 7.1
 
+dist: precise
+
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ [Travic CIのUbuntuイメージの変更](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default)に対応

