### PR TITLE
eccube.loggerがdev環境で動作しない不具合を修正

### DIFF
--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -121,6 +121,7 @@ services:
           - '@monolog.logger'
           - '@monolog.logger.front'
           - '@monolog.logger.admin'
+        lazy: true
 
     eccube.log.formatter.line:
         class: Monolog\Formatter\LineFormatter

--- a/app/config/eccube/services_test.yaml
+++ b/app/config/eccube/services_test.yaml
@@ -7,5 +7,4 @@ services:
     Eccube\EventListener\TransactionListener:
         arguments:
             - '@doctrine.orm.default_entity_manager'
-            - '@Eccube\Log\Logger'
             - false


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ `Eccube\Log\Logger`のコンテナ管理がクラス名から`eccube.logger`に変わったため対応。

## テスト（Test)
+ 既存テストが通ることを確認。

