### PR TITLE
OrderのテストデータもPurchaseFlowを使って作成するように変更

### DIFF
--- a/app/config/eccube/packages/dev/generator.yaml
+++ b/app/config/eccube/packages/dev/generator.yaml
@@ -15,5 +15,6 @@ services:
       - '@Eccube\Repository\PageRepository'
       - '@Eccube\Repository\Master\PrefRepository'
       - '@Eccube\Repository\TaxRuleRepository'
+      - '@eccube.purchase.flow.order'
       - '@session'
       - 'ja_JP'

--- a/app/config/eccube/packages/test/generator.yaml
+++ b/app/config/eccube/packages/test/generator.yaml
@@ -15,6 +15,7 @@ services:
       - '@Eccube\Repository\PageRepository'
       - '@Eccube\Repository\Master\PrefRepository'
       - '@Eccube\Repository\TaxRuleRepository'
+      - '@eccube.purchase.flow.order'
       - '@session'
       - 'ja_JP'
     public: true


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ `Generator#createOrder()`内でdeprecatedなメソッド`Order#getTotalPrice()`を使用していたので、Codeceptionで警告が発生
+ 管理画面用のPurchaseFlowを使って合計金額や税金等の計算をするように変更

## テスト（Test)
+ 既存のテストが通ることを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



