### PR TITLE
.envへの変更が有効になるように対応

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,8 @@
         "symfony/var-dumper": "^3.4",
         "symfony/web-profiler-bundle": "^3.4",
         "symfony/yaml": "^3.4",
-        "twig/twig": "^2.4"
+        "twig/twig": "^2.4",
+        "vlucas/phpdotenv": "v2.4.0"
     },
     "require-dev": {
         "dama/doctrine-test-bundle": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ef431b4478fb2f7b14d673356d923be",
+    "content-hash": "1deb1393a120c917d1656eea5dfcb5da",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -6265,6 +6265,56 @@
                 "templating"
             ],
             "time": "2017-09-27T18:10:31+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c",
+                "reference": "3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause-Attribution"
+            ],
+            "authors": [
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "http://www.vancelucas.com"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "time": "2016-09-01T10:05:43+00:00"
         },
         {
             "name": "zendframework/zend-code",

--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 
 use Eccube\Kernel;
 use Symfony\Component\Debug\Debug;
-use Symfony\Component\Dotenv\Dotenv;
+use Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\Request;
 
 // システム要件チェック
@@ -24,9 +24,9 @@ if (!isset($_SERVER['APP_ENV'])) {
     }
 
     if (file_exists(__DIR__.'/.env')) {
-        (new Dotenv())->load(__DIR__.'/.env');
+        (new Dotenv(__DIR__))->overload();
     } else {
-        (new Dotenv())->load(__DIR__.'/.env.install');
+        (new Dotenv(__DIR__, '.env.install'))->overload();
     }
 }
 

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -69,7 +69,9 @@ class SecurityController extends AbstractController
             $env = file_get_contents($envFile);
 
             $adminAllowHosts = \json_encode(
-                \explode("\n", StringUtil::convertLineFeed($data['admin_allow_hosts']))
+                array_filter(\explode("\n", StringUtil::convertLineFeed($data['admin_allow_hosts'])), function($str) {
+                    return StringUtil::isNotBlank($str);
+                })
             );
             $env = StringUtil::replaceOrAddEnv($env, [
                 'ECCUBE_ADMIN_ALLOW_HOSTS' => "'{$adminAllowHosts}'",

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -71,7 +71,7 @@ class SecurityController extends AbstractController
             $adminAllowHosts = \json_encode(
                 \explode("\n", StringUtil::convertLineFeed($data['admin_allow_hosts']))
             );
-            $env = StringUtil::replaceEnv($env, [
+            $env = StringUtil::replaceOrAddEnv($env, [
                 'ECCUBE_ADMIN_ALLOW_HOSTS' => "'{$adminAllowHosts}'",
                 'ECCUBE_FORCE_SSL' => $data['force_ssl'] ? 'true' : 'false',
                 'ECCUBE_SCHEME' => $data['force_ssl'] ? 'https' : 'http',
@@ -83,7 +83,7 @@ class SecurityController extends AbstractController
             $adminRoot = $this->eccubeConfig['eccube_admin_route'];
             if ($adminRoot !== $data['admin_route_dir']) {
 
-                $env = StringUtil::replaceEnv($env, [
+                $env = StringUtil::replaceOrAddEnv($env, [
                     'ECCUBE_ADMIN_ROUTE' => $data['admin_route_dir'],
                 ]);
 

--- a/src/Eccube/Controller/Admin/Store/TemplateController.php
+++ b/src/Eccube/Controller/Admin/Store/TemplateController.php
@@ -94,7 +94,7 @@ class TemplateController extends AbstractController
             $envFile = $this->getParameter('kernel.project_dir').'/.env';
             $env = file_get_contents($envFile);
 
-            $env = StringUtil::replaceEnv($env, [
+            $env = StringUtil::replaceOrAddEnv($env, [
                 'ECCUBE_TEMPLATE_CODE' => $Template->getCode(),
             ]);
 

--- a/src/Eccube/Util/StringUtil.php
+++ b/src/Eccube/Util/StringUtil.php
@@ -313,16 +313,21 @@ class StringUtil
     }
 
     /**
-     * envファイルのコンテンツを更新する.
+     * envファイルのコンテンツを更新または追加する.
      *
      * @param string $env
      * @param array $replacement
      * @return string
      */
-    public static function replaceEnv($env, array $replacement)
+    public static function replaceOrAddEnv($env, array $replacement)
     {
         foreach ($replacement as $key => $value) {
-            $env = preg_replace('/('.$key.')=(.*)/', '$1='.$value, $env);
+            $pattern = '/^('.$key.')=(.*)/m';
+            if (preg_match($pattern, $env)) {
+                $env = preg_replace($pattern, '$1='.$value, $env);
+            } else {
+                $env .= PHP_EOL."${key}=${value}";
+            }
         }
 
         return $env;

--- a/symfony.lock
+++ b/symfony.lock
@@ -470,6 +470,9 @@
     "twig/twig": {
         "version": "v2.4.4"
     },
+    "vlucas/phpdotenv": {
+        "version": "v2.4.0"
+    },
     "zendframework/zend-code": {
         "version": "3.3.0"
     },

--- a/tests/Eccube/Tests/Util/StringUtilTest.php
+++ b/tests/Eccube/Tests/Util/StringUtilTest.php
@@ -488,4 +488,25 @@ class StringUtilTest extends TestCase
         $this->actual = StringUtil::trimAll($text);
         $this->assertTrue($this->expected === $this->actual);
     }
+
+    /**
+     * @dataProvider replaceOrAddEnvProvider
+     */
+    public function testReplaceOrAddEnv($env, $replacement, $expected)
+    {
+        self::assertEquals($expected, StringUtil::replaceOrAddEnv($env, $replacement));
+    }
+
+    public function replaceOrAddEnvProvider()
+    {
+        return [
+            ['HOGE=HOGE', ['HOGE' => 'BAR'], 'HOGE=BAR'],
+            ['HOGE=HOGE', ['FOO' => 'BAR'], 'HOGE=HOGE'.PHP_EOL.'FOO=BAR'],
+            ['HOGE_HOGE=HOGE', ['HOGE' => 'BAR'], 'HOGE_HOGE=HOGE'.PHP_EOL.'HOGE=BAR'],
+            ['#HOGE=HOGE', ['HOGE' => 'BAR'], '#HOGE=HOGE'.PHP_EOL.'HOGE=BAR'],
+            ['HOGE=HOGE'.PHP_EOL.'FOO=FOO', ['HOGE' => 'BAR'], 'HOGE=BAR'.PHP_EOL.'FOO=FOO'],
+            ['HOGE=HOGE'.PHP_EOL.'FOO=FOO', ['FOO' => 'BAR'], 'HOGE=HOGE'.PHP_EOL.'FOO=BAR'],
+            ['HOGE=HOGE'.PHP_EOL.'FOO=FOO', ['HOGE' => 'hoge', 'FOO' => 'foo'], 'HOGE=hoge'.PHP_EOL.'FOO=foo'],
+        ];
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ .envよりも環境変数が優先されているためPHP dotenvを使うように変更
+ .envではなく環境変数で定義しているときに、管理画面から設定を変更したときは.envに追加するよう変更
+ .envのコメントアウト行を書き換えてしまう問題があったので、正規表現を変更

## テスト（Test)
+ StringUtilsTestにテストケースを追加

## マイナーバージョン互換性保持のための制限事項チェックリスト
- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



