### PR TITLE
商品規格登録画面の実装

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductClassController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductClassController.php
@@ -24,56 +24,31 @@
 
 namespace Eccube\Controller\Admin\Product;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\NoResultException;
 use Eccube\Controller\AbstractController;
-use Eccube\Entity\BaseInfo;
 use Eccube\Entity\ClassName;
-use Eccube\Entity\Master\SaleType;
 use Eccube\Entity\Product;
 use Eccube\Entity\ProductClass;
 use Eccube\Entity\ProductStock;
 use Eccube\Entity\TaxRule;
-use Eccube\Event\EccubeEvents;
-use Eccube\Event\EventArgs;
-use Eccube\Form\Type\Admin\ProductClassType;
+use Eccube\Form\Type\Admin\ProductClassMatrixType;
+use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\ClassCategoryRepository;
-use Eccube\Repository\Master\SaleTypeRepository;
 use Eccube\Repository\ProductClassRepository;
 use Eccube\Repository\ProductRepository;
 use Eccube\Repository\TaxRuleRepository;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Symfony\Bridge\Doctrine\Form\Type\EntityType;
-use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
-use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\FormError;
-use Symfony\Component\Form\FormInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @Route(service=ProductClassController::class)
- */
 class ProductClassController extends AbstractController
 {
     /**
-     * @var TaxRuleRepository
+     * @var ProductRepository
      */
-    protected $taxRuleRepository;
-
-    /**
-     * @var SaleTypeRepository
-     */
-    protected $saleTypeRepository;
-
-    /**
-     * @var ClassCategoryRepository
-     */
-    protected $classCategoryRepository;
+    protected $productRepository;
 
     /**
      * @var ProductClassRepository
@@ -81,815 +56,388 @@ class ProductClassController extends AbstractController
     protected $productClassRepository;
 
     /**
-     * @var BaseInfo
+     * @var ClassCategoryRepository
      */
-    protected $BaseInfo;
+    protected $classCategoryRepository;
 
     /**
-     * @var ProductRepository
+     * @var BaseInfoRepository
      */
-    protected $productRepository;
+    protected $baseInfoRepository;
+
+    /**
+     * @var TaxRuleRepository
+     */
+    protected $taxRuleRepository;
 
     /**
      * ProductClassController constructor.
-     *
-     * @param TaxRuleRepository $taxRuleRepository
-     * @param SaleTypeRepository $saleTypeRepository
-     * @param ClassCategoryRepository $classCategoryRepository
      * @param ProductClassRepository $productClassRepository
-     * @param BaseInfo $BaseInfo
-     * @param ProductRepository $productRepository
+     * @param ClassCategoryRepository $classCategoryRepository
      */
     public function __construct(
-        TaxRuleRepository $taxRuleRepository,
-        SaleTypeRepository $saleTypeRepository,
-        ClassCategoryRepository $classCategoryRepository,
+        ProductRepository $productRepository,
         ProductClassRepository $productClassRepository,
-        BaseInfo $BaseInfo,
-        ProductRepository $productRepository
+        ClassCategoryRepository $classCategoryRepository,
+        BaseInfoRepository $baseInfoRepository,
+        TaxRuleRepository $taxRuleRepository
     ) {
-        $this->taxRuleRepository = $taxRuleRepository;
-        $this->saleTypeRepository = $saleTypeRepository;
-        $this->classCategoryRepository = $classCategoryRepository;
-        $this->productClassRepository = $productClassRepository;
-        $this->BaseInfo = $BaseInfo;
         $this->productRepository = $productRepository;
+        $this->productClassRepository = $productClassRepository;
+        $this->classCategoryRepository = $classCategoryRepository;
+        $this->baseInfoRepository = $baseInfoRepository;
+        $this->taxRuleRepository = $taxRuleRepository;
     }
 
-
     /**
-     * 商品規格が登録されていなければ新規登録、登録されていれば更新画面を表示する
+     * 商品規格が登録されていなければ新規登録, 登録されていれば更新画面を表示する
      *
      * @Route("/%eccube_admin_route%/product/product/class/{id}", requirements={"id" = "\d+"}, name="admin_product_product_class")
      * @Template("@admin/Product/product_class.twig")
      */
     public function index(Request $request, $id)
     {
-        /** @var $Product \Eccube\Entity\Product */
-        $Product = $this->productRepository->find($id);
-        $hasClassCategoryFlg = false;
-
+        $Product = $this->findProduct($id);
         if (!$Product) {
-            throw new NotFoundHttpException(trans('product.text.error.product_not_found'));
+            throw new NotFoundHttpException();
         }
-
-        // 商品規格情報が存在しなければ新規登録させる
-        if (!$Product->hasProductClass()) {
-            // 登録画面を表示
-
-            log_info('商品規格新規登録表示', [$id]);
-
-            $builder = $this->formFactory->createBuilder(FormType::class, null, [
-                'allow_extra_fields' => true,
-            ]);
-
-            $builder
-                ->add('class_name1', EntityType::class, [
-                    'class' => 'Eccube\Entity\ClassName',
-                    'choice_label' => 'name',
-                    'placeholder' => trans('product.placeholder.select_category01'),
-                    'constraints' => [
-                        new Assert\NotBlank(),
-                    ],
-                ])
-                ->add('class_name2', EntityType::class, array(
-                    'class' => 'Eccube\Entity\ClassName',
-                    'choice_label' => 'name',
-                    'placeholder' => trans('product.placeholder.select_category02'),
-                    'required' => false,
-                ));
-
-            $event = new EventArgs(
-                [
-                    'builder' => $builder,
-                    'Product' => $Product,
-                ],
-                $request
-            );
-            $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_PRODUCT_CLASS_INDEX_INITIALIZE, $event);
-
-            $form = $builder->getForm();
-
-            $productClassForm = null;
-
-            if ('POST' === $request->getMethod()) {
-
-                $form->handleRequest($request);
-
-                if ($form->isValid()) {
-
-                    $data = $form->getData();
-
-                    $ClassName1 = $data['class_name1'];
-                    $ClassName2 = $data['class_name2'];
-
-                    log_info('選択された商品規格', [$ClassName1, $ClassName2]);
-
-                    // 各規格が選択されている際に、分類を保有しているか確認
-                    $class1Valied = $this->isValiedCategory($ClassName1);
-                    $class2Valied = $this->isValiedCategory($ClassName2);
-
-                    // 規格が選択されていないか、選択された状態で分類が保有されていれば、画面表示
-                    if($class1Valied && $class2Valied){
-                        $hasClassCategoryFlg = true;
-                    }
-
-                    if (!is_null($ClassName2) && $ClassName1->getId() == $ClassName2->getId()) {
-                        // 規格1と規格2が同じ値はエラー
-                        $form['class_name2']->addError(new FormError(trans('product.text.error.same_value')));
-                    } else {
-                        // 規格分類が設定されていない商品規格を取得
-                        $orgProductClasses = $Product->getProductClasses();
-                        $sourceProduct = $orgProductClasses[0];
-
-                        // 規格分類が組み合わされた商品規格を取得
-                        $ProductClasses = $this->createProductClasses($Product, $ClassName1, $ClassName2);
-
-                        // 組み合わされた商品規格にデフォルト値をセット
-                        foreach ($ProductClasses as $productClass) {
-                            $this->setDefaultProductClass($productClass, $sourceProduct);
-                        }
-
-                        $builder = $this->formFactory->createBuilder();
-
-                        $builder
-                            ->add('product_classes', CollectionType::class, [
-                                'entry_type' => ProductClassType::class,
-                                'allow_add' => true,
-                                'allow_delete' => true,
-                                'data' => $ProductClasses,
-                             ]);
-
-                        $event = new EventArgs(
-                            [
-                                'builder' => $builder,
-                                'Product' => $Product,
-                                'ProductClasses' => $ProductClasses,
-                            ],
-                            $request
-                        );
-                        $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_PRODUCT_CLASS_INDEX_CLASSES, $event);
-
-                        $productClassForm = $builder->getForm()->createView();
-
-                    }
-
-                }
-            }
-
-            return [
-                'form' => $form->createView(),
-                'classForm' => $productClassForm,
-                'Product' => $Product,
-                'not_product_class' => true,
-                'error' => null,
-                'has_class_category_flg' => $hasClassCategoryFlg,
-            ];
-        } else {
-            // 既に商品規格が登録されている場合、商品規格画面を表示する
-
-            log_info('商品規格登録済表示', [$id]);
-
-            // 既に登録されている商品規格を取得
-            $ProductClasses = $this->getProductClassesExcludeNonClass($Product);
-
-            // 設定されている規格分類1、2を取得(商品規格の規格分類には必ず同じ値がセットされている)
-            $ProductClass = $ProductClasses->first();
-            $ClassName1 = $ProductClass->getClassCategory1()->getClassName();
-            $ClassName2 = null;
-            if (!is_null($ProductClass->getClassCategory2())) {
-                $ClassName2 = $ProductClass->getClassCategory2()->getClassName();
-            }
-
-            // 規格分類が組み合わされた空の商品規格を取得
-            $createProductClasses = $this->createProductClasses($Product, $ClassName1, $ClassName2);
-
-            $mergeProductClasses = [];
-            $sortProductClasses = new ArrayCollection();
-
-            // 商品税率が設定されている場合、商品税率を項目に設定
-            if ($this->BaseInfo->isOptionProductTaxRule())  {
-                foreach ($ProductClasses as $class) {
-                    if ($class->getTaxRule()) {
-                        $class->setTaxRate($class->getTaxRule()->getTaxRate());
-                    }
-                }
-            }
-
-            // 登録済み商品規格と空の商品規格をマージ
-            $flag = false;
-
-            foreach ($createProductClasses as $index => $createProductClass) {
-                // 既に登録済みの商品規格にチェックボックスを設定
-                foreach ($ProductClasses as $productClass) {
-                    if ($productClass->getClassCategory1() == $createProductClass->getClassCategory1() &&
-                        $productClass->getClassCategory2() == $createProductClass->getClassCategory2()) {
-                        // チェックボックスを追加
-                        $productClass->setAdd(true);
-                        $flag = true;
-                        $sortProductClasses->add($productClass);
-                        break;
-                    }
-                }
-
-                if (!$flag) {
-                    // 商品の中に規格ない場合は削除されている規格を取得する
-                    $condition = array();
-                    $condition['Product'] = $Product;
-                    $condition['ClassCategory1'] = $createProductClass->getClassCategory1();
-                    $condition['ClassCategory2'] = $createProductClass->getClassCategory2();
-                    $condition['visible'] = false;
-
-                    $delProductClass = $this->productClassRepository->findOneBy($condition);
-                    if ($delProductClass){
-                        // 削除されている規格あった場合はその規格を使う
-                        $mergeProductClasses[] = $delProductClass;
-                    } else {
-                        // 取得できない場合はデフォルトの規格を使う
-                        $mergeProductClasses[] = $createProductClass;
-                    }
-                }
-
-                $flag = false;
-            }
-
-            // 登録済み商品規格と空の商品規格をマージ
-            foreach ($mergeProductClasses as $mergeProductClass) {
-                // 空の商品規格にデフォルト値を設定
-                $this->setDefaultProductClass($mergeProductClass, $sortProductClasses[0]);
-                $sortProductClasses->add($mergeProductClass);
-            }
-
-            $builder = $this->formFactory->createBuilder();
-
-            $builder
-                ->add('product_classes', CollectionType::class, [
-                    'entry_type' => ProductClassType::class,
-                    'allow_add' => true,
-                    'allow_delete' => true,
-                    'data' => $sortProductClasses,
-                ]);
-
-            $event = new EventArgs(
-                [
-                    'builder' => $builder,
-                    'Product' => $Product,
-                    'ProductClasses' => $sortProductClasses,
-                ],
-                $request
-            );
-            $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_PRODUCT_CLASS_INDEX_CLASSES, $event);
-
-            $productClassForm = $builder->getForm()->createView();
-
-            return [
-                'classForm' => $productClassForm,
-                'Product' => $Product,
-                'class_name1' => $ClassName1,
-                'class_name2' => $ClassName2,
-                'not_product_class' => false,
-                'error' => null,
-                'has_class_category_flg' => true,
-            ];
-        }
-    }
-
-    /**
-     * 商品規格の登録、更新、削除を行う
-     *
-     * @Route("/%eccube_admin_route%/product/product/class/edit/{id}", requirements={"id" = "\d+"}, name="admin_product_product_class_edit")
-     * @Template("@admin/Product/product_class.twig")
-     *
-     * @param Request     $request
-     * @param int         $id
-     * @return RedirectResponse
-     */
-    public function edit(Request $request, $id)
-    {
-        /** @var $Product \Eccube\Entity\Product */
-        $Product = $this->productRepository->find($id);
-
-        if (!$Product) {
-            throw new NotFoundHttpException(trans('product.text.error.product_not_found'));
-        }
-
-        /* @var FormBuilder $builder */
-        $builder = $this->formFactory->createBuilder(FormType::class, null, [
-            'allow_extra_fields' => true,
-        ]);
-        $builder->add('product_classes', CollectionType::class, array(
-                    'entry_type' => ProductClassType::class,
-                    'allow_add' => true,
-                    'allow_delete' => true,
-        ));
-
-        $event = new EventArgs(
-            array(
-                'builder' => $builder,
-                'Product' => $Product,
-            ),
-            $request
-        );
-        $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_PRODUCT_CLASS_EDIT_INITIALIZE, $event);
-
-        $form = $builder->getForm();
-
-        $ProductClasses = $this->getProductClassesExcludeNonClass($Product);
-
-        $form->handleRequest($request);
-        if ($form->isSubmitted()) {
-            switch ($request->get('mode')) {
-                case 'edit':
-                    // 新規登録
-                    log_info('商品規格新規登録開始', array($id));
-
-                    if (count($ProductClasses) > 0) {
-                        // 既に登録されていれば最初の画面に戻す
-                        log_info('商品規格登録済', array($id));
-                        return $this->redirectToRoute('admin_product_product_class', array('id' => $id));
-                    }
-
-                    $addProductClasses = array();
-
-                    $tmpProductClass = null;
-                    foreach ($form->get('product_classes') as $formData) {
-                        // 追加対象の行をvalidate
-                        $ProductClass = $formData->getData();
-
-                        if ($ProductClass->getAdd()) {
-                            if ($formData->isValid()) {
-                                $addProductClasses[] = $ProductClass;
-                            } else {
-                                // 対象行のエラー
-                                return $this->renderError($Product, $ProductClass, true, $form);
-                            }
-                        }
-                        $tmpProductClass = $ProductClass;
-                    }
-
-                    if (count($addProductClasses) == 0) {
-                        // 対象がなければエラー
-                        log_info('商品規格が未選択', array($id));
-                        $error = array('message' => trans('product.text.error.category_not_selected'));
-                        return $this->renderError($Product, $tmpProductClass, true, $form, $error);
-                    }
-
-                    // 選択された商品規格を登録
-                    $this->insertProductClass($Product, $addProductClasses);
-
-                    // デフォルトの商品規格を非表示
-                    /** @var ProductClass $defaultProductClass */
-                    $defaultProductClass = $this->productClassRepository
-                            ->findOneBy(array('Product' => $Product, 'ClassCategory1' => null, 'ClassCategory2' => null));
-                    $defaultProductClass->setVisible(false);
-
-                    $this->entityManager->flush();
-
-                    log_info('商品規格新規登録完了', array($id));
-
-                    $event = new EventArgs(
-                        array(
-                            'form' => $form,
-                            'Product' => $Product,
-                            'defaultProductClass' => $defaultProductClass,
-                        ),
-                        $request
-                    );
-                    $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_PRODUCT_CLASS_EDIT_COMPLETE, $event);
-
-                    $this->addSuccess('admin.product.product_class.save.complete', 'admin');
-
-                    break;
-                case 'update':
-                    // 更新
-                    log_info('商品規格更新開始', array($id));
-
-                    if (count($ProductClasses) == 0) {
-                        // 商品規格が0件であれば最初の画面に戻す
-                        log_info('商品規格が存在しません', array($id));
-                        return $this->redirectToRoute('admin_product_product_class', array('id' => $id));
-                    }
-
-                    $checkProductClasses = array();
-                    $removeProductClasses = array();
-
-                    $tempProductClass = null;
-                    foreach ($form->get('product_classes') as $formData) {
-                        // 追加対象の行をvalidate
-                        $ProductClass = $formData->getData();
-
-                        if ($ProductClass->getAdd()) {
-                            if ($formData->isValid()) {
-                                $checkProductClasses[] = $ProductClass;
-                            } else {
-                                return $this->renderError($Product, $ProductClass, false, $form);
-                            }
-                        } else {
-                            // 削除対象の行
-                            $removeProductClasses[] = $ProductClass;
-                        }
-                        $tempProductClass = $ProductClass;
-                    }
-
-                    if (count($checkProductClasses) == 0) {
-                        // 対象がなければエラー
-                        log_info('商品規格が存在しません', array($id));
-                        $error = array('message' => trans('product.text.error.category_not_selected'));
-                        return $this->renderError($Product, $tempProductClass, false, $form, $error);
-                    }
-
-                    // 登録対象と更新対象の行か判断する
-                    $addProductClasses = array();
-                    $updateProductClasses = array();
-                    foreach ($checkProductClasses as $cp) {
-                        $flag = false;
-
-                        // 既に登録済みの商品規格か確認
-                        foreach ($ProductClasses as $productClass) {
-                            if ($productClass->getProduct()->getId() == $id &&
-                                $productClass->getClassCategory1() == $cp->getClassCategory1() &&
-                                $productClass->getClassCategory2() == $cp->getClassCategory2()) {
-                                $updateProductClasses[] = $cp;
-
-                                // 商品情報
-                                $cp->setProduct($Product);
-                                // 商品在庫
-                                $productStock = $productClass->getProductStock();
-                                if (!$cp->isStockUnlimited()) {
-                                    $productStock->setStock($cp->getStock());
-                                } else {
-                                    $productStock->setStock(null);
-                                }
-                                $this->setDefaultProductClass($productClass, $cp);
-                                $flag = true;
-                                break;
-                            }
-                        }
-
-                        if (!$flag) {
-                            // 削除されている規格取得する
-                            $condition = array();
-                            $condition['Product'] = $Product;
-                            $condition['ClassCategory1'] = $cp->getClassCategory1();
-                            $condition['ClassCategory2'] = $cp->getClassCategory2();
-                            $condition['visible'] = false;
-
-                            $delProductClass = $this->productClassRepository->findOneBy($condition);
-                            if ($delProductClass){
-                                // 削除されている商品を見つけた場合は使います
-                                // 商品情報
-                                $cp->setProduct($Product);
-                                // 商品在庫
-                                $productStock = $productClass->getProductStock();
-                                if (!$cp->getStockUnlimited()) {
-                                    $productStock->setStock($cp->getStock());
-                                } else {
-                                    $productStock->setStock(null);
-                                }
-                                $this->setDefaultProductClass($delProductClass, $cp);
-                                // 削除されている規格を復活する（visibleを更新）
-                                $delProductClass->setVisible(false);
-                                $ProductClasses[] = $delProductClass;
-                            } else {
-                                $addProductClasses[] = $cp;
-                            }
-                        }
-                    }
-
-                    foreach ($removeProductClasses as $rc) {
-                        // 登録されている商品規格を非表示
-                        /** @var ProductClass $productClass */
-                        foreach ($ProductClasses as $productClass) {
-                            if ($productClass->getProduct()->getId() == $id &&
-                                $productClass->getClassCategory1() == $rc->getClassCategory1() &&
-                                $productClass->getClassCategory2() == $rc->getClassCategory2()) {
-                                $productClass->setVisible(false);
-                                break;
-                            }
-                        }
-                    }
-
-                    // 選択された商品規格を登録
-                    $this->insertProductClass($Product, $addProductClasses);
-
-                    $this->entityManager->flush();
-
-                    log_info('商品規格更新完了', array($id));
-
-                    $event = new EventArgs(
-                        array(
-                            'form' => $form,
-                            'Product' => $Product,
-                            'updateProductClasses' => $updateProductClasses,
-                            'addProductClasses' => $addProductClasses,
-                        ),
-                        $request
-                    );
-                    $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_PRODUCT_CLASS_EDIT_UPDATE, $event);
-
-                    $this->addSuccess('admin.product.product_class.update.complete', 'admin');
-
-                    break;
-
-                case 'delete':
-                    // 削除
-                    log_info('商品規格削除開始', array($id));
-
-                    if (count($ProductClasses) == 0) {
-                        // 既に商品が削除されていれば元の画面に戻す
-                        log_info('商品規格が存在しません', array($id));
-                        return $this->redirectToRoute('admin_product_product_class', array('id' => $id));
-                    }
-
-                    foreach ($ProductClasses as $ProductClass) {
-                        // 登録されている商品規格を非表示
-                        $ProductClass->setVisible(false);
-                    }
-
-                    // デフォルトの商品規格を表示
-                    /** @var ProductClass $defaultProductClass */
-
-                    $defaultProductClass = $this->productClassRepository
-                            ->findOneBy(array('Product' => $Product, 'ClassCategory1' => null, 'ClassCategory2' => null, 'visible' => false));
-                    $defaultProductClass->setVisible(true);
-
-                    $this->entityManager->flush();
-                    log_info('商品規格削除完了', array($id));
-
-                    $event = new EventArgs(
-                        array(
-                            'form' => $form,
-                            'Product' => $Product,
-                            'defaultProductClass' => $defaultProductClass,
-                        ),
-                        $request
-                    );
-                    $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_PRODUCT_PRODUCT_CLASS_EDIT_DELETE, $event);
-
-                    $this->addSuccess('admin.product.product_class.delete.complete', 'admin');
-
-                    break;
-                default:
-                    break;
-            }
-
-        }
-
-        return $this->redirectToRoute('admin_product_product_class', array('id' => $id));
-    }
-
-    /**
-     * 登録、更新時のエラー画面表示
-     *
-     * @param \Eccube\Entity\Product $Product
-     * @param \Eccube\Entity\ProductClass $ProductClass
-     * @param \Symfony\Component\HttpFoundation\Response $not_product_class
-     * @param FormInterface $classForm
-     * @param array $error
-     * @return array
-     */
-    protected function renderError($Product, $ProductClass, $not_product_class, $classForm, $error = null)
-    {
 
         $ClassName1 = null;
         $ClassName2 = null;
-        // 規格を取得
-        if (isset($ProductClass)) {
-            $ClassCategory1 = $ProductClass->getClassCategory1();
-            if ($ClassCategory1) {
-                $ClassName1 = $ClassCategory1->getClassName();
+
+        if ($Product->hasProductClass()) {
+            // 規格ありの商品は編集画面を表示する.
+            $ProductClasses = $Product->getProductClasses()
+                ->filter(function ($pc) {
+                return $pc->getClassCategory1() !== null;
+            });
+
+            // 設定されている規格名1, 2を取得(商品規格の規格分類には必ず同じ値がセットされている)
+            $FirstProductClass = $ProductClasses->first();
+            $ClassName1 = $FirstProductClass->getClassCategory1()->getClassName();
+            $ClassCategory2 = $FirstProductClass->getClassCategory2();
+            $ClassName2 = $ClassCategory2 ? $ClassCategory2->getClassName() : null;
+
+            // 規格名1/2から組み合わせを生成し, DBから取得した商品規格とマージする.
+            $ProductClasses = $this->mergeProductClassess(
+                $this->createProductClasses($ClassName1, $ClassName2),
+                $ProductClasses);
+
+            // 組み合わせのフォームを生成する.
+            $form = $this->createMatrixForm($ProductClasses, $ClassName1, $ClassName2,
+                ['product_classes_exist' => true]);
+            $form->handleRequest($request);
+
+            if ($form->isSubmitted() && $form->isValid()) {
+                // フォームではtokenを無効化しているのでここで確認する.
+                $this->isTokenValid();
+
+                $this->saveProductClasses($Product, $form['product_classes']->getData());
+
+                $this->addSuccess('admin.product.product_class.update.complete', 'admin');
+
+                return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId()]);
             }
-            $ClassCategory2 = $ProductClass->getClassCategory2();
-            if ($ClassCategory2) {
-                $ClassName2 = $ClassCategory2->getClassName();
+        } else {
+            // 規格なし商品
+            $form = $this->createMatrixForm();
+            $form->handleRequest($request);
+
+            if ($form->isSubmitted() && $form->isValid()) {
+                // フォームではtokenを無効化しているのでここで確認する.
+                $this->isTokenValid();
+
+                // 登録,更新ボタンが押下されたかどうか.
+                $isSave = $form['save']->isClicked();
+
+                // 規格名1/2から商品規格の組み合わせを生成する.
+                $ClassName1 = $form['class_name1']->getData();
+                $ClassName2 = $form['class_name2']->getData();
+                $ProductClasses = $this->createProductClasses($ClassName1, $ClassName2);
+
+                // 組み合わせのフォームを生成する.
+                // class_name1, class_name2が取得できるのがsubmit後のため, フォームを再生成して組み合わせ部分を構築している
+                // submit後だと, フォーム項目の追加やデータ変更が許可されないため.
+                $form = $this->createMatrixForm($ProductClasses, $ClassName1, $ClassName2,
+                    ['product_classes_exist' => true]);
+
+                // 登録ボタン押下時
+                if ($isSave) {
+                    $form->handleRequest($request);
+                    if ($form->isSubmitted() && $form->isValid()) {
+                        $this->saveProductClasses($Product, $form['product_classes']->getData());
+
+                        $this->addSuccess('admin.product.product_class.save.complete', 'admin');
+
+                        return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId()]);
+                    }
+                }
             }
         }
 
