### PR TITLE
Complete the installation with "composer create-project"

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -6,6 +6,8 @@ APP_SECRET=s$cretf0rt3st
 
 ###> doctrine/doctrine-bundle ###
 DATABASE_URL=sqlite:///%kernel.project_dir%/app/config/eccube/eccube.db
+# the version of your database engine
+DATABASE_SERVER_VERSION=3
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/swiftmailer-bundle ###

--- a/.env.dist
+++ b/.env.dist
@@ -1,4 +1,21 @@
-# APPLICATION CONFIG
+###> symfony/framework-bundle ###
+APP_ENV=dev
+APP_DEBUG=1
+APP_SECRET=s$cretf0rt3st
+###< symfony/framework-bundle ###
+
+###> doctrine/doctrine-bundle ###
+DATABASE_URL=sqlite:///%kernel.project_dir%/app/config/eccube/eccube.db
+###< doctrine/doctrine-bundle ###
+
+###> symfony/swiftmailer-bundle ###
+# For Gmail as a transport, use: "gmail://username:password@localhost"
+# For a generic SMTP server, use: "smtp://localhost:25?encryption=&auth_mode="
+# Delivery is disabled by default via "null://localhost"
+MAILER_URL=null://localhost
+###< symfony/swiftmailer-bundle ###
+
+###> APPLICATION CONFIG ###
 ECCUBE_AUTH_MAGIC=secret
 ECCUBE_FORCE_SSL=false
 ECCUBE_ADMIN_ALLOW_HOSTS='["127.0.0.1"]'
@@ -7,30 +24,4 @@ ECCUBE_COOKIE_NAME=eccube
 ECCUBE_LOCALE=ja
 ECCUBE_TIMEZONE=Asia/Tokyo
 ECCUBE_CURRENCY=JPY
-
-# PATH
-ECCUBE_ROOT_URLPATH=
-ECCUBE_TEMPLATE_CODE=default
-ECCUBE_ADMIN_ROUTE=admin
-ECCUBE_USER_DATA_ROUTE=user_data
-
-# PROXIES
-ECCUBE_TRUSTED_PROXIES_CONNECTION_ONLY=false
-ECCUBE_TRUSTED_PROXIES='["127.0.0.1/8", "::1"]'
-
-# DATABASE
-ECCUBE_DB_DEFAULT=sqlite
-ECCUBE_DB_HOST=
-ECCUBE_DB_PORT=
-ECCUBE_DB_DATABASE=/path/to/eccube/app/config/eccube/eccube_db
-ECCUBE_DB_USERNAME=
-ECCUBE_DB_PASSWORD=
-ECCUBE_DB_CHARASET=
-ECCUBE_DB_COLLATE=
-
-###> symfony/swiftmailer-bundle ###
-# For Gmail as a transport, use: "gmail://username:password@localhost"
-# For a generic SMTP server, use: "smtp://localhost:25?encryption=&auth_mode="
-# Delivery is disabled by default via "null://localhost"
-MAILER_URL=null://localhost
-###< symfony/swiftmailer-bundle ###
+###< APPLICATION CONFIG ###

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ php:
   - 7.1
   - 7.0
 
-services:
-  - mysql
-  - postgresql
-
 env:
   global:
     - KERNEL_CLASS=Eccube\Kernel
@@ -32,39 +28,33 @@ env:
     - ECCUBE_AUTH_MAGIC=s$cretVBJmtS0Ls+
 
   matrix:
-    - DB=mysql DATABASE_URL=mysql://root:@localhost/cube4_dev
-    - DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev
-    - DB=sqlite DATABASE_URL=sqlite:///%kernel.project_dir%/app/config/eccube/eccube.db
+    - DB=mysql DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
+    - DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
+    - DB=sqlite DATABASE_URL=sqlite:///%kernel.project_dir%/app/config/eccube/eccube.db DATABASE_SERVER_VERSION=3
     # カバレッジレポート用
-    - DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev COVERAGE=true
+    - DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9 COVERAGE=true
 
 matrix:
   fast_finish: true
   exclude:
     # php7.1以外のカバレッジレポート用matrixは除外
     - php: 7.0
