### PR TITLE
html/install.php削除の勧告

### DIFF
--- a/eccube_install.php
+++ b/eccube_install.php
@@ -82,6 +82,8 @@ if (PHP_VERSION_ID >= 50400 && empty($root_urlpath)) {
     out('PHP built-in web server to run applications, `php -S localhost:8080 -t html`', 'info');
     out('Open your browser and access the http://localhost:8080/', 'info');
 }
+out('Remove the web installer: `rm html/install.php`', 'info');
+
 exit(0);
 
 function displayHelp($argv)


### PR DESCRIPTION
インストール成功後、Webインストーラー `html/install.php` の削除を勧める。

また、ドキュメントの方もPRしました。
https://github.com/EC-CUBE/ec-cube.github.io/pull/144

