### PR TITLE
ext-intlを追加

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
+        "ext-intl": "^1.1",
         "ext-mbstring": "*",
         "composer/ca-bundle": "^1.0",
         "composer/composer": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9dc6c2745c9732774919286d65c97fcc",
+    "content-hash": "674e619eed472c286b774432e9a81b97",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -7622,6 +7622,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^5.6 || ^7.0",
+        "ext-intl": "^1.1",
         "ext-mbstring": "*"
     },
     "platform-dev": [],


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- herokuボタンが動かなくなっていたので、intlを有効にしています。
