### PR TITLE
[管理画面UI実装]出荷登録/空の出荷を作成できる

### DIFF
--- a/src/Eccube/Form/Type/Admin/ShippingType.php
+++ b/src/Eccube/Form/Type/Admin/ShippingType.php
@@ -289,15 +289,6 @@ class ShippingType extends AbstractType
             })
             ->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
                 $form = $event->getForm();
-                $OrderItems = $form['OrderItems']->getData();
-
-                if (empty($OrderItems) || count($OrderItems) < 1) {
-                    // 画面下部にエラーメッセージを表示させる
-                    $form['OrderItemsError']->addError(new FormError('shipping.text.error.product_not_added'));
-                }
-            })
-            ->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
-                $form = $event->getForm();
                 $Shipping = $event->getData();
                 $Delivery = $Shipping->getDelivery();
                 $Shipping->setShippingDeliveryName($Delivery ? $Delivery->getName() : null);

--- a/tests/Eccube/Tests/Web/Admin/Shipping/ShippingEditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Shipping/ShippingEditControllerTest.php
@@ -3,6 +3,7 @@
 namespace Eccube\Tests\Web\Admin\Shipping;
 
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+use Faker\Generator;
 
 class ShippingEditControllerTest extends AbstractAdminWebTestCase
 {
@@ -13,5 +14,68 @@ class ShippingEditControllerTest extends AbstractAdminWebTestCase
             $this->generateUrl('admin_shipping_new')
         );
         $this->assertTrue($this->client->getResponse()->isSuccessful());
+    }
+
+    public function testNewShippingEmptyShipment()
+    {
+        $arrFormData = $this->createShippingForm();
+
+        $this->client->request(
+            'POST',
+            $this->generateUrl('admin_shipping_new'),
+            array(
+                'shipping' => $arrFormData,
+                'mode' => 'register'
+            )
+        );
+
+        $crawler = $this->client->followRedirect();
+
+        $success = $crawler->filter('#page_admin_shipping_edit > div.c-container > div.c-contentsArea > div.alert.alert-success')->text();
+        $this->assertContains('出荷情報を登録しました。', $success);
+    }
+
+    /**
+     * @return array
+     */
+    private function createShippingForm(): array
+    {
+        /** @var Generator $faker */
+        $faker = $this->getFaker();
+        $tel = explode('-', $faker->phoneNumber);
+
+        $arrFormData = array(
+            'name' => array(
+                'name01' => $faker->lastName,
+                'name02' => $faker->firstName,
+            ),
+            'kana' => array(
+                'kana01' => $faker->lastKanaName,
+                'kana02' => $faker->firstKanaName,
+            ),
+            'company_name' => $faker->company,
+            'zip' => array(
+                'zip01' => $faker->postcode1(),
+                'zip02' => $faker->postcode2(),
+            ),
+            'address' => array(
+                'pref' => $faker->numberBetween(1, 47),
+                'addr01' => $faker->city,
+                'addr02' => $faker->streetAddress,
+            ),
+            'tel' => array(
+                'tel01' => $tel[0],
+                'tel02' => $tel[1],
+                'tel03' => $tel[2],
+            ),
+            'fax' => array(
+                'fax01' => $tel[0],
+                'fax02' => $tel[1],
+                'fax03' => $tel[2],
+            ),
+            'Delivery' => 1,
+            '_token' => 'dummy'
+        );
+        return $arrFormData;
     }
 }


### PR DESCRIPTION

## 概要(Overview・Refs Issue)
+ PullRequestの目的、関連するIssue番号など
  - [管理画面UI実装]出荷登録/空の出荷を作成できる
  - 同梱して出荷が空になった時に、備忘録的にメモを書き残しておくユースケースを想定。

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外した内容
  - Dont affect any validation others

## 実装に関する補足(Appendix)
+ none

## テスト（Test)
+ phpUnit


