### PR TITLE
Firefoxでお客様情報変更時にサブミットされないように修正

### DIFF
--- a/src/Eccube/Resource/template/default/Shopping/index.twig
+++ b/src/Eccube/Resource/template/default/Shopping/index.twig
@@ -254,7 +254,7 @@ $(function() {
                 </div>
                 {% if is_granted('ROLE_USER') == false %}
                 <div class="ec-orderAccount__change">
-                    <button id="customer" class="ec-inlineBtn">変更</button>
+                    <button id="customer" class="ec-inlineBtn" type="button">変更</button>
                 </div>
                 {% endif %}
                 <div class="ec-orderAccount__account">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ Firefoxでゲスト購入時にお客様情報変更しようと「変更」ボタンをクリックするとそのままサブミットされて購入処理が完了してしまう不具合を修正
