### PR TITLE
Show plugins from EC-CUBE package repository.

### DIFF
--- a/app/Acme/Controller/Admin/Store/OwnerStoreController.php
+++ b/app/Acme/Controller/Admin/Store/OwnerStoreController.php
@@ -82,9 +82,9 @@ class OwnerStoreController extends AbstractController
                     $items = array();
                     // Check plugin installed
                     $arrPluginInstalled = $this->pluginRepository->findAll();
-                    // update_status 1 : not install 、2 : Installed、 3 : Update、4 : paid purchase
+                    // Update_status 1 : not install/purchased 、2 : Installed、 3 : Update、4 : paid purchase
                     foreach ($data['item'] as $item) {
-                        // Not install
+                        // Not install/purchased
                         $item['update_status'] = 1;
                         /** @var Plugin $plugin */
                         foreach ($arrPluginInstalled as $plugin) {

--- a/app/Acme/Controller/Admin/Store/OwnerStoreController.php
+++ b/app/Acme/Controller/Admin/Store/OwnerStoreController.php
@@ -1,0 +1,199 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Acme\Controller\Admin\Store;
+
+use Eccube\Annotation\Component;
+use Eccube\Annotation\Inject;
+use Eccube\Application;
+use Eccube\Common\Constant;
+use Eccube\Controller\AbstractController;
+use Eccube\Entity\Plugin;
+use Eccube\Repository\PluginRepository;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @Component
+ * @Route(service=OwnerStoreController::class)
+ */
+class OwnerStoreController extends AbstractController
+{
+    /**
+     * @Inject("config")
+     * @var array
+     */
+    protected $appConfig;
+
+    /**
+     * @Inject(PluginRepository::class)
+     * @var PluginRepository
+     */
+    protected $pluginRepository;
+
+    /**
+     * Owner's Store Plugin Installation Screen - Search function
+     *
+     * @Route("/{_admin}/store/plugin/search", name="admin_store_plugin_owners_search")
+     * @Template("Store/plugin_search.twig")
+     * @param Application $app
+     * @param Request     $request
+     * @return array
+     */
+    public function search(Application $app, Request $request)
+    {
+        // Acquire downloadable plug-in information from owners store
+        $success = 0;
+        $items = array();
+        $promotionItems = array();
+        $message = '';
+        // Owner's store communication
+        // TODO: need change real server
+        $url = $this->appConfig['owners_store_url'].'?method=list';
+        list($json, $info) = $this->getRequestApi($url, $app);
+        if ($json === false) {
+            $message = $this->getResponseErrorMessage($info);
+        } else {
+            $data = json_decode($json, true);
+            if (isset($data['success'])) {
+                $success = $data['success'];
+                if ($success == '1') {
+                    $items = array();
+                    // Check plugin installed
+                    $arrPluginInstalled = $this->pluginRepository->findAll();
+                    // update_status 1 : not install 、2 : Installed、 3 : Update、4 : paid purchase
+                    foreach ($data['item'] as $item) {
+                        // Not install
+                        $item['update_status'] = 1;
+                        /** @var Plugin $plugin */
+                        foreach ($arrPluginInstalled as $plugin) {
+                            if ($plugin->getSource() == $item['product_id']) {
+                                // Need update
+                                $item['update_status'] = 3;
+                                if ($plugin->getVersion() == $item['version']) {
+                                    // Installed
+                                    $item['update_status'] = 2;
+                                }
+                            }
+                        }
+                        $items[] = $item;
+                    }
+
+                    // EC-CUBE version check
+                    foreach ($items as &$item) {
+                        // Not applicable version
+                        $item['version_check'] = 0;
+                        if (in_array(Constant::VERSION, $item['eccube_version'])) {
+                            // Match version
+                            $item['version_check'] = 1;
+                        }
+                        if ($item['price'] != '0' && $item['purchased'] == '0') {
+                            // Not purchased with paid items
+                            $item['update_status'] = 4;
+                        }
+                    }
+                    unset($item);
+
+                    // Promotion item
+                    $i = 0;
+                    foreach ($items as $item) {
+                        if ($item['promotion'] == 1) {
+                            $promotionItems[] = $item;
+                            unset($items[$i]);
+                        }
+                        $i++;
+                    }
+                } else {
+                    $message = $data['error_code'].' : '.$data['error_message'];
+                }
+            } else {
+                $success = 0;
+                $message = "EC-CUBEオーナーズストアにエラーが発生しています。";
+            }
+        }
+
+        return [
+            'success' => $success,
+            'items' => $items,
+            'promotionItems' => $promotionItems,
+            'message' => $message,
+        ];
+    }
+
+    /**
+     * API request processing
+     * TODO: need change when has real server (url)
+     *
+     * @param string  $url
+     * @param Application $app
+     * @return array
+     */
+    private function getRequestApi($url, $app)
+    {
+        $curl = curl_init($url);
+
+        // Option array
+        $options = array(
+            // HEADER
+            CURLOPT_HTTPGET => true,
+            CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FAILONERROR => true,
+            CURLOPT_CAINFO => \Composer\CaBundle\CaBundle::getSystemCaRootBundlePath(),
+        );
+
+        // Set option value
+        curl_setopt_array($curl, $options);
+        $result = curl_exec($curl);
+        $info = curl_getinfo($curl);
+        $message = curl_error($curl);
+        $info['message'] = $message;
+        curl_close($curl);
+
+        $app->log('http get_info', $info);
+
+        return array($result, $info);
+    }
+
+    /**
+     * Get message
+     *
+     * @param $info
+     * @return string
+     */
+    private function getResponseErrorMessage($info)
+    {
+        if (!empty($info)) {
+            $statusCode = $info['http_code'];
+            $message = $info['message'];
+
+            $message = $statusCode.' : '.$message;
+        } else {
+            $message = "タイムアウトエラーまたはURLの指定に誤りがあります。";
+        }
+
+        return $message;
+    }
+}

--- a/app/Acme/Controller/Admin/Store/OwnerStoreController.php
+++ b/app/Acme/Controller/Admin/Store/OwnerStoreController.php
@@ -70,7 +70,6 @@ class OwnerStoreController extends AbstractController
         $promotionItems = array();
         $message = '';
         // Owner's store communication
-        // TODO: need change real server
         $url = $this->appConfig['owners_store_url'].'?method=list';
         list($json, $info) = $this->getRequestApi($url, $app);
         if ($json === false) {
@@ -144,7 +143,6 @@ class OwnerStoreController extends AbstractController
 
     /**
      * API request processing
-     * TODO: need change when has real server (url)
      *
      * @param string  $url
      * @param Application $app

--- a/src/Eccube/Resource/config/constant.php
+++ b/src/Eccube/Resource/config/constant.php
@@ -253,7 +253,7 @@
   'csv_import_delimiter' => ',',
   'csv_import_enclosure' => '"',
   'csv_import_escape' => '\\',
-  'owners_store_url' => 'https://www.ec-cube.net/upgrade/api/index.php',
+  'owners_store_url' => 'http://dev-package-repo.ec-cube.net/api/packages.json',
   'name_len' => 16,
   'kana_len' => 25,
   'address1_len' => 32,

--- a/src/Eccube/Resource/config/constant.php
+++ b/src/Eccube/Resource/config/constant.php
@@ -253,7 +253,7 @@
   'csv_import_delimiter' => ',',
   'csv_import_enclosure' => '"',
   'csv_import_escape' => '\\',
-  'owners_store_url' => 'http://dev-package-repo.ec-cube.net/api/packages.json',
+  'owners_store_url' => 'https://www.ec-cube.net/upgrade/api/index.php',
   'name_len' => 16,
   'kana_len' => 25,
   'address1_len' => 32,

--- a/src/Eccube/Resource/config/nav.php
+++ b/src/Eccube/Resource/config/nav.php
@@ -1,287 +1,292 @@
 <?php return [
-  [
-    'id' => 'product',
-    'name' => '商品管理',
-    'has_child' => true,
-    'icon' => 'cb-tag',
-    'child' => 
     [
-      [
-        'id' => 'product_master',
-        'name' => '商品マスター',
-        'url' => 'admin_product',
-      ],
-      [
-        'id' => 'product_edit',
-        'name' => '商品登録',
-        'url' => 'admin_product_product_new',
-      ],
-      [
-        'id' => 'class_name',
-        'name' => '規格登録',
-        'url' => 'admin_product_class_name',
-      ],
-      [
-        'id' => 'class_category',
-        'name' => 'カテゴリ登録',
-        'url' => 'admin_product_category',
-      ],
-      [
-        'id' => 'product_csv_import',
-        'name' => '商品CSV登録',
-        'url' => 'admin_product_csv_import',
-      ],
-      [
-        'id' => 'category_csv_import',
-        'name' => 'カテゴリCSV登録',
-        'url' => 'admin_product_category_csv_import',
-      ],
-    ],
-  ],
-  [
-    'id' => 'order',
-    'name' => '受注管理',
-    'has_child' => true,
-    'icon' => 'cb-shopping-cart',
-    'child' => 
-    [
-      [
-        'id' => 'order_master',
-        'name' => '受注マスター',
-        'url' => 'admin_order',
-      ],
-      [
-        'id' => 'order_edit',
-        'name' => '受注登録',
-        'url' => 'admin_order_new',
-      ],
-    ],
-  ],
-  [
-    'id' => 'shipping',
-    'name' => '出荷管理',
-    'has_child' => true,
-    'icon' => 'cb-shopping-cart',
-    'child' => 
-    [
-      [
-        'id' => 'shipping_master',
-        'name' => '出荷マスター',
-        'url' => 'admin/shipping',
-      ],
-      [
-        'id' => 'shipping_edit',
-        'name' => '出荷登録',
-        'url' => 'admin/shipping/new',
-      ],
-    ],
-  ],
-  [
-    'id' => 'customer',
-    'name' => '会員管理',
-    'has_child' => true,
-    'icon' => 'cb-users',
-    'child' => 
-    [
-      [
-        'id' => 'customer_master',
-        'name' => '会員マスター',
-        'url' => 'admin_customer',
-      ],
-      [
-        'id' => 'customer_edit',
-        'name' => '会員登録',
-        'url' => 'admin_customer_new',
-      ],
-    ],
-  ],
-  [
-    'id' => 'content',
-    'name' => 'コンテンツ管理',
-    'has_child' => true,
-    'icon' => 'cb-file-text',
-    'child' => 
-    [
-      [
-        'id' => 'news',
-        'name' => '新着情報管理',
-        'url' => 'admin_content_news',
-      ],
-      [
-        'id' => 'file',
-        'name' => 'ファイル管理',
-        'url' => 'admin_content_file',
-      ],
-      [
-        'id' => 'layout',
-        'name' => 'レイアウト管理',
-        'url' => 'admin_content_layout',
-      ],
-      [
-        'id' => 'page',
-        'name' => 'ページ管理',
-        'url' => 'admin_content_page',
-      ],
-      [
-        'id' => 'block',
-        'name' => 'ブロック管理',
-        'url' => 'admin_content_block',
-      ],
-      [
-        'id' => 'cache',
-        'name' => 'キャッシュ管理',
-        'url' => 'admin_content_cache',
-      ],
-    ],
-  ],
-  [
-    'id' => 'setting',
-    'name' => '設定',
-    'has_child' => true,
-    'icon' => 'cb-cog',
-    'child' => 
-    [
-      [
-        'id' => 'shop',
-        'name' => '基本情報設定',
+        'id' => 'product',
+        'name' => '商品管理',
         'has_child' => true,
-        'child' => 
-        [
-          [
-            'id' => 'shop_index',
-            'name' => 'ショップマスター',
-            'url' => 'admin_setting_shop',
-          ],
-          [
-            'id' => 'tradelaw',
-            'name' => '特定商取引法',
-            'url' => 'admin_setting_shop_tradelaw',
-          ],
-          [
-            'id' => 'customer_agreement',
-            'name' => '利用規約設定',
-            'url' => 'admin_setting_shop_customer_agreement',
-          ],
-          [
-            'id' => 'shop_payment',
-            'name' => '支払方法設定',
-            'url' => 'admin_setting_shop_payment',
-          ],
-          [
-            'id' => 'shop_delivery',
-            'name' => '配送方法設定',
-            'url' => 'admin_setting_shop_delivery',
-          ],
-          [
-            'id' => 'shop_tax',
-            'name' => '税率設定',
-            'url' => 'admin_setting_shop_tax',
-          ],
-          [
-            'id' => 'shop_mail',
-            'name' => 'メール設定',
-            'url' => 'admin_setting_shop_mail',
-          ],
-          [
-            'id' => 'shop_csv',
-            'name' => 'CSV出力項目設定',
-            'url' => 'admin_setting_shop_csv',
-          ],
-        ],
-      ],
-      [
-        'id' => 'system',
-        'name' => 'システム情報設定',
-        'has_child' => true,
-        'child' => 
-        [
-          [
-            'id' => 'system_index',
-            'name' => 'システム情報',
-            'url' => 'admin_setting_system_system',
-          ],
-          [
-            'id' => 'member',
-            'name' => 'メンバー管理',
-            'url' => 'admin_setting_system_member',
-          ],
-          [
-            'id' => 'authority',
-            'name' => '権限管理',
-            'url' => 'admin_setting_system_authority',
-          ],
-          [
-            'id' => 'security',
-            'name' => 'セキュリティ管理',
-            'url' => 'admin_setting_system_security',
-          ],
-          [
-            'id' => 'log',
-            'name' => 'EC-CUBE ログ表示',
-            'url' => 'admin_setting_system_log',
-          ],
-          [
-            'id' => 'masterdata',
-            'name' => 'マスターデータ管理',
-            'url' => 'admin_setting_system_masterdata',
-          ],
-        ],
-      ],
+        'icon' => 'cb-tag',
+        'child' =>
+            [
+                [
+                    'id' => 'product_master',
+                    'name' => '商品マスター',
+                    'url' => 'admin_product',
+                ],
+                [
+                    'id' => 'product_edit',
+                    'name' => '商品登録',
+                    'url' => 'admin_product_product_new',
+                ],
+                [
+                    'id' => 'class_name',
+                    'name' => '規格登録',
+                    'url' => 'admin_product_class_name',
+                ],
+                [
+                    'id' => 'class_category',
+                    'name' => 'カテゴリ登録',
+                    'url' => 'admin_product_category',
+                ],
+                [
+                    'id' => 'product_csv_import',
+                    'name' => '商品CSV登録',
+                    'url' => 'admin_product_csv_import',
+                ],
+                [
+                    'id' => 'category_csv_import',
+                    'name' => 'カテゴリCSV登録',
+                    'url' => 'admin_product_category_csv_import',
+                ],
+            ],
     ],
-  ],
-  [
-    'id' => 'store',
-    'name' => 'オーナーズストア',
-    'has_child' => true,
-    'icon' => 'cb-info-circle',
-    'child' => 
     [
-      [
-        'id' => 'plugin',
-        'name' => 'プラグイン',
+        'id' => 'order',
+        'name' => '受注管理',
         'has_child' => true,
-        'child' => 
-        [
-          [
-            'id' => 'plugin_list',
-            'name' => 'プラグイン一覧',
-            'url' => 'admin_store_plugin',
-          ],
-          [
-            'id' => 'plugin_owners_install',
-            'name' => '購入済プラグイン',
-            'url' => 'admin_store_plugin_owners_install',
-          ],
-          [
-            'id' => 'plugin_handler',
-            'name' => '高度な設定',
-            'url' => 'admin_store_plugin_handler',
-          ],
-        ],
-      ],
-      [
-        'id' => 'template',
-        'name' => 'テンプレート',
-        'has_child' => true,
-        'child' => 
-        [
-          [
-            'id' => 'template_list',
-            'name' => 'テンプレート一覧',
-            'url' => 'admin_store_template',
-          ],
-          [
-            'id' => 'template_install',
-            'name' => 'アップロード',
-            'url' => 'admin_store_template_install',
-          ],
-        ],
-      ],
-      [
-        'id' => 'authentication_setting',
-        'name' => '認証キー設定',
-        'url' => 'admin_store_authentication_setting',
-      ],
+        'icon' => 'cb-shopping-cart',
+        'child' =>
+            [
+                [
+                    'id' => 'order_master',
+                    'name' => '受注マスター',
+                    'url' => 'admin_order',
+                ],
+                [
+                    'id' => 'order_edit',
+                    'name' => '受注登録',
+                    'url' => 'admin_order_new',
+                ],
+            ],
     ],
-  ],
+    [
+        'id' => 'shipping',
+        'name' => '出荷管理',
+        'has_child' => true,
+        'icon' => 'cb-shopping-cart',
+        'child' =>
+            [
+                [
+                    'id' => 'shipping_master',
+                    'name' => '出荷マスター',
+                    'url' => 'admin/shipping',
+                ],
+                [
+                    'id' => 'shipping_edit',
+                    'name' => '出荷登録',
+                    'url' => 'admin/shipping/new',
+                ],
+            ],
+    ],
+    [
+        'id' => 'customer',
+        'name' => '会員管理',
+        'has_child' => true,
+        'icon' => 'cb-users',
+        'child' =>
+            [
+                [
+                    'id' => 'customer_master',
+                    'name' => '会員マスター',
+                    'url' => 'admin_customer',
+                ],
+                [
+                    'id' => 'customer_edit',
+                    'name' => '会員登録',
+                    'url' => 'admin_customer_new',
+                ],
+            ],
+    ],
+    [
+        'id' => 'content',
+        'name' => 'コンテンツ管理',
+        'has_child' => true,
+        'icon' => 'cb-file-text',
+        'child' =>
+            [
+                [
+                    'id' => 'news',
+                    'name' => '新着情報管理',
+                    'url' => 'admin_content_news',
+                ],
+                [
+                    'id' => 'file',
+                    'name' => 'ファイル管理',
+                    'url' => 'admin_content_file',
+                ],
+                [
+                    'id' => 'layout',
+                    'name' => 'レイアウト管理',
+                    'url' => 'admin_content_layout',
+                ],
+                [
+                    'id' => 'page',
+                    'name' => 'ページ管理',
+                    'url' => 'admin_content_page',
+                ],
+                [
+                    'id' => 'block',
+                    'name' => 'ブロック管理',
+                    'url' => 'admin_content_block',
+                ],
+                [
+                    'id' => 'cache',
+                    'name' => 'キャッシュ管理',
+                    'url' => 'admin_content_cache',
+                ],
+            ],
+    ],
+    [
+        'id' => 'setting',
+        'name' => '設定',
+        'has_child' => true,
+        'icon' => 'cb-cog',
+        'child' =>
+            [
+                [
+                    'id' => 'shop',
+                    'name' => '基本情報設定',
+                    'has_child' => true,
+                    'child' =>
+                        [
+                            [
+                                'id' => 'shop_index',
+                                'name' => 'ショップマスター',
+                                'url' => 'admin_setting_shop',
+                            ],
+                            [
+                                'id' => 'tradelaw',
+                                'name' => '特定商取引法',
+                                'url' => 'admin_setting_shop_tradelaw',
+                            ],
+                            [
+                                'id' => 'customer_agreement',
+                                'name' => '利用規約設定',
+                                'url' => 'admin_setting_shop_customer_agreement',
+                            ],
+                            [
+                                'id' => 'shop_payment',
+                                'name' => '支払方法設定',
+                                'url' => 'admin_setting_shop_payment',
+                            ],
+                            [
+                                'id' => 'shop_delivery',
+                                'name' => '配送方法設定',
+                                'url' => 'admin_setting_shop_delivery',
+                            ],
+                            [
+                                'id' => 'shop_tax',
+                                'name' => '税率設定',
+                                'url' => 'admin_setting_shop_tax',
+                            ],
+                            [
+                                'id' => 'shop_mail',
+                                'name' => 'メール設定',
+                                'url' => 'admin_setting_shop_mail',
+                            ],
+                            [
+                                'id' => 'shop_csv',
+                                'name' => 'CSV出力項目設定',
+                                'url' => 'admin_setting_shop_csv',
+                            ],
+                        ],
+                ],
+                [
+                    'id' => 'system',
+                    'name' => 'システム情報設定',
+                    'has_child' => true,
+                    'child' =>
+                        [
+                            [
+                                'id' => 'system_index',
+                                'name' => 'システム情報',
+                                'url' => 'admin_setting_system_system',
+                            ],
+                            [
+                                'id' => 'member',
+                                'name' => 'メンバー管理',
+                                'url' => 'admin_setting_system_member',
+                            ],
+                            [
+                                'id' => 'authority',
+                                'name' => '権限管理',
+                                'url' => 'admin_setting_system_authority',
+                            ],
+                            [
+                                'id' => 'security',
+                                'name' => 'セキュリティ管理',
+                                'url' => 'admin_setting_system_security',
+                            ],
+                            [
+                                'id' => 'log',
+                                'name' => 'EC-CUBE ログ表示',
+                                'url' => 'admin_setting_system_log',
+                            ],
+                            [
+                                'id' => 'masterdata',
+                                'name' => 'マスターデータ管理',
+                                'url' => 'admin_setting_system_masterdata',
+                            ],
+                        ],
+                ],
+            ],
+    ],
+    [
+        'id' => 'store',
+        'name' => 'オーナーズストア',
+        'has_child' => true,
+        'icon' => 'cb-info-circle',
+        'child' =>
+            [
+                [
+                    'id' => 'plugin',
+                    'name' => 'プラグイン',
+                    'has_child' => true,
+                    'child' =>
+                        [
+                            [
+                                'id' => 'plugin_list',
+                                'name' => 'プラグイン一覧',
+                                'url' => 'admin_store_plugin',
+                            ],
+//          [
+//            'id' => 'plugin_owners_install',
+//            'name' => '購入済プラグイン',
+//            'url' => 'admin_store_plugin_owners_install',
+//          ],
+                            [
+                                'id' => 'plugin_search',
+                                'name' => 'プラグインを探す',
+                                'url' => 'admin_store_plugin_owners_search',
+                            ],
+                            [
+                                'id' => 'plugin_handler',
+                                'name' => '高度な設定',
+                                'url' => 'admin_store_plugin_handler',
+                            ],
+                        ],
+                ],
+                [
+                    'id' => 'template',
+                    'name' => 'テンプレート',
+                    'has_child' => true,
+                    'child' =>
+                        [
+                            [
+                                'id' => 'template_list',
+                                'name' => 'テンプレート一覧',
+                                'url' => 'admin_store_template',
+                            ],
+                            [
+                                'id' => 'template_install',
+                                'name' => 'アップロード',
+                                'url' => 'admin_store_template_install',
+                            ],
+                        ],
+                ],
+                [
+                    'id' => 'authentication_setting',
+                    'name' => '認証キー設定',
+                    'url' => 'admin_store_authentication_setting',
+                ],
+            ],
+    ],
 ];

--- a/src/Eccube/Resource/template/admin/Store/plugin.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin.twig
@@ -28,21 +28,21 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% block sub_title %}プラグイン一覧{% endblock %}
 
 {% block javascript %}
-<script>
-    function changeActionSubmit(action, form_name) {
-        document.forms[form_name].action = action;
-        document.forms[form_name].submit();
-        return false;
-    }
-    $(function(){
-        $('#readmeModal').on('show.bs.modal', function(event) {
-            var target = $(event.relatedTarget);
-            var modal = $(this)
-            modal.find('#readmeModalLabel').text(target.data('name'));
-            modal.find('#readmeContent').html(target.data('readme'));
+    <script>
+        function changeActionSubmit(action, form_name) {
+            document.forms[form_name].action = action;
+            document.forms[form_name].submit();
+            return false;
+        }
+        $(function(){
+            $('#readmeModal').on('show.bs.modal', function(event) {
+                var target = $(event.relatedTarget);
+                var modal = $(this)
+                modal.find('#readmeModalLabel').text(target.data('name'));
+                modal.find('#readmeContent').html(target.data('readme'));
+            });
         });
-    });
-</script>
+    </script>
 {% endblock javascript %}
 
 {% block main %}
@@ -50,7 +50,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         <div class="col-md-12">
             <div class="box">
                 <div class="box-header">
-                    <a href="{{ url('admin_store_plugin_owners_install') }}" class="btn btn-info btn-xs pull-right">プラグインの新規追加はこちら</a>
+                    <a href="{{ url('admin_store_plugin_owners_search') }}" class="btn btn-info btn-xs pull-right">プラグインの新規追加はこちら</a>
                     <h3 class="box-title">オーナーズストアプラグイン</h3>
                 </div><!-- /.box-header -->
                 <div class="box-body">
@@ -68,32 +68,32 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 </div><!-- /.box-body -->
             </div><!-- /.box -->
             {% if unregisterdPlugins is not empty %}
-            <div class="box">
-                <div class="box-header">
-                    <h3 class="box-title">未登録プラグイン</h3>
-                </div><!-- /.box-header -->
-                <div class="box-body">
-                    {{ include('Store/unregisterd_plugin_table.twig', {'Plugins': unregisterdPlugins}) }}
-                </div><!-- /.box-body -->
-            </div><!-- /.box -->
+                <div class="box">
+                    <div class="box-header">
+                        <h3 class="box-title">未登録プラグイン</h3>
+                    </div><!-- /.box-header -->
+                    <div class="box-body">
+                        {{ include('Store/unregisterd_plugin_table.twig', {'Plugins': unregisterdPlugins}) }}
+                    </div><!-- /.box-body -->
+                </div><!-- /.box -->
             {% endif %}
         </div><!-- /.col -->
     </div>
 {% endblock %}
 {% block modal %}
-<div class="modal fade" id="readmeModal" tabindex="-1" role="dialog" aria-labelledby="readmeModalLabel" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><svg class="cb cb-close" aria-hidden="true"><use xlink:href="#cb-close"></svg></button>
-                <h4 class="modal-title" id="readmeModalLabel">{# プラグイン名 #}</h4>
-            </div>
-            <div class="modal-body">
-                <div class="form-group" id="readmeContent">
-                    {# README #}
+    <div class="modal fade" id="readmeModal" tabindex="-1" role="dialog" aria-labelledby="readmeModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><svg class="cb cb-close" aria-hidden="true"><use xlink:href="#cb-close"></svg></button>
+                    <h4 class="modal-title" id="readmeModalLabel">{# プラグイン名 #}</h4>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group" id="readmeContent">
+                        {# README #}
+                    </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
 {% endblock %}

--- a/src/Eccube/Resource/template/admin/Store/plugin_owners_search.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_owners_search.twig
@@ -1,0 +1,75 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% set version_check = item.version_check  %}
+<div class="plugin-panel {% if version_check == 0 %}plugin-panel-not{% endif %} {% if item.promotion == 1 %}plugin-panel-pr{% endif %}">
+    {% if item.promotion == 1 %}
+        <p class="text-center text-primary">
+            <span class="glyphicon glyphicon-star"></span> <strong>おすすめ追加機能</strong> <span class="glyphicon glyphicon-star"></span>
+        </p>
+    {% endif %}
+    <div class="plugin-logo">
+        <a href="{{ item.product_url }}" target="_blank"><img class="img-rounded" src="{{ item.product_image_url }}"></a>
+    </div>
+    <div class="plugin-content-top">
+        <div class="plugin-title">
+            <span class="pull-right">
+                {% if item.update_status == 2 %}
+                    <h4><span class="label label-success">インストール済</span></h4>
+                {% elseif item.update_status == 3 %}
+                    <a class="btn btn-default btn-xs" href="{{ url('admin_store_plugin_upgrade', {'action': 'update', 'id': item.product_id, 'version': item.version}) }}">今すぐ更新</a>
+                {% elseif item.update_status == 4 %}
+                    <a class="btn btn-success btn-xs" href="{{ item.product_url }}" target="_blank">今すぐ購入</a>
+                {% else %}
+                    <a class="btn btn-warning btn-xs" href="{{ url('admin_store_plugin_upgrade', {'action': 'install', 'id': item.product_id, 'version': item.version}) }}">今すぐインストール</a>
+                {% endif %}
+            </span>
+            <a class="plugin-name" href="{{ item.product_url }}" target="_blank">{{ item.name }}</a>
+        </div>
+        <div class="plugin-description">
+            {{ item.summary }}
+        </div>
+        <div class="plugin-description">
+            {% if item.promotion == 1 %}
+                {{ item.description|ellipsis(500) }}
+            {% else %}
+                {{ item.description|ellipsis(400) }}
+            {% endif %}
+        </div>
+    </div>
+    <div class="clearfix"></div>
+    <div class="plugin-content-bottom">
+        <dl class="plugin-meta dl-horizontal">
+            <dt class="plugin-dowload">DL数</dt><dd>{{ item.download_number }}</dd>
+            <dt class="plugin-version">プラグインバージョン</dt><dd>{{ item.version }}</dd>
+            <dt class="plugin-update">更新日</dt><dd>{{ item.last_update_date|time_ago }}</dd>
+            <dt class="plugin-eccubeversion">EC-CUBE対応バージョン</dt><dd>{% for version in item.eccube_version %}{{ version }} {%- if loop.last == false%}, {% endif -%}{% endfor %}</dd>
+            <dt class="plugin-size">ファイルサイズ</dt><dd>約 {{ (item.file_size / 1024)|round(0, 'ceil')|number_format }} KB</dd>
+            <dt class="plugin-licence">ライセンス</dt><dd>{{ item.licence}}</dd>
+        </dl>
+        {% if version_check == 0 %}
+            <p class="text-danger">このプラグインはEC-CUBE {{ constant('Eccube\\Common\\Constant::VERSION') }}をサポートしていないため、正常に動作しない可能性があります。</p>
+        {% endif %}
+        <p class="plugin-developer">
+            <strong>提供元</strong> : {% if item.developer_url is not null %}<a href="{{ item.developer_url }}" target="_blank">{{ item.developer }}</a>{% else %}{{ item.developer }}{% endif %}
+        </p>
+    </div>
+</div>

--- a/src/Eccube/Resource/template/admin/Store/plugin_owners_search.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_owners_search.twig
@@ -60,7 +60,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         <dl class="plugin-meta dl-horizontal">
             <dt class="plugin-dowload">DL数</dt><dd>{{ item.download_number }}</dd>
             <dt class="plugin-version">プラグインバージョン</dt><dd>{{ item.version }}</dd>
-            <dt class="plugin-update">更新日</dt><dd>{{ item.last_update_date|time_ago }}</dd>
+            <dt class="plugin-update">最終更新日</dt><dd>{{ item.last_update_date|time_ago }}</dd>
             <dt class="plugin-eccubeversion">EC-CUBE対応バージョン</dt><dd>{% for version in item.eccube_version %}{{ version }} {%- if loop.last == false%}, {% endif -%}{% endfor %}</dd>
             <dt class="plugin-size">ファイルサイズ</dt><dd>約 {{ (item.file_size / 1024)|round(0, 'ceil')|number_format }} KB</dd>
             <dt class="plugin-licence">ライセンス</dt><dd>{{ item.licence}}</dd>
@@ -69,7 +69,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             <p class="text-danger">このプラグインはEC-CUBE {{ constant('Eccube\\Common\\Constant::VERSION') }}をサポートしていないため、正常に動作しない可能性があります。</p>
         {% endif %}
         <p class="plugin-developer">
-            <strong>提供元</strong> : {% if item.developer_url is not null %}<a href="{{ item.developer_url }}" target="_blank">{{ item.developer }}</a>{% else %}{{ item.developer }}{% endif %}
+            <strong>制作者</strong> : {% if item.developer_url is not null %}<a href="{{ item.developer_url }}" target="_blank">{{ item.developer }}</a>{% else %}{{ item.developer }}{% endif %}
         </p>
     </div>
 </div>

--- a/src/Eccube/Resource/template/admin/Store/plugin_owners_search.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_owners_search.twig
@@ -21,11 +21,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #}
 {% set version_check = item.version_check  %}
 <div class="plugin-panel {% if version_check == 0 %}plugin-panel-not{% endif %} {% if item.promotion == 1 %}plugin-panel-pr{% endif %}">
-    {% if item.promotion == 1 %}
-        <p class="text-center text-primary">
-            <span class="glyphicon glyphicon-star"></span> <strong>おすすめ追加機能</strong> <span class="glyphicon glyphicon-star"></span>
-        </p>
-    {% endif %}
     <div class="plugin-logo">
         <a href="{{ item.product_url }}" target="_blank"><img class="img-rounded" src="{{ item.product_image_url }}"></a>
     </div>
@@ -35,11 +30,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 {% if item.update_status == 2 %}
                     <h4><span class="label label-success">インストール済</span></h4>
                 {% elseif item.update_status == 3 %}
-                    <a class="btn btn-default btn-xs" href="{{ url('admin_store_plugin_upgrade', {'action': 'update', 'id': item.product_id, 'version': item.version}) }}">今すぐ更新</a>
+                    <a class="btn btn-default btn-xs" href="{{ url('admin_store_plugin_upgrade', {'action': 'update', 'id': item.product_id, 'version': item.version}) }}">アップデート</a>
                 {% elseif item.update_status == 4 %}
-                    <a class="btn btn-success btn-xs" href="{{ item.product_url }}" target="_blank">今すぐ購入</a>
+                    <a class="btn btn-success btn-xs" href="{{ item.product_url }}" target="_blank">購入</a>
                 {% else %}
-                    <a class="btn btn-warning btn-xs" href="{{ url('admin_store_plugin_upgrade', {'action': 'install', 'id': item.product_id, 'version': item.version}) }}">今すぐインストール</a>
+                    <a class="btn btn-warning btn-xs" href="{{ url('admin_store_plugin_upgrade', {'action': 'install', 'id': item.product_id, 'version': item.version}) }}">インストール</a>
                 {% endif %}
             </span>
             <a class="plugin-name" href="{{ item.product_url }}" target="_blank">{{ item.name }}</a>
@@ -58,12 +53,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     <div class="clearfix"></div>
     <div class="plugin-content-bottom">
         <dl class="plugin-meta dl-horizontal">
+            <dt class="plugin-price">価格</dt><dd>{{ item.price|price }}</dd>
             <dt class="plugin-dowload">DL数</dt><dd>{{ item.download_number }}</dd>
             <dt class="plugin-version">プラグインバージョン</dt><dd>{{ item.version }}</dd>
             <dt class="plugin-update">最終更新日</dt><dd>{{ item.last_update_date|time_ago }}</dd>
             <dt class="plugin-eccubeversion">EC-CUBE対応バージョン</dt><dd>{% for version in item.eccube_version %}{{ version }} {%- if loop.last == false%}, {% endif -%}{% endfor %}</dd>
             <dt class="plugin-size">ファイルサイズ</dt><dd>約 {{ (item.file_size / 1024)|round(0, 'ceil')|number_format }} KB</dd>
-            <dt class="plugin-licence">ライセンス</dt><dd>{{ item.licence}}</dd>
+            <dt class="plugin-licence">ライセンス</dt><dd>{{ item.licence }}</dd>
         </dl>
         {% if version_check == 0 %}
             <p class="text-danger">このプラグインはEC-CUBE {{ constant('Eccube\\Common\\Constant::VERSION') }}をサポートしていないため、正常に動作しない可能性があります。</p>

--- a/src/Eccube/Resource/template/admin/Store/plugin_search.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_search.twig
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% set menus = ['store', 'plugin', 'plugin_search'] %}
 
 {% block title %}オーナーズストア{% endblock %}
-{% block sub_title %}購入済プラグイン{% endblock %}
+{% block sub_title %}プラグインを探す{% endblock %}
 
 {% block javascript %}
     <script src="{{ app.config.admin_urlpath }}/assets/js/vendor/masonry.pkgd.min.js"></script>

--- a/src/Eccube/Resource/template/admin/Store/plugin_search.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_search.twig
@@ -43,7 +43,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         <div class="col-md-12">
             <div class="box">
                 <div class="box-header">
-                    <h3 class="box-title">プラグイン一覧</h3>
+                    <h3 class="box-title">検索結果</h3>
                 </div><!-- /.box-header -->
                 <div class="box-body">
                     <div class="row">

--- a/src/Eccube/Resource/template/admin/Store/plugin_search.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_search.twig
@@ -1,0 +1,78 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set menus = ['store', 'plugin', 'plugin_search'] %}
+
+{% block title %}オーナーズストア{% endblock %}
+{% block sub_title %}購入済プラグイン{% endblock %}
+
+{% block javascript %}
+    <script src="{{ app.config.admin_urlpath }}/assets/js/vendor/masonry.pkgd.min.js"></script>
+    <script>
+        $(function() {
+            $('.grid').masonry({
+                itemSelector: '.grid-item',
+                columnWidth: '.grid-item'
+            });
+        });
+    </script>
+{% endblock javascript %}
+
+{% block main %}
+    <div class="row">
+        <div class="col-md-12">
+            <div class="box">
+                <div class="box-header">
+                    <h3 class="box-title">プラグイン一覧</h3>
+                </div><!-- /.box-header -->
+                <div class="box-body">
+                    <div class="row">
+                        <div class="col-xs-12">
+                            {% if success == 1 %}
+                                <div class="plugin-block">
+                                    <div class="row">
+                                        {% for item in promotionItems %}
+                                            <div class="col-xs-12">
+                                                {{ include('Store/plugin_owners_search.twig') }}
+                                            </div>
+                                        {% endfor %}
+                                    </div><!-- .row -->
+                                    <div class="row grid">
+                                        {% for item in items %}
+                                            <div class="col-xs-12 grid-item">
+                                                {{ include('Store/plugin_owners_search.twig') }}
+                                            </div>
+                                        {% endfor %}
+                                    </div><!-- .row -->
+                                </div><!-- .plugin-block -->
+                            {% else %}
+                                <p class="text-danger">{{ message }}</p>
+                            {% endif %}
+                        </div><!-- .col-xs-12 -->
+                    </div><!-- .row -->
+                </div><!-- /.box-body -->
+            </div><!-- /.box -->
+        </div><!-- /.col -->
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- パッケージリポジトリと通信して、取得した情報が表示できる。
- 3.n管理画面で「プラグインを探す」画面が表示できる。

ただし、パッケージリポジトリは現在非公開のサーバー。
「プラグインを探す」にアクセスしてもエラーとなる。

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外し内容
  - Get list plugins from EC-CUBE package repository (current, private server)
  - Show information & status of each plugin

## 実装に関する補足(Appendix)

## テスト（Test)
+ Still not paginator
+ Still define exactly attributes of plugin
+ Keep some features of previous version

## 相談（Discussion）
+ Can not writing by Plugin, because event still not work well

