### PR TITLE
依存関係のあるプラグインを同時インストールする場合に、composerはプラグインそれぞれをrequireするように変更

### DIFF
--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -243,27 +243,22 @@ class OwnerStoreController extends AbstractController
 
             return $app->redirect($app->url('admin_store_plugin_owners_search'));
         }
-
-        $arrDependency = array();
+        $dependents = array();
         $items = $data['item'];
         $plugin = $this->pluginService->buildInfo($items, $pluginCode);
-        $arrDependency[] = $plugin;
-        $arrDependency = $this->pluginService->getDependency($items, $plugin, $arrDependency);
+        $dependents[] = $plugin;
+        $dependents = $this->pluginService->getDependency($items, $plugin, $dependents);
 
         // Unset first param
-        unset($arrDependency[0]);
-
+        unset($dependents[0]);
         $packageNames = '';
-        if (!empty($arrDependency)) {
-            foreach ($arrDependency as $item) {
-                $packageNames .= ' ' . self::$vendorName . '/' . $item['product_code'];
+        if (!empty($dependents)) {
+            foreach ($dependents as $item) {
+                $packageNames .= self::$vendorName.'/'.$item['product_code'].' ';
             }
         }
-
-        $packageNames .= ' '.self::$vendorName.'/'.$pluginCode;
-
+        $packageNames .= self::$vendorName.'/'.$pluginCode;
         $return = $this->composerService->execRequire($packageNames);
-
         if ($return) {
             $app->addSuccess('admin.plugin.install.complete', 'admin');
 

--- a/src/Eccube/Resource/template/admin/Store/plugin_confirm.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_confirm.twig
@@ -84,7 +84,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     <div class="row">
                         <div class="col-xs-12">
                             <span class="pull-right">
-                                <a class="btn btn-warning btn-xs" href="{{ url('admin_store_plugin_api_install', {'pluginCode': item.product_code, 'eccubeVersion': constant('Eccube\\Common\\Constant::VERSION'), 'version': item.version}) }}">インストール</a>
+                                <a class="btn btn-warning btn-xs prevention-mask" href="{{ url('admin_store_plugin_api_install', {'pluginCode': item.product_code, 'eccubeVersion': constant('Eccube\\Common\\Constant::VERSION'), 'version': item.version}) }}">インストール</a>
                                 <button class="btn btn-cancel btn-xs" type="button" onclick="return window.history.back()">戻る</button>
                             </span>
                         </div>

--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -72,9 +72,10 @@ class ComposerApiService implements ComposerServiceInterface
      */
     public function execRequire($packageName)
     {
+        $packageName = explode(" ", trim($packageName));
         $output = $this->runCommand(array(
             'command' => 'require',
-            'packages' => array($packageName),
+            'packages' => $packageName,
             '--no-interaction' => true,
             '--profile' => true,
             '--prefer-dist' => true,


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ PullRequestの目的、関連するIssue番号など
   - when install dependency plugin ( require other plugins), or single plugin ( dont require other ), composer will install all plugins ( main and require ) explicitly ( default of composer is install implicitly require plugin )

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外し内容
  - Compatible with composerApi

## 実装に関する補足(Appendix)
+ When click install will show loading box to prevent multi click.

## テスト（Test)
+ mySQL
+ pgSQL

## 相談（Discussion）
+ waiting time for installing too long , user can paste URL to re-action => install same plugin multi time
