### PR TITLE
依存しているプラグインが無効な場合は、プラグインを有効化できないようにする対応 

### DIFF
--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -299,7 +299,6 @@ class PluginController extends AbstractController
                 if ($DependPlugin) {
                     $dependName = $DependPlugin->getName();
                 }
-                // Todo: Add message to messages.ja.php and create mechanism for transmit dynamic parameters for flash messages.
                 $app->addError($Plugin->getName().'を有効化するためには、先に'.$dependName.'を有効化してください。', 'admin');
 
                 return $app->redirect($app->url('admin_store_plugin'));

--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -277,7 +277,6 @@ class PluginController extends AbstractController
 
     /**
      * 対象のプラグインを有効にします。
-     * Update new mechanism to check dependency plugin
      *
      * @Method("PUT")
      * @Route("/{_admin}/store/plugin/{id}/enable", requirements={"id" = "\d+"}, name="admin_store_plugin_enable")
@@ -292,10 +291,10 @@ class PluginController extends AbstractController
         if ($Plugin->getEnable() == Constant::ENABLED) {
             $app->addError('admin.plugin.already.enable', 'admin');
         } else {
-            $require = $this->pluginService->findRequirePluginNeedEnable($Plugin->getCode());
-            if (!empty($require)) {
-                $DependPlugin = $this->pluginRepository->findOneBy(['code' => $require[0]]);
-                $dependName = $require[0];
+            $requires = $this->pluginService->findRequirePluginNeedEnable($Plugin->getCode());
+            if (!empty($requires)) {
+                $DependPlugin = $this->pluginRepository->findOneBy(['code' => $requires[0]]);
+                $dependName = $requires[0];
                 if ($DependPlugin) {
                     $dependName = $DependPlugin->getName();
                 }


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ PullRequestの目的、関連するIssue番号など:
    - when enable plugins, check required plugins also be enable before

   プラグインを有効化するとき、
   依存先のプラグインが無効状態だった場合は、有効化できないようにする制御。  
   (エラーを表示する)
  

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外し内容
   -  Show message warning about required plugin have to enable before
   - Show only 1 plugin although have multi required plugins need enable.
## 実装に関する補足(Appendix)
+ 

## テスト（Test)
+ With mySQL + postgress
+ With dependency 3 level

## 相談（Discussion）
+ only show and disable with plugins which installed by user specification ( not dependency plugins )

