### PR TITLE
[3.0.16] Travis CIでPHP5.3のテストをできるように修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ php:
   - 7.0
   - 7.1
 
+dist: precise
+
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 3.0.16用に #2433 をcherry-pick しました。

## テスト（Test)
+ Travisでテストが通ることを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



