### PR TITLE
[WIP] カートの永続化

### DIFF
--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -441,7 +441,7 @@ class ProductController extends AbstractController
         );
 
         // カートへ追加
-        $this->cartService->addProduct($addCartData['product_class_id'], $addCartData['quantity']);
+        $this->cartService->addProduct($addCartData['product_class_id'], $addCartData['quantity'], $this->getUser());
 
         // 明細の正規化
         $flow = $this->purchaseFlow;

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -631,20 +631,20 @@ class ShoppingController extends AbstractShoppingController
     public function checkToCart(Request $request)
     {
         // カートチェック
-        if (!$this->cartService->isLocked()) {
-            log_info('カートが存在しません');
+        // if (!$this->cartService->isLocked()) {
+        //     log_info('カートが存在しません');
 
-            // カートが存在しない、カートがロックされていない時はエラー
-            return $this->redirectToRoute('cart');
-        }
+        //     // カートが存在しない、カートがロックされていない時はエラー
+        //     return $this->redirectToRoute('cart');
+        // }
 
-        // カートチェック
-        if (count($this->cartService->getCart()->getCartItems()) <= 0) {
-            log_info('カートに商品が入っていないためショッピングカート画面にリダイレクト');
+        // // カートチェック
+        // if (count($this->cartService->getCart()->getItems()) <= 0) {
+        //     log_info('カートに商品が入っていないためショッピングカート画面にリダイレクト');
 
-            // カートが存在しない時はエラー
-            return $this->redirectToRoute('cart');
-        }
+        //     // カートが存在しない時はエラー
+        //     return $this->redirectToRoute('cart');
+        // }
 
         return new Response();
     }

--- a/src/Eccube/Entity/Master/OrderStatus.php
+++ b/src/Eccube/Entity/Master/OrderStatus.php
@@ -54,4 +54,6 @@ class OrderStatus extends \Eccube\Entity\Master\AbstractMasterEntity
     const PENDING = 7;
     /** 購入処理中. */
     const PROCESSING = 8;
+    /** カート. */
+    const CART = 9;
 }

--- a/src/Eccube/Resource/doctrine/import_csv/mtb_order_status.csv
+++ b/src/Eccube/Resource/doctrine/import_csv/mtb_order_status.csv
@@ -7,3 +7,4 @@ id,name,sort_no,discriminator_type
 "4","取り寄せ中","5","orderstatus"
 "5","発送済み","6","orderstatus"
 "8","購入処理中","7","orderstatus"
+"9","カート","8","orderstatus"

--- a/src/Eccube/Resource/template/default/Block/cart.twig
+++ b/src/Eccube/Resource/template/default/Block/cart.twig
@@ -32,30 +32,32 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     <div class="ec-cartNaviIsset">
         {% for Cart in Carts %}
             {% for CartItem in Cart.Items %}
-                {% set ProductClass = CartItem.ProductClass %}
-                {% set Product = ProductClass.Product %}
-                <div class="ec-cartNaviIsset__cart">
-                    <div class="ec-cartNaviIsset__cartImage">
-                        <img src="{{ asset(Product.MainListImage, 'save_image') }}" alt="{{ Product.name }}">
-                    </div>
-                    <div class="ec-cartNaviIsset__cartContent">
-                        <div class="ec-cartNaviIsset__cartContentTitle">{{ Product.name }}
-                            <div class="ec-font-size-1">
-                                {% if ProductClass.ClassCategory1 and ProductClass.ClassCategory1.id %}
-                                    {{ ProductClass.ClassCategory1.ClassName.name }}：{{ ProductClass.ClassCategory1 }}
-                                {% endif %}
-                                {% if ProductClass.ClassCategory2 and ProductClass.ClassCategory2.id %}
-                                    <br>{{ ProductClass.ClassCategory2.ClassName.name }}：{{ ProductClass.ClassCategory2 }}
-                                {% endif %}
+                {% if CartItem.isProduct %}
+                    {% set ProductClass = CartItem.ProductClass %}
+                    {% set Product = ProductClass.Product %}
+                    <div class="ec-cartNaviIsset__cart">
+                        <div class="ec-cartNaviIsset__cartImage">
+                            <img src="{{ asset(Product.MainListImage, 'save_image') }}" alt="{{ Product.name }}">
+                        </div>
+                        <div class="ec-cartNaviIsset__cartContent">
+                            <div class="ec-cartNaviIsset__cartContentTitle">{{ Product.name }}
+                                <div class="ec-font-size-1">
+                                    {% if ProductClass.ClassCategory1 and ProductClass.ClassCategory1.id %}
+                                        {{ ProductClass.ClassCategory1.ClassName.name }}：{{ ProductClass.ClassCategory1 }}
+                                    {% endif %}
+                                    {% if ProductClass.ClassCategory2 and ProductClass.ClassCategory2.id %}
+                                        <br>{{ ProductClass.ClassCategory2.ClassName.name }}：{{ ProductClass.ClassCategory2 }}
+                                    {% endif %}
+                                </div>
                             </div>
