### PR TITLE
Product::getClassCategories() をコントローラへ移動

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/System/LogController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/LogController.php
@@ -78,7 +78,7 @@ class LogController extends  AbstractController
             );
             $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_SETTING_SYSTEM_LOG_INDEX_COMPLETE, $event);
         }
-        $logDir = $this->getParameter('kernel.logs_dir');
+        $logDir = $this->getParameter('kernel.logs_dir').DIRECTORY_SEPARATOR.$this->getParameter('kernel.environment');
         $logFile = $logDir.'/'.$formData['files'];
 
         return [

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -41,6 +41,7 @@ use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Eccube\Service\PurchaseFlow\PurchaseFlow;
 use Knp\Component\Pager\Paginator;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -293,6 +294,7 @@ class ProductController extends AbstractController
      * @Method("GET")
      * @Route("/products/detail/{id}", name="product_detail", requirements={"id" = "\d+"})
      * @Template("Product/detail.twig")
+     * @ParamConverter("Product", options={"repository_method" = "getSortedByClassCategories"})
      * @param Request $request
      * @param Product $Product
      * @return array

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -335,6 +335,7 @@ class ProductController extends AbstractController
             'subtitle' => $Product->getName(),
             'form' => $builder->getForm()->createView(),
             'Product' => $Product,
+            'ClassCategories' => json_encode($this->createClassCategoriesAsArray($Product)),
             'is_favorite' => $is_favorite,
         ];
     }
@@ -553,5 +554,51 @@ class ProductController extends AbstractController
             }
         }
         return true;
+    }
+
+    /**
+     * @param Product $Product
+     * @return array
+     */
+    private function createClassCategoriesAsArray(Product $Product)
+    {
+        $Product->_calc();
+        $class_categories = [
+            '__unselected' => [
+                '__unselected' => [
+                    'name'              => trans('product.text.please_select'),
+                    'product_class_id'  => '',
+                ],
+            ],
+        ];
+        foreach ($Product->getProductClasses() as $ProductClass) {
+            /* @var $ProductClass \Eccube\Entity\ProductClass */
+            $ClassCategory1 = $ProductClass->getClassCategory1();
+            $ClassCategory2 = $ProductClass->getClassCategory2();
+            if ($ClassCategory2 && !$ClassCategory2->isVisible()) {
+                continue;
+            }
+            $class_category_id1 = $ClassCategory1 ? (string) $ClassCategory1->getId() : '__unselected2';
+            $class_category_id2 = $ClassCategory2 ? (string) $ClassCategory2->getId() : '';
+            $class_category_name2 = $ClassCategory2 ? $ClassCategory2->getName().($ProductClass->getStockFind() ? '' : trans('product.text.out_of_stock')) : '';
+
+            $class_categories[$class_category_id1]['#'] = array(
+                'classcategory_id2' => '',
+                'name'              => trans('product.text.please_select'),
+                'product_class_id'  => '',
+            );
+            $class_categories[$class_category_id1]['#'.$class_category_id2] = array(
+                'classcategory_id2' => $class_category_id2,
+                'name'              => $class_category_name2,
+                'stock_find'        => $ProductClass->getStockFind(),
+                'price01'           => $ProductClass->getPrice01() === null ? '' : number_format($ProductClass->getPrice01IncTax()),
+                'price02'           => number_format($ProductClass->getPrice02IncTax()),
+                'product_class_id'  => (string) $ProductClass->getId(),
+                'product_code'      => $ProductClass->getCode() === null ? '' : $ProductClass->getCode(),
+                'sale_type'      => (string) $ProductClass->getSaleType()->getId(),
+            );
+        }
+
+        return $class_categories;
     }
 }

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -294,7 +294,7 @@ class ProductController extends AbstractController
      * @Method("GET")
      * @Route("/products/detail/{id}", name="product_detail", requirements={"id" = "\d+"})
      * @Template("Product/detail.twig")
-     * @ParamConverter("Product", options={"repository_method" = "getSortedByClassCategories"})
+     * @ParamConverter("Product", options={"repository_method" = "findWithSortedClassCategories"})
      * @param Request $request
      * @param Product $Product
      * @return array

--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -393,55 +393,6 @@ class Product extends \Eccube\Entity\AbstractEntity
         return count($codes) ? max($codes) : null;
     }
 