-        /* @var FormBuilder $builder */
-        $form = $this->formFactory->createBuilder()
-            ->add('class_name1', EntityType::class, array(
-                'class' => 'Eccube\Entity\ClassName',
-                'choice_label' => 'name',
-                'placeholder' => trans('product.placeholder.select_category01'),
-                'data' => $ClassName1,
-            ))
-            ->add('class_name2', EntityType::class, array(
-                'class' => 'Eccube\Entity\ClassName',
-                'choice_label' => 'name',
-                'placeholder' => trans('product.placeholder.select_category02'),
-                'data' => $ClassName2,
-            ))
-            ->getForm();
-
-        log_info('商品規格登録エラー');
-
-
         return [
-            'form' => $form->createView(),
-            'classForm' => $classForm->createView(),
             'Product' => $Product,
-            'class_name1' => $ClassName1,
-            'class_name2' => $ClassName2,
-            'not_product_class' => $not_product_class,
-            'error' => $error,
-            'has_class_category_flg' => true,
+            'form' => $form->createView(),
+            'clearForm' => $this->createForm(FormType::class)->createView(),
+            'ClassName1' => $ClassName1,
+            'ClassName2' => $ClassName2,
         ];
     }
 
-
     /**
-     * 規格1と規格2を組み合わせた商品規格を作成
+     * 商品規格を初期化する.
+     *
+     * @Route("/%eccube_admin_route%/product/product/class/{id}/clear", requirements={"id" = "\d+"}, name="admin_product_product_class_clear")
      */
