### PR TITLE
プラグイン操作コマンド実行後にキャッシュをクリア

### DIFF
--- a/src/Eccube/Command/PluginCommandTrait.php
+++ b/src/Eccube/Command/PluginCommandTrait.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Command;
+
+
+use Eccube\Repository\PluginRepository;
+use Eccube\Service\PluginService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+trait PluginCommandTrait
+{
+    /**
+     * @var PluginService
+     */
+    protected $pluginService;
+
+    /**
+     * @var PluginRepository
+     */
+    protected $pluginRepository;
+
+    /**
+     * @param PluginService $pluginService
+     * @required
+     */
+    public function setPluginService(PluginService $pluginService)
+    {
+        $this->pluginService = $pluginService;
+    }
+
+    /**
+     * @param PluginRepository $pluginRepository
+     * @required
+     */
+    public function setPluginRepository(PluginRepository $pluginRepository)
+    {
+        $this->pluginRepository = $pluginRepository;
+    }
+
+    protected function clearCache(SymfonyStyle $io)
+    {
+        try {
+            /* @var Command $command */
+            $command = $this->getApplication()->get('cache:clear');
+            $command->run(new ArrayInput([
+                'command' => 'cache:clear',
+                '--no-warmup' => true
+            ]), $io);
+        } catch (\Exception $e) {
+            $io->error($e->getMessage());
+        }
+    }
+}

--- a/src/Eccube/Command/PluginDisableCommand.php
+++ b/src/Eccube/Command/PluginDisableCommand.php
@@ -24,8 +24,6 @@
 namespace Eccube\Command;
 
 
-use Eccube\Repository\PluginRepository;
-use Eccube\Service\PluginService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -34,22 +32,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class PluginDisableCommand extends Command
 {
-    /**
-     * @var PluginService
-     */
-    private $pluginService;
-
-    /**
-     * @var PluginRepository
-     */
-    private $pluginRepository;
-
-    public function __construct(PluginService $pluginService, PluginRepository $pluginRepository)
-    {
-        parent::__construct();
-        $this->pluginService = $pluginService;
-        $this->pluginRepository = $pluginRepository;
-    }
+    use PluginCommandTrait;
 
     protected function configure()
     {
@@ -77,6 +60,7 @@ class PluginDisableCommand extends Command
         }
 
         $this->pluginService->disable($plugin);
+        $this->clearCache($io);
 
         $io->success('Plugin Disabled.');
     }

--- a/src/Eccube/Command/PluginEnableCommand.php
+++ b/src/Eccube/Command/PluginEnableCommand.php
@@ -24,8 +24,6 @@
 namespace Eccube\Command;
 
 
-use Eccube\Repository\PluginRepository;
-use Eccube\Service\PluginService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -34,22 +32,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class PluginEnableCommand extends Command
 {
-    /**
-     * @var PluginService
-     */
-    private $pluginService;
-
-    /**
-     * @var PluginRepository
-     */
-    private $pluginRepository;
-
-    public function __construct(PluginService $pluginService, PluginRepository $pluginRepository)
-    {
-        parent::__construct();
-        $this->pluginService = $pluginService;
-        $this->pluginRepository = $pluginRepository;
-    }
+    use PluginCommandTrait;
 
     protected function configure()
     {
@@ -77,6 +60,7 @@ class PluginEnableCommand extends Command
         }
 
         $this->pluginService->enable($plugin);
+        $this->clearCache($io);
 
         $io->success('Plugin Enabled.');
     }

--- a/src/Eccube/Command/PluginInstallCommand.php
+++ b/src/Eccube/Command/PluginInstallCommand.php
@@ -24,7 +24,6 @@
 namespace Eccube\Command;
 
 
-use Eccube\Service\PluginService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -33,20 +32,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class PluginInstallCommand extends Command
 {
-    /**
-     * @var PluginService
-     */
-    private $pluginService;
-
-    /**
-     * PluginInstallCommand constructor.
-     * @param PluginService $pluginService
-     */
-    public function __construct(PluginService $pluginService)
-    {
-        parent::__construct();
-        $this->pluginService = $pluginService;
-    }
+    use PluginCommandTrait;
 
     protected function configure()
     {
@@ -80,6 +66,7 @@ class PluginInstallCommand extends Command
             $this->pluginService->checkSamePlugin($config['code']);
             $this->pluginService->postInstall($config, $event, false);
 
+            $this->clearCache($io);
             $io->success('Installed.');
 
             return;

--- a/src/Eccube/Command/PluginUninstallCommand.php
+++ b/src/Eccube/Command/PluginUninstallCommand.php
@@ -24,8 +24,6 @@
 namespace Eccube\Command;
 
 
-use Eccube\Repository\PluginRepository;
-use Eccube\Service\PluginService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -34,22 +32,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class PluginUninstallCommand extends Command
 {
-    /**
-     * @var PluginService
-     */
-    private $pluginService;
-
-    /**
-     * @var PluginRepository
-     */
-    private $pluginRepository;
-
-    public function __construct(PluginService $pluginService, PluginRepository $pluginRepository)
-    {
-        parent::__construct();
-        $this->pluginService = $pluginService;
-        $this->pluginRepository = $pluginRepository;
-    }
+    use PluginCommandTrait;
 
     protected function configure()
     {
@@ -79,6 +62,7 @@ class PluginUninstallCommand extends Command
         }
 
         $this->pluginService->uninstall($plugin, $uninstallForce);
+        $this->clearCache($io);
 
         $io->success('Uninstalled.');
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ プラグインのインストール/有効/無効/削除時に変更された設定が読み込まれるようにキャッシュをクリア

## 実装に関する補足(Appendix)
+ WarmUpはしていません
+ Composer経由でインストールされたプラグインはComposerのPostスクリプトでキャッシュがクリアされる
