### PR TITLE
EccubeTestCase::url() を generateUrl に変更

### DIFF
--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -346,8 +346,19 @@ abstract class EccubeTestCase extends WebTestCase
         return $this->client->getProfile()->getCollector('swiftmailer');
     }
 
-    // TODO 暫定的に実装する
-    protected function url($route, $parameters = array(), $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
+    /**
+     * Generates a URL from the given parameters.
+     *
+     * @param string $route         The name of the route
+     * @param array  $parameters    An array of parameters
+     * @param int    $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
+     *
+     * @return string The generated URL
+     *
+     * @see UrlGeneratorInterface
+     * @see \Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait::generateUrl
+     */
+    protected function generateUrl($route, $parameters = array(), $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
         return $this->container->get('router')->generate($route, $parameters, $referenceType);
     }

--- a/tests/Eccube/Tests/Web/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/ProductControllerTest.php
@@ -42,7 +42,7 @@ class ProductControllerTest extends AbstractWebTestCase
     public function testRoutingDetail()
     {
         $client = $this->client;
-        $crawler = $client->request('GET', $this->url('product_detail', array('id' => '1')));
+        $crawler = $client->request('GET', $this->generateUrl('product_detail', array('id' => '1')));
         $this->assertTrue($client->getResponse()->isSuccessful());
     }
 

--- a/tests/Eccube/Tests/Web/TopControllerTest.php
+++ b/tests/Eccube/Tests/Web/TopControllerTest.php
@@ -29,7 +29,7 @@ class TopControllerTest extends AbstractWebTestCase
 
     public function testRoutingIndex()
     {
-        $crawler = $this->client->request('GET', $this->url('homepage'));
+        $crawler = $this->client->request('GET', $this->generateUrl('homepage'));
         $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- EccubeTestCase::url() を generateUrl に変更

## 方針(Policy)
+ControllerTrait::generateUrl() にあわせる

## テスト（Test)
+ ユニットテストが通るのを確認
