### PR TITLE
MailTypeのバリデーションを修正

### DIFF
--- a/src/Eccube/Form/Type/Admin/MailType.php
+++ b/src/Eccube/Form/Type/Admin/MailType.php
@@ -76,7 +76,6 @@ class MailType extends AbstractType
                 'mapped' => false,
                 'required' => false,
                 'constraints' => [
-                    new Assert\NotBlank(),
                     new TwigLint(),
                 ]
             ))


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ MailTypeのテンプレート内容(tpl_data)が必須になっていたが、メール通知画面でエラーになってしまっていたので、NotBlankを外しました。
