### PR TITLE
AdminProductListCustomizerのnamaspaceを変更

### DIFF
--- a/app/Acme/Doctrine/Query/AdminProductListCustomizer.php
+++ b/app/Acme/Doctrine/Query/AdminProductListCustomizer.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace Acme\Entity;
+namespace Acme\Doctrine\Query;
 
 
 use Eccube\Doctrine\Query\OrderByClause;
@@ -19,7 +19,9 @@ class AdminProductListCustomizer extends OrderByCustomizer
      */
     protected function createStatements($params, $queryKey)
     {
-        return [new OrderByClause('p.id')];
+        return [];
+        // このサンプルを動作させるには、以下を有効にしてください.
+        // return [new OrderByClause('p.id')];
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- Entity配下はコンテナの読み込み対象外のため、Customizerが動作しない
+ AdminProductListCustomizerをDoctrine配下のnamespaceに変更



