### PR TITLE
一括ステータス変更時にサブミットされる問題を修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Shipping/index.twig
+++ b/src/Eccube/Resource/template/admin/Shipping/index.twig
@@ -328,7 +328,7 @@
                     <div class="col-6">
                         <div id="btn_bulk" class="d-none">
                             <label class="mr-2">{{ 'admin.shipping.index.803'|trans }}</label>
-                            <button class="btn btn-ec-regular mr-2" data-toggle="modal" data-target="#sentUpdateModal" data-bulk-update="true">{{ 'admin.shipping.index.805'|trans }}</button>
+                            <button class="btn btn-ec-regular mr-2" data-toggle="modal" data-target="#sentUpdateModal" data-bulk-update="true" type="button">{{ 'admin.shipping.index.805'|trans }}</button>
                             <button type="button" class="btn btn-ec-delete" data-toggle="modal" data-target="#bulkDeleteModal">{{ 'admin.shipping.index.817'|trans }}</button>
                         </div>
                     </div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 一括で「発送済みに更新」ボタンをクリックしたときにサブミットされていたので修正
