### PR TITLE
APP_ENV=prod で composer install がエラーになるのを修正

### DIFF
--- a/src/Eccube/Command/GenerateDummyDataCommand.php
+++ b/src/Eccube/Command/GenerateDummyDataCommand.php
@@ -29,7 +29,7 @@ class GenerateDummyDataCommand extends Command
      */
     protected $deliveryRepository;
 
-    public function __construct(Generator $generator, EntityManager $entityManager, DeliveryRepository $deliveryRepository)
+    public function __construct(Generator $generator = null, EntityManager $entityManager = null, DeliveryRepository $deliveryRepository = null)
     {
         parent::__construct();
         $this->generator = $generator;


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ `APP_ENV=prod` では Fixture\Generator が autowire の対象ではないのでエラーになるのを修正

## 方針(Policy)
+ `APP_ENV=prod` でインストールが完了するように修正