### PR TITLE
Fix failed unserialize

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -1072,10 +1072,7 @@ class ShoppingController extends AbstractController
             }
 
             // 非会員用セッションを作成
-            $nonMember = array();
-            $nonMember['customer'] = $Customer;
-            $nonMember['pref'] = $Customer->getPref()->getId();
-            $app['session']->set($this->sessionKey, $nonMember);
+            $app['eccube.service.shopping']->setNonMember($this->sessionKey, $Customer);
 
             $customerAddresses = array();
             $customerAddresses[] = $CustomerAddress;

--- a/src/Eccube/Entity/Customer.php
+++ b/src/Eccube/Entity/Customer.php
@@ -32,7 +32,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 /**
  * Customer
  */
-class Customer extends \Eccube\Entity\AbstractEntity implements UserInterface
+class Customer extends \Eccube\Entity\AbstractEntity implements UserInterface, \Serializable
 {
     /**
      * @var integer
@@ -1237,5 +1237,42 @@ class Customer extends \Eccube\Entity\AbstractEntity implements UserInterface
         $this->CustomerAddresses[] = $customerAddresses;
 
         return $this;
+    }
+
+    /**
+     * String representation of object
+     * @link http://php.net/manual/en/serializable.serialize.php
+     * @return string the string representation of the object or null
+     * @since 5.1.0
+     */
+    public function serialize()
+    {
+        // see https://symfony.com/doc/2.7/security/entity_provider.html#create-your-user-entity
+        // CustomerRepository::loadUserByUsername() で Status をチェックしているため、ここでは不要
+        return serialize(array(
+            $this->id,
+            $this->email,
+            $this->password,
+            $this->salt,
+        ));
+    }
+
+    /**
+     * Constructs the object
+     * @link http://php.net/manual/en/serializable.unserialize.php
+     * @param string $serialized <p>
+     * The string representation of the object.
+     * </p>
+     * @return void
+     * @since 5.1.0
+     */
+    public function unserialize($serialized)
+    {
+        list (
+            $this->id,
+            $this->email,
+            $this->password,
+            $this->salt,
+            ) = unserialize($serialized);
     }
 }

--- a/src/Eccube/Entity/Member.php
+++ b/src/Eccube/Entity/Member.php
@@ -32,7 +32,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 /**
  * Member
  */
-class Member extends \Eccube\Entity\AbstractEntity implements UserInterface
+class Member extends \Eccube\Entity\AbstractEntity implements UserInterface, \Serializable
 {
     public static function loadValidatorMetadata(ClassMetadata $metadata)
     {
@@ -453,5 +453,40 @@ class Member extends \Eccube\Entity\AbstractEntity implements UserInterface
     public function getLoginDate()
     {
         return $this->login_date;
+    }
+
+    /**
+     * String representation of object
+     * @link http://php.net/manual/en/serializable.serialize.php
+     * @return string the string representation of the object or null
+     * @since 5.1.0
+     */
+    public function serialize()
+    {
+        return serialize(array(
+            $this->id,
+            $this->login_id,
+            $this->password,
+            $this->salt,
+        ));
+    }
+
+    /**
+     * Constructs the object
+     * @link http://php.net/manual/en/serializable.unserialize.php
+     * @param string $serialized <p>
+     * The string representation of the object.
+     * </p>
+     * @return void
+     * @since 5.1.0
+     */
+    public function unserialize($serialized)
+    {
+        list (
+            $this->id,
+            $this->login_id,
+            $this->password,
+            $this->salt,
+            ) = unserialize($serialized);
     }
 }

--- a/src/Eccube/Entity/Member.php
+++ b/src/Eccube/Entity/Member.php
@@ -463,6 +463,8 @@ class Member extends \Eccube\Entity\AbstractEntity implements UserInterface, \Se
      */
     public function serialize()
     {
+        // see https://symfony.com/doc/2.7/security/entity_provider.html#create-your-user-entity
+        // MemberRepository::loadUserByUsername() で Work をチェックしているため、ここでは不要
         return serialize(array(
             $this->id,
             $this->login_id,

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -119,10 +119,26 @@ class ShoppingService
         }
 
         $Customer = $nonMember['customer'];
+        $Customer->setPropertiesFromArray($nonMember, array('customer', 'id', 'pref', 'email', 'password', 'salt'));
         $Customer->setPref($this->app['eccube.repository.master.pref']->find($nonMember['pref']));
-
         return $Customer;
+    }
 
+    /**
+     * 非会員情報をセッションに設定する
+     *
+     * @param $sesisonKey
+     * @param Customer $Customer
+     * @return ShoppingService
+     */
+    public function setNonMember($sessionKey, Customer $Customer)
+    {
+        $nonMember = $Customer->toArray(array('id', 'email', 'password', 'salt'));
+        $nonMember['pref'] = $Customer->getPref()->getId();
+        $nonMember['customer'] = $Customer; // Customer::serialize() で対象となっているプロパティのみ保存される
+        $this->app['session']->set($sessionKey, $nonMember);
+
+        return $this;
     }
 
     /**

--- a/tests/Eccube/Tests/Entity/CustomerTest.php
+++ b/tests/Eccube/Tests/Entity/CustomerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Eccube\Tests\Entity;
+
+use Eccube\Entity\Member;
+use Eccube\Tests\EccubeTestCase;
+
+/**
+ * Customer test cases.
+ *
+ * @author Kentaro Ohkouchi
+ */
+class CustomerTest extends EccubeTestCase
+{
+    protected $Customer;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->Customer = $this->createCustomer();
+    }
+
+    public function testSerialize()
+    {
+        $this->expected = serialize(
+            array(
+                $this->Customer->getId(),
+                $this->Customer->getUsername(),
+                $this->Customer->getPassword(),
+                $this->Customer->getSalt()
+            )
+        );
+        $this->actual = $this->Customer->serialize();
+        $this->verify();
+    }
+
+    public function testUnserialize()
+    {
+        $serializable = serialize(
+            array(
+                $this->Customer->getId(),
+                $this->Customer->getUsername(),
+                $this->Customer->getPassword(),
+                $this->Customer->getSalt()
+            )
+        );
+        $this->expected = clone $this->Customer;
+        $this->Customer->unserialize($serializable);
+        $this->actual = $this->Customer;
+        $this->verify();
+    }
+}

--- a/tests/Eccube/Tests/Entity/MemberTest.php
+++ b/tests/Eccube/Tests/Entity/MemberTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Eccube\Tests\Entity;
+
+use Eccube\Entity\Member;
+use Eccube\Tests\EccubeTestCase;
+
+/**
+ * Member test cases.
+ *
+ * @author Kentaro Ohkouchi
+ */
+class MemberTest extends EccubeTestCase
+{
+    protected $Member;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->Member = $this->createMember();
+    }
+
+    public function testSerialize()
+    {
+        $this->expected = serialize(
+            array(
+                $this->Member->getId(),
+                $this->Member->getUsername(),
+                $this->Member->getPassword(),
+                $this->Member->getSalt()
+            )
+        );
+        $this->actual = $this->Member->serialize();
+        $this->verify();
+    }
+
+    public function testUnserialize()
+    {
+        $serializable = serialize(
+            array(
+                $this->Member->getId(),
+                $this->Member->getUsername(),
+                $this->Member->getPassword(),
+                $this->Member->getSalt()
+            )
+        );
+        $this->expected = clone $this->Member;
+        $this->Member->unserialize($serializable);
+        $this->actual = $this->Member;
+        $this->verify();
+    }
+}

