### PR TITLE
注文から商品の追加というpopupにて、検索実装できるように修正。

### DIFF
--- a/src/Eccube/Controller/Admin/Shipping/EditController.php
+++ b/src/Eccube/Controller/Admin/Shipping/EditController.php
@@ -267,7 +267,7 @@ class EditController extends AbstractController
 
     /**
      * @Route("/%eccube_admin_route%/shipping/search/product", name="admin_shipping_search_product")
-     * @Template("@admin/shipping/search_product.twig")
+     * @Template("@admin/Shipping/search_product.twig")
      */
     public function searchProduct(Request $request, $page_no = null, Paginator $paginator)
     {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 注文から商品の追加というpopupにて、検索ボタンを押すと、エラーメッセージが出てしまいました。
+ 検索実装できるように修正。

## 手順
1. Go to  出荷管理 / 出荷登録・編集
2. Click 注文から商品の追加
3. Click 検索 on popup

## 実装に関する補足(Appendix)
+ 「shipping」を「Shipping」に更新しました。

## テスト（Test)
・Webserver: Apache 2.4
・PHP: 7.1
・Database: MySQL 5.7 & PgSQL 9.6
・OS: Window and Linux




