### PR TITLE
フロントからポイント自由設定バグ修正

### DIFF
--- a/src/Eccube/Controller/EntryController.php
+++ b/src/Eccube/Controller/EntryController.php
@@ -125,6 +125,7 @@ class EntryController extends AbstractController
 
         /* @var $builder \Symfony\Component\Form\FormBuilderInterface */
         $builder = $this->formFactory->createBuilder(EntryType::class, $Customer);
+        $builder->remove('point');
 
         $event = new EventArgs(
             array(

--- a/src/Eccube/Controller/Mypage/ChangeController.php
+++ b/src/Eccube/Controller/Mypage/ChangeController.php
@@ -104,6 +104,7 @@ class ChangeController extends AbstractController
 
         /* @var $builder \Symfony\Component\Form\FormBuilderInterface */
         $builder = $this->formFactory->createBuilder(EntryType::class, $Customer);
+        $builder->remove('point');
 
         $event = new EventArgs(
             array(
@@ -153,6 +154,7 @@ class ChangeController extends AbstractController
 
         return [
             'form' => $form->createView(),
+            'loginCustomer' => $LoginCustomer,
         ];
     }
 

--- a/src/Eccube/Resource/template/default/Mypage/change.twig
+++ b/src/Eccube/Resource/template/default/Mypage/change.twig
@@ -220,11 +220,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 {% if BaseInfo.isOptionPoint %}
                                     <dl>
                                         <dt>
-                                            {{ form_label(form.point, 'ポイント', {'label_attr': {'class': 'ec-label'}}) }}
+                                            <label class="ec-label">ポイント</label>
                                         </dt>
                                         <dd>
-                                            {% if form.vars.value.point > 0 %}
-                                                {{ form.vars.value.point }} pt
+                                            {% if loginCustomer.point > 0 %}
+                                                {{ loginCustomer.point }} pt
                                             {% else  %}
                                                 0 pt
                                             {% endif %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ フロントからポイント自由設定バグ修正

## 再現手法
マイページの会員情報編集からブラウザのデバッグモードで
formにポイントinput追加してポイント設定可能になる
(windows場合は　chromeでcrtl+shift+l　からフロント側以下のソースに追加する)
`<input type="text" value="100000" name="entry[point]">`

![image](https://user-images.githubusercontent.com/14345299/33601518-d618857e-d9ef-11e7-9983-d6b6f336131e.png)
![image](https://user-images.githubusercontent.com/14345299/33601582-06eec280-d9f0-11e7-86ae-c28e930d62eb.png)

## 関連
https://github.com/EC-CUBE/ec-cube/pull/2690