### PR TITLE
プラグイン設定の規約化

### DIFF
--- a/app/Plugin/AnnotatedRouting/Controller/AnnotatedRoutingController.php
+++ b/app/Plugin/AnnotatedRouting/Controller/AnnotatedRoutingController.php
@@ -22,6 +22,7 @@
  */
 
 namespace Plugin\AnnotatedRouting\Controller;
+use Eccube\Annotation\Component;
 use Eccube\Application;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -29,7 +30,8 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * @Route("/arc")
+ * @Component
+ * @Route(value="/arc", service=AnnotatedRoutingController::class)
  */
 class AnnotatedRoutingController
 {

--- a/app/Plugin/EntityEvent/config.yml
+++ b/app/Plugin/EntityEvent/config.yml
@@ -1,5 +1,3 @@
 name: Entityイベント拡張のサンプル
 code: EntityEvent
 version: 1.0.0
-service:
-    - EntityEventServiceProvider

--- a/app/Plugin/FormExtension/config.yml
+++ b/app/Plugin/FormExtension/config.yml
@@ -1,5 +1,3 @@
 name: FormExtensionのサンプル
 code: FormExtension
 version: 1.0.0
-service:
-    - FormExtensionServiceProvider

--- a/app/Plugin/PurchaseProcessors/config.yml
+++ b/app/Plugin/PurchaseProcessors/config.yml
@@ -1,5 +1,3 @@
 name: PurchaseFlowにProcessorを追加するサンプル
 code: PurchaseProcessors
 version: 1.0.0
-service:
-    - PurchaseProcessorsServiceProvider

--- a/app/Plugin/QueryCustomize/config.yml
+++ b/app/Plugin/QueryCustomize/config.yml
@@ -1,5 +1,3 @@
 name: クエリビルダ拡張のサンプル
 code: QueryCustomize
 version: 1.0.0
-service:
-    - QueryCustomizeServiceProvider

--- a/app/Plugin/Strategy/config.yml
+++ b/app/Plugin/Strategy/config.yml
@@ -1,5 +1,3 @@
 name: 集計Strategy拡張のサンプル
 code: Strategy
 version: 1.0.0
-service:
-    - StrategyServiceProvider

--- a/app/Plugin/TwigUserFunc/Controller/TwigUserFuncController.php
+++ b/app/Plugin/TwigUserFunc/Controller/TwigUserFuncController.php
@@ -23,17 +23,29 @@
 
 namespace Plugin\TwigUserFunc\Controller;
 
+use Eccube\Annotation\Component;
+use Eccube\Annotation\Inject;
 use Eccube\Application;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 
+/**
+ * @Component
+ * @Route(service=TwigUserFuncController::class)
+ */
 class TwigUserFuncController
 {
+    /**
+     * @Inject("twig")
+     * @var \Twig_Environment
+     */
+    protected $twig;
+
     /**
      * @Route("/twiguserfunc")
      */
     public function index(Application $app)
     {
-        return $app['twig']
+        return $this->twig
             ->createTemplate("{{ eccube_block_hello({'name':'EC-CUBE'}) }}")
             ->render([]);
     }

--- a/app/Plugin/TwigUserFunc/config.yml
+++ b/app/Plugin/TwigUserFunc/config.yml
@@ -1,5 +1,3 @@
 name: Twigユーザ定義関数のサンプル
 code: TwigUserFunc
 version: 1.0.0
-service:
-    - TwigUserFuncServiceProvider

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -645,6 +645,7 @@ class Application extends \Silex\Application
             $config = $code['config'];
             // Doctrine Extend
             if (isset($config['orm.path']) && is_array($config['orm.path'])) {
+                // orm.pathが明示されている場合
                 $paths = array();
                 foreach ($config['orm.path'] as $path) {
                     $paths[] = $this['config']['plugin_realdir'].'/'.$config['code'].$path;
@@ -660,6 +661,25 @@ class Application extends \Silex\Application
                     'path' => $paths,
                     'use_simple_annotation_reader' => false,
                 );
+            } else {
+                // orm.pathを省略しても `/Resource/doctrine` と `/Entity` ディレクトリがある場合は設定を追加する
+                $doctrineDir = $this['config']['plugin_realdir'].'/'.$config['code'].'/Resource/doctrine';
+                if (glob($doctrineDir.'/*.yml')) {
+                    $ormMappings[] = array(
+                        'type' => 'yml',
+                        'namespace' => 'Plugin\\'.$config['code'].'\\Entity',
+                        'path' => [$doctrineDir],
+                    );
+                }
+                $entityDir = $this['config']['plugin_realdir'].'/'.$config['code'].'/Entity';
+                if (file_exists($entityDir)) {
+                    $ormMappings[] = array(
+                        'type' => 'annotation',
+                        'namespace' => 'Plugin\\'.$config['code'].'\\Entity',
+                        'path' => [$entityDir],
+                        'use_simple_annotation_reader' => false,
+                    );
+                }
             }
         }
 

--- a/src/Eccube/Di/Di.php
+++ b/src/Eccube/Di/Di.php
@@ -129,9 +129,11 @@ class {{ provider_class }} implements \Pimple\ServiceProviderInterface
             );
         }
 
-        $scanDirs = array_reduce($this->scanners, function($result, Scanner $wiring) {
-            return array_merge($result, $wiring->getScanDirs());
-        }, []);
+        $scanDirs = array_filter(array_reduce($this->scanners, function($result, Scanner $scanner) {
+            return array_merge($result, $scanner->getScanDirs());
+        }, []), function($dir) {
+            return file_exists($dir);
+        });
 
         $classes = $this->findClasses($scanDirs);
 

--- a/src/Eccube/Repository/PluginRepository.php
+++ b/src/Eccube/Repository/PluginRepository.php
@@ -36,4 +36,8 @@ use Eccube\Annotation\Repository;
  */
 class PluginRepository extends AbstractRepository
 {
+    public function findAllEnabled()
+    {
+        return $this->findBy(['enable' => '1']);
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ ServiceProvider(service)の規約化
    + `config.yml`の`service`設定を省略したとき、ファイル名が`ServiceProvider.php`で終わるファイルが`app/Plugin/<プラグインコード>/ServiceProvider`ディレクトリ直下にある場合は、`ServiceProviderInterface`の実装クラスとして登録する。
+ Entity(orm.path)の規約化
    + `config.yml`の`orm.path`設定を省略したとき、`app/Plugin/<プラグインコード>/Resource/doctrine`ディレクトリまたは、`app/Plugin/<プラグインコード>/Entity`ディレクトリが存在する場合はEntityとして登録する。

## 相談（Discussion）
+ #2521 の後にマージしてください。
