### PR TITLE
PurchaseFlowの修正

### DIFF
--- a/src/Eccube/Controller/AbstractShoppingController.php
+++ b/src/Eccube/Controller/AbstractShoppingController.php
@@ -26,7 +26,6 @@ namespace Eccube\Controller;
 
 use Eccube\Application;
 use Eccube\Entity\ItemHolderInterface;
-use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Eccube\Service\PurchaseFlow\PurchaseFlowResult;
 
 class AbstractShoppingController extends AbstractController
@@ -60,7 +59,7 @@ class AbstractShoppingController extends AbstractController
     protected function executePurchaseFlow(Application $app, ItemHolderInterface $itemHolder)
     {
         /** @var PurchaseFlowResult $flowResult */
-        $flowResult = $app['eccube.purchase.flow.shopping']->calculate($itemHolder, PurchaseContext::create());
+        $flowResult = $app['eccube.purchase.flow.shopping']->calculate($itemHolder, $app['eccube.purchase.context']());
         foreach ($flowResult->getWarning() as $warning) {
             $app->addRequestError($warning->getMessage());
         }

--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -34,7 +34,7 @@ use Eccube\Form\Type\AddCartType;
 use Eccube\Form\Type\Admin\OrderType;
 use Eccube\Form\Type\Admin\SearchCustomerType;
 use Eccube\Form\Type\Admin\SearchProductType;
-use Eccube\Service\PurchaseFlow\PurchageException;
+use Eccube\Service\PurchaseFlow\PurchaseException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
@@ -141,7 +141,7 @@ class EditController extends AbstractController
                     if ($flowResult->hasError() === false && $form->isValid()) {
                         try {
                             $app['eccube.purchase.flow.order']->purchase($TargetOrder, $purchaseContext);
-                        } catch (PurchageException $e) {
+                        } catch (PurchaseException $e) {
                             $app->addError($e->getMessage(), 'admin');
                             break;
                         }

--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -34,7 +34,6 @@ use Eccube\Form\Type\AddCartType;
 use Eccube\Form\Type\Admin\OrderType;
 use Eccube\Form\Type\Admin\SearchCustomerType;
 use Eccube\Form\Type\Admin\SearchProductType;
-use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Eccube\Service\PurchaseFlow\PurchageException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -106,7 +105,7 @@ class EditController extends AbstractController
 
         $form = $builder->getForm();
         $form->handleRequest($request);
-        $purchaseContext = PurchaseContext::create($OriginOrder);
+        $purchaseContext = $app['eccube.purchase.context']($OriginOrder);
 
         if ($form->isSubmitted()) {
             $event = new EventArgs(

--- a/src/Eccube/Controller/CartController.php
+++ b/src/Eccube/Controller/CartController.php
@@ -28,7 +28,6 @@ use Eccube\Application;
 use Eccube\Entity\ProductClass;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
-use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Eccube\Service\PurchaseFlow\PurchaseFlowResult;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -62,7 +61,7 @@ class CartController extends AbstractController
         // カートを取得して明細の正規化を実行
         $Cart = $app['eccube.service.cart']->getCart();
         /** @var PurchaseFlowResult $result */
-        $result = $app['eccube.purchase.flow.cart']->calculate($Cart, PurchaseContext::create());
+        $result = $app['eccube.purchase.flow.cart']->calculate($Cart, $app['eccube.purchase.context']());
 
         // 復旧不可のエラーが発生した場合はカートをクリアして再描画
         if ($result->hasError()) {
@@ -155,7 +154,7 @@ class CartController extends AbstractController
         $Cart = $app['eccube.service.cart']->getCart();
         /** @var PurchaseFlowResult $result */
 
-        $result = $app['eccube.purchase.flow.cart']->calculate($Cart, PurchaseContext::create());
+        $result = $app['eccube.purchase.flow.cart']->calculate($Cart, $app['eccube.purchase.context']());
 
         // 復旧不可のエラーが発生した場合はカートをクリアしてカート一覧へ
         if ($result->hasError()) {

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -34,7 +34,6 @@ use Eccube\Form\Type\AddCartType;
 use Eccube\Form\Type\Master\ProductListMaxType;
 use Eccube\Form\Type\Master\ProductListOrderByType;
 use Eccube\Form\Type\SearchProductType;
-use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -281,7 +280,7 @@ class ProductController
 
                     // 明細の正規化
                     $flow = $app['eccube.purchase.flow.cart'];
-                    $result = $flow->calculate($Cart, PurchaseContext::create());
+                    $result = $flow->calculate($Cart, $app['eccube.purchase.context']());
 
                     // 復旧不可のエラーが発生した場合は追加した明細を削除.
                     if ($result->hasError()) {

--- a/src/Eccube/Service/PurchaseFlow/PurchaseContext.php
+++ b/src/Eccube/Service/PurchaseFlow/PurchaseContext.php
@@ -10,12 +10,7 @@ class PurchaseContext extends \SplObjectStorage
 
     private $originHolder;
 
-    public static function create(ItemHolderInterface $originHolder = null)
-    {
-        return new self($originHolder);
-    }
-
-    protected function __construct(ItemHolderInterface $originHolder = null)
+    public function __construct(ItemHolderInterface $originHolder = null)
     {
         $this->originHolder = $originHolder;
     }

--- a/src/Eccube/Service/PurchaseFlow/PurchaseFlow.php
+++ b/src/Eccube/Service/PurchaseFlow/PurchaseFlow.php
@@ -47,12 +47,7 @@ class PurchaseFlow
 
     public function calculate(ItemHolderInterface $itemHolder, PurchaseContext $context)
     {
-        $this->calculateDeliveryFeeTotal($itemHolder);
-        $this->calculateCharge($itemHolder);
-        $this->calculateDiscount($itemHolder);
-        $this->calculateSubTotal($itemHolder); // Order の場合のみ
-        $this->calculateTax($itemHolder);
-        $this->calculateTotal($itemHolder);
+        $this->calculateAll($itemHolder);
 
         $flowResult = new PurchaseFlowResult($itemHolder);
 
@@ -63,10 +58,14 @@ class PurchaseFlow
             }
         }
 
+        $this->calculateAll($itemHolder);
+
         foreach ($this->itemHolderProcessors as $holderProcessor) {
             $result = $holderProcessor->process($itemHolder, $context);
             $flowResult->addProcessResult($result);
         }
+
+        $this->calculateAll($itemHolder);
 
         return $flowResult;
     }
@@ -191,5 +190,18 @@ class PurchaseFlow
                 return $sum;
             }, 0);
         $itemHolder->setTax($total);
+    }
+
+    /**
+     * @param ItemHolderInterface $itemHolder
+     */
+    protected function calculateAll(ItemHolderInterface $itemHolder)
+    {
+        $this->calculateDeliveryFeeTotal($itemHolder);
+        $this->calculateCharge($itemHolder);
+        $this->calculateDiscount($itemHolder);
+        $this->calculateSubTotal($itemHolder); // Order の場合のみ
+        $this->calculateTax($itemHolder);
+        $this->calculateTotal($itemHolder);
     }
 }

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -25,6 +25,7 @@
 namespace Eccube\ServiceProvider;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Eccube\Entity\ItemHolderInterface;
 use Eccube\EventListener\TransactionListener;
 use Eccube\Service\OrderHelper;
 use Eccube\Service\PurchaseFlow\Processor\AdminOrderRegisterPurchaseProcessor;
@@ -39,6 +40,7 @@ use Eccube\Service\PurchaseFlow\Processor\PaymentTotalLimitValidator;
 use Eccube\Service\PurchaseFlow\Processor\SaleLimitValidator;
 use Eccube\Service\PurchaseFlow\Processor\StockValidator;
 use Eccube\Service\PurchaseFlow\Processor\UpdateDatePurchaseProcessor;
+use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Eccube\Service\PurchaseFlow\PurchaseFlow;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
@@ -536,6 +538,10 @@ class EccubeServiceProvider implements ServiceProviderInterface, EventListenerPr
         };
         // TODO QueryCustomizerの追加方法は要検討
         $app['eccube.queries']->addCustomizer(new \Acme\Entity\AdminProductListCustomizer());
