### PR TITLE
Acmeをconfigで変更できるように対応

### DIFF
--- a/app/Acme/readme
+++ b/app/Acme/readme
@@ -1,0 +1,5 @@
+In the Acme directory you can place controllers, entities, repository ...etc for customization.
+To change the directory name and namespace, change the vendor_name in app/config/config.php.
+
+Acmeディレクトリには、カスタマイズ用のコントローラやエンティティ、レポジトリなどを配置できます。
+ディレクトリ名・名前空間を変更する場合は、app/config/config.phpのvendor_nameを変更してください。

--- a/app/Acme/readme
+++ b/app/Acme/readme
@@ -1,4 +1,4 @@
-In the Acme directory you can place controllers, entities, repository ...etc for customization.
+In the Acme directory you can place controllers, entities, repositories ...etc for customization.
 To change the directory name and namespace, change the vendor_name in app/config/config.php.
 
 Acmeディレクトリには、カスタマイズ用のコントローラやエンティティ、レポジトリなどを配置できます。

--- a/app/console
+++ b/app/console
@@ -1,10 +1,11 @@
 #!/usr/bin/env php
 <?php
-require_once __DIR__.'/../autoload.php';
+$loader = require_once __DIR__.'/../autoload.php';
 
 set_time_limit(0);
 
-$app = \Eccube\Application::getInstance();
+$app = \Eccube\Application::getInstance(['eccube.autoloader' => $loader]);
+
 $app->initialize();
 
 // Console

--- a/autoload.php
+++ b/autoload.php
@@ -26,10 +26,12 @@ if (extension_loaded('apc') && ini_get('apc.enabled')) {
     $apcLoader = new Symfony\Component\ClassLoader\ApcClassLoader(sha1(__FILE__), $loader);
     $apcLoader->register();
     $loader->unregister();
+    $loader = $apcLoader;
 } elseif (extension_loaded('wincache') && ini_get('wincache.fcenabled')) {
     $winCacheLoader = new Symfony\Component\ClassLoader\WinCacheClassLoader(sha1(__FILE__), $loader);
     $winCacheLoader->register();
     $loader->unregister();
+    $loader = $winCacheLoader;
 }
 
 define("RELATIVE_PUBLIC_DIR_PATH", '/html');

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,6 @@
         "psr-4": {
             "Eccube\\Entity\\": "app/proxy/entity",
             "Eccube\\": "src/Eccube",
-            "Acme\\": "app/Acme",
             "Plugin\\": "app/Plugin",
             "Dbtlr\\MigrationProvider\\Provider\\": "src/silex-doctrine-migrations"
         },

--- a/eccube_install.php
+++ b/eccube_install.php
@@ -51,7 +51,7 @@ if ($argv[2] != 'none') {
     composerInstall();
 }
 
-require __DIR__.'/autoload.php';
+$loader = require __DIR__.'/autoload.php';
 
 initializeDefaultVariables($database);
 

--- a/index.php
+++ b/index.php
@@ -22,7 +22,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-require __DIR__.'/autoload.php';
+$loader = require __DIR__.'/autoload.php';
 
 ini_set('display_errors', 'Off');
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
@@ -33,7 +33,7 @@ if (php_sapi_name() === 'cli-server' && is_file($filename)) {
     return false;
 }
 