-    private function createProductClasses( Product $Product, ClassName $ClassName1 = null, ClassName $ClassName2 = null)
+    public function clearProductClasses(Request $request, Product $Product)
     {
-
-        $ClassCategories1 = array();
-        if ($ClassName1) {
-            $ClassCategories1 = $this->classCategoryRepository->findBy(['ClassName' => $ClassName1], ['sort_no' => 'DESC']);
+        if (!$Product->hasProductClass()) {
+            return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId()]);
         }
 
-        $ClassCategories2 = array();
-        if ($ClassName2) {
-            $ClassCategories2 = $this->classCategoryRepository->findBy(['ClassName' => $ClassName2], ['sort_no' => 'DESC']);
-        }
+        $form = $this->createForm(FormType::class);
+        $form->handleRequest($request);
 
-        $ProductClasses = array();
-        foreach ($ClassCategories1 as $ClassCategory1) {
-            if ($ClassCategories2) {
-                foreach ($ClassCategories2 as $ClassCategory2) {
-                    $ProductClass = $this->newProductClass();
-                    $ProductClass->setProduct($Product);
-                    $ProductClass->setClassCategory1($ClassCategory1);
-                    $ProductClass->setClassCategory2($ClassCategory2);
-                    $ProductClass->setTaxRate(null);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $ProductClasses = $this->productClassRepository->findBy([
+                'Product' => $Product,
+            ]);
+
+            foreach ($ProductClasses as $ProductClass) {
+                // デフォルト規格のみ有効にする
+                if (null === $ProductClass->getClassCategory1() && null === $ProductClass->getClassCategory2()) {
                     $ProductClass->setVisible(true);
-                    $ProductClasses[] = $ProductClass;
+                } else {
+                    $ProductClass->setVisible(false);
                 }
-            } else {
-                $ProductClass = $this->newProductClass();
-                $ProductClass->setProduct($Product);
-                $ProductClass->setClassCategory1($ClassCategory1);
-                $ProductClass->setTaxRate(null);
-                $ProductClass->setVisible(true);
-                $ProductClasses[] = $ProductClass;
             }
 
+            $this->entityManager->flush();
+
+            $this->addSuccess('admin.product.product_class.clear.complete', 'admin');
         }
+
+        return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId()]);
+    }
+
+    /**
+     * 規格名1/2から, 商品規格の組み合わせを生成する.
+     *
+     * @param ClassName $ClassName1
+     * @param ClassName|null $ClassName2
+     * @return array|ProductClass[]
+     */
+    protected function createProductClasses(ClassName $ClassName1, ClassName $ClassName2 = null)
+    {
+        $ProductClasses = [];
+        $ClassCategories1 = $this->classCategoryRepository->findBy(['ClassName' => $ClassName1], ['sort_no' => 'DESC']);
+        $ClassCategories2 = [];
+        if ($ClassName2) {
+            $ClassCategories2 = $this->classCategoryRepository->findBy(['ClassName' => $ClassName2],
+                ['sort_no' => 'DESC']);
+        }
+        foreach ($ClassCategories1 as $ClassCategory1) {
+            // 規格1のみ
+            if (!$ClassName2) {
+                $ProductClass = new ProductClass();
+                $ProductClass->setClassCategory1($ClassCategory1);
+                $ProductClasses[] = $ProductClass;
+                continue;
+            }
+            // 規格1/2
+            foreach ($ClassCategories2 as $ClassCategory2) {
+                $ProductClass = new ProductClass();
+                $ProductClass->setClassCategory1($ClassCategory1);
+                $ProductClass->setClassCategory2($ClassCategory2);
+                $ProductClasses[] = $ProductClass;
+            }
+        }
+
         return $ProductClasses;
     }
 
     /**
-     * 新しい商品規格を作成
+     * 商品規格の配列をマージする.
+     *
+     * @param $ProductClassessForMatrix
+     * @param $ProductClasses
+     * @return array|ProductClass[]
      */
