### PR TITLE
Routingの移植

### DIFF
--- a/app/config/eccube/packages/security.yaml
+++ b/app/config/eccube/packages/security.yaml
@@ -67,5 +67,5 @@ security:
     access_control:
         # this is a catch-all for the admin area
         # additional security lives in the controllers
-        - { path: ^/%admin_route%/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/%admin_route%/, roles: ROLE_ADMIN }
+        - { path: ^/%admin_route%/login, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: %eccube.scheme% }
+        - { path: ^/%admin_route%/, roles: ROLE_ADMIN, requires_channel: %eccube.scheme%  }

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -6,6 +6,7 @@ parameters:
     app_locales: en|fr|de|es|cs|nl|ru|uk|ro|pt_BR|pl|it|ja|id|ca|sl|hr|zh_CN
     app.notifications.email_sender: anonymous@example.com
     admin_route: 'admin'
+    user_data_route: 'user_data'
     eccube.scheme: 'https'
 
     eccube.twig.block.templates:

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -6,6 +6,7 @@ parameters:
     app_locales: en|fr|de|es|cs|nl|ru|uk|ro|pt_BR|pl|it|ja|id|ca|sl|hr|zh_CN
     app.notifications.email_sender: anonymous@example.com
     admin_route: 'admin'
+    eccube.scheme: 'https'
 
     eccube.twig.block.templates:
       - render_blocks.twig

--- a/src/Eccube/Controller/UserDataController.php
+++ b/src/Eccube/Controller/UserDataController.php
@@ -74,7 +74,7 @@ class UserDataController
     protected $deviceTypeRepository;
 
     /**
-     * //@Route("/{_user_data}/{route}", name="user_data", requirements={"route": "([0-9a-zA-Z_\-]+\/?)+(?<!\/)"})
+     * //@Route("/%user_data_route%/{route}", name="user_data", requirements={"route": "([0-9a-zA-Z_\-]+\/?)+(?<!\/)"})
      */
     public function index(Application $app, Request $request, $route)
     {

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -133,23 +133,32 @@ class Kernel extends BaseKernel
 
     protected function configureRoutes(RouteCollectionBuilder $routes)
     {
+        $container = $this->getContainer();
+
+        $scheme = $container->getParameter('eccube.scheme');
+        $routes->setSchemes($scheme);
+
         $confDir = dirname(__DIR__).'/../app/config/eccube';
         if (is_dir($confDir.'/routes/')) {
-            $routes->import($confDir.'/routes/*'.self::CONFIG_EXTS, '/', 'glob');
+            $builder = $routes->import($confDir.'/routes/*'.self::CONFIG_EXTS, '/', 'glob');
+            $builder->setSchemes($scheme);
         }
         if (is_dir($confDir.'/routes/'.$this->environment)) {
-            $routes->import($confDir.'/routes/'.$this->environment.'/**/*'.self::CONFIG_EXTS, '/', 'glob');
+            $builder = $routes->import($confDir.'/routes/'.$this->environment.'/**/*'.self::CONFIG_EXTS, '/', 'glob');
+            $builder->setSchemes($scheme);
         }
-        $routes->import($confDir.'/routes'.self::CONFIG_EXTS, '/', 'glob');
+        $builder = $routes->import($confDir.'/routes'.self::CONFIG_EXTS, '/', 'glob');
+        $builder->setSchemes($scheme);
 
         // 有効なプラグインのルーティングをインポートする.
-        if ($this->getContainer()->hasParameter('eccube.plugins.enabled')) {
-            $plugins = $this->getContainer()->getParameter('eccube.plugins.enabled');
+        if ($container->hasParameter('eccube.plugins.enabled')) {
+            $plugins = $container->getParameter('eccube.plugins.enabled');
             $pluginDir = dirname(__DIR__).'/../app/Plugin';
             foreach ($plugins as $plugin) {
                 $dir = $pluginDir.'/'.$plugin['code'].'/Controller';
                 if (file_exists($dir)) {
-                    $routes->import($dir, '/', 'annotation');
+                    $builder = $routes->import($dir, '/', 'annotation');
+                    $builder->setSchemes($scheme);
                 }
             }
         }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- user_dataのルーティングを追加
  - パラメータに`user_data_route`を追加
  - %user_data_route%で使用できます
- SSL強制の対応
  - パラメータに`eccube.scheme`を追加
  - 各ルーティングに反映される用に修正(Kernel::configureRoutes)
  - securityのrequires_channelに反映

## 参考
- http://symfony.com/doc/current/routing/scheme.html
- http://symfony.com/doc/current/security/force_https.html

