### PR TITLE
テスト時は全てのコンポーネントをコンテナから取得できるように修正

### DIFF
--- a/src/Eccube/DependencyInjection/Compiler/LazyComponentPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/LazyComponentPass.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2017 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\DependencyInjection\Compiler;
+
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class LazyComponentPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->getDefinitions() as $definition) {
+            $definition->setLazy(true);
+        }
+    }
+}

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -12,6 +12,7 @@
 namespace Eccube;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Eccube\DependencyInjection\Compiler\LazyComponentPass;
 use Eccube\DependencyInjection\Compiler\PluginPass;
 use Eccube\DependencyInjection\Compiler\WebServerDocumentRootPass;
 use Eccube\DependencyInjection\EccubeExtension;
@@ -140,6 +141,11 @@ class Kernel extends BaseKernel
 
         // DocumentRootをルーティディレクトリに設定する.
         $container->addCompilerPass(new WebServerDocumentRootPass('%kernel.project_dir%/'));
+
+        // テスト時はコンテナからコンポーネントを直接取得できるようにしておく
+        if ($this->environment === 'test') {
+            $container->addCompilerPass(new LazyComponentPass());
+        }
 
         $container->register('app', Application::class)
             ->setSynthetic(true)

--- a/tests/Eccube/Tests/Service/AbstractServiceTestCase.php
+++ b/tests/Eccube/Tests/Service/AbstractServiceTestCase.php
@@ -26,12 +26,6 @@ namespace Eccube\Tests\Service;
 
 use Eccube\Tests\EccubeTestCase;
 
-class AbstractServiceTestCase extends EccubeTestCase
+abstract class AbstractServiceTestCase extends EccubeTestCase
 {
-public function setUp()
-    {
-        $this->markTestIncomplete(get_class($this).' は未実装です');
-        parent::setUp();
-    }
-
-    }
+}

--- a/tests/Eccube/Tests/Service/TaxRuleServiceTest.php
+++ b/tests/Eccube/Tests/Service/TaxRuleServiceTest.php
@@ -2,39 +2,47 @@
 
 namespace Eccube\Tests\Service;
 
+use Doctrine\ORM\EntityManager;
+use Eccube\Repository\BaseInfoRepository;
+use Eccube\Repository\TaxRuleRepository;
+use Eccube\Service\TaxRuleService;
+
 class TaxRuleServiceTest extends AbstractServiceTestCase
 {
+    /** @var TaxRuleService */
+    private $taxRuleService;
+
     public function setUp()
     {
-        $this->markTestIncomplete(get_class($this).' は未実装です');
         parent::setUp();
-        $this->BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $this->BaseInfo = $this->container->get(BaseInfoRepository::class)->get();
         $this->BaseInfo->setOptionProductTaxRule(0);
-        $this->TaxRule1 = $this->app['eccube.repository.tax_rule']->find(1);
+        $this->TaxRule1 = $this->container->get(TaxRuleRepository::class)->find(1);
         $this->TaxRule1->setApplyDate(new \DateTime('-1 day'));
-        $this->app['orm.em']->flush();
+        $this->container->get('doctrine')->getManager()->flush();
+        $this->taxRuleService = $this->container->get(TaxRuleService::class);
     }
 
     public function testRoundByCalcRuleWithDefault()
     {
         $input = 100.4;
         $this->expected = 101;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, 999);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, 999);
         $this->verify();
 
         $input = 100.5;
         $this->expected = 101;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, 999);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, 999);
         $this->verify();
 
         $input = 100;
         $this->expected = 100;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, 999);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, 999);
         $this->verify();
 
         $input = 101;
         $this->expected = 101;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, 999);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, 999);
         $this->verify();
     }
 
@@ -42,22 +50,22 @@ class TaxRuleServiceTest extends AbstractServiceTestCase
     {
         $input = 100.4;
         $this->expected = 101;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::CEIL);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::CEIL);
         $this->verify();
 
         $input = 100.5;
         $this->expected = 101;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::CEIL);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::CEIL);
         $this->verify();
 
         $input = 100;
         $this->expected = 100;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::CEIL);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::CEIL);
         $this->verify();
 
         $input = 101;
         $this->expected = 101;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::CEIL);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::CEIL);
         $this->verify();
     }
 
@@ -65,22 +73,22 @@ class TaxRuleServiceTest extends AbstractServiceTestCase
     {
         $input = 100.4;
         $this->expected = 100;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::ROUND);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::ROUND);
         $this->verify();
 
         $input = 100.5;
         $this->expected = 101;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::ROUND);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::ROUND);
         $this->verify();
 
         $input = 100;
         $this->expected = 100;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::ROUND);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::ROUND);
         $this->verify();
 
         $input = 101;
         $this->expected = 101;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::ROUND);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::ROUND);
         $this->verify();
     }
 
@@ -88,22 +96,22 @@ class TaxRuleServiceTest extends AbstractServiceTestCase
     {
         $input = 100.4;
         $this->expected = 100;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::FLOOR);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::FLOOR);
         $this->verify();
 
         $input = 100.5;
         $this->expected = 100;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::FLOOR);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::FLOOR);
         $this->verify();
 
         $input = 100;
         $this->expected = 100;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::FLOOR);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::FLOOR);
         $this->verify();
 
         $input = 101;
         $this->expected = 101;
-        $this->actual = $this->app['eccube.service.tax_rule']->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::FLOOR);
+        $this->actual = $this->taxRuleService->roundByRoundingType($input, \Eccube\Entity\Master\RoundingType::FLOOR);
         $this->verify();
     }
 
@@ -112,7 +120,7 @@ class TaxRuleServiceTest extends AbstractServiceTestCase
         $input = 1000;
         $rate = 8;
         $this->expected = 80.0;
-        $this->actual = $this->app['eccube.service.tax_rule']->calcTax($input, $rate, \Eccube\Entity\Master\RoundingType::ROUND);
+        $this->actual = $this->taxRuleService->calcTax($input, $rate, \Eccube\Entity\Master\RoundingType::ROUND);
         $this->verify();
     }
 
@@ -122,7 +130,7 @@ class TaxRuleServiceTest extends AbstractServiceTestCase
         $rate = 8;
         $adjust = -1;
         $this->expected = 80.0;
-        $this->actual = $this->app['eccube.service.tax_rule']->calcTax($input, $rate, \Eccube\Entity\Master\RoundingType::ROUND, $adjust);
+        $this->actual = $this->taxRuleService->calcTax($input, $rate, \Eccube\Entity\Master\RoundingType::ROUND, $adjust);
         $this->verify();
     }
 
@@ -131,7 +139,7 @@ class TaxRuleServiceTest extends AbstractServiceTestCase
         $input = 1000;
         $rate = 8;
         $this->expected = 80.0;
-        $this->actual = $this->app['eccube.service.tax_rule']->getTax($input);
+        $this->actual = $this->taxRuleService->getTax($input);
         $this->verify();
     }
 
@@ -140,7 +148,7 @@ class TaxRuleServiceTest extends AbstractServiceTestCase
         $input = 1000;
         $rate = 8;
         $this->expected = 1080.0;
-        $this->actual = $this->app['eccube.service.tax_rule']->getPriceIncTax($input);
+        $this->actual = $this->taxRuleService->getPriceIncTax($input);
         $this->verify();
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ Service等のテストを行う場合に、services.yamlを修正せずにテスト対象のコンポーネントをコンテナから取得できるようにする

## テスト（Test)
+ `TaxRuleService`を動作するように修正

## 相談（Discussion）
+ `services_test.yaml`で一括設定できるようなもっと良い方法があればそちらにしたい。