### PR TITLE
追加したページ(user_data以下)を表示できるように修正

### DIFF
--- a/src/Eccube/EventListener/TwigInitializeListener.php
+++ b/src/Eccube/EventListener/TwigInitializeListener.php
@@ -80,7 +80,13 @@ class TwigInitializeListener implements EventSubscriberInterface
      */
     public function setFrontVaribales(GetResponseEvent $event)
     {
-        $route = $event->getRequest()->attributes->get('_route');
+        /** @var \Symfony\Component\HttpFoundation\ParameterBag $reqAttributes */
+        $reqAttributes = $event->getRequest()->attributes;
+        $route = $reqAttributes->get('_route');
+        if ($route == 'user_data') {
+            $routeParams = $reqAttributes->get('_route_params', []);
+            $route = isset($routeParams['route']) ? $routeParams['route'] : $reqAttributes->get('route', '');
+        }
 
         // TODO レイアウトの端末判定を実装
         $DeviceType = $this->deviceTypeRepository->find(DeviceType::DEVICE_TYPE_PC);

--- a/src/Eccube/EventListener/TwigInitializeListener.php
+++ b/src/Eccube/EventListener/TwigInitializeListener.php
@@ -80,13 +80,9 @@ class TwigInitializeListener implements EventSubscriberInterface
      */
     public function setFrontVaribales(GetResponseEvent $event)
     {
-        /** @var \Symfony\Component\HttpFoundation\ParameterBag $reqAttributes */
-        $reqAttributes = $event->getRequest()->attributes;
-        $route = $reqAttributes->get('_route');
-        if ($route == 'user_data') {
-            $routeParams = $reqAttributes->get('_route_params', []);
-            $route = isset($routeParams['route']) ? $routeParams['route'] : $reqAttributes->get('route', '');
-        }
+        // TODO:FIXME: if page contains twig syntax, codeception test case will fail
+        // @see \EA06ContentsManagementCest::contentsmanagement_ページ管理
+        $route = $event->getRequest()->attributes->get('_route');
 
         // TODO レイアウトの端末判定を実装
         $DeviceType = $this->deviceTypeRepository->find(DeviceType::DEVICE_TYPE_PC);

--- a/src/Eccube/EventListener/TwigInitializeListener.php
+++ b/src/Eccube/EventListener/TwigInitializeListener.php
@@ -80,8 +80,6 @@ class TwigInitializeListener implements EventSubscriberInterface
      */
     public function setFrontVaribales(GetResponseEvent $event)
     {
-        // FIXME: if page contains twig syntax, codeception test case will fail
-        // @see \EA06ContentsManagementCest::contentsmanagement_ページ管理
         /** @var \Symfony\Component\HttpFoundation\ParameterBag $attributes */
         $attributes = $event->getRequest()->attributes;
         $route = $attributes->get('_route');

--- a/src/Eccube/EventListener/TwigInitializeListener.php
+++ b/src/Eccube/EventListener/TwigInitializeListener.php
@@ -80,9 +80,15 @@ class TwigInitializeListener implements EventSubscriberInterface
      */
     public function setFrontVaribales(GetResponseEvent $event)
     {
-        // TODO:FIXME: if page contains twig syntax, codeception test case will fail
+        // FIXME: if page contains twig syntax, codeception test case will fail
         // @see \EA06ContentsManagementCest::contentsmanagement_ページ管理
-        $route = $event->getRequest()->attributes->get('_route');
+        /** @var \Symfony\Component\HttpFoundation\ParameterBag $attributes */
+        $attributes = $event->getRequest()->attributes;
+        $route = $attributes->get('_route');
+        if ($route == 'user_data') {
+            $routeParams = $attributes->get('_route_params', []);
+            $route = isset($routeParams['route']) ? $routeParams['route'] : $attributes->get('route', '');
+        }
 
         // TODO レイアウトの端末判定を実装
         $DeviceType = $this->deviceTypeRepository->find(DeviceType::DEVICE_TYPE_PC);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ PullRequestの目的、関連するIssue番号など
  - Can show page of user with route

## テスト（Test)
+ with codeception EA06ContentsManagementCest.php

## 相談（Discussion）
+ pass with template base on codeception script
+ with only simple text, page not render good.


