### PR TITLE
購入履歴に紐づけできない商品があると、マイページ注文履歴でEntity was not found.になる問題を修正

### DIFF
--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -121,6 +121,10 @@ class Product extends \Eccube\Entity\AbstractEntity
      */
     public function isEnable()
     {
+        if ($this->__isInitialized__ === false) {
+            return false;
+        }
+        
         return $this->getStatus()->getId() === \Eccube\Entity\Master\Disp::DISPLAY_SHOW ? true : false;
     }
 

--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -121,10 +121,6 @@ class Product extends \Eccube\Entity\AbstractEntity
      */
     public function isEnable()
     {
-        if ($this->__isInitialized__ === false) {
-            return false;
-        }
-        
         return $this->getStatus()->getId() === \Eccube\Entity\Master\Disp::DISPLAY_SHOW ? true : false;
     }
 

--- a/src/Eccube/Entity/ProductClass.php
+++ b/src/Eccube/Entity/ProductClass.php
@@ -43,7 +43,7 @@ class ProductClass extends \Eccube\Entity\AbstractEntity
      */
     public function isEnable()
     {
-        if ($this->getProduct()->__isInitialized__ === false) {
+        if (EntityUtil::isEmpty($this->getProduct())) {
             return false;
         }
         

--- a/src/Eccube/Entity/ProductClass.php
+++ b/src/Eccube/Entity/ProductClass.php
@@ -43,6 +43,10 @@ class ProductClass extends \Eccube\Entity\AbstractEntity
      */
     public function isEnable()
     {
+        if ($this->getProduct()->__isInitialized__ === false) {
+            return false;
+        }
+        
         return $this->getProduct()->isEnable();
     }
 

--- a/src/Eccube/Resource/template/admin/Order/search_product.twig
+++ b/src/Eccube/Resource/template/admin/Order/search_product.twig
@@ -212,7 +212,7 @@
                             {% endif %}
                         {% endif %}
                     </td>
-                    <div class="extra-form">
+                    <td class="extra-form">
                         {% for f in form.getIterator %}
                             {% if f.vars.name matches '[^plg*]' %}
                                 {{ form_label(f) }}
@@ -220,7 +220,7 @@
                                 {{ form_errors(f) }}
                             {% endif %}
                         {% endfor %}
-                    </div>
+                    </td>
                     <td class="text-right">
                         <button onclick="fnAddOrderDetail($(this).parent().parent(), {{ Product.id }})" type="button" class="btn btn-default btn-sm" name="mode" value="modal">
                             決定


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 購入履歴に紐づけできない商品があると、マイページ注文履歴でEntity was not found.になる問題を修正

## 方針(Policy)
+ エラー処理の追加

## 実装に関する補足(Appendix)
+ 他サイトからの受注データ移行などで商品情報と紐付かない受注データを作成した場合などに現象が発生

## テスト（Test)
+ 注文履歴、注文履歴詳細

## 相談（Discussion）
+ 

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ 

- [ OK ] 既存機能の仕様変更
- [ OK ] フックポイントの呼び出しタイミングの変更
- [ OK ] フックポイントのパラメータの削除・データ型の変更
- [ OK ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ OK ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ OK ] 入出力ファイル(CSVなど)のフォーマット変更