-    private function newProductClass()
+    protected function mergeProductClassess($ProductClassessForMatrix, $ProductClasses)
     {
-        $SaleType = $this->saleTypeRepository->find(SaleType::SALE_TYPE_NORMAL);
+        $mergedProductClasses = [];
+        foreach ($ProductClassessForMatrix as $pcfm) {
+            foreach ($ProductClasses as $pc) {
+                if ($pcfm->getClassCategory1()->getId() === $pc->getClassCategory1()->getId()) {
+                    $cc2fm = $pcfm->getClassCategory2();
+                    $cc2 = $pc->getClassCategory2();
 
-        $ProductClass = new ProductClass();
-        $ProductClass->setSaleType($SaleType);
-        return $ProductClass;
+                    if (null === $cc2fm && null === $cc2) {
+                        $mergedProductClasses[] = $pc;
+                        continue 2;
+                    }
+
+                    if ($cc2fm && $cc2 && $cc2fm->getId() === $cc2->getId()) {
+                        $mergedProductClasses[] = $pc;
+                        continue 2;
+                    }
+                }
+            }
+
+            $mergedProductClasses[] = $pcfm;
+        }
+
+        return $mergedProductClasses;
     }
 
     /**
-     * 商品規格のコピーを取得.
+     * 商品規格を登録, 更新する.
      *
-     * @see http://symfony.com/doc/current/cookbook/form/form_collections.html
      * @param Product $Product
-     * @return \Eccube\Entity\ProductClass[]
+     * @param array|ProductClass[] $ProductClasses
      */
