### PR TITLE
Travis CI での PHPUnit の高速化

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,11 @@ install:
   - ./vendor/bin/simple-phpunit install
 
 before_script:
+  ## see https://github.com/symfony/symfony/blob/e0bdc0c35e9afdb3bee8af172f90e9648c4012fc/.travis.yml#L92-L97
   - phpenv config-rm xdebug.ini || true
+  - echo "session.gc_probability = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "opcache.enable_cli = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "apc.enable_cli = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,18 +51,17 @@ matrix:
     # php7.2
     - php: 7.2
 
+before_install:
+  ## see https://github.com/symfony/symfony/blob/e0bdc0c35e9afdb3bee8af172f90e9648c4012fc/.travis.yml#L92-L97
+  - phpenv config-rm xdebug.ini || true
+  - echo "opcache.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "apc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
 install:
   - composer install --dev --no-interaction -o
   - composer run-script installer-scripts
   - ./vendor/bin/simple-phpunit install
-
-before_script:
-  ## see https://github.com/symfony/symfony/blob/e0bdc0c35e9afdb3bee8af172f90e9648c4012fc/.travis.yml#L92-L97
-  - phpenv config-rm xdebug.ini || true
-  - echo "session.gc_probability = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - echo "opcache.enable_cli = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - echo "apc.enable_cli = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 script:
   - if [ $COVERAGE ]  ; then phpdbg -qrr ./bin/phpunit --coverage-clover=coverage.clover ; fi

--- a/tests/Eccube/Tests/Doctrine/ORM/Tools/PaginationTest.php
+++ b/tests/Eccube/Tests/Doctrine/ORM/Tools/PaginationTest.php
@@ -94,7 +94,7 @@ class PaginationTest extends EccubeTestCase
 
         // 初期データより大きい値を指定
         $price02 = $this->getFaker()->randomNumber(9);
-        for ($i = 0; $i < 30; $i++) {
+        for ($i = 0; $i < 5; $i++) {
             $Product = $this->createProduct(null, 3);
             $this->expectedIds[] = $Product->getId();
 
@@ -147,7 +147,7 @@ class PaginationTest extends EccubeTestCase
         // product_class.price02 でソートするようカスタマイズ
         $qb->orderBy('pc.price02', 'DESC');
 
-        $pageMax = 10;
+        $pageMax = 3;
         $pagination = $this->paginator->paginate(
             $qb,
             1,
@@ -201,7 +201,7 @@ class PaginationTest extends EccubeTestCase
             $expectedIds[] = $Product->getId();
         }
 
-        $pageMax = 10;
+        $pageMax = 3;
         try {
             $pagination = $this->paginator->paginate(
                 $qb,
@@ -263,7 +263,7 @@ class PaginationTest extends EccubeTestCase
         $pagination = $this->paginator->paginate(
             $qb,
             1,
-            30,
+            3,
             ['wrap-queries' => true]
         );
 
@@ -315,7 +315,7 @@ class PaginationTest extends EccubeTestCase
         $pagination = $this->paginator->paginate(
             $qb,
             1,
-            30,
+            3,
             ['wrap-queries' => true]
         );
 

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
@@ -350,7 +350,7 @@ class ProductRepositoryGetQueryBuilderBySearchDataTest extends AbstractProductRe
         );
         $this->deleteAllRows($tables);
         $productList = array();
-        for ($i = 0; $i <= 30; $i++) {
+        for ($i = 0; $i <= 5; $i++) {
             $classNo = mt_rand(1, 3);
             $productName = '商品-' . $i;
             $Product = $this->createProduct($productName, $classNo);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 過剰なデータ生成の削減
+ Zend OPcache と APCu を cli でも有効に設定
+ `composer install` の前に php.ini の設定をするよう修正

## テスト（Test)
+ ユニットテストが通ることを確認

## 相談（Discussion）
+ そろそろ PHP7.2 を allow_failures から外す🤔
