### PR TITLE
PHP7.2のテストを必須にする

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ matrix:
     # カバレッジレポートはphp7.1のmatrixで実行
     - php: 7.1
       env: DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9 COVERAGE=true
-    # php7.2
-    - php: 7.2
+#    # php7.2
+#    - php: 7.2
 
 before_install:
   ## see https://github.com/symfony/symfony/blob/e0bdc0c35e9afdb3bee8af172f90e9648c4012fc/.travis.yml#L92-L97


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ #2912 の変更でPHP 7.2がallow_failuresになっていたので必須に変更
