### PR TITLE
$eccubeConfigをEccubeConfigのインスタンスを使うように修正

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -1,5 +1,4 @@
 parameters:
-  eccube.constants:
     admin_route: '%admin_route%'
     nav: '%eccube.nav%'
     admin_allow_hosts: {}

--- a/app/config/eccube/packages/eccube_app.yaml
+++ b/app/config/eccube/packages/eccube_app.yaml
@@ -1,3 +1,0 @@
-parameters:
-  eccube.app:
-    config: '%eccube.constants%'

--- a/app/config/eccube/packages/install/twig.yaml
+++ b/app/config/eccube/packages/install/twig.yaml
@@ -1,7 +1,6 @@
 twig:
     globals:
-      eccube:
-        config: '@Eccube\Common\EccubeConfig'
+      eccube_config: '@Eccube\Common\EccubeConfig'
     paths:
       '%kernel.project_dir%/src/Eccube/Resource/template/install': ~
     debug: '%kernel.debug%'

--- a/app/config/eccube/packages/install/twig.yaml
+++ b/app/config/eccube/packages/install/twig.yaml
@@ -1,7 +1,7 @@
 twig:
     globals:
       eccube:
-        config: '%eccube.constants%'
+        config: '@Eccube\Common\EccubeConfig'
     paths:
       '%kernel.project_dir%/src/Eccube/Resource/template/install': ~
     debug: '%kernel.debug%'

--- a/app/config/eccube/packages/twig.yaml
+++ b/app/config/eccube/packages/twig.yaml
@@ -1,8 +1,7 @@
 twig:
     globals:
       BaseInfo: null
-      eccube:
-        config: '@Eccube\Common\EccubeConfig'
+      eccube_config: '@Eccube\Common\EccubeConfig'
     paths:
       '%eccube.theme.front_dir%': ~
       '%eccube.theme.front_default_dir%': ~

--- a/app/config/eccube/packages/twig.yaml
+++ b/app/config/eccube/packages/twig.yaml
@@ -2,7 +2,7 @@ twig:
     globals:
       BaseInfo: null
       eccube:
-        config: '%eccube.constants%'
+        config: '@Eccube\Common\EccubeConfig'
     paths:
       '%eccube.theme.front_dir%': ~
       '%eccube.theme.front_default_dir%': ~

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -40,7 +40,6 @@ services:
           $auth_magic: '%env(ECCUBE_AUTH_MAGIC)%'
           $auth_type: 'HMAC'
           $password_hash_algos: 'sha256'
-          $eccubeConfig: '%eccube.constants%'
           $projectRoot: '%kernel.project_dir%'
           $environment: '%kernel.environment%'
           $cartPurchaseFlow: '@eccube.purchase.flow.cart'
@@ -55,6 +54,9 @@ services:
         # you can exclude directories or files
         # but if a service is unused, it's removed anyway
         exclude: '../../../src/Eccube/{Annotation,Application,Common,ControllerProvider,DI,Entity,Exception,Log,Plugin,Routing,ServiceProvider,Util,Resource,Doctrine/ORM/tools/}'
+
+    Eccube\Common\EccubeConfig:
+        public: true
 
     Eccube\Service\TaxRuleService:
         lazy: true

--- a/src/Eccube/Common/EccubeConfig.php
+++ b/src/Eccube/Common/EccubeConfig.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Eccube\Common;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class EccubeConfig implements \ArrayAccess
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param $key
+     * @return mixed
+     */
+    public function get($key)
+    {
+        return $this->container->getParameter($key);
+    }
+
+    /**
+     * @param $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return $this->container->hasParameter($key);
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     * @return mixed
+     */
+    public function set($key, $value)
+    {
+        return $this->container->setParameter($key, $value);
+    }
+
+    /**
+     * @param mixed $offset
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return $this->has($offset);
+    }
+
+    /**
+     * @param mixed $offset
+     * @return mixed
+     */
+    public function offsetGet($offset)
+    {
+        return $this->get($offset);
+    }
+
+    /**
+     * @param mixed $offset
+     * @param mixed $value
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->set($offset, $value);
+    }
+
+    /**
+     * @param mixed $offset
+     * @throws \Exception
+     */
+    public function offsetUnset($offset)
+    {
+        throw new \Exception();
+    }
+}

--- a/src/Eccube/Controller/AbstractController.php
+++ b/src/Eccube/Controller/AbstractController.php
@@ -28,6 +28,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Common\Constant;
 use Eccube\Common\Translatable;
 use Eccube\Common\TranslatableTrait;
+use Eccube\Common\EccubeConfig;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -40,7 +41,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 class AbstractController extends Controller
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
@@ -70,10 +71,10 @@ class AbstractController extends Controller
     protected $session;
 
     /**
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      * @required
      */
-    public function setEccubeConfig(array $eccubeConfig)
+    public function setEccubeConfig(EccubeConfig $eccubeConfig)
     {
         $this->eccubeConfig = $eccubeConfig;
     }

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -26,6 +26,7 @@ namespace Eccube\Controller\Admin\Product;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Common\Constant;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Category;
 use Eccube\Entity\Product;
