### PR TITLE
ログの修正

### DIFF
--- a/app/config/eccube/packages/prod/monolog.yml
+++ b/app/config/eccube/packages/prod/monolog.yml
@@ -3,16 +3,18 @@ monolog:
         main:
             type: fingers_crossed
             action_level: error
+            passthru_level: info
             handler: main_rotating_file
         main_rotating_file:
             type: rotating_file
             max_files: 60
-            path: '%kernel.logs_dir%/%kernel.environment%/main.log'
+            path: '%kernel.logs_dir%/%kernel.environment%/site.log'
             formatter: eccube.log.formatter.line
             level: debug
         front:
             type: fingers_crossed
             action_level: error
+            passthru_level: info
             handler: front_rotating_file
             channels: ['front']
         front_rotating_file:
@@ -24,6 +26,7 @@ monolog:
         admin:
             type: fingers_crossed
             action_level: error
+            passthru_level: info
             handler: admin_rotating_file
             channels: ['admin']
         admin_rotating_file:

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -81,13 +81,6 @@ services:
         bind:
           $blockTemplates: '%eccube.twig.block.templates%'
 
-    Eccube\Log\Logger:
-        arguments:
-          - '@Eccube\Request\Context'
-          - '@monolog.logger'
-          - '@monolog.logger.front'
-          - '@monolog.logger.admin'
-
     Plugin\:
         resource: '../../../app/Plugin/*'
         exclude: '../../../app/Plugin/*/{Entity,Resource,ServiceProvider,Tests}'
@@ -120,6 +113,14 @@ services:
 
     # needed for the 'localizeddate' Twig filter
     # Twig\Extensions\IntlExtension: ~
+
+    eccube.logger:
+        class: Eccube\Log\Logger
+        arguments:
+          - '@Eccube\Request\Context'
+          - '@monolog.logger'
+          - '@monolog.logger.front'
+          - '@monolog.logger.admin'
 
     eccube.log.formatter.line:
         class: Monolog\Formatter\LineFormatter

--- a/app/config/eccube/services_dev.yaml
+++ b/app/config/eccube/services_dev.yaml
@@ -3,4 +3,4 @@ services:
         class: EasyCorp\EasyLog\EasyLogHandler
         public: false
         arguments:
-            - '%kernel.logs_dir%/%kernel.environment%/main.log'
+            - '%kernel.logs_dir%/%kernel.environment%/site.log'

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -52,6 +52,9 @@ class EccubeServiceProvider implements ServiceProviderInterface
         $app['monolog'] = $app->share(function () use ($app) {
             return $app['monolog.logger'];
         });
+        $app['eccube.logger'] = $app->share(function () use ($app) {
+            return $app->getParentContainer()->get('eccube.logger');
+        });
 
         $app['session'] = $app->share(function () use ($app) {
             return $app->getParentContainer()->get('session');


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- ログのファイル名を3.0に合わて、`site.log`で出力するように修正
- log_xxx()でEccube\Log\Loggerを使うように修正

## 関連

#2761


