### PR TITLE
Repositoryの例外処理の見直し

### DIFF
--- a/src/Eccube/Controller/Admin/AdminController.php
+++ b/src/Eccube/Controller/Admin/AdminController.php
@@ -284,12 +284,13 @@ class AdminController extends AbstractController
             $salt = $Member->getSalt();
             $password = $form->get('change_password')->getData();
 
+            $encoder = $this->encoderFactory->getEncoder($Member);
+
             // 2系からのデータ移行でsaltがセットされていない場合はsaltを生成.
             if (empty($salt)) {
-                $salt = bin2hex(openssl_random_pseudo_bytes(5));
+                $salt = $encoder->createSalt();
             }
 
-            $encoder = $this->encoderFactory->getEncoder($Member);
             $password = $encoder->encodePassword($password, $salt);
 
             $Member

--- a/src/Eccube/Controller/Admin/Content/NewsController.php
+++ b/src/Eccube/Controller/Admin/Content/NewsController.php
@@ -251,7 +251,9 @@ class NewsController extends AbstractController
             log_info('新着情報削除完了', [$News->getId()]);
 
         } catch (\Exception $e) {
-            $app->addError('admin.news.delete.error', 'admin');
+
+            $message = $app->trans('admin.delete.failed.foreign_key', ['%name%' => '新着情報']);
+            $app->addError($message, 'admin');
 
             log_error('新着情報削除エラー', [$News->getId(), $e]);
         }

--- a/src/Eccube/Controller/Admin/Content/NewsController.php
+++ b/src/Eccube/Controller/Admin/Content/NewsController.php
@@ -23,18 +23,19 @@
 
 namespace Eccube\Controller\Admin\Content;
 
-use Eccube\Annotation\Inject;
 use Eccube\Annotation\Component;
+use Eccube\Annotation\Inject;
 use Eccube\Application;
 use Eccube\Common\Constant;
 use Eccube\Controller\AbstractController;
+use Eccube\Entity\News;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
 use Eccube\Form\Type\Admin\NewsType;
 use Eccube\Repository\NewsRepository;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\HttpFoundation\Request;
