### PR TITLE
Composerの動作方法をサーバーによって自動で切り替える対応

### DIFF
--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -42,6 +42,7 @@ use Eccube\Plugin\ConfigManager as PluginConfigManager;
 use Eccube\Routing\EccubeRouter;
 use Eccube\ServiceProvider\CompatRepositoryProvider;
 use Eccube\ServiceProvider\CompatServiceProvider;
+use Eccube\ServiceProvider\ComposerServiceProvider;
 use Eccube\ServiceProvider\EntityEventServiceProvider;
 use Eccube\ServiceProvider\ForwardOnlyServiceProvider;
 use Eccube\ServiceProvider\MobileDetectServiceProvider;
@@ -338,6 +339,7 @@ class Application extends \Silex\Application
 
         $this->register(new CompatRepositoryProvider());
         $this->register(new CompatServiceProvider());
+        $this->register(new ComposerServiceProvider());
         $this->register(new ServiceProvider\EccubeServiceProvider());
         $this->register(new PagenatorServiceProvider());
         $this->register(new PaymentServiceProvider());

--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -29,7 +29,6 @@ use Eccube\Common\Constant;
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\Plugin;
 use Eccube\Repository\PluginRepository;
-use Eccube\Service\Composer\ComposerApiService;
 use Eccube\Service\PluginService;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -60,12 +59,6 @@ class OwnerStoreController extends AbstractController
      * @var PluginService
      */
     protected $pluginService;
-
-    /**
-     * @Inject(ComposerApiService::class)
-     * @var ComposerApiService
-     */
-    protected $composerService;
 
     /**
      * @var EntityManager
@@ -258,7 +251,8 @@ class OwnerStoreController extends AbstractController
             }
         }
         $packageNames .= self::$vendorName.'/'.$pluginCode;
-        $return = $this->composerService->execRequire($packageNames);
+        $return = $app['eccube.service.composer']->execRequire($packageNames);
+
         if ($return) {
             $app->addSuccess('admin.plugin.install.complete', 'admin');
 
@@ -338,7 +332,7 @@ class OwnerStoreController extends AbstractController
         }
         $pluginCode = $Plugin->getCode();
         $packageName = self::$vendorName.'/'.$pluginCode;
-        $return = $this->composerService->execRemove($packageName);
+        $return = $app['eccube.service.composer']->execRemove($packageName);
         if ($return) {
             $app->addSuccess('admin.plugin.uninstall.complete', 'admin');
         } else {

--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -29,6 +29,7 @@ use Eccube\Common\Constant;
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\Plugin;
 use Eccube\Repository\PluginRepository;
+use Eccube\Service\Composer\ComposerServiceInterface;
 use Eccube\Service\PluginService;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -59,6 +60,12 @@ class OwnerStoreController extends AbstractController
      * @var PluginService
      */
     protected $pluginService;
+
+    /**
+     * @Inject("eccube.service.composer")
+     * @var ComposerServiceInterface
+     */
+    protected $composerService;
 
     /**
      * @var EntityManager
@@ -251,8 +258,7 @@ class OwnerStoreController extends AbstractController
             }
         }
         $packageNames .= self::$vendorName.'/'.$pluginCode;
-        $return = $app['eccube.service.composer']->execRequire($packageNames);
-
+        $return = $this->composerService->execRequire($packageNames);
         if ($return) {
             $app->addSuccess('admin.plugin.install.complete', 'admin');
 
@@ -332,7 +338,7 @@ class OwnerStoreController extends AbstractController
         }
         $pluginCode = $Plugin->getCode();
         $packageName = self::$vendorName.'/'.$pluginCode;
-        $return = $app['eccube.service.composer']->execRemove($packageName);
+        $return = $this->composerService->execRemove($packageName);
         if ($return) {
             $app->addSuccess('admin.plugin.uninstall.complete', 'admin');
         } else {

--- a/src/Eccube/Resource/config/constant.php
+++ b/src/Eccube/Resource/config/constant.php
@@ -63,4 +63,5 @@
     'product_order_price_higher' => 3,
     'price_max' => 2147483647,
     'pageinrange' => false,
+    'composer_memory_limit' => 1536,
 ];

--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -40,21 +40,15 @@ class ComposerApiService implements ComposerServiceInterface
     protected $appConfig;
 
     /**
-     * @var \Eccube\Application
-     */
-    protected $app;
-
-    /**
      * @var Application $consoleApplication
      */
     private $consoleApplication;
 
     private $workingDir;
 
