### PR TITLE
CodeceptionからDBモジュールを削除

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,21 +46,21 @@ jobs:
   include:
     - stage: Unit Test
       env:
-        - DB=mysql DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
+        - DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
       script:
         - ./bin/phpunit --exclude-group cache-clear
         - ./bin/phpunit --group cache-clear
     - env:
-      - DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
+      - DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
       script:
         - ./bin/phpunit --exclude-group cache-clear
         - ./bin/phpunit --group cache-clear
     - stage: E2E Test
-      env: GROUP=admin01 APP_ENV=codeception DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
+      env: GROUP=admin01 APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
       script: ./codeception.sh -g ${GROUP}
-    - env: GROUP=admin02 APP_ENV=codeception DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
+    - env: GROUP=admin02 APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
       script: ./codeception.sh -g ${GROUP}
-    - env: GROUP=admin03 APP_ENV=codeception DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
+    - env: GROUP=admin03 APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
       script: ./codeception.sh -g ${GROUP}
-    - env: GROUP=front APP_ENV=codeception DB=pgsql DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
+    - env: GROUP=front APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
       script: ./codeception.sh -g ${GROUP}

--- a/codeception/_envs/travis.yml
+++ b/codeception/_envs/travis.yml
@@ -1,9 +1,5 @@
 modules:
     config:
-        Db:
-            user: 'postgres'
-            password: ''
-            dsn: 'pgsql:host=localhost;dbname=eccube_db'
         WebDriver:
             host: 'localhost'
             port: 9515

--- a/codeception/acceptance.suite.yml
+++ b/codeception/acceptance.suite.yml
@@ -8,17 +8,10 @@ class_name: AcceptanceTester
 modules:
     enabled:
         - \Helper\Acceptance
-        - Db
         - WebDriver
         - Asserts
         - MailCatcher
     config:
-        Db:
-            user: '%ECCUBE_DB_USERNAME%'
-            password: '%ECCUBE_DB_PASSWORD%'
-            populate: true
-            cleanup: false
-            reconnect: true
         WebDriver:
             host: '%WEB_DRIVER_HOST%'
             port: '%WEB_DRIVER_PORT%'
@@ -38,23 +31,17 @@ env:
             config:
                 WebDriver:
                     browser: firefox
-                Db:
-                    dsn: 'pgsql:host=%ECCUBE_DB_HOST%;dbname=%ECCUBE_DB_DATABASE%'
 
     front: # Backward compatibility
         modules:
             config:
                 WebDriver:
                     browser: firefox
-                Db:
-                    dsn: 'pgsql:host=%ECCUBE_DB_HOST%;dbname=%ECCUBE_DB_DATABASE%'
     admin: # Backward compatibility
         modules:
             config:
                 WebDriver:
                     browser: firefox
-                Db:
-                    dsn: 'pgsql:host=%ECCUBE_DB_HOST%;dbname=%ECCUBE_DB_DATABASE%'
     firefox:
         modules:
             config:
@@ -76,13 +63,3 @@ env:
                     capabilities:
                       chromeOptions:
                         args: ["--headless", "--disable-gpu"]
-    mysql:
-        modules:
-            config:
-                Db:
-                    dsn: 'mysql:host=%ECCUBE_DB_HOST%;dbname=%ECCUBE_DB_DATABASE%;charset=utf8'
-    pgsql:
-        modules:
-            config:
-                Db:
-                    dsn: 'pgsql:host=%ECCUBE_DB_HOST%;dbname=%ECCUBE_DB_DATABASE%'

--- a/codeception/acceptance/EF01TopCest.php
+++ b/codeception/acceptance/EF01TopCest.php
@@ -38,34 +38,36 @@ class EF01TopCest
         $minus1 = $today->sub(new DateInterval('P1D'));
         $minus2 = $today->sub(new DateInterval('P2D'));
 
-        $I->haveInDatabase('dtb_news', array('id' => rand(999, 9999), 'publish_date' => $minus1->format('Y-m-d 00:00:00'), 'title' => 'タイトル1', 'description' => 'コメント1', 'creator_id' => 1, 'sort_no' => 2, 'create_date' => $today->format('Y-m-d 00:00:00'), 'update_date' => $today->format('Y-m-d 00:00:00'), 'discriminator_type' => 'news'));
-        $I->haveInDatabase('dtb_news', array('id' => rand(999, 9999), 'publish_date' => $minus2->format('Y-m-d 00:00:00'), 'title' => 'タイトル2', 'description' => 'コメント2', 'creator_id' => 1, 'sort_no' => 3, 'create_date' => $today->format('Y-m-d 00:00:00'), 'update_date' => $today->format('Y-m-d 00:00:00'), 'discriminator_type' => 'news'));
+        $createNews = Fixtures::get('createNews');
+        $News1 = $createNews($minus1, 'タイトル1', 'コメント1');
+        $News2 = $createNews($minus2, 'タイトル2', 'コメント2');
+
         $I->reloadPage();
