### PR TITLE
travis-ciの実行数を一時的に制限

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,16 @@ cache:
 
 php:
   - 7.2
-  - 7.1
-  - 7.0
+#  - 7.1
+#  - 7.0
 
 env:
   matrix:
     - DB=mysql DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
     - DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
-    - DB=sqlite DATABASE_URL=sqlite:///%kernel.project_dir%/var/eccube.db DATABASE_SERVER_VERSION=3
+#    - DB=sqlite DATABASE_URL=sqlite:///%kernel.project_dir%/var/eccube.db DATABASE_SERVER_VERSION=3
     # カバレッジレポート用
-    - DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9 COVERAGE=true
+#    - DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9 COVERAGE=true
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- スタイルガイドの取り込み中、一時的にexperimental/sfブランチのtravis-ciの実行数を制限します
- php7.2 / postgres / mysql の組み合わせ
- 取り込み完了後、元に戻すのを忘れないこと

