### PR TITLE
メールテンプレート削除時の不具合修正

### DIFF
--- a/src/Eccube/Entity/MailHistory.php
+++ b/src/Eccube/Entity/MailHistory.php
@@ -191,10 +191,13 @@ class MailHistory extends \Eccube\Entity\AbstractEntity
     /**
      * Get MailTemplate
      *
-     * @return \Eccube\Entity\MailTemplate
+     * @return \Eccube\Entity\MailTemplate|null
      */
     public function getMailTemplate()
     {
+        if (EntityUtil::isEmpty($this->MailTemplate)) {
+            return null;
+        }
         return $this->MailTemplate;
     }
 

--- a/src/Eccube/Resource/template/admin/Order/mail.twig
+++ b/src/Eccube/Resource/template/admin/Order/mail.twig
@@ -84,7 +84,13 @@ $(function() {
                             {% for MailHistory in MailHistories %}
                                 <tr id="history_box__item--{{ MailHistory.id }}">
                                     <td id="history_box__send_date--{{ MailHistory.id }}">{{ MailHistory.send_date|date_format }}</td>
-                                    <td id="history_box__mail_template--{{ MailHistory.id }}">{{ MailHistory.subject }}</td>
+                                    <td id="history_box__mail_template--{{ MailHistory.id }}">
+                                        {% if MailHistory.mail_template is not empty %}
+                                            {{ MailHistory.mail_template.subject }}
+                                        {% else %}
+                                            {{ MailHistory.subject }}
+                                        {% endif %}
+                                    </td>
                                     <td id="history_box__subject--{{ MailHistory.id }}"><a href="#mailModal" data-toggle="modal" data-whatever="{{ MailHistory.id }}">{{ MailHistory.subject }}</a></td>
                                 </tr>
                             {% endfor %}

--- a/src/Eccube/Resource/template/admin/Order/mail.twig
+++ b/src/Eccube/Resource/template/admin/Order/mail.twig
@@ -86,7 +86,7 @@ $(function() {
                                     <td id="history_box__send_date--{{ MailHistory.id }}">{{ MailHistory.send_date|date_format }}</td>
                                     <td id="history_box__mail_template--{{ MailHistory.id }}">
                                         {% if MailHistory.mail_template is not empty %}
-                                            {{ MailHistory.mail_template.subject }}
+                                            {{ MailHistory.mail_template.name }}
                                         {% else %}
                                             {{ MailHistory.subject }}
                                         {% endif %}

--- a/src/Eccube/Resource/template/admin/Order/mail.twig
+++ b/src/Eccube/Resource/template/admin/Order/mail.twig
@@ -84,7 +84,7 @@ $(function() {
                             {% for MailHistory in MailHistories %}
                                 <tr id="history_box__item--{{ MailHistory.id }}">
                                     <td id="history_box__send_date--{{ MailHistory.id }}">{{ MailHistory.send_date|date_format }}</td>
-                                    <td id="history_box__mail_template--{{ MailHistory.id }}">{{ MailHistory.mail_template.subject }}</td>
+                                    <td id="history_box__mail_template--{{ MailHistory.id }}">{{ MailHistory.subject }}</td>
                                     <td id="history_box__subject--{{ MailHistory.id }}"><a href="#mailModal" data-toggle="modal" data-whatever="{{ MailHistory.id }}">{{ MailHistory.subject }}</a></td>
                                 </tr>
                             {% endfor %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 受注メール画面で件名をMailHistory.subjectではなくMailHistory.MailTemplate.subjectで参照しているため、MailHistory.MailTemplate.del_flg=1のデータがあるとEntity Not Foundエラーが発生する。