-    private function getProductClassesOriginal(Product $Product)
+    protected function saveProductClasses(Product $Product, $ProductClasses = [])
     {
-        $ProductClasses = $Product->getProductClasses();
-        return $ProductClasses->filter(function($ProductClass) {
-            return true;
-        });
-    }
+        foreach ($ProductClasses as $pc) {
+            // 新規登録時、チェックを入れていなければ更新しない
+            if (!$pc->getId() && !$pc->isVisible()) {
+                continue;
+            }
 
-    /**
-     * 規格なし商品を除いて商品規格を取得.
-     *
-     * @param Product $Product
-     * @return Collection
-     */
-    private function getProductClassesExcludeNonClass(Product $Product)
-    {
-        $ProductClasses = $Product->getProductClasses();
-        return new ArrayCollection(array_values($ProductClasses->filter(function($ProductClass) {
-            $ClassCategory1 = $ProductClass->getClassCategory1();
-            $ClassCategory2 = $ProductClass->getClassCategory2();
-            return ($ClassCategory1 || $ClassCategory2);
-        })->toArray()));
-    }
+            // 無効から有効にした場合は, 過去の登録情報を検索.
+            if (!$pc->getId()) {
+                /** @var ProductClass $ExistsProductClass */
+                $ExistsProductClass = $this->productClassRepository->findOneBy([
+                    'Product' => $Product,
+                    'ClassCategory1' => $pc->getClassCategory1(),
+                    'ClassCategory2' => $pc->getClassCategory2(),
+                ]);
 
-    /**
-     * デフォルトとなる商品規格を設定
-     *
-     * @param $productClassDest ProductClass コピー先となる商品規格
-     * @param $productClassOrig ProductClass コピー元となる商品規格
-     */
-    private function setDefaultProductClass($productClassDest, $productClassOrig)
-    {
-        $productClassDest->setDeliveryDuration($productClassOrig->getDeliveryDuration());
-        $productClassDest->setProduct($productClassOrig->getProduct());
-        $productClassDest->setSaleType($productClassOrig->getSaleType());
-        $productClassDest->setCode($productClassOrig->getCode());
-        $productClassDest->setStock($productClassOrig->getStock());
-        $productClassDest->setStockUnlimited($productClassOrig->isStockUnlimited());
-        $productClassDest->setSaleLimit($productClassOrig->getSaleLimit());
-        $productClassDest->setPrice01($productClassOrig->getPrice01());
-        $productClassDest->setPrice02($productClassOrig->getPrice02());
-        $productClassDest->setDeliveryFee($productClassOrig->getDeliveryFee());
+                // 過去の登録情報があればその情報を復旧する.
+                if ($ExistsProductClass) {
+                    $ExistsProductClass->copyProperties($pc, [
+                        'id',
+                        'price01_inc_tax',
+                        'price02_inc_tax',
+                        'create_date',
+                        'update_date',
+                        'Creator',
+                    ]);
+                    $pc = $ExistsProductClass;
+                }
+            }
 
-        // 個別消費税
-        if ($this->BaseInfo->isOptionProductTaxRule()) {
-            if ($productClassOrig->getTaxRate() !== false && $productClassOrig->getTaxRate() !== null) {
-                $productClassDest->setTaxRate($productClassOrig->getTaxRate());
-                if ($productClassDest->getTaxRule()) {
-                    $productClassDest->getTaxRule()->setTaxRate($productClassOrig->getTaxRate());
+            // 更新時, チェックを外した場合はPOST内容を破棄してvisibleのみ更新する.
+            if ($pc->getId() && !$pc->isVisible()) {
+                $this->entityManager->refresh($pc);
+                $pc->setVisible(false);
+                continue;
+            }
+
+            $pc->setProduct($Product);
+            $this->entityManager->persist($pc);
+
+            // 在庫の更新
+            $ProductStock = $pc->getProductStock();
+            if (!$ProductStock) {
+                $ProductStock = new ProductStock();
+                $ProductStock->setProductClass($pc);
+                $this->entityManager->persist($ProductStock);
+            }
+            $ProductStock->setStock($pc->isStockUnlimited() ? null : $pc->getStock());
+
+            if ($this->baseInfoRepository->get()->isOptionProductTaxRule()) {
+
+                $rate = $pc->getTaxRate();
+                $TaxRule = $pc->getTaxRule();
+                if (is_numeric($rate)) {
+                    if ($TaxRule) {
+                        $TaxRule->setTaxRate($rate);
+                    } else {
+                        // 初期税率設定の計算方法を設定する
+                        $RoundingType = $this->taxRuleRepository->find(TaxRule::DEFAULT_TAX_RULE_ID)
+                            ->getRoundingType();
+
+                        $TaxRule = new TaxRule();
+                        $TaxRule->setProduct($Product);
+                        $TaxRule->setProductClass($pc);
+                        $TaxRule->setTaxRate($rate);
+                        $TaxRule->setRoundingType($RoundingType);
+                        $TaxRule->setTaxAdjust(0);
+                        $TaxRule->setApplyDate(new \DateTime());
+                        $this->entityManager->persist($TaxRule);
+                    }
                 } else {
-                    $taxrule = $this->taxRuleRepository->newTaxRule();
-                    $taxrule->setTaxRate($productClassOrig->getTaxRate());
-                    $taxrule->setApplyDate(new \DateTime());
-                    $taxrule->setProduct($productClassDest->getProduct());
-                    $taxrule->setProductClass($productClassDest);
-                    $productClassDest->setTaxRule($taxrule);
-                }
-            } else {
-                if ($productClassDest->getTaxRule()) {
-                    $this->taxRuleRepository->delete($productClassDest->getTaxRule());
-                    $productClassDest->setTaxRule(null);
-                }
-            }
-        }
-    }
-
-
-    /**
-     * 商品規格を登録
-     *
-     * @param Product         $Product
-     * @param ProductClass[] $ProductClasses 登録される商品規格
-     */
-    private function insertProductClass($Product, $ProductClasses) {
-
-
-        // 選択された商品を登録
-        foreach ($ProductClasses as $ProductClass) {
-
-            $ProductClass->setVisible(true);
-            $ProductClass->setProduct($Product);
-            $this->entityManager->persist($ProductClass);
-
-            // 在庫情報を作成
-            $ProductStock = new ProductStock();
-            $ProductClass->setProductStock($ProductStock);
-            $ProductStock->setProductClass($ProductClass);
-            if (!$ProductClass->isStockUnlimited()) {
-                $ProductStock->setStock($ProductClass->getStock());
-            } else {
-                // 在庫無制限時はnullを設定
-                $ProductStock->setStock(null);
-            }
-            $this->entityManager->persist($ProductStock);
-
-        }
-
-        // 商品税率が設定されている場合、商品税率をセット
-        if ($this->BaseInfo->isOptionProductTaxRule()) {
-            // 初期設定の税設定.
-            $TaxRule = $this->taxRuleRepository->find(TaxRule::DEFAULT_TAX_RULE_ID);
-            // 初期税率設定の計算方法を設定する
-            $RoundingType = $TaxRule->getRoundingType();
-            foreach ($ProductClasses as $ProductClass) {
-                if ($ProductClass && is_numeric($taxRate = $ProductClass->getTaxRate())) {
-                    $TaxRule = new TaxRule();
-                    $TaxRule->setProduct($Product);
-                    $TaxRule->setProductClass($ProductClass);
-                    $TaxRule->setRoundingType($RoundingType);
-                    $TaxRule->setTaxRate($taxRate);
-                    $TaxRule->setTaxAdjust(0);
-                    $TaxRule->setApplyDate(new \DateTime());
-                    $this->entityManager->persist($TaxRule);
+                    if ($TaxRule) {
+                        $this->taxRuleRepository->delete($TaxRule);
+                        $pc->setTaxRule(null);
+                    }
                 }
             }
         }
 
+        // デフォルト規格を非表示にする.
+        $DefaultProductClass = $this->productClassRepository->findOneBy([
+            'Product' => $Product,
+            'ClassCategory1' => null,
+            'ClassCategory2' => null,
+        ]);
+        $DefaultProductClass->setVisible(false);
+
+        $this->entityManager->flush();
     }
 
     /**
-     * 規格の分類判定
+     * 商品規格登録フォームを生成する.
      *
-     * @param $class_name
-     * @return boolean
+     * @param array $ProductClasses
+     * @param ClassName|null $ClassName1
+     * @param ClassName|null $ClassName2
+     * @param array $options
+     * @return \Symfony\Component\Form\FormInterface
      */
-    private function isValiedCategory($class_name)
+    protected function createMatrixForm(
+        $ProductClasses = [],
+        ClassName $ClassName1 = null,
+        ClassName $ClassName2 = null,
+        array $options = []
+    ) {
+        $options = array_merge(['csrf_protection' => false], $options);
+        $builder = $this->formFactory->createBuilder(ProductClassMatrixType::class, [
+            'product_classes' => $ProductClasses,
+            'class_name1' => $ClassName1,
+            'class_name2' => $ClassName2,
+        ], $options);
+
+        return $builder->getForm();
+    }
+
+    /**
+     * 商品を取得する.
+     * 商品規格はvisible=trueのものだけを取得し, 規格分類はsort_no=DESCでソートされている.
+     *
+     * @param $id
+     * @return Product|null
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
+    protected function findProduct($id)
     {
-        if (empty($class_name)) {
-            return true;
+        $qb = $this->productRepository->createQueryBuilder('p')
+            ->addSelect(['pc', 'cc1', 'cc2'])
+            ->leftJoin('p.ProductClasses', 'pc')
+            ->leftJoin('pc.ClassCategory1', 'cc1')
+            ->leftJoin('pc.ClassCategory2', 'cc2')
+            ->where('p.id = :id')
+            ->andWhere('pc.visible = :pc_visible')
+            ->setParameter('id', $id)
+            ->setParameter('pc_visible', true)
+            ->orderBy('cc1.sort_no', 'DESC')
+            ->addOrderBy('cc2.sort_no', 'DESC');
+
+        try {
+            return $qb->getQuery()->getSingleResult();
+        } catch (NoResultException $e) {
+            return null;
         }
-        if (count($class_name->getClassCategories()) < 1) {
-            return false;
-        }
-        return true;
     }
 }

--- a/src/Eccube/Controller/Admin/Product/ProductClassController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductClassController.php
@@ -203,12 +203,14 @@ class ProductClassController extends AbstractController
                 'Product' => $Product,
             ]);
 
+            // デフォルト規格のみ有効にする
             foreach ($ProductClasses as $ProductClass) {
-                // デフォルト規格のみ有効にする
+                $ProductClass->setVisible(false);
+            }
+            foreach ($ProductClasses as $ProductClass) {
                 if (null === $ProductClass->getClassCategory1() && null === $ProductClass->getClassCategory2()) {
                     $ProductClass->setVisible(true);
-                } else {
-                    $ProductClass->setVisible(false);
+                    break;
                 }
             }
 

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -391,7 +391,11 @@ class ProductController extends AbstractController
             $has_class = $Product->hasProductClass();
             if (!$has_class) {
                 $ProductClasses = $Product->getProductClasses();
-                $ProductClass = $ProductClasses[0];
+                foreach ($ProductClasses as $productClass) {
+                    if ($productClass->isVisible()) {
+                        $ProductClass = $productClass;
+                    }
+                }
                 if ($this->BaseInfo->isOptionProductTaxRule() && $ProductClass->getTaxRule()) {
                     $ProductClass->setTaxRate($ProductClass->getTaxRule()->getTaxRate());
                 }

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -387,13 +387,17 @@ class ProductController extends AbstractController
             if (!$Product) {
                 throw new NotFoundHttpException();
             }
-            // 規格あり商品か
+            // 規格無しの商品の場合は、デフォルト規格を表示用に取得する
             $has_class = $Product->hasProductClass();
             if (!$has_class) {
                 $ProductClasses = $Product->getProductClasses();
-                foreach ($ProductClasses as $productClass) {
-                    if ($productClass->isVisible()) {
-                        $ProductClass = $productClass;
+                foreach ($ProductClasses as $pc) {
+                    if (!is_null($pc->getClassCategory1())) {
+                        continue;
+                    }
+                    if ($pc->isVisible()) {
+                        $ProductClass = $pc;
+                        break;
                     }
                 }
                 if ($this->BaseInfo->isOptionProductTaxRule() && $ProductClass->getTaxRule()) {

--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -411,6 +411,9 @@ class Product extends \Eccube\Entity\AbstractEntity
     public function hasProductClass()
     {
         foreach ($this->ProductClasses as $ProductClass) {
+            if (!$ProductClass->isVisible()) {
+                continue;
+            }
             if (!is_null($ProductClass->getClassCategory1())) {
                 return true;
             }

--- a/src/Eccube/Entity/ProductClass.php
+++ b/src/Eccube/Entity/ProductClass.php
@@ -39,7 +39,6 @@ class ProductClass extends \Eccube\Entity\AbstractEntity
 {
     private $price01_inc_tax = null;
     private $price02_inc_tax = null;
-    private $add = false;
     private $tax_rate = false;
 
     /**
@@ -111,30 +110,6 @@ class ProductClass extends \Eccube\Entity\AbstractEntity
             return false;
         }
     }
-
-    /**
-     * Set add
-     *
-     * @param  bool $add
-     * @return ProductClass
-     */
-    public function setAdd($add)
-    {
-        $this->add = $add;
-
-        return $this;
-    }
-
-    /**
-     * Get add
-     *
-     * @return bool
-     */
-    public function getAdd()
-    {
-        return $this->add;
-    }
-
 
     /**
      * Set tax_rate

--- a/src/Eccube/Form/Type/Admin/ProductClassEditType.php
+++ b/src/Eccube/Form/Type/Admin/ProductClassEditType.php
@@ -1,0 +1,280 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Form\Type\Admin;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Entity\ClassCategory;
+use Eccube\Entity\ProductClass;
+use Eccube\Form\DataTransformer;
+use Eccube\Form\Type\Master\DeliveryDurationType;
+use Eccube\Form\Type\Master\SaleTypeType;
+use Eccube\Form\Type\PriceType;
+use Eccube\Repository\BaseInfoRepository;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class ProductClassEditType extends AbstractType
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $entityManager;
+
+    /**
+     * @var ValidatorInterface
+     */
+    protected $validator;
+
+    /**
+     * @var BaseInfoRepository
+     */
+    protected $baseInfoRepository;
+
+    /**
+     * ProductClassEditType constructor.
+     *
+     * @param EntityManagerInterface $entityManager
+     * @param ValidatorInterface $validator
+     * @param BaseInfoRepository $baseInfoRepository
+     */
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        ValidatorInterface $validator,
+        BaseInfoRepository $baseInfoRepository
+    ) {
+        $this->entityManager = $entityManager;
+        $this->validator = $validator;
+        $this->baseInfoRepository = $baseInfoRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('checked', CheckboxType::class, [
+                'label' => false,
+                'required' => false,
+                'mapped' => false,
+            ])
+            ->add('code', TextType::class, [
+                'required' => false,
+            ])
+            ->add('stock', NumberType::class, [
+                'required' => false,
+            ])
+            ->add('stock_unlimited', CheckboxType::class, [
+                'required' => false,
+                'label' => 'productclass.label.unlimited',
+            ])
+            ->add('sale_limit', NumberType::class, [
+                'required' => false,
+            ])
+            ->add('price01', PriceType::class, [
+                'required' => false,
+            ])
+            ->add('price02', PriceType::class, [
+                'required' => false,
+            ])
+            ->add('tax_rate', TextType::class, [
+                'required' => false,
+            ])
+            ->add('delivery_fee', PriceType::class, [
+                'required' => false,
+            ])
+            ->add('sale_type', SaleTypeType::class, [
+                'multiple' => false,
+                'expanded' => false,
+            ])
+            ->add('delivery_duration', DeliveryDurationType::class, [
+                'required' => false,
+                'placeholder' => 'productclass.placeholder.not_specified',
+            ]);
+
+        $transformer = new DataTransformer\EntityToIdTransformer($this->entityManager, ClassCategory::class);
+        $builder
+            ->add($builder->create('ClassCategory1', HiddenType::class)
+                ->addModelTransformer($transformer)
+            )
+            ->add($builder->create('ClassCategory2', HiddenType::class)
+                ->addModelTransformer($transformer)
+            );
+
+        // 各行の個別税率設定.
+        $this->setTaxRate($builder);
+
+        // 各行の登録チェックボックス.
+        $this->setCheckbox($builder);
+
+        // バリデーションの設定. 各行にチェックが付いているときだけ検証する.
+        $this->addValidations($builder);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => ProductClass::class,
+        ]);
+    }
+
+    /**
+     * 各行の個別税率設定の制御.
+     *
+     * @param FormBuilderInterface $builder
+     */
+    protected function setTaxRate(FormBuilderInterface $builder)
+    {
+        if (!$this->baseInfoRepository->get()->isOptionProductTaxRule()) {
+            return;
+        }
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
+            $data = $event->getData();
+            if (!$data instanceof ProductClass) {
+                return;
+            }
+            if ($data->getId() && $data->getTaxRule()) {
+                $form = $event->getForm();
+                $form['tax_rate']->setData($data->getTaxRule()->getTaxRate());
+            }
+        });
+    }
+
+    /**
+     * 各行の登録チェックボックスの制御.
+     *
+     * @param FormBuilderInterface $builder
+     */
+    protected function setCheckbox(FormBuilderInterface $builder)
+    {
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
+            $data = $event->getData();
+            if (!$data instanceof ProductClass) {
+                return;
+            }
+            if ($data->getId() && $data->isVisible()) {
+                $form = $event->getForm();
+                $form['checked']->setData(true);
+            }
+        });
+
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
+            $form = $event->getForm();
+            $data = $event->getData();
+            $data->setVisible($form['checked']->getData() ? true : false);
+        });
+    }
+
+    protected function addValidations(FormBuilderInterface $builder)
+    {
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
+            $form = $event->getForm();
+            $data = $form->getData();
+
+            if (!$form['checked']->getData()) {
+                // チェックがついていない場合はバリデーションしない.
+                return;
+            }
+
+            // 在庫数
+            $errors = $this->validator->validate($data['stock'], [
+                new Assert\Regex([
+                    'pattern' => "/^\d+$/u",
+                    'message' => 'form.type.numeric.invalid',
+                ]),
+            ]);
+            $this->addErrors('stock', $form, $errors);
+
+            // 在庫数無制限
+            if (empty($data['stock_unlimited']) && null === $data['stock']) {
+                $form['stock_unlimited']->addError(new FormError('productclass.text.error.set_stock_quantitiy'));
+            }
+
+            // 販売制限数
+            $errors = $this->validator->validate($data['sale_limit'], [
+                new Assert\Length([
+                    'max' => 10,
+                ]),
+                new Assert\GreaterThanOrEqual([
+                    'value' => 1,
+                ]),
+                new Assert\Regex([
+                    'pattern' => "/^\d+$/u",
+                    'message' => 'form.type.numeric.invalid',
+                ]),
+            ]);
+            $this->addErrors('sale_limit', $form, $errors);
+
+            foreach ($errors as $error) {
+                $form['sale_limit']->addError(new FormError($error->getMessage()));
+            }
+
+            // 販売価格
+            $errors = $this->validator->validate($data['price02'], [
+                new Assert\NotBlank(),
+            ]);
+
+            $this->addErrors('price02', $form, $errors);
+
+            // 税率
+            $errors = $this->validator->validate($data['tax_rate'], [
+                new Assert\Range(['min' => 0, 'max' => 100]),
+                new Assert\Regex([
+                    'pattern' => "/^\d+(\.\d+)?$/",
+                    'message' => 'form.type.float.invalid'
+                ]),
+
+            ]);
+            $this->addErrors('tax_rate', $form, $errors);
+
+            // 販売種別
+            $errors = $this->validator->validate($data['sale_type'], [
+                new Assert\NotBlank(),
+            ]);
+            $this->addErrors('sale_type', $form, $errors);
+        });
+    }
+
+    protected function addErrors($key, FormInterface $form, ConstraintViolationListInterface $errors)
+    {
+        foreach ($errors as $error) {
+            $form[$key]->addError(new FormError($error->getMessage()));
+        }
+    }
+}

