### PR TITLE
商品詳細画面にて通貨記号「¥」が重複して表示されてしまっていたので削除

### DIFF
--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -264,7 +264,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             {% else %}
                                 <div class="ec-price"><span
                                             class="ec-price__price">{{ Product.getPrice02IncTaxMin|price }}</span>
-                                    ～ <span class="ec-price__unit">¥</span><span
+                                    ～ <span class="ec-price__unit"></span><span
                                             class="ec-price__price">{{ Product.getPrice02IncTaxMax|price }}</span><span
                                             class="ec-price__tax">{{'shopping.label.tax_incl'|trans}}</span>
                                 </div>

--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -264,8 +264,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             {% else %}
                                 <div class="ec-price"><span
                                             class="ec-price__price">{{ Product.getPrice02IncTaxMin|price }}</span>
-                                    ～ <span class="ec-price__unit"></span><span
-                                            class="ec-price__price">{{ Product.getPrice02IncTaxMax|price }}</span><span
+                                    ～ <span class="ec-price__price">{{ Product.getPrice02IncTaxMax|price }}</span><span
                                             class="ec-price__tax">{{'shopping.label.tax_incl'|trans}}</span>
                                 </div>
                             {% endif %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 商品詳細画面にて「¥」が重複して表示されてしまっていたので削除

## 実装に関する補足(Appendix)
+ 通貨記号は 'price' フィルタでロケーションに合わせてつく。
