### PR TITLE
installing plugin & required plugin in same time

### DIFF
--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -256,7 +256,19 @@ class OwnerStoreController extends AbstractController
             $em->getConnection()->beginTransaction();
         }
 
-        $return = $this->composerService->execRequire($pluginCode);
+        $arrDependency = array();
+        if($data && !empty($data['item'])){
+            $items = $data['item'];
+            $plugin = $this->pluginService->buildInfo($items, $pluginCode);
+            $arrDependency[] = $plugin;
+            $arrDependency = $this->pluginService->getDependency($items, $plugin, $arrDependency);
+
+            // Unset first param
+            unset($arrDependency[0]);
+        }
+
+        $return = $this->composerService->execRequire($pluginCode, $arrDependency);
+
         if ($return) {
             $app->addSuccess('admin.plugin.install.complete', 'admin');
 
@@ -324,6 +336,7 @@ class OwnerStoreController extends AbstractController
          * @link https://dev.mysql.com/doc/refman/5.7/en/lock-tables.html
          * @var EntityManagerInterface $em
          */
+
         $em = $this->em;
         if ($em->getConnection()->isTransactionActive()) {
             $em->getConnection()->commit();

--- a/src/Eccube/Resource/template/admin/Store/plugin_confirm.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_confirm.twig
@@ -84,7 +84,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     <div class="row">
                         <div class="col-xs-12">
                             <span class="pull-right">
-                                <a class="btn btn-warning btn-xs" href="{{ url('admin_store_plugin_api_install', {'pluginCode': item.product_code, 'eccubeVersion': constant('Eccube\\Common\\Constant::VERSION'), 'version': item.version}) }}">インストール</a>
+                                <a class="btn btn-warning btn-xs prevention-mask" href="{{ url('admin_store_plugin_api_install', {'pluginCode': item.product_code, 'eccubeVersion': constant('Eccube\\Common\\Constant::VERSION'), 'version': item.version}) }}">インストール</a>
                                 <button class="btn btn-cancel btn-xs" type="button" onclick="return window.history.back()">戻る</button>
                             </span>
                         </div>

--- a/src/Eccube/Service/ComposerProcessService.php
+++ b/src/Eccube/Service/ComposerProcessService.php
@@ -46,16 +46,25 @@ class ComposerProcessService
     /**
      * This function to install a plugin by composer require
      *
-     * @param string $packageName
+     * @param $packageName
+     * @param array $arrDependency
      * @return bool
      */
-    public function execRequire($packageName)
+    public function execRequire($packageName, $arrDependency = array())
     {
         set_time_limit(0);
         $this->setupComposer();
+
         // Build command
-        $packageName = self::$vendorName.'/'.$packageName;
-        $command = $this->getPHP().' '.$this->composerFile.' require '.$packageName;
+        $packageNames = '';
+        if (!empty($arrDependency)) {
+            foreach ($arrDependency as $item) {
+                $packageNames .= ' ' . self::$vendorName . '/' . $item['product_code'];
+            }
+        }
+
+        $packageNames .= ' ' . self::$vendorName . '/' . $packageName;
+        $command = $this->getPHP().' '.$this->composerFile.' require '.$packageNames;
         $command .= ' --prefer-dist --no-progress --no-suggest --no-scripts --ignore-platform-reqs --profile --no-ansi --no-interaction -d ';
         $command .= $this->appConfig['root_dir'].' 2>&1';
         log_info($command);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ PullRequestの目的、関連するIssue番号など
   - when install dependency plugin ( require other plugins), or single plugin ( dont require other ), composer will install all plugins ( main and require ) explicitly ( default of composer is install implicitly require plugin )

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外し内容
  - Still not compatible with composerApi

## 実装に関する補足(Appendix)
+ When click install will show loading box to prevent multi click.

## テスト（Test)
+ mySQL
+ pgSQL

## 相談（Discussion）
+ waiting time for installing too long , user can paste URL to re-action => install same plugin multi time
