### PR TITLE
[CoC]Entityイベントハンドラーの自動登録

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -249,6 +249,9 @@ class Application extends \Silex\Application
                 ]),
                 new \Eccube\Di\Scanner\QueryExtensionScanner([
                     $this['config']['root_dir'].'/src/Eccube/Repository'
+                ]),
+                new \Eccube\Di\Scanner\EntityEventScanner([
+                    $this['config']['root_dir'].'/app/Acme/Entity'
                 ])
             ],
             'eccube.di.generator.dir' => $this['config']['root_dir'].'/app/cache/provider'

--- a/src/Eccube/Di/Scanner/EntityEventScanner.php
+++ b/src/Eccube/Di/Scanner/EntityEventScanner.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Di\Scanner;
+
+
+use Eccube\Annotation\EntityEvent;
+use Eccube\Di\ComponentDefinition;
+
+class EntityEventScanner extends ComponentScanner
+{
+    public function __construct($scanDirs)
+    {
+        parent::__construct($scanDirs);
+    }
+
+    public function getAnnotationClass()
+    {
+        return EntityEvent::class;
+    }
+
+    public function createComponentDefinition($anno, $refClass)
+    {
+        return new ComponentDefinition($refClass->getName(), $refClass);
+    }
+
+    public function generateExtend(\Twig_Environment $twig, array $components)
+    {
+        return $twig->createTemplate(
+'$app->extend("eccube.entity.event.dispatcher", function ($eventDispatcher, $app) {
+    {% for event in events -%}
+    $eventDispatcher->addEventListener($app["{{ event.id }}"]);
+    {% endfor %}
+
+    return $eventDispatcher;
+});')->render(['events' => $components]);
+    }
+
+
+}

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -25,14 +25,13 @@
 namespace Eccube\ServiceProvider;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Eccube\Entity\ItemHolderInterface;
 use Eccube\Entity\BaseInfo;
+use Eccube\Entity\ItemHolderInterface;
 use Eccube\EventListener\ForwardOnlyListener;
 use Eccube\EventListener\TransactionListener;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\DeliveryRepository;
 use Eccube\Service\PurchaseFlow\Processor\AdminOrderRegisterPurchaseProcessor;
-use Eccube\Service\PurchaseFlow\Processor\DeletedProductValidator;
 use Eccube\Service\PurchaseFlow\Processor\DeliveryFeeFreeProcessor;
 use Eccube\Service\PurchaseFlow\Processor\DeliveryFeeProcessor;
 use Eccube\Service\PurchaseFlow\Processor\DeliverySettingValidator;
@@ -206,7 +205,6 @@ class EccubeServiceProvider implements ServiceProviderInterface, EventListenerPr
             return $templates;
         };
 
-        $app['eccube.entity.event.dispatcher']->addEventListener(new \Acme\Entity\SoldOutEventListener());
         $app['eccube.queries'] = function () {
             return new \Eccube\Doctrine\Query\Queries();
         };

--- a/tests/Eccube/Tests/Di/Scanner/EntityEventScannerTest.php
+++ b/tests/Eccube/Tests/Di/Scanner/EntityEventScannerTest.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Tests\Di\Scanner;
+
+use Doctrine\Common\EventManager;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Eccube\Di\Scanner\EntityEventScanner;
+use Eccube\Entity\BaseInfo;
+use Eccube\Entity\Event\EntityEventDispatcher;
+use Eccube\Tests\Di\Test\PostUpdateEventClass;
+use Eccube\Tests\Di\Test\PreUpdateEventClass;
+
+class EntityEventScannerTest extends AbstractScannerTest
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->container['eccube.entity.event.dispatcher'] = function() {
+            $eventManager = $this->createMock(EventManager::class);
+            $em = $this->createMock(EntityManager::class);
+            $em->method('getEventManager')->willReturn($eventManager);
+            return new EntityEventDispatcher($em);
+        };
+    }
+
+    protected function getAutoWiring()
+    {
+        return new EntityEventScanner([__DIR__.'/../Test']);
+    }
+
+    public function testEntityEvent()
+    {
+        $this->di->build($this->container);
+
+        self::assertArrayHasKey(PreUpdateEventClass::class, $this->container);
+        self::assertArrayHasKey(PostUpdateEventClass::class, $this->container);
+    }
+
+    public function testEventDispatch()
+    {
+        $this->di->build($this->container);
+
+        $eventArgs = $this->createMock(LifecycleEventArgs::class);
+        $eventArgs->method('getEntity')->willReturn(new BaseInfo());
+
+        /**
+         * @var EntityEventDispatcher
+         */
+        $eventDispatcher = $this->container['eccube.entity.event.dispatcher'];
+        $eventDispatcher->preUpdate($eventArgs);
+
+        self::assertTrue($this->container[PreUpdateEventClass::class]->executed);
+    }
+}

--- a/tests/Eccube/Tests/Di/Test/PostUpdateEventClass.php
+++ b/tests/Eccube/Tests/Di/Test/PostUpdateEventClass.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Tests\Di\Test;
+
+
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Eccube\Annotation\PreUpdate;
+use Eccube\Entity\Event\EntityEventListener;
+use Eccube\Entity\BaseInfo;
+
+/**
+ * @PreUpdate(BaseInfo::class)
+ */
+class PostUpdateEventClass implements EntityEventListener
+{
+    public $executed = false;
+
+    public function execute(LifecycleEventArgs $eventArgs)
+    {
+        $this->executed = true;
+    }
+}

--- a/tests/Eccube/Tests/Di/Test/PreUpdateEventClass.php
+++ b/tests/Eccube/Tests/Di/Test/PreUpdateEventClass.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Tests\Di\Test;
+
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Eccube\Annotation\PreUpdate;
+use Eccube\Entity\BaseInfo;
+use Eccube\Entity\Event\EntityEventListener;
+
+/**
+ * @PreUpdate(BaseInfo::class)
+ */
+class PreUpdateEventClass implements EntityEventListener
+{
+    public $executed = false;
+
+    public function execute(LifecycleEventArgs $eventArgs)
+    {
+        $this->executed = true;
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ `EntityEvent`を継承したアノテーション(`PreUpdate`など)が付けられたクラスのコンテナ登録と有効化を自動で行う。
+ #2517 の後にマージしてください。
+ 関連 https://github.com/EC-CUBE/ec-cube/pull/2261
