### PR TITLE
Codeception用にGeneratorの設定を変更

### DIFF
--- a/app/config/eccube/packages/test/generator.yaml
+++ b/app/config/eccube/packages/test/generator.yaml
@@ -17,3 +17,4 @@ services:
       - '@Eccube\Repository\TaxRuleRepository'
       - '@session'
       - 'ja_JP'
+    public: true


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ [eccube-codeception](https://github.com/EC-CUBE/eccube-codeception/)でテストデータの登録にGeneratorをコンテナから取得して利用しているのでtest環境ではコンポーネントをpublicに変更。
+ エラーが発生しているわけではないが警告が出るので修正しました。


## マイナーバージョン互換性保持のための制限事項チェックリスト
- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



