### PR TITLE
プラグイン操作コマンドの移植

### DIFF
--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -22,6 +22,7 @@ services:
           $auth_magic: '%env(ECCUBE_AUTH_MAGIC)%'
           $auth_type: 'HMAC'
           $password_hash_algos: 'sha256'
+          $projectRoot: '%kernel.project_dir%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/composer.json
+++ b/composer.json
@@ -102,6 +102,7 @@
             "src/Eccube/Resource/functions/env.php"
         ],
         "psr-4": {
+            "Eccube\\Entity\\": "app/proxy/entity",
             "Acme\\": "app/Acme",
             "Eccube\\": "src/Eccube",
             "Plugin\\": "app/Plugin",

--- a/src/Eccube/Command/PluginDisableCommand.php
+++ b/src/Eccube/Command/PluginDisableCommand.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Command;
+
+
+use Eccube\Repository\PluginRepository;
+use Eccube\Service\PluginService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class PluginDisableCommand extends Command
+{
+    /**
+     * @var PluginService
+     */
+    private $pluginService;
+
+    /**
+     * @var PluginRepository
+     */
+    private $pluginRepository;
+
+    public function __construct(PluginService $pluginService, PluginRepository $pluginRepository)
+    {
+        parent::__construct();
+        $this->pluginService = $pluginService;
+        $this->pluginRepository = $pluginRepository;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('eccube:plugin:disable')
+            ->addOption('code', null, InputOption::VALUE_OPTIONAL, 'plugin code');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $code = $input->getOption('code');
+
+        if (empty($code)) {
+            $io->error('code is required.');
+
+            return;
+        }
+
+        $plugin = $this->pluginRepository->findByCode($code);
+        if (is_null($plugin)) {
+            $io->error("Plugin `$code` is not found.");
+            return;
+        }
+
+        $this->pluginService->disable($plugin);
+
+        $io->success('Plugin Disabled.');
+    }
+}

--- a/src/Eccube/Command/PluginEnableCommand.php
+++ b/src/Eccube/Command/PluginEnableCommand.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Command;
+
+
+use Eccube\Repository\PluginRepository;
+use Eccube\Service\PluginService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class PluginEnableCommand extends Command
+{
+    /**
+     * @var PluginService
+     */
+    private $pluginService;
+
+    /**
+     * @var PluginRepository
+     */
+    private $pluginRepository;
+
+    public function __construct(PluginService $pluginService, PluginRepository $pluginRepository)
+    {
+        parent::__construct();
+        $this->pluginService = $pluginService;
+        $this->pluginRepository = $pluginRepository;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('eccube:plugin:enable')
+            ->addOption('code', null, InputOption::VALUE_OPTIONAL, 'plugin code');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $code = $input->getOption('code');
+
+        if (empty($code)) {
+            $io->error('code is required.');
+
+            return;
+        }
+
+        $plugin = $this->pluginRepository->findByCode($code);
+        if (is_null($plugin)) {
+            $io->error("Plugin `$code` is not found.");
+            return;
+        }
+
+        $this->pluginService->enable($plugin);
+
+        $io->success('Plugin Enabled.');
+    }
+}

--- a/src/Eccube/Command/PluginInstallCommand.php
+++ b/src/Eccube/Command/PluginInstallCommand.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Command;
+
+
+use Eccube\Service\PluginService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class PluginInstallCommand extends Command
+{
+    /**
+     * @var PluginService
+     */
+    private $pluginService;
+
+    /**
+     * PluginInstallCommand constructor.
+     * @param PluginService $pluginService
+     */
+    public function __construct(PluginService $pluginService)
+    {
+        parent::__construct();
+        $this->pluginService = $pluginService;
+    }
+
+    protected function configure()
+    {
+        $this->setName('eccube:plugin:install')
+            ->addOption('path', null, InputOption::VALUE_OPTIONAL, 'path of tar or zip')
+            ->addOption('code', null, InputOption::VALUE_OPTIONAL, 'plugin code')
+            ->setDescription('Install plugin from local.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $path = $input->getOption('path');
+        $code = $input->getOption('code');
+
+        // アーカイブからインストール
+        if ($path) {
+            if ($this->pluginService->install($path)) {
+                $io->success('Installed.');
+                return;
+            }
+        }
+
+        // 設置済ファイルからインストール
+        if ($code) {
+            $pluginDir = $this->pluginService->calcPluginDir($code);
+            $this->pluginService->checkPluginArchiveContent($pluginDir);
+            $config = $this->pluginService->readYml($pluginDir.'/config.yml');
+            $event = $this->pluginService->readYml($pluginDir.'/event.yml');
+            $this->pluginService->checkSamePlugin($config['code']);
+            $this->pluginService->postInstall($config, $event, false);
+
+            $io->success('Installed.');
+
+            return;
+        }
+
+        $io->error('path or code is required.');
+    }
+}

--- a/src/Eccube/Command/PluginUninstallCommand.php
+++ b/src/Eccube/Command/PluginUninstallCommand.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Command;
+
+
+use Eccube\Repository\PluginRepository;
+use Eccube\Service\PluginService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class PluginUninstallCommand extends Command
+{
+    /**
+     * @var PluginService
+     */
+    private $pluginService;
+
+    /**
+     * @var PluginRepository
+     */
+    private $pluginRepository;
+
+    public function __construct(PluginService $pluginService, PluginRepository $pluginRepository)
+    {
+        parent::__construct();
+        $this->pluginService = $pluginService;
+        $this->pluginRepository = $pluginRepository;
+    }
+
+    protected function configure()
+    {
+        $this->setName('eccube:plugin:uninstall')
+            ->addOption('code', null, InputOption::VALUE_OPTIONAL, 'plugin code')
+            ->addOption('uninstall-force', null, InputOption::VALUE_OPTIONAL, 'if set true, remove directory')
+            ->setDescription('Uninstall plugin.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $code = $input->getOption('code');
+        $uninstallForce = $input->getOption('uninstall-force');
+
+        if (empty($code)) {
+            $io->error('code is required.');
+
+            return;
+        }
+
+        $plugin = $this->pluginRepository->findByCode($code);
+        if (is_null($plugin)) {
+            $io->error("Plugin `$code` is not installed.");
+            return;
+        }
+
+        $this->pluginService->uninstall($plugin, $uninstallForce);
+
+        $io->success('Uninstalled.');
+    }
+}

--- a/src/Eccube/DependencyInjection/EccubeExtension.php
+++ b/src/Eccube/DependencyInjection/EccubeExtension.php
@@ -57,7 +57,7 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
             $mappings[$code] = [
                 'is_bundle' => false,
                 'type' => 'annotation',
-                'dir' => '%kernel.project_dir%/app/plugins/'.$code.'/Entity',
+                'dir' => '%kernel.project_dir%/app/Plugin/'.$code.'/Entity',
                 'prefix' => $namespace,
                 'alias' => $code,
             ];

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -149,6 +149,6 @@ class Kernel extends BaseKernel
         $reader = new Reference('annotation_reader');
         $driver = new Definition('Eccube\\Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver', array($reader, ["%kernel.project_dir%/src/Eccube/Entity"]));
         $driver->addMethodCall('setTraitProxiesDirectory', [$container->getParameter('kernel.project_dir')."/app/proxy/entity"]);
-        $container->addCompilerPass(new DoctrineOrmMappingsPass($driver, ['Eccube\\Entity\\'], []));
+        $container->addCompilerPass(new DoctrineOrmMappingsPass($driver, ['Eccube\\Entity'], []));
     }
 }

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -77,6 +77,9 @@ class Kernel extends BaseKernel
      */
     public function boot()
     {
+        // Symfonyがsrc/Eccube/Entity以下を読み込む前にapp/proxy/entity以下をロードする
+        $this->loadEntityProxies();
+
         parent::boot();
 
         // Symfony で用意されているコンポーネントはここで追加
@@ -150,5 +153,12 @@ class Kernel extends BaseKernel
         $driver = new Definition('Eccube\\Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver', array($reader, ["%kernel.project_dir%/src/Eccube/Entity"]));
         $driver->addMethodCall('setTraitProxiesDirectory', [$container->getParameter('kernel.project_dir')."/app/proxy/entity"]);
         $container->addCompilerPass(new DoctrineOrmMappingsPass($driver, ['Eccube\\Entity'], []));
+    }
+
+    protected function loadEntityProxies()
+    {
+        foreach (glob(__DIR__ . '/../../app/proxy/entity/*.php') as $file) {
+            require_once $file;
+        }
     }
 }

