### PR TITLE
[管理画面UI実装]出荷マスター/一括削除

### DIFF
--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -172,6 +172,7 @@ class OrderController extends AbstractController
         $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_ORDER_INDEX_INITIALIZE, $event);
 
         $searchForm = $builder->getForm();
+        $searchData = [];
 
         /**
          * ページの表示件数は, 以下の順に優先される.

--- a/src/Eccube/Controller/Admin/Shipping/ShippingController.php
+++ b/src/Eccube/Controller/Admin/Shipping/ShippingController.php
@@ -85,6 +85,7 @@ class ShippingController extends AbstractController
         $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_SHIPPING_INDEX_INITIALIZE, $event);
 
         $searchForm = $builder->getForm();
+        $searchData = [];
 
         /**
          * ページの表示件数は, 以下の順に優先される.
@@ -110,8 +111,6 @@ class ShippingController extends AbstractController
         }
 
         if ('POST' === $request->getMethod()) {
-
-            $searchData = [];
 
             $searchForm->handleRequest($request);
 

--- a/src/Eccube/Entity/Shipping.php
+++ b/src/Eccube/Entity/Shipping.php
@@ -251,7 +251,7 @@ class Shipping extends \Eccube\Entity\AbstractEntity
     /**
      * @var \Doctrine\Common\Collections\Collection
      *
-     * @ORM\OneToMany(targetEntity="Eccube\Entity\OrderItem", mappedBy="Shipping", cascade={"persist","remove"})
+     * @ORM\OneToMany(targetEntity="Eccube\Entity\OrderItem", mappedBy="Shipping")
      */
     private $OrderItems;
 

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -1871,6 +1871,8 @@ return [
     'admin.shipping.index.828' => '処理完了',
     'admin.shipping.index.829' => '発送済みにします',
     'admin.shipping.index.830' => '出荷情報を発送済みにします。同時におこなう操作を選択してから［変更を確定］ボタンを押してください。この操作は取り消すことができません。ご注意ください。',
+    'admin.shipping.index.831' => '出荷情報を削除してもよろしいですか？',
+    'admin.shipping.delete.complete' => '出荷情報を削除しました。',
     'admin.shipping.search_product.800' => '注文日・注文ID<br>注文者<br>注文内容',
     'admin.shipping.search_product.801' => '注文ID: %order_id%',
     'admin.shipping.search_product.802' => '決定',

--- a/src/Eccube/Resource/template/admin/Shipping/index.twig
+++ b/src/Eccube/Resource/template/admin/Shipping/index.twig
@@ -118,6 +118,12 @@
             $('#bulkChangeComplete').on('click', function() {
                 location.reload(true);
             });
+
+            $('#btn_bulk_delete').on('click', function(event) {
+                event.preventDefault();
+                $('#form_bulk').attr('action', "{{ url('admin_shipping_bulk_delete') }}").submit();
+                return false;
+            });
         });
 
 
@@ -316,13 +322,14 @@
     <div class="c-contentsArea__primaryCol">
         <div class="c-primaryCol">
             {% if pagination and pagination.totalItemCount %}
+            <form id="form_bulk" method="POST" action="">
+                <input type="hidden" name="{{ constant('Eccube\\Common\\Constant::TOKEN_NAME') }}" value="{{ csrf_token(constant('Eccube\\Common\\Constant::TOKEN_NAME')) }}">
                 <div class="row justify-content-between mb-2">
                     <div class="col-6">
                         <div id="btn_bulk" class="d-none">
                             <label class="mr-2">{{ 'admin.shipping.index.803'|trans }}</label>
                             <button class="btn btn-ec-regular mr-2" data-toggle="modal" data-target="#sentUpdateModal" data-bulk-update="true">{{ 'admin.shipping.index.805'|trans }}</button>
-                            {# TODO 一括削除 #}
-                            <button class="btn btn-ec-delete">{{ 'admin.shipping.index.817'|trans }}</button>
+                            <button type="button" class="btn btn-ec-delete" data-toggle="modal" data-target="#bulkDeleteModal">{{ 'admin.shipping.index.817'|trans }}</button>
                         </div>
                     </div>
                     <div class="col-5 text-right">
@@ -370,7 +377,7 @@
                             {% for Shipping in pagination %}
                             <tr>
                                 <td class="align-middle pl-3">
-                                    <input type="checkbox" id="check-{{ Shipping.id }}" data-id="{{ Shipping.id }}" name="ids{{ Shipping.id }}"
+                                    <input type="checkbox" id="check-{{ Shipping.id }}" data-id="{{ Shipping.id }}" name="ids[]" value="{{ Shipping.id }}"
                                            data-mark-as-shipped-url="{{ url('admin_shipping_mark_as_shipped', { id: Shipping.id}) }}"
                                            data-preview-notify-mail-url="{{ url('admin_shipping_preview_notify_mail', { id: Shipping.id}) }}" />
                                 </td>
@@ -426,6 +433,7 @@
                         </div>
                         </div>
                 </div>
+            </form>
             {% else %}
                 <div class="card rounded border-0">
                     <div class="card-body p-4">
@@ -469,6 +477,28 @@
                         <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'admin.shipping.index.815'|trans }}</button>
                         <button id="bulkChange" class="btn btn-ec-conversion" type="button">{{ 'admin.shipping.index.816'|trans }}</button>
                         <button id="bulkChangeComplete" class="btn btn-ec-regular" style="display: none" type="button">{{ 'admin.shipping.index.826'|trans }}</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="modal fade" id="bulkDeleteModal" tabindex="-1" role="dialog" aria-labelledby="discontinuance" aria-hidden="true" data-keyboard="false" data-backdrop="static">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title font-weight-bold">{{ 'admin.product.index.495'|trans }}</h5>
+                        <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                    </div>
+                    <div class="modal-body text-left">
+                        <p class="text-left">{{ 'admin.shipping.index.831'|trans }}</p>
+                        <ul id="bulkErrors"></ul>
+                        <div class="progress" style="display: none">
+                            <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'admin.product.index.cancel'|trans }}</button>
+                        <button class="btn btn-ec-delete" type="button" id="btn_bulk_delete">{{ 'admin.product.index.permanently_delete' | trans }}</button>
                     </div>
                 </div>
             </div>

--- a/src/Eccube/Resource/template/admin/Shipping/index.twig
+++ b/src/Eccube/Resource/template/admin/Shipping/index.twig
@@ -491,10 +491,6 @@
                     </div>
                     <div class="modal-body text-left">
                         <p class="text-left">{{ 'admin.shipping.index.831'|trans }}</p>
-                        <ul id="bulkErrors"></ul>
-                        <div class="progress" style="display: none">
-                            <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
-                        </div>
                     </div>
                     <div class="modal-footer">
                         <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'admin.product.index.cancel'|trans }}</button>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 出荷一覧から出荷を一括削除する機能を実装

## 方針(Policy)
+ 出荷を削除する
+ 出荷にひも付いている受注明細は残る(shipping_id=nullになる)
+ 確認ダイアログを表示する

## 実装に関する補足(Appendix)
+ 受注一覧と出荷一覧で検索条件でバリデーションエラーとなった場合にシステムエラーが発生してしまっていたので修正
+ 変更箇所を少なくするためインデント調整なし

## テスト（Test)
+ UnitTestを追加

