### PR TITLE
Implementation of forwardToRoute

### DIFF
--- a/src/Eccube/Controller/AbstractController.php
+++ b/src/Eccube/Controller/AbstractController.php
@@ -32,6 +32,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -148,6 +149,24 @@ class AbstractController extends Controller
         } else {
             $this->session->getFlashBag()->set('eccube.' . $namespace . '.login.target.path', $targetPath);
         }
+    }
+
+    /**
+     * Forwards the request to another controller.
+     *
+     * @param string $route The name of the route
+     * @param array  $path An array of path parameters
+     * @param array  $query An array of query parameters
+     *
+     * @return Response A Response instance
+     */
+    public function forwardToRoute($route, array $path = [], array $query = [])
+    {
+        $Route = $this->get('router')->getRouteCollection()->get($route);
+        if (!$Route) {
+            throw new RouteNotFoundException(sprintf('The named route "%s" as such route does not exist.', $route));
+        }
+        return $this->forward($Route->getDefault('_controller'), $path, $query);
     }
 
     protected function isTokenValid()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ AbstractController::forwardToRoute を実装する

## 方針(Policy)
+ `Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait::forward()` の第一引数が `Controllerclass:methodName` なので、利便性が悪い。ルーティング名を渡せるようにする

## テスト（Test)
+ 以下のようなコードで、トップページから商品詳細ページに forward されるのを確認
```php
    /**
     * @Route("/", name="homepage")
     * @Template("index.twig")
     */
    public function index(Application $app, Request $request)
    {
        return $this->forwardToRoute('product_detail', ['Product' => 1]);
    }

```

## 相談（Discussion）
+ 単体テストをどうやって書いたらよいか
