### PR TITLE
メッセージがロケールで切り替わらない不具合の修正

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -456,7 +456,7 @@ class Application extends \Silex\Application
         $this->register(new \Silex\Provider\TranslationServiceProvider(), array(
             'locale' => $this['config']['locale'],
             'translator.cache_dir' => $this['debug'] ? null : $this['config']['root_dir'].'/app/cache/translator',
-            'locale_fallbacks' => ['ja', 'en'],
+            'locale_fallbacks' => [$this['config']['locale'], 'en'],
         ));
         $this->extend('translator', function ($translator, \Silex\Application $app) {
             $translator->addLoader('php', new \Symfony\Component\Translation\Loader\PhpFileLoader());


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

config.phpのlocaleを変更しても、メッセージが切り替わらない問題の修正
locale_follbacksがja, en固定になっていたため