--- a/src/Eccube/Repository/PluginRepository.php
+++ b/src/Eccube/Repository/PluginRepository.php
@@ -47,4 +47,13 @@ class PluginRepository extends AbstractRepository
     {
         return $this->findBy(['enabled' => '1']);
     }
+
+    /**
+     * @param $code プラグインコード
+     * @return Plugin
+     */
+    public function findByCode($code)
+    {
+        return $this->findOneBy(array('code' => $code));
+    }
 }

--- a/src/Eccube/Service/EntityProxyService.php
+++ b/src/Eccube/Service/EntityProxyService.php
@@ -126,7 +126,10 @@ class EntityProxyService
             $includedFileSets[] = $includedFiles;
         }
 
-        $declaredTraits = get_declared_traits();
+        $declaredTraits = array_map(function ($fqcn) {
+            // FQCNが'\'で始まるように正規化
+            return strpos($fqcn, '\\') === 0 ? $fqcn : '\\'.$fqcn;
+        }, get_declared_traits());
 
         // ディレクトリセットに含まれるTraitの一覧を作成
         $traitSets = array_map(function() { return []; }, $dirSets);

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -416,7 +416,7 @@ class PluginService
         }
     }
 
-    public function uninstall(\Eccube\Entity\Plugin $plugin)
+    public function uninstall(\Eccube\Entity\Plugin $plugin, $force = true)
     {
         $pluginDir = $this->calcPluginDir($plugin->getCode());
         ConfigManager::removePluginConfigCache();
@@ -425,8 +425,11 @@ class PluginService
         $this->callPluginManagerMethod(Yaml::parse(file_get_contents($pluginDir.'/'.self::CONFIG_YML)), 'uninstall');
         $this->disable($plugin);
         $this->unregisterPlugin($plugin);
-        $this->deleteFile($pluginDir);
-        $this->removeAssets($plugin->getCode());
+
+        if ($force) {
+            $this->deleteFile($pluginDir);
+            $this->removeAssets($plugin->getCode());
+        }
 
         // スキーマを更新する
         $this->schemaService->updateSchema([], $this->projectRoot.'/app/proxy/entity');

--- a/src/Eccube/Service/SchemaService.php
+++ b/src/Eccube/Service/SchemaService.php
@@ -23,9 +23,8 @@
 
 namespace Eccube\Service;
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
-use Eccube\Annotation\Inject;
 use Eccube\Annotation\Service;
 use Eccube\Doctrine\ORM\Mapping\Driver\ReloadSafeAnnotationDriver;
 use Eccube\Util\StringUtil;
@@ -37,10 +36,18 @@ class SchemaService
 {
 
     /**
-     * @Inject("orm.em")
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     protected $entityManager;
+
+    /**
+     * SchemaService constructor.
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
 
     public function updateSchema($generatedFiles, $proxiesDirectory)
     {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ インストール/有効化/無効化/アンインストールコマンドを移植
```
# プラグインインストール
$ bin/console eccube:plugin:install --code EntityExtension
# プラグイン有効化
$ bin/console eccube:plugin:enable --code EntityExtension
# プラグイン無効化
$ bin/console eccube:plugin:disable --code EntityExtension
# プラグインアンインストール
$ bin/console eccube:plugin:uninstall --code EntityExtension
```
## 相談（Discussion）
+ `src/Eccube/Entity`以下が先にロードされてしまうので、Kernerlで`app/proxy/entity`以下をロードするようにしました。