### PR TITLE
フロントからユーザー登録するときエラー修正

### DIFF
--- a/src/Eccube/Controller/EntryController.php
+++ b/src/Eccube/Controller/EntryController.php
@@ -164,7 +164,8 @@ class EntryController extends AbstractController
                     $Customer
                         ->setSalt($salt)
                         ->setPassword($password)
-                        ->setSecretKey($secretKey);
+                        ->setSecretKey($secretKey)
+                        ->setPoint(0);
 
                     $CustomerAddress = new CustomerAddress();
                     $CustomerAddress


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ フロントから新規ユーザーすると point not null のDBエラー発生されます。
(SQLSTATE[23502]: Not null violation)

## テスト環境
+ PHP Version 7.1.10
+ PostgreSQL 9.5.4