### PR TITLE
Composerの動作方法をサーバーによって自動で切り替える対応

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -42,6 +42,7 @@ use Eccube\Plugin\ConfigManager as PluginConfigManager;
 use Eccube\Routing\EccubeRouter;
 use Eccube\ServiceProvider\CompatRepositoryProvider;
 use Eccube\ServiceProvider\CompatServiceProvider;
+use Eccube\ServiceProvider\ComposerServiceProvider;
 use Eccube\ServiceProvider\EntityEventServiceProvider;
 use Eccube\ServiceProvider\ForwardOnlyServiceProvider;
 use Eccube\ServiceProvider\MobileDetectServiceProvider;
@@ -338,6 +339,7 @@ class Application extends \Silex\Application
 
         $this->register(new CompatRepositoryProvider());
         $this->register(new CompatServiceProvider());
+        $this->register(new ComposerServiceProvider());
         $this->register(new ServiceProvider\EccubeServiceProvider());
         $this->register(new PagenatorServiceProvider());
         $this->register(new PaymentServiceProvider());

--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -29,7 +29,6 @@ use Eccube\Common\Constant;
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\Plugin;
 use Eccube\Repository\PluginRepository;
-use Eccube\Service\Composer\ComposerApiService;
 use Eccube\Service\PluginService;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -60,12 +59,6 @@ class OwnerStoreController extends AbstractController
      * @var PluginService
      */
     protected $pluginService;
-
-    /**
-     * @Inject(ComposerApiService::class)
-     * @var ComposerApiService
-     */
-    protected $composerService;
 
     /**
      * @var EntityManager
@@ -258,7 +251,7 @@ class OwnerStoreController extends AbstractController
             }
         }
         $packageNames .= self::$vendorName.'/'.$pluginCode;
-        $return = $this->composerService->execRequire($packageNames);
+        $return = $app['eccube.service.composer']->execRequire($packageNames);
         if ($return) {
             $app->addSuccess('admin.plugin.install.complete', 'admin');
 
@@ -338,7 +331,7 @@ class OwnerStoreController extends AbstractController
         }
         $pluginCode = $Plugin->getCode();
         $packageName = self::$vendorName.'/'.$pluginCode;
-        $return = $this->composerService->execRemove($packageName);
+        $return = $app['eccube.service.composer']->execRemove($packageName);
         if ($return) {
             $app->addSuccess('admin.plugin.uninstall.complete', 'admin');
         } else {

--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -29,6 +29,7 @@ use Eccube\Common\Constant;
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\Plugin;
 use Eccube\Repository\PluginRepository;
+use Eccube\Service\Composer\ComposerServiceInterface;
 use Eccube\Service\PluginService;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -59,6 +60,12 @@ class OwnerStoreController extends AbstractController
      * @var PluginService
      */
     protected $pluginService;
+
+    /**
+     * @Inject("eccube.service.composer")
+     * @var ComposerServiceInterface
+     */
+    protected $composerService;
 
     /**
      * @var EntityManager
@@ -251,7 +258,7 @@ class OwnerStoreController extends AbstractController
             }
         }
         $packageNames .= self::$vendorName.'/'.$pluginCode;
-        $return = $app['eccube.service.composer']->execRequire($packageNames);
+        $return = $this->composerService->execRequire($packageNames);
         if ($return) {
             $app->addSuccess('admin.plugin.install.complete', 'admin');
 
@@ -331,7 +338,7 @@ class OwnerStoreController extends AbstractController
         }
         $pluginCode = $Plugin->getCode();
         $packageName = self::$vendorName.'/'.$pluginCode;
-        $return = $app['eccube.service.composer']->execRemove($packageName);
+        $return = $this->composerService->execRemove($packageName);
         if ($return) {
             $app->addSuccess('admin.plugin.uninstall.complete', 'admin');
         } else {

--- a/src/Eccube/Resource/config/constant.php
+++ b/src/Eccube/Resource/config/constant.php
@@ -63,4 +63,5 @@
     'product_order_price_higher' => 3,
     'price_max' => 2147483647,
     'pageinrange' => false,
+    'composer_memory_limit' => 1536,
 ];

--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -40,21 +40,15 @@ class ComposerApiService implements ComposerServiceInterface
     protected $appConfig;
 
     /**
-     * @var \Eccube\Application
-     */
-    protected $app;
-
-    /**
      * @var Application $consoleApplication
      */
     private $consoleApplication;
 
     private $workingDir;
 
