### PR TITLE
getEnabledを利用している箇所をisEnabledに変更

### DIFF
--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -352,7 +352,7 @@ class OwnerStoreController extends AbstractController
     {
         $this->isTokenValid($app);
 
-        if ($Plugin->getEnabled()) {
+        if ($Plugin->isEnabled()) {
             $this->pluginService->disable($Plugin);
         }
         $pluginCode = $Plugin->getCode();

--- a/src/Eccube/ServiceProvider/EccubePluginServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubePluginServiceProvider.php
@@ -287,7 +287,7 @@ class EccubePluginServiceProvider implements ServiceProviderInterface, BootableP
             ->getHandlers();
 
         foreach ($handlers as $handler) {
-            if ($handler->getPlugin()->getEnabled()) {
+            if ($handler->getPlugin()->isEnabled()) {
 
                 $priority = $handler->getPriority();
             } else {
@@ -318,7 +318,7 @@ class EccubePluginServiceProvider implements ServiceProviderInterface, BootableP
                 ->findOneBy(array('code' => $config['code']));
 
             // const
-            if (is_null($plugin) || !$plugin->getEnabled()) {
+            if (is_null($plugin) || !$plugin->isEnabled()) {
                 // プラグインが無効化されていれば読み込まない
                 continue;
             }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ #2643 の取り込みで、isEnabledがgetEnabledに先祖がえりしていました。
getEnabled→isEnabledに再度置き換えています。

## 方針(Policy)
なし

## 実装に関する補足(Appendix)
なし

## テスト（Test)
isEnabledに置き換えることで、動作することを確認。

## 相談（Discussion）
なし


