### PR TITLE
モーダルがある画面で、tooltipとmodalが競合する問題を修正

### DIFF
--- a/html/template/admin/assets/js/script.js
+++ b/html/template/admin/assets/js/script.js
@@ -30,7 +30,7 @@ directoryTreeRegister();
 //Bootstrap ツールチップ
 var toolTip = function(){
     $(function () {
-        $('[data-toggle="tooltip"]').tooltip()
+        $('[data-tooltip="tooltip"]').tooltip()
     })
 };
 

--- a/src/Eccube/Resource/template/admin/Content/block.twig
+++ b/src/Eccube/Resource/template/admin/Content/block.twig
@@ -45,10 +45,10 @@
                                                 </a>
                                             </div>
                                             <div class="col-auto text-right">
-                                                <a href="{{ url('admin_content_block_edit', {id: Block.id}) }}" class="btn btn-ec-actionIcon mr-3" data-toggle="tooltip" data-placement="top" title="{{ 'admin.content.block_edit.14'|trans }}">
+                                                <a href="{{ url('admin_content_block_edit', {id: Block.id}) }}" class="btn btn-ec-actionIcon mr-3" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.content.block_edit.14'|trans }}">
                                                     <i class="fa fa-pencil fa-lg text-secondary"></i>
                                                 </a>
-                                                <a href="{{ url('admin_content_block_delete', {id: Block.Id} ) }}" class="btn btn-ec-actionIcon mr-3 {% if not Block.deletable %}disabled{% endif %}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.content.block_edit.17'|trans }}" {{ csrf_token_for_anchor() }} data-method="delete">
+                                                <a href="{{ url('admin_content_block_delete', {id: Block.Id} ) }}" class="btn btn-ec-actionIcon mr-3 {% if not Block.deletable %}disabled{% endif %}" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.content.block_edit.17'|trans }}" {{ csrf_token_for_anchor() }} data-method="delete">
                                                     <i class="fa fa-close fa-lg text-secondary"></i>
                                                 </a>
                                             </div>

--- a/src/Eccube/Resource/template/admin/Content/file.twig
+++ b/src/Eccube/Resource/template/admin/Content/file.twig
@@ -156,15 +156,15 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                         <td class="align-middle text-right pr-3">
                                                             <div class="row justify-content-end">
                                                                 <div class="col-auto text-center">
-                                                                    <a href="{{ url('admin_content_file_view') }}?file={{ file.file_path|e('url') }}" class="btn btn-ec-actionIcon" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{'admin.content.file.36'|trans}}" ><i class="fa fa-eye fa-lg text-secondary" aria-hidden="true"></i></a>
+                                                                    <a href="{{ url('admin_content_file_view') }}?file={{ file.file_path|e('url') }}" class="btn btn-ec-actionIcon" data-tooltip="tooltip" data-placement="top" title="" data-original-title="{{'admin.content.file.36'|trans}}" ><i class="fa fa-eye fa-lg text-secondary" aria-hidden="true"></i></a>
                                                                 </div>
 
                                                                 <div class="col-auto text-center">
-                                                                    <a href="{{ url('admin_content_file_download') }}?select_file={{ file.file_path|e('url') }}" class="btn btn-ec-actionIcon" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{'admin.content.file.37'|trans}}"><i class="fa fa-cloud-download fa-lg text-secondary" aria-hidden="true"></i></a>
+                                                                    <a href="{{ url('admin_content_file_download') }}?select_file={{ file.file_path|e('url') }}" class="btn btn-ec-actionIcon" data-tooltip="tooltip" data-placement="top" title="" data-original-title="{{'admin.content.file.37'|trans}}"><i class="fa fa-cloud-download fa-lg text-secondary" aria-hidden="true"></i></a>
                                                                 </div>
 
                                                                 <div class="col-auto text-center">
-                                                                    <a class="btn btn-ec-actionIcon" href="{{ url('admin_content_file_delete', { 'select_file': file.file_path}) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{'admin.content.file.34'|trans}}"><i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i></a>
+                                                                    <a class="btn btn-ec-actionIcon" href="{{ url('admin_content_file_delete', { 'select_file': file.file_path}) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-tooltip="tooltip" data-placement="top" title="" data-original-title="{{'admin.content.file.34'|trans}}"><i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i></a>
                                                                 </div>
                                                             </div>
                                                         </td>

--- a/src/Eccube/Resource/template/admin/Content/layout.twig
+++ b/src/Eccube/Resource/template/admin/Content/layout.twig
@@ -94,7 +94,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.content.layout.block_edit'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.content.layout.block_edit'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col-4 text-right"><a data-toggle="collapse" href="#layoutBlockEdit" aria-expanded="false" aria-controls="layoutBlockEdit"><i class="fa fa-angle-up fa-lg"></i></a></div>
                             </div>

--- a/src/Eccube/Resource/template/admin/Content/layout_list.twig
+++ b/src/Eccube/Resource/template/admin/Content/layout_list.twig
@@ -54,7 +54,7 @@
                             <div class="card-header">
                                 <div class="row">
                                     <div class="col-8">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.content.layout_list.default_layout'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.content.layout_list.default_layout'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                     </div>
                                     <div class="col-4 text-right"><a data-toggle="collapse" href="#defaultLayout-pc" aria-expanded="false" aria-controls="defaultLayout-pc"><i class="fa fa-angle-up fa-lg"></i></a></div>
                                 </div>
@@ -128,7 +128,7 @@
                             <div class="card-header">
                                 <div class="row">
                                     <div class="col-8">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.content.layout_list.default_layout'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.content.layout_list.default_layout'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                     </div>
                                     <div class="col-4 text-right"><a data-toggle="collapse" href="#defaultLayout-mobile" aria-expanded="false" aria-controls="defaultLayout-mobile"><i class="fa fa-angle-up fa-lg"></i></a></div>
                                 </div>

--- a/src/Eccube/Resource/template/admin/Content/page.twig
+++ b/src/Eccube/Resource/template/admin/Content/page.twig
@@ -82,7 +82,7 @@
                                             {# TODO 削除出来ないページの表示 #}
                                             <div class="col-auto text-center">{% if Page.edit_type == constant('Eccube\\Entity\\Page::EDIT_TYPE_USER') %}
                                                 <a class="btn btn-ec-actionIcon"
-                                                   data-toggle="tooltip"
+                                                   data-tooltip="tooltip"
                                                    data-placement="top"
                                                    title="{{ 'admin.content.page.delete'|trans }}"
                                                    href="{{ url('admin_content_page_delete', { 'id': Page.id}) }}" {{ csrf_token_for_anchor() }}

--- a/src/Eccube/Resource/template/admin/Content/page_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/page_edit.twig
@@ -137,7 +137,7 @@
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                          title="Tooltip"><span class="card-title">{{ 'admin.content.page_edit.layout_setting'|trans }}</span><i
                                                 class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
@@ -169,7 +169,7 @@
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                          title="Tooltip"><span class="card-title">{{ 'admin.content.page_edit.meta_setting'|trans }}</span><i
                                                 class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>

--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -61,7 +61,7 @@
                                 {% if Customer.id %}
                                     <div class="row mb-2">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.customer.edit.95'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -309,7 +309,7 @@
                             <div class="card-header">
                                 <div class="row">
                                     <div class="col-8">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                              title="Tooltip">
                                         <span class="card-title">
                                             {{ 'admin.customer.edit.sipping'|trans }}
@@ -404,7 +404,7 @@
                             <div class="card-header">
                                 <div class="row">
                                     <div class="col-8">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                              title="Tooltip">
                                         <span class="card-title">
                                             {{ 'admin.customer.edit.99'|trans }}
@@ -467,7 +467,7 @@
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                          title="Tooltip">
                                         <span class="card-title">{{ 'admin.customer.edit.109'|trans }}</span>
                                         <i class="fa fa-question-circle fa-lg ml-1"></i>

--- a/src/Eccube/Resource/template/admin/Customer/index.twig
+++ b/src/Eccube/Resource/template/admin/Customer/index.twig
@@ -340,7 +340,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                     <td class="align-middle"></td>
                                                     <td class="align-middle pr-3">
                                                         <div class="row justify-content-end">
-                                                            <div class="col-auto text-center"><a "{{ url('admin_customer_delete', { 'id': Customer.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete" class="btn btn-ec-actionIcon" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{ 'admin.customer.index.delete'|trans }}"><i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i></a></div>
+                                                            <div class="col-auto text-center"><a "{{ url('admin_customer_delete', { 'id': Customer.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete" class="btn btn-ec-actionIcon" data-tooltip="tooltip" data-placement="top" title="" data-original-title="{{ 'admin.customer.index.delete'|trans }}"><i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i></a></div>
                                                         </div>
                                                     </td>
                                                 </tr>

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -116,7 +116,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.edit.label.order'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.edit.label.order'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col-4 text-right"><a data-toggle="collapse" href="#orderOverview" aria-expanded="false" aria-controls="orderOverview"><i class="fa fa-angle-up fa-lg"></i></a></div>
                             </div>