@@ -79,7 +80,7 @@ class NewsController extends AbstractController
     {
         $NewsList = $this->newsRepository->findBy(array(), array('rank' => 'DESC'));
 
-        $builder = $app->form();
+        $builder = $this->formFactory->createBuilder();
 
         $event = new EventArgs(
             array(
@@ -107,9 +108,8 @@ class NewsController extends AbstractController
      *
      * @param Application $app
      * @param Request $request
-     * @param integer $id
-     * @throws NotFoundHttpException
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @param null $id
+     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
      */
     public function edit(Application $app, Request $request, $id = null)
     {
@@ -122,7 +122,7 @@ class NewsController extends AbstractController
             $News = new \Eccube\Entity\News();
         }
 
-        $News->setLinkMethod((bool) $News->getLinkMethod());
+        $News->setLinkMethod((bool)$News->getLinkMethod());
 
         $builder = $this->formFactory
             ->createBuilder(NewsType::class, $News);
@@ -137,40 +137,32 @@ class NewsController extends AbstractController
         $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_CONTENT_NEWS_EDIT_INITIALIZE, $event);
 
         $form = $builder->getForm();
+        $form->handleRequest($request);
 
-        if ('POST' === $request->getMethod()) {
-            $form->handleRequest($request);
-            if ($form->isValid()) {
-                $data = $form->getData();
-                if (empty($data['url'])) {
-                    $News->setLinkMethod(Constant::DISABLED);
-                }
-
-                $status = $this->newsRepository->save($News);
-
-                if ($status) {
-
-                    $event = new EventArgs(
-                        array(
-                            'form' => $form,
-                            'News' => $News,
-                        ),
-                        $request
-                    );
-                    $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_CONTENT_NEWS_EDIT_COMPLETE, $event);
-
-                    $app->addSuccess('admin.news.save.complete', 'admin');
-
-                    return $app->redirect($app->url('admin_content_news'));
-                }
-                $app->addError('admin.news.save.error', 'admin');
+        if ($form->isSubmitted() && $form->isValid()) {
+            if (!$News->getUrl()) {
+                $News->setLinkMethod(Constant::DISABLED);
             }
+            $this->newsRepository->save($News);
+
+            $event = new EventArgs(
+                array(
+                    'form' => $form,
+                    'News' => $News,
+                ),
+                $request
+            );
+            $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_CONTENT_NEWS_EDIT_COMPLETE, $event);
+
+            $app->addSuccess('admin.news.save.complete', 'admin');
+
+            return $app->redirect($app->url('admin_content_news'));
         }
 
-        return $app->render('Content/news_edit.twig', array(
+        return [
             'form' => $form->createView(),
             'News' => $News,
-        ));
+        ];
     }
 
     /**
@@ -181,24 +173,21 @@ class NewsController extends AbstractController
      *
      * @param Application $app
      * @param Request $request
-     * @param integer $id
-     * @throws NotFoundHttpException
+     * @param News $News
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function up(Application $app, Request $request, $id)
+    public function up(Application $app, Request $request, News $News)
     {
         $this->isTokenValid($app);
 
-        $TargetNews = $this->newsRepository->find($id);
-        if (!$TargetNews) {
-            throw new NotFoundHttpException();
-        }
+        try {
+            $this->newsRepository->up($News);
 
-        $status = $this->newsRepository->up($TargetNews);
-
-        if ($status) {
             $app->addSuccess('admin.news.up.complete', 'admin');
-        } else {
+        } catch (\Exception $e) {
+
+            log_error('新着情報表示順更新エラー', [$News->getId(), $e]);
+
             $app->addError('admin.news.up.error', 'admin');
         }
 
@@ -213,24 +202,21 @@ class NewsController extends AbstractController
      *
      * @param Application $app
      * @param Request $request
-     * @param integer $id
-     * @throws NotFoundHttpException
+     * @param News $News
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function down(Application $app, Request $request, $id)
+    public function down(Application $app, Request $request, News $News)
     {
         $this->isTokenValid($app);
 
-        $TargetNews = $this->newsRepository->find($id);
-        if (!$TargetNews) {
-            throw new NotFoundHttpException();
-        }
+        try {
+            $this->newsRepository->down($News);
 
-        $status = $this->newsRepository->down($TargetNews);
-
-        if ($status) {
             $app->addSuccess('admin.news.down.complete', 'admin');
-        } else {
+        } catch (\Exception $e) {
+
+            log_error('新着情報表示順更新エラー', [$News->getId(), $e]);
+
             $app->addError('admin.news.down.error', 'admin');
         }
 
@@ -245,35 +231,29 @@ class NewsController extends AbstractController
      *
      * @param Application $app
      * @param Request $request
-     * @param integer $id
-     * @throws NotFoundHttpException
+     * @param News $News
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function delete(Application $app, Request $request, $id)
+    public function delete(Application $app, Request $request, News $News)
     {
         $this->isTokenValid($app);
 
-        $TargetNews = $this->newsRepository->find($id);
-        if (!$TargetNews) {
-            throw new NotFoundHttpException();
-        }
+        log_info('新着情報削除開始', [$News->getId()]);
 
-        $status = $this->newsRepository->delete($TargetNews);
+        try {
+            $this->newsRepository->delete($News);
 
-        $event = new EventArgs(
-            array(
-                'TargetNews' => $TargetNews,
-                'status' => $status,
-            ),
-            $request
-        );
-        $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_CONTENT_NEWS_DELETE_COMPLETE, $event);
-        $status = $event->getArgument('status');
+            $event = new EventArgs(['News' => $News], $request);
+            $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_CONTENT_NEWS_DELETE_COMPLETE, $event);
 
-        if ($status) {
             $app->addSuccess('admin.news.delete.complete', 'admin');
-        } else {
-            $app->addSuccess('admin.news.delete.error', 'admin');
+
+            log_info('新着情報削除完了', [$News->getId()]);
+
+        } catch (\Exception $e) {
+            $app->addError('admin.news.delete.error', 'admin');
+
+            log_error('新着情報削除エラー', [$News->getId(), $e]);
         }
 
         return $app->redirect($app->url('admin_content_news'));

--- a/src/Eccube/Controller/Admin/Customer/CustomerController.php
+++ b/src/Eccube/Controller/Admin/Customer/CustomerController.php
@@ -296,7 +296,9 @@ class CustomerController extends AbstractController
             $app->addSuccess('admin.customer.delete.complete', 'admin');
         } catch (ForeignKeyConstraintViolationException $e) {
             log_error('会員削除失敗', [$e], 'admin');
-            $app->addError('admin.customer.delete.failed', 'admin');
+
+            $message = $app->trans('admin.delete.failed.foreign_key', ['%name%' => '会員']);
+            $app->addError($message, 'admin');
         }
 
         log_info('会員削除完了', array($id));

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -308,7 +308,8 @@ class OrderController extends AbstractController
         });
         if ($hasShipping) {
             log_info('受注削除失敗', [$Order->getId()]);
-            $app->addError('admin.order.delete.failed', 'admin');
+            $message = $app->trans('admin.delete.failed.foreign_key', ['%name%' => '受注']);
+            $app->addError($message, 'admin');
 
             return $app->redirect($app->url('admin_order_page', array('page_no' => $page_no)).'?resume='.Constant::ENABLED);
         }

--- a/src/Eccube/Controller/Admin/Product/CategoryController.php
+++ b/src/Eccube/Controller/Admin/Product/CategoryController.php
@@ -217,7 +217,8 @@ class CategoryController extends AbstractController
         } catch (\Exception $e) {
             log_info('カテゴリ削除エラー', [$id, $e]);
 
-            $app->addError('admin.category.delete.error', 'admin');
+            $message = $app->trans('admin.delete.failed.foreign_key', ['%name%' => 'カテゴリ']);
+            $app->addError($message, 'admin');
         }
 
         if ($Parent) {

--- a/src/Eccube/Controller/Admin/Product/CategoryController.php
+++ b/src/Eccube/Controller/Admin/Product/CategoryController.php
@@ -24,7 +24,6 @@
 
 namespace Eccube\Controller\Admin\Product;
 
-use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\ORM\EntityManager;
 use Eccube\Annotation\Component;
 use Eccube\Annotation\Inject;
@@ -36,9 +35,9 @@ use Eccube\Event\EventArgs;
 use Eccube\Form\Type\Admin\CategoryType;
 use Eccube\Repository\CategoryRepository;
 use Eccube\Service\CsvExportService;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\HttpFoundation\Request;
@@ -203,18 +202,17 @@ class CategoryController extends AbstractController
         try {
             $this->categoryRepository->delete($TargetCategory);
 
-            log_info('カテゴリ削除完了', array($id));
-
             $event = new EventArgs(
                 array(
                     'Parent' => $Parent,
                     'TargetCategory' => $TargetCategory,
-                ),
-                $request
+                ), $request
             );
             $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_CATEGORY_DELETE_COMPLETE, $event);
 
             $app->addSuccess('admin.category.delete.complete', 'admin');
+
+            log_info('カテゴリ削除完了', array($id));
 
         } catch (\Exception $e) {
             log_info('カテゴリ削除エラー', [$id, $e]);

--- a/src/Eccube/Controller/Admin/Product/ClassCategoryController.php
+++ b/src/Eccube/Controller/Admin/Product/ClassCategoryController.php
@@ -207,8 +207,8 @@ class ClassCategoryController extends AbstractController
             } catch (\Exception $e) {
                 log_error('規格分類削除エラー', array($id, $e));
 
-                $app->addError('admin.class_category.delete.error', 'admin');
-            }
+                $message = $app->trans('admin.delete.failed.foreign_key', ['%name%' => '規格分類']);
+                $app->addError($message, 'admin');            }
         }
 
         return $app->redirect($app->url('admin_product_class_category', array('class_name_id' => $ClassName->getId())));

--- a/src/Eccube/Controller/Admin/Product/ClassCategoryController.php
+++ b/src/Eccube/Controller/Admin/Product/ClassCategoryController.php
@@ -127,29 +127,24 @@ class ClassCategoryController extends AbstractController
             $form->handleRequest($request);
             if ($form->isValid()) {
                 log_info('規格分類登録開始', array($id));
-                $status = $this->classCategoryRepository->save($TargetClassCategory);
 
-                if ($status) {
+                $this->classCategoryRepository->save($TargetClassCategory);
 
-                    log_info('規格分類登録完了', array($id));
+                log_info('規格分類登録完了', array($id));
 
-                    $event = new EventArgs(
-                        array(
-                            'form' => $form,
-                            'ClassName' => $ClassName,
-                            'TargetClassCategory' => $TargetClassCategory,
-                        ),
-                        $request
-                    );
-                    $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_CLASS_CATEGORY_INDEX_COMPLETE, $event);
+                $event = new EventArgs(
+                    array(
+                        'form' => $form,
+                        'ClassName' => $ClassName,
+                        'TargetClassCategory' => $TargetClassCategory,
+                    ),
+                    $request
+                );
+                $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_CLASS_CATEGORY_INDEX_COMPLETE, $event);
 
-                    $app->addSuccess('admin.class_category.save.complete', 'admin');
+                $app->addSuccess('admin.class_category.save.complete', 'admin');
 
-                    return $app->redirect($app->url('admin_product_class_category', array('class_name_id' => $ClassName->getId())));
-                } else {
-                    log_info('規格分類登録エラー', array($id));
-                    $app->addError('admin.class_category.save.error', 'admin');
-                }
+                return $app->redirect($app->url('admin_product_class_category', array('class_name_id' => $ClassName->getId())));
             }
         }
 
@@ -193,11 +188,8 @@ class ClassCategoryController extends AbstractController
         if ($num > 0) {
             $app->addError('admin.class_category.delete.hasproduct', 'admin');
         } else {
-            $status = $this->classCategoryRepository->delete($TargetClassCategory);
-
-            if ($status === true) {
-
-                log_info('規格分類削除完了', array($id));
+            try {
+                $this->classCategoryRepository->delete($TargetClassCategory);
 
                 $event = new EventArgs(
                     array(
@@ -209,8 +201,11 @@ class ClassCategoryController extends AbstractController
                 $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_CLASS_CATEGORY_DELETE_COMPLETE, $event);
 
                 $app->addSuccess('admin.class_category.delete.complete', 'admin');
-            } else {
-                log_info('規格分類削除エラー', array($id));
+
+                log_info('規格分類削除完了', array($id));
+
+            } catch (\Exception $e) {
+                log_error('規格分類削除エラー', array($id, $e));
 
                 $app->addError('admin.class_category.delete.error', 'admin');
             }
@@ -240,27 +235,20 @@ class ClassCategoryController extends AbstractController
             return $app->redirect($app->url('admin_product_class_category', array('class_name_id' => $ClassName->getId())));
         }
 
-        $status = $this->classCategoryRepository->toggleVisibility($TargetClassCategory);
+        $this->classCategoryRepository->toggleVisibility($TargetClassCategory);
 
-        if ($status === true) {
+        log_info('規格分類表示変更完了', array($id));
 
-            log_info('規格分類表示変更完了', array($id));
+        $event = new EventArgs(
+            array(
+                'ClassName' => $ClassName,
+                'TargetClassCategory' => $TargetClassCategory,
+            ),
+            $request
+        );
+        $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_CLASS_CATEGORY_DELETE_COMPLETE, $event);
 
-            $event = new EventArgs(
-                array(
-                    'ClassName' => $ClassName,
-                    'TargetClassCategory' => $TargetClassCategory,
-                ),
-                $request
-            );
-            $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_CLASS_CATEGORY_DELETE_COMPLETE, $event);
-
-            $app->addSuccess('admin.class_category.delete.complete', 'admin');
-        } else {
-            log_info('規格分類表示変更エラー', array($id));
-
-            $app->addError('admin.class_category.delete.error', 'admin');
-        }
+        $app->addSuccess('admin.class_category.delete.complete', 'admin');
 
         return $app->redirect($app->url('admin_product_class_category', array('class_name_id' => $ClassName->getId())));
     }

--- a/src/Eccube/Controller/Admin/Product/ClassNameController.php
+++ b/src/Eccube/Controller/Admin/Product/ClassNameController.php
@@ -156,7 +156,8 @@ class ClassNameController extends AbstractController
             log_info('商品規格削除完了', array($ClassName->getId()));
 
         } catch (\Exception $e) {
-            $app->addError('admin.class_name.delete.error', 'admin');
+            $message = $app->trans('admin.delete.failed.foreign_key', ['%name%' => '商品規格']);
+            $app->addError($message, 'admin');
 
             log_error('商品企画削除エラー', [$ClassName->getId(), $e]);
         }

--- a/src/Eccube/Controller/Admin/Product/ClassNameController.php
+++ b/src/Eccube/Controller/Admin/Product/ClassNameController.php
@@ -25,17 +25,18 @@
 namespace Eccube\Controller\Admin\Product;
 
 use Doctrine\ORM\EntityManager;
-use Eccube\Annotation\Inject;
 use Eccube\Annotation\Component;
+use Eccube\Annotation\Inject;
 use Eccube\Application;
 use Eccube\Controller\AbstractController;
+use Eccube\Entity\ClassName;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
 use Eccube\Form\Type\Admin\ClassNameType;
 use Eccube\Repository\ClassNameRepository;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\HttpFoundation\Request;
@@ -105,27 +106,23 @@ class ClassNameController extends AbstractController
             $form->handleRequest($request);
             if ($form->isValid()) {
                 log_info('商品規格登録開始', array($id));
-                $status = $this->classNameRepository->save($TargetClassName);
 
-                if ($status) {
-                    log_info('商品規格登録完了', array($id));
+                $this->classNameRepository->save($TargetClassName);
 
-                    $event = new EventArgs(
-                        array(
-                            'form' => $form,
-                            'TargetClassName' => $TargetClassName,
-                        ),
-                        $request
-                    );
-                    $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_CLASS_NAME_INDEX_COMPLETE, $event);
+                log_info('商品規格登録完了', array($id));
 
-                    $app->addSuccess('admin.class_name.save.complete', 'admin');
+                $event = new EventArgs(
+                    array(
+                        'form' => $form,
+                        'TargetClassName' => $TargetClassName,
+                    ),
+                    $request
+                );
+                $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_CLASS_NAME_INDEX_COMPLETE, $event);
 
-                    return $app->redirect($app->url('admin_product_class_name'));
-                } else {
-                    log_info('商品規格登録エラー', array($id));
-                    $app->addError('admin.class_name.save.error', 'admin');
-                }
+                $app->addSuccess('admin.class_name.save.complete', 'admin');
+
+                return $app->redirect($app->url('admin_product_class_name'));
             }
         }
 
@@ -142,34 +139,26 @@ class ClassNameController extends AbstractController
      * @Method("DELETE")
      * @Route("/{_admin}/product/class_name/{id}/delete", requirements={"id" = "\d+"}, name="admin_product_class_name_delete")
      */
-    public function delete(Application $app, Request $request, $id)
+    public function delete(Application $app, Request $request, ClassName $ClassName)
     {
         $this->isTokenValid($app);
 
-        $TargetClassName = $this->classNameRepository->find($id);
-        if (!$TargetClassName) {
-            $app->deleteMessage();
-            return $app->redirect($app->url('admin_product_class_name'));
-        }
+        log_info('商品規格削除開始', array($ClassName->getId()));
 
-        log_info('商品規格削除開始', array($id));
+        try {
+            $this->classNameRepository->delete($ClassName);
 
-        $status = $this->classNameRepository->delete($TargetClassName);
-
-        if ($status === true) {
-            log_info('商品規格削除完了', array($id));
-
-            $event = new EventArgs(
-                array(
-                    'TargetClassName' => $TargetClassName,
-                ),
-                $request
-            );
+            $event = new EventArgs(['ClassName' => $ClassName,], $request);
             $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_CLASS_NAME_DELETE_COMPLETE, $event);
 
             $app->addSuccess('admin.class_name.delete.complete', 'admin');
-        } else {
+
+            log_info('商品規格削除完了', array($ClassName->getId()));
+
+        } catch (\Exception $e) {
             $app->addError('admin.class_name.delete.error', 'admin');
+
+            log_error('商品企画削除エラー', [$ClassName->getId(), $e]);
         }
 
         return $app->redirect($app->url('admin_product_class_name'));
@@ -191,6 +180,7 @@ class ClassNameController extends AbstractController
             }
             $this->entityManager->flush();
         }
