### PR TITLE
コードエディタの実装

### DIFF
--- a/src/Eccube/Form/Type/Admin/BlockType.php
+++ b/src/Eccube/Form/Type/Admin/BlockType.php
@@ -27,7 +27,6 @@ namespace Eccube\Form\Type\Admin;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
@@ -75,7 +74,7 @@ class BlockType extends AbstractType
                     )),
                 )
             ))
-            ->add('block_html', TextareaType::class, array(
+            ->add('block_html', HiddenType::class, array(
                 'label' => 'ブロックデータ',
                 'mapped' => false,
                 'required' => false,

--- a/src/Eccube/Form/Type/Admin/MainEditType.php
+++ b/src/Eccube/Form/Type/Admin/MainEditType.php
@@ -30,7 +30,6 @@ use Eccube\Entity\Master\DeviceType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
@@ -92,7 +91,7 @@ class MainEditType extends AbstractType
                     )),
                 )
             ))
-            ->add('tpl_data', TextareaType::class, array(
+            ->add('tpl_data', HiddenType::class, array(
                 'label' => false,
                 'mapped' => false,
                 'required' => true,

--- a/src/Eccube/Resource/template/admin/Content/block_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/block_edit.twig
@@ -30,6 +30,28 @@
 
 {% form_theme form 'Form/bootstrap_3_horizontal_layout.html.twig' %}
 
+{% block javascript %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.8/ace.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.8/ext-language_tools.js"></script>
+    <script>
+        ace.require("ace/ext/language_tools");
+        var editor = ace.edit("editor");
+        editor.session.setMode("ace/mode/twig");
+        editor.setTheme("ace/theme/tomorrow");
+        editor.setValue("{{ form.block_html.vars.value|escape('js') }}");
+        editor.setOptions({
+            enableBasicAutocompletion: true,
+            enableSnippets: true,
+            enableLiveAutocompletion: true,
+            showInvisibles: true
+        });
+
+        $('#content_block_form').on('submit', function (elem) {
+            $('#block_block_html').val(editor.getValue());
+        });
+    </script>
+{% endblock %}
+
 {% block main %}
 <div class="row" id="aside_wrap">
 <form name="content_block_form" id="content_block_form" method="post" action="
@@ -69,7 +91,8 @@
                     <div id="detail_box__block_html" class="form-group">
                         {{ form_label(form.block_html) }}
                         <div class="col-sm-9 col-lg-10">
-                            {{ form_widget(form.block_html, { attr : { 'rows' : 15, style : 'font-size:12px' } }) }}
+                            <div id="editor" style="height: 480px"></div>
+                            {{ form_widget(form.block_html) }}
                             {{ form_errors(form.block_html) }}
                         </div>
                     </div>

--- a/src/Eccube/Resource/template/admin/Content/page_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/page_edit.twig
@@ -30,6 +30,28 @@
 
 {% form_theme form 'Form/bootstrap_3_horizontal_layout.html.twig' %}
 
+{% block javascript %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.8/ace.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.8/ext-language_tools.js"></script>
+    <script>
+        ace.require("ace/ext/language_tools");
+        var editor = ace.edit("editor");
+        editor.session.setMode("ace/mode/twig");
+        editor.setTheme("ace/theme/tomorrow");
+        editor.setValue("{{ form.tpl_data.vars.value|escape('js') }}");
+        editor.setOptions({
+            enableBasicAutocompletion: true,
+            enableSnippets: true,
+            enableLiveAutocompletion: true,
+            showInvisibles: true
+        });
+
+        $('#content_page_form').on('submit', function (elem) {
+            $('#main_edit_tpl_data').val(editor.getValue());
+        });
+    </script>
+{% endblock %}
+
 {% block main %}
 <div class="row" id="aside_wrap">
     <form role="form" name="content_page_form" id="content_page_form" method="post"
@@ -80,7 +102,8 @@
                         <div id="detail_box__tpl_data" class="form-group">
                             {{ form_label(form.tpl_data) }}
                             <div class="col-sm-9 col-lg-10">
-                                {{ form_widget(form.tpl_data, { attr : { 'rows' : 15, style : 'font-size:12px' } }) }}
+                                <div id="editor" style="height: 480px"></div>
+                                {{ form_widget(form.tpl_data) }}
                                 {{ form_errors(form.tpl_data) }}
                             </div>
                         </div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

コードエディタの実装

- ace.jsを利用しています。
  - https://ace.c9.io/ , https://github.com/ajaxorg/ace
  - Cloud9やGitHubのエディタ部分で利用されているライブラリです
  - ライセンスはBSD 3-clause
-  ページ編集、ブロック編集に適用しています

## 対応機能

|              | syntax highlight | auto complete |
|--------------|------------------|---------------|
| html         | ○                | ○             |
| css          | ○                | ○             |
| javascript   | ○                | ○             |
| twig         | ○                | -             |


## 動作イメージ
![ace](https://user-images.githubusercontent.com/8196725/28957221-f1912f60-792b-11e7-84ba-80cf8509e51e.gif)




