### PR TITLE
プラグインのインストール/削除時の、DBの更新まわりの不具合を修正

### DIFF
--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -355,8 +355,11 @@ class OwnerStoreController extends AbstractController
         $this->isTokenValid($app);
 
         if ($Plugin->isEnabled()) {
-            $this->pluginService->disable($Plugin);
+            $app->addError('admin.plugin.uninstall.error.not_disable', 'admin');
+
+            return $app->redirect($app->url('admin_store_plugin'));
         }
+
         $pluginCode = $Plugin->getCode();
         $packageName = self::$vendorName.'/'.$pluginCode;
         try {

--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -349,6 +349,13 @@ class PluginController extends AbstractController
     public function uninstall(Application $app, Plugin $Plugin)
     {
         $this->isTokenValid($app);
+
+        if ($Plugin->isEnabled()) {
+            $app->addError('admin.plugin.uninstall.error.not_disable', 'admin');
+
+            return $app->redirect($app->url('admin_store_plugin'));
+        }
+
         // Check other plugin depend on it
         $pluginCode = $Plugin->getCode();
         $otherDepend = $this->pluginService->findDependentPlugin($pluginCode);

--- a/src/Eccube/Resource/template/admin/Store/plugin_table.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_table.twig
@@ -49,9 +49,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     </a>
                                 {% endif %}
                                 /
-                                <a href="{{ url('admin_store_plugin_uninstall', { id : Plugin.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="このプラグインを削除してもよろしいですか？">
+                                {% if Plugin.enabled %}
                                     削除
-                                </a>
+                                {% else %}
+                                    <a href="{{ url('admin_store_plugin_uninstall', { id : Plugin.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="このプラグインを削除してもよろしいですか？">
+                                        削除
+                                    </a>
+                                {% endif %}
                             </td>
                             <td class="tv text-center">{{ Plugin.version }}</td>
                             <td class="tc"><p>{{ Plugin.code }}</p>

--- a/src/Eccube/Resource/template/admin/Store/plugin_table_official.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_table_official.twig
@@ -51,9 +51,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     </a>
                                 {% endif %}
                                 /
-                                <a href="{{ url('admin_store_plugin_delete_confirm', { id : Plugin.id }) }}">
-                                    削除
-                                </a>
+                                {% if Plugin.enabled %}
+                                    <span class="disabled">削除</span>
+                                {% else %}
+                                    <a href="{{ url('admin_store_plugin_delete_confirm', { id : Plugin.id }) }}">
+                                        削除
+                                    </a>
+                                {% endif %}
                             </td>
                             <td class="tc">
                                 <div class="plugin-logo">

--- a/src/Eccube/Service/EntityProxyService.php
+++ b/src/Eccube/Service/EntityProxyService.php
@@ -122,7 +122,15 @@ class EntityProxyService
             $includedFileSets[] = $includedFiles;
         }
 
+        // トレイトの名前を取得
+        // 先頭に必ず"\"が付与されるように正規化する
         $declaredTraits = get_declared_traits();
+        foreach ($declaredTraits as &$declaredTrait) {
+            if (!(substr($declaredTrait, 0, 1) == '\\')) {
+                $declaredTrait = '\\'.$declaredTrait;
+            }
+        }
+        unset($declaredTrait);
 
         // ディレクトリセットに含まれるTraitの一覧を作成
         $traitSets = array_map(function() { return []; }, $dirSets);

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -415,6 +415,10 @@ class PluginService
         // スキーマを更新する
         $this->schemaService->updateSchema([], $this->appConfig['root_dir'].'/app/proxy/entity');
 
+        // プラグインのネームスペースに含まれるEntityのテーブルを削除する
+        $namespace = 'Plugin\\'.$plugin->getCode().'\\Entity';
+        $this->schemaService->dropTable($namespace);
+
         ConfigManager::writePluginConfigCache();
         return true;
     }

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -191,6 +191,17 @@ class PluginService
             // dbにプラグイン登録
             $plugin = $this->registerPlugin($config, $event, $source);
 
+            // プラグインmetadata定義を追加
+            $entityDir = $this->appConfig['plugin_realdir'].'/'.$plugin->getCode().'/Entity';
+            if (file_exists($entityDir)) {
+                $ormConfig = $this->entityManager->getConfiguration();
+                $chain = $ormConfig->getMetadataDriverImpl();
+                $driver = $ormConfig->newDefaultAnnotationDriver([$entityDir], false);
+                $namespace = 'Plugin\\'.$config['code'].'\\Entity';
+                $chain->addDriver($driver, $namespace);
+                $ormConfig->addEntityNamespace($plugin->getCode(), $namespace);
+            }
+
             // インストール時には一時的に利用するProxyを生成してからスキーマを更新する
             $generatedFiles = $this->regenerateProxy($plugin, true, $tmpProxyOutputDir);
             $this->schemaService->updateSchema($generatedFiles, $tmpProxyOutputDir);

--- a/src/Eccube/Service/SchemaService.php
+++ b/src/Eccube/Service/SchemaService.php
@@ -76,4 +76,28 @@ class SchemaService
             rmdir($outputDir);
         }
     }
+
+    /**
+     * ネームスペースに含まれるEntityのテーブルを削除する
+     *
+     * @param $targetNamespace string 削除対象のネームスペース
+     */
+    public function dropTable($targetNamespace)
+    {
+        $chain = $this->entityManager->getConfiguration()->getMetadataDriverImpl();
+        $drivers = $chain->getDrivers();
+
+        $dropMetas = [];
+        foreach ($drivers as $namespace => $driver) {
+            if ($targetNamespace === $namespace) {
+                $allClassNames = $driver->getAllClassNames();
+
+                foreach ($allClassNames as $className) {
+                    $dropMetas[] = $this->entityManager->getMetadataFactory()->getMetadataFor($className);
+                }
+            }
+        }
+        $tool = new SchemaTool($this->entityManager);
+        $tool->dropSchema($dropMetas);
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
3.nのプラグインのインストール/削除時の、DBの更新まわりの不具合を修正しました。

- インストール時に、テーブルが作成されない。
- 削除時に、プラグインが作成したテーブルが消えない。
- 無効化時に、プラグインのトレイトのuseがProxyから消えない。

参考：
プラグインのライフサイクルとエンティティProxy再生成/スキーマ更新タイミングの調整
https://github.com/EC-CUBE/ec-cube/pull/2546

## 方針(Policy)

- 有効状態では、プラグインを削除できないようにする。
(metaデータの再読み込みを実現しないといけないため、有効状態での削除は実現難易度が高い)

## 実装に関する補足(Appendix)

- プラグイン有効状態での削除は、metaデータの再読み込みを実現しないといけないため

## テスト（Test)
- アノテーションでのテーブル追加
- トレイトでのProduct拡張
について、テーブルが追加/削除できていることをテストしました。

## 相談（Discussion）
なし

