### PR TITLE
プラグインのアンインストール時に全テーブルが削除される不具合の修正

### DIFF
--- a/src/Eccube/DependencyInjection/Compiler/PluginPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/PluginPass.php
@@ -12,10 +12,6 @@ class PluginPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasParameter('eccube.plugins.disabled')) {
-            return;
-        }
-
         $plugins = $container->getParameter('eccube.plugins.disabled');
 
         if (empty($plugins)) {

--- a/src/Eccube/DependencyInjection/EccubeExtension.php
+++ b/src/Eccube/DependencyInjection/EccubeExtension.php
@@ -32,6 +32,7 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
         if (!array_key_exists('APP_ENV', $_ENV) || $_ENV['APP_ENV'] == 'test') {
             return;
         }
+
         // doctrine.yml, または他のprependで差し込まれたdoctrineの設定値を取得する.
         $configs = $container->getExtensionConfig('doctrine');
 
@@ -55,19 +56,18 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
         $stmt = $conn->query('select * from dtb_plugin');
         $plugins = $stmt->fetchAll();
 
-        $enabled = array_filter($plugins, function($plugin) {
-            return true === (bool) $plugin['enabled'];
+        $enabled = array_filter($plugins, function ($plugin) {
+            return true === (bool)$plugin['enabled'];
         });
 
-        $disabled = array_filter($plugins, function($plugin) {
-            return false === (bool) $plugin['enabled'];
+        $disabled = array_filter($plugins, function ($plugin) {
+            return false === (bool)$plugin['enabled'];
         });
 
         // 他で使いまわすため, パラメータで保持しておく.
         $container->setParameter('eccube.plugins.enabled', $enabled);
         $container->setParameter('eccube.plugins.disabled', $disabled);
 
-        // mapping情報の構築
         $pluginDir = $container->getParameter('kernel.project_dir').'/app/Plugin';
         $this->configureTwigPaths($container, $enabled, $pluginDir);
         $this->configureTranslations($container, $enabled, $pluginDir);
@@ -87,7 +87,7 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
 
         if (!empty($paths)) {
             $container->prependExtensionConfig('twig', [
-                'paths' => $paths
+                'paths' => $paths,
             ]);
         }
     }
@@ -98,7 +98,7 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
 
         foreach ($enabled as $plugin) {
             $code = $plugin['code'];
-            $dir = $pluginDir . '/' . $code . '/Resource/locale';
+            $dir = $pluginDir.'/'.$code.'/Resource/locale';
             if (file_exists($dir)) {
                 $paths[] = $dir;
             }
@@ -107,8 +107,8 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
         if (!empty($paths)) {
             $container->prependExtensionConfig('framework', [
                 'translator' => [
-                    'paths' => $paths
-                ]
+                    'paths' => $paths,
+                ],
             ]);
         }
     }

--- a/src/Eccube/DependencyInjection/EccubeExtension.php
+++ b/src/Eccube/DependencyInjection/EccubeExtension.php
@@ -23,10 +23,6 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
      */
     public function prepend(ContainerBuilder $container)
     {
-        // TODO EC-CUBEのインストール状態のチェックを行う
-        if (!$container->hasParameter('eccube.install')) {
-            //return;
-        }
         // FIXME WebTestCase で DATABASE_URL が取得できず落ちる
         if (!array_key_exists('APP_ENV', $_ENV) || $_ENV['APP_ENV'] == 'test') {
             return;

--- a/src/Eccube/DependencyInjection/EccubeExtension.php
+++ b/src/Eccube/DependencyInjection/EccubeExtension.php
@@ -23,6 +23,9 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
      */
     public function prepend(ContainerBuilder $container)
     {
+        $container->setParameter('eccube.plugins.enabled', []);
+        $container->setParameter('eccube.plugins.disabled', []);
+
         // FIXME WebTestCase で DATABASE_URL が取得できず落ちる
         if (!array_key_exists('APP_ENV', $_ENV) || $_ENV['APP_ENV'] == 'test') {
             return;

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -124,15 +124,13 @@ class Kernel extends BaseKernel
         $builder->setSchemes($scheme);
 
         // 有効なプラグインのルーティングをインポートする.
-        if ($container->hasParameter('eccube.plugins.enabled')) {
-            $plugins = $container->getParameter('eccube.plugins.enabled');
-            $pluginDir = $this->getProjectDir().'/app/Plugin';
-            foreach ($plugins as $plugin) {
-                $dir = $pluginDir.'/'.$plugin['code'].'/Controller';
-                if (file_exists($dir)) {
-                    $builder = $routes->import($dir, '/', 'annotation');
-                    $builder->setSchemes($scheme);
-                }
+        $plugins = $container->getParameter('eccube.plugins.enabled');
+        $pluginDir = $this->getProjectDir().'/app/Plugin';
+        foreach ($plugins as $plugin) {
+            $dir = $pluginDir.'/'.$plugin['code'].'/Controller';
+            if (file_exists($dir)) {
+                $builder = $routes->import($dir, '/', 'annotation');
+                $builder->setSchemes($scheme);
             }
         }
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- `bin/console eccube:plugin:uninstall --code=Xxx`を実行した際にテーブルがすべて削除される
- 各driverがすべてのエンティティのメタデータを保持していたため, 削除対象のテーブルを絞れていなかった
- namespaceごとにdriverを生成するように修正(https://github.com/EC-CUBE/ec-cube/commit/b7c8e96950fc6538f4e67c0eaf90387db48fd128)
- その他細かな修正



