### PR TITLE
Twigのurl, path関数の移植

### DIFF
--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -149,3 +149,8 @@ services:
     Symfony\Component\HttpFoundation\ParameterBag:
     Eccube\Entity\BaseInfo:
         factory: ['@Eccube\Repository\BaseInfoRepository', 'get']
+
+    Eccube\Twig\Extension\IgnoreRoutingNotFoundExtension:
+        # Symfony\Bridge\Twig\Extension\RoutingExtensionの後に登録するため,
+        # autoconfigureはfalseにし, CompilerPassで追加する.
+        autoconfigure: false

--- a/src/Eccube/DependencyInjection/Compiler/TwigExtensionPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/TwigExtensionPass.php
@@ -3,6 +3,7 @@
 namespace Eccube\DependencyInjection\Compiler;
 
 
+use Eccube\Twig\Extension\IgnoreRoutingNotFoundExtension;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -16,7 +17,7 @@ class TwigExtensionPass implements CompilerPassInterface
             $definition = $container->getDefinition('twig');
             $definition->addMethodCall(
                 'addExtension',
-                [new Reference('Eccube\Twig\Extension\IgnoreRoutingNotFoundExtension')]
+                [new Reference(IgnoreRoutingNotFoundExtension::class)]
             );
         }
     }

--- a/src/Eccube/DependencyInjection/Compiler/TwigExtensionPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/TwigExtensionPass.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Eccube\DependencyInjection\Compiler;
+
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class TwigExtensionPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        // 本番時はtwigのurl(), path()を差し替える.
+        if (!$container->getParameter('kernel.debug')) {
+            $definition = $container->getDefinition('twig');
+            $definition->addMethodCall(
+                'addExtension',
+                [new Reference('Eccube\Twig\Extension\IgnoreRoutingNotFoundExtension')]
+            );
+        }
+    }
+}

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -16,6 +16,7 @@ use Eccube\DependencyInjection\Compiler\AutoConfigurationTagPass;
 use Eccube\DependencyInjection\Compiler\LazyComponentPass;
 use Eccube\DependencyInjection\Compiler\PluginPass;
 use Eccube\DependencyInjection\Compiler\TemplateListenerPass;
+use Eccube\DependencyInjection\Compiler\TwigExtensionPass;
 use Eccube\DependencyInjection\Compiler\WebServerDocumentRootPass;
 use Eccube\DependencyInjection\EccubeExtension;
 use Eccube\Doctrine\DBAL\Types\UTCDateTimeType;
@@ -153,6 +154,9 @@ class Kernel extends BaseKernel
 
         // テンプレートフックポイントを動作させるように.
         $container->addCompilerPass(new TemplateListenerPass());
+
+        // twigのurl,path関数を差し替え
+        $container->addCompilerPass(new TwigExtensionPass());
 
         $container->register('app', Application::class)
             ->setSynthetic(true)

--- a/src/Eccube/Twig/Extension/EccubeExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeExtension.php
@@ -24,31 +24,24 @@
 
 namespace Eccube\Twig\Extension;
 
-use Eccube\Common\Constant;
 use Eccube\Service\TaxRuleService;
 use Eccube\Util\StringUtil;
