### PR TITLE
Entity拡張機構を移植

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ composer.phar
 .idea
 *.php~
 .env
+.web-server-pid
+var/
+src/var/

--- a/app/config/eccube/packages/doctrine.yaml
+++ b/app/config/eccube/packages/doctrine.yaml
@@ -17,10 +17,3 @@ doctrine:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore
         auto_mapping: true
-        mappings:
-            Eccube:
-                is_bundle: false
-                type: annotation
-                dir: '%kernel.project_dir%/src/Eccube/Entity'
-                prefix: 'Eccube\Entity\'
-                alias: Eccube

--- a/composer.json
+++ b/composer.json
@@ -102,6 +102,7 @@
             "src/Eccube/Resource/functions/env.php"
         ],
         "psr-4": {
+            "Acme\\": "app/Acme",
             "Eccube\\": "src/Eccube",
             "Plugin\\": "app/Plugin",
             "Dbtlr\\MigrationProvider\\Provider\\": "src/silex-doctrine-migrations"

--- a/src/Eccube/Command/GenerateProxyCommand.php
+++ b/src/Eccube/Command/GenerateProxyCommand.php
@@ -24,37 +24,45 @@
 namespace Eccube\Command;
 
 use Eccube\Entity\ProxyGenerator;
-use Eccube\Repository\PluginRepository;
 use Eccube\Service\EntityProxyService;
-use Knp\Command\Command;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 
-class GenerateProxyCommand extends Command
+class GenerateProxyCommand extends ContainerAwareCommand
 {
+    /**
+     * @var EntityProxyService
+     */
+    private $entityProxyService;
+
+    public function __construct(EntityProxyService $entityProxyService)
+    {
+        parent::__construct();
+        $this->entityProxyService = $entityProxyService;
+    }
+
     protected function configure()
     {
         $this
-            ->setName('generate-proxies')
-            ->setDescription('generate entity proxies');
+            ->setName('eccube:generate:proxies')
+            ->setDescription('Generate entity proxies');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var \Eccube\Application $app */
-        $app = $this->getSilexApplication();
-        /** @var EntityProxyService $entityProxyService */
-        $entityProxyService = $app[EntityProxyService::class];
+        // TODO プラグインディレクトリ
+//        $dirs = array_map(function($p) use ($app) {
+//            return $app['config']['root_dir'].'/app/Plugin/'.$p->getCode().'/Entity';
+//        }, $app[PluginRepository::class]->findAllEnabled());
+//
 
-        $dirs = array_map(function($p) use ($app) {
-            return $app['config']['root_dir'].'/app/Plugin/'.$p->getCode().'/Entity';
-        }, $app[PluginRepository::class]->findAllEnabled());
-
-        $entityProxyService->generate(
-            array_merge([$app['config']['vendor_dir'].'/Entity'], $dirs),
+        $projectRoot = $this->getContainer()->getParameter('kernel.project_dir');
+        $this->entityProxyService->generate(
+            [$projectRoot.'/app/Acme/Entity'], // TODO Acme
             [],
-            $app['config']['root_dir'].'/app/proxy/entity',
+            $projectRoot.'/app/proxy/entity',
             $output
         );
     }

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -11,17 +11,18 @@
 
 namespace Eccube;
 
-use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
-use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\HttpKernel\Kernel as BaseKernel;
-use Symfony\Component\Routing\RouteCollectionBuilder;
-
-use Pimple\Container as PimpleContainer;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Pimple\ServiceProviderInterface;
 use Silex\Api\BootableProviderInterface;
 use Silex\Api\EventListenerProviderInterface;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\Routing\RouteCollectionBuilder;
 
 class Kernel extends BaseKernel
 {
@@ -150,5 +151,20 @@ class Kernel extends BaseKernel
             $routes->import($confDir.'/routes/'.$this->environment.'/**/*'.self::CONFIG_EXTS, '/', 'glob');
         }
         $routes->import($confDir.'/routes'.self::CONFIG_EXTS, '/', 'glob');
+    }
+
+    protected function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $this->addEntityExtensionPass($container);
+    }
+
+    protected function addEntityExtensionPass(ContainerBuilder $container)
+    {
+        $reader = new Reference('annotation_reader');
+        $driver = new Definition('Eccube\\Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver', array($reader, ["%kernel.project_dir%/src/Eccube/Entity"]));
+        $driver->addMethodCall('setTraitProxiesDirectory', [$container->getParameter('kernel.project_dir')."/app/proxy/entity"]);
+        $container->addCompilerPass(new DoctrineOrmMappingsPass($driver, ['Eccube\\Entity\\'], []));
     }
 }

--- a/src/Eccube/Service/EntityProxyService.php
+++ b/src/Eccube/Service/EntityProxyService.php
@@ -26,8 +26,8 @@ namespace Eccube\Service;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Annotation\EntityExtension;
-use Eccube\Annotation\Inject;
 use Eccube\Annotation\Service;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
@@ -43,10 +43,14 @@ use Zend\Code\Reflection\ClassReflection;
 class EntityProxyService
 {
     /**
-     * @Inject("orm.em")
      * @var EntityManager
      */
     protected $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
 
     /**
      * EntityのProxyを生成します。


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ src/Acme以下のEntity拡張Traitを使ってEntity拡張できるように修正
+ 以下のコマンドでProxy生成とスキーマ更新できます。

```bash
$ bin/console eccube:generate:proxies
$ bin/console doctrine:schema:update
```

## 方針(Policy)
+ デフォルトのORM Mapping設定を`doctrine.yml`から外して、独自のDoctrineOrmMappingsPassをKernelで設定するように変更

## 実装に関する補足(Appendix)
+ `src/Acme`のクラスを読み込めるように`composer.json`にパスを一時的に追記

## テスト（Test)
+ 通りません
