### PR TITLE
ClassName の物理削除の対応

### DIFF
--- a/src/Eccube/Entity/ClassName.php
+++ b/src/Eccube/Entity/ClassName.php
@@ -68,12 +68,6 @@ class ClassName extends \Eccube\Entity\AbstractEntity
      */
     private $rank;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="del_flg", type="smallint", options={"unsigned":true,"default":0})
-     */
-    private $del_flg = 0;
 
     /**
      * @var \DateTime
@@ -173,30 +167,6 @@ class ClassName extends \Eccube\Entity\AbstractEntity
     public function getRank()
     {
         return $this->rank;
-    }
-
-    /**
-     * Set delFlg.
-     *
-     * @param int $delFlg
-     *
-     * @return ClassName
-     */
-    public function setDelFlg($delFlg)
-    {
-        $this->del_flg = $delFlg;
-
-        return $this;
-    }
-
-    /**
-     * Get delFlg.
-     *
-     * @return int
-     */
-    public function getDelFlg()
-    {
-        return $this->del_flg;
     }
 
     /**

--- a/src/Eccube/Repository/ClassNameRepository.php
+++ b/src/Eccube/Repository/ClassNameRepository.php
@@ -145,7 +145,6 @@ class ClassNameRepository extends AbstractRepository
                     $rank = 0;
                 }
                 $ClassName->setRank($rank + 1);
-                $ClassName->setDelFlg(0);
             }
 
             $em->persist($ClassName);
@@ -169,6 +168,10 @@ class ClassNameRepository extends AbstractRepository
      */
     public function delete($ClassName)
     {
+        if (is_null($ClassName->getId())) {
+            // 存在しない場合は何もしない
+            return false;
+        }
         $em = $this->getEntityManager();
         $em->getConnection()->beginTransaction();
         try {
@@ -184,8 +187,7 @@ class ClassNameRepository extends AbstractRepository
                 ->getQuery()
                 ->execute();
 
-            $ClassName->setDelFlg(1);
-            $em->persist($ClassName);
+            $em->remove($ClassName);
             $em->flush();
 
             $em->getConnection()->commit();

--- a/src/Eccube/Resource/doctrine/import_csv/dtb_class_name.csv
+++ b/src/Eccube/Resource/doctrine/import_csv/dtb_class_name.csv
@@ -1,3 +1,3 @@
-class_name_id,creator_id,name,rank,create_date,update_date,del_flg,discriminator_type
-"1","1","材質","1","2017-03-07 10:14:52","2017-03-07 10:14:52","0","classname"
-"2","1","サイズ","2","2017-03-07 10:14:52","2017-03-07 10:14:52","0","classname"
+class_name_id,creator_id,name,rank,create_date,update_date,discriminator_type
+"1","1","材質","1","2017-03-07 10:14:52","2017-03-07 10:14:52","classname"
+"2","1","サイズ","2","2017-03-07 10:14:52","2017-03-07 10:14:52","classname"

--- a/tests/Eccube/Tests/Repository/ClassCategoryRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/ClassCategoryRepositoryTest.php
@@ -28,7 +28,6 @@ class ClassCategoryRepositoryTest extends EccubeTestCase
             $ClassName
                 ->setName('class-'.$i)
                 ->setCreator($this->Member)
-                ->setDelFlg(0)
                 ->setRank($i);
             for ($j = 0; $j < 3; $j++) {
                 $ClassCategory = new ClassCategory();

--- a/tests/Eccube/Tests/Repository/ClassNameRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/ClassNameRepositoryTest.php
@@ -28,7 +28,6 @@ class ClassNameRepositoryTest extends EccubeTestCase
             $ClassName
                 ->setName('class-'.$i)
                 ->setCreator($this->Member)
-                ->setDelFlg(0)
                 ->setRank($i)
                 ;
             $this->app['orm.em']->persist($ClassName);
@@ -174,18 +173,11 @@ class ClassNameRepositoryTest extends EccubeTestCase
         $ClassName = $this->app['eccube.repository.class_name']->findOneBy(
             array('name' => 'class-0')
         );
-
-        $updateDate = $ClassName->getUpdateDate();
-        sleep(1);
+        $ClassNameId = $ClassName->getId();
         $result = $this->app['eccube.repository.class_name']->delete($ClassName);
 
         $this->assertTrue($result);
-        $this->assertEquals(Constant::ENABLED, $ClassName->getDelFlg());
-        $this->assertTrue(0 === $ClassName->getRank());
-
-        $this->expected = $updateDate;
-        $this->actual = $ClassName->getUpdateDate();
-        $this->assertNotEquals($this->expected, $this->actual);
+        self::assertNull($this->app['orm.em']->find(ClassName::class, $ClassNameId));
     }
 
     public function testDeleteWithException()

--- a/tests/Eccube/Tests/Web/Admin/Product/AbstractProductCommonTestCase.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/AbstractProductCommonTestCase.php
@@ -116,7 +116,6 @@ abstract class AbstractProductCommonTestCase extends AbstractAdminWebTestCase
         $TestClassName = new ClassName();
         $TestClassName->setName($this->faker->word)
             ->setRank($this->faker->randomNumber(3))
-            ->setDelFlg(Constant::DISABLED)
             ->setCreator($Creator);
 
         $this->app['orm.em']->persist($TestClassName);

--- a/tests/Eccube/Tests/Web/Admin/Product/ClassCategoryContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ClassCategoryContorllerTest.php
@@ -134,7 +134,6 @@ class ClassCategoryControllerTest extends AbstractAdminWebTestCase
         $TestClassName = new \Eccube\Entity\ClassName();
         $TestClassName->setName('形状')
             ->setRank(100)
-            ->setDelFlg(false)
             ->setCreator($TestCreator);
 
         return $TestClassName;

--- a/tests/Eccube/Tests/Web/Admin/Product/ClassNameContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ClassNameContorllerTest.php
@@ -40,7 +40,6 @@ class ClassNameControllerTest extends AbstractAdminWebTestCase
             $ClassName
                 ->setName('class-'.$i)
                 ->setCreator($this->Member)
-                ->setDelFlg(0)
                 ->setRank($i)
                 ;
             $this->app['orm.em']->persist($ClassName);
@@ -169,7 +168,6 @@ class ClassNameControllerTest extends AbstractAdminWebTestCase
         $TestClassName = new \Eccube\Entity\ClassName();
         $TestClassName->setName('形状')
             ->setRank(100)
-            ->setDelFlg(false)
             ->setCreator($TestCreator);
 
         return $TestClassName;


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ ClassName の物理削除対応
+ 関連 #2314

## 方針(Policy)
- del_flg を廃止
- ClassName の非表示対応はしない
   - ClassName に関連する商品自体購入できなくなってしまい、非表示にあまり意味が無いため
## テスト（Test)
+ ユニットテストが通るのを確認
