### PR TITLE
CsrfTokenManagerをMockに差し替え

### DIFF
--- a/app/config/eccube/services_test.yaml
+++ b/app/config/eccube/services_test.yaml
@@ -1,0 +1,4 @@
+services:
+    security.csrf.token_manager:
+        class: Eccube\Tests\Mock\CsrfTokenManagerMock
+        public: true

--- a/tests/Eccube/Tests/Web/ContactControllerTest.php
+++ b/tests/Eccube/Tests/Web/ContactControllerTest.php
@@ -72,7 +72,7 @@ class ContactControllerTest extends AbstractWebTestCase
             ),
             'email' => $email,
             'contents' => $faker->realText(),
-            '_token' => $this->getCsrfToken('contact')
+            '_token' => 'dummy',
         );
 
         return $form;


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- テスト時には、CsrfTokenManagerはモックを利用するように修正しました。

## 方針(Policy)

フォームでcsrfトークンを送信する際は、以下のようにダミーの文字列を渡してください。
`$this->getToken('xxxx')`で事前に発行する必要はありません。

```
        $this->client->request(
            'POST',
            $this->generateUrl('admin_content_block_edit', array('id' => 1)),
            array(
                'block' => array(
                    'name' => 'newblock',
                    '_token' => 'dummy',
                ),
            )
        );
```