### PR TITLE
@ForwardOnly アノテーション追加

### DIFF
--- a/src/Eccube/Annotation/ForwardOnly.php
+++ b/src/Eccube/Annotation/ForwardOnly.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Eccube\Annotation;
+
+use Doctrine\Common\Annotations\Annotation\Target;
+use Doctrine\ORM\Mapping\Annotation;
+
+
+/**
+ * @Annotation
+ * @Target("METHOD")
+ */
+final class ForwardOnly implements Annotation
+{
+    /**
+     * @var string
+     */
+    public $value;
+}

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -26,6 +26,7 @@ namespace Eccube\Controller;
 
 use Doctrine\ORM\EntityManager;
 use Eccube\Annotation\Component;
+use Eccube\Annotation\ForwardOnly;
 use Eccube\Annotation\Inject;
 use Eccube\Application;
 use Eccube\Entity\BaseInfo;
@@ -173,6 +174,7 @@ class ShoppingController extends AbstractShoppingController
      * 購入確認画面から, 他の画面へのリダイレクト.
      * 配送業者や支払方法、お問い合わせ情報をDBに保持してから遷移する.
      *
+     * @ForwardOnly
      * @Route("/shopping/redirect", name="shopping_redirect_to")
      * @Template("Shopping/index.twig")
      */
@@ -567,6 +569,7 @@ class ShoppingController extends AbstractShoppingController
     /**
      * カート画面のチェック
      *
+     * @ForwardOnly
      * @Route("/shopping/check_to_cart", name="shopping_check_to_cart")
      */
     public function checkToCart(Application $app, Request $request)
@@ -593,6 +596,7 @@ class ShoppingController extends AbstractShoppingController
     /**
      * 受注情報を初期化する.
      *
+     * @ForwardOnly
      * @Route("/shopping/initialize_order", name="shopping_initialize_order")
      */
     public function initializeOrder(Application $app, Request $request)
@@ -649,6 +653,7 @@ class ShoppingController extends AbstractShoppingController
     /**
      * フォームを作成し, イベントハンドラを設定する
      *
+     * @ForwardOnly
      * @Route("/shopping/create_form", name="shopping_create_form")
      */
     public function createForm(Application $app, Request $request)
@@ -676,6 +681,7 @@ class ShoppingController extends AbstractShoppingController
     /**
      * mode に応じて各変更ページへリダイレクトする.
      *
+     * @ForwardOnly
      * @Route("/shopping/redirect_to_change", name="shopping_redirect_to_change")
      */
     public function redirectToChange(Application $app, Request $request)
@@ -718,6 +724,7 @@ class ShoppingController extends AbstractShoppingController
     /**
      * 複数配送時のエラーを表示する
      *
+     * @ForwardOnly
      * @Route("/shopping/handle_multiple_errors", name="shopping_handle_multiple_errors")
      */
     public function handleMultipleErrors(Application $app, Request $request)
@@ -745,6 +752,7 @@ class ShoppingController extends AbstractShoppingController
     /**
      * 受注の存在チェック
      *
+     * @ForwardOnly
      * @Route("/shopping/exists_order", name="shopping_exists_order")
      */
     public function existsOrder(Application $app, Request $request)
@@ -764,6 +772,7 @@ class ShoppingController extends AbstractShoppingController
     /**
      * 受注完了処理
      *
+     * @ForwardOnly
      * @Route("/shopping/complete_order", name="shopping_complete_order")
      */
     public function completeOrder(Application $app, Request $request)
@@ -860,6 +869,7 @@ class ShoppingController extends AbstractShoppingController
     /**
      * 受注完了の後処理
      *
+     * @ForwardOnly
      * @Route("/shopping/after_complete", name="shopping_after_complete")
      */
     public function afterComplete(Application $app, Request $request)

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -174,7 +174,6 @@ class ShoppingController extends AbstractShoppingController
      * 購入確認画面から, 他の画面へのリダイレクト.
      * 配送業者や支払方法、お問い合わせ情報をDBに保持してから遷移する.
      *
-     * @ForwardOnly
      * @Route("/shopping/redirect", name="shopping_redirect_to")
      * @Template("Shopping/index.twig")
      */

--- a/src/Eccube/EventListener/ForwardOnlyListener.php
+++ b/src/Eccube/EventListener/ForwardOnlyListener.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Eccube\EventListener;
+
+use Eccube\Application;
+use Eccube\Annotation\ForwardOnly;
+use Monolog\Logger;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Check to ForwardOnly annotation.
+ *
+ * @author Kentaro Ohkouchi
+ */
+class ForwardOnlyListener implements EventSubscriberInterface
+{
+    private $app;
+
+    /**
+     * Constructor function.
+     *
+     * @param Application $app
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+
+    /**
+     * Kernel Controller listener callback.
+     *
+     * @param FilterControllerEvent $event
+     */
+    public function onController(FilterControllerEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+        list($controller, $method) = $event->getController();
+        $refClass = new \ReflectionClass($controller);
+        $refMethod = $refClass->getMethod($method);
+        $anno = $this->app['eccube.di.annotation_reader']->getMethodAnnotation($refMethod, ForwardOnly::class);
+        if ($anno) {
+            $log = $refClass->getName().'::'.$refMethod->getName().' is Forward Only';
+            $this->app->log($log, array(), Logger::ERROR);
+            log_error($log);
+            throw new \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException($log);
+        }
+    }
+
+    /**
+     * Return the events to subscribe to.
+     *
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::CONTROLLER => 'onController',
+        );
+    }
+}

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -27,6 +27,7 @@ namespace Eccube\ServiceProvider;
 use Doctrine\Common\Collections\ArrayCollection;
 use Eccube\Entity\ItemHolderInterface;
 use Eccube\Entity\BaseInfo;
+use Eccube\EventListener\ForwardOnlyListener;
 use Eccube\EventListener\TransactionListener;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\DeliveryRepository;
@@ -276,6 +277,7 @@ class EccubeServiceProvider implements ServiceProviderInterface, EventListenerPr
         // Add event subscriber to TaxRuleEvent
         $app['orm.em']->getEventManager()->addEventSubscriber(new \Eccube\Doctrine\EventSubscriber\TaxRuleEventSubscriber($app[TaxRuleService::class]));
 
+        $dispatcher->addSubscriber(new ForwardOnlyListener($app));
         $dispatcher->addSubscriber(new TransactionListener($app));
     }
 }

--- a/tests/Eccube/Tests/EventListener/ForwardOnlyListenerTest.php
+++ b/tests/Eccube/Tests/EventListener/ForwardOnlyListenerTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Eccube\Tests\EventListener;
+
+use Eccube\Tests\Web\AbstractWebTestCase;
+
+class ForwardOnlyListenerTest extends AbstractWebTestCase
+{
+
+    public function testForwardOnly()
+    {
+        try {
+            $this->client->request('GET', $this->app->url("shopping_check_to_cart"));
+            self::fail();
+        } catch (\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException $e) {
+            self::assertEquals('Eccube\Controller\ShoppingController::checkToCart is Forward Only', $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ `@ForwardOnly` アノテーションのサポート
+ Sub Request(Forward) 専用のコントローラメソッドに付与することで、該当のメソッドが Master Request でアクセスされた場合 HTTP Status 403 を返す

## 方針(Policy)
+ ForwardOnly のチェックは Symfony Event Dispatcher Component を使用する

## テスト（Test)
+ WebTestCase を作成し、ユニットテストが通ることを確認

## 相談（Discussion）
+ EventListener がコールされるタイミングは適切か？