+                            <div class="ec-cartNaviIsset__cartContentPrice">
+                                {{ CartItem.price}}
+                                <div class="ec-cartNaviIsset__cartContentTax">{{'shopping.label.tax_incl'|trans}}</div>
+                            </div>
+                            <div class="ec-cartNaviIsset__cartContentNumber">{{'shopping.label.qty'|trans}}{{ CartItem.quantity }}</div>
                         </div>
-                        <div class="ec-cartNaviIsset__cartContentPrice">
-                            {{ CartItem.price}}
-                            <div class="ec-cartNaviIsset__cartContentTax">{{'shopping.label.tax_incl'|trans}}</div>
-                        </div>
-                        <div class="ec-cartNaviIsset__cartContentNumber">{{'shopping.label.qty'|trans}}{{ CartItem.quantity }}</div>
                     </div>
-                </div>
+                {% endif %}
             {% endfor %}
         {% endfor %}
         <div class="ec-cartNaviIsset__action">

--- a/src/Eccube/Resource/template/default/Block/cart.twig
+++ b/src/Eccube/Resource/template/default/Block/cart.twig
@@ -31,7 +31,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% if totalQuantity > 0 %}
     <div class="ec-cartNaviIsset">
         {% for Cart in Carts %}
-            {% for CartItem in Cart.CartItems %}
+            {% for CartItem in Cart.Items %}
                 {% set ProductClass = CartItem.ProductClass %}
                 {% set Product = ProductClass.Product %}
                 <div class="ec-cartNaviIsset__cart">

--- a/src/Eccube/Resource/template/default/Cart/index.twig
+++ b/src/Eccube/Resource/template/default/Cart/index.twig
@@ -146,7 +146,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                             <li class="ec-cartHeader__label">{{'shopping.label.qty'|trans}}</li>
                             <li class="ec-cartHeader__label">{{'shopping.label.subtotal'|trans}}</li>
                             </ol>
-                            {% for CartItem in Cart.CartItems %}
+                            {% for CartItem in Cart.Items %}
                                 {% set ProductClass = CartItem.ProductClass %}
                                 {% set Product = ProductClass.Product %}
                                 <ul class="ec-cartRow">

--- a/src/Eccube/Service/Cart/CartItemAllocator.php
+++ b/src/Eccube/Service/Cart/CartItemAllocator.php
@@ -24,7 +24,7 @@
 namespace Eccube\Service\Cart;
 
 
-use Eccube\Entity\CartItem;
+use Eccube\Entity\OrderItem;
 
 /**
  * 商品をカートに振り分けるインターフェイス
@@ -34,8 +34,8 @@ interface CartItemAllocator
     /**
      * 商品の振り分け先となるカートの識別子を決定します。
      *
-     * @param CartItem $Item カート商品
+     * @param OrderItem $Item カート商品
      * @return string
      */
-    public function allocate(CartItem $Item);
+    public function allocate(OrderItem $Item);
 }

