### PR TITLE
日本語windowsの場合はインストール時にエラーとなるので英語のロケールをセット

### DIFF
--- a/src/Eccube/Doctrine/Common/CsvDataFixtures/CsvFixture.php
+++ b/src/Eccube/Doctrine/Common/CsvDataFixtures/CsvFixture.php
@@ -27,6 +27,12 @@ class CsvFixture implements FixtureInterface
      */
     public function load(ObjectManager $manager)
     {
+        // 日本語windowsの場合はインストール時にエラーとなるので英語のロケールをセット
+        // ロケールがミスマッチしてSplFileObject::READ_CSVができないのを回避
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            setLocale(LC_ALL, 'English_United States.1252');
+        }
+
         // CSV Reader に設定
         $this->file->setFlags(\SplFileObject::READ_CSV | \SplFileObject::READ_AHEAD | \SplFileObject::SKIP_EMPTY |\SplFileObject::DROP_NEW_LINE);
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 日本語windowsでインストール時にロケールがミスマッチしてSplFileObject::READ_CSVができないエラーとなるので英語のロケールをセットして回避
  + https://github.com/EC-CUBE/ec-cube/issues/1780
  + https://github.com/EC-CUBE/ec-cube/issues/2524
+ 以下にブランチを間違ってプルリクを送ってしまっています。experimentalブランチに再PRします。
  + https://github.com/EC-CUBE/ec-cube/pull/2536

## 実装に関する補足(Appendix)
+ windowsかどうかの判定用の関数がないので、DIRECTORY_SEPARATORで判定をしてwindowsの場合にのみ実行されるようにしている。

## テスト（Test)
+ windows環境で問題なくインストールできることを確認
+ linux環境についてはTravis CIでBuild Jobがpassしていることを確認