@@ -124,7 +125,7 @@ class CsvImportController
     protected $eventDispatcher;
 
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
@@ -151,9 +152,9 @@ class CsvImportController
      * @param FormFactoryInterface $formFactory
      * @param SessionInterface $session
      * @param EventDispatcherInterface $eventDispatcher
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(DeliveryDurationRepository $deliveryDurationRepository, SaleTypeRepository $saleTypeRepository, TagRepository $tagRepository, CategoryRepository $categoryRepository, ClassCategoryRepository $classCategoryRepository, ProductStatusRepository $productStatusRepository, ProductRepository $productRepository, BaseInfo $BaseInfo, EntityManagerInterface $entityManager, FormFactoryInterface $formFactory, SessionInterface $session, EventDispatcherInterface $eventDispatcher, array $eccubeConfig)
+    public function __construct(DeliveryDurationRepository $deliveryDurationRepository, SaleTypeRepository $saleTypeRepository, TagRepository $tagRepository, CategoryRepository $categoryRepository, ClassCategoryRepository $classCategoryRepository, ProductStatusRepository $productStatusRepository, ProductRepository $productRepository, BaseInfo $BaseInfo, EntityManagerInterface $entityManager, FormFactoryInterface $formFactory, SessionInterface $session, EventDispatcherInterface $eventDispatcher, EccubeConfig $eccubeConfig)
     {
         $this->deliveryDurationRepository = $deliveryDurationRepository;
         $this->saleTypeRepository = $saleTypeRepository;

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -127,7 +127,7 @@ class CsvImportController
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     private $errors = array();
 
@@ -168,7 +168,7 @@ class CsvImportController
         $this->formFactory = $formFactory;
         $this->session = $session;
         $this->eventDispatcher = $eventDispatcher;
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
     /**
@@ -580,7 +580,7 @@ class CsvImportController
                         } else {
                             $Category->setHierarchy(1);
                         }
-                        if ($this->appConfig['category_nest_level'] < $Category->getHierarchy()) {
+                        if ($this->eccubeConfig['category_nest_level'] < $Category->getHierarchy()) {
                             $this->addErrors(($data->key() + 1) . '行目のカテゴリが最大レベルを超えているため設定できません。');
                             return $this->render($form, $headers);
                         }
@@ -631,11 +631,11 @@ class CsvImportController
             // ヘッダ行の出力
             $row = array();
             foreach ($headers as $key => $value) {
-                $row[] = mb_convert_encoding($key, $this->appConfig['csv_export_encoding'], 'UTF-8');
+                $row[] = mb_convert_encoding($key, $this->eccubeConfig['csv_export_encoding'], 'UTF-8');
             }
 
             $fp = fopen('php://output', 'w');
-            fputcsv($fp, $row, $this->appConfig['csv_export_separator']);
+            fputcsv($fp, $row, $this->eccubeConfig['csv_export_separator']);
             fclose($fp);
         });
 
@@ -666,7 +666,7 @@ class CsvImportController
         if (!empty($this->fileName)) {
             try {
                 $fs = new Filesystem();
-                $fs->remove($this->appConfig['csv_temp_realdir'] . '/' . $this->fileName);
+                $fs->remove($this->eccubeConfig['csv_temp_realdir'] . '/' . $this->fileName);
             } catch (\Exception $e) {
                 // エラーが発生しても無視する
             }
@@ -690,9 +690,9 @@ class CsvImportController
     {
         // アップロードされたCSVファイルを一時ディレクトリに保存
         $this->fileName = 'upload_' . StringUtil::random() . '.' . $formFile->getClientOriginalExtension();
-        $formFile->move($this->appConfig['csv_temp_realdir'], $this->fileName);
+        $formFile->move($this->eccubeConfig['csv_temp_realdir'], $this->fileName);
 
-        $file = file_get_contents($this->appConfig['csv_temp_realdir'] . '/' . $this->fileName);
+        $file = file_get_contents($this->eccubeConfig['csv_temp_realdir'] . '/' . $this->fileName);
 
         if ('\\' === DIRECTORY_SEPARATOR && PHP_VERSION_ID >= 70000) {
             // Windows 環境の PHP7 の場合はファイルエンコーディングを CP932 に合わせる
@@ -719,7 +719,7 @@ class CsvImportController
         set_time_limit(0);
 
         // アップロードされたCSVファイルを行ごとに取得
-        $data = new CsvImportService($file, $this->appConfig['csv_import_delimiter'], $this->appConfig['csv_import_enclosure']);
+        $data = new CsvImportService($file, $this->eccubeConfig['csv_import_delimiter'], $this->eccubeConfig['csv_import_enclosure']);
 
         $ret = $data->setHeaderRowNumber(0);
 

--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -50,7 +50,7 @@ class OwnerStoreController extends AbstractController
      * @Inject("config")
      * @var array
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * @Inject(PluginRepository::class)
@@ -100,7 +100,7 @@ class OwnerStoreController extends AbstractController
         $promotionItems = array();
         $message = '';
         // Owner's store communication
-        $url = $this->appConfig['package_repo_url'].'/search/packages.json';
+        $url = $this->eccubeConfig['package_repo_url'].'/search/packages.json';
         list($json, $info) = $this->getRequestApi($url);
         if ($json === false) {
             $message = $this->getResponseErrorMessage($info);
@@ -178,7 +178,7 @@ class OwnerStoreController extends AbstractController
     public function doConfirm(Application $app, Request $request, $id)
     {
         // Owner's store communication
-        $url = $this->appConfig['package_repo_url'].'/search/packages.json';
+        $url = $this->eccubeConfig['package_repo_url'].'/search/packages.json';
         list($json, $info) = $this->getRequestApi($url);
         $data = json_decode($json, true);
         $items = $data['item'];
@@ -221,7 +221,7 @@ class OwnerStoreController extends AbstractController
     public function apiInstall(Application $app, Request $request, $pluginCode, $eccubeVersion, $version)
     {
         // Check plugin code
-        $url = $this->appConfig['package_repo_url'].'/search/packages.json'.'?eccube_version='.$eccubeVersion.'&plugin_code='.$pluginCode.'&version='.$version;
+        $url = $this->eccubeConfig['package_repo_url'].'/search/packages.json'.'?eccube_version='.$eccubeVersion.'&plugin_code='.$pluginCode.'&version='.$version;
         list($json, $info) = $this->getRequestApi($url);
         $existFlg = false;
         $data = json_decode($json, true);
@@ -274,7 +274,7 @@ class OwnerStoreController extends AbstractController
         try {
             $this->composerService->execRequire($packageNames);
             // Do report to package repo
-            $url = $this->appConfig['package_repo_url'] . '/report';
+            $url = $this->eccubeConfig['package_repo_url'] . '/report';
             $this->postRequestApi($url, $data);
             $app->addSuccess('admin.plugin.install.complete', 'admin');
 
@@ -284,7 +284,7 @@ class OwnerStoreController extends AbstractController
         }
 
         // Do report to package repo
-        $url = $this->appConfig['package_repo_url'] . '/report/fail';
+        $url = $this->eccubeConfig['package_repo_url'] . '/report/fail';
         $this->postRequestApi($url, $data);
         $app->addError('admin.plugin.install.fail', 'admin');
 
@@ -303,7 +303,7 @@ class OwnerStoreController extends AbstractController
     public function deleteConfirm(Application $app, Plugin $Plugin)
     {
         // Owner's store communication
-        $url = $this->appConfig['package_repo_url'].'/search/packages.json';
+        $url = $this->eccubeConfig['package_repo_url'].'/search/packages.json';
         list($json, $info) = $this->getRequestApi($url);
         $data = json_decode($json, true);
         $items = $data['item'];

--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -87,7 +87,7 @@ class PluginController extends AbstractController
      * @Inject("config")
      * @var array
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * @Inject(BaseInfo::class)
@@ -167,7 +167,7 @@ class PluginController extends AbstractController
         // オーナーズストアからダウンロード可能プラグイン情報を取得
         $authKey = $this->BaseInfo->getAuthenticationKey();
         // オーナーズストア通信
-        $url = $this->appConfig['package_repo_url'].'/search/packages.json';
+        $url = $this->eccubeConfig['package_repo_url'].'/search/packages.json';
         list($json, $info) = $this->getRequestApi($request, $authKey, $url, $app);
 
         $officialPluginsDetail = [];
@@ -590,7 +590,7 @@ class PluginController extends AbstractController
             $pluginCodes[] = $plugin->getCode();
         }
         // DB登録済みプラグインコードPluginディレクトリから排他
-        $dirs = $finder->in($this->appConfig['plugin_realdir'])->depth(0)->directories();
+        $dirs = $finder->in($this->eccubeConfig['plugin_realdir'])->depth(0)->directories();
 
         // プラグイン基本チェック
         $unregisteredPlugins = array();

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -33,6 +33,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Tools\Setup;
 use Eccube\Common\Constant;
+use Eccube\Common\EccubeConfig;
 use Eccube\Controller\AbstractController;
 use Eccube\Form\Type\Install\Step1Type;
 use Eccube\Form\Type\Install\Step3Type;
@@ -109,7 +110,7 @@ class InstallController extends AbstractController
         FormFactoryInterface $formFactory,
         PasswordEncoder $encoder,
         $environment,
-        $eccubeConfig
+        EccubeConfig $eccubeConfig
     ) {
         $this->rootDir = realpath(__DIR__.'/../../../..');
         $this->configDir = realpath($this->rootDir.'/app/config/eccube');

--- a/src/Eccube/Controller/ShippingMultipleController.php
+++ b/src/Eccube/Controller/ShippingMultipleController.php
@@ -79,7 +79,7 @@ class ShippingMultipleController extends AbstractShoppingController
      * @Inject("config")
      * @var array
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * @Inject(ShoppingService::class)

--- a/src/Eccube/EventListener/IpAddrListener.php
+++ b/src/Eccube/EventListener/IpAddrListener.php
@@ -2,6 +2,7 @@
 
 namespace Eccube\EventListener;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -9,11 +10,11 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 class IpAddrListener implements EventSubscriberInterface
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->eccubeConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/AddressType.php
+++ b/src/Eccube/Form/Type/AddressType.php
@@ -23,6 +23,7 @@
 
 namespace Eccube\Form\Type;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Form\Type\Master\PrefType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -46,9 +47,9 @@ class AddressType extends AbstractType
      * {@inheritdoc}
      *
      * AddressType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->config = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Admin/BlockType.php
+++ b/src/Eccube/Form/Type/Admin/BlockType.php
@@ -25,6 +25,7 @@
 namespace Eccube\Form\Type\Admin;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Block;
 use Eccube\Form\Validator\TwigLint;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
@@ -45,7 +46,7 @@ class BlockType extends AbstractType
     protected $entityManager;
 
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
@@ -53,9 +54,9 @@ class BlockType extends AbstractType
      * BlockType constructor.
      *
      * @param $entityManager
-     * @param $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(EntityManagerInterface $entityManager, $eccubeConfig)
+    public function __construct(EntityManagerInterface $entityManager, EccubeConfig $eccubeConfig)
     {
         $this->entityManager = $entityManager;
         $this->eccubeConfig = $eccubeConfig;

--- a/src/Eccube/Form/Type/Admin/CategoryType.php
+++ b/src/Eccube/Form/Type/Admin/CategoryType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -33,15 +34,15 @@ use Symfony\Component\Validator\Constraints as Assert;
 class CategoryType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
     /**
      * CategoryType constructor.
-     * @param $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->eccubeConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Admin/ChangePasswordType.php
+++ b/src/Eccube/Form/Type/Admin/ChangePasswordType.php
@@ -38,7 +38,7 @@ class ChangePasswordType extends AbstractType
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * ChangePasswordType constructor.
@@ -46,7 +46,7 @@ class ChangePasswordType extends AbstractType
      */
     public function __construct(EccubeConfig $eccubeConfig)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
     /**
@@ -72,8 +72,8 @@ class ChangePasswordType extends AbstractType
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Length(array(
-                        'min' => $this->appConfig['password_min_len'],
-                        'max' => $this->appConfig['password_max_len'],
+                        'min' => $this->eccubeConfig['password_min_len'],
+                        'max' => $this->eccubeConfig['password_max_len'],
                     )),
                     new Assert\Regex(array(
                         'pattern' => '/^[[:graph:][:space:]]+$/i',

--- a/src/Eccube/Form/Type/Admin/ChangePasswordType.php
+++ b/src/Eccube/Form/Type/Admin/ChangePasswordType.php
@@ -23,6 +23,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
@@ -35,15 +36,15 @@ use Symfony\Component\Validator\Constraints as Assert;
 class ChangePasswordType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
     /**
      * ChangePasswordType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->appConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Admin/ClassCategoryType.php
+++ b/src/Eccube/Form/Type/Admin/ClassCategoryType.php
@@ -36,11 +36,11 @@ class ClassCategoryType extends AbstractType
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     public function __construct(EccubeConfig $eccubeConfig)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
     /**
@@ -54,7 +54,7 @@ class ClassCategoryType extends AbstractType
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Length(array(
-                        'max' => $this->appConfig['stext_len'],
+                        'max' => $this->eccubeConfig['stext_len'],
                     )),
                 ),
             ))

--- a/src/Eccube/Form/Type/Admin/ClassCategoryType.php
+++ b/src/Eccube/Form/Type/Admin/ClassCategoryType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -33,11 +34,11 @@ use Symfony\Component\Validator\Constraints as Assert;
 class ClassCategoryType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->appConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Admin/ClassNameType.php
+++ b/src/Eccube/Form/Type/Admin/ClassNameType.php
@@ -36,7 +36,7 @@ class ClassNameType extends AbstractType
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * {@inheritdoc}
@@ -46,7 +46,7 @@ class ClassNameType extends AbstractType
      */
     public function __construct(EccubeConfig $eccubeConfig)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
     /**
@@ -60,7 +60,7 @@ class ClassNameType extends AbstractType
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Length(array(
-                        'max' => $this->appConfig['stext_len'],
+                        'max' => $this->eccubeConfig['stext_len'],
                     )),
                 ),
             ))

--- a/src/Eccube/Form/Type/Admin/ClassNameType.php
+++ b/src/Eccube/Form/Type/Admin/ClassNameType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -33,7 +34,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class ClassNameType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
@@ -41,9 +42,9 @@ class ClassNameType extends AbstractType
      * {@inheritdoc}
      *
      * ClassNameType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->appConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Admin/CsvImportType.php
+++ b/src/Eccube/Form/Type/Admin/CsvImportType.php
@@ -35,7 +35,7 @@ class CsvImportType extends AbstractType
     /**
      * @var array
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * CsvImportType constructor.
@@ -43,7 +43,7 @@ class CsvImportType extends AbstractType
      */
     public function __construct(EccubeConfig $eccubeConfig)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
 
@@ -60,8 +60,8 @@ class CsvImportType extends AbstractType
                 'constraints' => array(
                     new Assert\NotBlank(array('message' => 'ファイルを選択してください。')),
                     new Assert\File(array(
-                        'maxSize' => $this->appConfig['csv_size'] . 'M',
-                        'maxSizeMessage' => 'CSVファイルは' . $this->appConfig['csv_size'] . 'M以下でアップロードしてください。',
+                        'maxSize' => $this->eccubeConfig['csv_size'] . 'M',
+                        'maxSizeMessage' => 'CSVファイルは' . $this->eccubeConfig['csv_size'] . 'M以下でアップロードしてください。',
                     )),
                 ),
             ));

--- a/src/Eccube/Form/Type/Admin/CsvImportType.php
+++ b/src/Eccube/Form/Type/Admin/CsvImportType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -38,9 +39,9 @@ class CsvImportType extends AbstractType
 
     /**
      * CsvImportType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->appConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Admin/CustomerType.php
+++ b/src/Eccube/Form/Type/Admin/CustomerType.php
@@ -48,7 +48,7 @@ class CustomerType extends AbstractType
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * CustomerType constructor.
@@ -56,7 +56,7 @@ class CustomerType extends AbstractType
      */
     public function __construct(EccubeConfig $eccubeConfig)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
     /**
@@ -75,7 +75,7 @@ class CustomerType extends AbstractType
                 'required' => false,
                 'constraints' => array(
                     new Assert\Length(array(
-                        'max' => $this->appConfig['stext_len'],
+                        'max' => $this->eccubeConfig['stext_len'],
                     ))
                 ),
             ))
@@ -112,7 +112,7 @@ class CustomerType extends AbstractType
             ->add('birth', BirthdayType::class, array(
                 'required' => false,
                 'input' => 'datetime',
-                'years' => range(date('Y'), date('Y') - $this->appConfig['birth_max']),
+                'years' => range(date('Y'), date('Y') - $this->eccubeConfig['birth_max']),
                 'widget' => 'choice',
                 'format' => 'yyyy-MM-dd',
                 'placeholder' => array('year' => '----', 'month' => '--', 'day' => '--'),
@@ -157,7 +157,7 @@ class CustomerType extends AbstractType
                 'required' => false,
                 'constraints' => array(
                     new Assert\Length(array(
-                        'max' => $this->appConfig['ltext_len'],
+                        'max' => $this->eccubeConfig['ltext_len'],
                     )),
                 ),
             ));

--- a/src/Eccube/Form/Type/Admin/CustomerType.php
+++ b/src/Eccube/Form/Type/Admin/CustomerType.php
@@ -23,6 +23,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Form\Type\AddressType;
 use Eccube\Form\Type\KanaType;
 use Eccube\Form\Type\Master\CustomerStatusType;
@@ -45,15 +46,15 @@ use Symfony\Component\Validator\Constraints as Assert;
 class CustomerType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
     /**
      * CustomerType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->appConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Admin/LogType.php
+++ b/src/Eccube/Form/Type/Admin/LogType.php
@@ -37,7 +37,7 @@ class LogType extends AbstractType
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
 
     /**
@@ -52,7 +52,7 @@ class LogType extends AbstractType
      */
     public function __construct(EccubeConfig $eccubeConfig, KernelInterface $kernel)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
         $this->kernel = $kernel;
     }
 

--- a/src/Eccube/Form/Type/Admin/LogType.php
+++ b/src/Eccube/Form/Type/Admin/LogType.php
@@ -23,6 +23,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -34,7 +35,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class LogType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
@@ -46,10 +47,10 @@ class LogType extends AbstractType
 
     /**
      * LogType constructor.
-     * @param $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      * @param KernelInterface $kernel
      */
