### PR TITLE
カート等での個別税率のバグ修正

### DIFF
--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -65,7 +65,7 @@ class ProductRepository extends EntityRepository
         // Product
         try {
             $qb = $this->createQueryBuilder('p');
-            $qb->addSelect(array('pc', 'cc1', 'cc2', 'pi', 'ps'))
+            $qb
                 ->innerJoin('p.ProductClasses', 'pc')
                 ->leftJoin('pc.ClassCategory1', 'cc1')
                 ->leftJoin('pc.ClassCategory2', 'cc2')


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)

+ 該当箇所がカートや商品詳細ページで個別税率が動作することを妨げている。商品一覧ページでは個別税率が動作するにも関わらず、カートには８％で入ってしまう。

+ ここでoneToManyのリレーションをaddSelectしても意味はないと考えられる

## 参照
[フォーラム](https://xoops.ec-cube.net/modules/newbb/viewtopic.php?topic_id=19325&forum=8&post_id=83204#forumpost83204)
[フォーラム](https://xoops.ec-cube.net/modules/newbb/viewtopic.php?topic_id=18796&forum=2&post_id=81019#forumpost81019)


