### PR TITLE
管理画面の出荷関係のRouting名のセパレータが他と異なり `/` となっていたので他と合わせて `_` に変更

### DIFF
--- a/src/Eccube/Controller/Admin/Shipping/EditController.php
+++ b/src/Eccube/Controller/Admin/Shipping/EditController.php
@@ -117,8 +117,8 @@ class EditController
     /**
      * 出荷登録/編集画面.
      *
-     * @Route("/{_admin}/shipping/edit", name="admin/shipping/new")
-     * @Route("/{_admin}/shipping/{id}/edit", requirements={"id" = "\d+"}, name="admin/shipping/edit")
+     * @Route("/{_admin}/shipping/edit", name="admin_shipping_new")
+     * @Route("/{_admin}/shipping/{id}/edit", requirements={"id" = "\d+"}, name="admin_shipping_edit")
      * @Template("Shipping/edit.twig")
      *
      * TODO templateアノテーションを利用するかどうか検討.http://symfony.com/doc/current/best_practices/controllers.html
@@ -233,7 +233,7 @@ class EditController
 
                         log_info('出荷登録完了', array($TargetShipping->getId()));
 
-                        return $app->redirect($app->url('admin/shipping/edit', array('id' => $TargetShipping->getId())));
+                        return $app->redirect($app->url('admin_shipping_edit', array('id' => $TargetShipping->getId())));
                     }
 
                     break;

--- a/src/Eccube/Controller/Admin/Shipping/ShippingController.php
+++ b/src/Eccube/Controller/Admin/Shipping/ShippingController.php
@@ -78,8 +78,8 @@ class ShippingController
     protected $formFactory;
 
     /**
-     * @Route("/{_admin}/shipping", name="admin/shipping")
-     * @Route("/{_admin}/shipping/page/{page_no}", name="admin/shipping/page")
+     * @Route("/{_admin}/shipping", name="admin_shipping")
+     * @Route("/{_admin}/shipping/page/{page_no}", name="admin_shipping_page")
      *
      * @Security("has_role('ROLE_ADMIN')")
      * @Template("Shipping/index.twig")

--- a/src/Eccube/Resource/config/nav.php
+++ b/src/Eccube/Resource/config/nav.php
@@ -72,12 +72,12 @@
                 [
                     'id' => 'shipping_master',
                     'name' => '出荷マスター',
-                    'url' => 'admin/shipping',
+                    'url' => 'admin_shipping',
                 ],
                 [
                     'id' => 'shipping_edit',
                     'name' => '出荷登録',
-                    'url' => 'admin/shipping/new',
+                    'url' => 'admin_shipping_new',
                 ],
             ],
     ],

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -221,7 +221,7 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                                     <h4>お届け先名</h4>
                                     {% for Shipping in Order.Shippings  %}
                                         <div class="form-group">
-                                            出荷番号: <span class="number"><a href="{{ url('admin/shipping/edit', { id : Shipping.id }) }}" }}">{{ Shipping.id }}</a></span><br>
+                                            出荷番号: <span class="number"><a href="{{ url('admin_shipping_edit', { id : Shipping.id }) }}">{{ Shipping.id }}</a></span><br>
                                             {{ Shipping.Name01 }} {{ Shipping.Name02 }} ({{ Shipping.Kana01 }} {{ Shipping.Kana02 }})<br>
                                             〒{{ Shipping.Zip01 }}-{{ Shipping.Zip02 }}<br>
                                             {{ Shipping.Pref }}{{ Shipping.Addr01 }}{{ Shipping.Addr02 }}
@@ -445,7 +445,7 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                                             </div>
                                         </div>
                                         {% if orderItemForm.vars.value.Shipping.id is defined %}
-                                        出荷情報 <a href="{{ url('admin/shipping/edit', { id : orderItemForm.vars.value.Shipping.id }) }}">{{ orderItemForm.vars.value.Shipping.id }}</a><br>
+                                        出荷情報 <a href="{{ url('admin_shipping_edit', { id : orderItemForm.vars.value.Shipping.id }) }}">{{ orderItemForm.vars.value.Shipping.id }}</a><br>
                                         {% endif %}
 
                                     </div>
@@ -476,12 +476,12 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                                     <dd class="form-group form-inline">
                                         {{ Order.charge|price }}
                                     </dd>
-                                    <dt id="product_info_result_box__add_point" {{ form_label(form.add_point) }}：</dt>
+                                    <dt id="product_info_result_box__add_point" {{ form_label(form.add_point) }}>：</dt>
                                     <dd class="form-group form-inline">
                                         {{ form_widget(form.add_point) }}
                                         {{ form_errors(form.add_point) }}
                                     </dd>
-                                    <dt id="product_info_result_box__use_point" {{ form_label(form.use_point) }}：</dt>
+                                    <dt id="product_info_result_box__use_point" {{ form_label(form.use_point) }}>：</dt>
                                     <dd class="form-group form-inline">
                                         {{ form_widget(form.use_point) }}
                                         {{ form_errors(form.use_point) }}

--- a/src/Eccube/Resource/template/admin/Shipping/edit.twig
+++ b/src/Eccube/Resource/template/admin/Shipping/edit.twig
@@ -226,7 +226,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     <h4>注文者名</h4>
                                     {% for Order in Shipping.Orders  %}
                                         <div class="form-group">
-                                            注文番号: <span class="number"><a href="{{ url('admin_order_edit', { id : Order.id }) }}" }}">{{ Order.id }}</a></span><br>
+                                            注文番号: <span class="number"><a href="{{ url('admin_order_edit', { id : Order.id }) }}">{{ Order.id }}</a></span><br>
                                             {{ Order.Name01 }} {{ Order.Name02 }} ({{ Order.Kana01 }} {{ Order.Kana02 }})<br>
                                             〒{{ Order.Zip01 }}-{{ Order.Zip02 }}<br>
                                             {{ Order.Pref }}{{ Order.Addr01 }}{{ Order.Addr02 }}
@@ -469,7 +469,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             <div id="detail__back_button" class="row hidden-xs hidden-sm">
                 <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
                     {% if id is not null %}
-                        <p><a href="{{ url('admin/shipping/page', { page_no: app.session.get('eccube.admin.Shipping.search.page_no')|default('1') }) }}?resume=1">戻る</a></p>
+                        <p><a href="{{ url('admin_shipping_page', { page_no: app.session.get('eccube.admin.Shipping.search.page_no')|default('1') }) }}?resume=1">戻る</a></p>
                     {% endif %}
                 </div>
             </div>

--- a/src/Eccube/Resource/template/admin/Shipping/index.twig
+++ b/src/Eccube/Resource/template/admin/Shipping/index.twig
@@ -114,7 +114,7 @@
 {% block main %}
     <!--検索条件設定テーブルここから-->
     <div id="search_wrap" class="search-box">
-        <form name="search_form" id="search_form" method="post" action="{{ url('admin/shipping') }}">
+        <form name="search_form" id="search_form" method="post" action="{{ url('admin_shipping') }}">
             {{ form_widget(searchForm._token) }}
             <div id="search_box_main" class="row">
                 <div id="search_box_main__body" class="col-md-12 accordion">
@@ -297,7 +297,7 @@
                                                 <ul class="dropdown-menu">
                                             {% endfor %}
                                             {% for pageMax in pageMaxis if pageMax.name != page_count %}
-                                                <li><a href="{{ path('admin/shipping/page', {'page_no': 1, 'page_count': pageMax.name}) }}">{{ pageMax.name|e }}件</a></li>
+                                                <li><a href="{{ path('admin_shipping_page', {'page_no': 1, 'page_count': pageMax.name}) }}">{{ pageMax.name|e }}件</a></li>
                                             {% endfor %}
                                                 </ul>
                                         </li>
@@ -338,7 +338,7 @@
                                                 {% for Shipping in pagination %}
                                                     <tr id="result_list_main__item--{{ Shipping.id }}">
                                                         <td id="result_list_main__id_check--{{ Shipping.id }}" class="text-center"><input type="checkbox" id="check-{{ Shipping.id }}" data-id="{{ Shipping.id }}" name="ids{{ Shipping.id }}"></td>
-                                                        <td id="result_list_main__id--{{ Shipping.id }}"><a href="{{ url('admin/shipping/edit', { id : Shipping.id }) }}">{{ Shipping.id }}</a></td>
+                                                        <td id="result_list_main__id--{{ Shipping.id }}"><a href="{{ url('admin_shipping_edit', { id : Shipping.id }) }}">{{ Shipping.id }}</a></td>
                                                         <td id="result_list_main__tracking_number--{{ Shipping.id }}"> {{ Shipping.TrackingNumber|default('未登録') }} </td>
                                                         <td id="result_list_main__name--{{ Shipping.id }}">{{ Shipping.name01 }} {{ Shipping.name02 }}</td>
                                                         <td id="result_list_main__payment_method--{{ Shipping.id }}">{{ Shipping.zip01 }}-{{ Shipping.zip02 }}<br />{{ Shipping.pref }}{{ Shipping.addr01 }}{{ Shipping.addr02 }}</td>
@@ -354,7 +354,7 @@
                             </form>
                         </div><!-- /.box-body -->
                         {% if pagination.totalItemCount > 0 %}
-                            {% include "pager.twig" with { 'pages' : pagination.paginationData, 'routes' : 'admin/shipping/page' } %}
+                            {% include "pager.twig" with { 'pages' : pagination.paginationData, 'routes' : 'admin_shipping_page' } %}
                         {% endif %}
                     {% else %}
                         <div class="box-header with-arrow">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 管理画面の出荷関係のRouting名のセパレータが他と異なり `/` となっていたので他と合わせて `_` に変更
+ テンプレートの軽微な不具合を修正（閉じ括弧忘れ等）
