### PR TITLE
商品登録画面で、画像の削除ができない不具合を修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -572,7 +572,7 @@ class ProductController extends AbstractController
 
                 // 削除
                 $fs = new Filesystem();
-                $fs->remove($this->eccubeConfig['eccube_image_save_realdir'].'/'.$delete_image);
+                $fs->remove($this->eccubeConfig['eccube_save_image_dir'].'/'.$delete_image);
             }
             $this->entityManager->persist($Product);
             $this->entityManager->flush();
@@ -790,7 +790,7 @@ class ProductController extends AbstractController
                     $filename = date('mdHis').uniqid('_').'.'.$extension;
                     try {
                         $fs = new Filesystem();
-                        $fs->copy($this->eccubeConfig['eccube_image_save_realdir'].'/'.$Image->getFileName(), $this->eccubeConfig['eccube_image_save_realdir'].'/'.$filename);
+                        $fs->copy($this->eccubeConfig['eccube_save_image_dir'].'/'.$Image->getFileName(), $this->eccubeConfig['eccube_save_image_dir'].'/'.$filename);
                     } catch (\Exception $e) {
                         // エラーが発生しても無視する
                     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 商品管理で、画像のアップロードと更新ができるように。

## 実装に関する補足(Appendix)
+ 画像の登録時に、eccube_save_image_dirを使ったから、画像の削除と新規作成のところに、「eccube_image_save_realdir」を「eccube_image_save_realdir」に更新しました。

## テスト（Test)
・Webserver: Apache 2.4
・PHP: 7.1
・Database: MySQL 5.7 & PgSQL 9.6


