### PR TITLE
Shipping::name01 が重複してテストが時折失敗するのを修正

### DIFF
--- a/tests/Eccube/Tests/Web/Admin/Shipping/ShippingControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Shipping/ShippingControllerTest.php
@@ -93,9 +93,14 @@ class ShippingControllerTest extends AbstractAdminWebTestCase
 
     public function testSearchOrderByName()
     {
+        $faker = $this->getFaker();
         /** @var Shipping $Shipping */
         $Shipping = $this->shippingRepository->findOneBy(array());
         $name = $Shipping->getName01();
+        $name .= $faker->realText(10);
+        $Shipping->setName01($name);
+        $this->entityManager->flush($Shipping);
+
         $Shippings = $this->shippingRepository->findBy(array('name01' => $name));
         $cnt = count($Shippings);
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ `ShippingControllerTest::testSearchOrderByName()` にて、 Shipping::name01 が重複してテストが時折失敗するのを修正

## 方針(Policy)
+ Shipping::name01 が重複しないよう、テキストを追加

## 実装に関する補足(Appendix)
失敗するケース
https://travis-ci.org/nanasess/ec-cube/jobs/365446720

## テスト（Test)
+ ユニットテストを修正
