### PR TITLE
商品マスターで resume が効かないのを修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -221,6 +221,10 @@ class ProductController extends AbstractController
                 $searchData = [];
 
                 $pagination = $this->buildPagination($paginator, $request, $searchData, $page_no, $page_count);
+                $viewData = FormUtil::getViewData($searchForm);
+
+                $session->set('eccube.admin.product.search', $viewData);
+                $session->set('eccube.admin.product.search.page_no', $page_no);
             } else {
                 // pagingなどの処理
                 if (is_null($page_no)) {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 商品マスターの初回検索時、詳細ページや表示件数変更をした際に `resume=1` で検索結果が復元できないのを修正

## 実装に関する補足(Appendix)
- `cache:clear` をしてから初回の表示で再現します

## テスト（Test)
+ 画面で確認

