### PR TITLE
商品一覧の表示件数を20/40に初期値する #1869

### DIFF
--- a/src/Eccube/Resource/doctrine/import_csv/mtb_product_list_max.csv
+++ b/src/Eccube/Resource/doctrine/import_csv/mtb_product_list_max.csv
@@ -1,4 +1,3 @@
 id,name,rank,discriminator_type
-"15","15件","0","productlistmax"
-"30","30件","1","productlistmax"
-"50","50件","2","productlistmax"
+"20","20件","0","productlistmax"
+"40","40件","1","productlistmax"


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 商品一覧の表示件数を20/40に初期値する #1869