### PR TITLE
管理画面IDについて検索10桁数が超えるとシステムエラー

### DIFF
--- a/src/Eccube/Form/Type/Admin/SearchShippingType.php
+++ b/src/Eccube/Form/Type/Admin/SearchShippingType.php
@@ -167,6 +167,9 @@ class SearchShippingType extends AbstractType
             ->add('order_id', TextType::class, array(
                 'label' => '注文番号',
                 'required' => false,
+                'constraints' => array(
+                    new Assert\Length(array('max' => 10)),
+                ),
             ))
         ;
 

--- a/src/Eccube/Form/Type/OrderSearchType.php
+++ b/src/Eccube/Form/Type/OrderSearchType.php
@@ -67,6 +67,7 @@ class OrderSearchType extends AbstractType
                     new Assert\Type(array(
                         'type' => 'integer',
                     )),
+                    new Assert\Length(array('max' => 10)),
                 ),
             ))
             ->add('order_id_end', IntegerType::class, array(
@@ -76,6 +77,7 @@ class OrderSearchType extends AbstractType
                     new Assert\Type(array(
                         'type' => 'integer',
                     )),
+                    new Assert\Length(array('max' => 10)),
                 ),
             ))
             ->add('status', OrderStatusType::class, array(

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -160,7 +160,7 @@ class CustomerRepository extends AbstractRepository implements UserProviderInter
         if (isset($searchData['multi']) && StringUtil::isNotBlank($searchData['multi'])) {
             //スペース除去
             $clean_key_multi = preg_replace('/\s+|[　]+/u', '', $searchData['multi']);
-            $id = preg_match('/^\d+$/', $clean_key_multi) ? $clean_key_multi : null;
+            $id = preg_match('/^\d{0,10}$/', $clean_key_multi) ? $clean_key_multi : null;
             $qb
                 ->andWhere('c.id = :customer_id OR CONCAT(c.name01, c.name02) LIKE :name OR CONCAT(c.kana01, c.kana02) LIKE :kana OR c.email LIKE :email')
                 ->setParameter('customer_id', $id)

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -274,7 +274,7 @@ class OrderRepository extends AbstractRepository
         }
         // multi
         if (isset( $searchData['multi']) && StringUtil::isNotBlank($searchData['multi'])) {
-            $multi = preg_match('/^\d+$/', $searchData['multi']) ? $searchData['multi'] : null;
+            $multi = preg_match('/^\d{0,10}$/', $searchData['multi']) ? $searchData['multi'] : null;
             $qb
                 ->andWhere('o.id = :multi OR o.name01 LIKE :likemulti OR o.name02 LIKE :likemulti OR ' .
                            'o.kana01 LIKE :likemulti OR o.kana02 LIKE :likemulti OR o.company_name LIKE :likemulti')

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -153,7 +153,7 @@ class ProductRepository extends AbstractRepository
 
         // id
         if (isset($searchData['id']) && StringUtil::isNotBlank($searchData['id'])) {
-            $id = preg_match('/^\d+$/', $searchData['id']) ? $searchData['id'] : null;
+            $id = preg_match('/^\d{0,10}$/', $searchData['id']) ? $searchData['id'] : null;
             $qb
                 ->andWhere('p.id = :id OR p.name LIKE :likeid OR pc.code LIKE :likeid')
                 ->setParameter('id', $id)

--- a/src/Eccube/Repository/ShippingRepository.php
+++ b/src/Eccube/Repository/ShippingRepository.php
@@ -56,7 +56,7 @@ class ShippingRepository extends AbstractRepository
         }
         // multi
         if (isset( $searchData['multi']) && StringUtil::isNotBlank($searchData['multi'])) {
-            $multi = preg_match('/^\d+$/', $searchData['multi']) ? $searchData['multi'] : null;
+            $multi = preg_match('/^\d{0,10}$/', $searchData['multi']) ? $searchData['multi'] : null;
             $qb
                 ->andWhere('s.id = :multi OR s.name01 LIKE :likemulti OR s.name02 LIKE :likemulti OR ' .
                            's.kana01 LIKE :likemulti OR s.kana02 LIKE :likemulti OR s.company_name LIKE :likemulti')


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 管理画面IDについて検索10桁数が超えるとシステムエラー

## エラー情報
例:
管理画面の受注マスターから[受注ID・注文者名・注文者会社名]に1111111111111111111111111入力し検索すると下記のエラー発生する

```
DriverException
An exception occurred while executing 'SELECT count(DISTINCT d0_.id) AS sclr_0 FROM dtb_order d0_ WHERE ((d0_.id = ? OR d0_.name01 LIKE ? OR d0_.name02 LIKE ? OR d0_.kana01 LIKE ? OR d0_.kana02 LIKE ? OR d0_.company_name LIKE ?) AND d0_.order_status_id IN (?, ?, ?, ?, ?, ?, ?)) AND d0_.discriminator_type IN ('order')' with params ["1111111111111111111111111", "%1111111111111111111111111%", "%1111111111111111111111111%", "%1111111111111111111111111%", "%1111111111111111111111111%", "%1111111111111111111111111%", 7, 1, 2, 6, 3, 4, 5]:

SQLSTATE[22003]: Numeric value out of range: 7
```

## 環境
PHP Version 7.1.10
PostgreSQL 9.5.4





