### PR TITLE
SwiftMailerの設定を追加

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -28,13 +28,9 @@ ECCUBE_DB_PASSWORD=
 ECCUBE_DB_CHARASET=
 ECCUBE_DB_COLLATE=
 
-# MAIL
-ECCUBE_MAIL_TRANSPORT=smtp
-ECCUBE_MAIL_HOST=localhost
-ECCUBE_MAIL_PORT=1025
-ECCUBE_MAIL_USERNAME=null
-ECCUBE_MAIL_PASSWORD=null
-ECCUBE_MAIL_ENCRYPTION=null
-ECCUBE_MAIL_AUTH_MODE=null
-ECCUBE_MAIL_CHARSET_ISO_2022_JP=false
-ECCUBE_MAIL_SPOOL=false
+###> symfony/swiftmailer-bundle ###
+# For Gmail as a transport, use: "gmail://username:password@localhost"
+# For a generic SMTP server, use: "smtp://localhost:25?encryption=&auth_mode="
+# Delivery is disabled by default via "null://localhost"
+MAILER_URL=null://localhost
+###< symfony/swiftmailer-bundle ###

--- a/app/config/eccube/packages/dev/swiftmailer.yaml
+++ b/app/config/eccube/packages/dev/swiftmailer.yaml
@@ -1,2 +1,4 @@
-#swiftmailer:
-    #delivery_address: me@example.com
+# See https://symfony.com/doc/current/email/dev_environment.html
+swiftmailer:
+    #  send all emails to a specific address
+    #delivery_addresses: ['me@example.com']


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
SwiftMailerの設定方法を
https://symfony.com/doc/current/email.html 
に倣って.envファイルに`MAILER_URL`を設定するように変更する。

設定した`MAILER_URL`は、
`app/config/eccube/packages/swiftmailer.yaml`
から呼び出される。


## 相談（Discussion）
設定方法は MAILER_URL 以外に下記URLのように設定する方法があるため、
どちらを採用するかは検討する必要があります。
https://symfony.com/doc/current/reference/configuration/swiftmailer.html