+
+        $app['eccube.purchase.context'] = $app->protect(function (ItemHolderInterface $origin = null) {
+            return new PurchaseContext($origin);
+        });
 
         $app['eccube.purchase.flow.cart.item_processors'] = function ($app) {
             $processors = new ArrayCollection();

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DeletedProductValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DeletedProductValidatorTest.php
@@ -52,7 +52,7 @@ class DeletedProductValidatorTest extends EccubeTestCase
      */
     public function testProductIsValid()
     {
-        $result = $this->validator->process($this->cartItem, PurchaseContext::create());
+        $result = $this->validator->process($this->cartItem, new PurchaseContext());
 
         self::assertFalse($result->isError());
     }
@@ -63,7 +63,7 @@ class DeletedProductValidatorTest extends EccubeTestCase
     public function testDisplayStatusWithClosed()
     {
         $this->Product->setDelFlg(1);
-        $result = $this->validator->process($this->cartItem, PurchaseContext::create());
+        $result = $this->validator->process($this->cartItem, new PurchaseContext());
 
         self::assertEquals(0, $this->cartItem->getQuantity());
         self::assertTrue($result->isWarning());

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DeliveryFeeFreeProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DeliveryFeeFreeProcessorTest.php
@@ -60,7 +60,7 @@ class DeliveryFeeFreeProcessorTest extends EccubeTestCase
      */
     public function testProcess()
     {
-        $result = $this->processor->process($this->Order, PurchaseContext::create());
+        $result = $this->processor->process($this->Order, new PurchaseContext());
         self::assertInstanceOf(ProcessResult::class, $result);
         self::assertFalse($result->isError());
 
@@ -79,7 +79,7 @@ class DeliveryFeeFreeProcessorTest extends EccubeTestCase
         $BaseInfo = $this->app['eccube.repository.base_info']->get();
         $BaseInfo->setDeliveryFreeAmount(1); // 1円以上で送料無料
 
-        $result = $this->processor->process($this->Order, PurchaseContext::create());
+        $result = $this->processor->process($this->Order, new PurchaseContext());
         self::assertInstanceOf(ProcessResult::class, $result);
         self::assertFalse($result->isError());
 
@@ -98,7 +98,7 @@ class DeliveryFeeFreeProcessorTest extends EccubeTestCase
         $BaseInfo = $this->app['eccube.repository.base_info']->get();
         $BaseInfo->setDeliveryFreeQuantity(1); // 1個以上で送料無料
 
-        $result = $this->processor->process($this->Order, PurchaseContext::create());
+        $result = $this->processor->process($this->Order, new PurchaseContext());
         self::assertInstanceOf(ProcessResult::class, $result);
         self::assertFalse($result->isError());
 

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DeliveryFeeProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DeliveryFeeProcessorTest.php
@@ -44,7 +44,7 @@ class DeliveryFeeProcessorTest extends EccubeTestCase
                 $Order->getShipmentItems()->removeElement($ShipmentItem);
             }
         }
-        $processor->process($Order, PurchaseContext::create());
+        $processor->process($Order, new PurchaseContext());
         self::assertNotEmpty($this->getDeliveryFees($Order));
     }
 
