### PR TITLE
heroku-postgresqlのversion指定

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,9 +5,11 @@
     "repository": "https://github.com/EC-CUBE/ec-cube",
     "keywords": ["php", "ec", "e-commerce", "ec-cube"],
     "addons": [
-        "plan": "heroku-postgresql",
-        "options": {
-            "version": "9.6"
+        {
+            "plan": "heroku-postgresql",
+            "options": {
+              "version": "9.6"
+            }
         }
     ],
     "buildpacks": [

--- a/app.json
+++ b/app.json
@@ -5,7 +5,10 @@
     "repository": "https://github.com/EC-CUBE/ec-cube",
     "keywords": ["php", "ec", "e-commerce", "ec-cube"],
     "addons": [
-        "heroku-postgresql"
+        "plan": "heroku-postgresql",
+        "options": {
+            "version": "9.6"
+        }
     ],
     "buildpacks": [
         {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
postgresqlの10だとエラーになるため、heroku-postgresqlのversion指定
https://github.com/EC-CUBE/ec-cube/issues/2852

forkしてdeploy完了することを動作確認済み




