### PR TITLE
RepositoryアノテーションをEccube\\Entity以外のEntityに対応

### DIFF
--- a/src/Eccube/DI/AutoWiring/RepositoryAutoWiring.php
+++ b/src/Eccube/DI/AutoWiring/RepositoryAutoWiring.php
@@ -52,7 +52,7 @@ class RepositoryAutoWiring extends ComponentAutoWiring
      */
     public function createComponentDefinition($anno, $refClass)
     {
-        return new RepositoryDefinition($refClass->getName(), $refClass);
+        return new RepositoryDefinition($refClass->getName(), $refClass, $anno->value);
     }
 
     /**

--- a/tests/Eccube/Tests/DI/AutoWiring/RepositoryDefinitionTest.php
+++ b/tests/Eccube/Tests/DI/AutoWiring/RepositoryDefinitionTest.php
@@ -23,29 +23,23 @@
 
 namespace Eccube\Tests\DI\AutoWiring;
 
-use Eccube\DI\AutoWiring\RepositoryAutoWiring;
+use Eccube\DI\AutoWiring\RepositoryDefinition;
+use Eccube\Repository\ProductRepository;
 use Eccube\Tests\DI\Test\Repository\TestRepository;
-use Eccube\Tests\DI\Test\RepositoryClazz;
 
-class RepositoryAutoWiringTest extends AbstractAutowiringTest
+class RepositoryDefinitionTest extends \PHPUnit_Framework_TestCase
 {
-
-    protected function getAutoWiring()
+    public function testGetEntityName_Ecucube_Entity()
     {
-        return new RepositoryAutoWiring([__DIR__.'/../Test']);
+        $refClass = new \ReflectionClass(ProductRepository::class);
+        $def = new RepositoryDefinition(ProductRepository::class, $refClass, null);
+        self::assertEquals("Eccube\\Entity\\Product", $def->getEntityName());
     }
 
-    public function testRepository()
+    public function testGetEntityName_Test()
     {
-        $this->di->build($this->container);
-
-        self::assertArrayHasKey(RepositoryClazz::class, $this->container);
-    }
-
-    public function testRepository2()
-    {
-        $this->di->build($this->container);
-
-        self::assertArrayHasKey(TestRepository::class, $this->container);
+        $refClass = new \ReflectionClass(TestRepository::class);
+        $def = new RepositoryDefinition(TestRepository::class, $refClass, null);
+        self::assertEquals("Eccube\\Tests\\DI\\Test\\Entity\\Test", $def->getEntityName());
     }
 }

--- a/tests/Eccube/Tests/DI/Test/Entity/Test.php
+++ b/tests/Eccube/Tests/DI/Test/Entity/Test.php
@@ -21,31 +21,10 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-namespace Eccube\Tests\DI\AutoWiring;
+namespace Eccube\Tests\DI\Test\Entity;
 
-use Eccube\DI\AutoWiring\RepositoryAutoWiring;
-use Eccube\Tests\DI\Test\Repository\TestRepository;
-use Eccube\Tests\DI\Test\RepositoryClazz;
 
-class RepositoryAutoWiringTest extends AbstractAutowiringTest
+class Test
 {
 
-    protected function getAutoWiring()
-    {
-        return new RepositoryAutoWiring([__DIR__.'/../Test']);
-    }
-
-    public function testRepository()
-    {
-        $this->di->build($this->container);
-
-        self::assertArrayHasKey(RepositoryClazz::class, $this->container);
-    }
-
-    public function testRepository2()
-    {
-        $this->di->build($this->container);
-
-        self::assertArrayHasKey(TestRepository::class, $this->container);
-    }
 }

--- a/tests/Eccube/Tests/DI/Test/Repository/TestRepository.php
+++ b/tests/Eccube/Tests/DI/Test/Repository/TestRepository.php
@@ -21,31 +21,13 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-namespace Eccube\Tests\DI\AutoWiring;
+namespace Eccube\Tests\DI\Test\Repository;
 
-use Eccube\DI\AutoWiring\RepositoryAutoWiring;
-use Eccube\Tests\DI\Test\Repository\TestRepository;
-use Eccube\Tests\DI\Test\RepositoryClazz;
+use Eccube\Annotation\Repository;
 
-class RepositoryAutoWiringTest extends AbstractAutowiringTest
+/**
+ * @Repository
+ */
+class TestRepository
 {
-
-    protected function getAutoWiring()
-    {
-        return new RepositoryAutoWiring([__DIR__.'/../Test']);
-    }
-
-    public function testRepository()
-    {
-        $this->di->build($this->container);
-
-        self::assertArrayHasKey(RepositoryClazz::class, $this->container);
-    }
-
-    public function testRepository2()
-    {
-        $this->di->build($this->container);
-
-        self::assertArrayHasKey(TestRepository::class, $this->container);
-    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ `@Repository`アノテーションが`Eccube\\Entity`以下の名前空間にしか対応していなかったので、対応しました。