-    public function __construct(\Eccube\Application $app)
+    public function __construct($appConfig)
     {
-        $this->app = $app;
-        $this->appConfig = $app['config'];
+        $this->appConfig = $appConfig;
     }
 
     /**

--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -23,7 +23,6 @@
 namespace Eccube\Service\Composer;
 
 use Composer\Console\Application;
-use Eccube\Annotation\Inject;
 use Eccube\Annotation\Service;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -36,10 +35,14 @@ use Symfony\Component\Console\Output\BufferedOutput;
 class ComposerApiService implements ComposerServiceInterface
 {
     /**
-     * @Inject("config")
      * @var array
      */
     protected $appConfig;
+
+    /**
+     * @var \Eccube\Application
+     */
+    protected $app;
 
     /**
      * @var Application $consoleApplication
@@ -47,6 +50,12 @@ class ComposerApiService implements ComposerServiceInterface
     private $consoleApplication;
 
     private $workingDir;
+
+    public function __construct(\Eccube\Application $app)
+    {
+        $this->app = $app;
+        $this->appConfig = $app['config'];
+    }
 
     /**
      * Run get info command

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -36,7 +36,7 @@ use Eccube\Plugin\ConfigManager;
 use Eccube\Plugin\ConfigManager as PluginConfigManager;
 use Eccube\Repository\PluginEventHandlerRepository;
 use Eccube\Repository\PluginRepository;
-use Eccube\Service\Composer\ComposerApiService;
+use Eccube\Service\Composer\ComposerServiceInterface;
 use Eccube\Util\Cache;
 use Eccube\Util\Str;
 use Symfony\Component\Filesystem\Filesystem;
@@ -90,8 +90,8 @@ class PluginService
     protected $schemaService;
 
     /**
-     * @Inject(ComposerApiService::class)
-     * @var ComposerApiService
+     * @Inject("eccube.service.composer")
+     * @var ComposerServiceInterface
      */
     protected $composerService;
 

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -82,18 +82,18 @@ class SystemService
 
     /**
      * Try to set new values memory_limit | return true
-     * @param $memory | EX: 1536M
+     * @param string $memory | EX: 1536M
      * @return bool
      */
     public function canSetMemoryLimit($memory)
     {
         try {
-            ini_set('memory_limit', $memory);
+            $ret = ini_set('memory_limit', $memory);
         } catch (\Exception $exception) {
             return false;
         }
 
-        return true;
+        return ($ret === false) ? false : true;
     }
 
     /**

--- a/src/Eccube/ServiceProvider/ComposerServiceProvider.php
+++ b/src/Eccube/ServiceProvider/ComposerServiceProvider.php
@@ -38,10 +38,9 @@ class ComposerServiceProvider implements ServiceProviderInterface
         $app['eccube.service.composer'] = function () use ($app) {
             /**@var \Eccube\Service\SystemService $systemService */
             $systemService = $app['eccube.service.system'];
-            if ($systemService->isSetMemoryLimit() || ($systemService->getMemoryLimit() >= SystemService::MEMORY)) {
+            if ($systemService->isSetMemoryLimit() || $systemService->getMemoryLimit() == -1 || $systemService->getMemoryLimit() >= SystemService::MEMORY) {
                 return new ComposerApiService($app);
             } else {
-                $app['eccube.listener.transaction.enabled'] = true;
                 return new ComposerProcessService($app);
             }
         };

--- a/src/Eccube/ServiceProvider/ComposerServiceProvider.php
+++ b/src/Eccube/ServiceProvider/ComposerServiceProvider.php
@@ -26,7 +26,6 @@ namespace Eccube\ServiceProvider;
 
 use Eccube\Service\Composer\ComposerApiService;
 use Eccube\Service\Composer\ComposerProcessService;