--- a/tests/Eccube/Tests/Service/ShoppingServiceTest.php
+++ b/tests/Eccube/Tests/Service/ShoppingServiceTest.php
@@ -4,6 +4,7 @@ namespace Eccube\Tests\Service;
 
 use Eccube\Application;
 use Eccube\Common\Constant;
+use Eccube\Entity\Customer;
 use Eccube\Entity\Master\Taxrule;
 use Eccube\Entity\Shipping;
 use Eccube\Exception\ShoppingException;
@@ -130,6 +131,34 @@ class ShoppingServiceTest extends AbstractServiceTestCase
         $this->expected = $NonMember->getPref()->getId();
         $this->actual = $Customer->getPref()->getId();
         $this->verify('都道府県IDが一致するか');
+
+        $this->expected = $NonMember->getName01();
+        $this->actual = $Customer->getName01();
+        $this->verify('name01 が一致するか');
+    }
+
+    public function testSetNonMember()
+    {
+        $NonMember = $this->createNonMember();
+        $CopyNonMember = new Customer();
+        $CopyNonMember->copyProperties($NonMember);
+        $this->app['eccube.service.shopping']->setNonMember('eccube.front.shopping.nonmember', $CopyNonMember);
+
+        $Customer = $this->app['eccube.service.shopping']->getNonMember('eccube.front.shopping.nonmember');
+
+        $this->expected = $NonMember->getEmail();
+        $this->actual = $Customer->getEmail();
+        $this->verify('保存したメールアドレスが一致するか');
+
+        $this->expected = $NonMember->getPref()->getId();
+        $this->actual = $Customer->getPref()->getId();
+        $this->verify('保存した都道府県IDが一致するか');
+
+        $this->expected = $NonMember->getName01();
+        $this->actual = $Customer->getName01();
+        $this->verify('保存した name01 が一致するか');
+
+        $this->assertNotSame($Customer, $NonMember);
     }
 
     public function testGetDeliveries()

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
@@ -150,8 +150,12 @@ class ShoppingControllerWithNonmemberTest extends AbstractShoppingControllerTest
         $this->assertNotNull($this->app['session']->get('eccube.front.shopping.nonmember.customeraddress'));
 
         $this->expected = $formData['name']['name01'];
-        $this->actual = $Nonmember['customer']->getName01();
-        $this->verify();
+        $this->actual = $Nonmember['name01'];
+        $this->verify('name01はセッションに保存されているか');
+
+        $this->expected = $formData['email']['first'];
+        $this->actual = $Nonmember['customer']->getEmail();
+        $this->verify('Email はセッションから unserialize されているか');
 
         $this->assertTrue($client->getResponse()->isRedirect($this->app->url('shopping')));
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ Symfony 2.7.41 の更新で、 unserialize に失敗するようになったのを修正
+ https://github.com/symfony/symfony/issues/24731
+ https://github.com/symfony/symfony/pull/25669

## 方針(Policy)
+ Customer 及び Member に Serializable インターフェイスを実装
+ `ShoppingService::setNonMember()` を追加

## 実装に関する補足(Appendix)
+ Symfony のドキュメントでは、ユーザーの有効無効判定をするには [AdvancedUserInterface](https://symfony.com/doc/2.7/security/entity_provider.html#forbid-inactive-users-advanceduserinterface) を実装し、`active` プロパティも serialize/unserialize しろとあるが、 EC-CUBE の場合は`UserProviderInterface::loadUserByUsername()` で有効無効判定をしているため不要
+ 非会員の場合、 Customer オブジェクトをセッションに保存するが、 serialize 対象のプロパティしか保存されないため、 `ShoppingService::setNonMember()`, `ShoppingService::getNonMember()` を使用する必要がある

## テスト（Test)
+ テストを行っている範囲など、レビューアが安心できるような情報

## 相談（Discussion）
+ 特に無し

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更


