### PR TITLE
FirefoxでのAjaxカート追加エラー対応

### DIFF
--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -133,7 +133,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         });
     </script>
     <script>
-        $('#add-cart').on('click', function () {
+        $('#add-cart').on('click', function (e) {
+            e.preventDefault();
             {% if form.classcategory_id1 is defined %}
             // 規格1フォームの必須チェック
             if ($('#classcategory_id1').val() == '__unselected' || $('#classcategory_id1').val() == '') {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ Firefox(56.0.2/macOS 10.13.1)でカートに追加したとき、Ajaxリクエストが終わる前に遷移してしまっていたので対応。