-    public function __construct(\Eccube\Application $app)
+    public function __construct($appConfig)
     {
-        $this->app = $app;
-        $this->appConfig = $app['config'];
+        $this->appConfig = $appConfig;
     }
 
     /**

--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -23,7 +23,6 @@
 namespace Eccube\Service\Composer;
 
 use Composer\Console\Application;
-use Eccube\Annotation\Inject;
 use Eccube\Annotation\Service;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -36,10 +35,14 @@ use Symfony\Component\Console\Output\BufferedOutput;
 class ComposerApiService implements ComposerServiceInterface
 {
     /**
-     * @Inject("config")
      * @var array
      */
     protected $appConfig;
+
+    /**
+     * @var \Eccube\Application
+     */
+    protected $app;
 
     /**
      * @var Application $consoleApplication
@@ -47,6 +50,12 @@ class ComposerApiService implements ComposerServiceInterface
     private $consoleApplication;
 
     private $workingDir;
+
+    public function __construct(\Eccube\Application $app)
+    {
+        $this->app = $app;
+        $this->appConfig = $app['config'];
+    }
 
     /**
      * Run get info command

--- a/src/Eccube/Service/Composer/ComposerProcessService.php
+++ b/src/Eccube/Service/Composer/ComposerProcessService.php
@@ -45,11 +45,13 @@ class ComposerProcessService implements ComposerServiceInterface
     private $workingDir;
     private $composerFile;
     private $composerSetup;
+    private $pathPHP;
 
     public function __construct(\Eccube\Application $app)
     {
         $this->app = $app;
         $this->appConfig = $app['config'];
+        $this->pathPHP = $app['eccube.service.system']->getPHP();
     }
 
     /**
@@ -65,7 +67,7 @@ class ComposerProcessService implements ComposerServiceInterface
             return false;
         }
         // Build command
-        $command = $this->getPHP().' '.$this->composerFile.' require '.$packageName;
+        $command = $this->pathPHP.' '.$this->composerFile.' require '.$packageName;
         $command .= ' --prefer-dist --no-progress --no-suggest --no-scripts --ignore-platform-reqs --profile --no-ansi --no-interaction -d ';
         $command .= $this->workingDir.' 2>&1';
         log_info($command);
@@ -88,7 +90,7 @@ class ComposerProcessService implements ComposerServiceInterface
             return false;
         }
         // Build command
-        $command = $this->getPHP().' '.$this->composerFile.' remove '.$packageName;
+        $command = $this->pathPHP.' '.$this->composerFile.' remove '.$packageName;
         $command .= ' --no-progress --no-scripts --ignore-platform-reqs --profile --no-ansi --no-interaction --no-update-with-dependencies -d ';
         $command .= $this->workingDir.' 2>&1';
         log_info($command);
@@ -120,16 +122,6 @@ class ComposerProcessService implements ComposerServiceInterface
     public function setWorkingDir($workingDir)
     {
         $this->workingDir = $workingDir;
-    }
-
-    /**
-     * Get environment php command
-     *
-     * @return string
-     */
-    private function getPHP()
-    {
-        return 'php';
     }
 
     /**
@@ -174,7 +166,7 @@ class ComposerProcessService implements ComposerServiceInterface
                 $result = copy('https://getcomposer.org/installer', $this->composerSetup);
                 log_info($this->composerSetup.' : '.$result);
             }
-            $command = $this->getPHP().' '.$this->composerSetup;
+            $command = $this->pathPHP.' '.$this->composerSetup;
             $this->runCommand($command);
 
             unlink($this->composerSetup);

--- a/src/Eccube/Service/Composer/ComposerProcessService.php
+++ b/src/Eccube/Service/Composer/ComposerProcessService.php
@@ -22,8 +22,8 @@
  */
 namespace Eccube\Service\Composer;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Annotation\Service;
-use Eccube\Service\SystemService;
 
 /**
  * Class ComposerProcessService
@@ -38,20 +38,20 @@ class ComposerProcessService implements ComposerServiceInterface
     protected $appConfig;
 
     /**
-     * @var \Eccube\Application
+     * @var EntityManagerInterface
      */
