### PR TITLE
Trait でクラス定数(っぽいもの)を追加する仕組み

### DIFF
--- a/src/Eccube/Entity/Master/AbstractMasterEntity.php
+++ b/src/Eccube/Entity/Master/AbstractMasterEntity.php
@@ -131,6 +131,9 @@ abstract class AbstractMasterEntity extends \Eccube\Entity\AbstractEntity
 
     protected static function getConstantValue($name)
     {
+        if (in_array($name, ['id', 'name', 'rank'])) {
+            throw new \InvalidArgumentException();
+        }
         // see also. http://qiita.com/Hiraku/items/71e385b56dcaa37629fe
         $class = get_class(new static());
         $ref = new \ReflectionClass($class);

--- a/src/Eccube/Entity/Master/AbstractMasterEntity.php
+++ b/src/Eccube/Entity/Master/AbstractMasterEntity.php
@@ -113,4 +113,35 @@ abstract class AbstractMasterEntity extends \Eccube\Entity\AbstractEntity
     {
         return $this->rank;
     }
+
+    public function __get($name)
+    {
+        return self::getConstantValue($name);
+    }
+
+    public function __set($name, $value)
+    {
+        throw new \InvalidArgumentException();
+    }
+
+    public static function __callStatic($name, $arguments)
+    {
+        return self::getConstantValue($name);
+    }
+
+    protected static function getConstantValue($name)
+    {
+        // see also. http://qiita.com/Hiraku/items/71e385b56dcaa37629fe
+        $class = get_class(new static());
+        $ref = new \ReflectionClass($class);
+        // クラス定数が存在していれば, クラス定数から値を取得する
+        $constants = $ref->getConstants();
+        if (array_key_exists($name, $constants)) {
+            return $constants[$name];
+        }
+        // XXX $obj = new static(); とすると segmentation fault が発生するため, リフレクションで値を取得する
+        $refProperty = $ref->getProperty($name);
+        $refProperty->setAccessible(true);
+        return $refProperty->getValue(new $class);
+    }
 }

--- a/tests/Eccube/Tests/Entity/AbstractEntityTest.php
+++ b/tests/Eccube/Tests/Entity/AbstractEntityTest.php
@@ -11,7 +11,7 @@ use Eccube\Entity\AbstractEntity;
  */
 class AbstractEntityTest extends \PHPUnit_Framework_TestCase
 {
-     private $objEntity;
+    private $objEntity;
 
     public function testNewInstance()
     {

--- a/tests/Eccube/Tests/Entity/Master/AbstractMasterEntityTest.php
+++ b/tests/Eccube/Tests/Entity/Master/AbstractMasterEntityTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Eccube\Tests\Entity\Master;
+
+use Eccube\Tests\EccubeTestCase;
+use Eccube\Entity\Master\Sex;
+
+/**
+ * AbstractMasterEntity test cases.
+ *
+ * @author Kentaro Ohkouchi
+ */
+class AbstractMasterEntityTest extends EccubeTestCase
+{
+    public function testGetConstant()
+    {
+        self::assertEquals(1, TestSexDecorator::TEST_MALE, 'constant access');
+        self::assertEquals(1, TestSexDecorator::TEST_MALE(), 'enum like access');
+    }
+
+    public function testGetConstantWithTrait()
+    {
+        self::assertEquals(2, TestSexDecorator::TEST_FEMALE(), 'enum like access via trait');
+    }
+
+    public function testExplicitOverwriteConstant()
+    {
+        try {
+            $c = new TestSexDecorator();
+            // クラス変数を上書きしようとすると InvalidArgumentException になる
+            $c->TEST_FEMALE = 3;
+            self::fail();
+        } catch (\InvalidArgumentException $e) {
+            self::assertInstanceOf(\InvalidArgumentException::class, $e);
+        }
+    }
+}
+
+class TestSexDecorator extends Sex
+{
+    use TestSexTrait;
+    const TEST_MALE = 1;
+}
+
+trait TestSexTrait
+{
+    private $TEST_FEMALE = 2;
+}

--- a/tests/Eccube/Tests/Entity/Master/AbstractMasterEntityTest.php
+++ b/tests/Eccube/Tests/Entity/Master/AbstractMasterEntityTest.php
@@ -34,6 +34,29 @@ class AbstractMasterEntityTest extends EccubeTestCase
             self::assertInstanceOf(\InvalidArgumentException::class, $e);
         }
     }
+
+    public function testInvalidFields()
+    {
+        // id, name, rank は取得できない
+        try {
+            $c = TestSexDecorator::id();
+            self::fail();
+        } catch (\InvalidArgumentException $e) {
+            self::assertInstanceOf(\InvalidArgumentException::class, $e);
+        }
+        try {
+            $c = TestSexDecorator::name();
+            self::fail();
+        } catch (\InvalidArgumentException $e) {
+            self::assertInstanceOf(\InvalidArgumentException::class, $e);
+        }
+        try {
+            $c = TestSexDecorator::rank();
+            self::fail();
+        } catch (\InvalidArgumentException $e) {
+            self::assertInstanceOf(\InvalidArgumentException::class, $e);
+        }
+    }
 }
 
 class TestSexDecorator extends Sex


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
現在、一部のマスタデータにクラス定数が定義されており、簡潔に ID 値を取得できる。
しかし、カスタマイズ時にマスタ値を追加した場合、 [Entity拡張機構](https://github.com/EC-CUBE/ec-cube/pull/2267)を使用して、クラス定数を追加できないため、不便。

## 方針(Policy)
+ trait で追加可能な、クラス定数と同等の仕組みを実装する
+ 定義した値を変更できないようにする
+ 既存のクラス定数も同じように使用できるようにする

こんな感じに使用します
```php
echo CustomerStatus::ACTIVE();
// => 2
```

従来のクラス定数にも同じように使用できます
```php
echo CustomerStatus::ACTIVE;
// => 2
```

trait を追加することで、定義を増やすことができます。
```php
trait CustomerStatusTrait
{
    private $LEAVE = 3;
}

echo CustomerStatus::LEAVE();
// => 3
```

値を変更しようとすると  `InvalidArgumentException` になります

```php
$obj = new CustomerStatus();
$obj->LEAVE = 4;
// => InvalidArgumentException
```

## 実装に関する補足(Appendix)
+ こちらを参考にしました→ http://qiita.com/Hiraku/items/71e385b56dcaa37629fe
+ `AbstractMasterEntity` で、 以下のようにすると segmentation fault になるため、 `ReflactionProperty` で値を取得しています。
```php
$obj = new static(); // segmentation fault になる
return $obj->$name;
```
