### PR TITLE
マスターの値を取得するメソッド追加

### DIFF
--- a/src/Eccube/Application/ApplicationTrait.php
+++ b/src/Eccube/Application/ApplicationTrait.php
@@ -134,4 +134,22 @@ trait ApplicationTrait
         $this->offsetUnset($key);
         $this[$key] = $service;
     }
+
+    /**
+     * プライマリーキーを使用してオブジェクトを取得する.
+     *
+     * 主に、マスタデータを取得するために使用する.
+     *
+     * @param string $class
+     * @param integer $id
+     * @throws \InvalidArgumentException $class が不正な場合
+     * @return object|null エンティティのインスタンス
+     */
+    public function find($class, $id)
+    {
+        if (!class_exists($class)) {
+            throw new \InvalidArgumentException();
+        }
+        return $this['orm.em']->getRepository($class)->find($id);
+    }
 }

--- a/tests/Eccube/Tests/Application/ApplicationTraitTest.php
+++ b/tests/Eccube/Tests/Application/ApplicationTraitTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Eccube\Tests\Application;
+
+use Eccube\Tests\EccubeTestCase;
+use Eccube\Entity\Master\CustomerStatus;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * ApplicationTrait test cases.
+ */
+class ApplicationTraitTest extends EccubeTestCase
+{
+    public function testFind()
+    {
+        $Status = $this->app->find(CustomerStatus::class, CustomerStatus::ACTIVE);
+
+        self::assertInstanceOf(CustomerStatus::class, $Status);
+        self::assertEquals(CustomerStatus::ACTIVE, $Status->getId());
+    }
+
+    public function testWithFailure()
+    {
+        try {
+            $Status = $this->app->find('\Foo\Bar\Class', CustomerStatus::ACTIVE);
+            self::fail();
+        } catch (\InvalidArgumentException $e) {
+            self::assertInstanceOf(\InvalidArgumentException::class, $e);
+        }
+    }
+
+    public function testWithNotEntity()
+    {
+        try {
+            $Status = $this->app->find(Request::class, 1);
+            self::fail();
+        } catch (\Doctrine\Common\Persistence\Mapping\MappingException $e) {
+            self::assertInstanceOf(\Doctrine\Common\Persistence\Mapping\MappingException::class, $e);
+        }
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
マスターの値を取り出すのに記述が多いため、簡潔に記述できるメソッドを追加

```php
/* before */
$Status = $app['orm.em']->getRepository(CustomerStatus::class)->find(CustomerStatus::ACTIVE);
// or
$Status = $app['eccube.repository.master.customer_status']->find(CustomerStatus::ACTIVE);

/* after */
$Status = $app->find(CustomerStatus::class, CustomerStatus::ACTIVE);
```

## 実装に関する補足(Appendix)
+ マスター以外の Entity も検索できてしまう


## 相談（Discussion）
+ できるだけ短かいメソッド名にしたかったので、 `find` としたが、もっと適切なメソッド名があれば変更する



