### PR TITLE
BaseInfoのインジェクション

### DIFF
--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -157,3 +157,6 @@ services:
         tags:
             - { name: monolog.processor }
             - { name: kernel.event_listener, event: kernel.request, priority: 1024 }
+
+    Eccube\Entity\BaseInfo:
+        factory: ['@Eccube\Repository\BaseInfoRepository', 'get']


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

BaseInfoをインジェクションできるように修正

## 方針(Policy)

コンストラクタインジェクション/セッターインジェクションで利用可能です。

```php
public function __construct(BaseInfo $BaseInfo)
{
    $this->BaseInfo = $BaseInfo;
}
```

DoctrineのParamConverterと重複するため、コントローラのメソッドインジェクションでは利用できません。

以下のコードは、`Unable to guess how to get a Doctrine instance from the request information for parameter "baseInfo".`がthrowされます。

```php
// XxxController.php

/**
  * @Route("/xxx")
  */
public function xxx(BaseInfo $BaseInfo)
{
}
```