@@ -139,7 +139,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                         </div>
                                         <div class="row mb-3">
                                             <div class="col-3">
-                                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'admin.order.index.298'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                                <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span>{{ 'admin.order.index.298'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                             </div>
                                             <div class="col">
                                                 {{ form_widget(form.OrderStatus) }}
@@ -183,7 +183,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.edit.label.customer_info'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.edit.label.customer_info'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col-4 text-right"><a data-toggle="collapse" href="#ordererInfo" aria-expanded="false" aria-controls="ordererInfo"><i class="fa fa-angle-up fa-lg"></i></a></div>
                             </div>
@@ -215,7 +215,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 {% endif %}
                                 <div class="row mb-2">
                                     <div class="col-3">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'admin.order.edit.customer_id'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span>{{ 'admin.order.edit.customer_id'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                     </div>
                                     <div class="col">
                                         <p id="order_CustomerId">{{ form.Customer.vars.value is empty ? 'admin.order.edit.256'|trans :  form.Customer.vars.value }}</p>
@@ -351,7 +351,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.edit.label.product_info'|trans }}<i class="fa fa-question-circle fa-lg ml-1"></i></span></div>
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.edit.label.product_info'|trans }}<i class="fa fa-question-circle fa-lg ml-1"></i></span></div>
                                 </div>
                                 <div class="col-4 text-right"><a data-toggle="collapse" href="#orderItem" aria-expanded="false" aria-controls="orderItem"><i class="fa fa-angle-up fa-lg"></i></a></div>
                             </div>
@@ -493,7 +493,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                             <td class="align-middle text-right pr-3">
                                                 <div class="row justify-content-end">
                                                     {# TODO 商品・明細を削除できるようにする #}
-                                                    <div class="col-auto text-center"><a class="btn btn-ec-actionIcon delete" data-toggle="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}"><i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i></a></div>
+                                                    <div class="col-auto text-center"><a class="btn btn-ec-actionIcon delete" data-tooltip="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}"><i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i></a></div>
                                                 </div>
                                             </td>
                                             {{ form_widget(orderItemForm.Order) }}
@@ -622,7 +622,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.common.label.memo'|trans }}<i class="fa fa-question-circle fa-lg ml-1"></i></span></div>
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.common.label.memo'|trans }}<i class="fa fa-question-circle fa-lg ml-1"></i></span></div>
                                 </div>
                                 <div class="col-4 text-right"><a data-toggle="collapse" href="#freeArea" aria-expanded="false" aria-controls="freeArea"><i class="fa fa-angle-up fa-lg"></i></a></div>
                             </div>

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -402,26 +402,26 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                             <span class="badge {{ attribute(cssClassStatus, Order.OrderStatus.id) }}">{{ Order.OrderStatus }}</span>
                                         </td>
                                         <td class="align-middle">
-                                            <a class="btn btn-ec-actionIcon" href="{{ url('admin_order_edit', { id : Order.id }) }}#order_note" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{ Order.note }}" aria-describedby="tooltip819464">
+                                            <a class="btn btn-ec-actionIcon" href="{{ url('admin_order_edit', { id : Order.id }) }}#order_note" data-tooltip="tooltip" data-placement="top" title="" data-original-title="{{ Order.note }}" aria-describedby="tooltip819464">
                                                 <i class="fa fa-commenting fa-lg text-secondary" aria-hidden="true"></i>
                                             </a>
                                         </td>
                                         <td class="align-middle pr-3">
                                             <div class="row justify-content-end">
                                                 <div class="col-auto text-center">
-                                                    <a class="btn btn-ec-actionIcon action-mail" href="{{ url('admin_order_mail', {'id': Order.id}) }}" data-toggle="tooltip" data-placement="top" title data-original-title="{{ 'admin.order.index.btn_send_mail'|trans }}">
+                                                    <a class="btn btn-ec-actionIcon action-mail" href="{{ url('admin_order_mail', {'id': Order.id}) }}" data-tooltip="tooltip" data-placement="top" title data-original-title="{{ 'admin.order.index.btn_send_mail'|trans }}">
                                                         <i class="fa fa-send fa-lg text-secondary" aria-hidden="true"></i>
                                                     </a>
                                                 </div>
                                                 <div class="col-auto text-center">
                                                     {# TODO: This func is not implemented yet #}
-                                                    <a class="btn btn-ec-actionIcon" href="" data-toggle="tooltip" data-placement="top" title data-original-title="{{ 'admin.order.index.btn_form'|trans }}">
+                                                    <a class="btn btn-ec-actionIcon" href="" data-tooltip="tooltip" data-placement="top" title data-original-title="{{ 'admin.order.index.btn_form'|trans }}">
                                                         <i class="fa fa-table fa-lg text-secondary" aria-hidden="true"></i>
                                                     </a>
                                                 </div>
                                                 <div class="col-auto text-center">
                                                     {# TODO: This func is not implemented yet #}
-                                                    <a class="btn btn-ec-actionIcon action-delete" href="{{ url('admin_order_delete', { id : Order.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="こ{{'admin.order.index.336'|trans}}" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{ 'common.label.delete'|trans }}">
+                                                    <a class="btn btn-ec-actionIcon action-delete" href="{{ url('admin_order_delete', { id : Order.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="こ{{'admin.order.index.336'|trans}}" data-tooltip="tooltip" data-placement="top" title="" data-original-title="{{ 'common.label.delete'|trans }}">
                                                         <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
                                                     </a>
                                                 </div>

--- a/src/Eccube/Resource/template/admin/Order/mail.twig
+++ b/src/Eccube/Resource/template/admin/Order/mail.twig
@@ -80,7 +80,7 @@ $(function() {
                 <div class="card-header">
                     <div class="row">
                         <div class="col-8">
-                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.mail.349'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                            <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.mail.349'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                         </div>
                         <div class="col-4 text-right"><a data-toggle="collapse" href="#mailTo" aria-expanded="false" aria-controls="mailTo"><i class="fa fa-angle-up fa-lg"></i></a></div>
                     </div>
@@ -160,7 +160,7 @@ $(function() {
                     <div class="card-body">
                         <div class="row mb-2">
                             <div class="col-3">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'admin.order.mail.358'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i><span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></div>
+                                <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span>{{ 'admin.order.mail.358'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i><span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></div>
                             </div>
                             <div class="col">
                                 {{ form_widget(form.template, {'id': 'template-change'}) }}

--- a/src/Eccube/Resource/template/admin/Order/mail_all.twig
+++ b/src/Eccube/Resource/template/admin/Order/mail_all.twig
@@ -73,7 +73,7 @@ $(function() {
                         <div class="card-body">
                             <div class="row mb-2">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'admin.order.mail.358'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i><span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></div>
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span>{{ 'admin.order.mail.358'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i><span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></div>
                                 </div>
                                 <div class="col">
                                     {{ form_widget(form.template, {'id': 'template-change'}) }}

--- a/src/Eccube/Resource/template/admin/Order/order_item_prototype.twig
+++ b/src/Eccube/Resource/template/admin/Order/order_item_prototype.twig
@@ -51,7 +51,7 @@
     </td>
     <td class="align-middle text-right pr-3">
         <div class="row justify-content-end">
-            <div class="col-auto text-center"><a class="btn btn-ec-actionIcon delete" data-toggle="tooltip" data-placement="top" title="削除"><i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i></a></div>
+            <div class="col-auto text-center"><a class="btn btn-ec-actionIcon delete" data-tooltip="tooltip" data-placement="top" title="削除"><i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i></a></div>
         </div>
     </td>
     {{ form_widget(orderItemForm.Order) }}

--- a/src/Eccube/Resource/template/admin/Product/category.twig
+++ b/src/Eccube/Resource/template/admin/Product/category.twig
@@ -168,32 +168,32 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                     <div class="col-auto text-right">
                                                         {# TODO: 「上へ移動」「下へ移動」のボタンの動作の実装 #}
                                                         <a class="btn btn-ec-actionIcon mr-3" href=""
-                                                           data-toggle="tooltip" data-placement="top"
+                                                           data-tooltip="tooltip" data-placement="top"
                                                            title="{{ 'admin.product.category.up'|trans }}">
                                                             <i class="fa fa-arrow-up fa-lg text-secondary"></i>
                                                         </a>
                                                         <a class="btn btn-ec-actionIcon mr-3" href=""
-                                                           data-toggle="tooltip" data-placement="top"
+                                                           data-tooltip="tooltip" data-placement="top"
                                                            title="{{ 'admin.product.category.down'|trans }}">
                                                             <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                                         </a>
                                                         <a class="btn btn-ec-actionIcon mr-3"
                                                            href="{{ url('admin_product_category_edit', {id: Category.id}) }}"
-                                                           data-toggle="tooltip" data-placement="top"
+                                                           data-tooltip="tooltip" data-placement="top"
                                                            title="{{ 'admin.product.category.rename'|trans }}">
                                                             <i class="fa fa-pencil fa-lg text-secondary"></i>
                                                         </a>
                                                         {% if Category.Children|length > 0 or Category.hasProductCategories %}
                                                             {# TODO: 削除できない場合のxアイコンの表現をわかりやすくする #}
                                                             <a class="btn btn-ec-actionIcon mr-3"
-                                                               data-toggle="tooltip" data-placement="top"
+                                                               data-tooltip="tooltip" data-placement="top"
                                                                title="{{ 'admin.product.category.text01'|trans }}">
                                                                 <i class="fa fa-close fa-lg text-secondary"></i>
                                                             </a>
                                                         {% else %}
                                                             <a class="btn btn-ec-actionIcon mr-3"
                                                                href="{{ url('admin_product_category_delete', {id: Category.id}) }}"
-                                                               data-toggle="tooltip" data-placement="top"
+                                                               data-tooltip="tooltip" data-placement="top"
                                                                title="{{ 'admin.product.category.410'|trans }}" {{ csrf_token_for_anchor() }}
                                                                data-method="delete">
                                                                 <i class="fa fa-close fa-lg text-secondary"></i>

--- a/src/Eccube/Resource/template/admin/Product/class_category.twig
+++ b/src/Eccube/Resource/template/admin/Product/class_category.twig
@@ -134,17 +134,17 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                             {# TODO 表示名 #}
                                             <div class="col d-flex align-items-center">{{ ClassCategory.name }}</div>
                                             <div class="col-auto text-right">
-                                                <a class="btn btn-ec-actionIcon mr-3 up {% if loop.first %}disabled{% endif %}" href="" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_category.430'|trans }}">
+                                                <a class="btn btn-ec-actionIcon mr-3 up {% if loop.first %}disabled{% endif %}" href="" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.product.class_category.430'|trans }}">
                                                     <i class="fa fa-arrow-up fa-lg text-secondary"></i>
                                                 </a>
-                                                <a class="btn btn-ec-actionIcon mr-3 down {% if loop.last %}disabled{% endif %}" href="" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_category.431'|trans }}">
+                                                <a class="btn btn-ec-actionIcon mr-3 down {% if loop.last %}disabled{% endif %}" href="" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.product.class_category.431'|trans }}">
                                                     <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                                 </a>
                                                 {# TODO 編集機能 #}
-                                                <a class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_category.432'|trans }}">
+                                                <a class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.product.class_category.432'|trans }}">
                                                     <i class="fa fa-pencil fa-lg text-secondary"></i>
                                                 </a>
-                                                <a class="btn btn-ec-actionIcon mr-3" href="{{ url('admin_product_class_category_delete', {class_name_id: ClassName.id, id: ClassCategory.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-toggle="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}">
+                                                <a class="btn btn-ec-actionIcon mr-3" href="{{ url('admin_product_class_category_delete', {class_name_id: ClassName.id, id: ClassCategory.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-tooltip="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}">
                                                     <i class="fa fa-close fa-lg text-secondary"></i>
                                                 </a>
                                             </div>
@@ -169,10 +169,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 {#<button class="btn btn-ec-sub" type="submit">キャンセル</button>#}
                                 {#</div>#}
                                 {#<div class="col text-right justify-content-end">#}
-                                {#<a class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip" data-placement="top" title="上へ移動"><i class="fa fa-arrow-up fa-lg text-secondary"></i></a>#}
-                                {#<a class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip" data-placement="top" title="下へ移動"><i class="fa fa-arrow-down fa-lg text-secondary"></i></a>#}
-                                {#<a class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip" data-placement="top" title="名前を編集"><i class="fa fa-pencil fa-lg text-secondary"></i></a>#}
-                                {#<a class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip" data-placement="top" title="削除"><i class="fa fa-close fa-lg text-secondary"></i></a>#}
+                                {#<a class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip" data-placement="top" title="上へ移動"><i class="fa fa-arrow-up fa-lg text-secondary"></i></a>#}
+                                {#<a class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip" data-placement="top" title="下へ移動"><i class="fa fa-arrow-down fa-lg text-secondary"></i></a>#}
+                                {#<a class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip" data-placement="top" title="名前を編集"><i class="fa fa-pencil fa-lg text-secondary"></i></a>#}
+                                {#<a class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip" data-placement="top" title="削除"><i class="fa fa-close fa-lg text-secondary"></i></a>#}
                                 {#</div>#}
                                 {#</form>#}
                                 {#</li>#}

--- a/src/Eccube/Resource/template/admin/Product/class_name.twig
+++ b/src/Eccube/Resource/template/admin/Product/class_name.twig
@@ -131,17 +131,17 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                         {# TODO 表示名 #}
                                         <div class="col d-flex align-items-center"><a href="{{ url('admin_product_class_category', {class_name_id : ClassName.id }) }}">{{ ClassName.name }} ({{ ClassName.ClassCategories|length }})</a></div>
                                         <div class="col-auto text-right">
-                                            <a class="btn btn-ec-actionIcon mr-3 up {% if loop.first %}disabled{% endif %}" href="" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_name.439'|trans }}">
+                                            <a class="btn btn-ec-actionIcon mr-3 up {% if loop.first %}disabled{% endif %}" href="" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.product.class_name.439'|trans }}">
                                                 <i class="fa fa-arrow-up fa-lg text-secondary"></i>
                                             </a>
-                                            <a class="btn btn-ec-actionIcon mr-3 down {% if loop.last %}disabled{% endif %}" href="" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_name.440'|trans }}">
+                                            <a class="btn btn-ec-actionIcon mr-3 down {% if loop.last %}disabled{% endif %}" href="" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.product.class_name.440'|trans }}">
                                                 <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                             </a>
                                             {# TODO 編集機能 #}
-                                            <a class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_name.441'|trans }}">
+                                            <a class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.product.class_name.441'|trans }}">
                                                 <i class="fa fa-pencil fa-lg text-secondary"></i>
                                             </a>
-                                            <a class="btn btn-ec-actionIcon mr-3 {% if ClassName.ClassCategories|length > 0 %}disabled{% endif %}" href="{{ url('admin_product_class_name_delete', {id: ClassName.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-toggle="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}">
+                                            <a class="btn btn-ec-actionIcon mr-3 {% if ClassName.ClassCategories|length > 0 %}disabled{% endif %}" href="{{ url('admin_product_class_name_delete', {id: ClassName.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-tooltip="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}">
                                                 <i class="fa fa-close fa-lg text-secondary"></i>
                                             </a>
                                         </div>
@@ -166,10 +166,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                             {#<button class="btn btn-ec-sub" type="submit">キャンセル</button>#}
                                         {#</div>#}
                                         {#<div class="col text-right justify-content-end">#}
-                                            {#<a class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip" data-placement="top" title="上へ移動"><i class="fa fa-arrow-up fa-lg text-secondary"></i></a>#}
-                                            {#<a class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip" data-placement="top" title="下へ移動"><i class="fa fa-arrow-down fa-lg text-secondary"></i></a>#}
-                                            {#<a class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip" data-placement="top" title="名前を編集"><i class="fa fa-pencil fa-lg text-secondary"></i></a>#}
-                                            {#<a class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip" data-placement="top" title="削除"><i class="fa fa-close fa-lg text-secondary"></i></a>#}
+                                            {#<a class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip" data-placement="top" title="上へ移動"><i class="fa fa-arrow-up fa-lg text-secondary"></i></a>#}
+                                            {#<a class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip" data-placement="top" title="下へ移動"><i class="fa fa-arrow-down fa-lg text-secondary"></i></a>#}
+                                            {#<a class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip" data-placement="top" title="名前を編集"><i class="fa fa-pencil fa-lg text-secondary"></i></a>#}
+                                            {#<a class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip" data-placement="top" title="削除"><i class="fa fa-close fa-lg text-secondary"></i></a>#}
                                         {#</div>#}
                                     {#</form>#}
                                 {#</li>#}

--- a/src/Eccube/Resource/template/admin/Product/csv_category.twig
+++ b/src/Eccube/Resource/template/admin/Product/csv_category.twig
@@ -74,7 +74,7 @@ $(function() {
         <div class="c-primaryCol">
             <div class="card rounded border-0 mb-4">
                 <div class="card-header">
-                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'admin.product.csv_category.csv_file_upload'|trans}}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
+                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span>{{ 'admin.product.csv_category.csv_file_upload'|trans}}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
                 </div>
                 <div class="card-body">
                     <div class="row">
@@ -102,7 +102,7 @@ $(function() {
                 <div class="card-header">
                     <div class="row justify-content-between">
                         <div class="col-6">
-                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="align-middle">{{ 'admin.product.csv_category.category_csv_format'|trans}}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
+                            <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span class="align-middle">{{ 'admin.product.csv_category.category_csv_format'|trans}}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
                         </div>
                         <div class="col-4 text-right">
                             <a href="{{ url('admin_product_csv_template', {'type': 'category'}) }}" class="btn btn-ec-regular" id="download-button">{{ 'admin.product.csv_category.download'|trans}}</a>

--- a/src/Eccube/Resource/template/admin/Product/csv_product.twig
+++ b/src/Eccube/Resource/template/admin/Product/csv_product.twig
@@ -68,7 +68,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             <div class="c-primaryCol">
                 <div class="card rounded border-0 mb-4">
                     <div class="card-header">
-                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.csv_product.upload_header.tooltip'|trans }}"><span>{{ 'admin.product.csv_product.upload_header'|trans }}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
+                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.product.csv_product.upload_header.tooltip'|trans }}"><span>{{ 'admin.product.csv_product.upload_header'|trans }}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
                     </div>
                     <div class="card-body">
                         <div class="row">
@@ -93,7 +93,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     <div class="card-header">
                         <div class="row justify-content-between">
                             <div class="col-6">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.csv_product.format_header.tooltip'|trans }}"><span class="align-middle">{{ 'admin.product.csv_product.format_header'|trans }}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
+                                <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.product.csv_product.format_header.tooltip'|trans }}"><span class="align-middle">{{ 'admin.product.csv_product.format_header'|trans }}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
                             </div>
                             <div class="col-4 text-right">
                                 <a href="{{ url('admin_product_csv_template', {'type': 'product'}) }}" class="btn btn-ec-regular" id="download-button">{{ 'admin.product.csv_product.download_template_button'|trans }}</a>

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -159,7 +159,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     </div>
                     <div class="col-6">
                         <div class="mb-2">
-                            <label class="col-form-label" data-toggle="tooltip" data-placement="top" title="Tooltip">
+                            <label class="col-form-label" data-tooltip="tooltip" data-placement="top" title="Tooltip">
                                 {{ 'admin.product.index.473'|trans }}
                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
                             </label>
@@ -381,14 +381,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                 </td>
                                                 <td class="align-middle pr-3" colspan="3">
                                                     <div class="row">
-                                                        <div class="col text-center" data-toggle="tooltip"
+                                                        <div class="col text-center" data-tooltip="tooltip"
                                                              data-placement="top"
                                                              title="{{ 'admin.product.index.display'|trans }}"><a class="btn btn-ec-actionIcon"
                                                                            href="{{ url('product_detail', {id:Product.id}) }}"
                                                                            target="_blank"><i
                                                                         class="fa fa-eye fa-lg text-secondary"
                                                                         aria-hidden="true"></i></a></div>
-                                                        <div class="col text-center" data-toggle="tooltip"
+                                                        <div class="col text-center" data-tooltip="tooltip"
                                                              data-placement="top"
                                                              title="{{ 'admin.product.index.duplicate'|trans }}"><a class="btn btn-ec-actionIcon"
                                                                            href="{{ url('admin_product_product_copy', {'id' : Product.id}) }}" {{ csrf_token_for_anchor() }}
@@ -396,7 +396,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                                            data-message="{{ 'admin.product.index.text01'|trans }}"><i
                                                                         class="fa fa-files-o fa-lg text-secondary"
                                                                         aria-hidden="true"></i></a></div>
-                                                        <div class="col text-center" data-toggle="tooltip"
+                                                        <div class="col text-center" data-tooltip="tooltip"
                                                              data-placement="top"
                                                              title="{{ 'admin.product.index.abolition'|trans }}"><a class="btn btn-ec-actionIcon" data-toggle="modal"
                                                                            data-target="#discontinuance_{{ Product.id }}"><i

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -189,7 +189,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                          title="Tooltip">
                                     <span class="card-title">
                                         {{ 'admin.product.product.basic_configuration'|trans }}
@@ -209,7 +209,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             <div class="card-body">
                                 <div class="row">
                                     <div class="col-3">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                              title="Tooltip">
                                             <span>{{ 'admin.product.product.500'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -223,7 +223,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 </div>
                                 <div class="row">
                                     <div class="col-3">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                              title="Tooltip">
                                             <span>{{ 'admin.product.product.name'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -239,7 +239,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 {% if has_class == false %}
                                     <div class="row">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.sale_type'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -255,7 +255,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 {% endif %}
                                 <div class="row">
                                     <div class="col-3">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                              title="Tooltip">
                                             <span>{{ 'admin.product.product.image'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -283,7 +283,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 </div>
                                 <div class="row">
                                     <div class="col-3">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                              title="Tooltip">
                                             <span>{{ 'admin.product.product.description'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -306,7 +306,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 <div class="collapse ec-collapse" id="addComment">
                                     <div class="row bg-ec-formGray pt-3 mb-2">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.description_list'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -323,7 +323,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 {% if has_class == false %}
                                     <div class="row">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.price02'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -349,7 +349,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     <div class="collapse ec-collapse" id="addPrice">
                                         <div class="row bg-ec-formGray pt-3 mb-2">
                                             <div class="col-3">
-                                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                                <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                                      title="Tooltip">
                                                     <span>{{ 'admin.product.product.price01'|trans }}</span>
                                                     <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -366,7 +366,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     </div>
                                     <div class="row">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.stock'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -399,7 +399,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 {% endif %}
                                 <div class="row">
                                     <div class="col-3">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                              title="Tooltip">
                                             <span>{{ 'admin.product.product.search_word'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -417,7 +417,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 {% if has_class == false %}
                                     <div class="row">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.code'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -431,7 +431,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     </div>
                                     <div class="row">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.sale_limit'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -445,7 +445,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     </div>
                                     <div class="row">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.delivery_duration'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -461,7 +461,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     {% if BaseInfo.option_product_delivery_fee %}
                                         <div class="row">
                                             <div class="col-3">
-                                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                                <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                                      title="Tooltip">
                                                     <span>{{ 'admin.product.product.delivery_fee'|trans }}</span>
                                                     <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -478,7 +478,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     {% if BaseInfo.option_product_tax_rule %}
                                         <div class="row">
                                             <div class="col-3">
-                                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                                <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                                      title="Tooltip">
                                                     <span>{{ 'admin.product.product.tax_rate'|trans }}</span>
                                                     <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -521,7 +521,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             <div class="card-header">
                                 <div class="row">
                                     <div class="col-8">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                              title="Tooltip">
                                         <span class="card-title">
                                             {{ 'admin.product.product.511'|trans }}
@@ -540,7 +540,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             <div class="collapse show ec-cardCollapse" id="standardConfig">
                                 <div class="card-body">
                                     {% if has_class == true %}
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                              title="Tooltip">
                                             <span>{{ 'admin.product.product.text03'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -611,7 +611,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                          title="Tooltip">
                                         <span class="card-title">{{ 'admin.product.product.508'|trans }}</span>
                                         <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -649,7 +649,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                          title="Tooltip">
                                         <span class="card-title">{{ 'admin.product.product.category'|trans }}</span>
                                         <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -757,7 +757,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                          title="Tooltip">
                                         <span class="card-title">
                                             {{ 'admin.product.product.tag'|trans }}
@@ -856,7 +856,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                          title="Tooltip">
                                         <span class="card-title">
                                             {{ 'admin.product.product.523'|trans }}

--- a/src/Eccube/Resource/template/admin/Product/tag.twig
+++ b/src/Eccube/Resource/template/admin/Product/tag.twig
@@ -148,20 +148,20 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                             <div class="col-auto text-right">
                                                 <a class="btn btn-ec-actionIcon up mr-3 {% if loop.first %}disabled{% endif %}"
                                                    href="#"
-                                                   data-toggle="tooltip"
+                                                   data-tooltip="tooltip"
                                                    data-placement="top" title="{{ 'admin.product.tag.up'|trans }}"><i
                                                             class="fa fa-arrow-up fa-lg text-secondary"></i></a>
                                                 <a
                                                         class="btn btn-ec-actionIcon down mr-3 {% if loop.last %}disabled{% endif %}"
                                                         href="#"
-                                                        data-toggle="tooltip"
+                                                        data-tooltip="tooltip"
                                                         data-placement="top"
                                                         title="{{ 'admin.product.tag.down'|trans }}"><i
                                                             class="fa fa-arrow-down fa-lg text-secondary"></i></a>
                                                 <a
                                                         class="btn btn-ec-actionIcon mr-3"
                                                         href="{{ url('admin_product_tag_edit', {id: Tag.id}) }}"
-                                                        data-toggle="tooltip"
+                                                        data-tooltip="tooltip"
                                                         data-placement="top"
                                                         title="{{ 'admin.product.tag.edit'|trans }}"><i
                                                             class="fa fa-pencil fa-lg text-secondary"></i></a>
@@ -170,43 +170,42 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                         href="{{ url('admin_product_tag_delete', {id: Tag.id}) }}"
                                                         data-toggle="modal"
                                                         data-target="#confirmModal-{{ Tag.id }}"
-                                                        data-toggle="tooltip"
+                                                        data-tooltip="tooltip"
                                                         data-placement="top"
                                                         title="{{ 'admin.product.tag.delete'|trans }}"><i
                                                             class="fa fa-close fa-lg text-secondary"></i></a>
-                                            </div>
-                                        </div>
-
-                                        <div class="modal fade" id="confirmModal-{{ Tag.id }}" tabindex="-1"
-                                             role="dialog"
-                                             aria-labelledby="confirmModal-{{ Tag.id }}" aria-hidden="true">
-                                            <div class="modal-dialog" role="document">
-                                                <div class="modal-content">
-                                                    <div class="modal-header">
-                                                        <h5 class="modal-title font-weight-bold">
-                                                            {{ 'admin.product.tag.delete.confirm.title'|trans }}</h5>
-                                                        <button class="close" type="button"
-                                                                data-dismiss="modal"
-                                                                aria-label="Close"><span
-                                                                    aria-hidden="true">×</span>
-                                                        </button>
-                                                    </div>
-                                                    <div class="modal-body text-left">
-                                                        <p class="text-left">
-                                                            {{ 'admin.product.tag.delete.confirm.message'|trans }}</p>
-                                                    </div>
-                                                    <div class="modal-footer">
-                                                        <button class="btn btn-ec-sub" type="button"
-                                                                data-dismiss="modal">{{ 'admin.product.index.cancel'|trans }}
-                                                        </button>
-                                                        <a
-                                                                href="{{ url('admin_product_tag_delete', {'id' : Tag.id}) }}"
-                                                                class="btn btn-ec-delete"
-                                                                data-confirm="false"
-                                                                {{ csrf_token_for_anchor() }}
-                                                                data-method="delete">
-                                                            {{ 'admin.product.index.delete'|trans }}
-                                                        </a>
+                                                <div class="modal fade" id="confirmModal-{{ Tag.id }}" tabindex="-1"
+                                                     role="dialog"
+                                                     aria-labelledby="confirmModal-{{ Tag.id }}" aria-hidden="true">
+                                                    <div class="modal-dialog" role="document">
+                                                        <div class="modal-content">
+                                                            <div class="modal-header">
+                                                                <h5 class="modal-title font-weight-bold">
+                                                                    {{ 'admin.product.tag.delete.confirm.title'|trans }}</h5>
+                                                                <button class="close" type="button"
+                                                                        data-dismiss="modal"
+                                                                        aria-label="Close"><span
+                                                                            aria-hidden="true">×</span>
+                                                                </button>
+                                                            </div>
+                                                            <div class="modal-body text-left">
+                                                                <p class="text-left">
+                                                                    {{ 'admin.product.tag.delete.confirm.message'|trans }}</p>
+                                                            </div>
+                                                            <div class="modal-footer">
+                                                                <button class="btn btn-ec-sub" type="button"
+                                                                        data-dismiss="modal">{{ 'admin.product.index.cancel'|trans }}
+                                                                </button>
+                                                                <a
+                                                                        href="{{ url('admin_product_tag_delete', {'id' : Tag.id}) }}"
+                                                                        class="btn btn-ec-delete"
+                                                                        data-confirm="false"
+                                                                        {{ csrf_token_for_anchor() }}
+                                                                        data-method="delete">
+                                                                    {{ 'admin.product.index.delete'|trans }}
+                                                                </a>
+                                                            </div>
+                                                        </div>
                                                     </div>
                                                 </div>
                                             </div>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery.twig
@@ -96,13 +96,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                     </div>
                                                     <div class="col-auto text-right">
                                                         {# TODO ドラッグドロップで変更後の「上へ」「下へ」リンクの制御が不十分 #}
-                                                        <a href="{{ url('admin_setting_shop_delivery_up', {id: Delivery.Id} ) }}" class="btn btn-ec-actionIcon mr-3 {% if loop.first %}disabled{% endif %}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.common.label.move.up'|trans }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">
+                                                        <a href="{{ url('admin_setting_shop_delivery_up', {id: Delivery.Id} ) }}" class="btn btn-ec-actionIcon mr-3 {% if loop.first %}disabled{% endif %}" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.common.label.move.up'|trans }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">
                                                             <i class="fa fa-arrow-up fa-lg text-secondary"></i>
                                                         </a>
-                                                        <a href="{{ url('admin_setting_shop_delivery_down', {id: Delivery.Id} ) }}" class="btn btn-ec-actionIcon mr-3 {% if loop.last %}disabled{% endif %}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.common.label.move.down'|trans }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">
+                                                        <a href="{{ url('admin_setting_shop_delivery_down', {id: Delivery.Id} ) }}" class="btn btn-ec-actionIcon mr-3 {% if loop.last %}disabled{% endif %}" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.common.label.move.down'|trans }}" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">
                                                             <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                                         </a>
-                                                        <a href="{{ url('admin_setting_shop_delivery_delete', {id: Delivery.Id} ) }}" class="btn btn-ec-actionIcon mr-3" data-toggle="tooltip" data-placement="top" title="{{ 'admin.common.label.delete'|trans }}" {{ csrf_token_for_anchor() }} data-method="delete">
+                                                        <a href="{{ url('admin_setting_shop_delivery_delete', {id: Delivery.Id} ) }}" class="btn btn-ec-actionIcon mr-3" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.common.label.delete'|trans }}" {{ csrf_token_for_anchor() }} data-method="delete">
                                                             <i class="fa fa-close fa-lg text-secondary"></i>
                                                         </a>
                                                     </div>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
@@ -65,7 +65,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             </div>
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                          title="Tooltip">
                                         <span>{{ 'admin.setting.shop.delivery_edit.slip_number_url'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
@@ -117,17 +117,17 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                             <div class="col d-flex align-items-center"><a>{{ child.vars.value }}</a></div>
                                             <div class="col-auto text-right"><a class="btn btn-ec-actionIcon mr-3"
                                                                                 href=""
-                                                                                data-toggle="tooltip"
+                                                                                data-tooltip="tooltip"
                                                                                 data-placement="top"
                                                                                 title="上へ移動"><i
                                                             class="fa fa-arrow-up fa-lg text-secondary"></i></a><a
-                                                        class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip"
+                                                        class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip"
                                                         data-placement="top" title="下へ移動"><i
                                                             class="fa fa-arrow-down fa-lg text-secondary"></i></a><a
-                                                        class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip"
+                                                        class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip"
                                                         data-placement="top" title="名前を編集"><i
                                                             class="fa fa-pencil fa-lg text-secondary"></i></a><a
-                                                        class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip"
+                                                        class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip"
                                                         data-placement="top" title="削除"><i
                                                             class="fa fa-close fa-lg text-secondary"></i></a></div>
                                         </div>
@@ -150,16 +150,16 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                 </div>
                                             </div>
                                             <div class="col-5 text-right"><a class="btn btn-ec-actionIcon mr-3" href=""
-                                                                             data-toggle="tooltip" data-placement="top"
+                                                                             data-tooltip="tooltip" data-placement="top"
                                                                              title="上へ移動"><i
                                                             class="fa fa-arrow-up fa-lg text-secondary"></i></a><a
-                                                        class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip"
+                                                        class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip"
                                                         data-placement="top" title="下へ移動"><i
                                                             class="fa fa-arrow-down fa-lg text-secondary"></i></a><a
-                                                        class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip"
+                                                        class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip"
                                                         data-placement="top" title="名前を編集"><i
                                                             class="fa fa-pencil fa-lg text-secondary"></i></a><a
-                                                        class="btn btn-ec-actionIcon mr-3" href="" data-toggle="tooltip"
+                                                        class="btn btn-ec-actionIcon mr-3" href="" data-tooltip="tooltip"
                                                         data-placement="top" title="削除"><i
                                                             class="fa fa-close fa-lg text-secondary"></i></a></div>
                                         </div>
@@ -177,7 +177,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 <li class="list-group-item">
                                     <div class="row justify-content-start">
                                         <div class="col-2">
-                                            <div class="d-inline-block align-middle" data-toggle="tooltip"
+                                            <div class="d-inline-block align-middle" data-tooltip="tooltip"
                                                  data-placement="top" title="Tooltip"><span
                                                         class="card-title">{{ 'admin.setting.shop.delivery_edit.delivery_fees_all_pref'|trans }}</span><i
                                                         class="fa fa-question-circle fa-lg ml-1"></i></div>
@@ -213,7 +213,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                          title="Tooltip">
                                     <span class="card-title">{{ 'admin.setting.shop.delivery_edit.note'|trans }}<i
                                                 class="fa fa-question-circle fa-lg ml-1"></i></span></div>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
@@ -163,46 +163,38 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                         </span>
                                         </div>
                                         <div class="col-3 text-right">
-                                            <div class="row">
-                                                <div class="col text-center" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.608'|trans }}">
-                                                    <a class="btn btn-ec-actionIcon mr-3 action-up" data-toggle="tooltip" data-placement="top" title="{{'admin.setting.shop.payment.608'|trans}}">
-                                                        <i class="fa fa-arrow-up fa-lg text-secondary"></i>
-                                                    </a>
-                                                </div>
-                                                <div class="col text-center" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.609'|trans }}">
-                                                    <a class="btn btn-ec-actionIcon mr-3 action-down"  data-toggle="tooltip" data-placement="top" title="{{'admin.setting.shop.payment.609'|trans}}">
-                                                        <i class="fa fa-arrow-down fa-lg text-secondary"></i>
-                                                    </a>
-                                                </div>
-                                                <div class="col text-center" data-toggle="tooltip" data-placement="top" title="{{'admin.setting.shop.payment.607'|trans}}">
-                                                    <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_{{ Payment.id }}">
-                                                        <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
-                                                    </a>
-                                                    <div class="modal fade" id="delete_{{ Payment.id }}" tabindex="-1"
-                                                         role="dialog"
-                                                         aria-labelledby="delete_{{ Payment.id }}" aria-hidden="true">
-                                                        <div class="modal-dialog" role="document">
-                                                            <div class="modal-content">
-                                                                <div class="modal-header">
-                                                                    <h5 class="modal-title font-weight-bold">
-                                                                        {{ 'admin.setting.shop.payment.modal.header'|trans }}</h5>
-                                                                    <button class="close" type="button"
-                                                                            data-dismiss="modal"
-                                                                            aria-label="Close"><span
-                                                                                aria-hidden="true">×</span>
-                                                                    </button>
-                                                                </div>
-                                                                <div class="modal-body text-left">
-                                                                    <p class="text-left">
-                                                                        {{ 'admin.setting.shop.payment.modal.body'|trans }}</p>
-                                                                </div>
-                                                                <div class="modal-footer">
-                                                                    <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}
-                                                                    </button>
-                                                                    <a class="btn btn-ec-delete" href="{{ url('admin_setting_shop_payment_delete', {'id' : Payment.id}) }}" {{ csrf_token_for_anchor() }}
-                                                                       data-method="delete" data-confirm="false">{{ 'common.label.delete'|trans }}</a>
-                                                                </div>
-                                                            </div>
+                                            <a class="btn btn-ec-actionIcon mr-3 action-up" data-tooltip="tooltip" data-placement="top" title="{{'admin.setting.shop.payment.608'|trans}}">
+                                                <i class="fa fa-arrow-up fa-lg text-secondary"></i>
+                                            </a>
+                                            <a class="btn btn-ec-actionIcon mr-3 action-down"  data-tooltip="tooltip" data-placement="top" title="{{'admin.setting.shop.payment.609'|trans}}">
+                                                <i class="fa fa-arrow-down fa-lg text-secondary"></i>
+                                            </a>
+                                            <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_{{ Payment.id }}" data-tooltip="tooltip" data-placement="top" title="{{'admin.setting.shop.payment.607'|trans}}">
+                                                <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
+                                            </a>
+                                            <div class="modal fade" id="delete_{{ Payment.id }}" tabindex="-1"
+                                                 role="dialog"
+                                                 aria-labelledby="delete_{{ Payment.id }}" aria-hidden="true">
+                                                <div class="modal-dialog" role="document">
+                                                    <div class="modal-content">
+                                                        <div class="modal-header">
+                                                            <h5 class="modal-title font-weight-bold">
+                                                                {{ 'admin.setting.shop.payment.modal.header'|trans }}</h5>
+                                                            <button class="close" type="button"
+                                                                    data-dismiss="modal"
+                                                                    aria-label="Close"><span
+                                                                        aria-hidden="true">×</span>
+                                                            </button>
+                                                        </div>
+                                                        <div class="modal-body text-left">
+                                                            <p class="text-left">
+                                                                {{ 'admin.setting.shop.payment.modal.body'|trans }}</p>
+                                                        </div>
+                                                        <div class="modal-footer">
+                                                            <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}
+                                                            </button>
+                                                            <a class="btn btn-ec-delete" href="{{ url('admin_setting_shop_payment_delete', {'id' : Payment.id}) }}" {{ csrf_token_for_anchor() }}
+                                                               data-method="delete" data-confirm="false">{{ 'common.label.delete'|trans }}</a>
                                                         </div>
                                                     </div>
                                                 </div>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/payment_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/payment_edit.twig
@@ -178,7 +178,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'paymentregister.label.logo_image.tooltip'|trans }}">
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="{{ 'paymentregister.label.logo_image.tooltip'|trans }}">
                                         <span>{{ 'paymentregister.label.logo_image'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i>
                                     </div>
                                 </div>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/shop_master.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/shop_master.twig
@@ -212,7 +212,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'common.label.option_delivery_fee_free_amount'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span>{{ 'common.label.option_delivery_fee_free_amount'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col mb-2">
                                     <div class="input-group col-4 pl-0">
@@ -228,7 +228,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             </div>
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'common.label.option_delivery_free_quantity'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span>{{ 'common.label.option_delivery_free_quantity'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col mb-2">
                                     <div class="input-group col-4 pl-0">
@@ -257,7 +257,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             </div>
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'common.label.option_multiple_shipping'|trans }}</span></div>
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span>{{ 'common.label.option_multiple_shipping'|trans }}</span></div>
                                 </div>
                                 <div class="col mb-2">
                                     <div class="c-toggleSwitch">
@@ -364,7 +364,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'shopmaster.label.option_product_tax_rule'|trans }}</span></div>
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span>{{ 'shopmaster.label.option_product_tax_rule'|trans }}</span></div>
                                 </div>
                                 <div class="col mb-2">
                                     <div class="c-toggleSwitch">
@@ -400,7 +400,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             </div>
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'shopmaster.label.basic_point_rate'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span>{{ 'shopmaster.label.basic_point_rate'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col mb-2">
                                     <div class="input-group col-4 pl-0">
@@ -414,7 +414,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             </div>
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'shopmaster.label.point_conversion_rate'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip"><span>{{ 'shopmaster.label.point_conversion_rate'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col mb-2">
                                     <div class="input-group col-4 pl-0">

--- a/src/Eccube/Resource/template/admin/Setting/Shop/tax_rule.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/tax_rule.twig
@@ -180,7 +180,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                         </td>
                                         <td class="align-middle action">
                                             <div class="row justify-content-end pr-2">
-                                                <div class="col-auto text-center pr-0"><a class="btn btn-ec-actionIcon edit-button" data-toggle="tooltip" data-id="{{ TaxRule.id }}" data-placement="top" title="{{ 'common.label.edit'|trans }}"><i class="fa fa-pencil fa-lg text-secondary" aria-hidden="true"></i></a></div>
+                                                <div class="col-auto text-center pr-0"><a class="btn btn-ec-actionIcon edit-button" data-tooltip="tooltip" data-id="{{ TaxRule.id }}" data-placement="top" title="{{ 'common.label.edit'|trans }}"><i class="fa fa-pencil fa-lg text-secondary" aria-hidden="true"></i></a></div>
                                                 {% if TaxRule.default_tax_rule %}
                                                     <div class="col-auto text-center">
                                                         <a class="btn btn-ec-actionIcon">
@@ -189,7 +189,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                     </div>
                                                 {% else %}
                                                     <div class="col-auto text-center">
-                                                        <a class="btn btn-ec-actionIcon" data-toggle="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}" href="{{ url('admin_setting_shop_tax_delete', { id : TaxRule.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete">
+                                                        <a class="btn btn-ec-actionIcon" data-tooltip="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}" href="{{ url('admin_setting_shop_tax_delete', { id : TaxRule.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete">
                                                             <i class="fa fa-times fa-lg text-secondary" aria-hidden="true"></i></a></div>
                                                 {% endif %}
                                             </div>

--- a/src/Eccube/Resource/template/admin/Shipping/csv_shipping.twig
+++ b/src/Eccube/Resource/template/admin/Shipping/csv_shipping.twig
@@ -76,7 +76,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             <div class="c-primaryCol">
                 <div class="card rounded border-0 mb-4">
                     <div class="card-header">
-                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="" data-original-title="Tooltip">
+                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="" data-original-title="Tooltip">
                             <span>{{'admin.shipping.csv_shipping.title_csv_upload'|trans}}</span>
                             <i class="fa fa-question-circle fa-lg fa-lg ml-1"></i>
                         </div>
@@ -110,7 +110,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     <div class="card-header">
                         <div class="row justify-content-between">
                             <div class="col-6">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="" data-original-title="Tooltip">
+                                <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="" data-original-title="Tooltip">
                                     <span class="align-middle">{{ 'admin.shipping.csv_shipping.title_csv_format'|trans }}</span>
                                     <i class="fa fa-question-circle fa-lg fa-lg ml-1"></i>
                                 </div>

--- a/src/Eccube/Resource/template/admin/Shipping/edit.twig
+++ b/src/Eccube/Resource/template/admin/Shipping/edit.twig
@@ -111,7 +111,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                          title="Tooltip">
                                         <span class="card-title">{{ 'admin.shipping.edit.description_title'|trans }}</span>
                                         <i class="fa fa-question-circle fa-lg ml-1" aria-hidden="true"></i>
@@ -273,7 +273,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                          title="Tooltip">
                                         <span class="card-title">{{ 'admin.shipping.edit.produtcs_title'|trans }}</span><i
                                                 class="fa fa-question-circle fa-lg ml-1"
@@ -344,7 +344,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                          title="Tooltip">
                                     <span class="card-title">{{ 'admin.shipping.edit.note_title'|trans }}<i
                                                 class="fa fa-question-circle fa-lg ml-1"></i></span></div>

--- a/src/Eccube/Resource/template/admin/Shipping/index.twig
+++ b/src/Eccube/Resource/template/admin/Shipping/index.twig
@@ -328,8 +328,8 @@
                                         <div class="row text-center">
                                             {# TODO メール送信ボタン #}
                                             {# TODO 発送済みにするボタン #}
-                                            <div class="col" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{ 'admin.shipping.index.824'|trans }}"><a class="btn btn-ec-actionIcon" href="/shipment/mail/"><i class="fa fa-send fa-lg text-secondary" aria-hidden="true"></i></a></div>
-                                            <div class="col" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{ 'admin.shipping.index.825'|trans }}"><a class="btn btn-ec-actionIcon"><i class="fa fa-check fa-lg text-secondary" aria-hidden="true"></i></a></div>
+                                            <div class="col" data-tooltip="tooltip" data-placement="top" title="" data-original-title="{{ 'admin.shipping.index.824'|trans }}"><a class="btn btn-ec-actionIcon" href="/shipment/mail/"><i class="fa fa-send fa-lg text-secondary" aria-hidden="true"></i></a></div>
+                                            <div class="col" data-tooltip="tooltip" data-placement="top" title="" data-original-title="{{ 'admin.shipping.index.825'|trans }}"><a class="btn btn-ec-actionIcon"><i class="fa fa-check fa-lg text-secondary" aria-hidden="true"></i></a></div>
                                         </div>
                                     </td>
                                 </tr>

--- a/src/Eccube/Resource/template/admin/Shipping/order_item_prototype.twig
+++ b/src/Eccube/Resource/template/admin/Shipping/order_item_prototype.twig
@@ -25,7 +25,7 @@
     <td class="align-middle text-right pr-3">
         <div class="row justify-content-end">
             <div class="col-auto text-center"><a class="btn btn-ec-actionIcon remove-order-item"
-                                                 data-toggle="tooltip"
+                                                 data-tooltip="tooltip"
                                                  data-placement="top" title="{{ 'admin.shipping.edit.remove'|trans }}"><i
                             class="fa fa-close fa-lg text-secondary"
                             aria-hidden="true"></i></a></div>

--- a/src/Eccube/Resource/template/admin/index.twig
+++ b/src/Eccube/Resource/template/admin/index.twig
@@ -50,7 +50,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             <div class="c-primaryCol">
                 <div class="card rounded border-0 mb-4">
                     <div class="card-header">
-                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip">
+                        <div class="d-inline-block" data-tooltip="tooltip" data-placement="top" title="Tooltip">
                             <span
                                     class="card-title">{{ 'admin.index.intro'|trans }}</span><i
                                     class="fa fa-question-circle fa-lg ml-1" aria-hidden="true"></i></div>
@@ -140,7 +140,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div id="chart-statistics" class="card rounded border-0 h-100">
                             {# TODO: Calculate metrics, representations on charts #}
                             <div class="card-header">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                      title="Tooltip">
                                     <span class="card-title">{{ 'admin.index.summary.sales.situation'|trans }}</span>
                                     <i class="fa fa-question-circle fa-lg ml-1" aria-hidden="true"></i>
@@ -197,25 +197,25 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                             <hr style="top: 208px;">
                                                             <hr style="top: 234px;">
                                                             <hr style="top: 260px;">
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 165px; margin-top: 96px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 82px; margin-top: 179px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 200px; margin-top: 61px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 166px; margin-top: 95px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 165px; margin-top: 96px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 82px; margin-top: 179px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 200px; margin-top: 61px;"></div>
                                                         </div>
@@ -259,25 +259,25 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                             <hr style="top: 208px;">
                                                             <hr style="top: 234px;">
                                                             <hr style="top: 260px;">
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 165px; margin-top: 96px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 82px; margin-top: 179px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 200px; margin-top: 61px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 166px; margin-top: 95px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 165px; margin-top: 96px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 82px; margin-top: 179px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 200px; margin-top: 61px;"></div>
                                                         </div>
@@ -321,25 +321,25 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                                             <hr style="top: 208px;">
                                                             <hr style="top: 234px;">
                                                             <hr style="top: 260px;">
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 165px; margin-top: 96px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 82px; margin-top: 179px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 200px; margin-top: 61px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 166px; margin-top: 95px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 165px; margin-top: 96px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 82px; margin-top: 179px;"></div>
-                                                            <div class="c-graf__bar" data-toggle="tooltip"
+                                                            <div class="c-graf__bar" data-tooltip="tooltip"
                                                                  data-placement="top" title="Tooltip"
                                                                  style="height: 200px; margin-top: 61px;"></div>
                                                         </div>
@@ -377,7 +377,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             </form>
 
                             <div class="card-header">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                      title="Tooltip">
                                     <span class="card-title">{{ 'admin.index.summary.shop.situation'|trans }}</span>
                                     <i class="fa fa-question-circle fa-lg ml-1" aria-hidden="true"></i>
@@ -432,7 +432,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                     <div class="col mb-4">
                         <div id="ec-cube-news" class="card rounded border-0 h-100">
                             <div class="card-header">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                <div class="d-inline-block" data-tooltip="tooltip" data-placement="top"
                                      title="Tooltip"><span class="card-title">{{ 'admin.index.161'|trans }}</span></div>
                             </div>
                             <div class="card-body p-0">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
モーダルで削除確認を表示する場合。
削除ボタンのコードで `data-toggle="tooltip"` と `data-toggle="modal"` がコードで競合する問題の対応。

## 方針(Policy)
- script.jsを修正しています。
-  `data-toggle="tooltip"` を `data-tooltip="tooltip"` に置き換えました。

## 実装に関する補足(Appendix)
- 支払い方法管理ページの削除ボタンについては、すでに本件の問題が発生していたのでdata-toggleとdata-tooltip両方を指定するようにしました。
- タグ管理のページについては、modalのタグの位置をモックアップに合わせて修正しました。

## テスト（Test)
tooltip表示されることを確認

## 相談（Discussion）
なし