-      env: DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev COVERAGE=true
+      env: DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9 COVERAGE=true
     - php: 7.2
-      env: DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev COVERAGE=true
+      env: DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9 COVERAGE=true
   allow_failures:
     # sqlite
-    - env: DB=sqlite DATABASE_URL=sqlite:///%kernel.project_dir%/app/config/eccube/eccube.db
+    - env: DB=sqlite DATABASE_URL=sqlite:///%kernel.project_dir%/app/config/eccube/eccube.db DATABASE_SERVER_VERSION=3
     # カバレッジレポートはphp7.1のmatrixで実行
     - php: 7.1
-      env: DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev COVERAGE=true
+      env: DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9 COVERAGE=true
     # php7.2
     - php: 7.2
 
-before_install:
-  - if [[ $DB = 'mysql' ]]; then mysql -e 'CREATE DATABASE cube4_dev;' ; fi
-  - if [[ $DB = 'pgsql' ]]; then psql -c 'CREATE DATABASE cube4_dev;' -U postgres ; fi
-
 install:
   - composer install --dev --no-interaction -o
+  - composer run-script installer-scripts
   - ./vendor/bin/simple-phpunit install
-  # - bin/console doctrine:database:create
-  - bin/console doctrine:schema:create
-  - bin/console eccube:fixtures:load
 
 before_script:
   - phpenv config-rm xdebug.ini || true

--- a/app/config/eccube/packages/doctrine.yaml
+++ b/app/config/eccube/packages/doctrine.yaml
@@ -8,7 +8,7 @@ parameters:
 doctrine:
     dbal:
         driver: 'pdo_sqlite'
-        # server_version: '5.7'
+        server_version: "%env(DATABASE_SERVER_VERSION)%"
         charset: utf8
 
         # for mysql only

--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -1,7 +1,7 @@
 parameters:
   eccube.constants:
-    admin_route: %admin_route%
-    nav: %eccube.nav%
+    admin_route: '%admin_route%'
+    nav: '%eccube.nav%'
     admin_allow_hosts: {}
     auth_type: HMAC
     csv_size: 5                 # post_max_size, upload_max_filesize に任せればよい？

--- a/app/config/eccube/packages/security.yaml
+++ b/app/config/eccube/packages/security.yaml
@@ -59,9 +59,9 @@ security:
     access_control:
         # this is a catch-all for the admin area
         # additional security lives in the controllers
-        - { path: ^/%admin_route%/login, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: %eccube.scheme% }
-        - { path: ^/%admin_route%/, roles: ROLE_ADMIN, requires_channel: %eccube.scheme%  }
-        - { path: ^/mypage/login, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: %eccube.scheme% }
-        - { path: ^/mypage/withdraw_complete, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: %eccube.scheme% }
-        - { path: ^/mypage/change, roles: IS_AUTHENTICATED_FULLY, requires_channel: %eccube.scheme% }
-        - { path: ^/mypage/, roles: ROLE_USER, requires_channel: %eccube.scheme%  }
+        - { path: ^/%admin_route%/login, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: '%eccube.scheme%' }
+        - { path: ^/%admin_route%/, roles: ROLE_ADMIN, requires_channel: '%eccube.scheme%'  }
+        - { path: ^/mypage/login, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: '%eccube.scheme%' }
+        - { path: ^/mypage/withdraw_complete, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: '%eccube.scheme%' }
+        - { path: ^/mypage/change, roles: IS_AUTHENTICATED_FULLY, requires_channel: '%eccube.scheme%' }
+        - { path: ^/mypage/, roles: ROLE_USER, requires_channel: '%eccube.scheme%' }

--- a/app/config/eccube/packages/twig.yaml
+++ b/app/config/eccube/packages/twig.yaml
@@ -1,7 +1,7 @@
 twig:
     globals:
       eccube:
-        config: %eccube.constants%
+        config: '%eccube.constants%'
     paths:
       '%kernel.project_dir%/app/template/%eccube.theme%': ~
       '%kernel.project_dir%/src/Eccube/Resource/template/default': ~

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -75,7 +75,7 @@ services:
     Eccube\Twig\Extension\EccubeBlockExtension:
         tags: ['twig.extension']
         bind:
