### PR TITLE
プラグインインストール/削除時に、複数プロセスからのDBアクセスによるデッドロック回避コードを追加。

### DIFF
--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -222,6 +222,17 @@ class OwnerStoreController extends AbstractController
             $execute = sprintf('cd %s &&', $this->appConfig['root_dir']);
             $execute .= sprintf(' composer require ec-cube/%s', $pluginCode);
 
+            // 環境に依存せず動作させるために
+            // TODO: サーバー環境に応じて、この処理をやるやらないを切り替える必要あり
+            @ini_set('memory_limit', '1536M');
+            putenv('COMPOSER_HOME='.$app['config']['plugin_realdir'].'/.composer');
+
+            // Composerを他プロセスから動かしプラグインのインストール処理行う
+            // DBのデッドロックを回避するためトランザクションをリセットしておく
+            // TODO: トランザクションを利用しないアノテーションを作成し、コントローラに適用することで、この回避コードを削除する。
+            $app['orm.em']->commit();
+            $app['orm.em']->beginTransaction();
+
             $install = new Process($execute);
             $install->setTimeout(null);
             $install->run();

--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -341,6 +341,17 @@ class PluginController extends AbstractController
             $execute = sprintf('cd %s &&', $this->appConfig['root_dir']);
             $execute .= sprintf(' composer remove ec-cube/%s', $pluginCode);
 
+            // 環境に依存せず動作させるために
+            // TODO: サーバー環境に応じて、この処理をやるやらないを切り替える必要あり
+            @ini_set('memory_limit', '1536M');
+            putenv('COMPOSER_HOME='.$app['config']['plugin_realdir'].'/.composer');
+
+            // Composerを他プロセスから動かしプラグインのインストール処理行う
+            // DBのデッドロックを回避するためトランザクションをリセットしておく
+            // TODO: トランザクションを利用しないアノテーションを作成し、コントローラに適用することで、この回避コードを削除する。
+            $app['orm.em']->commit();
+            $app['orm.em']->beginTransaction();
+
             $install = new Process($execute);
             $install->setTimeout(null);
             $install->run();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
プラグインインストール時にComposerを他プロセスから起動しています。
他プロセスからDBを更新する(updateSchema)のタイミングでデッドロックが発生しているのを回避しました。

ついでですが、
サーバー環境によってcomposer利用できないケースがあったので、
- メモリ
- composerのHOMEディレクトリ
を指定するコードを追加しています

## 方針(Policy)
トランザクションをcommit→beginでクリアしています。

この修正を入れていない時のデッドロックの状況は以下の通り
```
+----+------+------------------+-----------+---------+------+---------------------------------+------------------------------------------------------------------------------------------------------+
| Id | User | Host             | db        | Command | Time | State                           | Info                                                                                                 |
+----+------+------------------+-----------+---------+------+---------------------------------+------------------------------------------------------------------------------------------------------+
| 22 | root | 172.19.0.1:43062 | eccube_db | Sleep   | 180  |                                 |                                                                                                      |
| 25 | root | 172.19.0.1:43108 | eccube_db | Query   | 118  | Waiting for table metadata lock | ALTER TABLE dtb_authority_role CHANGE create_date create_date DATETIME NOT NULL, CHANGE update_date  |
| 27 | root | localhost        |           | Query   | 0    | starting                        | show processlist                                                                                     |
+----+------+------------------+-----------+---------+------+---------------------------------+------------------------------------------------------------------------------------------------------+
```

## 実装に関する補足(Appendix)
- カスタマイズするような機能ではないので、トランザクションcommitしても影響ないと判断しました
- 将来的には、トランザクションを利用しないアノテーションを作って、インストールのコントローラに適用したいと思います。（そうすれば今回の回避コードは不要になる）

## テスト（Test)
+ テストを行っている範囲など、レビューアが安心できるような情報

## 相談（Discussion）
