### PR TITLE
ForwardOnlyListenerの修正

### DIFF
--- a/src/Eccube/Annotation/ForwardOnly.php
+++ b/src/Eccube/Annotation/ForwardOnly.php
@@ -4,16 +4,32 @@ namespace Eccube\Annotation;
 
 use Doctrine\Common\Annotations\Annotation\Target;
 use Doctrine\ORM\Mapping\Annotation;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
 
 
 /**
  * @Annotation
  * @Target("METHOD")
  */
-final class ForwardOnly implements Annotation
+final class ForwardOnly implements ConfigurationInterface
 {
     /**
-     * @var string
+     * Returns the alias name for an annotated configuration.
+     *
+     * @return string
      */
-    public $value;
+    public function getAliasName()
+    {
+        return 'forward_only';
+    }
+
+    /**
+     * Returns whether multiple annotations of this type are allowed.
+     *
+     * @return bool
+     */
+    public function allowArray()
+    {
+        return false;
+    }
 }

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -273,7 +273,7 @@ class EccubeServiceProvider implements ServiceProviderInterface, EventListenerPr
         // Add event subscriber to TaxRuleEvent
         $app['orm.em']->getEventManager()->addEventSubscriber(new \Eccube\Doctrine\EventSubscriber\TaxRuleEventSubscriber($app[TaxRuleService::class]));
 
-        $dispatcher->addSubscriber(new ForwardOnlyListener($app));
+        $dispatcher->addSubscriber(new ForwardOnlyListener());
         $dispatcher->addSubscriber(new TransactionListener($app));
     }
 }

--- a/tests/Eccube/Tests/EventListener/ForwardOnlyListenerTest.php
+++ b/tests/Eccube/Tests/EventListener/ForwardOnlyListenerTest.php
@@ -13,7 +13,7 @@ class ForwardOnlyListenerTest extends AbstractWebTestCase
             $this->client->request('GET', $this->app->url("shopping_check_to_cart"));
             self::fail();
         } catch (\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException $e) {
-            self::assertEquals('Eccube\Controller\ShoppingController::checkToCart is Forward Only', $e->getMessage());
+            self::assertEquals('Eccube\Controller\ShoppingController:checkToCart is Forward Only', $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- /admin にアクセスした際に動作しない不具合の修正
  - $event->getController()はクロージャを返す場合もあるため
- `@ForwardOnly` を`Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface` の実装に変更
  - ConfigurationInterfaceの実装にしておくと、アノテーションを解析して`$request->attributes`にセットしてくれるようです
  - https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/EventListener/ControllerListener.php