-          $blockTemplates: %eccube.twig.block.templates%
+          $blockTemplates: '%eccube.twig.block.templates%'
 
     Plugin\:
         resource: '../../../app/Plugin/*'

--- a/composer.json
+++ b/composer.json
@@ -116,6 +116,12 @@
         ],
         "post-update-cmd": [
             "@auto-scripts"
+        ],
+        "post-create-project-cmd": [
+            "bin/console doctrine:database:create",
+            "bin/console doctrine:schema:create",
+            "bin/console eccube:fixtures:load",
+            "@auto-scripts"
         ]
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -111,6 +111,11 @@
             "cache:warmup": "symfony-cmd",
             "assets:install --symlink --relative html": "symfony-cmd"
         },
+        "installer-scripts": {
+            "doctrine:database:create": "bin/console doctrine:database:create",
+            "doctrine:schema:create": "bin/console doctrine:schema:create",
+            "eccube:fixtures:load": "bin/console eccube:fixtures:load"
+        },
         "post-install-cmd": [
             "@auto-scripts"
         ],
@@ -118,9 +123,7 @@
             "@auto-scripts"
         ],
         "post-create-project-cmd": [
-            "bin/console doctrine:database:create",
-            "bin/console doctrine:schema:create",
-            "bin/console eccube:fixtures:load",
+            "@installer-scripts",
             "@auto-scripts"
         ]
     },

--- a/src/Eccube/DependencyInjection/EccubeExtension.php
+++ b/src/Eccube/DependencyInjection/EccubeExtension.php
@@ -47,6 +47,17 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
         $params = $config['dbal']['connections'][$config['dbal']['default_connection']];
         $conn = \Doctrine\DBAL\DriverManager::getConnection($params);
 
+        $sm = $conn->getSchemaManager();
+        $tables = array_filter(
+            $sm->listTables(),
+            function ($table) {
+                return $table->getName() === 'dtb_plugin';
+            }
+        );
+        if (empty($tables)) {
+            return;
+        }
+
         $stmt = $conn->query('select * from dtb_plugin');
         $plugins = $stmt->fetchAll();
 

--- a/src/Eccube/DependencyInjection/EccubeExtension.php
+++ b/src/Eccube/DependencyInjection/EccubeExtension.php
@@ -46,6 +46,9 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
         // 直接dbalのconnectionを生成し, dbアクセスを行う.
         $params = $config['dbal']['connections'][$config['dbal']['default_connection']];
         $conn = \Doctrine\DBAL\DriverManager::getConnection($params);
+        if (!$conn->isConnected()) {
+            return;
+        }
 
         $sm = $conn->getSchemaManager();
         $tables = array_filter(


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ composer create-project でインストールできるよう .env.dist を修正
+ composer.json に `post-create-project-cmd`, `installer-scripts` を追加

## 方針(Policy)
+ `APP_ENV=dev`+ sqlite の環境でインストール完了するように、 .env.dist の初期値を設定する
+ 以下のようなコマンドでインストールを完了できるようにする
```
composer create-project ec-cube/ec-cube ec-cube "dev-experimental/sf" 
```

## 実装に関する補足(Appendix)
+ composer install で `dtb_plugin` テーブルを見に行ってしまい、エラーになる問題を修正
+ 一部、yaml の構文で deprecated が出ていたので修正しています
+ PostgreSQL, MySQL を使用する場合は、.env ファイルを修正した後に `composer run-script installer-scripts` を実行する

## テスト（Test)
+ `composer run-script post-create-project-cmd` でインストール完了することを確認。 
+ Travis-CI のテストが成功することを確認

## 相談（Discussion）
+ PostgreSQL, MySQL だと `bin/console doctrine:database:create` で、` Unknown database 'database name'` のエラーになってしまう。
    - [Doctrine DBAL の不具合](https://github.com/doctrine/DoctrineBundle/issues/351) のため`doctrine.dbal.server_version` を指定する。(適当な番号でも動く...)
   - [Doctrine DBAL 2.5 は修正されない模様](https://github.com/doctrine/dbal/pull/2671#issuecomment-313668012)