--- a/src/Eccube/Form/Type/Admin/ProductClassMatrixType.php
+++ b/src/Eccube/Form/Type/Admin/ProductClassMatrixType.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Eccube\Form\Type\Admin;
+
+
+use Eccube\Entity\ClassName;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+class ProductClassMatrixType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('class_name1', EntityType::class, [
+                'class' => ClassName::class,
+                'placeholder' => '規格1を選択してください',
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('class_name2', EntityType::class, [
+                'class' => ClassName::class,
+                'placeholder' => '規格2を選択してください',
+                'constraints' => new Callback(function (
+                    ClassName $ClassName2 = null,
+                    ExecutionContextInterface $context
+                ) {
+                    $ClassName1 = $context->getRoot()->get('class_name1')->getData();
+                    if ($ClassName1 && $ClassName2) {
+                        if ($ClassName1->getId() === $ClassName2->getId()) {
+                            $context->buildViolation('規格1と同じ規格は選択できません.')
+                                ->atPath('class_name2')
+                                ->addViolation();
+                        }
+                    }
+                }),
+                'required' => false,
+            ])
+            ->add('product_classes', CollectionType::class, [
+                'entry_type' => ProductClassEditType::class,
+                'allow_add' => true,
+                'error_bubbling' => false,
+            ])
+            ->add('save', SubmitType::class);
+
+        if ($options['product_classes_exist']) {
+            $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
+                $form = $event->getForm();
+                $ProductClasses = $form['product_classes']->getData();
+                $hasVisible = false;
+                foreach ($ProductClasses as $ProductClass) {
+                    if ($ProductClass->isVisible()) {
+                        $hasVisible = true;
+                        break;
+                    }
+                }
+
+                if (!$hasVisible) {
+                    $form['product_classes']->addError(new FormError('選択されていません'));
+                }
+            });
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'product_classes_exist' => false,
+        ]);
+    }
+}

--- a/src/Eccube/Form/Type/Admin/ProductClassType.php
+++ b/src/Eccube/Form/Type/Admin/ProductClassType.php
@@ -134,11 +134,6 @@ class ProductClassType extends AbstractType
                 'required' => false,
                 'placeholder' => 'productclass.placeholder.not_specified',
             ])
