### PR TITLE
商品登録/カテゴリが検索ができる

### DIFF
--- a/html/template/admin/assets/js/script.js
+++ b/html/template/admin/assets/js/script.js
@@ -14,19 +14,6 @@ var mainNavArea = function(){
 };
 mainNavArea();
 
-//c-directoryTreeRegister
-var directoryTreeRegister = function(){
-    $(function () {
-        $(".c-directoryTree--registerItem label").on('click',function () {
-            $tar = $(this).siblings("input");
-            var value = $tar.prop("checked")
-            $tar.prop("checked",!value);
-        });
-    })
-};
-
-directoryTreeRegister();
-
 //Bootstrap ツールチップ
 var toolTip = function(){
     $(function () {

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -584,12 +584,16 @@ class ProductController extends AbstractController
             $searchForm->handleRequest($request);
         }
 
+        // ツリー表示のため、ルートからのカテゴリを取得
+        $TopCategories = $this->categoryRepository->getList(null);
+
         return [
             'Product' => $Product,
             'form' => $form->createView(),
             'searchForm' => $searchForm->createView(),
             'has_class' => $has_class,
             'id' => $id,
+            'TopCategories' => $TopCategories,
         ];
     }
 

--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -30,6 +30,7 @@ use Eccube\Form\Validator\TwigLint;
 use Eccube\Repository\CategoryRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -69,6 +70,16 @@ class ProductType extends AbstractType
          * @var ArrayCollection $arrCategory array of category
          */
         $arrCategory = $this->categoryRepository->getList(null, true);
+        foreach ($arrCategory as $Category) {
+            $formId = 'category_' . $Category->getId();
+            $builder
+                ->add($formId, CheckboxType::class, array(
+                    'label' => $Category->getName(),
+                    'mapped' => false,
+                    'value' => '1',
+                    'required' => false,
+                ));
+        }
 
         $builder
             // 商品規格情報

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -177,6 +177,37 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         }
 
     </script>
+    <script>
+        searchWord = function(){
+            var searchText = $(this).val(), // 検索ボックスに入力された値
+                targetText
+
+            // 検索ボックスに値が入っていない場合
+            if (searchText == '') {
+                // 全て表示する
+                $('.category-li').show();
+                return;
+            }
+
+            // 検索ボックスに値が入ってる場合
+            // 表示を全て空にする
+            $('.category-li').hide();
+
+            // 検索ワードが（子を含めて）含まれる要素のみ表示
+            $('.category-li').each(function() {
+                targetText = $(this).text();
+
+                // 検索対象となるリストに入力された文字列が存在するかどうかを判断
+                if (targetText.indexOf(searchText) != -1) {
+                    // 存在する場合はそのリストのテキストを用意した配列に格納
+                    $(this).show();
+                }
+            });
+        };
+
+        // searchWordの実行
+        $('#search-category').on('input', searchWord);
+    </script>
 {% endblock javascript %}
 
 {% block main %}
