### PR TITLE
コンポーネントの自動タグ付け

### DIFF
--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -62,29 +62,6 @@ services:
         resource: '../../../src/Eccube/Controller'
         tags: ['controller.service_arguments']
 
-    # Form Extensions
-    Eccube\Form\Extension\DoctrineOrmExtension:
-        tags:
-            - { name: 'form.type_extension', extended_type: 'Symfony\Component\Form\Extension\Core\Type\FormType' }
-    Eccube\Form\Extension\FreezeTypeExtension:
-        tags:
-            - { name: 'form.type_extension', extended_type: 'Symfony\Component\Form\Extension\Core\Type\FormType' }
-    Eccube\Form\Extension\HelpTypeExtension:
-        tags:
-            - { name: 'form.type_extension', extended_type: 'Symfony\Component\Form\Extension\Core\Type\FormType' }
-
-    # DoctrineEventSubscribers
-    Eccube\Doctrine\EventSubscriber\InitSubscriber:
-        tags: ['doctrine.event_subscriber']
-    Eccube\Doctrine\EventSubscriber\TaxRuleEventSubscriber:
-        tags: ['doctrine.event_subscriber']
-    Eccube\Doctrine\EventSubscriber\SaveEventSubscriber:
-        tags: ['doctrine.event_subscriber']
-    Eccube\Doctrine\EventSubscriber\LoadEventSubscriber:
-        tags: ['doctrine.event_subscriber']
-    Eccube\Doctrine\EventSubscriber\UpdatePointEventSubscriber:
-        tags: ['doctrine.event_subscriber']
-
     Eccube\Twig\Extension\EccubeBlockExtension:
         tags: ['twig.extension']
         bind:

--- a/src/Eccube/DependencyInjection/Compiler/AutoConfigurationTagPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/AutoConfigurationTagPass.php
@@ -27,8 +27,17 @@ class AutoConfigurationTagPass implements CompilerPassInterface
 
     protected function configureDoctrineEventSubscriberTag(ContainerBuilder $container)
     {
-        $container->registerForAutoconfiguration(EventSubscriber::class)
-            ->addTag('doctrine.event_subscriber');
+        foreach ($container->getDefinitions() as $definition) {
+            $class = $definition->getClass();
+            if (!is_subclass_of($class, EventSubscriber::class)) {
+                continue;
+            }
+            if ($definition->hasTag('doctrine.event_subscriber')) {
+                continue;
+            }
+
+            $definition->addTag('doctrine.event_subscriber');
+        }
     }
 
     protected function configureFormTypeExtensionTag(ContainerBuilder $container)

--- a/src/Eccube/DependencyInjection/Compiler/AutoConfigurationTagPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/AutoConfigurationTagPass.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Eccube\DependencyInjection\Compiler;
+
+use Doctrine\Common\EventSubscriber;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Form\AbstractTypeExtension;
+
+/**
+ * サービスタグの自動設定を行う
+ *
+ * 以下のタグは自動設定が行われないため, 自動設定対象になるように処理する
+ *
+ * - doctrine.event_subscriber
+ * - form.type_extension
+ *
+ * PluginPassで無効なプラグインのタグは解除されるため, PluginPassより先行して実行する必要がある
+ */
+class AutoConfigurationTagPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $this->configureDoctrineEventSubscriberTag($container);
+        $this->configureFormTypeExtensionTag($container);
+    }
+
+    protected function configureDoctrineEventSubscriberTag(ContainerBuilder $container)
+    {
+        $container->registerForAutoconfiguration(EventSubscriber::class)
+            ->addTag('doctrine.event_subscriber');
+    }
+
+    protected function configureFormTypeExtensionTag(ContainerBuilder $container)
+    {
+        foreach ($container->getDefinitions() as $definition) {
+            $class = $definition->getClass();
+            if (!is_subclass_of($class, AbstractTypeExtension::class)) {
+                continue;
+            }
+            if ($definition->hasTag('form.type_extension')) {
+                continue;
+            }
+
+            $ref = new \ReflectionClass($class);
+            $instance = $ref->newInstanceWithoutConstructor();
+            $type = $instance->getExtendedType();
+
+            $definition->addTag('fform.type_extension', ['extended_type' => $type]);
+        }
+    }
+}

--- a/src/Eccube/DependencyInjection/Compiler/AutoConfigurationTagPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/AutoConfigurationTagPass.php
@@ -55,7 +55,7 @@ class AutoConfigurationTagPass implements CompilerPassInterface
             $instance = $ref->newInstanceWithoutConstructor();
             $type = $instance->getExtendedType();
 
-            $definition->addTag('fform.type_extension', ['extended_type' => $type]);
+            $definition->addTag('form.type_extension', ['extended_type' => $type]);
         }
     }
 }

--- a/src/Eccube/Doctrine/EventSubscriber/TaxRuleEventSubscriber.php
+++ b/src/Eccube/Doctrine/EventSubscriber/TaxRuleEventSubscriber.php
@@ -34,9 +34,12 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
 