-    /**
-     * Get ClassCategories
-     *
-     * @return array
-     * @deprecated Use ProductController::createClassCategoriesAsArray() instead.
-     */
-    public function getClassCategories()
-    {
-        @trigger_error('The '.__METHOD__.' method is deprecated, Use ProductController::createClassCategoriesAsArray() instead.', E_USER_DEPRECATED);
-        $this->_calc();
-        $class_categories = array(
-            '__unselected' => array(
-                '__unselected' => array(
-                    'name'              => trans('product.text.please_select'),
-                    'product_class_id'  => '',
-                ),
-            ),
-        );
-        foreach ($this->getProductClasses() as $ProductClass) {
-            /* @var $ProductClass \Eccube\Entity\ProductClass */
-            $ClassCategory1 = $ProductClass->getClassCategory1();
-            $ClassCategory2 = $ProductClass->getClassCategory2();
-            if ($ClassCategory2 && !$ClassCategory2->isVisible()) {
-                continue;
-            }
-            $class_category_id1 = $ClassCategory1 ? (string) $ClassCategory1->getId() : '__unselected2';
-            $class_category_id2 = $ClassCategory2 ? (string) $ClassCategory2->getId() : '';
-            $class_category_name2 = $ClassCategory2 ? $ClassCategory2->getName() . ($ProductClass->getStockFind() ? '' : trans('product.text.out_of_stock')) : '';
-
-            $class_categories[$class_category_id1]['#'] = array(
-                'classcategory_id2' => '',
-                'name'              => trans('product.text.please_select'),
-                'product_class_id'  => '',
-            );
-            $class_categories[$class_category_id1]['#'.$class_category_id2] = array(
-                'classcategory_id2' => $class_category_id2,
-                'name'              => $class_category_name2,
-                'stock_find'        => $ProductClass->getStockFind(),
-                'price01'           => $ProductClass->getPrice01() === null ? '' : number_format($ProductClass->getPrice01IncTax()),
-                'price02'           => number_format($ProductClass->getPrice02IncTax()),
-                'product_class_id'  => (string) $ProductClass->getId(),
-                'product_code'      => $ProductClass->getCode() === null ? '' : $ProductClass->getCode(),
-                'sale_type'      => (string) $ProductClass->getSaleType()->getId(),
-            );
-        }
-
-        return $class_categories;
-    }
-
     public function getMainListImage()
     {
         $ProductImages = $this->getProductImage();

--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -397,9 +397,11 @@ class Product extends \Eccube\Entity\AbstractEntity
      * Get ClassCategories
      *
      * @return array
+     * @deprecated Use ProductController::createClassCategoriesAsArray() instead.
      */
     public function getClassCategories()
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated, Use ProductController::createClassCategoriesAsArray() instead.', E_USER_DEPRECATED);
         $this->_calc();
         $class_categories = array(
             '__unselected' => array(
@@ -418,7 +420,6 @@ class Product extends \Eccube\Entity\AbstractEntity
             }
             $class_category_id1 = $ClassCategory1 ? (string) $ClassCategory1->getId() : '__unselected2';
             $class_category_id2 = $ClassCategory2 ? (string) $ClassCategory2->getId() : '';
-            $class_category_name1 = $ClassCategory1 ? $ClassCategory1->getName() . ($ProductClass->getStockFind() ? '' : trans('product.text.out_of_stock')) : '';
             $class_category_name2 = $ClassCategory2 ? $ClassCategory2->getName() . ($ProductClass->getStockFind() ? '' : trans('product.text.out_of_stock')) : '';
 
             $class_categories[$class_category_id1]['#'] = array(
@@ -441,7 +442,8 @@ class Product extends \Eccube\Entity\AbstractEntity
         return $class_categories;
     }
 
-    public function getMainListImage() {
+    public function getMainListImage()
+    {
         $ProductImages = $this->getProductImage();
         return empty($ProductImages) ? null : $ProductImages[0];
     }

--- a/src/Eccube/Form/Type/Admin/LogType.php
+++ b/src/Eccube/Form/Type/Admin/LogType.php
@@ -65,7 +65,8 @@ class LogType extends AbstractType
         $files = array();
         $finder = new Finder();
         $finder->name('*.log')->depth('== 0');
-        foreach ($finder->in($this->kernel->getLogDir()) as $file) {
+        $dirs = $this->kernel->getLogDir().DIRECTORY_SEPARATOR.$this->kernel->getEnvironment();
+        foreach ($finder->in($dirs) as $file) {
             $files[$file->getFilename()] = $file->getFilename();
         }
 

--- a/src/Eccube/Form/Type/Admin/MemberType.php
+++ b/src/Eccube/Form/Type/Admin/MemberType.php
@@ -41,6 +41,11 @@ class MemberType extends AbstractType
     protected $eccubeConfig;
 
     /**
+     * @var string
+     */
+    protected $blankMessage = 'admin.system.member.form.not.blank';
+
+    /**
      * MemberType constructor.
      *
      * @param EccubeConfig $eccubeConfig
@@ -60,7 +65,7 @@ class MemberType extends AbstractType
             ->add('name', TextType::class, array(
                 'label' => 'member.label.name',
                 'constraints' => array(
-                    new Assert\NotBlank(),
+                    new Assert\NotBlank(array('message' => $this->blankMessage)),
                     new Assert\Length(array('max' => $this->eccubeConfig['eccube_stext_len'])),
                 ),
             ))
@@ -68,14 +73,14 @@ class MemberType extends AbstractType
                 'required' => false,
                 'label' => 'member.label.organization',
                 'constraints' => array(
-                    new Assert\NotBlank(),
+                    new Assert\NotBlank(array('message' => $this->blankMessage)),
                     new Assert\Length(array('max' => $this->eccubeConfig['eccube_stext_len'])),
                 ),
             ))
             ->add('login_id', TextType::class, array(
                 'label' => 'member.label.login_id',
                 'constraints' => array(
-                    new Assert\NotBlank(),
+                    new Assert\NotBlank(array('message' => $this->blankMessage)),
                     new Assert\Length(array(
                         'min' => $this->eccubeConfig['eccube_id_min_len'],
                         'max' => $this->eccubeConfig['eccube_id_max_len'],
@@ -92,7 +97,7 @@ class MemberType extends AbstractType
                     'label' => 'member.label.varify_pass',
                 ),
                 'constraints' => array(
-                    new Assert\NotBlank(),
+                    new Assert\NotBlank(array('message' => $this->blankMessage)),
                     new Assert\Length(array(
                         'min' => $this->eccubeConfig['eccube_id_min_len'],
                         'max' => $this->eccubeConfig['eccube_id_max_len'],
@@ -107,7 +112,7 @@ class MemberType extends AbstractType
                 'multiple' => false,
                 'placeholder' => 'form.empty_value',
                 'constraints' => array(
-                    new Assert\NotBlank(),
+                    new Assert\NotBlank(array('message' => $this->blankMessage)),
                 ),
             ))
             ->add('Work', EntityType::class, array(
@@ -116,7 +121,7 @@ class MemberType extends AbstractType
                 'expanded' => true,
                 'multiple' => false,
                 'constraints' => array(
-                    new Assert\NotBlank(),
+                    new Assert\NotBlank(array('message' => $this->blankMessage)),
                 ),
             ))
         ;

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -67,6 +67,33 @@ class ProductRepository extends AbstractRepository
         $this->eccubeConfig = $eccubeConfig;
     }
 
+    /**
+     * Get the Product as sorted by ClassCategories.
+     *
+     * @param integer $productId
+     * @return Product
+     */
+    public function getSortedByClassCategories($productId)
+    {
+        $qb = $this->createQueryBuilder('p');
+        $qb->addSelect(array('pc', 'cc1', 'cc2', 'pi', 'ps'))
+            ->innerJoin('p.ProductClasses', 'pc')
+            ->leftJoin('pc.ClassCategory1', 'cc1')
+            ->leftJoin('pc.ClassCategory2', 'cc2')
+            ->leftJoin('p.ProductImage', 'pi')
+            ->innerJoin('pc.ProductStock', 'ps')
+            ->where('p.id = :id')
+            ->orderBy('cc1.sort_no', 'DESC')
+            ->addOrderBy('cc2.sort_no', 'DESC');
+        $product = $qb
+            ->setParameters(array(
+                'id' => $productId,
+            ))
+            ->getQuery()
+            ->getSingleResult();
+        return $product;
+    }
+
    /**
      * get query builder.
      *

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -68,12 +68,12 @@ class ProductRepository extends AbstractRepository
     }
 
     /**
-     * Get the Product as sorted by ClassCategories.
+     * Find the Product with sorted ClassCategories.
      *
      * @param integer $productId
      * @return Product
      */
-    public function getSortedByClassCategories($productId)
+    public function findWithSortedClassCategories($productId)
     {
         $qb = $this->createQueryBuilder('p');
         $qb->addSelect(array('pc', 'cc1', 'cc2', 'pi', 'ps'))

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -229,6 +229,7 @@ return [
     'admin.delivery.visible.complete' => '表示に変更しました。',
     'admin.delivery.hidden.complete' => '非表示に変更しました。',
     'admin_title' => 'EC-CUBE 管理機能',
+    'admin.system.member.form.not.blank' => '入力されていません。',
     'normal_price_title' => '通常価格',
     'sale_price_title' => '販売価格',
     'form.address1.help' => '市区町村名 (例：千代田区神田神保町)',

--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -105,7 +105,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 {% block javascript %}
     <script>
-        eccube.classCategories = {{ Product.class_categories|json_encode|raw }};
+        eccube.classCategories = {{ ClassCategories|raw }};
 
         // 規格2に選択肢を割り当てる。
         function fnSetClassCategories(form, classcat_id2_selected) {

--- a/tests/Eccube/Tests/Web/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/ProductControllerTest.php
@@ -24,11 +24,19 @@
 
 namespace Eccube\Tests\Web;
 
+use Eccube\Controller\ProductController;
+use Eccube\Entity\BaseInfo;
+use Eccube\Entity\Product;
 use Eccube\Entity\ProductClass;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\ClassCategoryRepository;
+use Eccube\Repository\CustomerFavoriteProductRepository;
+use Eccube\Repository\ProductRepository;
+use Eccube\Service\CartService;
+use Eccube\Service\PurchaseFlow\PurchaseFlow;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpKernel\Client;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class ProductControllerTest extends AbstractWebTestCase
 {
@@ -212,5 +220,58 @@ class ProductControllerTest extends AbstractWebTestCase
         $html = $crawler->filter('div.ec-productRole__profile')->html();
         $this->assertContains('カートに入れる', $html);
         $this->assertContains('お気に入りに追加済みです', $html);
+    }
+
+    public function testCreateClassCategories()
+    {
+        $Controller = new ProductController(
+            $this->container->get('eccube.purchase.flow.cart'),
+            $this->container->get(CustomerFavoriteProductRepository::class),
+            $this->container->get(CartService::class),
+            $this->container->get(ProductRepository::class),
+            $this->container->get(BaseInfo::class),
+            $this->container->get('security.authentication_utils')
+        );
+        $faker = $this->getFaker();
+        $Product = $this->createProduct($faker->word, 3);
+
+        $RefClass = new \ReflectionClass($Controller);
+        $RefMethod = $RefClass->getMethod('createClassCategoriesAsArray');
+        $RefMethod->setAccessible(true);
+        $actuals = $RefMethod->invoke($Controller, $Product);
+
+        foreach ($Product->getClassCategories1() as $class_category_id => $name) {
+            $this->assertArrayHasKey($class_category_id, $actuals);
+
+            $ClassCategory2 = $Product->getClassCategories2($class_category_id);
+            if (empty($ClassCategory2)) {
+                $this->markTestSkipped('ClassCategory2 is empty.');
+            }
+
+            foreach ($ClassCategory2 as $class_category_id2 => $name2) {
+                $this->assertArrayHasKey('#'.$class_category_id2, $actuals[$class_category_id]);
+
+                $actual = $actuals[$class_category_id]['#'.$class_category_id2];
+
+                $this->assertEquals($class_category_id2, $actual['classcategory_id2']);
+                $this->assertEquals($name2, $actual['name']);
+
+                $ProductClass = $Product
+                    ->getProductClasses()
+                    ->filter(
+                        function ($ProductClass) use ($actual) {
+                            return $ProductClass->getId() == $actual['product_class_id'];
+                        })
+                    ->first();
+
+                if ($ProductClass->getPrice01IncTax()) {
+                    $this->assertEquals(number_format($ProductClass->getPrice01IncTax()), $actual['price01']);
+                }
+                $this->assertEquals(number_format($ProductClass->getPrice02IncTax()), $actual['price02']);
+                $this->assertEquals($ProductClass->getCode(), $actual['product_code']);
+                $this->assertEquals($ProductClass->getSaleType()->getId(), $actual['sale_type']);
+                $this->assertEquals($ProductClass->getStockFind(), $actual['stock_find']);
+            }
+        }
     }
 }

--- a/tests/Eccube/Tests/Web/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/ProductControllerTest.php
@@ -105,7 +105,6 @@ class ProductControllerTest extends AbstractWebTestCase
      */
     public function testProductClassSortByRank()
     {
-        $this->markTestIncomplete('FIXME Order by ProductClass');
         /* @var $ClassCategory \Eccube\Entity\ClassCategory */
         //set 金 rank
         $ClassCategory = $this->classCategoryRepository->findOneBy(array('name' => '金'));


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ Product::getClassCategories() をコントローラへ移動
+ #2837 商品詳細画面の規格プルダウンのソートを修正

## 方針(Policy)
+ 規格プルダウンのソート順は、 `@ParamConverter` から `ProductRepository:: findWithSortedClassCategories()` をコールしています


## テスト（Test)
+ experimental/sf ブランチでユニットテストが通るのを確認

## 相談（Discussion）
+ `findWithSortedClassCategories` や `createClassCategoriesAsArray` は不自然でないかどうか。