+
         return true;
     }
 }

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -592,11 +592,7 @@ class CsvImportController
                             return $this->render($app, $form, $headers);
                         }
 
-                        $status = $this->categoryRepository->save($Category);
-
-                        if (!$status) {
-                            $this->addErrors(($data->key() + 1) . '行目のカテゴリが設定できません。');
-                        }
+                        $this->categoryRepository->save($Category);
 
                         if ($this->hasErrors()) {
                             return $this->render($app, $form, $headers);

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -680,7 +680,8 @@ class ProductController extends AbstractController
 
                 } catch (ForeignKeyConstraintViolationException $e) {
                     log_info('商品削除エラー', array($id));
-                    $app->addError('admin.delete.failed', 'admin');
+                    $message = $app->trans('admin.delete.failed.foreign_key', ['%name%' => '商品']);
+                    $app->addError($message, 'admin');
                 }
             } else {
                 log_info('商品削除エラー', array($id));

--- a/src/Eccube/Controller/Admin/Setting/Shop/PaymentController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/PaymentController.php
@@ -244,7 +244,9 @@ class PaymentController extends AbstractController
             $app->addSuccess('admin.delete.complete', 'admin');
         } catch(ForeignKeyConstraintViolationException $e) {
             $this->entityManager->rollback();
-            $app->addError('admin.payment.delete.error', 'admin');
+
+            $message = $app->trans('admin.delete.failed.foreign_key', ['%name%' => '支払方法']);
+            $app->addError($message, 'admin');
         }
 
         return $app->redirect($app->url('admin_setting_shop_payment'));

--- a/src/Eccube/Controller/Admin/Setting/System/MemberController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/MemberController.php
@@ -315,7 +315,8 @@ class MemberController extends AbstractController
         } catch (\Exception $e) {
             log_info('メンバー削除エラー', [$Member->getId(), $e]);
 
-            $app->addError('admin.member.delete.error', 'admin');
+            $message = $app->trans('admin.delete.failed.foreign_key', ['%name%' => 'メンバー']);
+            $app->addError($message, 'admin');
         }
 
         return $app->redirect($app->url('admin_setting_system_member'));

--- a/src/Eccube/Controller/Admin/Setting/System/MemberController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/MemberController.php
@@ -142,9 +142,9 @@ class MemberController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $salt = bin2hex(openssl_random_pseudo_bytes(5));
-            $rawPassword = $Member->getPassword();
             $encoder = $this->encoderFactory->getEncoder($Member);
+            $salt = $encoder->createSalt();
+            $rawPassword = $Member->getPassword();
             $encodedPassword = $encoder->encodePassword($rawPassword, $salt);
             $Member
                 ->setSalt($salt)

--- a/src/Eccube/Controller/Mypage/MypageController.php
+++ b/src/Eccube/Controller/Mypage/MypageController.php
@@ -362,7 +362,7 @@ class MypageController extends AbstractController
         );
         $this->eventDispatcher->dispatch(EccubeEvents::FRONT_MYPAGE_MYPAGE_DELETE_COMPLETE, $event);
 
-        log_info('お気に入り商品削除完了', [$Customer->getId(), $Product->getId()]);
+        log_info('お気に入り商品削除完了', [$Customer->getId(), $CustomerFavoriteProduct->getId()]);
 
         return $app->redirect($app->url('mypage_favorite'));
     }

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -30,6 +30,8 @@ use Eccube\Annotation\Inject;
 use Eccube\Application;
 use Eccube\Entity\BaseInfo;
 use Eccube\Common\Constant;
+use Eccube\Entity\Master\Disp;
+use Eccube\Entity\Product;
 use Eccube\Entity\ProductClass;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
