### PR TITLE
`__toString()`メソッドがnullを返さないように対応

### DIFF
--- a/src/Eccube/Entity/Category.php
+++ b/src/Eccube/Entity/Category.php
@@ -43,7 +43,7 @@ class Category extends \Eccube\Entity\AbstractEntity
      */
     public function __toString()
     {
-        return $this->getName();
+        return (string) $this->getName();
     }
 
     /**

--- a/src/Eccube/Entity/ClassCategory.php
+++ b/src/Eccube/Entity/ClassCategory.php
@@ -42,7 +42,7 @@ class ClassCategory extends \Eccube\Entity\AbstractEntity
      */
     public function __toString()
     {
-        return $this->getName();
+        return (string) $this->getName();
     }
 
     /**

--- a/src/Eccube/Entity/Customer.php
+++ b/src/Eccube/Entity/Customer.php
@@ -352,7 +352,7 @@ class Customer extends \Eccube\Entity\AbstractEntity implements UserInterface
      */
     public function __toString()
     {
-        return $this->getName01() . ' ' . $this->getName02();
+        return (string) ($this->getName01() . ' ' . $this->getName02());
     }
 
     /**

--- a/src/Eccube/Entity/Layout.php
+++ b/src/Eccube/Entity/Layout.php
@@ -20,7 +20,7 @@ class Layout extends AbstractEntity
      */
     public function __toString()
     {
-        return $this->name;
+        return (string) $this->name;
     }
 
     /**

--- a/src/Eccube/Entity/MailHistory.php
+++ b/src/Eccube/Entity/MailHistory.php
@@ -42,7 +42,7 @@ class MailHistory extends AbstractEntity
      */
     public function __toString()
     {
-        return $this->getSubject();
+        return (string) $this->getSubject();
     }
 
     /**

--- a/src/Eccube/Entity/Master/AbstractMasterEntity.php
+++ b/src/Eccube/Entity/Master/AbstractMasterEntity.php
@@ -15,7 +15,7 @@ abstract class AbstractMasterEntity extends \Eccube\Entity\AbstractEntity
      */
     public function __toString()
     {
-        return $this->getName();
+        return (string) $this->getName();
     }
 
     /**

--- a/src/Eccube/Entity/Member.php
+++ b/src/Eccube/Entity/Member.php
@@ -53,7 +53,7 @@ class Member extends \Eccube\Entity\AbstractEntity implements UserInterface
      */
     public function __toString()
     {
-        return $this->getName();
+        return (string) $this->getName();
     }
 
     /**

--- a/src/Eccube/Entity/News.php
+++ b/src/Eccube/Entity/News.php
@@ -42,7 +42,7 @@ class News extends AbstractEntity
      */
     public function __toString()
     {
-        return $this->getTitle();
+        return (string) $this->getTitle();
     }
 
     /**

--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -57,7 +57,7 @@ class Product extends \Eccube\Entity\AbstractEntity
      */
     public function __toString()
     {
-        return $this->getName();
+        return (string) $this->getName();
     }
 
     public function _calc()

--- a/src/Eccube/Entity/ProductImage.php
+++ b/src/Eccube/Entity/ProductImage.php
@@ -20,7 +20,7 @@ class ProductImage extends \Eccube\Entity\AbstractEntity
      */
     public function __toString()
     {
-        return $this->getFileName();
+        return (string) $this->getFileName();
     }
 
     /**

--- a/src/Eccube/Entity/Template.php
+++ b/src/Eccube/Entity/Template.php
@@ -54,7 +54,7 @@ class Template extends \Eccube\Entity\AbstractEntity
      */
     public function __toString()
     {
-        return $this->getName();
+        return (string) $this->getName();
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ `__toString()`が文字列を返さなかった場合にFatalエラーが発生する。[参照](http://php.net/manual/ja/language.oop5.magic.php#object.tostring)

## テスト（Test)
+ codeceptionのテストが失敗していたので対応。