### PR TITLE
トークンチェックを動作するように修正

### DIFF
--- a/src/Eccube/Controller/AbstractController.php
+++ b/src/Eccube/Controller/AbstractController.php
@@ -137,10 +137,9 @@ class AbstractController extends Controller
 
     protected function isTokenValid()
     {
-        $csrf = $this->container->get(CsrfTokenManagerInterface::class);
         $request = $this->container->get('request_stack')->getCurrentRequest();
-        $name = Constant::TOKEN_NAME;
-        if (!$csrf->isTokenValid(new CsrfToken($name, $request->get($name)))) {
+
+        if (!$this->isCsrfTokenValid(Constant::TOKEN_NAME, $request->get(Constant::TOKEN_NAME))) {
             throw new AccessDeniedHttpException('CSRF token is invalid.');
         }
 

--- a/src/Eccube/Twig/Extension/CsrfExtension.php
+++ b/src/Eccube/Twig/Extension/CsrfExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Eccube\Twig\Extension;
+
+
+use Eccube\Common\Constant;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class CsrfExtension extends AbstractExtension
+{
+    /**
+     * @var CsrfTokenManagerInterface
+     */
+    protected $tokenManager;
+
+    /**
+     * CsrfExtension constructor.
+     *
+     * @param CsrfTokenManagerInterface $tokenManager
+     */
+    public function __construct(CsrfTokenManagerInterface $tokenManager)
+    {
+        $this->tokenManager = $tokenManager;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('csrf_token_for_anchor', [$this, 'getCsrfTokenForAnchor'], ['is_safe' => ['all']]),
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function getCsrfTokenForAnchor()
+    {
+        $token = $this->tokenManager->getToken(Constant::TOKEN_NAME)->getValue();
+
+        return 'token-for-anchor=\''.$token.'\'';
+    }
+}

--- a/src/Eccube/Twig/Extension/EccubeExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeExtension.php
@@ -65,7 +65,6 @@ class EccubeExtension extends AbstractExtension
             new TwigFunction('is_object', array($this, 'isObject')),
             new TwigFunction('calc_inc_tax', array($this, 'getCalcIncTax')),
             new TwigFunction('active_menus', array($this, 'getActiveMenus')),
-            new TwigFunction('csrf_token_for_anchor', array($this, 'getCsrfTokenForAnchor'), array('is_safe' => array('all'))),
 
             // Override: \Symfony\Bridge\Twig\Extension\RoutingExtension::url
             // new \Twig_SimpleFunction('url', array($this, 'getUrl'), array('is_safe_callback' => array($RoutingExtension, 'isUrlGenerationSafe'))),
@@ -134,17 +133,6 @@ class EccubeExtension extends AbstractExtension
         }
 
         return $menus;
-    }
-
-    /**
-     * Name of this extension
-     *
-     * @return string
-     */
-    public function getCsrfTokenForAnchor()
-    {
-        $token = $this->app['csrf.token_manager']->getToken(Constant::TOKEN_NAME)->getValue();
-        return 'token-for-anchor=\'' . $token . '\'';
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- AbscractController::isTokenValid()を動作するように修正
  - isCsrfTokenValidのラッパーとして実装
- Twig関数の`csrf_token_for_anchor`を動作するように修正




