### PR TITLE
フロントでユーザ編集時に起こるエラー対応

### DIFF
--- a/src/Eccube/Form/Type/Front/EntryType.php
+++ b/src/Eccube/Form/Type/Front/EntryType.php
@@ -129,6 +129,7 @@ class EntryType extends AbstractType
                             'message' => 'form.type.numeric.invalid'
                         )),
                     ),
+                    'mapped' => false
                 ]
             );
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ `dtb_customer`の`point`でnot null制約違反が発生していたので対応
+ フロントからポイントを変更できないように`mapped => false`を追加