--- a/src/Eccube/Service/Cart/CartItemComparator.php
+++ b/src/Eccube/Service/Cart/CartItemComparator.php
@@ -24,7 +24,7 @@
 namespace Eccube\Service\Cart;
 
 
-use Eccube\Entity\CartItem;
+use Eccube\Entity\OrderItem;
 
 /**
  * カートに追加する明細(CartItem)同士が同じ明細になるかどうか判定するインターフェイス。
@@ -32,9 +32,9 @@ use Eccube\Entity\CartItem;
 interface CartItemComparator
 {
     /**
-     * @param CartItem $item1 明細1
-     * @param CartItem $item2 明細2
+     * @param OrderItem $item1 明細1
+     * @param OrderItem $item2 明細2
      * @return boolean 同じ明細になる場合はtrue
      */
-    public function compare(CartItem $item1, CartItem $item2);
+    public function compare(OrderItem $item1, OrderItem $item2);
 }

--- a/src/Eccube/Service/Cart/ProductClassComparator.php
+++ b/src/Eccube/Service/Cart/ProductClassComparator.php
@@ -24,7 +24,7 @@
 namespace Eccube\Service\Cart;
 
 
-use Eccube\Entity\CartItem;
+use Eccube\Entity\OrderItem;
 
 /**
  * 商品規格で明細を比較するCartItemComparator
@@ -32,11 +32,11 @@ use Eccube\Entity\CartItem;
 class ProductClassComparator implements CartItemComparator
 {
     /**
-     * @param CartItem $Item1 明細1
-     * @param CartItem $Item2 明細2
+     * @param OrderItem $Item1 明細1
+     * @param OrderItem $Item2 明細2
      * @return boolean 同じ明細になる場合はtrue
      */
-    public function compare(CartItem $Item1, CartItem $Item2)
+    public function compare(OrderItem $Item1, OrderItem $Item2)
     {
         $ProductClass1 = $Item1->getProductClass();
         $ProductClass2 = $Item2->getProductClass();

--- a/src/Eccube/Service/Cart/SaleTypeCartAllocator.php
+++ b/src/Eccube/Service/Cart/SaleTypeCartAllocator.php
@@ -23,7 +23,7 @@
 
 namespace Eccube\Service\Cart;
 
-use Eccube\Entity\CartItem;
+use Eccube\Entity\OrderItem;
 
 /**
  * 販売種別ごとにカートを振り分けるCartItemAllocator
@@ -33,10 +33,10 @@ class SaleTypeCartAllocator implements CartItemAllocator
     /**
      * 商品の振り分け先となるカートの識別子を決定します。
      *
-     * @param CartItem $Item カート商品
+     * @param OrderItem $Item カート商品
      * @return string
      */
-    public function allocate(CartItem $Item)
+    public function allocate(OrderItem $Item)
     {
         $ProductClass = $Item->getProductClass();
         if ($ProductClass && $ProductClass->getSaleType()) {

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -26,6 +26,9 @@ namespace Eccube\Service;
 
 use Eccube\Entity\Customer;
 use Eccube\Entity\Master\OrderStatus;
+use Eccube\Entity\Master\OrderItemType;
+use Eccube\Entity\Master\TaxDisplayType;
+use Eccube\Entity\Master\TaxType;
 use Eccube\Entity\Order;
 use Eccube\Entity\OrderItem;
 use Eccube\Entity\ItemHolderInterface;
@@ -238,11 +241,18 @@ class CartService
             return false;
         }
 
+        $ProductItemType = $this->entityManager->find(OrderItemType::class, OrderItemType::PRODUCT);
+        // TODO
+        $TaxExclude = $this->entityManager->getRepository(TaxDisplayType::class)->find(TaxDisplayType::EXCLUDED);
+        $Taxion = $this->entityManager->getRepository(TaxType::class)->find(TaxType::TAXATION);
         $newItem = new OrderItem();
         $newItem->setQuantity($quantity)
             ->setPrice($ProductClass->getPrice02IncTax())
             ->setProductClass($ProductClass)
-            ->setProductName($ProductClass->getProduct()->getName());
+            ->setProductName($ProductClass->getProduct()->getName())
+            ->setOrderItemType($ProductItemType)
+            ->setTaxDisplayType($TaxExclude)
+            ->setTaxType($Taxion);
 
         $allCartItems = $this->mergeAllCartItems([$newItem]);
         $this->restoreCarts($allCartItems);

--- a/src/Eccube/Service/OrderHelper.php
+++ b/src/Eccube/Service/OrderHelper.php
@@ -179,6 +179,26 @@ class OrderHelper
         return $Order;
     }
 
+    /**
+     * カートの受注データを生成する.
+     *
+     * @param Customer $Customer
+     * @return Order
+     */
+    public function createOrderInCart()
+    {
+        $OrderStatus = $this->orderStatusRepository->find(OrderStatus::CART);
+        $Order = new Order($OrderStatus);
+
+        // pre_order_idを生成
+        $Order->setPreOrderId($this->createPreOrderId());
+
+        $this->entityManager->persist($Order);
+        $this->entityManager->flush();
+
+        return $Order;
+    }
+
     public function createPreOrderId()
     {
         // ランダムなpre_order_idを作成

--- a/src/Eccube/Service/PurchaseFlow/Processor/DisplayStatusValidator.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/DisplayStatusValidator.php
@@ -2,7 +2,6 @@
 
 namespace Eccube\Service\PurchaseFlow\Processor;
 
-use Eccube\Entity\CartItem;
 use Eccube\Entity\ItemInterface;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Eccube\Service\PurchaseFlow\ValidatableItemProcessor;
@@ -32,8 +31,6 @@ class DisplayStatusValidator extends ValidatableItemProcessor
      */
     protected function handle(ItemInterface $item, PurchaseContext $context)
     {
-        if ($item instanceof CartItem) {
-            $item->setQuantity(0);
-        }
+        $item->setQuantity(0);
     }
 }

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -1320,6 +1320,4 @@ class ShoppingService
         $this->eventDispatcher->dispatch(EccubeEvents::SERVICE_SHOPPING_NOTIFY_COMPLETE, $event);
 
     }