-    protected $app;
+    protected $entityManagerInterface;
 
     private $workingDir;
     private $composerFile;
     private $composerSetup;
     private $pathPHP;
 
-    public function __construct(\Eccube\Application $app)
+    public function __construct($config, $entityManagerInterface, $pathPHP)
     {
-        $this->app = $app;
-        $this->appConfig = $app['config'];
-        $this->pathPHP = $app['eccube.service.system']->getPHP();
+        $this->appConfig = $config;
+        $this->entityManagerInterface = $entityManagerInterface;
+        $this->pathPHP = $pathPHP;
     }
 
     /**
@@ -140,7 +140,7 @@ class ComposerProcessService implements ComposerServiceInterface
             }
         }
 
-        $em = $this->app['orm.em'];
+        $em = $this->entityManagerInterface;
         if ($em->getConnection()->isTransactionActive()) {
             $em->getConnection()->commit();
             $em->getConnection()->beginTransaction();

--- a/src/Eccube/Service/Composer/ComposerProcessService.php
+++ b/src/Eccube/Service/Composer/ComposerProcessService.php
@@ -53,12 +53,6 @@ class ComposerProcessService implements ComposerServiceInterface
     }
 
     /**
-     * @Inject(SystemService::class)
-     * @var SystemService
-     */
-    protected $systemService;
-
-    /**
      * This function to install a plugin by composer require
      *
      * @param string $packageName format foo/bar or foo/bar:1.0.0 or "foo/bar 1.0.0"

--- a/src/Eccube/Service/Composer/ComposerProcessService.php
+++ b/src/Eccube/Service/Composer/ComposerProcessService.php
@@ -212,14 +212,14 @@ class ComposerProcessService implements ComposerServiceInterface
     public function isSetCliMemoryLimit()
     {
         $oldMemory = exec($this->pathPHP.' -i | grep "memory_limit"');
-        $tmpMem = '2GB';
+        $tmpMem = '1.5GB';
 
         if ($oldMemory) {
             $memory = explode('=>', $oldMemory);
             $originGrepMemmory = trim($memory[2]);
 
             if ($originGrepMemmory == $tmpMem) {
-                $tmpMem = '2.5GB';
+                $tmpMem = '1.49GB';
             }
 
             $newMemory = exec($this->pathPHP.' -d memory_limit='.$tmpMem.' -i | grep "memory_limit"');

--- a/src/Eccube/Service/Composer/ComposerProcessService.php
+++ b/src/Eccube/Service/Composer/ComposerProcessService.php
@@ -135,8 +135,8 @@ class ComposerProcessService implements ComposerServiceInterface
             return false;
         }
 
-        if (!$systemService->isSetGrepMemoryLimit()) {
-            if ($systemService->getGrepMemoryLimit() < SystemService::MEMORY) {
+        if (!$systemService->isSetCliMemoryLimit()) {
+            if ($systemService->getCliMemoryLimit() < SystemService::MEMORY) {
                 return false;
             }
         }
@@ -149,7 +149,7 @@ class ComposerProcessService implements ComposerServiceInterface
 
         @ini_set('memory_limit', '1536M');
         // Config for some environment
-        putenv('COMPOSER_HOME=' . $this->appConfig['plugin_realdir'] . '/.composer');
+        putenv('COMPOSER_HOME='.$this->appConfig['plugin_realdir'].'/.composer');
         $this->workingDir = $this->workingDir ? $this->workingDir : $this->appConfig['root_dir'];
         $this->setupComposer();
     }

--- a/src/Eccube/Service/Composer/ComposerProcessService.php
+++ b/src/Eccube/Service/Composer/ComposerProcessService.php
@@ -40,17 +40,17 @@ class ComposerProcessService implements ComposerServiceInterface
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManagerInterface;
+    protected $entityManager;
 
     private $workingDir;
     private $composerFile;
     private $composerSetup;
     private $pathPHP;
 
-    public function __construct($config, $entityManagerInterface, $pathPHP)
+    public function __construct($appConfig, $entityManager, $pathPHP)
     {
-        $this->appConfig = $config;
-        $this->entityManagerInterface = $entityManagerInterface;
+        $this->appConfig = $appConfig;
+        $this->entityManager = $entityManager;
         $this->pathPHP = $pathPHP;
     }
 
@@ -140,7 +140,7 @@ class ComposerProcessService implements ComposerServiceInterface
             }
         }
 
-        $em = $this->entityManagerInterface;
+        $em = $this->entityManager;
         if ($em->getConnection()->isTransactionActive()) {
             $em->getConnection()->commit();
             $em->getConnection()->beginTransaction();

--- a/src/Eccube/Service/Composer/ComposerProcessService.php
+++ b/src/Eccube/Service/Composer/ComposerProcessService.php
@@ -136,7 +136,7 @@ class ComposerProcessService implements ComposerServiceInterface
         }
 
         if (!$systemService->isSetCliMemoryLimit()) {
-            if ($systemService->getCliMemoryLimit() < SystemService::MEMORY) {
+            if ($systemService->getCliMemoryLimit() < SystemService::MEMORY && $systemService->getCliMemoryLimit() != -1) {
                 return false;
             }
         }

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -26,6 +26,7 @@ namespace Eccube\Service;
 use Doctrine\ORM\EntityManager;
 use Eccube\Annotation\Inject;
 use Eccube\Annotation\Service;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 /**
  * @Service
@@ -77,17 +78,15 @@ class SystemService
 
     /**
      * Get environment php command
-     *
      * @return string
      */
     public function getPHP()
     {
-        return 'php';
+        return (new PhpExecutableFinder())->find();
     }
 
     /**
      * Check permission php.ini and set new memory_limit
-     * @param string $memoryLimit
      * @return bool
      */
     public function isSetMemoryLimit()
