### PR TITLE
Entity コンバーターの実装

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -708,6 +708,10 @@ class Application extends \Silex\Application
             $saveEventSubscriber = new \Eccube\Doctrine\EventSubscriber\SaveEventSubscriber($app);
             $em->getEventManager()->addEventSubscriber($saveEventSubscriber);
 
+            // load
+            $loadEventSubscriber = new \Eccube\Doctrine\EventSubscriber\LoadEventSubscriber($app);
+            $em->getEventManager()->addEventSubscriber($loadEventSubscriber);
+
             // clear cache
             $clearCacheEventSubscriber = new \Eccube\Doctrine\EventSubscriber\ClearCacheEventSubscriber($app);
             $em->getEventManager()->addEventSubscriber($clearCacheEventSubscriber);

--- a/src/Eccube/Doctrine/EventSubscriber/LoadEventSubscriber.php
+++ b/src/Eccube/Doctrine/EventSubscriber/LoadEventSubscriber.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Eccube\Doctrine\EventSubscriber;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ORM\Events;
+use Eccube\Application;
+use Eccube\Entity\AbstractEntity;
+
+class LoadEventSubscriber implements EventSubscriber
+{
+    /**
+     * @var Application
+     */
+    private $app;
+
+    /**
+     * @param Application $app
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    public function getSubscribedEvents()
+    {
+        return [Events::postLoad];
+    }
+
+    public function postLoad(LifecycleEventArgs $args)
+    {
+        $entity = $args->getObject();
+        if ($entity instanceof AbstractEntity) {
+            $entity->setAnnotationReader($this->app['eccube.di.annotation_reader']);
+        }
+    }
+}

--- a/src/Eccube/Doctrine/EventSubscriber/SaveEventSubscriber.php
+++ b/src/Eccube/Doctrine/EventSubscriber/SaveEventSubscriber.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Doctrine\EventSubscriber;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;

--- a/tests/Eccube/Tests/Entity/AbstractEntityTest.php
+++ b/tests/Eccube/Tests/Entity/AbstractEntityTest.php
@@ -2,6 +2,7 @@
 
 namespace Eccube\Tests\Entity;
 
+use Doctrine\ORM\Mapping\Id;
 use Eccube\Entity\AbstractEntity;
 
 /**
@@ -105,6 +106,7 @@ class AbstractEntityTest extends \PHPUnit_Framework_TestCase
 
     public function testChildrens()
     {
+        $Date = new \DateTime('2017-09-25 00:00:00 +00:00');
         $TestChildrens = new \Doctrine\Common\Collections\ArrayCollection();
         $TestChildrens[] = new TestChildren('child1');
         $TestChildrens[] = new TestChildren('child2');
@@ -113,7 +115,7 @@ class AbstractEntityTest extends \PHPUnit_Framework_TestCase
             'field1' => 1,
             'field2' => 2,
             'field3' => 3,
-            'field4' => 4,
+            'field4' => $Date,
             'testField4' => 5,
             'TestChildrens' => $TestChildrens
         );
@@ -122,10 +124,109 @@ class AbstractEntityTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->objEntity->getField1(), 1);
         $this->assertEquals($this->objEntity->getField2(), 2);
         $this->assertEquals($this->objEntity->field3, 3);
-        $this->assertEquals($this->objEntity->getField4(), 4);
+        $this->assertEquals($this->objEntity->getField4(), $Date);
         $this->assertEquals($this->objEntity->getTestField4(), 5);
         $expected = $arrProps;
         $actual = $this->objEntity->toArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testChildrensWithToNormalizedArray()
+    {
+        $Date = new \DateTime('2017-09-25 00:00:00 +00:00');
+        $TestChildrens = new \Doctrine\Common\Collections\ArrayCollection();
+        $TestChildrens[] = new TestChildren('child1');
+        $TestChildrens[] = new TestChildren('child2');
+        $TestChildrens[] = new TestChildren('child3');
+        $arrProps = array(
+            'field1' => 1,
+            'field2' => 2,
+            'field3' => 3,
+            'field4' => $Date,
+            'testField4' => 5,
+            'TestChildrens' => $TestChildrens
+        );
+
+        $this->objEntity = new TestChildEntity($arrProps);
+        $this->assertEquals($this->objEntity->getField1(), 1);
+        $this->assertEquals($this->objEntity->getField2(), 2);
+        $this->assertEquals($this->objEntity->field3, 3);
+        $this->assertEquals($this->objEntity->getField4(), $Date);
+        $this->assertEquals($this->objEntity->getTestField4(), 5);
+        $expected = $arrProps;
+        $expected['field4'] = '2017-09-25T00:00:00Z';
+        $expected['TestChildrens'] = [
+            ["childField" => "child1"],
+            ["childField" => "child2"],
+            ["childField" => "child3"],
+        ];
+        $actual = $this->objEntity->toNormalizedArray();
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testChildrensWithToJSON()
+    {
+        $Date = new \DateTime('2017-09-25 00:00:00 +00:00');
+        $TestChildrens = new \Doctrine\Common\Collections\ArrayCollection();
+        $TestChildrens[] = new TestChildren('child1');
+        $TestChildrens[] = new TestChildren('child2');
+        $TestChildrens[] = new TestChildren('child3');
+        $arrProps = array(
+            'field1' => 1,
+            'field2' => 2,
+            'field3' => 3,
+            'field4' => $Date,
+            'testField4' => 5,
+            'TestChildrens' => $TestChildrens
+        );
+
+        $this->objEntity = new TestChildEntity($arrProps);
+        $this->assertEquals($this->objEntity->getField1(), 1);
+        $this->assertEquals($this->objEntity->getField2(), 2);
+        $this->assertEquals($this->objEntity->field3, 3);
+        $this->assertEquals($this->objEntity->getField4(), $Date);
+        $this->assertEquals($this->objEntity->getTestField4(), 5);
+        $expected = $arrProps;
+        $expected['field4'] = '2017-09-25T00:00:00Z';
+        $expected['TestChildrens'] = [
+            ["childField" => "child1"],
+            ["childField" => "child2"],
+            ["childField" => "child3"],
+        ];
+        $actual = $this->objEntity->toJSON();
+
+        $this->assertEquals($expected, json_decode($actual, true));
+    }
+
+    public function testChildrensWithToXML()
+    {
+        $Date = new \DateTime('2017-09-25 00:00:00 +00:00');
+        $TestChildrens = new \Doctrine\Common\Collections\ArrayCollection();
+        $TestChildrens[] = new TestChildren('child1');
+        $TestChildrens[] = new TestChildren('child2');
+        $TestChildrens[] = new TestChildren('child3');
+        $arrProps = array(
+            'field1' => 1,
+            'field2' => 2,
+            'field3' => 3,
+            'field4' => $Date,
+            'testField4' => 5,
+            'TestChildrens' => $TestChildrens
+        );
+
+        $this->objEntity = new TestChildEntity($arrProps);
+        $this->assertEquals($this->objEntity->getField1(), 1);
+        $this->assertEquals($this->objEntity->getField2(), 2);
+        $this->assertEquals($this->objEntity->field3, 3);
+        $this->assertEquals($this->objEntity->getField4(), $Date);
+        $this->assertEquals($this->objEntity->getTestField4(), 5);
+
+        $expected = '<?xml version="1.0"?>
+<TestChildEntity><field1>1</field1><field2>2</field2><field3>3</field3><testField4>5</testField4><field4>2017-09-25T00:00:00Z</field4><TestChildrens><childField>child1</childField></TestChildrens><TestChildrens><childField>child2</childField></TestChildrens><TestChildrens><childField>child3</childField></TestChildrens></TestChildEntity>
+';
+        $actual = $this->objEntity->toXML();
+
         $this->assertEquals($expected, $actual);
     }
 
@@ -297,8 +398,11 @@ class TestChildEntity extends TestExtendsEntity
     }
 }
 
-class TestChildren
+class TestChildren extends AbstractEntity
 {
+    /**
+     * @Id
+     */
     private $childField;
 
     public function __construct($childField)


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ toJSON, toXML メソッドを実装する

## 方針(Policy)
+ 基本的に EC-CUBE API の [entityToArray](https://github.com/EC-CUBE/eccube-api/blob/fbdbb05bff6232319bfe674b2aa7be9bf6bc5436/Util/EntityUtil.php#L61-L107) からの移植
   - メタデータは ClassMetaData ではなく、アノテーションから取得する
   - 既存の toArray() の互換性を保持する
   - DateTime は [W3C Datetime format](https://www.w3.org/TR/NOTE-datetime) を使用する。
       - タイムゾーンは UTC とし、 **Z** の表記を使用する (https://github.com/EC-CUBE/eccube-api/issues/27)
   - toJSON() は `json_encode()` 関数、 toXML() は Symfony Serializer Component を使用する
   - アノテーションの取得に `AnnotationReader` が必要なため、 AbstractEntity で保持できるようにする
     - Doctrine から Entity を取得した場合は `LoadEventSubscriber` で AnnotationReader をセットする

## 実装に関する補足(Appendix)
+ 当初、  Symfony Serializer Component にすべて置き換えようとしたが、 Order や Product 等、特殊な実装の Entity を汎用的に処理できないため断念
+ 参考 https://symfony.com/doc/current/components/serializer.html

## テスト（Test)
+ ユニットテストが通っていることを確認

## 相談（Discussion）
+ denormalize も作りたいが、 Doctrine でデータを取得し直す必要がある。 Entity の中で find をコールするのはナンセンスなので、ヘルパークラスを作成する必要がありそう。
