### PR TITLE
#2819 の修正

### DIFF
--- a/src/Eccube/Form/Type/Admin/MasterdataDataType.php
+++ b/src/Eccube/Form/Type/Admin/MasterdataDataType.php
@@ -87,11 +87,11 @@ class MasterdataDataType extends AbstractType
             $form = $event->getForm();
             $data = $form->getData();
             if (strlen($data['id']) && strlen($data['name']) == 0) {
-                $form['name']->addError(new FormError($trans->trans('This value should not be blank.')));
+                $form['name']->addError(new FormError($trans->trans('This value should not be blank.', [], 'validators')));
             }
 
             if (strlen($data['name']) && strlen($data['id']) == 0) {
-                $form['id']->addError(new FormError($trans->trans('This value should not be blank.')));
+                $form['id']->addError(new FormError($trans->trans('This value should not be blank.', [], 'validators')));
             }
         });
     }

--- a/src/Eccube/Form/Type/Admin/MemberType.php
+++ b/src/Eccube/Form/Type/Admin/MemberType.php
@@ -41,11 +41,6 @@ class MemberType extends AbstractType
     protected $eccubeConfig;
 
     /**
-     * @var string
-     */
-    protected $blankMessage = 'admin.system.member.form.not.blank';
-
-    /**
      * MemberType constructor.
      *
      * @param EccubeConfig $eccubeConfig
@@ -65,7 +60,7 @@ class MemberType extends AbstractType
             ->add('name', TextType::class, array(
                 'label' => '名前',
                 'constraints' => array(
-                    new Assert\NotBlank(array('message' => $this->blankMessage)),
+                    new Assert\NotBlank(),
                     new Assert\Length(array('max' => $this->eccubeConfig['eccube_stext_len'])),
                 ),
             ))
@@ -73,14 +68,14 @@ class MemberType extends AbstractType
                 'required' => false,
                 'label' => '所属',
                 'constraints' => array(
-                    new Assert\NotBlank(array('message' => $this->blankMessage)),
+                    new Assert\NotBlank(),
                     new Assert\Length(array('max' => $this->eccubeConfig['eccube_stext_len'])),
                 ),
             ))
             ->add('login_id', TextType::class, array(
                 'label' => 'ログインID',
                 'constraints' => array(
-                    new Assert\NotBlank(array('message' => $this->blankMessage)),
+                    new Assert\NotBlank(),
                     new Assert\Length(array(
                         'min' => $this->eccubeConfig['eccube_id_min_len'],
                         'max' => $this->eccubeConfig['eccube_id_max_len'],
@@ -97,7 +92,7 @@ class MemberType extends AbstractType
                     'label' => 'パスワード(確認)',
                 ),
                 'constraints' => array(
-                    new Assert\NotBlank(array('message' => $this->blankMessage)),
+                    new Assert\NotBlank(),
                     new Assert\Length(array(
                         'min' => $this->eccubeConfig['eccube_id_min_len'],
                         'max' => $this->eccubeConfig['eccube_id_max_len'],
@@ -112,7 +107,7 @@ class MemberType extends AbstractType
                 'multiple' => false,
                 'placeholder' => 'form.empty_value',
                 'constraints' => array(
-                    new Assert\NotBlank(array('message' => $this->blankMessage)),
+                    new Assert\NotBlank(),
                 ),
             ))
             ->add('Work', EntityType::class, array(
@@ -121,7 +116,7 @@ class MemberType extends AbstractType
                 'expanded' => true,
                 'multiple' => false,
                 'constraints' => array(
-                    new Assert\NotBlank(array('message' => $this->blankMessage)),
+                    new Assert\NotBlank(),
                 ),
             ))
         ;

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -188,12 +188,8 @@ return [
     'admin.delivery.visible.complete' => '表示に変更しました。',
     'admin.delivery.hidden.complete' => '非表示に変更しました。',
     'admin_title' => 'EC-CUBE 管理機能',
-    'admin.system.member.form.not.blank' => '入力されていません。',
     'normal_price_title' => '通常価格',
     'sale_price_title' => '販売価格',
     'form.address1.help' => '市区町村名 (例：千代田区神田神保町)',
     'form.address2.help' => '番地・ビル名 (例：1-3-5)',
-    'This value should not be blank.' => '入力されていません。',
-    'This value should be the user\'s current password.' => '現在のパスワードが正しくありません。',
-    'Invalid twig format. {{ error }}' => 'Twigのフォーマットが正しくありません。{{ error }}',
 ];

--- a/src/Eccube/Resource/locale/validators.ja.php
+++ b/src/Eccube/Resource/locale/validators.ja.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'This value should not be blank.' => '入力されていません。',
+    'This value should be the user\'s current password.' => '現在のパスワードが正しくありません。',
+    'Invalid twig format. {{ error }}' => 'Twigのフォーマットが正しくありません。{{ error }}',
+];

--- a/tests/Eccube/Tests/Form/Type/Admin/LogTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/LogTypeTest.php
@@ -42,10 +42,11 @@ class LogTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         parent::setUp();
 
         $this->fileName = '_test_site_'.date('YmdHis').'.log';
-        $this->logTest = $this->container->getParameter('kernel.logs_dir').'/'.$this->fileName;
+        $this->logTest = $this->container->getParameter('kernel.logs_dir').'/test/'.$this->fileName;
 
         // Check and create the file to test if it does not exist
         if (!file_exists($this->logTest)) {
+            @mkdir(dirname($this->logTest));
             file_put_contents($this->logTest, 'Lorem Ipsum is simply dummy text ...');
         }
 

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/LogControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/LogControllerTest.php
@@ -132,7 +132,7 @@ class LogControllerTest extends AbstractAdminWebTestCase
     public function dataProvider()
     {
         return array(
-            array('', '', '空であってはなりません。'),
+            array('', '', '入力されていません。'),
             array('a', '', '有効な数字ではありません。'),
             array(-1, '', '0以上でなければなりません。'),
             array(0, '', ''),


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ #2819 に対する修正を追加
+ `LogType`のテストが失敗していたので修正
+ Validatorのエラーメッセージは`validators.ja.php`でデフォルトのメッセージをオーバーライドするように変更

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



