### PR TITLE
受注検索画面：sessionに検索条件がない状態でgetリクエストを送信する際のNoticeを解消

### DIFF
--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -119,6 +119,7 @@ class OrderController extends AbstractController
                     $session->set('eccube.admin.order.search.page_no', $page_no);
                 }
                 $viewData = $session->get('eccube.admin.order.search');
+                $searchData = null;
                 if (!is_null($viewData)) {
                     // sessionに保持されている検索条件を復元.
                     $searchData = \Eccube\Util\FormUtil::submitAndGetData($searchForm, $viewData);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 受注検索画面：sessionに検索条件がない状態でパラメータ付きのgetリクエストを送信する際、「Notice: Undefined variable: searchData」のContextErrorExceptionが発生しないように修正。
    + sessionに `'eccube.admin.order.search'` が設定されている場合しか `$searchData` が定義されないため、 `'eccube.admin.order.search'` が設定されていない状態だと127行目の `if (!is_null($searchData)) {` で
 `Notice: Undefined variable: searchData` の `ContextErrorException` が発生する。

## 方針(Policy)
+ sessionがいずれの場合にも `$searchData` を初期化するコードを追加

## 再現手順
1. 普通に検索
    + sessionが作成される
1. `http://127.0.0.1:8081/index_dev.php/admin/order?resume=1` へアクセス
    + sessionが存在し、 `$searchData` が定義されるため `ContextErrorException` は発生しない
1. `http://127.0.0.1:8081/index_dev.php/admin/order` へアクセス
    + sessionが削除される
1. `http://127.0.0.1:8081/index_dev.php/admin/order?resume=1` へアクセス
    + sessionが存在せず、 `$searchData` が定義されないため `ContextErrorException` が発生する

## テスト
+ ユニットテストが通ることを確認
+ 再現手順でエラーが出ないことを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



