### PR TITLE
商品登録/カテゴリがチェックボックスで選択できるように修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -455,8 +455,8 @@ class ProductController extends AbstractController
                 $Categories = $form->get('Category')->getData();
                 $categoriesIdList = [];
                 foreach ($Categories as $Category) {
-                    foreach($Category->getPath() as $ParentCategory){
-                        if (!isset($categoriesIdList[$ParentCategory->getId()])){
+                    foreach($Category->getPath() as $ParentCategory) {
+                        if (!isset($categoriesIdList[$ParentCategory->getId()])) {
                             $ProductCategory = $this->createProductCategory($Product, $ParentCategory, $count);
                             $this->entityManager->persist($ProductCategory);
                             $count++;
@@ -586,6 +586,9 @@ class ProductController extends AbstractController
 
         // ツリー表示のため、ルートからのカテゴリを取得
         $TopCategories = $this->categoryRepository->getList(null);
+        $ChoicedCategoryIds = array_map(function ($Category) {
+            return $Category->getId();
+        }, $form->get('Category')->getData());
 
         return [
             'Product' => $Product,
@@ -594,6 +597,7 @@ class ProductController extends AbstractController
             'has_class' => $has_class,
             'id' => $id,
             'TopCategories' => $TopCategories,
+            'ChoicedCategoryIds' => $ChoicedCategoryIds
         ];
     }
 

--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -25,6 +25,7 @@
 namespace Eccube\Form\Type\Admin;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Eccube\Entity\Category;
 use Eccube\Form\Type\Master\ProductStatusType;
 use Eccube\Form\Validator\TwigLint;
 use Eccube\Repository\CategoryRepository;
@@ -67,8 +68,6 @@ class ProductType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $Categories = $this->categoryRepository->getList(null, true);
-
         $builder
             // 商品規格情報
             ->add('class', ProductClassType::class, array(
@@ -100,7 +99,10 @@ class ProductType extends AbstractType
                 'multiple' => true,
                 'mapped' => false,
                 'expanded' => true,
-                'choices' => $Categories,
+                'choices' => $this->categoryRepository->getList(null, true),
+                'choice_value' => function (Category $Category = null) {
+                    return $Category ? $Category->getId() : null;
+                }
             ))
 
             // 詳細な説明

--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -31,6 +31,7 @@ use Eccube\Repository\CategoryRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -66,20 +67,7 @@ class ProductType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        /**
-         * @var ArrayCollection $arrCategory array of category
-         */
-        $arrCategory = $this->categoryRepository->getList(null, true);
-        foreach ($arrCategory as $Category) {
-            $formId = 'category_' . $Category->getId();
-            $builder
-                ->add($formId, CheckboxType::class, array(
-                    'label' => $Category->getName(),
-                    'mapped' => false,
-                    'value' => '1',
-                    'required' => false,
-                ));
-        }
+        $Categories = $this->categoryRepository->getList(null, true);
 
         $builder
             // 商品規格情報
@@ -106,14 +94,13 @@ class ProductType extends AbstractType
                 'label' => 'product.label.product_description_list',
                 'required' => false,
             ))
-            ->add('Category', EntityType::class, array(
-                'class' => 'Eccube\Entity\Category',
-                'choice_label' => 'NameWithLevel',
+            ->add('Category', ChoiceType::class, array(
+                'choice_label' => 'Name',
                 'label' => 'product.label.product_category',
                 'multiple' => true,
                 'mapped' => false,
-                // Choices list (overdrive mapped)
-                'choices' => $arrCategory,
+                'expanded' => true,
+                'choices' => $Categories,
             ))
 
             // 詳細な説明

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -713,14 +713,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     </div>
                                 </div>
 
-                                {% macro tree(Category, form) %}
+                                {% macro tree(ChoicedIds, Category, form) %}
                                     {% import _self as selfMacro %}
                                     <li class="c-directoryTree--registerItem category-li">
-                                        <input type="checkbox" id="admin_product_category_{{ Category.id }}" name="admin_product[Category][]" value="{{ Category.id }}" {% if Category.id in form.vars.value %}checked{% endif %}>
+                                        <input type="checkbox" id="admin_product_category_{{ Category.id }}" name="admin_product[Category][]" value="{{ Category.id }}" {% if Category.id in ChoicedIds %}checked{% endif %}>
                                         <label for="admin_product_category_{{ Category.id }}">{{ Category.name }}</label>
                                         <ul>
                                             {% for child,ChildCategory in Category.children %}
-                                                {{ selfMacro.tree(ChildCategory, form) }}
+                                                {{ selfMacro.tree(ChoicedIds, ChildCategory, form) }}
                                             {% endfor %}
                                         </ul>
                                     </li>
@@ -730,9 +730,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     {% import _self as renderMacro %}
                                     {% for TopCategory in TopCategories %}
                                         <ul>
-                                            {{ renderMacro.tree(TopCategory, form.Category) }}
+                                            {{ renderMacro.tree(ChoicedCategoryIds, TopCategory, form.Category) }}
                                         </ul>
                                     {% endfor %}
+                                    {{ form_errors(form.Category) }}
                                 </div>
                                 <div class="d-block text-center">
                                     <button class="btn btn-block btn-ec-regular" type="button"

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -697,7 +697,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         <div class="collapse show ec-cardCollapse" id="category">
                             <div class="card-body">
                                 <div class="mb-3">
-                                    {# TODO: カテゴリ検索機能の実装 #}
                                     <div class="form-row">
                                         <div class="col">
                                             <div class="input-group mb-3">
@@ -716,18 +715,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
                                 {% macro tree(Category, form) %}
                                     {% import _self as selfMacro %}
-                                    {% set category_id = 'category_'~Category.id %}
                                     <li class="c-directoryTree--registerItem category-li">
-                                        {#{{ form_widget(attribute(form, category_id)) }}#}
-                                        <input type="checkbox" id="admin_product_category_{{ category_id }}" name="admin_product[{{ category_id }}]" value="1">
-                                        <label for="admin_product_category_{{ category_id }}">{{ attribute(form, category_id).vars.label }}</label>
-                                        {% if Category.children|length > 0 %}
-                                            <ul>
-                                                {% for ChildCategory in Category.children %}
-                                                    {{ selfMacro.tree(ChildCategory, form) }}
-                                                {% endfor %}
-                                            </ul>
-                                        {% endif %}
+                                        <input type="checkbox" id="admin_product_category_{{ Category.id }}" name="admin_product[Category][]" value="{{ Category.id }}" {% if Category.id in form.vars.value %}checked{% endif %}>
+                                        <label for="admin_product_category_{{ Category.id }}">{{ Category.name }}</label>
+                                        <ul>
+                                            {% for child,ChildCategory in Category.children %}
+                                                {{ selfMacro.tree(ChildCategory, form) }}
+                                            {% endfor %}
+                                        </ul>
                                     </li>
                                 {% endmacro %}
 
@@ -735,7 +730,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     {% import _self as renderMacro %}
                                     {% for TopCategory in TopCategories %}
                                         <ul>
-                                            {{ renderMacro.tree(TopCategory, form) }}
+                                            {{ renderMacro.tree(TopCategory, form.Category) }}
                                         </ul>
                                     {% endfor %}
                                 </div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 商品登録時にカテゴリをチェックボックスで選択できるよう修正
+ #2992 の続き

## 方針(Policy)
+ `ChoiceType` を使用する
+ 再帰に対応するため、 `form_widget` は使用せず、 独自に HTML 描画する

## テスト（Test)
+ ユニットテストが通ることを確認