-$app = \Eccube\Application::getInstance();
+$app = \Eccube\Application::getInstance(['eccube.autoloader' => $loader]);
 
 // インストールされてなければインストーラにリダイレクト
 if ($app['config']['eccube_install']) {

--- a/index_dev.php
+++ b/index_dev.php
@@ -42,7 +42,7 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
 
-require_once __DIR__.'/autoload.php';
+$loader = require_once __DIR__.'/autoload.php';
 
 Debug::enable();
 
@@ -52,7 +52,7 @@ if (php_sapi_name() === 'cli-server' && is_file($filename)) {
     return false;
 }
 
-$app = \Eccube\Application::getInstance();
+$app = \Eccube\Application::getInstance(['eccube.autoloader' => $loader]);
 
 // debug enable.
 $app['debug'] = true;

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -105,10 +105,12 @@ class Application extends \Silex\Application
         $this->initLogger();
 
         // init class loader.
-        $prefix = $this['config']['vendor_prefix'];
-        $path = $this['config']['root_dir'].'/app/'.$this['config']['vendor_dir'];
-        $loader = $this['eccube.autoloader'];
-        $loader->addPsr4($prefix, $path);
+        if (isset($this['eccube.autoloader'])) {
+            $prefix = $this['config']['vendor_prefix'];
+            $path = $this['config']['root_dir'].'/app/'.$this['config']['vendor_dir'];
+            $loader = $this['eccube.autoloader'];
+            $loader->addPsr4($prefix, $path);
+        }
     }
 
     /**

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -667,7 +667,7 @@ class Application extends \Silex\Application
         if (isset($this['config']['vendor_dir'])) {
             $ormMappings[] = array(
                 'type' => 'annotation',
-                'namespace' => $this['config']['vendor_prefix'].'\Entity',
+                'namespace' => $this['config']['vendor_prefix'].'Entity',
                 'path' => array(
                     $this['config']['vendor_dir'].'/Entity',
                 ),

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -284,7 +284,6 @@ class Application extends \Silex\Application
                     $this['config']['vendor_dir'].'/Controller',
                     $this['config']['root_dir'].'/src/Eccube/Controller',
                 ], $pluginSubDirs('Controller'))),
-<<<<<<< HEAD
                 new FormTypeAutoWiring(array_merge([
                     $this['config']['vendor_dir'].'/Form/Type',
                     $this['config']['root_dir'].'/src/Eccube/Form/Type'

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -281,23 +281,28 @@ class Application extends \Silex\Application
         $this->register(new DIServiceProvider(), [
             'eccube.di.wirings' => [
                 new RouteAutoWiring(array_merge([
-                    $this['config']['root_dir'].'/app/Acme/Controller',
                     $this['config']['vendor_dir'].'/Controller',
+                    $this['config']['root_dir'].'/src/Eccube/Controller',
                 ], $pluginSubDirs('Controller'))),
+<<<<<<< HEAD
                 new FormTypeAutoWiring(array_merge([
+                    $this['config']['vendor_dir'].'/Form/Type',
                     $this['config']['root_dir'].'/src/Eccube/Form/Type'
                 ], $pluginSubDirs('Form/Type'))),
                 new FormExtensionAutoWiring(array_merge([
+                    $this['config']['vendor_dir'].'/Form/Extension',
                     $this['config']['root_dir'].'/src/Eccube/Form/Extension'
                 ], $pluginSubDirs('Form/Extension'))),
                 new ServiceAutoWiring(array_merge([
+                    $this['config']['vendor_dir'].'/Service',
                     $this['config']['root_dir'].'/src/Eccube/Service'
                 ], $pluginSubDirs('Service'))),
                 new RepositoryAutoWiring(array_merge([
+                    $this['config']['vendor_dir'].'/Repository',
                     $this['config']['root_dir'].'/src/Eccube/Repository'
                 ], $pluginSubDirs('Repository'))),
                 new QueryExtensionAutoWiring(array_merge([
-                    $this['config']['root_dir'].'/src/Eccube/Repository'
+                    $this['config']['vendor_dir'].'/Repository'
                 ], $pluginSubDirs('Repository'))),
                 new EntityEventAutowiring(array_merge([
                     $this['config']['vendor_dir'].'/Entity'

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -23,6 +23,7 @@
 
 namespace Eccube;
 
+use Composer\Autoload\ClassLoader;
 use Doctrine\DBAL\Types\Type;
 use Eccube\DI\AutoWiring\EntityEventAutowiring;
 use Eccube\DI\AutoWiring\FormExtensionAutoWiring;
@@ -102,6 +103,12 @@ class Application extends \Silex\Application
 
         // init monolog
         $this->initLogger();
+
+        // init class loader.
+        $prefix = $this['config']['vendor_prefix'];
+        $path = $this['config']['root_dir'].'/app/'.$this['config']['vendor_dir'];
+        $loader = $this['eccube.autoloader'];
+        $loader->addPsr4($prefix, $path);
     }
 
     /**
@@ -251,7 +258,7 @@ class Application extends \Silex\Application
             'eccube.di.wirings' => [
                 new RouteAutoWiring(array_merge([
                     $this['config']['root_dir'].'/app/Acme/Controller',
-                    $this['config']['root_dir'].'/src/Eccube/Controller'
+                    $this['config']['root_dir'].'/app/'.$this['config']['vendor_dir'].'Controller',
                 ], $pluginSubDirs('Controller'))),
                 new FormTypeAutoWiring(array_merge([
                     $this['config']['root_dir'].'/src/Eccube/Form/Type'
@@ -269,7 +276,7 @@ class Application extends \Silex\Application
                     $this['config']['root_dir'].'/src/Eccube/Repository'
                 ], $pluginSubDirs('Repository'))),
                 new EntityEventAutowiring(array_merge([
-                    $this['config']['root_dir'].'/app/Acme/Entity'
+                    $this['config']['vendor_dir'].'/Entity'
                 ], $pluginSubDirs('Entity')))
             ],
             'eccube.di.generator.dir' => $this['config']['root_dir'].'/app/cache/provider'
@@ -320,7 +327,7 @@ class Application extends \Silex\Application
 
         $this['eccube.router.extend'] = function ($app) {
             // TODO ディレクトリ名は暫定
-            $resource = $app['config']['root_dir'].'/app/Acme/Controller';
+            $resource = $app['config']['root_dir'].'/app/'.$app['config']['vendor_dir'].'Controller';
             $cachePrefix = 'Extend';
 
             $router = $app['eccube.router']($resource, $cachePrefix);
@@ -634,9 +641,9 @@ class Application extends \Silex\Application
         // TODO namespace は暫定
         $ormMappings[] = array(
             'type' => 'annotation',
-            'namespace' => 'Acme\Entity',
+            'namespace' => $this['config']['vendor_prefix'].'Entity',
             'path' => array(
-                __DIR__.'/../../app/Acme/Entity',
+                __DIR__.'/../../app/'.$this['config']['vendor_dir'].'Entity',
             ),
             'use_simple_annotation_reader' => false,
         );

--- a/src/Eccube/Command/GenerateProxyCommand.php
+++ b/src/Eccube/Command/GenerateProxyCommand.php
@@ -52,7 +52,7 @@ class GenerateProxyCommand extends Command
         }, $app[PluginRepository::class]->findAllEnabled());
 
         $entityProxyService->generate(
-            array_merge([$app['config']['root_dir'].'/app/Acme/Entity'], $dirs),
+            array_merge([$app['config']['vendor_dir'].'/Entity'], $dirs),
             [],
             $app['config']['root_dir'].'/app/proxy/entity',
             $output

--- a/src/Eccube/Resource/config/config.php
+++ b/src/Eccube/Resource/config/config.php
@@ -12,6 +12,5 @@
     'currency' => env('CURRENCY', 'JPY'),
     'trusted_proxies_connection_only' => env('TRUSTED_PROXIES_CONNECTION_ONLY', false),
     'trusted_proxies' => env('TRUSTED_PROXIES', []),
-    'vendor_prefix' => 'Acme\\',
-    'vendor_dir' => 'Acme/',
+    'vendor_psr4' => ['Acme\\', 'Acme/']
 ];

--- a/src/Eccube/Resource/config/config.php
+++ b/src/Eccube/Resource/config/config.php
@@ -12,5 +12,5 @@
     'currency' => env('CURRENCY', 'JPY'),
     'trusted_proxies_connection_only' => env('TRUSTED_PROXIES_CONNECTION_ONLY', false),
     'trusted_proxies' => env('TRUSTED_PROXIES', []),
-    'vendor_psr4' => ['Acme\\', 'Acme/']
+    'vendor_name' => 'Acme',
 ];

--- a/src/Eccube/Resource/config/config.php
+++ b/src/Eccube/Resource/config/config.php
@@ -12,4 +12,6 @@
     'currency' => env('CURRENCY', 'JPY'),
     'trusted_proxies_connection_only' => env('TRUSTED_PROXIES_CONNECTION_ONLY', false),
     'trusted_proxies' => env('TRUSTED_PROXIES', []),
+    'vendor_prefix' => 'Acme\\',
+    'vendor_dir' => 'Acme/',
 ];

--- a/src/Eccube/Resource/functions/env.php
+++ b/src/Eccube/Resource/functions/env.php
@@ -8,10 +8,6 @@ function env($key, $default = null)
         return $default;
     }
 
-    if (is_array($value)) {
-        return $value;
-    }
-
     switch (strtolower($value))
     {
         case 'true':
@@ -26,7 +22,7 @@ function env($key, $default = null)
         return $value;
     }
 
-    $decoded = json_decode($value);
+    $decoded = json_decode($value, true);
     if ($decoded !== null) {
         return $decoded;
     }

--- a/tests/Eccube/Tests/Application/MonologTraitTest.php
+++ b/tests/Eccube/Tests/Application/MonologTraitTest.php
@@ -36,7 +36,7 @@ class MonologTraitTest extends \PHPUnit_Framework_TestCase
 
     public function createApplication()
     {
-        $app = new \Eccube\Application();
+        $app = new \Eccube\Application(['eccube.autoloader' => $GLOBALS['eccube.autoloader']]);
         $app->register(new MonologServiceProvider(), array(
             'monolog.handler' => function () use ($app) {
                 return new TestHandler($app['monolog.level']);

--- a/tests/Eccube/Tests/Application/SecurityTraitTest.php
+++ b/tests/Eccube/Tests/Application/SecurityTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Eccube\Tests\Application;
 
+use Eccube\Application;
 use Eccube\Tests\EccubeTestCase;
 use Silex\Provider\SecurityServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -83,7 +84,9 @@ class SecurityTraitTest extends EccubeTestCase
 
     public function createApplication($users = array())
     {
-        $app = \Eccube\Application::getInstance();
+        $app = Application::getInstance([
+            'eccube.autoloader' => $GLOBALS['eccube.autoloader']
+        ]);
         $app['debug'] = true;
         if (!$app->offsetExists('config')) {
             // ログの内容をERRORレベルでしか出力しないように設定を上書き

--- a/tests/Eccube/Tests/Command/AbstractCommandTest.php
+++ b/tests/Eccube/Tests/Command/AbstractCommandTest.php
@@ -143,7 +143,9 @@ abstract class AbstractCommandTest extends EccubeTestCase
 
     public function createApplication()
     {
-        $app = Application::getInstance();
+        $app = Application::getInstance([
+            'eccube.autoloader' => $GLOBALS['eccube.autoloader']
+        ]);
         $app['debug'] = true;
         $app->initialize();
         // Console

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -6,12 +6,10 @@ use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Migration;
 use Eccube\Application;
 use Eccube\Entity\Customer;
-use Eccube\Util\Cache;
 use Faker\Factory as Faker;
 use GuzzleHttp\Client;
 use Silex\WebTestCase;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Abstract class that other unit tests can extend, provides generic methods for EC-CUBE tests.
@@ -297,7 +295,9 @@ abstract class EccubeTestCase extends WebTestCase
     public function createApplication()
     {
         Application::clearInstance();
-        $app = Application::getInstance();
+        $app = Application::getInstance([
+            'eccube.autoloader' => $GLOBALS['eccube.autoloader']
+        ]);
         $app['debug'] = true;
 
         $app->initialize();

--- a/tests/Eccube/Tests/Functions/EnvFunctionTest.php
+++ b/tests/Eccube/Tests/Functions/EnvFunctionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Eccube\Tests\Functions;
+
+class EnvFunctionTest extends \PHPUnit\Framework\TestCase
+{
+    public function testEnv()
+    {
+        self::assertNull(env('ECCUBE_ENV_TEST'));
+
+        putenv('ECCUBE_ENV_TEST=');
+        self::assertSame('', env('ECCUBE_ENV_TEST'));
+
+        putenv('ECCUBE_ENV_TEST=true');
+        self::assertTrue(env('ECCUBE_ENV_TEST'));
+
+        putenv('ECCUBE_ENV_TEST=false');
+        self::assertFalse(env('ECCUBE_ENV_TEST'));
+
+        putenv('ECCUBE_ENV_TEST=[]');
+        self::assertSame([], env('ECCUBE_ENV_TEST'));
+
+        putenv('ECCUBE_ENV_TEST=[1]');
+        self::assertSame([1], env('ECCUBE_ENV_TEST'));
+
+        putenv('ECCUBE_ENV_TEST=[1,2,3]');
+        self::assertSame([1,2,3], env('ECCUBE_ENV_TEST'));
+
+        putenv('ECCUBE_ENV_TEST={}');
+        self::assertSame([], env('ECCUBE_ENV_TEST'));
+
+        putenv('ECCUBE_ENV_TEST={"aaa":"bbb"}');
+        self::assertSame(['aaa' => 'bbb'], env('ECCUBE_ENV_TEST'));
+
+        putenv('ECCUBE_ENV_TEST={"aaa":"bbb", "ccc":"ddd"}');
+        self::assertSame(['aaa' => 'bbb', 'ccc' => 'ddd'], env('ECCUBE_ENV_TEST'));
+    }
+}

--- a/tests/Eccube/Tests/Transaction/TransactionListenerTest.php
+++ b/tests/Eccube/Tests/Transaction/TransactionListenerTest.php
@@ -265,7 +265,9 @@ class TransactionListenerTest extends WebTestCase
      */
     public function createApplication()
     {
-        $app = Application::getInstance();
+        $app = Application::getInstance([
+            'eccube.autoloader' => $GLOBALS['eccube.autoloader']
+        ]);
         $app['debug'] = true;
 
         // ログの内容をERRORレベルでしか出力しないように設定を上書き

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,6 +23,9 @@
 
 $loader = require __DIR__ . '/../autoload.php';
 $loader->add('Eccube\Tests', __DIR__);
+
+$GLOBALS['eccube.autoloader'] = $loader;
+
 if (file_exists(sys_get_temp_dir().'/migrations.sql')) {
     unlink(sys_get_temp_dir().'/migrations.sql');
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Acmeをconfigで変更できるように修正

## 方針(Policy)

app/config/eccube/config.phpの`vender_name`で任意のディレクトリ名を指定できます。

```php
# app/config/eccube/config.php

<?php return [
    ...
    'vendor_name' => 'Lockon'
]
```
上記のように設定した場合、 `app/Lockon`以下に各クラスを配置することができます
コントローラやエンティティを配置する場合は以下のようなコードになります。

```php
# app/Lockon/Controller/HogeController.php

namespace Lockon\Controller;

class HogeController {
...
}

# app/Lockon/Entity/Maker.php

namespace Lockon\Entity;

class Maker extends AbstractEntity {
...
} 

```

## テスト（Test)

- Travisにパスすることを確認

## その他

- Acme\Controller\Admin\Store\OwnerStoreControllerで定義しているルーティング(admin_store_plugin_owners_search)が, nav.phpで参照されているため、現状では変更すると落ちます
- 試す場合は、nav.phpの参照箇所( https://github.com/EC-CUBE/ec-cube/blob/experimental/3.1/src/Eccube/Resource/config/nav.php#L258 )をコメントアウトしてください