-use Silex\Application;
-use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Twig\Extension\AbstractExtension;
-use Twig\TwigFilter;;
+use Twig\TwigFilter;
 use Twig\TwigFunction;
 
 class EccubeExtension extends AbstractExtension
 {
     /**
-     * @var \Twig_Environment
+     * @var TaxRuleService
      */
-    protected $twig;
+    protected $TaxRuleService;
 
-    public function __construct(TaxRuleService $TaxRuleService, \Twig_Environment $twig)
+    public function __construct(TaxRuleService $TaxRuleService)
     {
         $this->TaxRuleService = $TaxRuleService;
-        $this->twig = $twig;
     }
-
-    protected $TaxRuleService;
 
     /**
      * Returns a list of functions to add to the existing list.
@@ -57,20 +50,11 @@ class EccubeExtension extends AbstractExtension
      */
     public function getFunctions()
     {
-        $RoutingExtension = $this->twig->getExtension(RoutingExtension::class);
-
-        // $app = $this->app;
         return array(
             new TwigFunction('has_errors', array($this, 'hasErrors')),
             new TwigFunction('is_object', array($this, 'isObject')),
             new TwigFunction('calc_inc_tax', array($this, 'getCalcIncTax')),
             new TwigFunction('active_menus', array($this, 'getActiveMenus')),
-
-            // Override: \Symfony\Bridge\Twig\Extension\RoutingExtension::url
-            // new \Twig_SimpleFunction('url', array($this, 'getUrl'), array('is_safe_callback' => array($RoutingExtension, 'isUrlGenerationSafe'))),
-            // // Override: \Symfony\Bridge\Twig\Extension\RoutingExtension::path
-            // new \Twig_SimpleFunction('path', array($this, 'getPath'), array('is_safe_callback' => array($RoutingExtension, 'isUrlGenerationSafe'))),
-
             new TwigFunction('php_*', function() {
                     $arg_list = func_get_args();
                     $function = array_shift($arg_list);
@@ -195,52 +179,6 @@ class EccubeExtension extends AbstractExtension
     public function getTimeAgo($date)
     {
         return StringUtil::timeAgo($date);
-    }
-
-    /**
-     * bind から URL へ変換します。
-     * \Symfony\Bridge\Twig\Extension\RoutingExtension::getPath の処理を拡張し、
-     * RouteNotFoundException 発生時に E_USER_WARNING を発生させ、
-     * 文字列 "/404?bind={bind}" を返します。
-     *
-     * @param string $name
-     * @param array $parameters
-     * @param boolean $relative
-     * @return string URL
-     */
-    public function getPath($name, $parameters = array(), $relative = false)
-    {
-        $RoutingExtension = $this->app['twig']->getExtension(RoutingExtension::class);
-        try {
-            return $RoutingExtension->getPath($name, $parameters, $relative);
-        } catch (RouteNotFoundException $e) {
-            trigger_error($e->getMessage(), E_USER_WARNING);
-        }
-
-        return $RoutingExtension->getPath('homepage').'404?bind='.$name;
-    }
-
-    /**
-     * bind から URL へ変換します。
-     * \Symfony\Bridge\Twig\Extension\RoutingExtension::getUrl の処理を拡張し、
-     * RouteNotFoundException 発生時に E_USER_WARNING を発生させ、
-     * 文字列 "/404?bind={bind}" を返します。
-     *
-     * @param string $name
-     * @param array $parameters
-     * @param boolean $schemeRelative
-     * @return string URL
-     */
-    public function getUrl($name, $parameters = array(), $schemeRelative = false)
-    {
-        $RoutingExtension = $this->app['twig']->getExtension(RoutingExtension::class);
-        try {
-            return $RoutingExtension->getUrl($name, $parameters, $schemeRelative);
-        } catch (RouteNotFoundException $e) {
-            trigger_error($e->getMessage(), E_USER_WARNING);
-        }
-
-        return $RoutingExtension->getUrl('homepage').'404?bind='.$name;
     }
 
     /**

--- a/src/Eccube/Twig/Extension/IgnoreRoutingNotFoundExtension.php
+++ b/src/Eccube/Twig/Extension/IgnoreRoutingNotFoundExtension.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Eccube\Twig\Extension;
+
+use Symfony\Bridge\Twig\Extension\RoutingExtension;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+
+class IgnoreRoutingNotFoundExtension extends RoutingExtension
+{
+    /**
+     * bind から URL へ変換します。
+     * \Symfony\Bridge\Twig\Extension\RoutingExtension::getPath の処理を拡張し、
+     * RouteNotFoundException 発生時に 文字列 "/404?bind={bind}" を返します。
+     *
+     * @param string $name
+     * @param array $parameters
+     * @param bool $relative
+     * @return string
+     */
+    public function getPath($name, $parameters = array(), $relative = false)
+    {
+        try {
+            return parent::getPath($name, $parameters, $relative);
+        } catch (RouteNotFoundException $e) {
+
+            log_warning($e->getMessage(), ['exception' => $e]);
+
+            return parent::getPath('homepage').'404?bind='.$name;
+        }
+    }
+
+    /**
+     * bind から URL へ変換します。
+     * \Symfony\Bridge\Twig\Extension\RoutingExtension::getUrl の処理を拡張し、
+     * RouteNotFoundException 発生時に 文字列 "/404?bind={bind}" を返します。
+     *
+     * @param string $name
+     * @param array $parameters
+     * @param bool $schemeRelative
+     * @return string
+     */
+    public function getUrl($name, $parameters = array(), $schemeRelative = false)
+    {
+        try {
+            return parent::getUrl($name, $parameters, $schemeRelative);
+        } catch (RouteNotFoundException $e) {
+
+            log_warning($e->getMessage(), ['exception' => $e]);
+
+            return parent::getUrl('homepage').'404?bind='.$name;
+        }
+    }
+}

--- a/tests/Eccube/Tests/DependencyInjection/Compiler/TwigExtensionPassTest.php
+++ b/tests/Eccube/Tests/DependencyInjection/Compiler/TwigExtensionPassTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Eccube\Tests\DependencyInjection\Compiler;
+
+use Eccube\DependencyInjection\Compiler\TwigExtensionPass;
+use Eccube\Twig\Extension\IgnoreRoutingNotFoundExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouteCollection;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+class TwigExtensionPassTest extends TestCase
+{
+    protected $contailer;
+
+    public function setUp()
+    {
+        $this->container = new ContainerBuilder();
+
+        $this->container->register(RouteCollection::class);
+        $this->container->register(RequestContext::class);
+        $this->container->register(UrlGeneratorInterface::class, UrlGenerator::class)
+            ->setAutowired(true);
+        $this->container->register(IgnoreRoutingNotFoundExtension::class)
+            ->setAutowired(true);
+        $this->container->register(\Twig_LoaderInterface::class, ArrayLoader::class);
+        $this->container->register('twig', Environment::class)
+            ->setPublic(true)
+            ->setAutowired(true);
+    }
+
+    public function testProcess()
+    {
+        $this->container->setParameter('kernel.debug', false);
+        $this->container->addCompilerPass(new TwigExtensionPass());
+        $this->container->compile();
+
+        /** @var Environment $twig */
+        $twig = $this->container->get('twig');
+        self::assertTrue($twig->hasExtension(IgnoreRoutingNotFoundExtension::class));
+        self::assertInstanceOf(
+            IgnoreRoutingNotFoundExtension::class,
+            $twig->getExtension(IgnoreRoutingNotFoundExtension::class)
+        );
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ Twigのurl, path関数を動作するように修正

## 実装に関する補足(Appendix)
- services.yamlでの定義やautoconfigureの自動タグ付けの場合、EccubeのTwig拡張  -> `Symfony\Bridge\Twig\Extension\RoutingExtension`の順に登録されるため、標準の挙動をオーバーライドすることができない
- そのため、autoconfigureはfalseにし, TwigExtensionPassで登録するように対応しています。

