### PR TITLE
トグルボタンの実装

### DIFF
--- a/src/Eccube/Form/Type/Admin/ShopMasterType.php
+++ b/src/Eccube/Form/Type/Admin/ShopMasterType.php
@@ -29,9 +29,9 @@ use Eccube\Form\EventListener\ConvertKanaListener;
 use Eccube\Form\Type\AddressType;
 use Eccube\Form\Type\PriceType;
 use Eccube\Form\Type\TelType;
+use Eccube\Form\Type\ToggleSwitchType;
 use Eccube\Form\Type\ZipType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
@@ -173,12 +173,12 @@ class ShopMasterType extends AbstractType
                     ]),
                 ],
             ])
-
             // 送料設定
             ->add('delivery_free_amount', PriceType::class, [
                 'label' => 'common.label.option_delivery_fee_free_amount',
                 'required' => false,
             ])
+            //
             ->add('delivery_free_quantity', IntegerType::class, [
                 'label' => 'common.label.option_delivery_free_quantity',
                 'required' => false,
@@ -189,85 +189,26 @@ class ShopMasterType extends AbstractType
                     ]),
                 ],
             ])
-            ->add('option_product_delivery_fee', ChoiceType::class, [
-                'label' => 'common.label.option_product_delivery_fee',
-                'choices' => array_flip([
-                    '0' => 'common.label.disabled',
-                    '1' => 'common.label.enabled',
-                ]),
-                'expanded' => true,
-                'multiple' => false,
-            ])
-            ->add('option_multiple_shipping', ChoiceType::class, [
-                'label' => 'common.label.option_multiple_shipping',
-                'choices' => array_flip([
-                    '0' => 'common.label.disabled',
-                    '1' => 'common.label.enabled',
-                ]),
-                'expanded' => true,
-                'multiple' => false,
-            ])
-
+            ->add('option_product_delivery_fee', ToggleSwitchType::class)
+            // 複数配送
+            ->add('option_multiple_shipping', ToggleSwitchType::class)
             // 会員設定