@@ -70,7 +70,7 @@ class DeliveryFeeProcessorTest extends EccubeTestCase
         $DeliveryFee->setOrderItemType($OrderItemType);
         $Order->addItem($DeliveryFee);
 
-        $processor->process($Order, PurchaseContext::create());
+        $processor->process($Order, new PurchaseContext());
 
         $DeliveryFeeList = $this->getDeliveryFees($Order);
         self::assertCount(1, $DeliveryFeeList);

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DeliverySettingValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DeliverySettingValidatorTest.php
@@ -53,7 +53,7 @@ class DeliverySettingValidatorTest extends EccubeTestCase
      */
     public function testDeliverySettingIsValid()
     {
-        $result = $this->validator->process($this->cartItem, PurchaseContext::create());
+        $result = $this->validator->process($this->cartItem, new PurchaseContext());
 
         self::assertFalse($result->isError());
     }
@@ -67,7 +67,7 @@ class DeliverySettingValidatorTest extends EccubeTestCase
         $ProductType->setId(10000);
         $this->ProductClass->setProductType($ProductType);
 
-        $this->validator->process($this->cartItem, PurchaseContext::create());
+        $this->validator->process($this->cartItem, new PurchaseContext());
 
         self::assertEquals(0, $this->cartItem->getQuantity());
     }

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DisplayStatusValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DisplayStatusValidatorTest.php
@@ -60,7 +60,7 @@ class DisplayStatusValidatorTest extends EccubeTestCase
         $Disp = $app['eccube.repository.master.disp']->find(Disp::DISPLAY_SHOW);
         $this->Product->setStatus($Disp);
 
-        $this->validator->process($this->cartItem, PurchaseContext::create());
+        $this->validator->process($this->cartItem, new PurchaseContext());
 
         self::assertEquals(10, $this->cartItem->getQuantity());
     }
@@ -75,7 +75,7 @@ class DisplayStatusValidatorTest extends EccubeTestCase
         $Disp = $app['eccube.repository.master.disp']->find(Disp::DISPLAY_HIDE);
         $this->Product->setStatus($Disp);
 