-class TaxRuleEventSubscriber implements EventSubscriber, ServiceSubscriberInterface
+class TaxRuleEventSubscriber implements EventSubscriber
 {
-    use ContainerAwareTrait;
+    /**
+     * @var TaxRuleService
+     */
+    protected $container;
 
     /**
      * TaxRuleEventSubscriber constructor.
@@ -123,30 +126,5 @@ class TaxRuleEventSubscriber implements EventSubscriber, ServiceSubscriberInterf
             $entity->setPriceIncTax($this->getTaxRuleService()->getPriceIncTax($entity->getPrice(),
                 $entity->getProduct(), $entity->getProductClass()));
         }
-    }
-
-    /**
-     * Returns an array of service types required by such instances, optionally keyed by the service names used internally.
-     *
-     * For mandatory dependencies:
-     *
-     *  * array('logger' => 'Psr\Log\LoggerInterface') means the objects use the "logger" name
-     *    internally to fetch a service which must implement Psr\Log\LoggerInterface.
-     *  * array('Psr\Log\LoggerInterface') is a shortcut for
-     *  * array('Psr\Log\LoggerInterface' => 'Psr\Log\LoggerInterface')
-     *
-     * otherwise:
-     *
-     *  * array('logger' => '?Psr\Log\LoggerInterface') denotes an optional dependency
-     *  * array('?Psr\Log\LoggerInterface') is a shortcut for
-     *  * array('Psr\Log\LoggerInterface' => '?Psr\Log\LoggerInterface')
-     *
-     * @return array The required service types, optionally keyed by service names
-     */
-    public static function getSubscribedServices()
-    {
-        return [
-            TaxRuleService::class,
-        ];
     }
 }

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -12,6 +12,7 @@
 namespace Eccube;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Eccube\DependencyInjection\Compiler\AutoConfigurationTagPass;
 use Eccube\DependencyInjection\Compiler\LazyComponentPass;
 use Eccube\DependencyInjection\Compiler\PluginPass;
 use Eccube\DependencyInjection\Compiler\TemplateListenerPass;
@@ -133,6 +134,9 @@ class Kernel extends BaseKernel
         $this->addEntityExtensionPass($container);
 
         $container->registerExtension(new EccubeExtension());
+
+        // サービスタグの自動設定を行う
+        $container->addCompilerPass(new AutoConfigurationTagPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 11);
 
         // サービスタグの収集より先に実行し, 付与されているタグをクリアする.
         // FormPassは優先度0で実行されているので, それより速いタイミングで実行させる.

--- a/tests/Eccube/Tests/DependencyInjection/Compiler/AutoConfigurationTagPassTest.php
+++ b/tests/Eccube/Tests/DependencyInjection/Compiler/AutoConfigurationTagPassTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Eccube\Tests\DependencyInjection\Compiler;
+
+use Doctrine\Common\EventSubscriber;
+use Eccube\DependencyInjection\Compiler\AutoConfigurationTagPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\BirthdayType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+
+class AutoConfigurationTagPassTest extends TestCase
+{
+    public function testConfigureDoctrineEventSubscriberTag()
+    {
+        $container = new ContainerBuilder();
+        $container->register(Subscriber::class, Subscriber::class);
+
+        $definition = $container->getDefinition(Subscriber::class);
+        self::assertFalse($definition->hasTag('doctrine.event_subscriber'));
+
+        $container->addCompilerPass(new AutoConfigurationTagPass());
+        $container->compile();
+
+        $definition = $container->getDefinition(Subscriber::class);
+        self::assertTrue($definition->hasTag('doctrine.event_subscriber'));
+    }
+
+    public function testConfigureFormTypeExtensionTag()
+    {
+        $container = new ContainerBuilder();
+        $container->register(FormTypeExtension::class, FormTypeExtension::class);
+
+        $definition = $container->getDefinition(FormTypeExtension::class);
+        self::assertFalse($definition->hasTag('form.type_extension'));
+
+        $container->addCompilerPass(new AutoConfigurationTagPass());
+        $container->compile();
+
+        $definition = $container->getDefinition(FormTypeExtension::class);
+        self::assertTrue($definition->hasTag('form.type_extension'));
+
+        $attribute = $definition->getTag('form.type_extension');
+        self::assertSame(FormType::class, $attribute[0]['extended_type']);
+    }
+}
+
+class Subscriber implements EventSubscriber
+{
+    public function getSubscribedEvents()
+    {
+    }
+}
+
+class FormTypeExtension extends AbstractTypeExtension
+{
+    public function getExtendedType()
+    {
+        return FormType::class;
+    }
+}

--- a/tests/Eccube/Tests/DependencyInjection/Compiler/AutoConfigurationTagPassTest.php
+++ b/tests/Eccube/Tests/DependencyInjection/Compiler/AutoConfigurationTagPassTest.php
@@ -7,7 +7,6 @@ use Eccube\DependencyInjection\Compiler\AutoConfigurationTagPass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\Form\Extension\Core\Type\BirthdayType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 
 class AutoConfigurationTagPassTest extends TestCase


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- `doctrine.event_subscriber`や`form.type_extension`は自動でタグ付けが行われないため, タグを自動で付与するように修正しました。

##  参考
- https://symfony.com/doc/current/reference/dic_tags.html
- https://symfony.com/doc/current/doctrine/event_listeners_subscribers.html#configuring-the-listener-subscriber
- https://symfony.com/doc/current/form/create_form_type_extension.html#registering-your-form-type-extension-as-a-service



