### PR TITLE
styleguideの組み込み準備

### DIFF
--- a/src/Eccube/Resource/template/admin/Form/bootstrap_4_layout.html.twig
+++ b/src/Eccube/Resource/template/admin/Form/bootstrap_4_layout.html.twig
@@ -1,0 +1,54 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{%- extends 'bootstrap_4_layout.html.twig' -%}
+
+{%- block form_rest -%}
+    {% set attr = attr|merge({class: attr.class|default('')}) %}
+    {% if attr.class == 'search' %}
+        <div class="col-md-offset-1 col-lg-offset-2 search clearfix">
+        {% for child in form %}
+            {% if not child.rendered %}
+                <div class="col-sm-6 col-md-5 col-lg-5">
+                    {{ form_row(child) }}
+                </div>
+            {% endif %}
+        {% endfor %}
+        </div>
+    {% else %}
+        {{ parent() }}
+    {% endif %}
+{%- endblock form_rest -%}
+
+
+{%- block form_widget -%}
+    {% set attr = attr|merge({class: attr.class|default('')}) %}
+    {% if attr.class == 'input_search' %}
+        {{- parent() -}}
+    {% else %}
+        <div class="form-group">
+            {{- parent() -}}
+        </div>
+    {% endif %}
+{%- endblock form_widget -%}
+
+
+


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

styleguideの組み込み準備のためbootstrap_4_layout.html.twigを追加




# スタイルガイドの組み込みガイドライン

## htmlソース

Herokuで最新の画面を確認いただけます。
http://eccube3-admin-styleguide.herokuapp.com/

または以下のリポジトリからソースをビルドしてソースを確認んしてください。
https://github.com/EC-CUBE/Eccube-Styleguide-Admin

## 方針(Policy)
まずはtwigの組み込みを最優先とします。
新機能/実装に変更が必要な箇所はあとで対応しますので、 `{# TODO #}` のコメントをつけて別途チケットに起こしてください。

## 実装に関する補足(Appendix)

### スタイルガイド用のファイル

スタイルガイド用のファイルを用意しているので、 `extends` や `form_theme` しているところは最初に書き換えてください。

| 元ファイル | スタイルガイド組み込み用 |
|:---|:---|
| Resource/template/admin/default_frame.twig | Resource/template/admin/styleguide_frame.twig |
| Resource/template/admin/nav.twig | Resource/template/admin/styleguide_nav.twig |
| Resource/template/admin/alert.twig | Resource/template/admin/styleguide_alert.twig |
| Resource/template/admin/pager.twig | Resource/template/admin/styleguide_pager.twig |
| Resource/template/admin/Form/bootstrap_3_horizontal_layout.html.twig | Resource/template/admin/Form/bootstrap_4_horizontal_layout.html.twig |
| Resource/template/admin/Form/bootstrap_3_layout.html.twig | Resource/template/admin/Form/bootstrap_4_layout.html.twig |

### 言語ファイルについて

messages.ja.phpにない日本語は切り出してmessages.ja.phpへ追加してください。
messages.en.phpには追加の必要はありません。（英訳がない部分をわかりやすくするため）

メッセージIDの先頭は画面ごとに決まっています。
messages.ja.phpで使われているものを利用してください。

例：
`admin.{大分類}.{画面}.{自由}`
`admin.product.index.473`

`自由` の部分は翻訳語の意味を表すものが望ましいが、訳が難しい場合は連番でも構いません。