-            ->add('add', CheckboxType::class, [
-                'label' => false,
-                'required' => false,
-                'value' => 1,
-            ])
             ->addEventListener(FormEvents::POST_SUBMIT, function ($event) {
                 $form = $event->getForm();
                 $data = $form->getData();

--- a/src/Eccube/Repository/BaseInfoRepository.php
+++ b/src/Eccube/Repository/BaseInfoRepository.php
@@ -55,7 +55,7 @@ class BaseInfoRepository extends AbstractRepository
 
     /**
      * @param int $id
-     * @return mixed
+     * @return BaseInfo
      *
      * @throws \Doctrine\ORM\NoResultException
      * @throws \Doctrine\ORM\NonUniqueResultException

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -529,7 +529,7 @@ return [
     'admin.product.search.stock' => '在庫なし',
     'admin.product.product_class.save.complete' => '商品規格を登録しました。',
     'admin.product.product_class.update.complete' => '商品規格を更新しました。',
-    'admin.product.product_class.delete.complete' => '商品規格を削除しました。',
+    'admin.product.product_class.clear.complete' => '商品規格を削除しました。',
     'admin.product.copy.complete' => '商品を複製しました。',
     'admin.product.copy.failed' => '商品の複製に失敗しました。',
     'admin.product.csv_import.save.complete' => '商品登録CSVファイルをアップロードしました。',

--- a/src/Eccube/Resource/template/admin/Product/product_class.twig
+++ b/src/Eccube/Resource/template/admin/Product/product_class.twig
@@ -26,11 +26,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% block title %}{{ 'admin.product.product_class.title'|trans }}{% endblock %}
 {% block sub_title %}{{ 'admin.product.product_class.sub_title'|trans }}{% endblock %}
 
-{% if not_product_class %}
-    {% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
-{% else %}
-    {% form_theme classForm '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
-{% endif %}
+{% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
+{% form_theme clearForm '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
 
 {% block javascript %}
     <script>
@@ -42,32 +39,32 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 var index = $(this).attr('id').match(/\d+/);
 
                 if (check) {
-                    $('#form_product_classes_' + index + '_stock').prop('disabled', true);
+                    $('#product_class_matrix_product_classes_' + index + '_stock').prop('disabled', true);
                 } else {
-                    $('#form_product_classes_' + index + '_stock').prop('disabled', false);
+                    $('#product_class_matrix_product_classes_' + index + '_stock').prop('disabled', false);
                 }
             });
 
 
             // 無制限チェックボックス
-            $('input[id$=_stock_unlimited]').click(function () {
+            $('input[id$=_stock_unlimited]').on('click', function () {
                 var check = $(this).prop('checked');
                 var index = $(this).attr('id').match(/\d+/);
 
                 if (check) {
-                    $('#form_product_classes_' + index + '_stock').prop('disabled', true);
+                    $('#product_class_matrix_product_classes_' + index + '_stock').prop('disabled', true);
                 } else {
-                    $('#form_product_classes_' + index + '_stock').prop('disabled', false);
+                    $('#product_class_matrix_product_classes_' + index + '_stock').prop('disabled', false);
                 }
             });
 
             // 登録チェックボックス
-            $('#add-all').click(function () {
-                var addall = $('#add-all').prop('checked');
-                if (addall) {
-                    $('input[id$=_add]').prop('checked', true);
+            $('#check-all').click(function () {
+                var checked = $('#check-all').prop('checked');
+                if (checked) {
+                    $('input[id$=_checked]').prop('checked', true);
                 } else {
-                    $('input[id$=_add]').prop('checked', false);
+                    $('input[id$=_checked]').prop('checked', false);
                 }
             });
 
@@ -75,55 +72,49 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             $('#copy').on('click', function (event) {
                 event.preventDefault();
 
-                var check = $('#form_product_classes_0_add').prop('checked');
+                var check = $('#product_class_matrix_product_classes_0_add').prop('checked');
                 $('input[id$=_add]').prop('checked', check);
 
-                var product_code = $('#form_product_classes_0_code').val();
+                var product_code = $('#product_class_matrix_product_classes_0_code').val();
                 $('input[id$=_code]').val(product_code);
 
-                var stock = $('#form_product_classes_0_stock').val();
+                var stock = $('#product_class_matrix_product_classes_0_stock').val();
                 $('input[id$=_stock]').val(stock);
 
-                var stock_unlimited = $('#form_product_classes_0_stock_unlimited').prop('checked');
+                var stock_unlimited = $('#product_class_matrix_product_classes_0_stock_unlimited').prop('checked');
                 // 無制限チェックボックス
                 $('input[id$=_stock_unlimited]').each(function () {
                     var index = $(this).attr('id').match(/\d+/);
 
                     if (stock_unlimited) {
                         $(this).prop('checked', true);
-                        $('#form_product_classes_' + index + '_stock').prop('disabled', true);
+                        $('#product_class_matrix_product_classes_' + index + '_stock').prop('disabled', true);
                     } else {
                         $(this).prop('checked', false);
-                        $('#form_product_classes_' + index + '_stock').prop('disabled', false);
+                        $('#product_class_matrix_product_classes_' + index + '_stock').prop('disabled', false);
                     }
                 });
 
-                var sale_limit = $('#form_product_classes_0_sale_limit').val();
+                var sale_limit = $('#product_class_matrix_product_classes_0_sale_limit').val();
                 $('input[id$=_sale_limit]').val(sale_limit);
 
-                var price01 = $('#form_product_classes_0_price01').val();
+                var price01 = $('#product_class_matrix_product_classes_0_price01').val();
                 $('input[id$=_price01]').val(price01);
 
-                var price02 = $('#form_product_classes_0_price02').val();
+                var price02 = $('#product_class_matrix_product_classes_0_price02').val();
                 $('input[id$=_price02]').val(price02);
 
-                var delivery_fee = $('#form_product_classes_0_delivery_fee').val();
+                var delivery_fee = $('#product_class_matrix_product_classes_delivery_fee').val();
                 $('input[id$=_delivery_fee]').val(delivery_fee);
 
-                var delivery_duration = $('#form_product_classes_0_delivery_duration').val();
+                var delivery_duration = $('#product_class_matrix_product_classes_0_delivery_duration').val();
                 $('select[id$=_delivery_duration]').val(delivery_duration);
 
-                var tax_rate = $('#form_product_classes_0_tax_rate').val();
+                var tax_rate = $('#product_class_matrix_product_classes_0_tax_rate').val();
                 $('input[id$=_tax_rate]').val(tax_rate);
 
-                var sale_type = $('#form_product_classes_0_sale_type').val();
+                var sale_type = $('#product_class_matrix_product_classes_0_sale_type').val();
                 $('select[id$=_sale_type]').val(sale_type);
-            });
-
-            $(document).on('click', 'button[type=submit]', function (event) {
-                if ($(this).data('action')) {
-                    $(this).parents('form').attr('action', $(this).data('action'));
-                }
             });
         });
     </script>
@@ -131,110 +122,133 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 
 {% block main %}
-    <form id="form" method="post">
-        {% if classForm %}
-            {{ form_widget(classForm._token) }}
-        {% else %}
-            {{ form_widget(form._token) }}
-        {% endif %}
-        <div class="c-contentsArea__cols">
-            <div class="c-contentsArea__primaryCol">
-                <div class="c-primaryCol">
-                    <div class="card rounded border-0 mb-4">
+    <div class="c-contentsArea__cols">
+        <div class="c-contentsArea__primaryCol">
+            <div class="c-primaryCol">
+                <div class="card rounded border-0 mb-4">
+                    {% if Product.hasProductClass %}
+
+                        {# 規格あり商品 #}
                         <div class="card-header">
                             <div class="row">
-                                <div class="col-8"><span
-                                            class="card-title align-middle">{{ 'admin.product.product_class.product_name_label'|trans }}{{ Product.name }}</span>
+                                <div class="col-8">
+                                    <span class="card-title align-middle">{{ 'admin.product.product_class.product_name_label'|trans }}{{ Product.name }}</span>
                                 </div>
-                                {% if not_product_class %}
-                                    <div class="col-4 text-right">
-                                        <button class="btn btn-ec-conversion" type="submit"
-                                                data-action="{{ url('admin_product_product_class', { id : Product.id}) }}">
-                                            {{ 'admin.product.product_class.create_product_class_matrix'|trans }}
-                                        </button>
-                                    </div>
-                                {% else %}
-                                    <div class="col-4 text-right">
-                                        <button class="btn btn-ec-delete" type="button"
-                                                data-toggle="modal"
-                                                data-target="#initializationConfirm">{{ 'admin.product.product_class.clear_product_class_matrix'|trans }}
-                                        </button>
-                                        <div class="modal fade" id="initializationConfirm" tabindex="-1" role="dialog"
-                                             aria-labelledby="deleteConfirm" aria-hidden="true">
-                                            <div class="modal-dialog" role="document">
-                                                <div class="modal-content">
-                                                    <div class="modal-header">
-                                                        <h5 class="modal-title font-weight-bold">{{ 'admin.product.product_class.clear_product_class_message'|trans }}</h5>
-                                                        <button class="close" type="button" data-dismiss="modal"
-                                                                aria-label="Close"><span aria-hidden="true">×</span>
-                                                        </button>
-                                                    </div>
-                                                    <div class="modal-body">
-                                                        <p class="text-left">
-                                                            {{ 'admin.product.product_class.clear_product_class_alert'|trans }}</p>
-                                                    </div>
-                                                    <div class="modal-footer">
-                                                        <button class="btn btn-ec-sub" type="button"
-                                                                data-dismiss="modal">
-                                                            {{ 'admin.product.product_class.clear_product_class_cancel'|trans }}
-                                                        </button>
-                                                        <button class="btn btn-ec-delete" type="submit" name="mode"
-                                                                value="delete"
-                                                                data-action="{{ url('admin_product_product_class_edit', { id : Product.id}) }}">
+                                <div class="col-4 text-right">
+                                    {# 規格の初期化ボタン #}
+                                    <button class="btn btn-ec-delete" type="button"
+                                            data-toggle="modal"
+                                            data-target="#initializationConfirm">{{ 'admin.product.product_class.clear_product_class_matrix'|trans }}
+                                    </button>
+                                    {# 規格の初期化モーダル #}
+                                    <div class="modal fade" id="initializationConfirm" tabindex="-1"
+                                         role="dialog"
+                                         aria-labelledby="deleteConfirm" aria-hidden="true">
+                                        <div class="modal-dialog" role="document">
+                                            <div class="modal-content">
+                                                <div class="modal-header">
+                                                    <h5 class="modal-title font-weight-bold">{{ 'admin.product.product_class.clear_product_class_message'|trans }}</h5>
+                                                    <button class="close" type="button" data-dismiss="modal"
+                                                            aria-label="Close"><span aria-hidden="true">×</span>
+                                                    </button>
+                                                </div>
+                                                <div class="modal-body">
+                                                    <p class="text-left">
+                                                        {{ 'admin.product.product_class.clear_product_class_alert'|trans }}</p>
+                                                </div>
+                                                <div class="modal-footer">
+                                                    <button class="btn btn-ec-sub" type="button"
+                                                            data-dismiss="modal">
+                                                        {{ 'admin.product.product_class.clear_product_class_cancel'|trans }}
+                                                    </button>
+                                                    <form method="post"
+                                                          action="{{ url('admin_product_product_class_clear', { id: Product.id }) }}">
+                                                        {{ form_widget(clearForm._token) }}
+                                                        <button class="btn btn-ec-delete" type="submit">
                                                             {{ 'admin.product.product_class.clear_product_class_execute'|trans }}
                                                         </button>
-                                                    </div>
+                                                    </form>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
-                                {% endif %}
+                                </div>
                             </div>
                         </div>
                         <div class="card-body">
                             <div class="row mb-2">
                                 <div class="col">
                                     <div class="d-inline-block mr-2">
-                                        <span>{{ 'admin.product.product_class.class_name1_label'|trans }}</span></div>
-                                    {% if not_product_class %}
-                                        {{ form_widget(form.class_name1) }}
-                                        {{ form_errors(form.class_name1) }}
-                                    {% else %}
-                                        {#TODO 規格の管理名称実装後に対応 #}
-                                        <div class="d-inline-block"><span>{{ class_name1 }} [{{ 'admin.product.product_class.class_display_name_label'|trans }}{{ class_name1 }}
-                                                ]</span>
-                                        </div>
-
-                                    {% endif %}
+                                        <span>{{ 'admin.product.product_class.class_name1_label'|trans }}</span>
+                                    </div>
+                                    <div class="d-inline-block"><span>{# TODO 規格の管理名に変更する #}{{ ClassName1.name }}{# TODO 規格の管理名に変更する #}
+                                            [{{ 'admin.product.product_class.class_display_name_label'|trans }}{{ ClassName1.name }}
+                                            ]</span>
+                                    </div>
                                 </div>
                             </div>
-                            <div class="row">
-                                <div class="col">
-                                    <div class="d-inline-block mr-2">
-                                        <span>{{ 'admin.product.product_class.class_name2_label'|trans }}</span></div>
-                                    {% if not_product_class %}
-                                        {{ form_widget(form.class_name2) }}
-                                        {{ form_errors(form.class_name2) }}
-                                    {% else %}
-                                        {#TODO 規格の管理名称実装後に対応 #}
-                                        <div class="d-inline-block"><span>{{ class_name2 }} [{{ 'admin.product.product_class.class_display_name_label'|trans }}{{ class_name2 }}
+                            {% if ClassName2 %}
+                                <div class="row">
+                                    <div class="col">
+                                        <div class="d-inline-block mr-2">
+                                            <span>{{ 'admin.product.product_class.class_name2_label'|trans }}</span>
+                                        </div>
+                                        <div class="d-inline-block"><span>{# TODO 規格の管理名に変更する #}{{ ClassName2.name }}{# TODO 規格の管理名に変更する #}
+                                                [{{ 'admin.product.product_class.class_display_name_label'|trans }}{{ ClassName2.name }}
                                                 ]</span>
                                         </div>
-                                    {% endif %}
+                                    </div>
                                 </div>
-                            </div>
+                            {% endif %}
                         </div>
-                    </div>
-                    {% if classForm %}
+                    {% else %}
+                        {# 規格なし商品 #}
+                        <form method="post" action="{{ url('admin_product_product_class', { id: Product.id }) }}">
+                            <input type="hidden" name="_token" value="{{ csrf_token('_token') }}">
+                            <div class="card-header">
+                                <div class="row">
+                                    <div class="col-8">
+                                        <span class="card-title align-middle">{{ 'admin.product.product_class.product_name_label'|trans }}{{ Product.name }}</span>
+                                    </div>
+                                    <div class="col-4 text-right">
+                                        {# 商品規格の設定ボタン #}
+                                        <button class="btn btn-ec-conversion" type="submit">
+                                            {{ 'admin.product.product_class.create_product_class_matrix'|trans }}
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="card-body">
+                                <div class="form-row mb-2">
+                                    {{ form_widget(form.class_name1) }}
+                                    {{ form_errors(form.class_name1) }}
+                                </div>
+                                <div class="form-row">
+                                    {{ form_widget(form.class_name2) }}
+                                    {{ form_errors(form.class_name2) }}
+                                </div>
+                            </div>
+                        </form>
+                    {% endif %}
+                </div>
+
+                {% if form.product_classes|length > 0 %}
+                    <form method="post" action="{{ url('admin_product_product_class', {'id': Product.id}) }}">
+                        <input type="hidden" name="_token" value="{{ csrf_token('_token') }}">
+                        <input type="hidden" name="{{ form.class_name1.vars.full_name }}"
+                               value="{{ form.class_name1.vars.value }}">
+                        <input type="hidden" name="{{ form.class_name2.vars.full_name }}"
+                               value="{{ form.class_name2.vars.value }}">
+
                         <div class="card rounded border-0 mb-4">
                             <div class="card-header">
                                 <div class="row justify-content-between">
-                                    <div class="col-6"><span class="align-middle">
-                                            {#<p class="font-weight-bold text-danger">{{ 'admin.order.mail_all.354'|trans({'%count%': ids|split(',')|length}) }}</p>#}
-
+                                    <div class="col-6">
+                                        <span class="align-middle">
                                             {{ 'admin.product.product_class.product_class_matrix_count'|trans({
-                                                '%count%' : classForm.product_classes|length
+                                                '%count%' : form.product_classes|length
                                             }) }}</span>
+                                        {{ form_errors(form.product_classes) }}
                                     </div>
                                     <div class="col-4 text-right">
                                         <button id="copy" class="btn btn-ec-regular"><i
@@ -246,10 +260,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 <table class="table table-sm">
                                     <thead>
                                     <th class="pt-2 pb-2 pl-3">
-                                        <input type="checkbox" id="add-all">
+                                        <input type="checkbox" id="check-all">
                                     </th>
-                                    <th class="pt-2 pb-2">{{ class_name1 is defined ? class_name1 }}</th>
-                                    <th class="pt-2 pb-2">{{ class_name2 is defined ? class_name2 }}</th>
+                                    <th class="pt-2 pb-2">{{ ClassName1 ? ClassName1.name }}</th>
+                                    <th class="pt-2 pb-2">{{ ClassName2 ? ClassName2.name }}</th>
                                     <th class="pt-2 pb-2">{{ 'admin.product.product_class.product_code'|trans }}</th>
                                     <th class="pt-2 pb-2">{{ 'admin.product.product_class.product_stock'|trans }}</th>
                                     <th class="pt-2 pb-2">{{ 'admin.product.product_class.product_sale_limit'|trans }}</th>
@@ -264,10 +278,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     <th class="pt-2 pb-2">{{ 'admin.product.product_class.delivery_date'|trans }}</th>
                                     <th class="pt-2 pb-2 pr-3">{{ 'admin.product.product_class.sale_tyle'|trans }}</th>
                                     </thead>
-                                    {% for product_class_form in classForm.product_classes %}
+                                    {% for product_class_form in form.product_classes %}
                                         <tr>
                                             <td class="align-middle pl-3">
-                                                {{ form_widget(product_class_form.add) }}
+                                                {{ form_widget(product_class_form.checked) }}
                                             </td>
                                             <td class="align-middle">
                                                 {{ product_class_form.vars.value.ClassCategory1 }}
@@ -336,42 +350,49 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 </table>
                             </div>
                         </div>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
-        <div class="c-conversionArea">
-            <div class="c-conversionArea__container">
-                <div class="row justify-content-between align-items-center">
-                    <div class="col-6">
-                        <div class="c-conversionArea__leftBlockItem"><a class="c-beseLink"
-                                                                        href="{{ url('admin_product') ~ '?resume=1' }}"><i
-                                        class="fa fa-backward" aria-hidden="true"></i><span>{{ 'admin.product.product_class.product_list'|trans }}</span></a>
-                        </div>
-                    </div>
-                    <div class="col-6">
-                        {% if classForm and classForm.product_classes|length > 0 and has_class_category_flg %}
-                            <div class="row align-items-center justify-content-end">
-                                <div class="col-auto">
-                                    {% if not_product_class %}
-                                        <button class="btn btn-ec-conversion px-5" type="submit" name="mode"
-                                                value="edit"
-                                                data-action="{{ url('admin_product_product_class_edit', { id : Product.id}) }}">
-                                            {{ 'admin.product.product_class.register'|trans }}
-                                        </button>
-                                    {% else %}
-                                        <button class="btn btn-ec-conversion px-5" type="submit" name="mode"
-                                                value="update"
-                                                data-action="{{ url('admin_product_product_class_edit', { id : Product.id}) }}">
-                                            {{ 'admin.product.product_class.update'|trans }}
-                                        </button>
-                                    {% endif %}
+                        <div class="c-conversionArea">
+                            <div class="c-conversionArea__container">
+                                <div class="row justify-content-between align-items-center">
+                                    <div class="col-6">
+                                        <div class="c-conversionArea__leftBlockItem">
+                                            <a class="c-beseLink" href="{{ url('admin_product', {'resume': 1}) }}"><i
+                                                        class="fa fa-backward"
+                                                        aria-hidden="true"></i><span>{{ 'admin.product.product_class.product_list'|trans }}</span></a>
+                                        </div>
+                                    </div>
+                                    <div class="col-6">
+                                        <div class="row align-items-center justify-content-end">
+                                            <div class="col-auto">
+                                                <button class="btn btn-ec-conversion px-5" name="{{ form.save.vars.full_name }}" type="submit">
+                                                    {{ Product.hasProductClass
+                                                    ? 'admin.product.product_class.update'|trans
+                                                    : 'admin.product.product_class.register'|trans }}
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
-                        {% endif %}
+                        </div>
+                    </form>
+
+                {% else %}
+                    <div class="c-conversionArea">
+                        <div class="c-conversionArea__container">
+                            <div class="row justify-content-between align-items-center">
+                                <div class="col-6">
+                                    <div class="c-conversionArea__leftBlockItem">
+                                        <a class="c-beseLink" href="{{ url('admin_product', {'resume': 1}) }}"><i
+                                                    class="fa fa-backward"
+                                                    aria-hidden="true"></i><span>{{ 'admin.product.product_class.product_list'|trans }}</span></a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
-                </div>
+                {% endif %}
+
             </div>
         </div>
-    </form>
+    </div>
 {% endblock %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- 商品規格登録画面を動作するように修正しました

## 実装に関する補足(Appendix)
- #3035 マージ後, 規格の管理名称の表示に対応する必要があります
- 無効にした商品規格は, visible=falseでレコードを残し、再度有効にすると過去のレコードを復旧します

