### PR TITLE
管理者情報を環境変数で定義するように修正

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,6 +12,15 @@
             }
         }
     ],
+    "env": {
+        "ADMIN_USER": {
+            "description": "The login id of admin user.",
+            "value": "admin"
+        },
+        "ADMIN_PASS": {
+            "description": "The password of admin user."
+        }
+    },
     "buildpacks": [
         {
             "url": "heroku/php"


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- 管理者のID・パスワードを環境変数で定義するように修正
- herokuの初期画面でID・パスワードを入力できるようになります。