-use Eccube\Service\SystemService;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
@@ -38,10 +37,12 @@ class ComposerServiceProvider implements ServiceProviderInterface
         $app['eccube.service.composer'] = function () use ($app) {
             /**@var \Eccube\Service\SystemService $systemService */
             $systemService = $app['eccube.service.system'];
-            if ($systemService->isSetMemoryLimit() || $systemService->getMemoryLimit() == -1 || $systemService->getMemoryLimit() >= SystemService::MEMORY) {
-                return new ComposerApiService($app);
+            $composerMemory = $app['config']['composer_memory_limit'];
+            $memoryLimit = $systemService->getMemoryLimit();
+            if ($systemService->canSetMemoryLimit($composerMemory.'M') || $memoryLimit == -1 || $memoryLimit >= $composerMemory) {
+                return new ComposerApiService($app['config']);
             } else {
-                return new ComposerProcessService($app);
+                return new ComposerProcessService($app['config'], $app['orm.em'], $systemService->getPHP());
             }
         };
     }

--- a/src/Eccube/ServiceProvider/ComposerServiceProvider.php
+++ b/src/Eccube/ServiceProvider/ComposerServiceProvider.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+namespace Eccube\ServiceProvider;
+
+use Eccube\Service\Composer\ComposerApiService;
+use Eccube\Service\Composer\ComposerProcessService;
+use Eccube\Service\SystemService;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+class ComposerServiceProvider implements ServiceProviderInterface
+{
+
+    public function register(Container $app)
+    {
+        $app['eccube.service.composer'] = function () use ($app) {
+            /**@var \Eccube\Service\SystemService $systemService */
+            $systemService = $app['eccube.service.system'];
+            if ($systemService->isSetMemoryLimit() || ($systemService->getMemoryLimit() >= SystemService::MEMORY)) {
+                return new ComposerApiService($app);
+            } else {
+                $app['eccube.listener.transaction.enabled'] = true;
+                return new ComposerProcessService($app);
+            }
+        };
+    }
+}

--- a/src/Eccube/ServiceProvider/ComposerServiceProvider.php
+++ b/src/Eccube/ServiceProvider/ComposerServiceProvider.php
@@ -20,8 +20,6 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
-
-
 namespace Eccube\ServiceProvider;
 
 use Eccube\Service\Composer\ComposerApiService;
@@ -29,9 +27,15 @@ use Eccube\Service\Composer\ComposerProcessService;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
+/**
+ * Class ComposerServiceProvider
+ * @package Eccube\ServiceProvider
+ */
 class ComposerServiceProvider implements ServiceProviderInterface
 {
-
+    /**
+     * @param Container $app
+     */
     public function register(Container $app)
     {
         $app['eccube.service.composer'] = function () use ($app) {
@@ -39,6 +43,7 @@ class ComposerServiceProvider implements ServiceProviderInterface
             $systemService = $app['eccube.service.system'];
             $composerMemory = $app['config']['composer_memory_limit'];
             $memoryLimit = $systemService->getMemoryLimit();
+            // Check memory and can set memory for composer api
             if ($systemService->canSetMemoryLimit($composerMemory.'M') || $memoryLimit == -1 || $memoryLimit >= $composerMemory) {
                 return new ComposerApiService($app['config']);
             } else {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ PullRequestの目的、関連するIssue番号など
    - Base on RAM of server, decide composer using composerAPI or composer.phar
 
## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外し内容
   - condition to switch : RAM 1.5GB 

## 実装に関する補足(Appendix)
- checking environment base on : php-web and php-cli

## テスト（Test)
- test on linux server with memory < 1 GB
- test on linux serer with memory > 1.5GB

## 相談（Discussion）
- check path of "php" need apply for others ( maybe create 1 issue about change php path )
- in php version > 5.4 , dont have restrict memory (safe mod ). so it auto expand memory when setting
