### PR TITLE
個別税率設定変更後にBaseInfoのキャッシュをクリアするように修正

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/Shop/TaxRuleController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/TaxRuleController.php
@@ -31,6 +31,7 @@ use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
 use Eccube\Form\Type\Admin\TaxRuleType;
 use Eccube\Repository\TaxRuleRepository;
+use Eccube\Util\CacheUtil;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -176,7 +177,7 @@ class TaxRuleController extends AbstractController
      * @Method("POST")
      * @Route("/%eccube_admin_route%/setting/shop/tax/edit_param", name="admin_setting_shop_tax_edit_param")
      */
-    public function editParameter(Request $request)
+    public function editParameter(Request $request, CacheUtil $cacheUtil)
     {
         $builder = $this->formFactory
             ->createBuilder(TaxRuleType::class);
@@ -196,7 +197,10 @@ class TaxRuleController extends AbstractController
         if ($form->isSubmitted() && $form['option_product_tax_rule']->isValid()) {
 
             $this->BaseInfo->setOptionProductTaxRule($form['option_product_tax_rule']->getData());
+            $this->entityManager->persist($this->BaseInfo);
             $this->entityManager->flush();
+
+            $cacheUtil->clearCache();
 
             $event = new EventArgs(
                 array(

--- a/tests/Eccube/Tests/Web/Admin/Setting/Shop/TaxRuleControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/Shop/TaxRuleControllerTest.php
@@ -80,6 +80,9 @@ class TaxRuleControllerTest extends AbstractAdminWebTestCase
         $this->assertSame(true, $actual);
     }
 
+    /**
+     * @group cache-clear
+     */
     public function testRoutingEditParam()
     {
         $this->client->request(
@@ -90,6 +93,9 @@ class TaxRuleControllerTest extends AbstractAdminWebTestCase
         $this->assertTrue($this->client->getResponse()->isRedirect($redirectUrl));
     }
 
+    /**
+     * @group cache-clear
+     */
     public function testEditParam()
     {
         $BaseInfo = $this->container->get(BaseInfoRepository::class)->get();
@@ -115,6 +121,9 @@ class TaxRuleControllerTest extends AbstractAdminWebTestCase
         $this->verify();
     }
 
+    /**
+     * @group cache-clear
+     */
     public function testEditParamFail()
     {
         $BaseInfo = $this->container->get(BaseInfoRepository::class)->get();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 個別税率設定の有効無効を変更したとき、DB上は更新されているがキャッシュが有効になっているので画面上では更新されない不具合を修正
+ dev環境では問題ないが、prod環境で発生

## 相談（Discussion）
+ 頻繁に変更する設定でもないので、他のキャッシュもまとめて削除しています。