-        $this->validator->process($this->cartItem, PurchaseContext::create());
+        $this->validator->process($this->cartItem, new PurchaseContext());
 
         self::assertEquals(0, $this->cartItem->getQuantity());
     }

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PaymentProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PaymentProcessorTest.php
@@ -102,7 +102,7 @@ class PaymentProcessorTest extends EccubeTestCase
     public function testCartNoItems()
     {
         $cart = new Cart();
-        $result = $this->validator->process($cart, PurchaseContext::create());
+        $result = $this->validator->process($cart, new PurchaseContext());
 
         self::assertFalse($result->isError());
     }
@@ -114,7 +114,7 @@ class PaymentProcessorTest extends EccubeTestCase
         $item->setObject($this->ProductClass1);
         $cart->addItem($item);
 
-        $result = $this->validator->process($cart, PurchaseContext::create());
+        $result = $this->validator->process($cart, new PurchaseContext());
 
         self::assertFalse($result->isError());
     }
@@ -130,7 +130,7 @@ class PaymentProcessorTest extends EccubeTestCase
         $item2->setObject($this->ProductClass2);
         $cart->addItem($item2);
 
-        $result = $this->validator->process($cart, PurchaseContext::create());
+        $result = $this->validator->process($cart, new PurchaseContext());
 
         self::assertFalse($result->isError());
     }
@@ -156,7 +156,7 @@ class PaymentProcessorTest extends EccubeTestCase
         $item3->setObject($this->ProductClass3);
         $cart->addItem($item3);
 
-        $result = $this->validator->process($cart, PurchaseContext::create());
+        $result = $this->validator->process($cart, new PurchaseContext());
 
         self::assertTrue($result->isError());
         self::assertCount(3, $cart->getItems());

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PaymentTotalLimitValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PaymentTotalLimitValidatorTest.php
@@ -38,7 +38,7 @@ class PaymentTotalLimitValidatorTest extends EccubeTestCase
         $cart = new Cart();
         $cart->setTotal(100);
 
-        $result = $validator->process($cart, PurchaseContext::create());
+        $result = $validator->process($cart, new PurchaseContext());
         self::assertFalse($result->isError());
     }
 
@@ -49,7 +49,7 @@ class PaymentTotalLimitValidatorTest extends EccubeTestCase
         $cart = new Cart();
         $cart->setTotal(1001);
 
-        $result = $validator->process($cart, PurchaseContext::create());
+        $result = $validator->process($cart, new PurchaseContext());
         self::assertTrue($result->isError());
     }
 
@@ -60,7 +60,7 @@ class PaymentTotalLimitValidatorTest extends EccubeTestCase
         $order = new Order();
         $order->setTotal(100);
 
-        $result = $validator->process($order, PurchaseContext::create());
+        $result = $validator->process($order, new PurchaseContext());
         self::assertFalse($result->isError());
     }
 
@@ -71,7 +71,7 @@ class PaymentTotalLimitValidatorTest extends EccubeTestCase
         $order = new Order();
         $order->setTotal(1001);
 
-        $result = $validator->process($order, PurchaseContext::create());
+        $result = $validator->process($order, new PurchaseContext());
         self::assertTrue($result->isError());
     }
 }

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/StockValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/StockValidatorTest.php
@@ -37,14 +37,14 @@ class StockValidatorTest extends EccubeTestCase
     public function testValidStock()
     {
         $this->cartItem->setQuantity(1);
-        $this->validator->process($this->cartItem, PurchaseContext::create());
+        $this->validator->process($this->cartItem, new PurchaseContext());
         self::assertEquals(1, $this->cartItem->getQuantity());
     }
 
     public function testValidStockFail()
     {
         $this->cartItem->setQuantity(PHP_INT_MAX);
-        $result = $this->validator->process($this->cartItem, PurchaseContext::create());
+        $result = $this->validator->process($this->cartItem, new PurchaseContext());
 
         self::assertEquals($this->ProductClass->getStock(), $this->cartItem->getQuantity());
         self::assertTrue($result->isWarning());
@@ -60,7 +60,7 @@ class StockValidatorTest extends EccubeTestCase
         $Order->getShipmentItems()[0]->setQuantity(1);
         $this->ProductClass->setStock(100);
 
-        $this->validator->process($Order->getShipmentItems()[0], PurchaseContext::create());
+        $this->validator->process($Order->getShipmentItems()[0], new PurchaseContext());
         self::assertEquals(1, $Order->getShipmentItems()[0]->getQuantity());
     }
 }

--- a/tests/Eccube/Tests/Service/PurchaseFlow/PurchaseFlowTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/PurchaseFlowTest.php
@@ -41,7 +41,7 @@ class PurchaseFlowTest extends EccubeTestCase
         $itemHolder = new Cart();
 
         $expected = new PurchaseFlowResult($itemHolder);
