### PR TITLE
商品検索画面のカテゴリのソート順を修正

### DIFF
--- a/src/Eccube/Form/Type/Admin/SearchProductType.php
+++ b/src/Eccube/Form/Type/Admin/SearchProductType.php
@@ -45,6 +45,8 @@ class SearchProductType extends AbstractType
     {
         $app = $this->app;
 
+        $Categories = $this->app['eccube.repository.category']->getList(null, true);
+
         $builder
             ->add('id', 'text', array(
                 'label' => '商品ID',
@@ -60,10 +62,13 @@ class SearchProductType extends AbstractType
                 'required' => false,
             ))
              */
-            ->add('category_id', 'category', array(
+            ->add('category_id', 'entity', array(
                 'label' => 'カテゴリ',
                 'empty_value' => '選択してください',
                 'required' => false,
+                'class' => 'Eccube\Entity\Category',
+                'property' => 'NameWithLevel',
+                'choices' => $Categories,
             ))
             ->add('status', 'disp', array(
                 'label' => '種別',


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

管理画面＞商品管理＞商品マスタで、カテゴリのソート順がずれていたのを修正

## 実装に関する補足(Appendix)

- フロントや商品登録画面は#1893 #1813 で修正されていたが、商品マスタの検索画面が未対応だった。
- カテゴリのリストを他の修正と合わせ、CategoryRepository::getList()で取得するように修正しています。

## テスト（Test)

- travis-ciのテストにパスすることを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



