### PR TITLE
購入時の確認画面を追加

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -213,9 +213,49 @@ class ShoppingController extends AbstractShoppingController
      *
      * @Route("/shopping/confirm", name="shopping_confirm")
      * @Method("POST")
-     * @Template("Shopping/index.twig")
+     * @Template("Shopping/confirm.twig")
      */
     public function confirm(Application $app, Request $request)
+    {
+        // カートチェック
+        $response = $app->forward($app->path("shopping_check_to_cart"));
+        if ($response->isRedirection() || $response->getContent()) {
+            return $response;
+        }
+
+        // 受注の存在チェック
+        $response = $app->forward($app->path("shopping_exists_order"));
+        if ($response->isRedirection() || $response->getContent()) {
+            return $response;
+        }
+
+        // フォームの生成
+        $app->forward($app->path("shopping_create_form"));
+        $form = $this->parameterBag->get(OrderType::class);
+        $form->handleRequest($request);
+
+        $form = $this->parameterBag->get(OrderType::class);
+        $Order = $this->parameterBag->get('Order');
+
+        $flowResult = $this->executePurchaseFlow($app, $Order);
+        if ($flowResult->hasWarning() || $flowResult->hasError()) {
+            return $app->redirect($app->url('shopping_error'));
+        }
+
+        return [
+            'form' => $form->createView(),
+            'Order' => $Order,
+        ];
+    }
+
+    /**
+     * 購入処理
+     *
+     * @Route("/shopping/order", name="shopping_order")
+     * @Method("POST")
+     * @Template("Shopping/index.twig")
+     */
+    public function order(Application $app, Request $request)
     {
         // カートチェック
         $response = $app->forward($app->path("shopping_check_to_cart"));

--- a/src/Eccube/Resource/doctrine/import_csv/dtb_page.csv
+++ b/src/Eccube/Resource/doctrine/import_csv/dtb_page.csv
@@ -42,3 +42,4 @@ id,device_type_id,page_name,url,file_name,edit_type,author,description,keyword,u
 "43","10","商品購入/お届け先の複数指定","shopping_shipping_multiple_change","Shopping/index","2",,,,,"2017-03-07 01:15:03","2017-03-07 01:15:03","noindex","page"
 "38","10","パスワード変更(完了ページ)","forgot_reset","Forgot/reset","2",,,,,"2017-03-07 01:15:02","2017-03-07 01:15:05","noindex","page"
 "44","10","MYページ/お届け先編集","mypage_delivery_edit","Mypage/delivery_edit","2",,,,,"2017-03-07 01:15:05","2017-03-07 01:15:05","noindex","page"
+"45","10","商品購入/ご注文確認","shopping_confirm","Shopping/confirm","2",,,,,"2017-03-07 01:15:03","2017-03-07 01:15:03","noindex","page"

--- a/src/Eccube/Resource/doctrine/import_csv/dtb_page_layout.csv
+++ b/src/Eccube/Resource/doctrine/import_csv/dtb_page_layout.csv
@@ -43,3 +43,4 @@ page_id,layout_id,discriminator_type
 "43","3","pagelayout"
 "38","3","pagelayout"
 "44","3","pagelayout"
+"45","3","pagelayout"

--- a/src/Eccube/Resource/template/default/Cart/index.twig
+++ b/src/Eccube/Resource/template/default/Cart/index.twig
@@ -198,6 +198,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     <div class="ec-cartRole__total">合計：<span class="ec-cartRole__totalAmount">{{ Cart.totalPrice|price }}</span>
                     </div>
                     <a class="ec-blockBtn--action" href="{{ path('cart_buystep', {'index':loop.index0}) }}">レジに進む</a>
+                    {% if loop.last %}
+                    <a class="ec-blockBtn--cancel" href="{{ path('homepage') }}">お買い物を続ける</a>
+                    {% endif %}
                 </div>
                 {% endfor %}
             </form>
@@ -214,6 +217,5 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             </div>
         {% endif %}
     </div>
-
 
 {% endblock %}

--- a/src/Eccube/Resource/template/default/Cart/index.twig
+++ b/src/Eccube/Resource/template/default/Cart/index.twig
@@ -52,6 +52,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 <li class="ec-progress__item">
                     <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
                     </div>
+                    <div class="ec-progress__label">ご注文手続き
+                    </div>
+                </li>
+                <li class="ec-progress__item">
+                    <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
+                    </div>
                     <div class="ec-progress__label">ご注文内容確認
                     </div>
                 </li>

--- a/src/Eccube/Resource/template/default/Shopping/complete.twig
+++ b/src/Eccube/Resource/template/default/Shopping/complete.twig
@@ -51,6 +51,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             <li class="ec-progress__item">
                 <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
                 </div>
+                <div class="ec-progress__label">ご注文手続き
+                </div>
+            </li>
+            <li class="ec-progress__item">
+                <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
+                </div>
                 <div class="ec-progress__label">ご注文内容確認
                 </div>
             </li>

--- a/src/Eccube/Resource/template/default/Shopping/confirm.twig
+++ b/src/Eccube/Resource/template/default/Shopping/confirm.twig
@@ -150,7 +150,7 @@ $(function() {
 
 <div class="ec-role">
     <div class="ec-pageHeader">
-        <h1>ご注文手続き</h1>
+        <h1>ご注文内容のご確認</h1>
     </div>
 </div>
 
@@ -172,13 +172,13 @@ $(function() {
                 </div>
             </li>
             {% endif %}
-            <li class="ec-progress__item is-complete">
+            <li class="ec-progress__item">
                 <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
                 </div>
                 <div class="ec-progress__label">ご注文手続き
                 </div>
             </li>
-            <li class="ec-progress__item">
+            <li class="ec-progress__item is-complete">
                 <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
                 </div>
                 <div class="ec-progress__label">ご注文内容確認
@@ -226,48 +226,44 @@ $(function() {
 </div><!-- /.row -->
 
 
-<form id="shopping-form" method="post" action="{{ url('shopping_confirm') }}">
+<form id="shopping-form" method="post" action="{{ url('shopping_order') }}">
     {{ form_widget(form._token) }}
     {{ form_widget(form.mode) }}
     {{ form_widget(form.param) }}
     <div class="ec-orderRole">
         <div class="ec-orderRole__detail">
+            <div class="ec-orderOrder">
+                <ul class="ec-borderedList">
+                    {% for orderDetail in Order.orderItems %}
+                    <li>
+                        <div class="ec-imageGrid">
+                            <div class="ec-imageGrid__img">
+                                <img src="{{ asset((orderDetail.product is null ? null : orderDetail.product.MainListImage)|no_image_product, 'save_image') }}">
+                            </div>
+                            <div class="ec-imageGrid__content">
+                                <p>{{ orderDetail.productName }}</p>
+                                {% if orderDetail.productClass is not null and orderDetail.productClass.classCategory1 %}
+                                    <p>{{ orderDetail.productClass.classCategory1.className }}：{{ orderDetail.productClass.classCategory1 }}</p>
+                                {% endif %}
+                                {% if orderDetail.productClass is not null and orderDetail.productClass.classCategory2 %}
+                                    <p>{{ orderDetail.productClass.classCategory2.className }}：{{ orderDetail.productClass.classCategory2 }}</p>
+                                {% endif %}
+                                <p>{{ orderDetail.priceIncTax|price }} × {{ orderDetail.quantity|number_format }}<span class="ec-imageGrid__contentTotal">小計：{{ orderDetail.totalPrice|price }}</span></p>
+                            </div>
+                        </div>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
             <div class="ec-orderAccount">
                 <div class="ec-rectHeading">
                     <h2>お客様情報</h2>
                 </div>
-                {% if is_granted('ROLE_USER') == false %}
-                <div class="ec-orderAccount__change">
-                    <button id="customer" class="ec-inlineBtn" type="button">変更</button>
-                </div>
-                {% endif %}
                 <div class="ec-orderAccount__account">
                     <p><span class="customer-edit customer-name01">{{ Order.name01 }}</span> <span class="customer-edit customer-name02">{{ Order.name02 }}</span> 様</p>
                     <p>〒<span class="customer-edit customer-zip01">{{ Order.zip01 }}</span>-<span class="customer-edit customer-zip02">{{ Order.zip02 }}</span>　<span class="customer-edit customer-pref">{{ Order.pref }}</span><span class="customer-edit customer-addr01">{{ Order.addr01 }}</span><span class="customer-edit customer-addr02">{{ Order.addr02 }}</span></p>
                     <p><span class="customer-edit customer-tel01">{{ Order.tel01 }}</span>-<span class="customer-edit customer-tel02">{{ Order.tel02 }}</span>-<span class="customer-edit customer-tel03">{{ Order.tel03 }}</span></p>
                 </div>
-                {% if is_granted('ROLE_USER') == false %}
-                <div class="ec-orderAccount__account">
-                    <p><span class="customer-edit customer-email">{{ Order.email }}</span></p>
-                    <p><span class="customer-edit customer-company_name">{{ Order.companyName }}</span></p>
-                </div>
-                <div class="mod-button" style="display:none;">
-                    <span id="customer-ok"><button type="button" class="btn btn-default btn-sm">OK</button></span>
-                    <span id="customer-cancel"><button type="button" class="btn btn-default btn-sm">キャンセル</button></span>
-                </div>
-                <input type="hidden" id="customer-name01" class="customer-in" name="customer_name01" value="{{ Order.name01 }}">
-                <input type="hidden" id="customer-name02" class="customer-in" name="customer_name02" value="{{ Order.name02 }}">
-                <input type="hidden" id="customer-zip01" class="customer-in" name="customer_zip01" value="{{ Order.zip01 }}">
-                <input type="hidden" id="customer-zip02" class="customer-in" name="customer_zip02" value="{{ Order.zip02 }}">
-                <input type="hidden" id="customer-pref" class="customer-in" name="customer_pref" value="{{ Order.pref }}">
-                <input type="hidden" id="customer-addr01" class="customer-in" name="customer_addr01" value="{{ Order.addr01 }}">
-                <input type="hidden" id="customer-addr02" class="customer-in" name="customer_addr02" value="{{ Order.addr02 }}">
-                <input type="hidden" id="customer-tel01" class="customer-in" name="customer_tel01" value="{{ Order.tel01 }}">
-                <input type="hidden" id="customer-tel02" class="customer-in" name="customer_tel02" value="{{ Order.tel02 }}">
-                <input type="hidden" id="customer-tel03" class="customer-in" name="customer_tel03" value="{{ Order.tel03 }}">
-                <input type="hidden" id="customer-email" class="customer-in" name="customer_email" value="{{ Order.email }}">
-                <input type="hidden" id="customer-company-name" class="customer-in" name="customer_company_name" value="{{ Order.companyName }}">
-                {% endif %}
             </div>
             <div class="ec-orderDelivery">
                 <div class="ec-rectHeading">
@@ -275,15 +271,6 @@ $(function() {
                 </div>
                 {% for shipping in Order.shippings %}
                     {% set idx = loop.index0 %}
-                    <div class="ec-orderDelivery__title">お届け先{% if Order.multiple %}({{ loop.index }}){% endif %}
-                        <div class="ec-orderDelivery__change">
-                            {% if is_granted('ROLE_USER') %}
-                                <a href="{{ url('shopping_shipping', {'id': shipping.id}) }}" class="ec-inlineBtn btn-shipping" data-id="{{ shipping.id }}">変更</a>
-                            {% else %}
-                                <a href="{{ url('shopping_shipping_edit_change', {'id': shipping.id}) }}" class="ec-inlineBtn btn-shipping-edit" data-id="{{ shipping.id }}">変更</a>
-                            {% endif %}
-                        </div>
-                    </div>
                     <div class="ec-orderDelivery__item">
                         <ul class="ec-borderedList">
                             {% for orderItem in shipping.orderItems %}
@@ -314,16 +301,18 @@ $(function() {
                         <div class="ec-selects">
                             <div class="ec-select">
                                 <label>配送方法</label>
-                                {{ form_widget(form.Shippings[idx].Delivery, {'attr': {'class': 'delivery form-control'}}) }}
-                                {{ form_errors(form.Shippings[idx].Delivery) }}
+                                {{ Order.Shippings[idx].Delivery }}
+                                {{ form_widget(form.Shippings[idx].Delivery, {'type': 'hidden'}) }}
                             </div>
                             <div class="ec-select ec-select__delivery">
                                 <label>お届け日</label>
-                                {{ form_widget(form.Shippings[idx].shipping_delivery_date, {'attr': {'class': 'form-control'}}) }}
+                                {{ Order.Shippings[idx].shipping_delivery_date?:"指定なし" }}
+                                {{ form_widget(form.Shippings[idx].shipping_delivery_date, {'type': 'hidden'}) }}
                             </div>
                             <div class="ec-select ec-select__time">
                                 <label>お届け時間</label>
-                                {{ form_widget(form.Shippings[idx].DeliveryTime, {'attr': {'class': 'form-control'}}) }}
+                                {{ Order.Shippings[idx].shipping_delivery_time?:"指定なし" }}
+                                {{ form_widget(form.Shippings[idx].DeliveryTime, {'type': 'hidden'}) }}
                             </div>
                         </div>
                     </div>
@@ -337,16 +326,8 @@ $(function() {
                     <h2>お支払方法</h2>
                 </div>
                 <div class="ec-blockRadio">
-                    {% for key, child in form.Payment %}
-                        {% set Payment = form.Payment.vars.choices[key].data %}
-                        {% if Payment.visible %}
-                            <label>{{ form_widget(child, {'attr': {'class': 'payment' }}) }}<span>{{ child.vars.label }}</span></label>
-                            {% if Payment.payment_image is not null %}
-                                <img src="{{ asset(Payment.payment_image, 'save_image') }}">
-                            {% endif %}
-                        {% endif %}
-                    {% endfor %}
-                    {{ form_errors(form.Payment) }}
+                    {{ Order.Payment }}
+                    {{ form_widget(form.Payment, {'type': 'hidden'}) }}
                 </div>
             </div>
             <div class="ec-orderConfirm">
@@ -354,8 +335,8 @@ $(function() {
                     <h2>お問い合わせ</h2>
                 </div>
                 <div class="ec-input">
-                    {{ form_widget(form.message, {'attr': {'class': 'form-control', 'placeholder': 'お問い合わせ事項がございましたら、こちらにご入力ください。(3000文字まで)', 'rows': '6'}}) }}
-                    {{ form_errors(form.message) }}
+                    {{ Order.message }}
+                    {{ form_widget(form.message, {'type': 'hidden'}) }}
                 </div>
                 {% for f in form.getIterator %}
                     <div class="ec-input">
@@ -388,8 +369,7 @@ $(function() {
                 {% endif %}
                 <div class="ec-totalBox__total">合計<span class="ec-totalBox__price">{{ Order.total|price }}</span><span class="ec-totalBox__taxLabel">税込</span></div>
                 <div class="ec-totalBox__btn">
-                    <button type="submit" class="ec-blockBtn--action">確認する</button>
-                    <a href="{{ url("cart") }}" class="ec-blockBtn--cancel">カートに戻る</a>
+                    <button type="submit" class="ec-blockBtn--action">注文する</button>
                 </div>
             </div>
         </div>

--- a/src/Eccube/Resource/template/default/Shopping/confirm.twig
+++ b/src/Eccube/Resource/template/default/Shopping/confirm.twig
@@ -370,6 +370,7 @@ $(function() {
                 <div class="ec-totalBox__total">合計<span class="ec-totalBox__price">{{ Order.total|price }}</span><span class="ec-totalBox__taxLabel">税込</span></div>
                 <div class="ec-totalBox__btn">
                     <button type="submit" class="ec-blockBtn--action">注文する</button>
+                    <a href="{{ url('shopping') }}" class="ec-blockBtn--cancel">ご注文手続きに戻る</a>
                 </div>
             </div>
         </div>

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -75,14 +75,20 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
         // カート画面
         $this->scenarioCartIn($client);
 
-        // 確認画面
+        // 手続き画面
         $crawler = $this->scenarioConfirm($client);
+        $this->expected = 'ご注文手続き';
+        $this->actual = $crawler->filter('h1')->text();
+        $this->verify();
+
+        // 確認画面
+        $crawler = $this->scenarioComplete($client, $this->app->path('shopping_confirm'));
         $this->expected = 'ご注文内容のご確認';
         $this->actual = $crawler->filter('h1')->text();
         $this->verify();
 
         // 完了画面
-        $crawler = $this->scenarioComplete($client, $this->app->path('shopping_confirm'));
+        $this->scenarioComplete($client, $this->app->path('shopping_order'));
         $this->assertTrue($client->getResponse()->isRedirect($this->app->url('shopping_complete')));
 
         $BaseInfo = $this->app['eccube.repository.base_info']->get();

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
@@ -60,7 +60,7 @@ class ShoppingControllerWithNonmemberTest extends AbstractShoppingControllerTest
     }
 
     /**
-     * 非会員情報入力→購入確認画面
+     * 非会員情報入力→注文手続画面
      */
     public function testConfirmWithNonmember()
     {
@@ -71,7 +71,7 @@ class ShoppingControllerWithNonmemberTest extends AbstractShoppingControllerTest
         $this->scenarioInput($client, $formData);
 
         $crawler = $client->request('GET', $this->app->path('shopping'));
-        $this->expected = 'ご注文内容のご確認';
+        $this->expected = 'ご注文手続き';
         $this->actual = $crawler->filter('h1')->text();
         $this->verify();
 
@@ -79,7 +79,7 @@ class ShoppingControllerWithNonmemberTest extends AbstractShoppingControllerTest
     }
 
     /**
-     * 非会員情報入力→購入確認画面→完了画面
+     * 非会員情報入力→注文手続画面→購入確認画面→完了画面
      */
     public function testCompleteWithNonmember()
     {
@@ -91,12 +91,16 @@ class ShoppingControllerWithNonmemberTest extends AbstractShoppingControllerTest
         $this->scenarioInput($client, $formData);
 
         $crawler = $this->scenarioConfirm($client);
+        $this->expected = 'ご注文手続き';
+        $this->actual = $crawler->filter('h1')->text();
+        $this->verify();
+
+        $crawler = $this->scenarioComplete($client, $this->app->path('shopping_confirm'));
         $this->expected = 'ご注文内容のご確認';
         $this->actual = $crawler->filter('h1')->text();
         $this->verify();
 
-        $this->scenarioComplete($client, $this->app->path('shopping_confirm'));
-
+        $this->scenarioComplete($client, $this->app->path('shopping_order'));
         $this->assertTrue($client->getResponse()->isRedirect($this->app->url('shopping_complete')));
 
         $BaseInfo = $this->app['eccube.repository.base_info']->get();


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ 購入フローに確認画面を追加
+ 関連 https://github.com/EC-CUBE/ec-cube/issues/2582

## 実装に関する補足(Appendix)
+ 既存のルーティング `shopping_confirm` で確認画面を表示し、新規ルーティング `shopping_order` で従来の購入処理を行っています。