-        $news = Fixtures::get('news');
-        $newsset = array();
-        $newsset[] = array (
-            'date' => $news[0]->getPublishDate(),
-            'title' => $news[0]->getTitle(),
-            'comment' => $news[0]->getDescription(),
-        );
-        $newsset[] = array (
-            'date' => $minus1->format('Y-m-d 00:00:00'),
-            'title' => 'タイトル1',
-            'comment' => 'コメント1',
-        );
-        $newsset[] = array (
-            'date' => $minus2->format('Y-m-d 00:00:00'),
-            'title' => 'タイトル2',
-            'comment' => 'コメント2',
-        );
-        foreach ($newsset as $key => $news) {
-            $I->see($news['title'], 'div.ec-news .ec-news__item:nth-child('.(count($newsset) - $key).') .ec-newsline__title');
+
+        $findNews = Fixtures::get('findNews');
+        $newsAll = $findNews();
+        foreach ($newsAll as $index => $news) {
+            $rowNum = $index + 1;
+            $I->see($news['title'], 'div.ec-news .ec-news__item:nth-child('.$rowNum.') .ec-newsline__title');
+            // 5件を超えるとread moreが表示される.
+            if ($rowNum > 5) {
+                break;
+            }
         }
+
+        $em = Fixtures::get('entityManager');
+        $em->remove($News1);
+        $em->remove($News2);
+        $em->flush([$News1, $News2]);
     }
 
     public function topページ_新着情報(\AcceptanceTester $I)
     {
         $I->wantTo('EF0101-UC01-T02 TOPページ 新着情報');
+
+        $createNews = Fixtures::get('createNews');
+        $News = $createNews(new \DateTime(), 'タイトル1', 'コメント1', 'https://www.ec-cube.net');
+
         $topPage = TopPage::go($I);
 
         // 各新着情報の箇所を押下する
@@ -73,16 +75,16 @@ class EF01TopCest
         $topPage->新着情報選択(1);
 
         // 押下された新着情報のセクションが広がり、詳細情報、リンクが表示される
-        $I->assertContains('一人暮らしからオフィスなどさまざまなシーンで あなたの生活をサポートするグッズをご家庭へお届けします！', $topPage->新着情報詳細(1));
+        $I->assertContains('コメント1', $topPage->新着情報詳細(1));
 
         // 「詳しくはこちら」リンクを押下する
-        $today = new DateTime();
-        $I->haveInDatabase('dtb_news', array('id' => rand(999, 9999), 'publish_date' => $today->format('Y-m-d 00:00:00'), 'title' => 'タイトル1', 'description' => 'コメント1', 'creator_id' => 1, 'url' => 'http://www.ec-cube.net', 'sort_no' => 2, 'create_date' => $today->format('Y-m-d 00:00:00'), 'update_date' => $today->format('Y-m-d 00:00:00'), 'discriminator_type' => 'news'));
-        $I->reloadPage();
-        $topPage->新着情報選択(1);
         $I->assertContains('詳しくはこちら', $topPage->新着情報詳細(1));
         $topPage->新着情報リンククリック(1);
-        $I->seeInTitle('ECサイト構築・リニューアルは「ECオープンプラットフォームEC-CUBE」');
+        $I->amOnUrl($News->getUrl());
+
+        $em = Fixtures::get('entityManager');
+        $em->remove($News);
+        $em->flush($News);
     }
 
     public function topページ_カテゴリ検索(\AcceptanceTester $I)


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- DBモジュールを削除し, EntityManagerを利用するように統一しました。
- DBの接続設定は, `.env`の`DATABASE_URL`を参照します。

## 変更点

#3048 からの変更点は以下のとおりです。

`local.yaml`の、DB設定が不要になりました。

```diff
modules:
    config:
-        Db:
-            user: 'postgres'
-            password: ''
-            dsn: 'pgsql:host=localhost;dbname=eccube_db'
        WebDriver:
            host: 'localhost'
            port: 9515
            url: 'http://localhost:8000'
        MailCatcher:
            url: 'localhost'
            port: 1080
```

また、EntityManagerを使用するため, PostgreSQL以外のDBも使用することができます。





