### PR TITLE
商品一覧画面の送信用検索フォームが表示されないように修正

### DIFF
--- a/src/Eccube/Resource/template/default/Product/list.twig
+++ b/src/Eccube/Resource/template/default/Product/list.twig
@@ -53,11 +53,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     {% else %}
         <div class="ec-searchnavRole">
             <form name="form1" id="form1" method="get" action="?">
-                {{ form_widget(search_form.category_id, { type : 'hidden' }) }}
-                {{ form_widget(search_form.name, { type : 'hidden' }) }}
-                {{ form_widget(search_form.disp_number, { type : 'hidden' }) }}
-                {{ form_widget(search_form.orderby, { type : 'hidden' }) }}
-                {{ form_widget(search_form, { type : 'hidden' }) }}
+                {% for item in search_form %}
+                    <input type="hidden" id="{{ item.vars.id }}"
+                           name="{{ item.vars.full_name }}"
+                           {% if item.vars.value is not empty %}value="{{ item.vars.value }}" {% endif %}/>
+                {% endfor %}
             </form>
             <div class="ec-searchnavRole__topicpath">
                 <ol class="ec-topicpath">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 商品一覧画面の送信用検索フォームが表示されないように修正

## 実装に関する補足(Appendix)
+ `{ type : 'hidden' }` を指定しても `category_id` のformが表示されてしまうため、twigに直接コードを埋め込む形で修正。
+ codeceptionの `Ef0201-uc04-t01 商品一覧ページ 表示件数` が通らない原因となっていた。
  + https://github.com/EC-CUBE/eccube-codeception/pull/81

## テスト（Test)
+ 本体のUnitTestが通ることを確認
+ codeceptionの `Ef0201-uc04-t01` が通ることを確認