-    public function __construct($eccubeConfig, KernelInterface $kernel)
+    public function __construct(EccubeConfig $eccubeConfig, KernelInterface $kernel)
     {
         $this->appConfig = $eccubeConfig;
         $this->kernel = $kernel;

--- a/src/Eccube/Form/Type/Admin/MainEditType.php
+++ b/src/Eccube/Form/Type/Admin/MainEditType.php
@@ -26,6 +26,7 @@ namespace Eccube\Form\Type\Admin;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Layout;
 use Eccube\Entity\Master\DeviceType;
 use Eccube\Entity\Page;
@@ -55,7 +56,7 @@ class MainEditType extends AbstractType
     protected $deviceTypeRepository;
 
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
@@ -63,12 +64,12 @@ class MainEditType extends AbstractType
      * MainEditType constructor.
      * @param EntityManagerInterface $entityManager
      * @param DeviceTypeRepository $deviceTypeRepository
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
         EntityManagerInterface $entityManager,
         DeviceTypeRepository $deviceTypeRepository,
-        array $eccubeConfig
+        EccubeConfig $eccubeConfig
     ) {
         $this->entityManager = $entityManager;
         $this->deviceTypeRepository = $deviceTypeRepository;

--- a/src/Eccube/Form/Type/Admin/MasterdataDataType.php
+++ b/src/Eccube/Form/Type/Admin/MasterdataDataType.php
@@ -23,6 +23,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -39,7 +40,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class MasterdataDataType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
@@ -50,10 +51,10 @@ class MasterdataDataType extends AbstractType
 
     /**
      * MasterdataDataType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      * @param TranslatorInterface $translator
      */
-    public function __construct(array $eccubeConfig, TranslatorInterface $translator)
+    public function __construct(EccubeConfig $eccubeConfig, TranslatorInterface $translator)
     {
         $this->appConfig = $eccubeConfig;
         $this->translator = $translator;

--- a/src/Eccube/Form/Type/Admin/MasterdataDataType.php
+++ b/src/Eccube/Form/Type/Admin/MasterdataDataType.php
@@ -42,7 +42,7 @@ class MasterdataDataType extends AbstractType
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * @var TranslatorInterface
@@ -56,7 +56,7 @@ class MasterdataDataType extends AbstractType
      */
     public function __construct(EccubeConfig $eccubeConfig, TranslatorInterface $translator)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
         $this->translator = $translator;
     }
 
@@ -72,7 +72,7 @@ class MasterdataDataType extends AbstractType
                 'required' => false,
                 'constraints' => array(
                     new Assert\Length(array(
-                        'max' => $this->appConfig['int_len'],
+                        'max' => $this->eccubeConfig['int_len'],
                     )),
                     new Assert\Regex(array(
                         'pattern' => '/^\d+$/u',

--- a/src/Eccube/Form/Type/Admin/MemberType.php
+++ b/src/Eccube/Form/Type/Admin/MemberType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
@@ -35,17 +36,17 @@ use Symfony\Component\Validator\Constraints as Assert;
 class MemberType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
     /**
      * MemberType constructor.
      *
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
-        array $eccubeConfig
+        EccubeConfig $eccubeConfig
     ) {
         $this->eccubeConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Admin/NewsType.php
+++ b/src/Eccube/Form/Type/Admin/NewsType.php
@@ -26,6 +26,7 @@ namespace Eccube\Form\Type\Admin;
 use Eccube\Annotation\FormType;
 use Eccube\Annotation\Inject;
 use Eccube\Application;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\News;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -39,11 +40,11 @@ use Symfony\Component\Validator\Constraints as Assert;
 class NewsType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
-    public function __construct($eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->eccubeConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Admin/OrderItemType.php
+++ b/src/Eccube/Form/Type/Admin/OrderItemType.php
@@ -25,6 +25,7 @@
 namespace Eccube\Form\Type\Admin;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Master\OrderItemType as OrderItemTypeMaster;
 use Eccube\Entity\Master\TaxDisplayType;
 use Eccube\Entity\Master\TaxType;
@@ -50,7 +51,7 @@ class OrderItemType extends AbstractType
     protected $entityManager;
 
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
@@ -72,14 +73,14 @@ class OrderItemType extends AbstractType
     /**
      * OrderItemType constructor.
      * @param EntityManagerInterface $entityManager
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      * @param ProductClassRepository $productClassRepository
      * @param OrderItemRepository $orderItemRepository
      * @param RequestStack $requestStack
      */
     public function __construct(
         EntityManagerInterface $entityManager,
-        array $eccubeConfig,
+        EccubeConfig $eccubeConfig,
         ProductClassRepository $productClassRepository,
         OrderItemRepository $orderItemRepository,
         RequestStack $requestStack

--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -25,6 +25,7 @@
 namespace Eccube\Form\Type\Admin;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\BaseInfo;
 use Eccube\Form\DataTransformer;
 use Eccube\Form\Type\AddressType;
@@ -55,7 +56,7 @@ class OrderType extends AbstractType
     protected $entityManager;
 
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
@@ -67,10 +68,10 @@ class OrderType extends AbstractType
     /**
      * OrderType constructor.
      * @param EntityManagerInterface $entityManager
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      * @param BaseInfo $BaseInfo
      */
-    public function __construct(EntityManagerInterface $entityManager, array $eccubeConfig, BaseInfo $BaseInfo)
+    public function __construct(EntityManagerInterface $entityManager, EccubeConfig $eccubeConfig, BaseInfo $BaseInfo)
     {
         $this->entityManager = $entityManager;
         $this->eccubeConfig = $eccubeConfig;

--- a/src/Eccube/Form/Type/Admin/SearchCustomerType.php
+++ b/src/Eccube/Form/Type/Admin/SearchCustomerType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Master\CustomerStatus;
 use Eccube\Form\Type\Master\CategoryType as MasterCategoryType;
 use Eccube\Form\Type\Master\CustomerStatusType;
@@ -42,7 +43,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class SearchCustomerType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
@@ -54,12 +55,12 @@ class SearchCustomerType extends AbstractType
     /**
      * SearchCustomerType constructor.
      *
-     * @param $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      * @param CustomerStatusRepository $customerStatusRepository
      */
     public function __construct(
         CustomerStatusRepository $customerStatusRepository,
-        array $eccubeConfig
+        EccubeConfig $eccubeConfig
     ) {
         $this->eccubeConfig = $eccubeConfig;
         $this->customerStatusRepository = $customerStatusRepository;

--- a/src/Eccube/Form/Type/Admin/SearchOrderType.php
+++ b/src/Eccube/Form/Type/Admin/SearchOrderType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Form\Type\Master\OrderStatusType;
 use Eccube\Form\Type\Master\PaymentType;
 use Eccube\Form\Type\Master\SexType;
@@ -37,11 +38,11 @@ use Symfony\Component\Validator\Constraints as Assert;
 class SearchOrderType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->eccubeConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Admin/SearchShippingType.php
+++ b/src/Eccube/Form/Type/Admin/SearchShippingType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Form\Type\Master\OrderStatusType;
 use Eccube\Form\Type\Master\ShippingStatusType;
 use Symfony\Component\Form\AbstractType;
@@ -36,11 +37,11 @@ use Symfony\Component\Validator\Constraints as Assert;
 class SearchShippingType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
-    public function __construct($eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->eccubeConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Admin/SecurityType.php
+++ b/src/Eccube/Form/Type/Admin/SecurityType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -37,7 +38,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class SecurityType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
@@ -48,10 +49,10 @@ class SecurityType extends AbstractType
 
     /**
      * SecurityType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      * @param ValidatorInterface $validator
      */
-    public function __construct(array $eccubeConfig, ValidatorInterface $validator)
+    public function __construct(EccubeConfig $eccubeConfig, ValidatorInterface $validator)
     {
         $this->appConfig = $eccubeConfig;
         $this->validator = $validator;

--- a/src/Eccube/Form/Type/Admin/SecurityType.php
+++ b/src/Eccube/Form/Type/Admin/SecurityType.php
@@ -40,7 +40,7 @@ class SecurityType extends AbstractType
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * @var ValidatorInterface
@@ -54,7 +54,7 @@ class SecurityType extends AbstractType
      */
     public function __construct(EccubeConfig $eccubeConfig, ValidatorInterface $validator)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
         $this->validator = $validator;
     }
 
@@ -68,7 +68,7 @@ class SecurityType extends AbstractType
                 'label' => 'ディレクトリ名',
                 'constraints' => array(
                     new Assert\NotBlank(),
-                    new Assert\Length(array('max' => $this->appConfig['stext_len'])),
+                    new Assert\Length(array('max' => $this->eccubeConfig['stext_len'])),
                     new Assert\Regex(array(
                        'pattern' => "/^[0-9a-zA-Z]+$/",
                    )),
@@ -78,7 +78,7 @@ class SecurityType extends AbstractType
                 'required' => false,
                 'label' => 'IP制限',
                 'constraints' => array(
-                    new Assert\Length(array('max' => $this->appConfig['stext_len'])),
+                    new Assert\Length(array('max' => $this->eccubeConfig['stext_len'])),
                 ),
             ))
             ->add('force_ssl', CheckboxType::class, array(

--- a/src/Eccube/Form/Type/Admin/ShippingType.php
+++ b/src/Eccube/Form/Type/Admin/ShippingType.php
@@ -25,6 +25,7 @@
 namespace Eccube\Form\Type\Admin;
 
 use Doctrine\ORM\EntityRepository;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\BaseInfo;
 use Eccube\Form\Type\AddressType;
 use Eccube\Form\Type\KanaType;
@@ -50,7 +51,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class ShippingType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
@@ -70,7 +71,7 @@ class ShippingType extends AbstractType
     protected $BaseInfo;
 
     public function __construct(
-        $eccubeConfig,
+        EccubeConfig $eccubeConfig,
         DeliveryRepository $deliveryRepository,
         DeliveryTimeRepository $deliveryTimeRepository,
         BaseInfo $BaseInfo

--- a/src/Eccube/Form/Type/Admin/ShopMasterType.php
+++ b/src/Eccube/Form/Type/Admin/ShopMasterType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Form\EventListener\ConvertKanaListener;
 use Eccube\Form\Type\AddressType;
 use Eccube\Form\Type\PriceType;
@@ -48,15 +49,15 @@ use Symfony\Component\Validator\Constraints as Assert;
 class ShopMasterType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
     /**
      * ShopMasterType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->eccubeConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Admin/TagType.php
+++ b/src/Eccube/Form/Type/Admin/TagType.php
@@ -42,7 +42,7 @@ class TagType extends AbstractType
      * @Inject("config")
      * @var array
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
 
     /**
@@ -66,7 +66,7 @@ class TagType extends AbstractType
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Length(array(
-                        'max' => $this->appConfig['stext_len'],
+                        'max' => $this->eccubeConfig['stext_len'],
                     )),
                 ),
             ))

--- a/src/Eccube/Form/Type/Admin/TemplateType.php
+++ b/src/Eccube/Form/Type/Admin/TemplateType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -34,11 +35,11 @@ use Symfony\Component\Validator\Constraints as Assert;
 class TemplateType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->eccubeConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/CustomerType.php
+++ b/src/Eccube/Form/Type/CustomerType.php
@@ -55,7 +55,7 @@ class CustomerType extends AbstractType
      * @Inject("config")
      * @var array
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * @var \Eccube\Application $app
@@ -78,22 +78,22 @@ class CustomerType extends AbstractType
             ->add('name', NameType::class, array(
                 'options' => array(
                     'attr' => array(
-                        'maxlength' => $this->appConfig['stext_len'],
+                        'maxlength' => $this->eccubeConfig['stext_len'],
                     ),
                     'constraints' => array(
                         new Assert\NotBlank(),
-                        new Assert\Length(array('max' => $this->appConfig['stext_len'])),
+                        new Assert\Length(array('max' => $this->eccubeConfig['stext_len'])),
                     ),
                 ),
             ))
             ->add('kana', NameType::class, array(
                 'options' => array(
                     'attr' => array(
-                        'maxlength' => $this->appConfig['stext_len'],
+                        'maxlength' => $this->eccubeConfig['stext_len'],
                     ),
                     'constraints' => array(
                         new Assert\NotBlank(),
-                        new Assert\Length(array('max' => $this->appConfig['stext_len'])),
+                        new Assert\Length(array('max' => $this->eccubeConfig['stext_len'])),
                         new Assert\Regex(array(
                             'pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u",
                         )),
@@ -104,7 +104,7 @@ class CustomerType extends AbstractType
                 'required' => false,
                 'constraints' => array(
                     new Assert\Length(array(
-                        'max' => $this->appConfig['stext_len'],
+                        'max' => $this->eccubeConfig['stext_len'],
                     ))
                 ),
             ))
@@ -136,7 +136,7 @@ class CustomerType extends AbstractType
             ->add('birth', BirthdayType::class, array(
                 'required' => false,
                 'input' => 'datetime',
-                'years' => range(date('Y'), date('Y') - $this->appConfig['birth_max']),
+                'years' => range(date('Y'), date('Y') - $this->eccubeConfig['birth_max']),
                 'widget' => 'choice',
                 'format' => 'yyyy-MM-dd',
                 'placeholder' => array('year' => '----', 'month' => '--', 'day' => '--'),

--- a/src/Eccube/Form/Type/Front/CustomerAddressType.php
+++ b/src/Eccube/Form/Type/Front/CustomerAddressType.php
@@ -26,6 +26,7 @@
 namespace Eccube\Form\Type\Front;
 
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Form\Type\AddressType;
 use Eccube\Form\Type\KanaType;
 use Eccube\Form\Type\NameType;
@@ -43,14 +44,14 @@ use Symfony\Component\Validator\Constraints as Assert;
 class CustomerAddressType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
     /**
      * @param array $config
      */
-    public function __construct($eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->eccubeConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Front/CustomerLoginType.php
+++ b/src/Eccube/Form/Type/Front/CustomerLoginType.php
@@ -39,7 +39,7 @@ class CustomerLoginType extends AbstractType
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * @var AuthenticationUtils
@@ -49,7 +49,7 @@ class CustomerLoginType extends AbstractType
     public function __construct(AuthenticationUtils $authenticationUtils, EccubeConfig $eccubeConfig)
     {
         $this->authenticationUtils = $authenticationUtils;
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
     /**
@@ -59,7 +59,7 @@ class CustomerLoginType extends AbstractType
     {
         $builder->add('login_email', EmailType::class, array(
             'attr' => array(
-                'max_length' => $this->appConfig['stext_len'],
+                'max_length' => $this->eccubeConfig['stext_len'],
             ),
             'constraints' => array(
                 new Assert\NotBlank(),
@@ -72,7 +72,7 @@ class CustomerLoginType extends AbstractType
         ));
         $builder->add('login_pass', PasswordType::class, array(
             'attr' => array(
-                'max_length' => $this->appConfig['stext_len'],
+                'max_length' => $this->eccubeConfig['stext_len'],
             ),
             'constraints' => array(
                 new Assert\NotBlank(),

--- a/src/Eccube/Form/Type/Front/CustomerLoginType.php
+++ b/src/Eccube/Form/Type/Front/CustomerLoginType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Front;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
@@ -36,7 +37,7 @@ class CustomerLoginType extends AbstractType
 {
 
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
@@ -45,7 +46,7 @@ class CustomerLoginType extends AbstractType
      */
     protected $authenticationUtils;
 
-    public function __construct(AuthenticationUtils $authenticationUtils, array $eccubeConfig)
+    public function __construct(AuthenticationUtils $authenticationUtils, EccubeConfig $eccubeConfig)
     {
         $this->authenticationUtils = $authenticationUtils;
         $this->appConfig = $eccubeConfig;

--- a/src/Eccube/Form/Type/Front/EntryType.php
+++ b/src/Eccube/Form/Type/Front/EntryType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Front;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Form\Type\AddressType;
 use Eccube\Form\Type\KanaType;
 use Eccube\Form\Type\Master\JobType;
@@ -44,15 +45,15 @@ use Symfony\Component\Validator\Constraints as Assert;
 class EntryType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
     /**
      * EntryType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->appConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Front/EntryType.php
+++ b/src/Eccube/Form/Type/Front/EntryType.php
@@ -47,7 +47,7 @@ class EntryType extends AbstractType
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * EntryType constructor.
@@ -55,7 +55,7 @@ class EntryType extends AbstractType
      */
     public function __construct(EccubeConfig $eccubeConfig)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
 
@@ -75,7 +75,7 @@ class EntryType extends AbstractType
                 'required' => false,
                 'constraints' => array(
                     new Assert\Length(array(
-                        'max' => $this->appConfig['stext_len'],
+                        'max' => $this->eccubeConfig['stext_len'],
                     )),
                 ),
             ))
@@ -92,7 +92,7 @@ class EntryType extends AbstractType
             ->add('birth', BirthdayType::class, array(
                 'required' => false,
                 'input' => 'datetime',
-                'years' => range(date('Y'), date('Y') - $this->appConfig['birth_max']),
+                'years' => range(date('Y'), date('Y') - $this->eccubeConfig['birth_max']),
                 'widget' => 'choice',
                 'format' => 'yyyy/MM/dd',
                 'placeholder' => array('year' => '----', 'month' => '--', 'day' => '--'),

--- a/src/Eccube/Form/Type/Front/ForgotType.php
+++ b/src/Eccube/Form/Type/Front/ForgotType.php
@@ -39,7 +39,7 @@ class ForgotType extends AbstractType
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * ForgotType constructor.
@@ -47,7 +47,7 @@ class ForgotType extends AbstractType
      */
     public function __construct(EccubeConfig $eccubeConfig)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
     /**
@@ -57,7 +57,7 @@ class ForgotType extends AbstractType
     {
         $builder->add('login_email', TextType::class, array(
             'attr' => array(
-                'max_length' => $this->appConfig['stext_len']
+                'max_length' => $this->eccubeConfig['stext_len']
             ),
             'constraints' => array(
                 new Assert\NotBlank(),

--- a/src/Eccube/Form/Type/Front/ForgotType.php
+++ b/src/Eccube/Form/Type/Front/ForgotType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Front;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -36,15 +37,15 @@ use Symfony\Component\Validator\Constraints as Assert;
 class ForgotType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
     /**
      * ForgotType constructor.
-     * @param $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->appConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Front/NonMemberType.php
+++ b/src/Eccube/Form/Type/Front/NonMemberType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Front;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Form\Type\AddressType;
 use Eccube\Form\Type\KanaType;
 use Eccube\Form\Type\NameType;
@@ -38,15 +39,15 @@ use Symfony\Component\Validator\Constraints as Assert;
 class NonMemberType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
     /**
      * NonMemberType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->appConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/Front/NonMemberType.php
+++ b/src/Eccube/Form/Type/Front/NonMemberType.php
@@ -41,7 +41,7 @@ class NonMemberType extends AbstractType
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * NonMemberType constructor.
@@ -49,7 +49,7 @@ class NonMemberType extends AbstractType
      */
     public function __construct(EccubeConfig $eccubeConfig)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
 
@@ -69,7 +69,7 @@ class NonMemberType extends AbstractType
                 'required' => false,
                 'constraints' => array(
                     new Assert\Length(array(
-                        'max' => $this->appConfig['stext_len'],
+                        'max' => $this->eccubeConfig['stext_len'],
                     )),
                 ),
             ))

--- a/src/Eccube/Form/Type/Install/Step3Type.php
+++ b/src/Eccube/Form/Type/Install/Step3Type.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type\Install;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -41,7 +42,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class Step3Type extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
@@ -50,7 +51,7 @@ class Step3Type extends AbstractType
      */
     protected $validator;
 
-    public function __construct(ValidatorInterface $validator, $eccubeConfig)
+    public function __construct(ValidatorInterface $validator, EccubeConfig $eccubeConfig)
     {
         $this->validator = $validator;
         $this->eccubeConfig = $eccubeConfig;

--- a/src/Eccube/Form/Type/KanaType.php
+++ b/src/Eccube/Form/Type/KanaType.php
@@ -23,6 +23,7 @@
 
 namespace Eccube\Form\Type;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -31,15 +32,15 @@ use Symfony\Component\Validator\Constraints as Assert;
 class KanaType extends AbstractType
 {
     /**
-     * @var array
+     * @var \Eccube\Common\EccubeConfig
      */
     protected $appConfig;
 
     /**
      * KanaType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->appConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/KanaType.php
+++ b/src/Eccube/Form/Type/KanaType.php
@@ -34,7 +34,7 @@ class KanaType extends AbstractType
     /**
      * @var \Eccube\Common\EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * KanaType constructor.
@@ -42,7 +42,7 @@ class KanaType extends AbstractType
      */
     public function __construct(EccubeConfig $eccubeConfig)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
     /**
@@ -70,7 +70,7 @@ class KanaType extends AbstractType
                         'pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u",
                     )),
                     new Assert\Length(array(
-                        'max' => $this->appConfig['kana_len'],
+                        'max' => $this->eccubeConfig['kana_len'],
                     )),
                 ),
             ),
@@ -83,7 +83,7 @@ class KanaType extends AbstractType
                         'pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u",
                     )),
                     new Assert\Length(array(
-                        'max' => $this->appConfig['kana_len'],
+                        'max' => $this->eccubeConfig['kana_len'],
                     )),
                 ),
             ),

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -35,17 +36,17 @@ use Symfony\Component\Validator\Constraints as Assert;
 class NameType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
     /**
      * NameType constructor.
      *
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
-        array $eccubeConfig
+        EccubeConfig $eccubeConfig
     ) {
         $this->eccubeConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/PriceType.php
+++ b/src/Eccube/Form/Type/PriceType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
@@ -36,7 +37,7 @@ use Symfony\Component\Validator\Constraints\Range;
 class PriceType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
@@ -48,9 +49,9 @@ class PriceType extends AbstractType
     /**
      * PriceType constructor.
      *
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig, ContainerInterface $container)
+    public function __construct(EccubeConfig $eccubeConfig, ContainerInterface $container)
     {
         $this->eccubeConfig = $eccubeConfig;
         $this->container = $container;

--- a/src/Eccube/Form/Type/RepeatedPasswordType.php
+++ b/src/Eccube/Form/Type/RepeatedPasswordType.php
@@ -40,7 +40,7 @@ class RepeatedPasswordType extends AbstractType
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * RepeatedPasswordType constructor.
@@ -48,7 +48,7 @@ class RepeatedPasswordType extends AbstractType
      */
     public function __construct(EccubeConfig $eccubeConfig)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
     /**
@@ -65,8 +65,8 @@ class RepeatedPasswordType extends AbstractType
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Length(array(
-                        'min' => $this->appConfig['password_min_len'],
-                        'max' => $this->appConfig['password_max_len'],
+                        'min' => $this->eccubeConfig['password_min_len'],
+                        'max' => $this->eccubeConfig['password_max_len'],
                     )),
                     new Assert\Regex(array(
                         'pattern' => '/^[[:graph:][:space:]]+$/i',
@@ -76,7 +76,7 @@ class RepeatedPasswordType extends AbstractType
             ),
             'first_options' => array(
                 'attr' => array(
-                    'placeholder' => '半角英数字記号'.$this->appConfig['password_min_len'].'～'.$this->appConfig['password_max_len'].'文字',
+                    'placeholder' => '半角英数字記号'.$this->eccubeConfig['password_min_len'].'～'.$this->eccubeConfig['password_max_len'].'文字',
                 ),
             ),
             'second_options' => array(

--- a/src/Eccube/Form/Type/RepeatedPasswordType.php
+++ b/src/Eccube/Form/Type/RepeatedPasswordType.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Form\Type;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -37,15 +38,15 @@ use Symfony\Component\Validator\Constraints as Assert;
 class RepeatedPasswordType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
     /**
      * RepeatedPasswordType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->appConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/ShippingMultipleItemType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleItemType.php
@@ -46,7 +46,7 @@ class ShippingMultipleItemType extends AbstractType
      * @Inject("config")
      * @var array
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * @Inject("session")
@@ -74,7 +74,7 @@ class ShippingMultipleItemType extends AbstractType
             ->add('quantity', IntegerType::class, array(
                 'attr' => array(
                     'min' => 1,
-                    'maxlength' => $this->appConfig['int_len'],
+                    'maxlength' => $this->eccubeConfig['int_len'],
                 ),
                 'constraints' => array(
                     new Assert\NotBlank(),

--- a/src/Eccube/Form/Type/Shopping/ShippingType.php
+++ b/src/Eccube/Form/Type/Shopping/ShippingType.php
@@ -2,6 +2,7 @@
 
 namespace Eccube\Form\Type\Shopping;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Shipping;
 use Eccube\Repository\DeliveryFeeRepository;
 use Eccube\Repository\DeliveryRepository;
@@ -21,7 +22,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 class ShippingType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
@@ -37,11 +38,11 @@ class ShippingType extends AbstractType
 
     /**
      * ShippingType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      * @param DeliveryRepository $deliveryRepository
      * @param DeliveryFeeRepository $deliveryFeeRepository
      */
-    public function __construct(array $eccubeConfig, DeliveryRepository $deliveryRepository, DeliveryFeeRepository $deliveryFeeRepository)
+    public function __construct(EccubeConfig $eccubeConfig, DeliveryRepository $deliveryRepository, DeliveryFeeRepository $deliveryFeeRepository)
     {
         $this->eccubeConfig = $eccubeConfig;
         $this->deliveryRepository = $deliveryRepository;

--- a/src/Eccube/Form/Type/TelType.php
+++ b/src/Eccube/Form/Type/TelType.php
@@ -42,7 +42,7 @@ class TelType extends AbstractType
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * TelType constructor.
@@ -50,7 +50,7 @@ class TelType extends AbstractType
      */
     public function __construct(EccubeConfig $eccubeConfig)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
 
@@ -131,19 +131,19 @@ class TelType extends AbstractType
             'tel01_options' => array(
                 'constraints' => array(
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')), //todo  messageは汎用的に出来ないものか?
-                    new Assert\Length(array('max' => $this->appConfig['tel_len'], 'min' => $this->appConfig['tel_len_min'])),
+                    new Assert\Length(array('max' => $this->eccubeConfig['tel_len'], 'min' => $this->eccubeConfig['tel_len_min'])),
                 ),
             ),
             'tel02_options' => array(
                 'constraints' => array(
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')),
-                    new Assert\Length(array('max' => $this->appConfig['tel_len'], 'min' => $this->appConfig['tel_len_min'])),
+                    new Assert\Length(array('max' => $this->eccubeConfig['tel_len'], 'min' => $this->eccubeConfig['tel_len_min'])),
                 ),
             ),
             'tel03_options' => array(
                 'constraints' => array(
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')),
-                    new Assert\Length(array('max' => $this->appConfig['tel_len'], 'min' => $this->appConfig['tel_len_min'])),
+                    new Assert\Length(array('max' => $this->eccubeConfig['tel_len'], 'min' => $this->eccubeConfig['tel_len_min'])),
                 ),
             ),
             'tel01_name' => '',

--- a/src/Eccube/Form/Type/TelType.php
+++ b/src/Eccube/Form/Type/TelType.php
@@ -22,6 +22,7 @@
  */
 namespace Eccube\Form\Type;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -39,15 +40,15 @@ use Symfony\Component\Validator\Constraints as Assert;
 class TelType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
     /**
      * TelType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->appConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/ZipType.php
+++ b/src/Eccube/Form/Type/ZipType.php
@@ -23,6 +23,7 @@
 
 namespace Eccube\Form\Type;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -38,15 +39,15 @@ use Symfony\Component\Validator\Constraints as Assert;
 class ZipType extends AbstractType
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
     /**
      * ZipType constructor.
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->appConfig = $eccubeConfig;
     }

--- a/src/Eccube/Form/Type/ZipType.php
+++ b/src/Eccube/Form/Type/ZipType.php
@@ -41,7 +41,7 @@ class ZipType extends AbstractType
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * ZipType constructor.
@@ -49,7 +49,7 @@ class ZipType extends AbstractType
      */
     public function __construct(EccubeConfig $eccubeConfig)
     {
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
 
@@ -108,13 +108,13 @@ class ZipType extends AbstractType
             'zip01_options' => array(
                 'constraints' => array(
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')),
-                    new Assert\Length(array('min' => $this->appConfig['zip01_len'], 'max' => $this->appConfig['zip01_len'])),
+                    new Assert\Length(array('min' => $this->eccubeConfig['zip01_len'], 'max' => $this->eccubeConfig['zip01_len'])),
                 ),
             ),
             'zip02_options' => array(
                 'constraints' => array(
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')),
-                    new Assert\Length(array('min' => $this->appConfig['zip02_len'], 'max' => $this->appConfig['zip02_len'])),
+                    new Assert\Length(array('min' => $this->eccubeConfig['zip02_len'], 'max' => $this->eccubeConfig['zip02_len'])),
                 ),
             ),
             'zip01_name' => '',

--- a/src/Eccube/Repository/AbstractRepository.php
+++ b/src/Eccube/Repository/AbstractRepository.php
@@ -14,7 +14,7 @@ abstract class AbstractRepository extends ServiceEntityRepository
      * @Inject("config")
      * @var array
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * エンティティを削除します。
@@ -39,7 +39,7 @@ abstract class AbstractRepository extends ServiceEntityRepository
 
     protected function getCacheLifetime()
     {
-        // $options = $this->appConfig['doctrine_cache'];
+        // $options = $this->eccubeConfig['doctrine_cache'];
         // return $options['result_cache']['lifetime'];
         return 0;               // FIXME
     }

--- a/src/Eccube/Repository/BlockRepository.php
+++ b/src/Eccube/Repository/BlockRepository.php
@@ -42,7 +42,7 @@ class BlockRepository extends AbstractRepository
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * BlockRepository constructor.
@@ -55,7 +55,7 @@ class BlockRepository extends AbstractRepository
         EccubeConfig $eccubeConfig
     ) {
         parent::__construct($registry, Block::class);
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
     /**
@@ -187,7 +187,7 @@ class BlockRepository extends AbstractRepository
      */
     public function getWriteTemplatePath($isUser = false)
     {
-        return $this->appConfig['block_realdir'];
+        return $this->eccubeConfig['block_realdir'];
     }
 
     /**
@@ -206,8 +206,8 @@ class BlockRepository extends AbstractRepository
     public function getReadTemplateFile($fileName, $isUser = false)
     {
         $readPaths = array(
-            $this->appConfig['block_realdir'],
-            $this->appConfig['block_default_realdir'],
+            $this->eccubeConfig['block_realdir'],
+            $this->eccubeConfig['block_default_realdir'],
         );
         foreach ($readPaths as $readPath) {
             $filePath = $readPath . '/' . $fileName . '.twig';

--- a/src/Eccube/Repository/BlockRepository.php
+++ b/src/Eccube/Repository/BlockRepository.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Repository;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Block;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Bridge\Doctrine\RegistryInterface;
@@ -39,7 +40,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
 class BlockRepository extends AbstractRepository
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
@@ -47,11 +48,11 @@ class BlockRepository extends AbstractRepository
      * BlockRepository constructor.
      *
      * @param RegistryInterface $registry
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
         RegistryInterface $registry,
-        array $eccubeConfig
+        EccubeConfig $eccubeConfig
     ) {
         parent::__construct($registry, Block::class);
         $this->appConfig = $eccubeConfig;

--- a/src/Eccube/Repository/CategoryRepository.php
+++ b/src/Eccube/Repository/CategoryRepository.php
@@ -26,6 +26,7 @@ namespace Eccube\Repository;
 
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Category;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 
@@ -39,7 +40,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
 class CategoryRepository extends AbstractRepository
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
@@ -47,11 +48,11 @@ class CategoryRepository extends AbstractRepository
      * CategoryRepository constructor.
      *
      * @param RegistryInterface $registry
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
         RegistryInterface $registry,
-        array $eccubeConfig
+        EccubeConfig $eccubeConfig
     ) {
         parent::__construct($registry, Category::class);
         $this->appConfig = $eccubeConfig;

--- a/src/Eccube/Repository/CategoryRepository.php
+++ b/src/Eccube/Repository/CategoryRepository.php
@@ -42,7 +42,7 @@ class CategoryRepository extends AbstractRepository
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * CategoryRepository constructor.
@@ -55,7 +55,7 @@ class CategoryRepository extends AbstractRepository
         EccubeConfig $eccubeConfig
     ) {
         parent::__construct($registry, Category::class);
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
     /**
@@ -85,7 +85,7 @@ class CategoryRepository extends AbstractRepository
     public function getList(Category $Parent = null, $flat = false)
     {
         // TODO::doctrine_cache is not implement
-        // $options = $this->appConfig['doctrine_cache'];
+        // $options = $this->eccubeConfig['doctrine_cache'];
         // $lifetime = $options['result_cache']['lifetime'];
 
         $qb = $this->createQueryBuilder('c1')

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -60,7 +60,7 @@ class CustomerRepository extends AbstractRepository
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * @var EncoderFactoryInterface
@@ -90,7 +90,7 @@ class CustomerRepository extends AbstractRepository
         $this->entityManager = $entityManager;
         $this->orderRepository = $orderRepository;
         $this->encoderFactory = $encoderFactory;
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
 

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -25,6 +25,7 @@
 namespace Eccube\Repository;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Common\EccubeConfig;
 use Eccube\Doctrine\Query\Queries;
 use Eccube\Entity\Customer;
 use Eccube\Entity\Master\CustomerStatus;
@@ -57,7 +58,7 @@ class CustomerRepository extends AbstractRepository
     protected $orderRepository;
 
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
@@ -73,7 +74,7 @@ class CustomerRepository extends AbstractRepository
      * @param EntityManagerInterface $entityManager
      * @param OrderRepository $orderRepository
      * @param EncoderFactoryInterface $encoderFactory
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
         RegistryInterface $registry,
@@ -81,7 +82,7 @@ class CustomerRepository extends AbstractRepository
         EntityManagerInterface $entityManager,
         OrderRepository $orderRepository,
         EncoderFactoryInterface $encoderFactory,
-        array $eccubeConfig
+        EccubeConfig $eccubeConfig
     ) {
         parent::__construct($registry, Customer::class);
 

--- a/src/Eccube/Repository/PageRepository.php
+++ b/src/Eccube/Repository/PageRepository.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Repository;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Master\DeviceType;
 use Eccube\Entity\Page;
 use Symfony\Bridge\Doctrine\RegistryInterface;
@@ -40,7 +41,7 @@ use Symfony\Component\Filesystem\Filesystem;
 class PageRepository extends AbstractRepository
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
@@ -65,10 +66,10 @@ class PageRepository extends AbstractRepository
     /**
      * PageRepository constructor.
      * @param RegistryInterface $registry
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      * @param ContainerInterface $container
      */
-    public function __construct(RegistryInterface $registry, array $eccubeConfig, ContainerInterface $container)
+    public function __construct(RegistryInterface $registry, EccubeConfig $eccubeConfig, ContainerInterface $container)
     {
         parent::__construct($registry, Page::class);
         $this->appConfig = $eccubeConfig;

--- a/src/Eccube/Repository/PageRepository.php
+++ b/src/Eccube/Repository/PageRepository.php
@@ -43,7 +43,7 @@ class PageRepository extends AbstractRepository
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * @var string
@@ -72,7 +72,7 @@ class PageRepository extends AbstractRepository
     public function __construct(RegistryInterface $registry, EccubeConfig $eccubeConfig, ContainerInterface $container)
     {
         parent::__construct($registry, Page::class);
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
         $this->userDataRealDir = $container->getParameter('eccube.theme.user_data_dir');
         $this->templateRealDir = $container->getParameter('eccube.theme.app_dir');
         $this->templateDefaultRealDir = $container->getParameter('eccube.theme.src_dir');
@@ -165,7 +165,7 @@ class PageRepository extends AbstractRepository
     public function getByUrl(DeviceType $DeviceType, $url)
     {
         // Fixme
-//        $options = $this->appConfig['doctrine_cache'];
+//        $options = $this->eccubeConfig['doctrine_cache'];
 //        $lifetime = $options['result_cache']['lifetime'];
         $lifetime = $this->getCacheLifetime();
 

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -24,6 +24,7 @@
 
 namespace Eccube\Repository;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Doctrine\Query\Queries;
 use Eccube\Entity\Product;
 use Eccube\Util\StringUtil;
@@ -45,7 +46,7 @@ class ProductRepository extends AbstractRepository
 
     /**
      * @Inject("config")
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
@@ -54,12 +55,12 @@ class ProductRepository extends AbstractRepository
      *
      * @param RegistryInterface $registry
      * @param Queries $queries
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
         RegistryInterface $registry,
         Queries $queries,
-        array $eccubeConfig
+        EccubeConfig $eccubeConfig
     ) {
         parent::__construct($registry, Product::class);
         $this->queries = $queries;

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -48,7 +48,7 @@ class ProductRepository extends AbstractRepository
      * @Inject("config")
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * ProductRepository constructor.
@@ -64,7 +64,7 @@ class ProductRepository extends AbstractRepository
     ) {
         parent::__construct($registry, Product::class);
         $this->queries = $queries;
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
    /**
@@ -109,7 +109,7 @@ class ProductRepository extends AbstractRepository
 
         // Order By
         // 価格低い順
-        $config = $this->appConfig;
+        $config = $this->eccubeConfig;
         if (!empty($searchData['orderby']) && $searchData['orderby']->getId() == $config['product_order_price_lower']) {
             //@see http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html
             $qb->addSelect('MIN(pc.price02) as HIDDEN price02_min');

--- a/src/Eccube/Repository/TaxRuleRepository.php
+++ b/src/Eccube/Repository/TaxRuleRepository.php
@@ -25,6 +25,7 @@
 namespace Eccube\Repository;
 
 use Doctrine\ORM\NoResultException;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Customer;
 use Eccube\Entity\TaxRule;
 use Symfony\Bridge\Doctrine\RegistryInterface;
@@ -65,14 +66,14 @@ class TaxRuleRepository extends AbstractRepository
      * @param TokenStorageInterface $tokenStorage
      * @param AuthorizationCheckerInterface $authorizationChecker
      * @param BaseInfo $baseInfo
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
         RegistryInterface $registry,
         TokenStorageInterface $tokenStorage,
         AuthorizationCheckerInterface $authorizationChecker,
         BaseInfo $baseInfo,
-        array $eccubeConfig
+        EccubeConfig $eccubeConfig
     ) {
         parent::__construct($registry, TaxRule::class);
         $this->tokenStorage = $tokenStorage;

--- a/src/Eccube/Repository/TaxRuleRepository.php
+++ b/src/Eccube/Repository/TaxRuleRepository.php
@@ -79,7 +79,7 @@ class TaxRuleRepository extends AbstractRepository
         $this->tokenStorage = $tokenStorage;
         $this->authorizationChecker = $authorizationChecker;
         $this->baseInfo = $baseInfo;
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
     public function newTaxRule()
@@ -212,7 +212,7 @@ class TaxRuleRepository extends AbstractRepository
         // 地域設定を優先するが、システムパラメーターなどに設定を持っていくか
         // 後に書いてあるほど優先される
         $priorityKeys = [];
-        foreach (explode(',', $this->appConfig['tax_rule_priority']) as $key) {
+        foreach (explode(',', $this->eccubeConfig['tax_rule_priority']) as $key) {
             $priorityKeys[] = str_replace('_', '', preg_replace('/_id\z/', '', $key));
         }
 

--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -264,10 +264,10 @@
                                 </tbody>
                             </table>
                         </div>
-                        {% if Customer.CustomerAddresses|length < eccube.config.deliv_addr_max %}
+                        {% if Customer.CustomerAddresses|length < eccube_config.deliv_addr_max %}
                             <a href="{{ url('admin_customer_delivery_new', { id: Customer.id }) }}" class="btn btn-default">お届け先追加</a>
                         {% else %}
-                            <span class="ec-errorMessage">お届け先登録の上限の{{ eccube.config.deliv_addr_max }}件に達しています。お届け先を入力したい場合は、削除か変更を行ってください</span>
+                            <span class="ec-errorMessage">お届け先登録の上限の{{ eccube_config.deliv_addr_max }}件に達しています。お届け先を入力したい場合は、削除か変更を行ってください</span>
                         {% endif %}
                     </div>
                     {% else %}

--- a/src/Eccube/Resource/template/admin/Product/category.twig
+++ b/src/Eccube/Resource/template/admin/Product/category.twig
@@ -109,7 +109,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div id="edit_box__body_inner" class="col-md-9">
                             <form role="form" class="form-horizontal" name="form1" id="form1" method="post" action="{% if TargetCategory.id %}{{ path('admin_product_category_edit', {id: TargetCategory.id}) }}{% elseif Parent %}{{ url('admin_product_category_show', {'parent_id': Parent.id}) }}{% else %}{{ url('admin_product_category') }}{% endif %}" enctype="multipart/form-data">
                                 <div class="form-group">
-                                    {% if TargetCategory.hierarchy < eccube.config.category_nest_level %}
+                                    {% if TargetCategory.hierarchy < eccube_config.category_nest_level %}
                                         <div class="col-md-12 form-inline">
                                             {{ form_widget(form._token) }}
                                             {{ form_widget(form.name, {attr: {placeholder: 'カテゴリ名を入力'}}) }}

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -193,10 +193,10 @@ $(function() {
                                       </li>
                                     {% endfor %}
                                       <li>
-                                      {% if page_status == eccube.config.admin_product_stock_status %}
+                                      {% if page_status == eccube_config.admin_product_stock_status %}
                                           <a>{{ 'admin.product.search.stock'|trans }}</a>
                                       {% else %}
-                                          <a href="{{ path('admin_product_page', {'page_no': page_no, 'status': eccube.config.admin_product_stock_status} ) }}">{{ 'admin.product.search.stock'|trans }}</a>
+                                          <a href="{{ path('admin_product_page', {'page_no': page_no, 'status': eccube_config.admin_product_stock_status} ) }}">{{ 'admin.product.search.stock'|trans }}</a>
                                       {% endif %}
                                       </li>
                                     </ul>
@@ -290,10 +290,10 @@ $(function() {
                                             </li>
                                         {% endfor %}
                                         <li>
-                                            {% if page_status == eccube.config.admin_product_stock_status %}
+                                            {% if page_status == eccube_config.admin_product_stock_status %}
                                                 <a>{{ 'admin.product.search.stock'|trans }}</a>
                                             {% else %}
-                                                <a href="{{ path('admin_product_page', {'page_no': page_no, 'status': eccube.config.admin_product_stock_status} ) }}">{{ 'admin.product.search.stock'|trans }}</a>
+                                                <a href="{{ path('admin_product_page', {'page_no': page_no, 'status': eccube_config.admin_product_stock_status} ) }}">{{ 'admin.product.search.stock'|trans }}</a>
                                             {% endif %}
                                         </li>
                                     </ul>

--- a/src/Eccube/Resource/template/admin/Setting/System/authority.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/authority.twig
@@ -67,7 +67,7 @@ $(function() {
                 <div id="authority_list_box__header" class="box-header">
                     <h3 class="box-title">権限設定</h3>
                     <div style="margin-left: 10px;">
-                        <p>{{ app.request.baseUrl ~ '/' ~ eccube.config.admin_route}}以降からのURLを拒否URLに入力してください。</p>
+                        <p>{{ app.request.baseUrl ~ '/' ~ eccube_config.admin_route}}以降からのURLを拒否URLに入力してください。</p>
                         <p>拒否URL以降がアクセス拒否されます。(URLは前方一致)</p>
                         <p>例) /setting <span class="text-danger">※「/」を必ず記入してください</span></p>
                     </div>

--- a/src/Eccube/Resource/template/admin/Store/template.twig
+++ b/src/Eccube/Resource/template/admin/Store/template.twig
@@ -54,7 +54,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 {% for Template in Templates %}
                                 <tr>
                                     <td>
-                                        <input type="radio" name="template" value="{{ Template.id }}" {% if eccube.config.template_code == Template.code %}checked="checked"{% endif %}/>
+                                        <input type="radio" name="template" value="{{ Template.id }}" {% if eccube_config.template_code == Template.code %}checked="checked"{% endif %}/>
                                     </td>
                                     <td>{{ Template.name }}</td>
                                     <td>

--- a/src/Eccube/Resource/template/admin/index.twig
+++ b/src/Eccube/Resource/template/admin/index.twig
@@ -80,7 +80,7 @@ $(function(){
                         <h3 class="box-title">お知らせ</h3>
                     </div><!-- /.box-header -->
                     <div class="box-body no-padding no-border">
-                        <iframe name="information" class="link_list_wrap" src="{{ eccube.config.eccube_info_url }}"></iframe>
+                        <iframe name="information" class="link_list_wrap" src="{{ eccube_config.eccube_info_url }}"></iframe>
                     </div><!-- /.box-body -->
 
                 </div><!-- /.box -->

--- a/src/Eccube/Resource/template/admin/nav.twig
+++ b/src/Eccube/Resource/template/admin/nav.twig
@@ -20,7 +20,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #}
 
-{% for level1 in eccube.config.nav if app.request.baseUrl ~ '/' ~ eccube.config.admin_route ~ '/' ~ level1.id not in AuthorityRoles %}
+{% for level1 in eccube_config.nav if app.request.baseUrl ~ '/' ~ eccube_config.admin_route ~ '/' ~ level1.id not in AuthorityRoles %}
     <li class="{% if active_menus(menus)[0] == level1.id %}active{% endif %}">
         {% if level1.has_child is defined and level1.has_child == true %}
             <a class="toggle">
@@ -29,7 +29,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 <svg class="cb cb-angle-down"> <use xlink:href="#cb-angle-down" /></svg>
             </a>
             <ul {% if active_menus(menus)[0] == level1.id %}class="active" style="display: block;"{% endif %}>
-                {% for level2 in level1.child if app.request.baseUrl ~ '/' ~ eccube.config.admin_route ~ '/' ~ level1.id ~ '/' ~ level2.id not in AuthorityRoles %}
+                {% for level2 in level1.child if app.request.baseUrl ~ '/' ~ eccube_config.admin_route ~ '/' ~ level1.id ~ '/' ~ level2.id not in AuthorityRoles %}
                     {% if level2.url is defined and path(level2.url)  in AuthorityRoles %}
                     {% else %}
                     <li class="{% if active_menus(menus)[1] == level2.id %}active{% endif %}">

--- a/src/Eccube/Resource/template/default/Mypage/delivery.twig
+++ b/src/Eccube/Resource/template/default/Mypage/delivery.twig
@@ -41,10 +41,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 <div class="ec-off1Grid__cell">
                     <div class="ec-addressRole">
                         <div class="ec-addressRole__actions">
-                            {% if Customer.CustomerAddresses|length < eccube.config.deliv_addr_max %}
+                            {% if Customer.CustomerAddresses|length < eccube_config.deliv_addr_max %}
                                 <a class="ec-inlineBtn" href="{{ url('mypage_delivery_new') }}">新規お届け先を追加する</a>
                             {% else %}
-                                <span class="ec-errorMessage">お届け先登録の上限の{{ eccube.config.deliv_addr_max }}件に達しています。お届け先を入力したい場合は、削除か変更を行ってください</span>
+                                <span class="ec-errorMessage">お届け先登録の上限の{{ eccube_config.deliv_addr_max }}件に達しています。お届け先を入力したい場合は、削除か変更を行ってください</span>
                             {% endif %}
                         </div>
                     </div>

--- a/src/Eccube/Resource/template/default/Shopping/confirm.twig
+++ b/src/Eccube/Resource/template/default/Shopping/confirm.twig
@@ -276,7 +276,7 @@ $(function() {
                             {% for orderItem in shipping.orderItems %}
                             <li>
                                 <div class="ec-imageGrid">
-                                    <div class="ec-imageGrid__img"><img src="{ eccube.config.image_save_urlpath }/{{ (orderItem.product is null ? null : orderItem.product.MainListImage)|no_image_product }}" alt="{{ orderItem.productName }}"></div>
+                                    <div class="ec-imageGrid__img"><img src="{ eccube_config.image_save_urlpath }/{{ (orderItem.product is null ? null : orderItem.product.MainListImage)|no_image_product }}" alt="{{ orderItem.productName }}"></div>
                                     <div class="ec-imageGrid__content">
                                         <p>{{ orderItem.productName }}</p>
                                         {% if orderItem.productClass is not null and orderItem.productClass.classCategory1 %}

--- a/src/Eccube/Resource/template/default/Shopping/index.twig
+++ b/src/Eccube/Resource/template/default/Shopping/index.twig
@@ -294,7 +294,7 @@ $(function() {
                             {% for orderItem in shipping.orderItems %}
                             <li>
                                 <div class="ec-imageGrid">
-                                    <div class="ec-imageGrid__img"><img src="{{ eccube.config.image_save_urlpath }}/{{ (orderItem.product is null ? null : orderItem.product.MainListImage)|no_image_product }}" alt="{{ orderItem.productName }}"></div>
+                                    <div class="ec-imageGrid__img"><img src="{{ eccube_config.image_save_urlpath }}/{{ (orderItem.product is null ? null : orderItem.product.MainListImage)|no_image_product }}" alt="{{ orderItem.productName }}"></div>
                                     <div class="ec-imageGrid__content">
                                         <p>{{ orderItem.productName }}</p>
                                         {% if orderItem.productClass is not null and orderItem.productClass.classCategory1 %}

--- a/src/Eccube/Resource/template/default/Shopping/shipping.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping.twig
@@ -32,13 +32,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         <div class="ec-off1Grid">
             <div class="ec-off1Grid__cell">
                 <div class="ec-addressRole">
-                    {% if Customer.CustomerAddresses|length < eccube.config.deliv_addr_max %}
+                    {% if Customer.CustomerAddresses|length < eccube_config.deliv_addr_max %}
                         <div class="ec-addressRole__actions"><a class="ec-inlineBtn" href="{{ url('shopping_shipping_edit', {'id': shippingId}) }}">新規お届け先を追加する</a></div>
                     {% else %}
                         <div class="ec-alert-warning">
                             <div class="ec-alert-warning__text">
                                 <div class="ec-alert-warning__icon"><img src="{{ asset('assets/icon/exclamation-white.svg') }}"/></div>
-                                お届け先登録上限の{{ eccube.config.deliv_addr_max }}件に達しています。お届け先を入力したい場合は、削除か変更を行ってください
+                                お届け先登録上限の{{ eccube_config.deliv_addr_max }}件に達しています。お届け先を入力したい場合は、削除か変更を行ってください
                             </div>
                         </div>
                     {% endif %}

--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -24,6 +24,7 @@ namespace Eccube\Service\Composer;
 
 use Composer\Console\Application;
 use Eccube\Annotation\Service;
+use Eccube\Common\EccubeConfig;
 use Eccube\Exception\PluginException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -37,9 +38,9 @@ class ComposerApiService implements ComposerServiceInterface
 {
 
     /**
-     * @var array
+     * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * @var Application $consoleApplication
@@ -48,9 +49,9 @@ class ComposerApiService implements ComposerServiceInterface
 
     private $workingDir;
 
-    public function __construct($appConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
-        $this->appConfig = $appConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
     /**
@@ -210,12 +211,12 @@ class ComposerApiService implements ComposerServiceInterface
         set_time_limit(0);
         @ini_set('memory_limit', '1536M');
         // Config for some environment
-        putenv('COMPOSER_HOME='.$this->appConfig['plugin_realdir'].'/.composer');
+        putenv('COMPOSER_HOME='.$this->eccubeConfig['plugin_realdir'].'/.composer');
         $consoleApplication = new Application();
         $consoleApplication->resetComposer();
         $consoleApplication->setAutoExit(false);
         $this->consoleApplication = $consoleApplication;
-        $this->workingDir = $this->workingDir ? $this->workingDir : $this->appConfig['root_dir'];
+        $this->workingDir = $this->workingDir ? $this->workingDir : $this->eccubeConfig['root_dir'];
     }
 
     /**

--- a/src/Eccube/Service/Composer/ComposerProcessService.php
+++ b/src/Eccube/Service/Composer/ComposerProcessService.php
@@ -24,6 +24,7 @@ namespace Eccube\Service\Composer;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Annotation\Service;
+use Eccube\Common\EccubeConfig;
 use Eccube\Exception\PluginException;
 
 /**
@@ -34,9 +35,9 @@ use Eccube\Exception\PluginException;
 class ComposerProcessService implements ComposerServiceInterface
 {
     /**
-     * @var array config parameter
+     * @var EccubeConfig config parameter
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * @var EntityManagerInterface
@@ -51,13 +52,13 @@ class ComposerProcessService implements ComposerServiceInterface
     /**
      * ComposerProcessService constructor.
      *
-     * @param array                  $appConfig
+     * @param EccubeConfig                  $eccubeConfig
      * @param EntityManagerInterface $entityManager
      * @param string                 $pathPHP
      */
-    public function __construct($appConfig, $entityManager, $pathPHP)
+    public function __construct(EccubeConfig $eccubeConfig, $entityManager, $pathPHP)
     {
-        $this->appConfig = $appConfig;
+        $this->eccubeConfig = $eccubeConfig;
         $this->entityManager = $entityManager;
         $this->pathPHP = $pathPHP;
     }
@@ -145,7 +146,7 @@ class ComposerProcessService implements ComposerServiceInterface
             throw new PluginException("Php cli not found.");
         }
 
-        $composerMemory = $this->appConfig['composer_memory_limit'];
+        $composerMemory = $this->eccubeConfig['composer_memory_limit'];
         if (!$this->isSetCliMemoryLimit()) {
             $cliMemoryLimit = $this->getCliMemoryLimit();
             if ($cliMemoryLimit < $composerMemory && $cliMemoryLimit != -1) {
@@ -166,8 +167,8 @@ class ComposerProcessService implements ComposerServiceInterface
 
         @ini_set('memory_limit', $composerMemory.'M');
         // Config for some environment
-        putenv('COMPOSER_HOME='.$this->appConfig['plugin_realdir'].'/.composer');
-        $this->workingDir = $this->workingDir ? $this->workingDir : $this->appConfig['root_dir'];
+        putenv('COMPOSER_HOME='.$this->eccubeConfig['plugin_realdir'].'/.composer');
+        $this->workingDir = $this->workingDir ? $this->workingDir : $this->eccubeConfig['root_dir'];
         $this->setupComposer();
     }
 

--- a/src/Eccube/Service/CsvExportService.php
+++ b/src/Eccube/Service/CsvExportService.php
@@ -26,6 +26,7 @@ namespace Eccube\Service;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Common\EccubeConfig;
 use Eccube\Repository\CsvRepository;
 use Eccube\Repository\CustomerRepository;
 use Eccube\Repository\Master\CsvTypeRepository;
@@ -65,7 +66,7 @@ class CsvExportService
     protected $qb;
 
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $config;
 
@@ -112,7 +113,7 @@ class CsvExportService
      * @param CsvTypeRepository $csvTypeRepository
      * @param OrderRepository $orderRepository
      * @param CustomerRepository $customerRepository
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
         EntityManagerInterface $entityManager,
@@ -121,7 +122,7 @@ class CsvExportService
         OrderRepository $orderRepository,
         CustomerRepository $customerRepository,
         ProductRepository $productRepository,
-        array $eccubeConfig
+        EccubeConfig $eccubeConfig
     ) {
         $this->entityManager = $entityManager;
         $this->csvRepository = $csvRepository;

--- a/src/Eccube/Service/CsvExportService.php
+++ b/src/Eccube/Service/CsvExportService.php
@@ -68,7 +68,7 @@ class CsvExportService
     /**
      * @var EccubeConfig
      */
-    protected $config;
+    protected $eccubeConfig;
 
     /**
      * @var CsvType
@@ -129,7 +129,7 @@ class CsvExportService
         $this->csvTypeRepository = $csvTypeRepository;
         $this->orderRepository = $orderRepository;
         $this->customerRepository = $customerRepository;
-        $this->config = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
         $this->productRepository = $productRepository;
     }
 
@@ -138,7 +138,7 @@ class CsvExportService
      */
     public function setConfig($config)
     {
-        $this->config = $config;
+        $this->eccubeConfig = $config;
     }
 
     /**
@@ -321,11 +321,11 @@ class CsvExportService
                     $array[] = $elem->offsetGet($Csv->getReferenceFieldName());
                 }
             }
-            return implode($this->config['csv_export_multidata_separator'], $array);
+            return implode($this->eccubeConfig['csv_export_multidata_separator'], $array);
 
         } elseif ($data instanceof \DateTime) {
             // datetimeの場合は文字列に変換する.
-            return $data->format($this->config['csv_export_date_format']);
+            return $data->format($this->eccubeConfig['csv_export_date_format']);
 
         } else {
             // スカラ値の場合はそのまま.
@@ -342,7 +342,7 @@ class CsvExportService
      */
     public function getConvertEncodhingCallback()
     {
-        $config = $this->config;
+        $config = $this->eccubeConfig;
 
         return function ($value) use ($config) {
             return mb_convert_encoding(
@@ -371,7 +371,7 @@ class CsvExportService
             $this->convertEncodingCallBack = $this->getConvertEncodhingCallback();
         }
 
-        fputcsv($this->fp, array_map($this->convertEncodingCallBack, $row), $this->config['csv_export_separator']);
+        fputcsv($this->fp, array_map($this->convertEncodingCallBack, $row), $this->eccubeConfig['csv_export_separator']);
     }
 
     /**

--- a/src/Eccube/Service/MailService.php
+++ b/src/Eccube/Service/MailService.php
@@ -23,6 +23,7 @@
 
 namespace Eccube\Service;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Customer;
 use Eccube\Event\EccubeEvents;
@@ -57,7 +58,7 @@ class MailService
     protected $BaseInfo;
 
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
@@ -74,7 +75,7 @@ class MailService
      * @param BaseInfo $baseInfo
      * @param EventDispatcher $eventDispatcher
      * @param \Twig_Environment $twig
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
         \Swift_Mailer $mailer,
@@ -82,7 +83,7 @@ class MailService
         BaseInfo $baseInfo,
         EventDispatcher $eventDispatcher,
         \Twig_Environment $twig,
-        array $eccubeConfig
+        EccubeConfig $eccubeConfig
     ) {
         $this->mailer = $mailer;
         $this->mailTemplateRepository = $mailTemplateRepository;

--- a/src/Eccube/Service/OrderHelper.php
+++ b/src/Eccube/Service/OrderHelper.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManager;
 use Eccube\Annotation\Inject;
 use Eccube\Annotation\Service;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\CartItem;
 use Eccube\Entity\Customer;
 use Eccube\Entity\CustomerAddress;
@@ -92,7 +93,7 @@ class OrderHelper
 
     /**
      * @Inject("config")
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
@@ -107,9 +108,9 @@ class OrderHelper
      * @param OrderRepository $orderRepository
      * @param ShippingStatusRepository $shippingStatusRepository
      * @param EntityManager $entityManager
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(OrderItemTypeRepository $orderItemTypeRepository, OrderStatusRepository $orderStatusRepository, TaxRuleRepository $taxRuleRepository, DeliveryFeeRepository $deliveryFeeRepository, DeliveryRepository $deliveryRepository, PaymentRepository $paymentRepository, OrderRepository $orderRepository, ShippingStatusRepository $shippingStatusRepository, EntityManager $entityManager, array $eccubeConfig)
+    public function __construct(OrderItemTypeRepository $orderItemTypeRepository, OrderStatusRepository $orderStatusRepository, TaxRuleRepository $taxRuleRepository, DeliveryFeeRepository $deliveryFeeRepository, DeliveryRepository $deliveryRepository, PaymentRepository $paymentRepository, OrderRepository $orderRepository, ShippingStatusRepository $shippingStatusRepository, EntityManager $entityManager, EccubeConfig $eccubeConfig)
     {
         $this->orderItemTypeRepository = $orderItemTypeRepository;
         $this->orderStatusRepository = $orderStatusRepository;

--- a/src/Eccube/Service/OrderHelper.php
+++ b/src/Eccube/Service/OrderHelper.php
@@ -95,7 +95,7 @@ class OrderHelper
      * @Inject("config")
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * OrderHelper constructor.
@@ -121,7 +121,7 @@ class OrderHelper
         $this->orderRepository = $orderRepository;
         $this->shippingStatusRepository = $shippingStatusRepository;
         $this->entityManager = $entityManager;
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
     }
 
 

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -59,11 +59,6 @@ class PluginService
     protected $pluginRepository;
 
     /**
-     * @var array
-     */
-    protected $eccubeConfig;
-
-    /**
      * @var Application
      */
     protected $app;

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -762,7 +762,7 @@ class PluginService
      */
     public function findRequirePluginNeedEnable($pluginCode)
     {
-        $dir = $this->appConfig['plugin_realdir'].'/'.$pluginCode;
+        $dir = $this->eccubeConfig['plugin_realdir'].'/'.$pluginCode;
         $composerFile = $dir.'/composer.json';
         if (!file_exists($composerFile)) {
             return [];
@@ -826,7 +826,7 @@ class PluginService
         $plugins = $this->pluginRepository->matching($criteria);
         $dependents = [];
         foreach ($plugins as $plugin) {
-            $dir = $this->appConfig['plugin_realdir'].'/'.$plugin->getCode();
+            $dir = $this->eccubeConfig['plugin_realdir'].'/'.$plugin->getCode();
             $fileName = $dir.'/composer.json';
             if (!file_exists($fileName)) {
                 continue;
@@ -924,7 +924,7 @@ class PluginService
         // プラグインにリソースファイルがあれば所定の位置へコピー
         if (file_exists($assetsDir)) {
             $file = new Filesystem();
-            $file->mirror($assetsDir, $this->appConfig['plugin_html_realdir'].$pluginCode.'/assets');
+            $file->mirror($assetsDir, $this->eccubeConfig['plugin_html_realdir'].$pluginCode.'/assets');
         }
     }
 

--- a/src/Eccube/Service/PurchaseFlow/Processor/PaymentTotalLimitValidator.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PaymentTotalLimitValidator.php
@@ -23,6 +23,7 @@
 
 namespace Eccube\Service\PurchaseFlow\Processor;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\ItemHolderInterface;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Eccube\Service\PurchaseFlow\ValidatableItemHolderProcessor;
@@ -40,9 +41,9 @@ class PaymentTotalLimitValidator extends ValidatableItemHolderProcessor
     /**
      * PaymentTotalLimitValidator constructor.
      *
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->maxTotalFee = $eccubeConfig['max_total_fee'];
     }

--- a/src/Eccube/Service/PurchaseFlow/Processor/UpdateDatePurchaseProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/UpdateDatePurchaseProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Eccube\Service\PurchaseFlow\Processor;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\ItemHolderInterface;
 use Eccube\Entity\OrderStatus;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
@@ -14,16 +15,16 @@ use Eccube\Service\PurchaseFlow\ProcessResult;
 class UpdateDatePurchaseProcessor implements PurchaseProcessor
 {
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 
     /**
      * UpdateDatePurchaseProcessor constructor.
      *
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      */
-    public function __construct(array $eccubeConfig)
+    public function __construct(EccubeConfig $eccubeConfig)
     {
         $this->eccubeConfig = $eccubeConfig;
     }

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -26,6 +26,7 @@ namespace Eccube\Service;
 use Doctrine\ORM\EntityManager;
 use Eccube\Annotation\Inject;
 use Eccube\Annotation\Service;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Customer;
 use Eccube\Entity\Delivery;
@@ -132,7 +133,7 @@ class ShoppingService
     protected $entityManager;
 
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $appConfig;
 
@@ -188,7 +189,7 @@ class ShoppingService
      * @param PaymentRepository $paymentRepository
      * @param DeviceTypeRepository $deviceTypeRepository
      * @param EntityManager $entityManager
-     * @param array $eccubeConfig
+     * @param EccubeConfig $eccubeConfig
      * @param PrefRepository $prefRepository
      * @param Session $session
      * @param OrderRepository $orderRepository
@@ -211,7 +212,7 @@ class ShoppingService
         PaymentRepository $paymentRepository,
         DeviceTypeRepository $deviceTypeRepository,
         EntityManager $entityManager,
-        array $eccubeConfig,
+        EccubeConfig $eccubeConfig,
         PrefRepository $prefRepository,
         Session $session,
         OrderRepository $orderRepository,

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -135,7 +135,7 @@ class ShoppingService
     /**
      * @var EccubeConfig
      */
-    protected $appConfig;
+    protected $eccubeConfig;
 
     /**
      * @var PrefRepository
@@ -234,7 +234,7 @@ class ShoppingService
         $this->paymentRepository = $paymentRepository;
         $this->deviceTypeRepository = $deviceTypeRepository;
         $this->entityManager = $entityManager;
-        $this->appConfig = $eccubeConfig;
+        $this->eccubeConfig = $eccubeConfig;
         $this->prefRepository = $prefRepository;
         $this->session = $session;
         $this->orderRepository = $orderRepository;
@@ -1011,7 +1011,7 @@ class ShoppingService
             $period = new \DatePeriod (
                 new \DateTime($minDate.' day'),
                 new \DateInterval('P1D'),
-                new \DateTime($minDate + $this->appConfig['deliv_date_end_max'].' day')
+                new \DateTime($minDate + $this->eccubeConfig['deliv_date_end_max'].' day')
             );
 
             foreach ($period as $day) {

--- a/src/Eccube/ServiceProvider/EccubeServiceProvider.php
+++ b/src/Eccube/ServiceProvider/EccubeServiceProvider.php
@@ -25,6 +25,7 @@
 namespace Eccube\ServiceProvider;
 
 use Eccube\Application;
+use Eccube\Common\EccubeConfig;
 
 class EccubeServiceProvider implements ServiceProviderInterface
 {
@@ -38,9 +39,8 @@ class EccubeServiceProvider implements ServiceProviderInterface
         });
 
         $app['config'] = $app->share(function () use ($app) {
-            if ($app->getParentContainer()->hasParameter('eccube.app')) {
-                $EccubeApplication = $app->getParentContainer()->getParameter('eccube.app');
-                return $EccubeApplication['config'];
+            if ($app->getParentContainer()->has(EccubeConfig::class)) {
+                return $app->getParentContainer()->get(EccubeConfig::class);
             }
 
             return [];

--- a/tests/Eccube/Tests/Common/EccubeConfigTest.php
+++ b/tests/Eccube/Tests/Common/EccubeConfigTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Eccube\Common;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
+
+class EccubeConfigTest extends TestCase
+{
+    /**
+     * @var EccubeConfig
+     */
+    protected $eccubeConfig;
+
+    public function setup()
+    {
+        $container = new Container();
+        $this->eccubeConfig = new EccubeConfig($container);
+    }
+
+    public function testGet()
+    {
+        $this->eccubeConfig->set('hoge.fuga', true);
+        self::assertSame(true, $this->eccubeConfig->get('hoge.fuga'));
+    }
+
+    public function testGetNotFound()
+    {
+        $this->expectException(ParameterNotFoundException::class);
+        $this->eccubeConfig->get('hoge.fuga');
+    }
+
+    public function testHas()
+    {
+        self::assertFalse($this->eccubeConfig->has('hoge.fuga'));
+        $this->eccubeConfig->set('hoge.fuga', true);
+        self::assertTrue($this->eccubeConfig->has('hoge.fuga'));
+    }
+
+    public function testSet()
+    {
+        $this->eccubeConfig->set('hoge.fuga', true);
+        self::assertSame(true, $this->eccubeConfig->get('hoge.fuga'));
+    }
+
+    public function testOffsetGet()
+    {
+        $this->eccubeConfig->set('hoge.fuga', true);
+        self::assertSame(true, $this->eccubeConfig->offsetGet('hoge.fuga'));
+
+    }
+
+    public function testOffsetGetNotFound()
+    {
+        $this->expectException(ParameterNotFoundException::class);
+        $this->eccubeConfig->offsetGet('hoge.fuga');
+
+    }
+
+    public function testOffsetExist()
+    {
+        self::assertFalse($this->eccubeConfig->offsetExists('hoge.fuga'));
+        $this->eccubeConfig->set('hoge.fuga', true);
+        self::assertTrue($this->eccubeConfig->offsetExists('hoge.fuga'));
+
+    }
+
+    public function testOffsetSet()
+    {
+        $this->eccubeConfig->offsetSet('hoge.fuga', true);
+        self::assertSame(true, $this->eccubeConfig->offsetGet('hoge.fuga'));
+
+    }
+
+    public function testOffsetUnset()
+    {
+        $this->expectException(\Exception::class);
+        $this->eccubeConfig->offsetUnset('hoge.fuga');
+    }
+}

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -44,7 +44,7 @@ abstract class EccubeTestCase extends WebTestCase
     protected $entityManager;
 
     /**
-     * @var array
+     * @var EccubeConfig
      */
     protected $eccubeConfig;
 

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -3,6 +3,7 @@
 namespace Eccube\Tests;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Customer;
 use Eccube\Tests\Fixture\Generator;
 use Faker\Factory as Faker;
@@ -56,7 +57,7 @@ abstract class EccubeTestCase extends WebTestCase
         $this->client = self::createClient();
         $this->container = $this->client->getContainer();
         $this->entityManager = $this->container->get('doctrine')->getManager();
-        $this->eccubeConfig = $this->container->getParameter('eccube.constants');
+        $this->eccubeConfig = $this->container->get(EccubeConfig::class);
     }
 
     /**

--- a/tests/Eccube/Tests/Repository/BlockRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/BlockRepositoryTest.php
@@ -121,7 +121,7 @@ class BlockRepositoryTest extends EccubeTestCase
 
         file_put_contents(vfsStream::url('rootDir').'/'.$fileName.'.twig', 'test');
 
-        ReflectionUtil::setValue($this->blockRepository, 'appConfig', [
+        ReflectionUtil::setValue($this->blockRepository, 'eccubeConfig', [
             'block_realdir' =>  vfsStream::url('rootDir'),
             'block_default_realdir' => vfsStream::url('rootDir/default'),
         ]);
@@ -142,7 +142,7 @@ class BlockRepositoryTest extends EccubeTestCase
 
         file_put_contents(vfsStream::url('rootDir/default').'/'.$fileName.'.twig', 'test');
 
-        ReflectionUtil::setValue($this->blockRepository, 'appConfig', [
+        ReflectionUtil::setValue($this->blockRepository, 'eccubeConfig', [
             'block_realdir' =>  vfsStream::url('rootDir'),
             'block_default_realdir' => vfsStream::url('rootDir/default'),
         ]);

--- a/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
+++ b/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
@@ -59,9 +59,9 @@ class InstallControllerTest extends AbstractWebTestCase
         parent::setUp();
         $formFactory = $this->container->get('form.factory');
         $encoder = $this->container->get(PasswordEncoder::class);
-        $config = $this->container->get(EccubeConfig::class);
+        $eccubeConfig = $this->container->get(EccubeConfig::class);
         $this->session = new Session(new MockArraySessionStorage());
-        $this->controller = new InstallController($this->session, $formFactory, $encoder, 'install', $config);
+        $this->controller = new InstallController($this->session, $formFactory, $encoder, 'install', $eccubeConfig);
         $reflectionClass = new \ReflectionClass($this->controller);
         $propContainer = $reflectionClass->getProperty('container');
         $propContainer->setAccessible(true);

--- a/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
+++ b/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
@@ -25,6 +25,7 @@
 namespace Eccube\Tests\Web\Install;
 
 use Eccube\Common\Constant;
+use Eccube\Common\EccubeConfig;
 use Eccube\Tests\Web\AbstractWebTestCase;
 use Eccube\Controller\Install\InstallController;
 use Eccube\Security\Core\Encoder\PasswordEncoder;
@@ -58,7 +59,7 @@ class InstallControllerTest extends AbstractWebTestCase
         parent::setUp();
         $formFactory = $this->container->get('form.factory');
         $encoder = $this->container->get(PasswordEncoder::class);
-        $config = $this->container->getParameter('eccube.constants');
+        $config = $this->container->get(EccubeConfig::class);
         $this->session = new Session(new MockArraySessionStorage());
         $this->controller = new InstallController($this->session, $formFactory, $encoder, 'install', $config);
         $reflectionClass = new \ReflectionClass($this->controller);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

configパラメータを取得するEccubeConfigクラスを作成しています。

以下のように利用します。

```php
class Hoge {
   protected $eccubeConfig;

   public function __construct(EccubeConfig $eccubeConfig)
   {
       $this->eccubeConfig = $eccubeConfig;
   }
   public function xxx()
  {
       $this->eccubeConfig->get('kernel.debug');
       $this->eccubeConfig['eccube.theme'];
  }
}
```

パラメータの取得が以下の三種にばらついているので、EccubeConfigクラスで一括してアクセスできればと考えています。

- $eccubeConfig // eccube.constantsのみ
- $kernel->getParameter();
- $container->getParameter()

phpstormであればコード補完が効きますし、従来通りArrayAccessでも取得することができます。

## パラメータの定義

- eccubeで定義するものは、すべてeccubeプレフィクスをつける
- eccube.constantsで定義しているものはeccube.xxxに移行

```
parameters:
    eccube.admin_route: '%admin_route%'
    eccube.admin_allow_hosts: ...
    eccube.category_nest_level: xxx
    ...
```

## 補足
twigのグローバル変数定義時に、`@Eccube\Common\EccubeConfig`を解決してくれないため、変数名を`eccube.config`から`eccube_config`に変更しています。
https://github.com/EC-CUBE/ec-cube/pull/2801/commits/8b09e309467d4d945836756e565d9cc2d504359b


