### PR TITLE
管理画面のタイトル部分にスペースが入っているのを修正

### DIFF
--- a/src/Eccube/Resource/template/admin/styleguide_frame.twig
+++ b/src/Eccube/Resource/template/admin/styleguide_frame.twig
@@ -33,10 +33,7 @@
     <div class="c-contentsArea">
         <div class="c-pageTitle">
             <div class="c-pageTitle__titles">
-                <h2 class="c-pageTitle__title">
-                    {{ block('title') }}
-                </h2>
-                <span class="c-pageTitle__subTitle">{{ block('sub_title') }}</span>
+                <h2 class="c-pageTitle__title">{{ block('title') }}</h2><span class="c-pageTitle__subTitle">{{ block('sub_title') }}</span>
             </div>
         </div>
 


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
管理画面のタイトル部分にスペースが入っているのを修正しました。
これが要因で、codeceptionがNGになっています。

## 方針(Policy)
なし

## 実装に関する補足(Appendix)
なし

## テスト（Test)
ブラウザでスペースが入っていないことを確認

## 相談（Discussion）
なし



