### PR TITLE
dtb_order.statusのカラム名修正漏れ

### DIFF
--- a/src/Eccube/Controller/Admin/AdminController.php
+++ b/src/Eccube/Controller/Admin/AdminController.php
@@ -366,16 +366,16 @@ class AdminController extends AbstractController
     protected function getOrderEachStatus($em, array $excludes)
     {
         $sql = 'SELECT
-                    t1.status as status,
+                    t1.order_status_id as status,
                     COUNT(t1.id) as count
                 FROM
                     dtb_order t1
                 WHERE
-                    t1.status NOT IN (:excludes)
+                    t1.order_status_id NOT IN (:excludes)
                 GROUP BY
-                    t1.status
+                    t1.order_status_id
                 ORDER BY
-                    t1.status';
+                    t1.order_status_id';
         $rsm = new ResultSetMapping();;
         $rsm->addScalarResult('status', 'status');
         $rsm->addScalarResult('count', 'count');

--- a/src/Eccube/Doctrine/Filter/OrderStatusFilter.php
+++ b/src/Eccube/Doctrine/Filter/OrderStatusFilter.php
@@ -33,7 +33,7 @@ class OrderStatusFilter extends SQLFilter
     {
         // 決済処理中/購入処理中を除く.
         if ($targetEntity->reflClass->getName() === 'Eccube\Entity\Order') {
-            return $targetTableAlias . '.status <> 7 AND ' . $targetTableAlias . '.status <> 8';
+            return $targetTableAlias . '.order_status_id <> 7 AND ' . $targetTableAlias . '.order_status_id <> 8';
         }
 
         // 決済処理中/購入処理中を除く.

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -454,7 +454,7 @@ class Order extends \Eccube\Entity\AbstractEntity implements PurchaseInterface, 
      *
      * @ORM\ManyToOne(targetEntity="Eccube\Entity\Master\CustomerOrderStatus")
      * @ORM\JoinColumns({
-     *   @ORM\JoinColumn(name="status", referencedColumnName="id")
+     *   @ORM\JoinColumn(name="order_status_id", referencedColumnName="id")
      * })
      */
     private $CustomerOrderStatus;


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ #2643 で`Order->OrderStatus`のDBカラムを`status`から`order_status_id`に変更したが、`Order->CustomerOrderStatus`の方も同じDBカラムにマッピングされるので、変更が必要
+ 関連 #2643

## 相談（Discussion）
+ 3.0系から1つのカラムに複数フィールドをマッピングしているので同様に対応。Doctrineでエラーは出ていないが、ER上のリレーションが貼られないのでこのままで良いのかどうか。