@@ -301,22 +303,24 @@ class ProductController
      * @Route("/products/detail/{id}", name="product_detail", requirements={"id" = "\d+"})
      * @Template("Product/detail.twig")
      */
-    public function detail(Application $app, Request $request, $id)
+    public function detail(Application $app, Request $request, Product $Product)
     {
-        if ($this->BaseInfo->getNostockHidden() === Constant::ENABLED) {
-            $this->entityManager->getFilters()->enable('nostock_hidden');
+        $is_admin = $request->getSession()->has('_security_admin');
+
+        // 管理ユーザの場合はステータスやオプションにかかわらず閲覧可能.
+        if (!$is_admin) {
+            // 在庫なし商品の非表示オプションが有効な場合.
+            if ($this->BaseInfo->getNostockHidden()) {
+                if (!$Product->getStockFind()) {
+                    throw new NotFoundHttpException();
+                }
+            }
+            // 公開ステータスでない商品は表示しない.
+            if ($Product->getStatus()->getId() !== Disp::DISPLAY_SHOW) {
+                throw new NotFoundHttpException();
+            }
         }
 
-        /* @var $Product \Eccube\Entity\Product */
-        $Product = $this->productRepository->get($id);
-        if (!$request->getSession()->has('_security_admin') && $Product->getStatus()->getId() !== 1) {
-            throw new NotFoundHttpException();
-        }
-        if (count($Product->getProductClasses()) < 1) {
-            throw new NotFoundHttpException();
-        }
-
-        /* @var $builder \Symfony\Component\Form\FormBuilderInterface */
         $builder = $this->formFactory->createNamedBuilder(
             '',
             AddCartType::class,

--- a/src/Eccube/Repository/CustomerAddressRepository.php
+++ b/src/Eccube/Repository/CustomerAddressRepository.php
@@ -24,6 +24,8 @@
 
 namespace Eccube\Repository;
 
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Eccube\Annotation\Repository;
 
 /**
@@ -66,31 +68,14 @@ class CustomerAddressRepository extends AbstractRepository
     }
 
     /**
-     * @param  \Eccube\Entity\Customer $Customer
-     * @param  integer                 $id
-     * @return bool
+     * お届け先を削除します.
+     *
+     * @param \Eccube\Entity\CustomerAddress $CustomerAddress
      */
-    public function deleteByCustomerAndId(\Eccube\Entity\Customer $Customer, $id)
+    public function delete($CustomerAddress)
     {
-        $qb = $this->createQueryBuilder('od')
-            ->andWhere('od.Customer = :Customer AND od.id = :id')
-            ->setParameters(array(
-                'Customer' => $Customer,
-                'id' => $id,
-            ));
-
-        try {
-            $CustomerAddress = $qb
-                ->getQuery()
-                ->getSingleResult();
-        } catch (\Exception $e) {
-            return false;
-        }
-
         $em = $this->getEntityManager();
         $em->remove($CustomerAddress);
-        $em->flush();
-
-        return true;
+        $em->flush($CustomerAddress);
     }
 }

--- a/src/Eccube/Repository/CustomerFavoriteProductRepository.php
+++ b/src/Eccube/Repository/CustomerFavoriteProductRepository.php
@@ -81,35 +81,6 @@ class CustomerFavoriteProductRepository extends AbstractRepository
 
     /**
      * @param  \Eccube\Entity\Customer $Customer
-     * @param  \Eccube\Entity\Product  $Product
-     * @return bool
-     */
-    public function deleteFavorite(\Eccube\Entity\Customer $Customer, \Eccube\Entity\Product $Product)
-    {
-        $qb = $this->createQueryBuilder('cf')
-            ->andWhere('cf.Customer = :Customer AND cf.Product = :Product')
-            ->setParameters(array(
-                'Customer' => $Customer,
-                'Product' => $Product,
-            ));
-
-        try {
-            $CustomerFavoriteProduct = $qb
-                ->getQuery()
-                ->getSingleResult();
-        } catch (\Exception $e) {
-            return false;
-        }
-
-        $em = $this->getEntityManager();
-        $em->remove($CustomerFavoriteProduct);
-        $em->flush();
-
-        return true;
-    }
-
-    /**
-     * @param  \Eccube\Entity\Customer $Customer
      * @return QueryBuilder
      */
     public function getQueryBuilderByCustomer(\Eccube\Entity\Customer $Customer)
@@ -124,5 +95,17 @@ class CustomerFavoriteProductRepository extends AbstractRepository
         $qb->addOrderBy('cfp.create_date', 'DESC');
 
         return $qb;
+    }
+
+    /**
+     * お気に入りを削除します.
+     *
+     * @param \Eccube\Entity\CustomerFavoriteProduct $CustomerFavoriteProduct
+     */
+    public function delete($CustomerFavoriteProduct)
+    {
+        $em = $this->getEntityManager();
+        $em->remove($CustomerFavoriteProduct);
+        $em->flush($CustomerFavoriteProduct);
     }
 }

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -323,7 +323,7 @@ class CustomerRepository extends AbstractRepository implements UserProviderInter
      *
      * @return string
      */
