### PR TITLE
#2352にて失った下位互換を戻すための対応

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -249,7 +249,7 @@ class EditController extends AbstractController
 
                         if ($Customer) {
                             // 会員の場合、購入回数、購入金額などを更新
-                            $app['eccube.repository.customer']->updateBuyData($app, $Customer, $isNewOrder);
+                            $app['eccube.repository.customer']->updateBuyData($app, $Customer, $TargetOrder->getOrderStatus()->getId(), $isNewOrder);
                         }
 
                         $event = new EventArgs(

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -187,7 +187,7 @@ class OrderController extends AbstractController
         $Customer = $Order->getCustomer();
         if ($Customer) {
             // 会員の場合、購入回数、購入金額などを更新
-            $app['eccube.repository.customer']->updateBuyData($app, $Customer);
+            $app['eccube.repository.customer']->updateBuyData($app, $Customer, $Order->getOrderStatus()->getId());
         }
 
         $event = new EventArgs(

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -187,7 +187,7 @@ class OrderController extends AbstractController
         $Customer = $Order->getCustomer();
         if ($Customer) {
             // 会員の場合、購入回数、購入金額などを更新
-            $app['eccube.repository.customer']->updateBuyData($app, $Customer, $Order->getOrderStatus()->getId());
+            $app['eccube.repository.customer']->updateBuyData($app, $Customer, $Order->getOrderStatus()->getId(), false);
         }
 
         $event = new EventArgs(

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -453,6 +453,7 @@ class CustomerRepository extends EntityRepository implements UserProviderInterfa
                     $Customer->setLastBuyDate($now);
                 }
             } else {
+                // @deprecate 3.0.15リリース以前に作られたPluginの互換性保持のため、本実装を残す
                 if ($orderStatusId == $app['config']['order_cancel'] ||
                     $orderStatusId == $app['config']['order_pending'] ||
                     $orderStatusId == $app['config']['order_processing']) {

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -422,9 +422,10 @@ class CustomerRepository extends EntityRepository implements UserProviderInterfa
      *
      * @param $app
      * @param  Customer $Customer
+     * @param  $orderStatusId
      * @param  $isNewOrder
      */
-    public function updateBuyData($app, Customer $Customer, $isNewOrder = false)
+    public function updateBuyData($app, Customer $Customer, $orderStatusId, $isNewOrder = false)
     {
         // 会員の場合、初回購入時間・購入時間・購入回数・購入金額を更新
 
@@ -447,7 +448,11 @@ class CustomerRepository extends EntityRepository implements UserProviderInterfa
                 $Customer->setFirstBuyDate($now);
             }
 
-            if($isNewOrder) {
+            if ($orderStatusId == $app['config']['order_cancel'] ||
+                $orderStatusId == $app['config']['order_pending'] ||
+                $orderStatusId == $app['config']['order_processing']) {
+                // キャンセル、決済処理中、購入処理中は購入時間は更新しない
+            } else if ($isNewOrder){
                 $Customer->setLastBuyDate($now);
             }
 

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -425,7 +425,7 @@ class CustomerRepository extends EntityRepository implements UserProviderInterfa
      * @param  $orderStatusId
      * @param  $isNewOrder
      */
-    public function updateBuyData($app, Customer $Customer, $orderStatusId, $isNewOrder = false)
+    public function updateBuyData($app, Customer $Customer, $orderStatusId, $isNewOrder = null)
     {
         // 会員の場合、初回購入時間・購入時間・購入回数・購入金額を更新
 
@@ -448,12 +448,18 @@ class CustomerRepository extends EntityRepository implements UserProviderInterfa
                 $Customer->setFirstBuyDate($now);
             }
 
-            if ($orderStatusId == $app['config']['order_cancel'] ||
-                $orderStatusId == $app['config']['order_pending'] ||
-                $orderStatusId == $app['config']['order_processing']) {
-                // キャンセル、決済処理中、購入処理中は購入時間は更新しない
-            } else if ($isNewOrder){
-                $Customer->setLastBuyDate($now);
+            if (!is_null($isNewOrder)) {
+                if ($isNewOrder) {
+                    $Customer->setLastBuyDate($now);
+                }
+            } else {
+                if ($orderStatusId == $app['config']['order_cancel'] ||
+                    $orderStatusId == $app['config']['order_pending'] ||
+                    $orderStatusId == $app['config']['order_processing']) {
+                    // キャンセル、決済処理中、購入処理中は購入時間は更新しない
+                } else {
+                    $Customer->setLastBuyDate($now);
+                }
             }
 
             $Customer->setBuyTimes($data['buy_times']);

--- a/tests/Eccube/Tests/Repository/CustomerRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/CustomerRepositoryTest.php
@@ -197,7 +197,7 @@ class CustomerRepositoryTest extends EccubeTestCase
         $this->app['orm.em']->flush();
 
         $this->actual = 1;
-        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer);
+        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer, $this->app['config']['order_new']);
         $this->expected = $this->Customer->getBuyTimes();
         $this->verify();
 
@@ -209,7 +209,7 @@ class CustomerRepositoryTest extends EccubeTestCase
         $this->app['orm.em']->flush();
 
         $this->actual = 0;
-        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer);
+        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer, $this->app['config']['order_new']);
         $this->expected = $this->Customer->getBuyTimes();
         $this->verify();
 

--- a/tests/Eccube/Tests/Repository/CustomerRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/CustomerRepositoryTest.php
@@ -197,7 +197,7 @@ class CustomerRepositoryTest extends EccubeTestCase
         $this->app['orm.em']->flush();
 
         $this->actual = 1;
-        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer, $this->app['config']['order_new']);
+        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer, $this->app['config']['order_new'], false);
         $this->expected = $this->Customer->getBuyTimes();
         $this->verify();
 
@@ -209,7 +209,7 @@ class CustomerRepositoryTest extends EccubeTestCase
         $this->app['orm.em']->flush();
 
         $this->actual = 0;
-        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer, $this->app['config']['order_new']);
+        $this->app['eccube.repository.customer']->updateBuyData($this->app, $this->Customer, $this->app['config']['order_new'], false);
         $this->expected = $this->Customer->getBuyTimes();
         $this->verify();
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 関連するIssue番号: https://github.com/EC-CUBE/ec-cube/issues/2238
+ PullRequest番号    : https://github.com/EC-CUBE/ec-cube/pull/2352
+ PullRequestの目的:
     With PR : #2352, change parameter of function updateBuyData maybe affect to other plugin of 3rd party, so just append 1 more param.

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外し内容
  - function updateBuyData add 1 param to prevent update last_buy_date field.

## テスト（Test)
+ mySQL
+ pgSQL



