### PR TITLE
キャッシュの削除が発生するテストを別グループで実行するように修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,8 @@ before_script:
 
 script:
   - if [ $COVERAGE ]  ; then phpdbg -qrr ./bin/phpunit --coverage-clover=coverage.clover ; fi
-  - if [ ! $COVERAGE ]; then ./bin/phpunit; fi
+  - if [ ! $COVERAGE ]; then ./bin/phpunit --exclude-group cache-clear; fi
+  - if [ ! $COVERAGE ]; then ./bin/phpunit --group cache-clear; fi
 
 after_script:
   - if [ $COVERAGE ]; then wget https://scrutinizer-ci.com/ocular.phar ; fi

--- a/app/config/eccube/services_test.yaml
+++ b/app/config/eccube/services_test.yaml
@@ -8,3 +8,10 @@ services:
         arguments:
             - '@doctrine.orm.default_entity_manager'
             - false
+    # セッションの保存先をvar/sessions/testに変更する
+    session.storage.mock_file:
+        class: 'Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage'
+        arguments:
+            - '%session.save_path%'
+            - 'MOCKSESSID'
+            - '@session.storage.metadata_bag'

--- a/tests/Eccube/Tests/Web/Admin/Content/CacheControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/CacheControllerTest.php
@@ -26,6 +26,9 @@ namespace Eccube\Tests\Web\Admin\Content;
 
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 
+/**
+ * @group cache-clear
+ */
 class CacheControllerTest extends AbstractAdminWebTestCase
 {
     public function testRoutingAdminContentCache()
@@ -39,9 +42,6 @@ class CacheControllerTest extends AbstractAdminWebTestCase
 
     public function testRoutingAdminContentCachePost()
     {
-        // FIXME
-        $this->markTestIncomplete('テスト時のセッションがvar/cache/test/sessionsに生成されるため,処理を継続できない');
-
         $client = $this->client;
 
         $url = $this->generateUrl('admin_content_cache');


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- キャッシュ管理でキャッシュを削除した際に、後続のテストでコンテナの再コンパイルが行われ、メモリを使い切ってしまう
- キャッシュ管理のテストは別グループで実行するようにして回避しています

## 方針(Policy)

キャッシュの削除が発生するテストは以下のようにグループを指定します。

```php
/**
 * @group cache-clear
 */
class CacheControllerTest extends AbstractAdminWebTestCase
{
```

Travis-CIでは、
```yaml
- if [ ! $COVERAGE ]; then ./bin/phpunit --exclude-group cache-clear; fi
- if [ ! $COVERAGE ]; then ./bin/phpunit --group cache-clear; fi
```
のように、テスト自体を通常のテストとは別に実行するようにしています。
