### PR TITLE
日付フォーマットのローカライズ

### DIFF
--- a/app/config/eccube/packages/twig_extensions.yaml
+++ b/app/config/eccube/packages/twig_extensions.yaml
@@ -1,0 +1,10 @@
+services:
+    _defaults:
+        public: false
+        autowire: true
+        autoconfigure: true
+
+    #Twig\Extensions\ArrayExtension: ~
+    #Twig\Extensions\DateExtension: ~
+    Twig\Extensions\IntlExtension: ~
+    #Twig\Extensions\TextExtension: ~

--- a/composer.json
+++ b/composer.json
@@ -93,6 +93,7 @@
         "symfony/var-dumper": "^3.4",
         "symfony/web-profiler-bundle": "^3.4",
         "symfony/yaml": "^3.4",
+        "twig/extensions": "^1.5",
         "twig/twig": "^2.4",
         "vlucas/phpdotenv": "v2.4.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1deb1393a120c917d1656eea5dfcb5da",
+    "content-hash": "c9154d96745fd13c4a8a5e23ce0eaa7e",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -6200,6 +6200,62 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2018-02-16T09:50:28+00:00"
+        },
+        {
+            "name": "twig/extensions",
+            "version": "v1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig-extensions.git",
+                "reference": "d188c76168b853481cc75879ea045bf93d718e9c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig-extensions/zipball/d188c76168b853481cc75879ea045bf93d718e9c",
+                "reference": "d188c76168b853481cc75879ea045bf93d718e9c",
+                "shasum": ""
+            },
+            "require": {
+                "twig/twig": "~1.27|~2.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~3.3@dev",
+                "symfony/translation": "~2.3|~3.0"
+            },
+            "suggest": {
+                "symfony/translation": "Allow the time_diff output to be translated"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Twig_Extensions_": "lib/"
+                },
+                "psr-4": {
+                    "Twig\\Extensions\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Common additional features for Twig that do not directly belong in core",
+            "homepage": "http://twig.sensiolabs.org/doc/extensions/index.html",
+            "keywords": [
+                "i18n",
+                "text"
+            ],
+            "time": "2017-06-08T18:19:53+00:00"
         },
         {
             "name": "twig/twig",

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -74,8 +74,10 @@ class Kernel extends BaseKernel
         parent::boot();
 
         // DateTime/DateTimeTzのタイムゾーンを設定.
-        UTCDateTimeType::setTimeZone($this->container->getParameter('timezone'));
-        UTCDateTimeTzType::setTimeZone($this->container->getParameter('timezone'));
+        $timezone = $this->container->getParameter('timezone');
+        date_default_timezone_set($timezone);
+        UTCDateTimeType::setTimeZone($timezone);
+        UTCDateTimeTzType::setTimeZone($timezone);
 
         // Activate to $app
         $app = Application::getInstance(['debug' => $this->isDebug()]);

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -388,7 +388,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                         <td class="align-middle pl-3">
                                             <input type="checkbox"  name="ids{{ Order.id }}" id="check--{{ Order.id }}" value="on">
                                         </td>
-                                        <td class="align-middle" id="order_date--{{ Order.id }}">{{ Order.order_date|date('Y/m/d H:i') }}</td> {# TODO: date time format should follow locale #}
+                                        <td class="align-middle" id="order_date--{{ Order.id }}">{{ Order.order_date|date_min }}</td>
                                         <td class="align-middle" id="id--{{ Order.id }}"><a class="action-edit" href="{{ url('admin_order_edit', { id : Order.id }) }}">{{ Order.id }}</a></td>
                                         <td class="align-middle" id="name--{{ Order.id }}">{{ Order.name01 }} {{ Order.name02 }}</td>
                                         <td class="align-middle" id="payment_method--{{ Order.id }}">{{ Order.payment_method }}</td>

--- a/src/Eccube/Twig/Extension/IntlExtension.php
+++ b/src/Eccube/Twig/Extension/IntlExtension.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Eccube\Twig\Extension;
+
+
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class IntlExtension extends AbstractExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('date_day', [$this, 'date_day'], ['needs_environment' => true]),
+            new TwigFilter('date_min', [$this, 'date_min'], ['needs_environment' => true]),
+        ];
+    }
+
+    /**
+     * localizeddate('medium', 'none')のショートカット.
+     *
+     * 2015/08/28のように、日までのフォーマットで表示します(localeがjaの場合).
+     *
+     * @param Environment $env
+     * @param $date
+     * @return bool|string
+     */
+    public function date_day(Environment $env, $date)
+    {
+        return \twig_localized_date_filter($env, $date, 'medium', 'none');
+    }
+
+    /**
+     * localizeddate('medium', 'short')のショートカット.
+     *
+     * 2015/08/28 16:13のように、分までのフォーマットで表示します(localeがjaの場合).
+     *
+     * @param Environment $env
+     * @param $date
+     * @return bool|string
+     */
+    public function date_min(Environment $env, $date)
+    {
+        return \twig_localized_date_filter($env, $date, 'medium', 'short');
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -464,6 +464,15 @@
     "symfony/yaml": {
         "version": "v3.4.1"
     },
+    "twig/extensions": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "4851df0afc426b8f07204379d21fca25b6df5d68"
+        }
+    },
     "twig/twig": {
         "version": "v2.4.4"
     },

