### PR TITLE
出荷マスタの一括メール送信ボタンを削除

### DIFF
--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -1834,7 +1834,6 @@ return [
     'admin.shipping.index.801' => '注文番号',
     'admin.shipping.index.802' => '配送業者',
     'admin.shipping.index.803' => '一括操作',
-    'admin.shipping.index.804' => 'メールする',
     'admin.shipping.index.805' => '発送済みに更新',
     'admin.shipping.index.806' => '削除',
     'admin.shipping.index.807' => '一括で発送済みにします',

--- a/src/Eccube/Resource/template/admin/Shipping/index.twig
+++ b/src/Eccube/Resource/template/admin/Shipping/index.twig
@@ -206,8 +206,6 @@
                 <div class="row justify-content-between mb-2">
                     <div class="col-6">
                         <label class="mr-2">{{ 'admin.shipping.index.803'|trans }}</label>
-                        {# TODO 一括メール #}
-                        <button class="btn btn-ec-regular mr-2">{{ 'admin.shipping.index.804'|trans }}</button>
                         {# TODO 一括ステタース更新 #}
                         <button class="btn btn-ec-regular mr-2" data-toggle="modal" data-target="#sentUpdate">{{ 'admin.shipping.index.805'|trans }}</button>
                         <div class="modal fade" id="sentUpdate" tabindex="-1" role="dialog" aria-labelledby="sentUpdate" aria-hidden="true">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 出荷マスタの一括メール送信ボタンは使用しなくなったため削除