-
-
 }

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -257,13 +257,14 @@ class ShoppingService
     {
 
         // 受注データを取得
-        $preOrderId = $this->cartService->getPreOrderId();
-        if (!$preOrderId) {
+        //$preOrderId = $this->cartService->getPreOrderId();
+        $preOrderIds = $this->session->get('preOrderIds', []); // TODO
+        if (!$preOrderIds) {
             return null;
         }
 
         $condition = array(
-            'pre_order_id' => $preOrderId,
+            'pre_order_id' => $preOrderIds,
         );
 
         if (!is_null($status)) {


### PR DESCRIPTION
*試験的な実装です。現状、ログインしての購入のみサポートしています*

## 概要(Overview・Refs Issue)
+ カートをセッションではなく、 DB に保存するように改修

## 方針(Policy)
- [x] OrderStatus に CART を追加する
    - [x] Cart, CartItem は使用せず、 Order, OrderItem を使用するよう変更する
    - [x] 購入確認画面で OrderStatus::CART から PROCESSING に変更する
- [ ] ログイン時の流れ
    - [x] 非会員の場合は、セッションの pre_order_id をキーにしてカート情報を取得する
    - [ ] 会員ログイン後は、会員に紐づいた受注を取得する(未実装)
    - [ ] ログイン時に、セッションに保持した pre_order_id の受注に会員を紐付ける(未実装)

## 実装に関する補足(Appendix)
+ 複数配送設定画面で、商品の数量を変更しようとすると、CartItem と OrderItem の同期が難しいため、 OrderItem に一本化してしまう試みです

## テスト（Test)
+ まだまだこれから...

## 参考

https://github.com/EC-CUBE/ec-cube/issues/793

## 相談（Discussion）
+ CartService 不要になるかも
+ Item, ItemHolder も不要？拡張のために残しておく？