@@ -131,7 +130,7 @@ class SystemService
      * @return int|string
      */
     public function getGrepMemoryLimit(){
-        $grepMemory = exec('php -i | grep "memory_limit"');
+        $grepMemory = exec($this->getPHP() . ' -i | grep "memory_limit"');
         if($grepMemory){
             $grepMemory = explode('=>', $grepMemory);
             $exp = preg_split('#(?<=\d)(?=[a-z])#i', $grepMemory[2]);
@@ -159,7 +158,7 @@ class SystemService
      */
     public function isSetGrepMemoryLimit()
     {
-        $oldMemory = exec('php -i | grep "memory_limit"');
+        $oldMemory = exec($this->getPHP() . ' -i | grep "memory_limit"');
         $tmpMem = '2GB';
 
         if ($oldMemory) {
@@ -170,7 +169,7 @@ class SystemService
                 $tmpMem = '2.5GB';
             }
 
-            $newMemory = exec('php -d memory_limit=' . $tmpMem . ' -i | grep "memory_limit"');
+            $newMemory = exec($this->getPHP() . ' -d memory_limit=' . $tmpMem . ' -i | grep "memory_limit"');
             if ($newMemory) {
                 $newMemory = explode('=>', $newMemory);
                 $grepNewMemory = trim($newMemory[2]);

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -107,6 +107,12 @@ class SystemService
     public function getMemoryLimit()
     {
         $memoryLimit = ini_get('memory_limit');
+
+        // -1 unlimited
+        if ($memoryLimit == -1) {
+            return -1;
+        }
+
         if (preg_match('/^(\d+)(.)$/', $memoryLimit, $matches)) {
             $memoryValue = $matches[1];
             $memoryUnit = strtoupper($matches[2]);
@@ -115,7 +121,7 @@ class SystemService
                 return $memoryValue;
             } else {
                 if ($memoryUnit == 'K') {
-                    return $memoryValue / 1024;
+                    return ($memoryValue == 0) ? 0 : $memoryValue / 1024;
                 } else {
                     return $memoryValue * 1024;
                 }
@@ -133,6 +139,12 @@ class SystemService
         $grepMemory = exec($this->getPHP().' -i | grep "memory_limit"');
         if($grepMemory){
             $grepMemory = explode('=>', $grepMemory);
+
+            // -1 unlimited
+            if (trim($grepMemory[2]) == -1) {
+                return -1;
+            }
+
             $exp = preg_split('#(?<=\d)(?=[a-z])#i', $grepMemory[2]);
             $memo = trim($exp[0]);
             if ($exp[1] == 'M') {

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -38,6 +38,12 @@ class SystemService
      */
     protected $em;
 
+    /**
+     * 1536 Megabyte
+     * @var int
+     */
+    const MEMORY = 1536;
+
     public function getDbversion()
     {
 
@@ -67,5 +73,115 @@ class SystemService
             ->getSingleScalarResult();
 
         return $prefix.$version;
+    }
+
+    /**
+     * Check permission php.ini and set new memory_limit
+     * @param string $memoryLimit
+     * @return bool
+     */
+    public function isSetMemoryLimit()
+    {
+        // Get path php.ini loaded
+        $iniPath = php_ini_loaded_file();
+        if ($iniPath && is_writable($iniPath)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get memory_limit | Megabyte
+     * @return float|int
+     */
+    public function getMemoryLimit()
+    {
+        $memoryLimit = ini_get('memory_limit');
+        if (preg_match('/^(\d+)(.)$/', $memoryLimit, $matches)) {
+            $memoryValue = $matches[1];
+            $memoryUnit = strtoupper($matches[2]);
+
+            if ($memoryUnit == 'M') {
+                return $memoryValue;
+            } else {
+                if ($memoryUnit == 'K') {
+                    return $memoryValue / 1024;
+                } else {
+                    return $memoryValue * 1024;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Get grep memory_limit | Megabyte
+     * @return int|string
+     */
+    public function getGrepMemoryLimit(){
+        $grepMemory = exec('php -i | grep "memory_limit"');
+        if($grepMemory){
+            $grepMemory = explode('=>', $grepMemory);
+            $exp = preg_split('#(?<=\d)(?=[a-z])#i', $grepMemory[2]);
+            $memo = trim($exp[0]);
+            if ($exp[1] == 'M') {
+
+                return $memo;
+            } else {
+                if ($exp[1] == 'GB') {
+
+                    return $memo * 1024;
+                } else {
+
+                    return 0;
+                }
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Check to set new value grep "memory_limit"
+     * @return bool
+     */
+    public function isSetGrepMemoryLimit()
+    {
+        $oldMemory = exec('php -i | grep "memory_limit"');
+        $tmpMem = '2GB';
+
+        if ($oldMemory) {
+            $memory = explode('=>', $oldMemory);
+            $originGrepMemmory = trim($memory[2]);
+
+            if ($originGrepMemmory == $tmpMem) {
+                $tmpMem = '2.5GB';
+            }
+
+            $newMemory = exec('php -d memory_limit=' . $tmpMem . ' -i | grep "memory_limit"');
+            if ($newMemory) {
+                $newMemory = explode('=>', $newMemory);
+                $grepNewMemory = trim($newMemory[2]);
+                if ($grepNewMemory != $originGrepMemmory) {
+
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check php command line
+     * @return bool
+     */
+    public function isPhpCommandLine()
+    {
+        if (function_exists('exec') && null != exec('php -v')) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -26,6 +26,7 @@ namespace Eccube\Service;
 use Doctrine\ORM\EntityManager;
 use Eccube\Annotation\Inject;
 use Eccube\Annotation\Service;
+use Symfony\Component\HttpKernel\DataCollector\MemoryDataCollector;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 /**
@@ -40,10 +41,10 @@ class SystemService
     protected $em;
 
     /**
-     * 1536 Megabyte
-     * @var int
+     * @Inject("config")
+     * @var array
      */
-    const MEMORY = 1536;
+    protected $appConfig;
 
     public function getDbversion()
     {
@@ -91,17 +92,15 @@ class SystemService
      */
     public function isSetMemoryLimit()
     {
-        $setMemory = self::MEMORY;
-        if ($this->getMemoryLimit() == $setMemory) {
-            $setMemory = 2048;
+        $setMemory = $this->appConfig['composer_memory_limit'].'M';
+
+        try {
+            ini_set('memory_limit', $setMemory);
+        } catch (\Exception $exception) {
+            return false;
         }
 
-        @ini_set('memory_limit', $setMemory);
-        if ($this->getMemoryLimit() != $setMemory) {
-            return true;
-        }
-
-        return false;
+        return true;
     }
 
     /**
@@ -110,108 +109,12 @@ class SystemService
      */
     public function getMemoryLimit()
     {
-        $memoryLimit = ini_get('memory_limit');
-
-        // -1 unlimited
-        if ($memoryLimit == -1) {
+        // Data type: bytes
+        $memoryLimit = (new MemoryDataCollector())->getMemoryLimit();
+        if (-1 == $memoryLimit) {
             return -1;
         }
 
-        if (preg_match('/^(\d+)(.)$/', $memoryLimit, $matches)) {
-            $memoryValue = $matches[1];
-            $memoryUnit = strtoupper($matches[2]);
-
-            if ($memoryUnit == 'M') {
-                return $memoryValue;
-            } else {
-                if ($memoryUnit == 'K') {
-                    return ($memoryValue == 0) ? 0 : $memoryValue / 1024;
-                } else {
-                    return $memoryValue * 1024;
-                }
-            }
-        }
-
-        return 0;
-    }
-
-    /**
-     * Get grep memory_limit | Megabyte
-     * @return int|string
-     */
-    public function getCliMemoryLimit(){
-        $grepMemory = exec($this->getPHP().' -i | grep "memory_limit"');
-        if($grepMemory){
-            $grepMemory = explode('=>', $grepMemory);
-
-            // -1 unlimited
-            if (trim($grepMemory[2]) == -1) {
-                return -1;
-            }
-
-            $exp = preg_split('#(?<=\d)(?=[a-z])#i', $grepMemory[2]);
-            $memo = trim($exp[0]);
-            if ($exp[1] == 'M') {
-
-                return $memo;
-            } else {
-                if ($exp[1] == 'GB') {
-
-                    return $memo * 1024;
-                } else {
-
-                    return 0;
-                }
-            }
-        }
-
-        return 0;
-    }
-
-    /**
-     * Check to set new value grep "memory_limit"
-     * @return bool
-     */
-    public function isSetCliMemoryLimit()
-    {
-        $oldMemory = exec($this->getPHP().' -i | grep "memory_limit"');
-        $tmpMem = '2GB';
-
-        if ($oldMemory) {
-            $memory = explode('=>', $oldMemory);
-            $originGrepMemmory = trim($memory[2]);
-
-            if ($originGrepMemmory == $tmpMem) {
-                $tmpMem = '2.5GB';
-            }
-
-            $newMemory = exec($this->getPHP().' -d memory_limit=' . $tmpMem . ' -i | grep "memory_limit"');
-            if ($newMemory) {
-                $newMemory = explode('=>', $newMemory);
-                $grepNewMemory = trim($newMemory[2]);
-                if ($grepNewMemory != $originGrepMemmory) {
-
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Check php command line
-     * @return bool
-     */
-    public function isPhpCommandLine()
-    {
-        $php = exec('which php');
-        if (function_exists('exec') && null != $php) {
-            if (strpos(strtolower($php), 'php') !== false) {
-                return true;
-            }
-        }
-
-        return false;
+        return ($memoryLimit == 0) ? 0 : ($memoryLimit / 1024) / 1024;
     }
 }

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -40,12 +40,6 @@ class SystemService
      */
     protected $em;
 
-    /**
-     * @Inject("config")
-     * @var array
-     */
-    protected $appConfig;
-
     public function getDbversion()
     {
 
@@ -88,14 +82,13 @@ class SystemService
 
     /**
      * Try to set new values memory_limit | return true
+     * @param $memory | EX: 1536M
      * @return bool
      */
-    public function isSetMemoryLimit()
+    public function canSetMemoryLimit($memory)
     {
-        $setMemory = $this->appConfig['composer_memory_limit'].'M';
-
         try {
-            ini_set('memory_limit', $setMemory);
+            ini_set('memory_limit', $memory);
         } catch (\Exception $exception) {
             return false;
         }

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -180,8 +180,11 @@ class SystemService
      */
     public function isPhpCommandLine()
     {
-        if (function_exists('exec') && null != exec('php -v')) {
-            return true;
+        $php = exec('which php');
+        if (function_exists('exec') && null != $php) {
+            if (strpos(strtolower($php), 'php') !== false) {
+                return true;
+            }
         }
 
         return false;

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -76,6 +76,16 @@ class SystemService
     }
 
     /**
+     * Get environment php command
+     *
+     * @return string
+     */
+    public function getPHP()
+    {
+        return 'php';
+    }
+
+    /**
      * Check permission php.ini and set new memory_limit
      * @param string $memoryLimit
      * @return bool

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -129,8 +129,8 @@ class SystemService
      * Get grep memory_limit | Megabyte
      * @return int|string
      */
-    public function getGrepMemoryLimit(){
-        $grepMemory = exec($this->getPHP() . ' -i | grep "memory_limit"');
+    public function getCliMemoryLimit(){
+        $grepMemory = exec($this->getPHP().' -i | grep "memory_limit"');
         if($grepMemory){
             $grepMemory = explode('=>', $grepMemory);
             $exp = preg_split('#(?<=\d)(?=[a-z])#i', $grepMemory[2]);
@@ -156,9 +156,9 @@ class SystemService
      * Check to set new value grep "memory_limit"
      * @return bool
      */
-    public function isSetGrepMemoryLimit()
+    public function isSetCliMemoryLimit()
     {
-        $oldMemory = exec($this->getPHP() . ' -i | grep "memory_limit"');
+        $oldMemory = exec($this->getPHP().' -i | grep "memory_limit"');
         $tmpMem = '2GB';
 
         if ($oldMemory) {
@@ -169,7 +169,7 @@ class SystemService
                 $tmpMem = '2.5GB';
             }
 
-            $newMemory = exec($this->getPHP() . ' -d memory_limit=' . $tmpMem . ' -i | grep "memory_limit"');
+            $newMemory = exec($this->getPHP().' -d memory_limit=' . $tmpMem . ' -i | grep "memory_limit"');
             if ($newMemory) {
                 $newMemory = explode('=>', $newMemory);
                 $grepNewMemory = trim($newMemory[2]);

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -139,6 +139,7 @@ class SystemService
                 }
             }
         }
+
         return 0;
     }
 
@@ -169,6 +170,7 @@ class SystemService
                 }
             }
         }
+
         return false;
     }
 

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -86,14 +86,18 @@ class SystemService
     }
 
     /**
-     * Check permission php.ini and set new memory_limit
+     * Try to set new values memory_limit | return true
      * @return bool
      */
     public function isSetMemoryLimit()
     {
-        // Get path php.ini loaded
-        $iniPath = php_ini_loaded_file();
-        if ($iniPath && is_writable($iniPath)) {
+        $setMemory = self::MEMORY;
+        if ($this->getMemoryLimit() == $setMemory) {
+            $setMemory = 2048;
+        }
+
+        @ini_set('memory_limit', $setMemory);
+        if ($this->getMemoryLimit() != $setMemory) {
             return true;
         }
 

--- a/src/Eccube/ServiceProvider/ComposerServiceProvider.php
+++ b/src/Eccube/ServiceProvider/ComposerServiceProvider.php
@@ -41,7 +41,6 @@ class ComposerServiceProvider implements ServiceProviderInterface
             if ($systemService->isSetMemoryLimit() || ($systemService->getMemoryLimit() >= SystemService::MEMORY)) {
                 return new ComposerApiService($app);
             } else {
-                $app['eccube.listener.transaction.enabled'] = true;
                 return new ComposerProcessService($app);
             }
         };

--- a/src/Eccube/ServiceProvider/ComposerServiceProvider.php
+++ b/src/Eccube/ServiceProvider/ComposerServiceProvider.php
@@ -38,7 +38,8 @@ class ComposerServiceProvider implements ServiceProviderInterface
             /**@var \Eccube\Service\SystemService $systemService */
             $systemService = $app['eccube.service.system'];
             $composerMemory = $app['config']['composer_memory_limit'];
-            if ($systemService->isSetMemoryLimit() || $systemService->getMemoryLimit() == -1 || $systemService->getMemoryLimit() >= $composerMemory) {
+            $memoryLimit = $systemService->getMemoryLimit();
+            if ($systemService->canSetMemoryLimit($composerMemory.'M') || $memoryLimit == -1 || $memoryLimit >= $composerMemory) {
                 return new ComposerApiService($app);
             } else {
                 return new ComposerProcessService($app);

--- a/src/Eccube/ServiceProvider/ComposerServiceProvider.php
+++ b/src/Eccube/ServiceProvider/ComposerServiceProvider.php
@@ -26,7 +26,6 @@ namespace Eccube\ServiceProvider;
 
 use Eccube\Service\Composer\ComposerApiService;
 use Eccube\Service\Composer\ComposerProcessService;
-use Eccube\Service\SystemService;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
@@ -38,7 +37,8 @@ class ComposerServiceProvider implements ServiceProviderInterface
         $app['eccube.service.composer'] = function () use ($app) {
             /**@var \Eccube\Service\SystemService $systemService */
             $systemService = $app['eccube.service.system'];
-            if ($systemService->isSetMemoryLimit() || $systemService->getMemoryLimit() == -1 || $systemService->getMemoryLimit() >= SystemService::MEMORY) {
+            $composerMemory = $app['config']['composer_memory_limit'];
+            if ($systemService->isSetMemoryLimit() || $systemService->getMemoryLimit() == -1 || $systemService->getMemoryLimit() >= $composerMemory) {
                 return new ComposerApiService($app);
             } else {
                 return new ComposerProcessService($app);

--- a/src/Eccube/ServiceProvider/ComposerServiceProvider.php
+++ b/src/Eccube/ServiceProvider/ComposerServiceProvider.php
@@ -40,9 +40,9 @@ class ComposerServiceProvider implements ServiceProviderInterface
             $composerMemory = $app['config']['composer_memory_limit'];
             $memoryLimit = $systemService->getMemoryLimit();
             if ($systemService->canSetMemoryLimit($composerMemory.'M') || $memoryLimit == -1 || $memoryLimit >= $composerMemory) {
-                return new ComposerApiService($app);
+                return new ComposerApiService($app['config']);
             } else {
-                return new ComposerProcessService($app);
+                return new ComposerProcessService($app['config'], $app['orm.em'], $systemService->getPHP());
             }
         };
     }

--- a/src/Eccube/ServiceProvider/ComposerServiceProvider.php
+++ b/src/Eccube/ServiceProvider/ComposerServiceProvider.php
@@ -38,7 +38,7 @@ class ComposerServiceProvider implements ServiceProviderInterface
         $app['eccube.service.composer'] = function () use ($app) {
             /**@var \Eccube\Service\SystemService $systemService */
             $systemService = $app['eccube.service.system'];
-            if ($systemService->isSetMemoryLimit() || ($systemService->getMemoryLimit() >= SystemService::MEMORY)) {
+            if ($systemService->isSetMemoryLimit() || $systemService->getMemoryLimit() == -1 || $systemService->getMemoryLimit() >= SystemService::MEMORY) {
                 return new ComposerApiService($app);
             } else {
                 return new ComposerProcessService($app);

--- a/src/Eccube/ServiceProvider/ComposerServiceProvider.php
+++ b/src/Eccube/ServiceProvider/ComposerServiceProvider.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\ServiceProvider;
+
+use Eccube\Service\Composer\ComposerApiService;
+use Eccube\Service\Composer\ComposerProcessService;
+use Eccube\Service\SystemService;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+class ComposerServiceProvider implements ServiceProviderInterface
+{
+
+    public function register(Container $app)
+    {
+        $app['eccube.service.composer'] = function () use ($app) {
+            /**@var \Eccube\Service\SystemService $systemService */
+            $systemService = $app['eccube.service.system'];
+            if ($systemService->isSetMemoryLimit() || ($systemService->getMemoryLimit() >= SystemService::MEMORY)) {
+                return new ComposerApiService($app);
+            } else {
+                $app['eccube.listener.transaction.enabled'] = true;
+                return new ComposerProcessService($app);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ PullRequestの目的、関連するIssue番号など
    - base on memory of server, decide using ComposerApi or composer.phar

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外し内容
    - need both services : composerApiService & composerProcessService

## 実装に関する補足(Appendix)
+ checking environment php-web and php-cli

## テスト（Test)
+ test on linux server with memory < 1 GB
+ test on linux serer with memory > 1.5GB

## 相談（Discussion）
+ check path of "php" need apply for others ( maybe create 1 issue about change php path )
+ in php version > 5.4 , dont have restrict memory (safe mod ). so it auto expand memory when setting
