### PR TITLE
レイアウト追加画面(PC/モバイル)に移動できるよう修正

### DIFF
--- a/src/Eccube/Controller/Admin/Content/LayoutController.php
+++ b/src/Eccube/Controller/Admin/Content/LayoutController.php
@@ -28,6 +28,7 @@ use Doctrine\ORM\NoResultException;
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\BlockPosition;
 use Eccube\Entity\Layout;
+use Eccube\Entity\Master\DeviceType;
 use Eccube\Form\Type\Master\DeviceTypeType;
 use Eccube\Repository\BlockRepository;
 use Eccube\Repository\LayoutRepository;
@@ -180,6 +181,18 @@ class LayoutController extends AbstractController
 
         $form = $builder->getForm();
         $form->handleRequest($request);
+
+        if (is_null($id)) {     // admin_content_layout_new only
+            if ($deviceTypeId = $request->get('DeviceType')) {
+                if ($DeviceType = $this->entityManager->find(DeviceType::class, $deviceTypeId)) {
+                    $form['DeviceType']->setData($DeviceType);
+                } else {
+                    throw new BadRequestHttpException(trans('admin.content.layout.device_type.invalid'));
+                }
+            } else {
+                throw new BadRequestHttpException(trans('admin.content.layout.device_type.invalid'));
+            }
+        }
 
         if ($form->isSubmitted() && $form->isValid()) {
             // Layoutの更新

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -745,6 +745,7 @@ return [
     'admin.content.layout.device_type' => '端末種別',
     'admin.content.layout.block_edit' => 'レイアウトブロック編集',
     'admin.content.layout.list' => 'レイアウト一覧',
+    'admin.content.layout.device_type.invalid' => '無効な端末種別です。',
     'admin.content.layout.overview' => 'レイアウト概要',
     'admin.content.layout.section.head' => 'headセクション',
     'admin.content.layout.section.body_after' => '<body>タグ直後',

--- a/src/Eccube/Resource/template/admin/Content/layout.twig
+++ b/src/Eccube/Resource/template/admin/Content/layout.twig
@@ -212,11 +212,20 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     <div class="col-3 pr-0"><span>{{ 'admin.content.layout.name'|trans }}</span><span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></div>
                                     <div class="col">
                                         {{ form_widget(form.name) }}
+                                        {{ form_errors(form.name) }}
                                     </div>
                                 </div>
                                 <div class="row">
                                     <div class="col-3 pr-0"><span>{{ 'admin.content.layout.device_type'|trans }}</span></div>
-                                    <div class="col"><span>{{ form_widget(form.DeviceType) }}</span></div>{# TODO hidden にする #}
+                                    <div class="col">
+                                        <span>
+                                            {% if form.DeviceType.vars.value in form.DeviceType.vars.choices|keys %}
+                                                {{ form.DeviceType.vars.choices[form.DeviceType.vars.value].label }}
+                                            {% endif %}
+                                            {{ form_errors(form.DeviceType) }}
+                                            <input type="hidden" name="{{ form.DeviceType.vars.full_name }}" value="{{ form.DeviceType.vars.value }}" />
+                                        </span>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/src/Eccube/Resource/template/admin/Content/layout_list.twig
+++ b/src/Eccube/Resource/template/admin/Content/layout_list.twig
@@ -156,9 +156,8 @@
             <div class="c-primaryCol">
                 <div class="tab-content" id="pills-tabContent">
                     <div class="tab-pane fade show active" id="pills-pc" role="tabpanel" aria-labelledby="pills-pc-tab">
-                        {# TODO レイアウト追加画面(PC)に移動する #}
                         <div class="d-block mb-3">
-                            <a class="btn btn-ec-regular" href="{{ url('admin_content_layout_new')}}">{{ 'admin.content.layout_list.add_pc_layout'|trans }}</a>
+                            <a class="btn btn-ec-regular" href="{{ url('admin_content_layout_new')}}?DeviceType={{ constant('\\Eccube\\Entity\\Master\\DeviceType::DEVICE_TYPE_PC') }}">{{ 'admin.content.layout_list.add_pc_layout'|trans }}</a>
                         </div>
                         <div class="card rounded border-0 mb-4">
                             <div class="card-header">
@@ -238,9 +237,8 @@
                         {% endfor %}
                     </div>
                     <div class="tab-pane fade" id="pills-mobile" role="tabpanel" aria-labelledby="pills-mobile-tab">
-                        {# TODO レイアウト追加画面(スマホ)に移動する #}
                         <div class="d-block mb-3">
-                            <a class="btn btn-ec-regular" href="{{ url('admin_content_layout_new')}}">{{ 'admin.content.layout_list.add_mobile_layout'|trans }}</a>
+                            <a class="btn btn-ec-regular" href="{{ url('admin_content_layout_new')}}?DeviceType={{ constant('\\Eccube\\Entity\\Master\\DeviceType::DEVICE_TYPE_SP') }}">{{ 'admin.content.layout_list.add_mobile_layout'|trans }}</a>
                         </div>
                         <div class="card rounded border-0 mb-4">
                             <div class="card-header">

--- a/tests/Eccube/Tests/Web/Admin/Content/LayoutControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/LayoutControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Eccube\Tests\Web\Admin\Content;
 
+use Eccube\Entity\Master\DeviceType;
 use Eccube\Repository\PageLayoutRepository;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 
@@ -82,7 +83,7 @@ class LayoutControllerTest extends AbstractAdminWebTestCase
                 'form' => array(
                     '_token' => 'dummy',
                     'name' => 'テストレイアウト',
-                    'DeviceType' => 10
+                    'DeviceType' => DeviceType::DEVICE_TYPE_PC
                 ),
                 'name_1' => 'カゴの中',
                 'block_id_1' => 2,
@@ -97,6 +98,41 @@ class LayoutControllerTest extends AbstractAdminWebTestCase
         $this->assertTrue($this->client->getResponse()->isRedirect(
             $this->generateUrl('admin_content_layout_edit', array('id' => 1))
         ));
+    }
+
+    public function testIndexWithNew()
+    {
+        $this->client->request(
+            'GET',
+            $this->generateUrl(
+                'admin_content_layout_new',
+                ['DeviceType' => DeviceType::DEVICE_TYPE_PC]
+            )
+        );
+        $this->assertTrue($this->client->getResponse()->isOk());
+    }
+
+    public function testIndexWithInvalid()
+    {
+        $this->client->request(
+            'GET',
+            $this->generateUrl(
+                'admin_content_layout_new',
+                ['DeviceType' => 99999999]
+            )
+        );
+        $this->assertTrue($this->client->getResponse()->isClientError());
+    }
+
+    public function testIndexWithDeviceNotFound()
+    {
+        $this->client->request(
+            'GET',
+            $this->generateUrl(
+                'admin_content_layout_new'
+            )
+        );
+        $this->assertTrue($this->client->getResponse()->isClientError());
     }
 
     public function testIndexWithPostPreview()

--- a/tests/Eccube/Tests/Web/Admin/Content/LayoutControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/LayoutControllerTest.php
@@ -5,6 +5,7 @@ namespace Eccube\Tests\Web\Admin\Content;
 use Eccube\Entity\Master\DeviceType;
 use Eccube\Repository\PageLayoutRepository;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+use Symfony\Component\HttpFoundation\Response;
 
 class LayoutControllerTest extends AbstractAdminWebTestCase
 {
@@ -118,10 +119,10 @@ class LayoutControllerTest extends AbstractAdminWebTestCase
             'GET',
             $this->generateUrl(
                 'admin_content_layout_new',
-                ['DeviceType' => 99999999]
+                ['DeviceType' => 999]
             )
         );
-        $this->assertTrue($this->client->getResponse()->isClientError());
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
     }
 
     public function testIndexWithDeviceNotFound()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ レイアウト追加画面に移動した際、一覧画面で選択した端末種別が選択されるよう修正

## 実装に関する補足(Appendix)
+ Layout と DeviceType を `@ParamConverter` で処理しようと思ったが、 `admin_content_layout_new` の場合に、 Layout に DeviceTypeId が入ってしまい、うまく設定できなかった

## テスト（Test)
+ 無効な端末種別が設定された場合のテストを追加

