### PR TITLE
fix controller & unit test (Controller/Admin root) 

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -60,7 +60,7 @@ parameters:
     product_order_price_lower: 1
     product_order_newer: 2
     product_order_price_higher: 3
-    password_min_len: 4
-    password_max_len: 8
-    auth_magic: 'secret'
+    password_min_len: 8
+    password_max_len: 32
+    auth_magic: '%env(ECCUBE_AUTH_MAGIC)%'
     password_hash_algos: SHA256

--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -60,3 +60,7 @@ parameters:
     product_order_price_lower: 1
     product_order_newer: 2
     product_order_price_higher: 3
+    password_min_len: 4
+    password_max_len: 8
+    auth_magic: 'secret'
+    password_hash_algos: SHA256

--- a/src/Eccube/Controller/Admin/AdminController.php
+++ b/src/Eccube/Controller/Admin/AdminController.php
@@ -24,7 +24,6 @@
 
 namespace Eccube\Controller\Admin;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\QueryBuilder;

--- a/src/Eccube/Form/Type/Admin/ChangePasswordType.php
+++ b/src/Eccube/Form/Type/Admin/ChangePasswordType.php
@@ -23,9 +23,6 @@
 
 namespace Eccube\Form\Type\Admin;
 
-use Eccube\Annotation\FormType;
-use Eccube\Annotation\Inject;
-use Eccube\Application;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
@@ -34,9 +31,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @FormType
- */
+
 class ChangePasswordType extends AbstractType
 {
     /**
@@ -85,8 +80,6 @@ class ChangePasswordType extends AbstractType
                     )),
                 ),
             ))
-            // TODO:: Fix me
-            // ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
         ;
     }
 

--- a/src/Eccube/Form/Type/Admin/ChangePasswordType.php
+++ b/src/Eccube/Form/Type/Admin/ChangePasswordType.php
@@ -30,8 +30,6 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormError;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -42,19 +40,17 @@ use Symfony\Component\Validator\Constraints as Assert;
 class ChangePasswordType extends AbstractType
 {
     /**
-     * @Inject("config")
      * @var array
      */
     protected $appConfig;
 
     /**
-     * @var \Eccube\Application $app
-     * @Inject(Application::class)
+     * ChangePasswordType constructor.
+     * @param array $eccubeConfig
      */
-    protected $app;
-
-    public function __construct()
+    public function __construct(array $eccubeConfig)
     {
+        $this->appConfig = $eccubeConfig;
     }
 
     /**
@@ -62,7 +58,6 @@ class ChangePasswordType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $app = $this->app;
         $builder
             ->add('current_password', PasswordType::class, array(
                 'label' => '現在のパスワード',
@@ -90,7 +85,8 @@ class ChangePasswordType extends AbstractType
                     )),
                 ),
             ))
-            ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
+            // TODO:: Fix me
+            // ->addEventSubscriber(new \Eccube\Event\FormEventSubscriber());
         ;
     }
 

--- a/src/Eccube/Resource/template/admin/change_password.twig
+++ b/src/Eccube/Resource/template/admin/change_password.twig
@@ -24,7 +24,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% form_theme form '@admin/Form/bootstrap_3_horizontal_layout.html.twig' %}
 
 {% block title %}パスワード変更{% endblock %}
-
+{# TODO:: Block "sub_title" on template "@admin/default_frame.twig" does not exist⇒エラーが発生しる.だから、動けるために、追加します。  #}
+{% block sub_title %}{% endblock %}
 {% block main %}
 <div class="row" id="aside_wrap">
     <div id="detail_wrap" class="col-md-9">

--- a/src/Eccube/Resource/template/admin/change_password.twig
+++ b/src/Eccube/Resource/template/admin/change_password.twig
@@ -19,9 +19,9 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #}
-{% extends 'default_frame.twig' %}
+{% extends '@admin/default_frame.twig' %}
 
-{% form_theme form 'Form/bootstrap_3_horizontal_layout.html.twig' %}
+{% form_theme form '@admin/Form/bootstrap_3_horizontal_layout.html.twig' %}
 
 {% block title %}パスワード変更{% endblock %}
 

--- a/src/Eccube/Resource/template/admin/default_frame.twig
+++ b/src/Eccube/Resource/template/admin/default_frame.twig
@@ -32,7 +32,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 <link rel="stylesheet" href="{{ asset('assets/css/bootstrap.min.css', 'admin') }}">
 <link rel="stylesheet" href="{{ asset('assets/css/dashboard.css', 'admin') }}">
 {% block stylesheet %}{% endblock %}
-{# TODO: #}
+{# TODO:: Block "sub_title" on template "@admin/default_frame.twig" does not exist⇒エラーが発生しる.だから、動けるために、追加します。  #}
 {% block sub_title %}{% endblock %}
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>

--- a/src/Eccube/Resource/template/admin/default_frame.twig
+++ b/src/Eccube/Resource/template/admin/default_frame.twig
@@ -32,6 +32,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 <link rel="stylesheet" href="{{ asset('assets/css/bootstrap.min.css', 'admin') }}">
 <link rel="stylesheet" href="{{ asset('assets/css/dashboard.css', 'admin') }}">
 {% block stylesheet %}{% endblock %}
+{# TODO: #}
+{% block sub_title %}{% endblock %}
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
 <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>

--- a/src/Eccube/Resource/template/admin/default_frame.twig
+++ b/src/Eccube/Resource/template/admin/default_frame.twig
@@ -32,8 +32,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 <link rel="stylesheet" href="{{ asset('assets/css/bootstrap.min.css', 'admin') }}">
 <link rel="stylesheet" href="{{ asset('assets/css/dashboard.css', 'admin') }}">
 {% block stylesheet %}{% endblock %}
-{# TODO:: Block "sub_title" on template "@admin/default_frame.twig" does not exist⇒エラーが発生しる.だから、動けるために、追加します。  #}
-{% block sub_title %}{% endblock %}
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
 <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>

--- a/tests/Eccube/Tests/Web/Admin/AdminControllerProductNonStockTest.php
+++ b/tests/Eccube/Tests/Web/Admin/AdminControllerProductNonStockTest.php
@@ -9,12 +9,6 @@ use Symfony\Component\HttpKernel\Client;
  */
 class AdminControllerProductNonStockTest extends AbstractAdminWebTestCase
 {
-    public function setUp()
-    {
-        $this->markTestIncomplete(get_class($this).' は未実装です');
-        parent::setUp();
-    }
-
     /**
      * @var string
      */
@@ -25,7 +19,7 @@ class AdminControllerProductNonStockTest extends AbstractAdminWebTestCase
      */
     public function testAdminNonStockRedirect()
     {
-        $this->client->request('POST', $this->app->url('admin_homepage_nonstock'));
+        $this->client->request('POST', $this->generateUrl('admin_homepage_nonstock'));
         $this->assertTrue($this->client->getResponse()->isRedirect());
     }
 
@@ -36,7 +30,7 @@ class AdminControllerProductNonStockTest extends AbstractAdminWebTestCase
     {
         /* @var Client $client */
         $client = $this->client;
-        $crawler = $client->request('GET', $this->app->url('admin_homepage'));
+        $crawler = $client->request('GET', $this->generateUrl('admin_homepage'));
         $this->assertTrue($client->getResponse()->isSuccessful());
 
         $this->assertContains('在庫切れ商品', $crawler->filter($this->target)->html());
@@ -49,9 +43,11 @@ class AdminControllerProductNonStockTest extends AbstractAdminWebTestCase
      */
     public function testAdminNonStockWithSearch()
     {
+        $this->markTestIncomplete('Function not implement');
+
         /* @var Client $client */
         $client = $this->client;
-        $crawler = $client->request('GET', $this->app->url('admin_homepage'));
+        $crawler = $client->request('GET', $this->generateUrl('admin_homepage'));
         $this->assertTrue($client->getResponse()->isSuccessful());
 
         $this->assertContains('在庫切れ商品', $crawler->filter($this->target)->html());
@@ -59,7 +55,8 @@ class AdminControllerProductNonStockTest extends AbstractAdminWebTestCase
         $section = trim($crawler->filter($this->target.' .shop-stock-detail .item_number')->text());
         $this->expected = $showNumber = preg_replace('/\D/', '', $section);
 
-        $client->request('POST', $this->app->url('admin_homepage_nonstock'), array('admin_search_product' => array('_token' => 'dummy')));
+        $client->request('POST', $this->generateUrl('admin_homepage_nonstock'),
+                array('admin_search_product' => array('_token' =>  'dummy')));
 
         $crawler = $client->followRedirect();
         $this->actual = $crawler->filter('.tableish .item_box')->count();

--- a/tests/Eccube/Tests/Web/Admin/IndexControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/IndexControllerTest.php
@@ -23,27 +23,38 @@
 namespace Eccube\Tests\Web\Admin;
 
 use Eccube\Entity\Master\OrderStatus;
+use Eccube\Entity\Member;
+use Eccube\Repository\Master\OrderStatusRepository;
+use Eccube\Repository\OrderRepository;
 
 class IndexControllerTest extends AbstractAdminWebTestCase
 {
+    /** @var  Member */
     protected $Member;
+
+    /** @var OrderStatusRepository */
+    protected $orderStatusRepository;
+
+    /** @var OrderRepository */
+    protected $orderRepository;
 
     public function setUp()
     {
-        $this->markTestIncomplete(get_class($this).' は未実装です');
         parent::setUp();
         $this->Member = $this->createMember();
+        $this->orderStatusRepository = $this->container->get(OrderStatusRepository::class);
+        $this->orderRepository = $this->container->get(OrderRepository::class);
     }
 
     public function testRoutingAdminIndex()
     {
-        $crawler = $this->client->request('GET', $this->app['url_generator']->generate('admin_homepage'));
+        $this->client->request('GET', $this->generateUrl('admin_homepage'));
         $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 
     public function testRoutingAdminChangePassword()
     {
-        $this->client->request('GET', $this->app['url_generator']->generate('admin_change_password'));
+        $this->client->request('GET', $this->generateUrl('admin_change_password'));
         $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 
@@ -56,17 +67,17 @@ class IndexControllerTest extends AbstractAdminWebTestCase
         $Today = new \DateTime();
         $Yesterday = new \DateTime('-1 days');
 
-        $OrderNew = $this->app['eccube.repository.order_status']->find(OrderStatus::NEW);
-        $OrderPending = $this->app['eccube.repository.order_status']->find(OrderStatus::PENDING);
-        $OrderCancel = $this->app['eccube.repository.order_status']->find(OrderStatus::CANCEL);
-        $OrderProcessing = $this->app['eccube.repository.order_status']->find(OrderStatus::PROCESSING);
+        $OrderNew = $this->orderStatusRepository->find(OrderStatus::NEW);
+        $OrderPending = $this->orderStatusRepository->find(OrderStatus::PENDING);
+        $OrderCancel = $this->orderStatusRepository->find(OrderStatus::CANCEL);
+        $OrderProcessing = $this->orderStatusRepository->find(OrderStatus::PROCESSING);
 
         $todaysSales = 0;
         for ($i = 0; $i < 3; $i++) {
             $Order = $this->createOrder($Customer);
             $Order->setOrderStatus($OrderNew);
             $Order->setOrderDate($Today);
-            $this->app['orm.em']->flush();
+            $this->entityManager->flush();
             $todaysSales += $Order->getPaymentTotal();
         }
         $yesterdaysSales = 0;
@@ -74,7 +85,7 @@ class IndexControllerTest extends AbstractAdminWebTestCase
             $Order = $this->createOrder($Customer);
             $Order->setOrderStatus($OrderNew);
             $Order->setOrderDate($Yesterday);
-            $this->app['orm.em']->flush();
+            $this->entityManager->flush();
             $yesterdaysSales += $Order->getPaymentTotal();
         }
 
@@ -84,13 +95,13 @@ class IndexControllerTest extends AbstractAdminWebTestCase
                 $Order = $this->createOrder($Customer);
                 $Order->setOrderStatus($OrderStatus);
                 $Order->setOrderDate($OrderDate);
-                $this->app['orm.em']->flush();
+                $this->entityManager->flush();
             }
         }
 
         $crawler = $this->client->request(
             'GET',
-            $this->app->url('admin_homepage')
+            $this->generateUrl('admin_homepage')
         );
 
         $this->assertTrue($this->client->getResponse()->isSuccessful());
@@ -121,7 +132,7 @@ class IndexControllerTest extends AbstractAdminWebTestCase
         $endDate->setDate($Today->format('Y'), $Today->format('m'), $Today->format('t'));
         $endDate->setTime(23, 59, 59);
 
-        $qb = $this->app['eccube.repository.order']->createQueryBuilder('o');
+        $qb = $this->orderRepository->createQueryBuilder('o');
         $qb->andWhere($qb->expr()->notIn('o.OrderStatus',
                                          array(
                                              $OrderPending->getId(),
@@ -162,29 +173,29 @@ class IndexControllerTest extends AbstractAdminWebTestCase
         $client = $this->client;
 
         $form = $this->createChangePasswordFormData();
-        $crawler = $client->request(
+        $client->request(
             'POST',
-            $this->app->path('admin_change_password'),
+            $this->generateUrl('admin_change_password'),
             array('admin_change_password' => $form)
         );
 
-        $this->assertTrue($client->getResponse()->isRedirect($this->app->url('admin_change_password')));
+        $this->assertTrue($client->getResponse()->isRedirect($this->generateUrl('admin_change_password')));
 
         $Member = clone $this->Member;
-        $encoder = $this->app['security.encoder_factory']->getEncoder($this->Member);
+        $encoder = $this->container->get('security.encoder_factory')->getEncoder($this->Member);
         $this->expected = $encoder->encodePassword($form['change_password']['first'], $this->Member->getSalt());
         $this->actual = $this->Member->getPassword();
 
         // XXX 実行タイミングにより、稀にパスワード変更前のハッシュ値を参照する場合があるため、変更に成功した場合のみ assertion を実行する
-        $old_password = hash_hmac('sha256', 'password'.':'.$this->app['config']['auth_magic'], $this->Member->getSalt());
+        $old_password = hash_hmac('sha256', 'password'.':'.$this->eccubeConfig['auth_magic'], $this->Member->getSalt());
         if ($this->actual === $old_password) {
-            $this->markTestSkipped('Failed to change the password by HttpClient. Skip this test.');
+             $this->markTestSkipped('Failed to change the password by HttpClient. Skip this test.');
         }
 
         $this->verify(
             'パスワードのハッシュ値が異なります '.PHP_EOL
-            .' AUTH_MAGIC='.$this->app['config']['auth_magic'].PHP_EOL
-            .' HASH_Algos='.$this->app['config']['password_hash_algos'].PHP_EOL
+            .' AUTH_MAGIC='.$this->eccubeConfig['auth_magic'].PHP_EOL
+            .' HASH_Algos='.$this->eccubeConfig['password_hash_algos'].PHP_EOL
             .' Input Password='.$form['change_password']['first'].PHP_EOL
             .' Expected: salt='.$Member->getSalt().', raw password='.$Member->getPassword().PHP_EOL
             .' Actual: salt='.$this->Member->getSalt()
@@ -198,7 +209,7 @@ class IndexControllerTest extends AbstractAdminWebTestCase
 
         $client->request(
             'POST',
-            $this->app->path('admin_change_password'),
+            $this->generateUrl('admin_change_password'),
             array()
         );
         $this->assertTrue($client->getResponse()->isSuccessful());

--- a/tests/Eccube/Tests/Web/Admin/IndexControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/IndexControllerTest.php
@@ -189,7 +189,7 @@ class IndexControllerTest extends AbstractAdminWebTestCase
         // XXX 実行タイミングにより、稀にパスワード変更前のハッシュ値を参照する場合があるため、変更に成功した場合のみ assertion を実行する
         $old_password = hash_hmac('sha256', 'password'.':'.$this->eccubeConfig['auth_magic'], $this->Member->getSalt());
         if ($this->actual === $old_password) {
-             $this->markTestSkipped('Failed to change the password by HttpClient. Skip this test.');
+            $this->markTestSkipped('Failed to change the password by HttpClient. Skip this test.');
         }
 
         $this->verify(

--- a/tests/Eccube/Tests/Web/Admin/LoginControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/LoginControllerTest.php
@@ -28,11 +28,6 @@ use Eccube\Tests\Web\AbstractWebTestCase;
 class LoginControllerTest extends AbstractWebTestCase
 {
 
-    public function setUp()
-    {
-        parent::setUp();
-    }
-
     public function testRoutingAdminLogin()
     {
         $this->client->request('GET', $this->generateUrl('admin_login'));
@@ -48,12 +43,12 @@ class LoginControllerTest extends AbstractWebTestCase
     public function testRoutingAdminLoginCheck()
     {
         // see https://stackoverflow.com/a/38661340/4956633
-        $crawler = $this->client->request(
+        $this->client->request(
             'POST', $this->generateUrl('admin_login'),
             array(
                 'login_id' => 'admin',
                 'password' => 'password',
-                '_csrf_token' => $this->getCsrfToken('authenticate')
+                '_csrf_token' => 'dummy'
             )
         );
 
@@ -70,5 +65,4 @@ class LoginControllerTest extends AbstractWebTestCase
             $this->client->getResponse()->getStatusCode()
         );
     }
-
 }


### PR DESCRIPTION

## 概要(Overview・Refs Issue)
+ PullRequestの目的
  - Fix phpUnit and source code for Web/Admin

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外し内容
  - AdminLogin
  - AdminIndex
  - ProductNonStock 

## 実装に関する補足(Appendix)
+ in template, add @admin prefix at path
+ add block('sub_title') in default_template
+ not found : addEventSubscriber(new \Eccube\Event\FormEventSubscriber()); so comment out
+ AdminControllerProductNonStockTest#testAdminNonStockWithSearch skipt
+ to help Unittest rollback database, manual setting EccubeTestCase ( but not commit in this PR )

## 相談（Discussion）
+ Define some constant in eccube.yaml