-    public function getUniqueResetKey($app)
+    public function getUniqueResetKey()
     {
         do {
             $key = Str::random(32);

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -27,7 +27,6 @@ namespace Eccube\Repository;
 use Doctrine\ORM\EntityManager;
 use Eccube\Annotation\Inject;
 use Eccube\Annotation\Repository;
-use Eccube\Common\Constant;
 use Eccube\Doctrine\Query\Queries;
 use Eccube\Entity\Customer;
 use Eccube\Entity\Master\CustomerStatus;
@@ -80,13 +79,12 @@ class CustomerRepository extends AbstractRepository implements UserProviderInter
 
     public function newCustomer()
     {
-        $Customer = new \Eccube\Entity\Customer();
-        $Status = $this->getEntityManager()
-            ->getRepository('Eccube\Entity\Master\CustomerStatus')
-            ->find(1);
+        $CustomerStatus = $this->getEntityManager()
+            ->find(CustomerStatus::class, CustomerStatus::PROVISIONAL);
 
+        $Customer = new \Eccube\Entity\Customer();
         $Customer
-            ->setStatus($Status);
+            ->setStatus($CustomerStatus);
 
         return $Customer;
     }
@@ -107,19 +105,12 @@ class CustomerRepository extends AbstractRepository implements UserProviderInter
      */
     public function loadUserByUsername($username)
     {
-        // 本会員ステータスの会員のみ有効.
-        $query = $this->createQueryBuilder('c')
-            ->where('c.email = :email')
-            ->leftJoin('c.Status', 's')
-            ->andWhere('s.id = :status')
-            ->setParameters(array(
-                'email' => $username,
-                'status' => CustomerStatus::REGULAR,
-            ))
-            ->setMaxResults(1)
-            ->getQuery();
-        $Customer = $query->getOneOrNullResult();
-        if (!$Customer) {
+        $Customer = $this->findOneBy([
+            'email' => $username,
+            'Status' => CustomerStatus::REGULAR,
+        ]);
+
+        if (is_null($Customer)) {
             throw new UsernameNotFoundException(sprintf('Username "%s" does not exist.', $username));
         }
 
@@ -158,7 +149,7 @@ class CustomerRepository extends AbstractRepository implements UserProviderInter
      */
     public function supportsClass($class)
     {
-        return $class === 'Eccube\Entity\Customer';
+        return $class === Customer::class;
     }
 
     public function getQueryBuilderBySearchData($searchData)
@@ -173,9 +164,9 @@ class CustomerRepository extends AbstractRepository implements UserProviderInter
             $qb
                 ->andWhere('c.id = :customer_id OR CONCAT(c.name01, c.name02) LIKE :name OR CONCAT(c.kana01, c.kana02) LIKE :kana OR c.email LIKE :email')
                 ->setParameter('customer_id', $id)
-                ->setParameter('name', '%' . $clean_key_multi . '%')
-                ->setParameter('kana', '%' . $clean_key_multi . '%')
-                ->setParameter('email', '%' . $clean_key_multi . '%');
+                ->setParameter('name', '%'.$clean_key_multi.'%')
+                ->setParameter('kana', '%'.$clean_key_multi.'%')
+                ->setParameter('email', '%'.$clean_key_multi.'%');
         }
 
         // Pref
@@ -221,7 +212,7 @@ class CustomerRepository extends AbstractRepository implements UserProviderInter
         if (isset($searchData['tel']) && Str::isNotBlank($searchData['tel'])) {
             $qb
                 ->andWhere('CONCAT(c.tel01, c.tel02, c.tel03) LIKE :tel')
-                ->setParameter('tel', '%' . $searchData['tel'] . '%');
+                ->setParameter('tel', '%'.$searchData['tel'].'%');
         }
 
         // buy_total
@@ -303,7 +294,7 @@ class CustomerRepository extends AbstractRepository implements UserProviderInter
                 ->leftJoin('c.Orders', 'o')
                 ->leftJoin('o.OrderDetails', 'od')
                 ->andWhere('od.product_name LIKE :buy_product_name OR od.product_code LIKE :buy_product_name')
-                ->setParameter('buy_product_name', '%' . $searchData['buy_product_code'] . '%');
+                ->setParameter('buy_product_name', '%'.$searchData['buy_product_code'].'%');
         }
 
         // Order By
@@ -313,107 +304,86 @@ class CustomerRepository extends AbstractRepository implements UserProviderInter
     }
 
     /**
-     * ユニークなシークレットキーを返す
-     * @param $app
+     * ユニークなシークレットキーを返す.
+     *
      * @return string
      */
-    public function getUniqueSecretKey($app)
+    public function getUniqueSecretKey()
     {
-        $unique = Str::random(32);
-        $Customer = $this->findBy(array(
-            'secret_key' => $unique,
-        ));
-        if (count($Customer) == 0) {
-            return $unique;
-        } else {
-            return $this->getUniqueSecretKey($app);
-        }
+        do {
+            $key = Str::random(32);
+            $Customer = $this->findOneBy(['secret_key' => $key]);
+        } while ($Customer);
+
+        return $key;
     }
 
     /**
      * ユニークなパスワードリセットキーを返す
-     * @param $app
+     *
      * @return string
      */
     public function getUniqueResetKey($app)
     {
-        $unique = Str::random(32);
-        $Customer = $this->findBy(array(
-                        'reset_key' => $unique,
-        ));
-        if (count($Customer) == 0) {
-            return $unique;
-        } else {
-            return $this->getUniqueResetKey($app);
-        }
+        do {
+            $key = Str::random(32);
+            $Customer = $this->findOneBy(['reset_key' => $key]);
+        } while ($Customer);
+
+        return $key;
     }
 
     /**
-     * saltを生成する
+     * 仮会員をシークレットキーで検索する.
      *
-     * @param $byte
-     * @return string
+     * @param $secretKey
+     * @return null|Customer 見つからない場合はnullを返す.
      */
-    public function createSalt($byte)
+    public function getProvisionalCustomerBySecretKey($secretKey)
     {
-        return bin2hex(openssl_random_pseudo_bytes($byte));
+        return $this->findOneBy([
+            'secret_key' => $secretKey,
+            'Status' => CustomerStatus::PROVISIONAL,
+        ]);
     }
 
     /**
-     * 入力されたパスワードをSaltと暗号化する
+     * 本会員をemailで検索する.
      *
-     * @param $app
-     * @param  Customer $Customer
-     * @return mixed
+     * @param $email
+     * @return null|Customer 見つからない場合はnullを返す.
      */
-    public function encryptPassword($app, \Eccube\Entity\Customer $Customer)
-    {
-        $encoder = $this->encoderFactory->getEncoder($Customer);
-
-        return $encoder->encodePassword($Customer->getPassword(), $Customer->getSalt());
-    }
-
-    public function getProvisionalCustomerBySecretKey($secret_key)
-    {
-        $qb = $this->createQueryBuilder('c')
-            ->where('c.secret_key = :secret_key')
-            ->leftJoin('c.Status', 's')
-            ->andWhere('s.id = :status')
-            ->setParameter('secret_key', $secret_key)
-            ->setParameter('status', CustomerStatus::PROVISIONAL);
-        $query = $qb->getQuery();
-
-        return $query->getSingleResult();
-    }
-
     public function getRegularCustomerByEmail($email)
     {
-        $query = $this->createQueryBuilder('c')
-            ->where('c.email = :email AND c.Status = :status')
-            ->setParameter('email', $email)
-            ->setParameter('status', CustomerStatus::REGULAR)
-            ->setMaxResults(1)
-            ->getQuery();
-
-        $Customer = $query->getOneOrNullResult();
-
-        return $Customer;
+        return $this->findOneBy([
+            'email' => $email,
+            'Status' => CustomerStatus::REGULAR,
+        ]);
     }
 
-    public function getRegularCustomerByResetKey($reset_key)
+    /**
+     * 本会員をリセットキーで検索する.
+     *
+     * @param $resetKey
+     * @return null|Customer 見つからない場合はnullを返す.
+     */
+    public function getRegularCustomerByResetKey($resetKey)
     {
-        $query = $this->createQueryBuilder('c')
+        return $this->createQueryBuilder('c')
             ->where('c.reset_key = :reset_key AND c.Status = :status AND c.reset_expire >= :reset_expire')
-            ->setParameter('reset_key', $reset_key)
+            ->setParameter('reset_key', $resetKey)
             ->setParameter('status', CustomerStatus::REGULAR)
             ->setParameter('reset_expire', new \DateTime())
-            ->getQuery();
-
-        $Customer = $query->getSingleResult();
-
-        return $Customer;
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
     }
 
+    /**
+     * リセット用パスワードを生成する.
+     *
+     * @return string
+     */
     public function getResetPassword()
     {
         return Str::random(8);
@@ -430,12 +400,13 @@ class CustomerRepository extends AbstractRepository implements UserProviderInter
     {
         // 会員の場合、初回購入時間・購入時間・購入回数・購入金額を更新
 
-        $arr = array($this->appConfig['order_new'],
-                                $this->appConfig['order_pay_wait'],
-                                $this->appConfig['order_back_order'],
-                                $this->appConfig['order_deliv'],
-                                $this->appConfig['order_pre_end'],
-                        );
+        $arr = array(
+            $this->appConfig['order_new'],
+            $this->appConfig['order_pay_wait'],
+            $this->appConfig['order_back_order'],
+            $this->appConfig['order_deliv'],
+            $this->appConfig['order_pre_end'],
+        );
 
         $result = $this->orderRepository->getCustomerCount($Customer, $arr);
 
@@ -450,8 +421,9 @@ class CustomerRepository extends AbstractRepository implements UserProviderInter
             }
 
             if ($orderStatusId == $this->appConfig['order_cancel'] ||
-                    $orderStatusId == $this->appConfig['order_pending'] ||
-                    $orderStatusId == $this->appConfig['order_processing']) {
+                $orderStatusId == $this->appConfig['order_pending'] ||
+                $orderStatusId == $this->appConfig['order_processing']
+            ) {
                 // キャンセル、決済処理中、購入処理中は購入時間は更新しない
             } else {
                 $Customer->setLastBuyDate($now);

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -60,36 +60,7 @@ class ProductRepository extends AbstractRepository
      */
     protected $appConfig;
 
-    /**
-     * get Product.
-     *
-     * @deprecated Use ProductRepository::find()
-     * @param  integer $productId
-     * @return \Eccube\Entity\Product
-     *
-     * @throws NotFoundHttpException
-     */
-    public function get($productId)
-    {
-        // Product
-        try {
-            $qb = $this->createQueryBuilder('p')
-                ->andWhere('p.id = :id');
-
-            $product = $qb
-                ->getQuery()
-                ->setParameters(array(
-                    'id' => $productId,
-                ))
-                ->getSingleResult();
-        } catch (NoResultException $e) {
-            throw new NotFoundHttpException();
-        }
-
-        return $product;
-    }
-
-    /**
+   /**
      * get query builder.
      *
      * @param  array $searchData

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -69,6 +69,7 @@ return [
     'admin.register.failed' => '登録できませんでした。',
     'admin.delete.complete' => '削除が完了しました。',
     'admin.delete.failed' => '削除できませんでした。',
+    'admin.delete.failed.foreign_key' => '関連するデータがあるため, %name%を削除できませんでした。',
     'admin.delete.warning' => '既に削除されています。',
     'admin.rank.move.complete' => 'ランクの移動が完了しました。',
     'admin.order.save.complete' => '受注情報を保存しました。',

--- a/src/Eccube/Security/Core/Encoder/PasswordEncoder.php
+++ b/src/Eccube/Security/Core/Encoder/PasswordEncoder.php
@@ -94,4 +94,14 @@ class PasswordEncoder implements PasswordEncoderInterface
         return false;
     }
 
+    /**
+     * saltを生成する.
+     *
+     * @param int $length
+     * @return string
+     */
+    public function createSalt($length = 5)
+    {
+        return bin2hex(openssl_random_pseudo_bytes($length));
+    }
 }

--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -96,6 +96,10 @@ class Generator {
         $Pref = $this->app['eccube.repository.master.pref']->find($faker->numberBetween(1, 47));
         $Sex = $this->app['eccube.repository.master.sex']->find($faker->numberBetween(1, 2));
         $Job = $this->app['orm.em']->getRepository('Eccube\Entity\Master\Job')->find($faker->numberBetween(1, 18));
+
+        $encoder = $this->app['security.encoder_factory']->getEncoder($Customer);
+        $salt = $encoder->createSalt();
+        $password = $encoder->encodePassword('password', $salt);
         $Customer
             ->setName01($faker->lastName)
             ->setName02($faker->firstName)
@@ -117,13 +121,12 @@ class Generator {
             ->setBirth($faker->dateTimeThisDecade())
             ->setSex($Sex)
             ->setJob($Job)
-            ->setPassword('password')
-            ->setSalt($this->app['eccube.repository.customer']->createSalt(5))
-            ->setSecretKey($this->app['eccube.repository.customer']->getUniqueSecretKey($this->app))
+            ->setPassword($password)
+            ->setSalt($salt)
+            ->setSecretKey($this->app['eccube.repository.customer']->getUniqueSecretKey())
             ->setStatus($Status)
             ->setCreateDate(new \DateTime()) // FIXME
             ->setUpdateDate(new \DateTime());
-        $Customer->setPassword($this->app['eccube.repository.customer']->encryptPassword($this->app, $Customer));
         $this->app['orm.em']->persist($Customer);
         $this->app['orm.em']->flush($Customer);
 

--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -59,18 +59,20 @@ class Generator {
         $Work = $this->app['orm.em']->getRepository('Eccube\Entity\Master\Work')->find(1);
         $Authority = $this->app['eccube.repository.master.authority']->find(0);
         $Creator = $this->app['eccube.repository.member']->find(2);
-        $salt = $this->app['eccube.repository.member']->createSalt(5);
+
+        $salt = bin2hex(openssl_random_pseudo_bytes(5));
+        $password = 'password';
+        $encoder = $this->app['security.encoder_factory']->getEncoder($Member);
+        $password = $encoder->encodePassword($password, $salt);
 
         $Member
-            ->setPassword('password')
             ->setLoginId($username)
             ->setName($username)
             ->setSalt($salt)
+            ->setPassword($password)
             ->setWork($Work)
             ->setAuthority($Authority)
             ->setCreator($Creator);
-        $password = $this->app['eccube.repository.member']->encryptPassword($Member);
-        $Member->setPassword($password);
         $this->app['eccube.repository.member']->save($Member);
         return $Member;
     }

--- a/tests/Eccube/Tests/Repository/CategoryRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/CategoryRepositoryTest.php
@@ -3,10 +3,7 @@
 namespace Eccube\Tests\Repository;
 
 use Eccube\Tests\EccubeTestCase;
-use Eccube\Application;
-use Eccube\Common\Constant;
 use Eccube\Entity\Category;
-
 
 /**
  * CategoryRepository test cases.
@@ -172,23 +169,11 @@ class CategoryRepositoryTest extends EccubeTestCase
         $Category = new Category();
         $Category->setName($name)
             ->setLevel(1);
-        $result = $this->app['eccube.repository.category']->save($Category);
-        $this->assertTrue($result);
+        $this->app['eccube.repository.category']->save($Category);
 
         $this->expected = 12;
         $this->actual = $Category->getRank();
         $this->verify('カテゴリの rank は'.$this->expected.'ではありません');
-    }
-
-    public function testSaveWithException()
-    {
-        $faker = $this->getFaker();
-        $name = $faker->name;
-        $Category = new Category();
-        $Category->setName($name)
-            ->setLevel(null);   // level は not null なので例外になる
-        $result = $this->app['eccube.repository.category']->save($Category);
-        $this->assertFalse($result);
     }
 
     public function testSaveWithParent()
@@ -199,8 +184,7 @@ class CategoryRepositoryTest extends EccubeTestCase
         $Category->setName($name);
         $updateDate = $Category->getUpdateDate();
         sleep(1);
-        $result = $this->app['eccube.repository.category']->save($Category);
-        $this->assertTrue($result);
+        $this->app['eccube.repository.category']->save($Category);
 
         $this->expected = $updateDate;
         $this->actual = $Category->getUpdateDate();
@@ -216,8 +200,7 @@ class CategoryRepositoryTest extends EccubeTestCase
     {
         $Category = $this->app['eccube.repository.category']->findOneBy(array('name' => '孫2'));
 
-        $result = $this->app['eccube.repository.category']->delete($Category);
-        $this->assertTrue($result);
+        $this->app['eccube.repository.category']->delete($Category);
 
         $Category = $this->app['eccube.repository.category']->findOneBy(array('name' => '孫2'));
         $this->assertNull($Category);
@@ -229,8 +212,12 @@ class CategoryRepositoryTest extends EccubeTestCase
         $this->createProduct();
         $Category = $this->app['eccube.repository.category']->findOneBy(array('name' => '孫2'));
 
-        // 紐付いた商品が存在している場合は削除できない.
-        $result = $this->app['eccube.repository.category']->delete($Category);
-        $this->assertFalse($result);
+        try {
+            // 紐付いた商品が存在している場合は削除できない.
+            $this->app['eccube.repository.category']->delete($Category);
+            $this->fail();
+        } catch (\Exception $e) {
+
+        }
     }
 }

--- a/tests/Eccube/Tests/Repository/CustomerAddressRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/CustomerAddressRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Eccube\Tests\Repository;
 
+use Eccube\Entity\CustomerAddress;
 use Eccube\Tests\EccubeTestCase;
 
 /**
@@ -56,19 +57,17 @@ class CustomerAddressRepositoryTest extends EccubeTestCase
         }
     }
 
-    public function testDeleteByCustomerAndId()
+    public function testDelete()
     {
-        $CustomerAddress = $this->app['eccube.repository.customer_address']->findOrCreateByCustomerAndId($this->Customer, null);
+        $CustomerAddress = new CustomerAddress();
+        $CustomerAddress->setCustomer($this->Customer);
         $this->app['orm.em']->persist($CustomerAddress);
         $this->app['orm.em']->flush();
 
-        $result = $this->app['eccube.repository.customer_address']->deleteByCustomerAndId($this->Customer, $CustomerAddress->getId());
-        $this->assertTrue($result);
-    }
+        $id = $CustomerAddress->getId();
+        $this->app['eccube.repository.customer_address']->delete($CustomerAddress);
 
-    public function testDeleteByCustomerAndIdWithException()
-    {
-        $result = $this->app['eccube.repository.customer_address']->deleteByCustomerAndId($this->Customer, 9999);
-        $this->assertFalse($result);
+        $CustomerAddress = $this->app['eccube.repository.customer_address']->find($id);
+        $this->assertNull($CustomerAddress);
     }
 }

--- a/tests/Eccube/Tests/Repository/CustomerRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/CustomerRepositoryTest.php
@@ -105,25 +105,6 @@ class CustomerRepositoryTest extends EccubeTestCase
         $this->assertTrue($this->app['eccube.repository.customer']->supportsClass(get_class($this->Customer)));
     }
 
-    public function testCreateSalt()
-    {
-        $result = $this->app['eccube.repository.customer']->createSalt(5);
-
-        $this->expected = 5;
-        $this->actual = strlen(pack('H*', ($result))); // PHP5.4以降なら hex2bin が使える
-        $this->verify();
-    }
-
-    public function testEncryptPassword()
-    {
-        $Customer = $this->app['eccube.repository.customer']->loadUserByUsername($this->email);
-        $this->expected = $Customer->getPassword();
-
-        $Customer->setPassword('password');
-        $this->actual = $this->app['eccube.repository.customer']->encryptPassword($this->app, $Customer);
-        $this->verify();
-    }
-
     public function testGetProvisionalCustomerBySecretKey()
     {
         $this->expected = $this->Customer->getSecretKey();
@@ -140,15 +121,9 @@ class CustomerRepositoryTest extends EccubeTestCase
     {
         $secret = $this->Customer->getSecretKey();
 
-        try {
-            // CustomerStatus::REGULARなので取得できないはず
-            $Customer = $this->app['eccube.repository.customer']->getProvisionalCustomerBySecretKey($secret);
-            $this->fail();
-        } catch (\Doctrine\ORM\NoResultException $e) {
-            $this->expected = 'No result was found for query although at least one row was expected.';
-            $this->actual = $e->getMessage();
-        }
-        $this->verify();
+        // CustomerStatus::REGULARなので取得できないはず
+        $Customer = $this->app['eccube.repository.customer']->getProvisionalCustomerBySecretKey($secret);
+        $this->assertNull($Customer);
     }
 
     public function testGetRegularCustomerByEmail()
@@ -182,14 +157,8 @@ class CustomerRepositoryTest extends EccubeTestCase
             ->setResetExpire(new \DateTime($expire));
         $this->app['orm.em']->flush();
 
-        try {
-            $Customer = $this->app['eccube.repository.customer']->getRegularCustomerByResetKey($reset_key);
-            $this->fail();
-        } catch (\Doctrine\ORM\NoResultException $e) {
-            $this->expected = 'No result was found for query although at least one row was expected.';
-            $this->actual = $e->getMessage();
-        }
-        $this->verify();
+        $Customer = $this->app['eccube.repository.customer']->getRegularCustomerByResetKey($reset_key);
+        $this->assertNull($Customer);
     }
 
     public function testUpdateBuyData()

--- a/tests/Eccube/Tests/Repository/NewsRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/NewsRepositoryTest.php
@@ -20,7 +20,6 @@ class NewsRepositoryTest extends EccubeTestCase
     {
         parent::setUp();
         $this->removeNews();
-        $this->Member = $this->app['eccube.repository.member']->find(2);
 
         $faker = $this->getFaker();
         for ($i = 0; $i < 3; $i++) {
@@ -29,7 +28,6 @@ class NewsRepositoryTest extends EccubeTestCase
                 ->setTitle('news-'.$i)
                 ->setComment($faker->text())
                 ->setUrl($faker->url)
-                ->setCreator($this->Member)
                 ->setSelect(1)
                 ->setLinkMethod(1)
                 ->setRank($i)
@@ -57,9 +55,8 @@ class NewsRepositoryTest extends EccubeTestCase
         $this->assertEquals(1, $News->getRank());
 
         // rank up 1 => 2
-        $result = $this->app['eccube.repository.news']->up($News);
+        $this->app['eccube.repository.news']->up($News);
 
-        $this->assertTrue($result);
         $this->expected = 2;
         $this->actual = $News->getRank();
         $this->verify('rank は '.$this->expected.'ではありません');
@@ -71,9 +68,12 @@ class NewsRepositoryTest extends EccubeTestCase
             array('title' => 'news-2')
         );
 
-        $result = $this->app['eccube.repository.news']->up($News);
+        try {
+            $this->app['eccube.repository.news']->up($News);
+            $this->fail();
+        } catch (\Exception $e) {
 
-        $this->assertFalse($result);
+        }
     }
 
     public function testDown()
@@ -85,9 +85,8 @@ class NewsRepositoryTest extends EccubeTestCase
         $this->assertEquals(1, $News->getRank());
 
         // rank down 1 => 0
-        $result = $this->app['eccube.repository.news']->down($News);
+        $this->app['eccube.repository.news']->down($News);
 
-        $this->assertTrue($result);
         $this->expected = 0;
         $this->actual = $News->getRank();
         $this->verify('rank は '.$this->expected.'ではありません');
@@ -99,9 +98,11 @@ class NewsRepositoryTest extends EccubeTestCase
             array('title' => 'news-0')
         );
 
-        $result = $this->app['eccube.repository.news']->down($News);
+        try {
+            $this->app['eccube.repository.news']->down($News);
+        } catch (\Exception $e) {
 
-        $this->assertFalse($result);
+        }
     }
 
     public function testSave()
@@ -112,12 +113,10 @@ class NewsRepositoryTest extends EccubeTestCase
             ->setTitle('news-10')
             ->setComment($faker->text())
             ->setUrl($faker->url)
-            ->setCreator($this->Member)
             ->setSelect(1)
             ->setLinkMethod(1);
 
-        $result = $this->app['eccube.repository.news']->save($News);
-        $this->assertTrue($result);
+        $this->app['eccube.repository.news']->save($News);
 
         $this->expected = 3;
         $this->actual = $News->getRank();
@@ -133,34 +132,15 @@ class NewsRepositoryTest extends EccubeTestCase
             ->setTitle('news-10')
             ->setComment($faker->text())
             ->setUrl($faker->url)
-            ->setCreator($this->Member)
             ->setSelect(1)
             ->setLinkMethod(1);
 
-        $result = $this->app['eccube.repository.news']->save($News);
-        $this->assertTrue($result);
+        $this->app['eccube.repository.news']->save($News);
 
         $this->expected = 1;
         $this->actual = $News->getRank();
         $this->verify('rank は'.$this->expected.'ではありません');
     }
-
-    public function testSaveWithException()
-    {
-        $faker = $this->getFaker();
-        $News = new News();
-        $News
-            ->setTitle('news-10')
-            ->setComment($faker->text())
-            ->setUrl($faker->url)
-            ->setCreator($this->Member)
-            ->setSelect(null)   // select は not null なので例外になる
-            ->setLinkMethod(1);
-
-        $result = $this->app['eccube.repository.news']->save($News);
-        $this->assertFalse($result);
-    }
-
 
     public function testDelete()
     {
@@ -169,9 +149,8 @@ class NewsRepositoryTest extends EccubeTestCase
         );
 
         $newsId = $News->getId();
-        $result = $this->app['eccube.repository.news']->delete($News);
+        $this->app['eccube.repository.news']->delete($News);
 
-        $this->assertTrue($result);
         self::assertNull($this->app['eccube.repository.news']->find($newsId));
     }
 }

--- a/tests/Eccube/Tests/Repository/ProductRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryTest.php
@@ -11,36 +11,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class ProductRepositoryTest extends AbstractProductRepositoryTestCase
 {
-
-    public function testGet()
-    {
-        $Product = $this->app['eccube.repository.product']->findOneBy(
-            array('name' => '商品-1')
-        );
-        $this->assertTrue($Product instanceof \Eccube\Entity\Product);
-
-        $Db = $Product->Db;
-        $this->assertEquals('PostgreSQL', $Db->getName());
-        $product_id = $Product->getId();
-        $Result = $this->app['eccube.repository.product']->get($product_id);
-
-        $this->expected = $product_id;
-        $this->actual = $Result->getId();
-        $this->verify();
-    }
-
-    public function testGetWithException()
-    {
-        try {
-            $Product = $this->app['eccube.repository.product']->get(9999);
-            $this->fail();
-        } catch (NotFoundHttpException $e) {
-            $this->expected = 404;
-            $this->actual = $e->getStatusCode();
-        }
-        $this->verify();
-    }
-
     public function testGetFavoriteProductQueryBuilderByCustomer()
     {
         $Customer = $this->createCustomer();

--- a/tests/Eccube/Tests/Web/Admin/IndexControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/IndexControllerTest.php
@@ -168,9 +168,8 @@ class IndexControllerTest extends AbstractAdminWebTestCase
         $this->assertTrue($client->getResponse()->isRedirect($this->app->url('admin_change_password')));
 
         $Member = clone $this->Member;
-        $Member->setPassword($form['change_password']['first']);
-
-        $this->expected = $this->app['eccube.repository.member']->encryptPassword($Member);
+        $encoder = $this->app['security.encoder_factory']->getEncoder($this->Member);
+        $this->expected = $encoder->encodePassword($form['change_password']['first'], $this->Member->getSalt());
         $this->actual = $this->Member->getPassword();
 
         // XXX 実行タイミングにより、稀にパスワード変更前のハッシュ値を参照する場合があるため、変更に成功した場合のみ assertion を実行する

--- a/tests/Eccube/Tests/Web/ForgotControllerTest.php
+++ b/tests/Eccube/Tests/Web/ForgotControllerTest.php
@@ -116,23 +116,16 @@ class ForgotControllerTest extends AbstractWebTestCase
         }
     }
 
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
     public function testResetWithNotFound()
     {
-        // debugはONの時に404ページ表示しない例外になります。
-        if($this->app['debug'] == true){
-            $this->setExpectedException('\Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
-        }
         $client = $this->createClient();
 
         $crawler = $client->request(
            'GET',
            '/forgot/reset/aaaa'
         );
-        // debugはOFFの時に404ページが表示します。
-        if($this->app['debug'] == false){
-            $this->expected = 404;
-            $this->actual = $client->getResponse()->getStatusCode();
-            $this->verify();
-        }
     }
 }

--- a/tests/Eccube/Tests/Web/Mypage/DeliveryControllerTest.php
+++ b/tests/Eccube/Tests/Web/Mypage/DeliveryControllerTest.php
@@ -184,6 +184,9 @@ class DeliveryControllerTest extends AbstractWebTestCase
         $this->verify();
     }
 
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
     public function testDeleteWithFailure()
     {
         $this->logIn($this->Customer);
@@ -193,11 +196,5 @@ class DeliveryControllerTest extends AbstractWebTestCase
             'DELETE',
             $this->app->path('mypage_delivery_delete', array('id' => 999999999))
         );
-
-        $this->assertTrue($client->getResponse()->isRedirect($this->app->url('mypage_delivery')));
-
-        $this->expected = array('mypage.address.delete.failed');
-        $this->actual = $this->app['session']->getFlashBag()->get('eccube.front.error');
-        $this->verify();
     }
 }

--- a/tests/Eccube/Tests/Web/Mypage/MypageControllerTest.php
+++ b/tests/Eccube/Tests/Web/Mypage/MypageControllerTest.php
@@ -233,7 +233,7 @@ class MypageControllerTest extends AbstractWebTestCase
     {
         $CustomerFavoriteProduct = new \Eccube\Entity\CustomerFavoriteProduct();
         $CustomerFavoriteProduct->setCustomer($this->app->user());
-        $Product = $this->app['eccube.repository.product']->get(1);
+        $Product = $this->app['eccube.repository.product']->find(1);
         $CustomerFavoriteProduct->setCreateDate(new \DateTime());
         $CustomerFavoriteProduct->setUpdateDate(new \DateTime());
         $CustomerFavoriteProduct->setProduct($Product);


### PR DESCRIPTION
## 現状
- レポジトリ内で、\Exceptionで例外をcatchし、true/falseでハンドリングしている箇所が多々ある
  - ログ出力も行っておらず、何が発生したかわかりづらい
  - 外部キー制約違反など、明示的にコントローラ側で制御したほうがよいと思われる
- 不要なトランザクション
  - TransactionListenerにより、アプリケーションの起動、終了タイミングでbegin/commitが行われるようになっているため、レポジトリ内でのトランザクションは不要

## 対象箇所
| 対象レポジトリ                                    | 対応                                                                                        |
|---------------------------------------------------|---------------------------------------------------------------------------------------------|
| CategoryRepository::save                          | 不要なトランザクション, try-catchブロックを削除                                             |
| CategoryRepository::delete                        | 不要なトランザクション, try-catchブロックを削除, 外部キー制約違反はコントローラ側で制御する |
| ClassCategoryRepository::up                       | 使用していない                                             |
| ClassCategoryRepository::down                     | 使用していない                                             |
| ClassCategoryRepository::save                     | 不要なトランザクション, try-catchブロックを削除                                             |
| ClassCategoryRepository::delete                   | 不要なトランザクション, try-catchブロックを削除, 外部キー制約違反はコントローラ側で制御する |
| ClassCategoryRepository::toggleVisibility         | 不要なトランザクション, try-catchブロックを削除                                             |
| ClassNameRepository::up                           | 不要なトランザクション, try-catchブロックを削除                                             |
| ClassNameRepository::down                         | 不要なトランザクション, try-catchブロックを削除                                             |
| ClassNameRepository::save                         | 不要なトランザクション, try-catchブロックを削除                                             |
| ClassNameRepository::delete                       | 不要なトランザクション, try-catchブロックを削除, 外部キー制約違反はコントローラ側で制御する |
| CustomerAddressRepository::deleteByCustomerAndId  | deleteでよい.Customerのチェックはコントローラ側で制御する .外部キー制約違反は発生しない  |
| CustomerFavoriteProductRepository::deleteFavorite | deleteでよい.Customerのチェックはコントローラ側で制御する. 外部キー制約違反は発生しない  |
| MemberRepository::up                              | 不要なトランザクション, try-catchブロックを削除                                             |
| MemberRepository::down                            | 不要なトランザクション, try-catchブロックを削除                                             |
| MemberRepository::save                            | 不要なトランザクション, try-catchブロックを削除                                             |
| MemberRepository::delete                          | 不要なトランザクション, try-catchブロックを削除, 外部キー制約違反はコントローラ側で制御する |
| NewsRepository::up                                | 不要なトランザクション, try-catchブロックを削除                                             |
| NewsRepository::down                              | 不要なトランザクション, try-catchブロックを削除                                             |
| NewsRepository::save                              | 不要なトランザクション, try-catchブロックを削除                                             |
| NewsRepository::delete                            | 不要なトランザクション, try-catchブロックを削除                                             |
| ProductRepository::get                            | 既にdeprecatedになっている. findに移行する                                                              |

- delete時、SQLiteの場合は外部キー制約違反が発生するとDriverExceptionが発生する
- コントローラ側では\Exceptionでcatchしてハンドリングする

## その他クエリビルダで発生する例外
1レコードを取得するメソッドは、NonUniqueResultExceptionやNoResultExceptionをthrowする場合がある

- getSingleScalarResult -> NonUniqueResultException, NoResultException
- getSingleResult -> NonUniqueResultException, NoResultException
- getOneOrNullResult -> NonUniqueResultException

### getSingleScalarResult

- MAXやCOUNTのクエリで使用されている
- COALESCEでデフォルト値を指定する

### getSingleResult, getOneOrNullResult

- CustomerRepository::getProvisionalCustomerBySecretKey
getSingleResultで、コントローラ側で例外処理
  - https://github.com/EC-CUBE/ec-cube/blob/experimental/physical-delete/src/Eccube/Repository/CustomerRepository.php#L386
  - https://github.com/EC-CUBE/ec-cube/blob/experimental/physical-delete/src/Eccube/Controller/EntryController.php#L249

- CustomerRepository::getRegularCustomerByEmail
getOneOrNullResultでコントローラ側ではnullチェック
  - https://github.com/EC-CUBE/ec-cube/blob/experimental/physical-delete/src/Eccube/Repository/CustomerRepository.php#L389
  - https://github.com/EC-CUBE/ec-cube/blob/experimental/physical-delete/src/Eccube/Controller/ForgotController.php#L122

findやfindOneByの挙動と合わせ、例外ではなくnullチェックに統一する
https://github.com/EC-CUBE/ec-cube/commit/a5fed70387d8d0dd361b050699c971455f077b32#diff-0f35546f441e293c77ddea72dfc48fbbR255

## その他修正事項

- 外部キー制約違反のメッセージキーを統一
- CustomerRepository/MemberRepositoryにパスワードエンコーダが重複していたため、Eccube\Security\Core\PasswordEncoderに処理を統一