-        $this->assertEquals($expected, $this->flow->calculate($itemHolder, PurchaseContext::create()));
+        $this->assertEquals($expected, $this->flow->calculate($itemHolder, new PurchaseContext()));
     }
 
     public function testAddProcesser()
@@ -59,7 +59,7 @@ class PurchaseFlowTest extends EccubeTestCase
         $itemHolder = new Cart();
 
         $expected = new PurchaseFlowResult($itemHolder);
-        self::assertEquals($expected, $this->flow->calculate($itemHolder, PurchaseContext::create()));
+        self::assertEquals($expected, $this->flow->calculate($itemHolder, new PurchaseContext()));
     }
 
     public function testProcessItemHolderProcessor()
@@ -69,7 +69,7 @@ class PurchaseFlowTest extends EccubeTestCase
 
         $expected = new PurchaseFlowResult($itemHolder);
         $expected->addProcessResult(ProcessResult::success());
-        self::assertEquals($expected, $this->flow->calculate($itemHolder, PurchaseContext::create()));
+        self::assertEquals($expected, $this->flow->calculate($itemHolder, new PurchaseContext()));
     }
 
     public function testProcessItemHolderProcessor_validationErrors()
@@ -79,7 +79,7 @@ class PurchaseFlowTest extends EccubeTestCase
 
         $expected = new PurchaseFlowResult($itemHolder);
         $expected->addProcessResult(ProcessResult::error('error 1'));
-        self::assertEquals($expected, $this->flow->calculate($itemHolder, PurchaseContext::create()));
+        self::assertEquals($expected, $this->flow->calculate($itemHolder, new PurchaseContext()));
     }
 
     public function testProcessItemProcessors_validationErrors()
@@ -92,7 +92,7 @@ class PurchaseFlowTest extends EccubeTestCase
         $expected = new PurchaseFlowResult($itemHolder);
         $expected->addProcessResult(ProcessResult::warn('error 1'));
         $expected->addProcessResult(ProcessResult::warn('error 2'));
-        self::assertEquals($expected, $this->flow->calculate($itemHolder, PurchaseContext::create()));
+        self::assertEquals($expected, $this->flow->calculate($itemHolder, new PurchaseContext()));
     }
 
     public function testProcessItemProcessors_validationErrors_with_multi_items()
@@ -108,7 +108,7 @@ class PurchaseFlowTest extends EccubeTestCase
         $expected->addProcessResult(ProcessResult::warn('error 2'));
         $expected->addProcessResult(ProcessResult::warn('error 1'));
         $expected->addProcessResult(ProcessResult::warn('error 2'));
-        self::assertEquals($expected, $this->flow->calculate($itemHolder, PurchaseContext::create()));
+        self::assertEquals($expected, $this->flow->calculate($itemHolder, new PurchaseContext()));
     }
 }
 

--- a/tests/Eccube/Tests/Service/PurchaseFlow/ValidatableItemProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/ValidatableItemProcessorTest.php
@@ -46,7 +46,7 @@ class ValidatableItemProcessorTest extends EccubeTestCase
         $validator = new ValidatableItemProcessorTest_NormalValidator();
         $item = new CartItem();
 
-        $validator->process($item, PurchaseContext::create());
+        $validator->process($item, new PurchaseContext());
         $this->assertFalse($validator->handleCalled);
     }
 
@@ -55,7 +55,7 @@ class ValidatableItemProcessorTest extends EccubeTestCase
         $validator = new ValidatableItemProcessorTest_FailValidator();
         $item = new CartItem();
 
-        $validator->process($item, PurchaseContext::create());
+        $validator->process($item, new PurchaseContext());
     }
 
     public function testValidateOrderSuccess()
@@ -63,7 +63,7 @@ class ValidatableItemProcessorTest extends EccubeTestCase
         $validator = new ValidatableItemProcessorTest_NormalValidator();
         $item = new ShipmentItem();
 
-        $result = $validator->process($item, PurchaseContext::create());
+        $result = $validator->process($item, new PurchaseContext());
         self::assertFalse($validator->handleCalled);
         self::assertFalse($result->isError());
     }
@@ -73,7 +73,7 @@ class ValidatableItemProcessorTest extends EccubeTestCase
         $validator = new ValidatableItemProcessorTest_FailValidator();
         $item = new ShipmentItem();
 
-        $result = $validator->process($item, PurchaseContext::create());
+        $result = $validator->process($item, new PurchaseContext());
         self::assertFalse($validator->handleCalled);
         self::assertTrue($result->isWarning());
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#2424 の修正です

- PurchaseContext::create()の廃止
- Processor実行後の修正処理の実装漏れを修正
