### PR TITLE
管理画面で、タイトルとサブタイトルが逆になっている文言を修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -26,8 +26,8 @@
 
 {% set menus = ['customer', 'customer_edit'] %}
 
-{% block title %}{{ 'admin.customer.edit.92'|trans }}{% endblock %}
-{% block sub_title %}{{ 'admin.customer.edit.93'|trans }}{% endblock %}
+{% block title %}{{ 'admin.customer.edit.93'|trans }}{% endblock %}
+{% block sub_title %}{{ 'admin.customer.edit.92'|trans }}{% endblock %}
 
 {% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
 

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -23,8 +23,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 {% set menus = ['product', 'product_master'] %}
 
-{% block title %}{{ 'admin.product.index.468'|trans }}{% endblock %}
-{% block sub_title %}{{ 'admin.product.index.469'|trans }}{% endblock %}
+{% block title %}{{ 'admin.product.index.469'|trans }}{% endblock %}
+{% block sub_title %}{{ 'admin.product.index.468'|trans }}{% endblock %}
 
 {% form_theme searchForm '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
管理画面で、タイトルとサブタイトルが逆になっている文言を修正しました。

## 方針(Policy)
Eccube-Styleguide-Admin のモックに合わせています。

## 実装に関する補足(Appendix)
なし

## テスト（Test)
表示を確認

## 相談（Discussion）
なし




