### PR TITLE
APP_ENV=prod時に、登録しても画面上の表示が更新されない問題を修正

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/Shop/ShopController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/ShopController.php
@@ -29,6 +29,7 @@ use Eccube\Entity\BaseInfo;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
 use Eccube\Form\Type\Admin\ShopMasterType;
+use Eccube\Util\CacheUtil;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
@@ -71,7 +72,7 @@ class ShopController extends AbstractController
      * @param Request $request
      * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function index(Request $request)
+    public function index(Request $request, CacheUtil $cacheUtil)
     {
         $builder = $this->formFactory
             ->createBuilder(ShopMasterType::class, $this->BaseInfo);
@@ -107,6 +108,8 @@ class ShopController extends AbstractController
                   EccubeEvents::ADMIN_SETTING_SHOP_SHOP_INDEX_COMPLETE,
                   $event
                 );
+
+                $cacheUtil->clearCache();
 
                 $this->addSuccess('admin.flash.register_completed', 'admin');
 

--- a/tests/Eccube/Tests/Web/Admin/Setting/Shop/ShopControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/Shop/ShopControllerTest.php
@@ -47,6 +47,7 @@ class ShopControllerTest extends AbstractAdminWebTestCase
      * @param bool $isSuccess
      * @param bool $expected
      * @dataProvider dataSubmitProvider
+     * @group cache-clear
      */
     public function testSubmit($isSuccess, $expected)
     {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- APP_ENV=prod時に、登録しても画面上の表示が更新されない
- トグルボタンだけでなく、どの入力項目でも発生する
- 再度リロードすると、表示は更新される
- DBの値は更新されているため、SecondLevelCacheの影響を受けていると思われる
- キャッシュをクリアするように対応