-            ->add('option_customer_activate', ChoiceType::class, [
-                'label' => 'common.label.option_customer_activate',
-                'choices' => array_flip([
-                    '0' => 'common.label.disabled',
-                    '1' => 'common.label.enabled',
-                ]),
-                'expanded' => true,
-                'multiple' => false,
+            ->add('option_customer_activate', ToggleSwitchType::class)
+            // マイページに注文状況を表示する
+            ->add('option_mypage_order_status_display', ToggleSwitchType::class)
+            // 自動ログイン
+            ->add('option_remember_me', ToggleSwitchType::class)
+            // お気に入り商品設定
+            ->add('option_favorite_product', ToggleSwitchType::class)
+            // 在庫切れ商品を非表示にする
+            ->add('option_nostock_hidden', ToggleSwitchType::class, [
+                'label_off' => '表示',
+                'label_on' => '非表示'
             ])
-            ->add('option_mypage_order_status_display', ChoiceType::class, [
-                'label' => 'common.label.option_mypage_order_status_display',
-                'choices' => array_flip([
-                    '0' => 'common.label.disabled',
-                    '1' => 'common.label.enabled',
-
-                ]),
-                'expanded' => true,
-                'multiple' => false,
-            ])
-            ->add('option_remember_me', ChoiceType::class, [
-                'label' => 'common.label.option_remember_me',
-                'choices' => array_flip([
-                    '0' => 'common.label.disabled',
-                    '1' => 'common.label.enabled',
-                ]),
-                'expanded' => true,
-                'multiple' => false,
-            ])
-            ->add('option_favorite_product', ChoiceType::class, [
-                'label' => 'common.label.option_favorite_product',
-                'choices' => array_flip([
-                    '0' => 'common.label.disabled',
-                    '1' => 'common.label.enabled',
-                ]),
-                'expanded' => true,
-                'multiple' => false,
-            ])
-
-            // 商品設定
-            ->add('option_nostock_hidden', ChoiceType::class, [
-                'label' => 'common.label.nostock_hidden',
-                'choices' => array_flip([
-                    '0' => 'common.label.disabled',
-                    '1' => 'common.label.enabled',
-
-                ]),
-                'expanded' => true,
-                'multiple' => false,
-            ])
+            // 個別税率設定
+            ->add('option_product_tax_rule', ToggleSwitchType::class)
             // ポイント設定
-            ->add('option_point', ChoiceType::class, [
-                'label' => 'common.label.option_point', // TODO 未翻訳
-                'choices' => array_flip([
-                    '0' => 'common.label.disabled',
-                    '1' => 'common.label.enabled',
-                ]),
-                'expanded' => true,
-                'multiple' => false,
-            ])
+            ->add('option_point', ToggleSwitchType::class)
             ->add('basic_point_rate', NumberType::class, [
                 'required' => false,
                 'label' => 'common.label.basic_point_rate', // TODO 未翻訳

--- a/src/Eccube/Form/Type/Admin/ShopMasterType.php
+++ b/src/Eccube/Form/Type/Admin/ShopMasterType.php
@@ -202,8 +202,8 @@ class ShopMasterType extends AbstractType
             ->add('option_favorite_product', ToggleSwitchType::class)
             // 在庫切れ商品を非表示にする
             ->add('option_nostock_hidden', ToggleSwitchType::class, [
-                'label_off' => '表示',
-                'label_on' => '非表示'
+                'label_off' => 'common.label.display',
+                'label_on' => 'common.label.hide',
             ])
             // 個別税率設定
             ->add('option_product_tax_rule', ToggleSwitchType::class)

--- a/src/Eccube/Form/Type/ToggleSwitchType.php
+++ b/src/Eccube/Form/Type/ToggleSwitchType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Eccube\Form\Type;
+
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ToggleSwitchType extends AbstractType
+{
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['label_on'] = $options['label_on'];
+        $view->vars['label_off'] = $options['label_off'];
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'label' => false,
+            'label_on' => 'common.label.enabled',
+            'label_off' => 'common.label.disabled',
+        ]);
+    }
+
+    public function getParent()
+    {
+        return CheckboxType::class;
+    }
+}

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -12,6 +12,8 @@ return [
     'common.label.file_name' => 'ファイル名',
     'common.label.disabled' => '無効',
     'common.label.enabled' => '有効',
+    'common.label.display' => '表示',
+    'common.label.hide' => '非表示',
     'common.label.Open' => '',
     'common.label.close' => '閉じる',
     'common.label.company_name' => '会社名',

--- a/src/Eccube/Resource/template/admin/Form/bootstrap_4_horizontal_layout.html.twig
+++ b/src/Eccube/Resource/template/admin/Form/bootstrap_4_horizontal_layout.html.twig
@@ -1,2 +1,28 @@
 {%- extends 'bootstrap_4_horizontal_layout.html.twig' -%}
 
+{%- block toggle_switch_widget -%}
+    <div class="c-toggleSwitch">
+        <div class="c-toggleSwitch__btn">
+            <input type="checkbox"
+                   id="{{ form.vars.id }}"
+                   name="{{ form.vars.full_name }}"
+                   value="{{ form.vars.value }}"{{ form.vars.data ? ' checked' }}>
+            <label for="{{ form.vars.id }}"></label>
+        </div>
+        <div class="c-toggleSwitch__label">
+            <span class="{{ form.vars.id }}-on text-dark {{ form.vars.data ? '' : 'd-none' }}">{{ form.vars.label_on|trans }}</span>
+            <span class="{{ form.vars.id }}-off text-dark {{ form.vars.data ? 'd-none' : '' }}">{{ form.vars.label_off|trans }}</span>
+        </div>
+        <script>
+            $('#{{ form.vars.id }}').on('change', function (e) {
+                if ($(this).prop('checked')) {
+                    $('.{{ form.vars.id }}-on').removeClass('d-none');
+                    $('.{{ form.vars.id }}-off').addClass('d-none');
+                } else {
+                    $('.{{ form.vars.id }}-on').addClass('d-none');
+                    $('.{{ form.vars.id }}-off').removeClass('d-none');
+                }
+            });
+        </script>
+    </div>
+{%- endblock -%}

--- a/src/Eccube/Resource/template/admin/Setting/Shop/shop_master.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/shop_master.twig
@@ -214,45 +214,27 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                 <div class="col-3">
                                     <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'common.label.option_delivery_fee_free_amount'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
-                                <div class="col mb-2">
-                                    <div class="input-group col-4 pl-0">
-                                        <div class="input-group-prepend">
-                                            {# TODO フォームの左側の角が丸くなっている #}
-                                            <div class="input-group-text">￥</div>
-                                            {{ form_widget(form.delivery_free_amount, {'attr': {'class': 'notmoney'}}) }}
-                                            {{ form_errors(form.delivery_free_amount) }}
-                                        </div>
-
-                                    </div>
+                                <div class="col-4 mb-2">
+                                    {{ form_widget(form.delivery_free_amount) }}
+                                    {{ form_errors(form.delivery_free_amount) }}
                                 </div>
+                                <div class="col"></div>
                             </div>
                             <div class="row">
                                 <div class="col-3">
                                     <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'common.label.option_delivery_free_quantity'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
-                                <div class="col mb-2">
-                                    <div class="input-group col-4 pl-0">
-                                        {{ form_widget(form.delivery_free_quantity) }}
-                                        {{ form_errors(form.delivery_free_quantity) }}
-                                        <div class="input-group-append">
-                                            <div class="input-group-text">個</div>
-                                        </div>
-                                    </div>
+                                <div class="col-4 mb-2">
+                                    {{ form_widget(form.delivery_free_quantity) }}
+                                    {{ form_errors(form.delivery_free_quantity) }}
                                 </div>
+                                <div class="col"></div>
                             </div>
                             <div class="row">
                                 <div class="col-3"><span>{{ 'common.label.option_product_delivery_fee'|trans }}</span></div>
                                 <div class="col mb-2">
-                                    <div class="c-toggleSwitch">
-                                        <div class="c-toggleSwitch__btn">
-                                            {# TODO チェックボックスに変更する #}
-                                            {{ form_widget(form.option_product_delivery_fee) }}
-                                            {{ form_errors(form.option_product_delivery_fee) }}
-                                            <label for="switch_productCost"></label>
-                                        </div>
-                                        <div class="c-toggleSwitch__label"><span class="text-dark">無効</span>
-                                        </div>
-                                    </div>
+                                    {{ form_widget(form.option_product_delivery_fee) }}
+                                    {{ form_errors(form.option_product_delivery_fee) }}
                                 </div>
                             </div>
                             <div class="row">
@@ -260,16 +242,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'common.label.option_multiple_shipping'|trans }}</span></div>
                                 </div>
                                 <div class="col mb-2">
-                                    <div class="c-toggleSwitch">
-                                        <div class="c-toggleSwitch__btn">
-                                            {# TODO チェックボックスに変更する #}
-                                            {{ form_widget(form.option_multiple_shipping) }}
-                                            {{ form_errors(form.option_multiple_shipping) }}
-                                            <label for="switch_multiDelivery"></label>
-                                        </div>
-                                        <div class="c-toggleSwitch__label"><span class="text-dark">無効</span>
-                                        </div>
-                                    </div>
+                                    {{ form_widget(form.option_multiple_shipping) }}
+                                    {{ form_errors(form.option_multiple_shipping) }}
                                 </div>
                             </div>
                         </div>
@@ -280,61 +254,29 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             <div class="row">
                                 <div class="col-3"><span>{{ 'common.label.option_customer_activate'|trans }}</span></div>
                                 <div class="col mb-2">
-                                    <div class="c-toggleSwitch">
-                                        <div class="c-toggleSwitch__btn">
-                                            {# TODO チェックボックスに変更する #}
-                                            {{ form_widget(form.option_customer_activate) }}
-                                            {{ form_errors(form.option_customer_activate) }}
-                                            <label for="switch_provisionalUser"></label>
-                                        </div>
-                                        <div class="c-toggleSwitch__label"><span class="text-dark">有効</span>
-                                        </div>
-                                    </div>
+                                    {{ form_widget(form.option_customer_activate) }}
+                                    {{ form_errors(form.option_customer_activate) }}
                                 </div>
                             </div>
                             <div class="row">
                                 <div class="col-3"><span>{{ 'common.label.option_mypage_order_status_display'|trans }}</span></div>
                                 <div class="col mb-2">
-                                    <div class="c-toggleSwitch">
-                                        <div class="c-toggleSwitch__btn">
-                                            {# TODO チェックボックスに変更する #}
-                                            {{ form_widget(form.option_mypage_order_status_display) }}
-                                            {{ form_errors(form.option_mypage_order_status_display) }}
-                                            <label for="switch_mypageOrder"></label>
-                                        </div>
-                                        <div class="c-toggleSwitch__label"><span class="text-dark">有効</span>
-                                        </div>
-                                    </div>
+                                    {{ form_widget(form.option_mypage_order_status_display) }}
+                                    {{ form_errors(form.option_mypage_order_status_display) }}
                                 </div>
                             </div>
                             <div class="row">
                                 <div class="col-3"><span>{{ 'common.label.option_favorite_product'|trans }}</span></div>
                                 <div class="col mb-2">
-                                    <div class="c-toggleSwitch">
-                                        <div class="c-toggleSwitch__btn">
-                                            {# TODO チェックボックスに変更する #}
-                                            {{ form_widget(form.option_favorite_product) }}
-                                            {{ form_errors(form.option_favorite_product) }}
-                                            <label for="switch_favoriteProduct"></label>
-                                        </div>
-                                        <div class="c-toggleSwitch__label"><span class="text-dark">有効</span>
-                                        </div>
-                                    </div>
+                                    {{ form_widget(form.option_favorite_product) }}
+                                    {{ form_errors(form.option_favorite_product) }}
                                 </div>
                             </div>
                             <div class="row">
                                 <div class="col-3"><span>{{ 'common.label.option_remember_me'|trans }}</span></div>
                                 <div class="col mb-2">
-                                    <div class="c-toggleSwitch">
-                                        <div class="c-toggleSwitch__btn">
-                                            {# TODO チェックボックスに変更する #}
-                                            {{ form_widget(form.option_remember_me) }}
-                                            {{ form_errors(form.option_remember_me) }}
-                                            <label for="switch_autoLogin"></label>
-                                        </div>
-                                        <div class="c-toggleSwitch__label"><span class="text-dark">無効</span>
-                                        </div>
-                                    </div>
+                                    {{ form_widget(form.option_remember_me) }}
+                                    {{ form_errors(form.option_remember_me) }}
                                 </div>
                             </div>
                         </div>
@@ -345,16 +287,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             <div class="row">
                                 <div class="col-3"><span>{{ 'common.label.nostock_hidden'|trans }}</span></div>
                                 <div class="col mb-2">
-                                    <div class="c-toggleSwitch">
-                                        <div class="c-toggleSwitch__btn">
-                                            {# TODO チェックボックスに変更する #}
-                                            {{ form_widget(form.option_nostock_hidden) }}
-                                            {{ form_errors(form.option_nostock_hidden) }}
-                                            <label for="switch_productDisplay"></label>
-                                        </div>
-                                        <div class="c-toggleSwitch__label"><span class="text-dark">非表示</span>
-                                        </div>
-                                    </div>
+                                    {{ form_widget(form.option_nostock_hidden) }}
+                                    {{ form_errors(form.option_nostock_hidden) }}
                                 </div>
                             </div>
                         </div>
@@ -367,15 +301,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'shopmaster.label.option_product_tax_rule'|trans }}</span></div>
                                 </div>
                                 <div class="col mb-2">
-                                    <div class="c-toggleSwitch">
-                                        <div class="c-toggleSwitch__btn">
-                                            {# TODO 個別税率設定を税率設定画面からショップマスターに移植する #}
-                                            <input type="checkbox" id="switch_autoLogin">
-                                            <label for="switch_autoLogin"></label>
-                                        </div>
-                                        <div class="c-toggleSwitch__label"><span class="text-dark">無効</span>
-                                        </div>
-                                    </div>
+                                    {{ form_widget(form.option_product_tax_rule) }}
+                                    {{ form_errors(form.option_product_tax_rule) }}
                                 </div>
                             </div>
                         </div>
@@ -386,16 +313,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             <div class="row">
                                 <div class="col-3"><span>{{ 'shopmaster.label.option_point'|trans }}</span></div>
                                 <div class="col mb-2">
-                                    <div class="c-toggleSwitch">
-                                        <div class="c-toggleSwitch__btn">
-                                            {# TODO チェックボックスに変更する #}
-                                            {{ form_widget(form.option_point) }}
-                                            {{ form_errors(form.option_point) }}
-                                            <label for="switch_productDisplay"></label>
-                                        </div>
-                                        <div class="c-toggleSwitch__label"><span class="text-dark">有効</span>
-                                        </div>
-                                    </div>
+                                    {{ form_widget(form.option_point) }}
+                                    {{ form_errors(form.option_point) }}
                                 </div>
                             </div>
                             <div class="row">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- ショップマスター画面のトグルボタンを実装しています。


## ToggleSwitchTypeを追加

以下のように使用します。
```
// 自動ログイン
$builder->add('option_remember_me', ToggleSwitchType::class)
```

ラベルの文字列は、初期状態では「有効」「無効」ですが、変更したい場合は、
label_on, label_offオプションを使用できます。

```
// 在庫切れ商品を非表示にする
$builder->add('option_nostock_hidden', ToggleSwitchType::class, [
    'label_off' => '表示',
    'label_on' => '非表示'
])
```