@@ -669,7 +700,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     {# TODO: カテゴリ検索機能の実装 #}
                                     <div class="form-row">
                                         <div class="col">
-                                            <input class="form-control" type="search"
+                                            <input id="search-category" class="form-control" type="search"
                                                    placeholder="{{ 'admin.product.product.text12'|trans }}"
                                                    aria-label="Search">
                                         </div>
@@ -681,70 +712,33 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     </div>
                                 </div>
 
-                                {# TODO: カテゴリ選択方法の変更 #}
-                                <div id="detail_category_box__list"
-                                     class="accpanel padT08{% if form.Category.vars.valid == false %} has-error{% endif %}">
-                                    {{ form_widget(form.Category) }}
-                                    {{ form_errors(form.Category) }}
-                                </div>
-                                {#
-                                <div class="c-directoryTree--register rounded border mb-3 p-3">
-                                    <ul>
-                                        <li class="c-directoryTree--registerItem">
-                                            <input type="checkbox">
-                                            <label>カテゴリA</label>
+                                {% macro tree(Category, form) %}
+                                    {% import _self as selfMacro %}
+                                    {% set category_id = 'category_'~Category.id %}
+                                    <li class="c-directoryTree--registerItem category-li">
+                                        {# TODO: htmlの構造をモックと合わせる #}
+                                        {#{{ form_widget(attribute(form, category_id)) }}#}
+                                        <input type="checkbox" id="admin_product_{{ category_id }}" name="admin_product[{{ category_id }}]" class="form-check-input" value="1">
+                                        <label class="form-check-label" for="admin_product_{{ category_id }}">{{ attribute(form, category_id).vars.label }}</label>
+                                        {% if Category.children|length > 0 %}
                                             <ul>
-                                                <li class="c-directoryTree--registerItem">
-                                                    <input type="checkbox">
-                                                    <label>カテゴリA-a</label>
-                                                </li>
-                                                <li class="c-directoryTree--registerItem">
-                                                    <input type="checkbox">
-                                                    <label>カテゴリA-b</label>
-                                                </li>
-                                                <li class="c-directoryTree--registerItem">
-                                                    <input type="checkbox">
-                                                    <label>カテゴリA-c</label>
-                                                    <ul>
-                                                        <li class="c-directoryTree--registerItem">
-                                                            <input type="checkbox">
-                                                            <label>カテゴリA-c-1</label>
-                                                        </li>
-                                                        <li class="c-directoryTree--registerItem">
-                                                            <input type="checkbox">
-                                                            <label>カテゴリA-c-2</label>
-                                                            <ul>
-                                                                <li class="c-directoryTree--registerItem">
-                                                                    <input type="checkbox">
-                                                                    <label>カテゴリA-c-2-1</label>
-                                                                </li>
-                                                                <li class="c-directoryTree--registerItem">
-                                                                    <input type="checkbox">
-                                                                    <label>カテゴリA-c-2-2</label>
-                                                                </li>
-                                                            </ul>
-                                                        </li>
-                                                    </ul>
-                                                </li>
+                                                {% for ChildCategory in Category.children %}
+                                                    {{ selfMacro.tree(ChildCategory, form) }}
+                                                {% endfor %}
                                             </ul>
-                                        </li>
-                                    </ul>
-                                    <ul>
-                                        <li class="c-directoryTree--registerItem">
-                                            <input type="checkbox">
-                                            <label>カテゴリB</label>
-                                        </li>
-                                    </ul>
-                                    <ul>
-                                        <li class="c-directoryTree--registerItem">
-                                            <input type="checkbox">
-                                            <label>カテゴリC</label>
-                                        </li>
-                                    </ul>
+                                        {% endif %}
+                                    </li>
+                                {% endmacro %}
+
+                                <div class="c-directoryTree--register rounded border mb-3 p-3">
+                                    {% import _self as renderMacro %}
+                                    {% for TopCategory in TopCategories %}
+                                        <ul>
+                                            {{ renderMacro.tree(TopCategory, form) }}
+                                        </ul>
+                                    {% endfor %}
                                 </div>
-                                #}
                                 <div class="d-block text-center">
-                                    {# TODO onclickは適切ではないのでaタグで実装できるようにする #}
                                     <button class="btn btn-block btn-ec-regular" type="button"
                                             onclick='location.href="{{ url('admin_product_category') }}"'>
                                         {{ 'admin.product.product.text13'|trans }}

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -178,7 +178,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
     </script>
     <script>
-        searchWord = function(){
+        var searchWord = function(){
             var searchText = $(this).val(), // 検索ボックスに入力された値
                 targetText
 
@@ -700,14 +700,16 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     {# TODO: カテゴリ検索機能の実装 #}
                                     <div class="form-row">
                                         <div class="col">
-                                            <input id="search-category" class="form-control" type="search"
-                                                   placeholder="{{ 'admin.product.product.text12'|trans }}"
-                                                   aria-label="Search">
-                                        </div>
-                                        <div class="col-auto">
-                                            <button class="btn btn-ec-sub" type="submit">
-                                                <i class="fa fa-search"></i>
-                                            </button>
+                                            <div class="input-group mb-3">
+                                                <div class="input-group-prepend">
+                                                    <span class="input-group-text" id="basic-addon1">
+                                                            <i class="fa fa-search"></i>
+                                                    </span>
+                                                </div>
+                                                <input id="search-category" class="form-control" type="search"
+                                                       placeholder="{{ 'admin.product.product.text12'|trans }}"
+                                                       aria-label="Search">
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
@@ -716,10 +718,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     {% import _self as selfMacro %}
                                     {% set category_id = 'category_'~Category.id %}
                                     <li class="c-directoryTree--registerItem category-li">
-                                        {# TODO: htmlの構造をモックと合わせる #}
                                         {#{{ form_widget(attribute(form, category_id)) }}#}
-                                        <input type="checkbox" id="admin_product_{{ category_id }}" name="admin_product[{{ category_id }}]" class="form-check-input" value="1">
-                                        <label class="form-check-label" for="admin_product_{{ category_id }}">{{ attribute(form, category_id).vars.label }}</label>
+                                        <input type="checkbox" id="admin_product_category_{{ category_id }}" name="admin_product[{{ category_id }}]" value="1">
+                                        <label for="admin_product_category_{{ category_id }}">{{ attribute(form, category_id).vars.label }}</label>
                                         {% if Category.children|length > 0 %}
                                             <ul>
                                                 {% for ChildCategory in Category.children %}

--- a/tests/Eccube/Tests/Web/Admin/Product/CategoryContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CategoryContorllerTest.php
@@ -327,8 +327,8 @@ class CategoryControllerTest extends AbstractAdminWebTestCase
         );
 
         $CategoryLast = $this->categoryRepository->findOneBy(array('name' => '子2-2'));
-        $categoryNameLastElement = $crawler->filter('#admin_product_Category option')->last()->text();
-        $this->expected = $CategoryLast->getNameWithLevel();
+        $categoryNameLastElement = $crawler->filter('.c-directoryTree--register label')->last()->text();
+        $this->expected = $CategoryLast->getName();
         $this->actual = $categoryNameLastElement;
         $this->verify();
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- カテゴリの絞り込みができる
- リアルタイムで絞り込める
- 検索ボタンは削除してインプットグループとする

## 方針(Policy)
+ [こちら](https://github.com/okazy/ec-cube/commit/4d6b7defb7b6f89bfa322bbafdad172a002c2aae) の引継ぎ

## 実装に関する補足(Appendix)
+ label をクリックした時の動作は、 JavaScript ではなく label for を使用するようにしました

## テスト（Test)
+ 画面上で動作確認

## 相談（Discussion）
+ IME で確定前は絞り込めないので、日本語では小々使いにくいが改善した方が良いか？
   - 参考 https://qiita.com/dhtn/items/deb06e5c970ce0e974bb