--- a/tests/Eccube/Tests/Twig/Extension/IntlExtensionTest.php
+++ b/tests/Eccube/Tests/Twig/Extension/IntlExtensionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Eccube\Tests\Twig\Extension;
+
+use Eccube\Twig\Extension\IntlExtension;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+class IntlExtensionTest extends TestCase
+{
+    /**
+     * @var Environment
+     */
+    protected $twig;
+
+    public function setUp()
+    {
+        $loader = new ArrayLoader();
+        $loader->setTemplate('date_day_template', '{{ date|date_day }}');
+        $loader->setTemplate('date_min_template', '{{ date|date_min }}');
+
+        $this->twig = new Environment($loader);
+        $this->twig->addExtension(new IntlExtension());
+
+        // twig_localized_date_filterをautoloadするため.
+        class_exists('Twig_Extensions_Extension_Intl');
+    }
+
+    public function testDateDay()
+    {
+        $date = new \DateTime('2018-01-01', new \DateTimeZone('Asia/Tokyo'));
+        $this->assertSame('2018/01/01', $this->twig->render('date_day_template', ['date' => $date]));
+    }
+
+    public function testDateMin()
+    {
+        $date = new \DateTime('2018-01-01 12:34:56', new \DateTimeZone('Asia/Tokyo'));
+        $this->assertSame('2018/01/01 12:34', $this->twig->render('date_min_template', ['date' => $date]));
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- twigでの日付表示のため, IntlExtensionを導入
- 日付や日時は, localizeddateフィルタで出力する

## 使い方

```
年月日まで表示する場合
{{ Product.create_date|localizeddate('short', 'none') }}

→ 2018/3/29

年月日時分まで表示する場合
{{ Product.create_date|localizeddate('short', 'short') }}

→ 2018/3/29 13:36
```

EC-CUBEでよく使われる年月日、年月日時分のフォーマットは、以下のショートカットフィルタを用意しています。

```
年月日まで表示する場合
{{ Product.create_date|date_day }}

→ 2018/3/29

年月日時分まで表示する場合
{{ Product.create_date|date_min }}

→ 2018/3/29 13:36
```

## LOCALEによるフォーマットの切り替え

`ECCUBE_LOCALE`により、フォーマットが切り替わります。

```
// .env

ECCUBE_LOCALE=ja

→　2018/3/29 13:36

ECCUBE_LOCALE=ja

→　Mar 29, 2018, 13:36 PM

```

## TIMEZONEによる切り替え

`ECCUBE_TIMEZONE`を変更することで、TIMEZONEを考慮して表示します。

## 参考
http://twig-extensions.readthedocs.io/en/latest/intl.html

