### PR TITLE
各完了画面で、前画面の遷移チェックを行うように修正

### DIFF
--- a/src/Eccube/Controller/AbstractController.php
+++ b/src/Eccube/Controller/AbstractController.php
@@ -214,4 +214,26 @@ class AbstractController extends Controller
 
         return true;
     }
+
+    /**
+     * 指定したルーティングを遷移してきたかどうかをチェックします。
+     *
+     * @param $routes 判定対象のルーティング名
+     *
+     * @return bool
+     */
+    protected function isPreviousRouteValid(array $routes)
+    {
+        $lastRoute = $this->session->get('last_route');
+
+        if (!empty($lastRoute)) {
+            foreach ($routes as $route) {
+                if ($route === $lastRoute['name']) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Eccube/Controller/ContactController.php
+++ b/src/Eccube/Controller/ContactController.php
@@ -141,6 +141,10 @@ class ContactController extends AbstractController
      */
     public function complete()
     {
+        if (!$this->isPreviousRouteValid(['contact'])) {
+            return $this->redirectToRoute('homepage');
+        }
+
         return [];
     }
 }

--- a/src/Eccube/Controller/EntryController.php
+++ b/src/Eccube/Controller/EntryController.php
@@ -230,6 +230,10 @@ class EntryController extends AbstractController
      */
     public function complete()
     {
+        if (!$this->isPreviousRouteValid(['entry'])) {
+            return $this->redirectToRoute('homepage');
+        }
+
         return [];
     }
 

--- a/src/Eccube/Controller/ForgotController.php
+++ b/src/Eccube/Controller/ForgotController.php
@@ -158,6 +158,10 @@ class ForgotController extends AbstractController
      */
     public function complete(Request $request)
     {
+        if (!$this->isPreviousRouteValid(['forgot'])) {
+            return $this->redirectToRoute('homepage');
+        }
+
         return [];
     }
 

--- a/src/Eccube/Controller/Mypage/WithdrawController.php
+++ b/src/Eccube/Controller/Mypage/WithdrawController.php
@@ -147,6 +147,10 @@ class WithdrawController extends AbstractController
      */
     public function complete(Request $request)
     {
+        if (!$this->isPreviousRouteValid(['mypage_withdraw'])) {
+            return $this->redirectToRoute('homepage');
+        }
+
         return [];
     }
 }

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -318,6 +318,10 @@ class ShoppingController extends AbstractShoppingController
      */
     public function complete(Request $request)
     {
+        if (!$this->isPreviousRouteValid(['shopping_order'])) {
+            return $this->redirectToRoute('homepage');
+        }
+
         // 受注IDを取得
         $orderId = $this->session->get($this->sessionOrderKey);
 

--- a/src/Eccube/EventListener/LastRouteListener.php
+++ b/src/Eccube/EventListener/LastRouteListener.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Eccube\EventListener;
+
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class LastRouteListener implements EventSubscriberInterface
+{
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $session = $request->getSession();
+
+        $routeName = $request->get('_route');
+        $routeParams = $request->get('_route_params');
+        if ($routeName[0] == '_') {
+            return;
+        }
+        $routeData = ['name' => $routeName, 'params' => $routeParams];
+
+        $thisRoute = $session->get('this_route', []);
+        if ($thisRoute == $routeData) {
+            return;
+        }
+        $session->set('last_route', $thisRoute);
+        $session->set('this_route', $routeData);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            // RouterListener(32)より後に実行するため, 優先度を30に設定
+            KernelEvents::REQUEST => ['onKernelRequest', 30]
+        ];
+    }
+}

--- a/tests/Eccube/Tests/Web/ContactControllerTest.php
+++ b/tests/Eccube/Tests/Web/ContactControllerTest.php
@@ -194,6 +194,6 @@ class ContactControllerTest extends AbstractWebTestCase
     {
         $this->client = $this->createClient();
         $this->client->request('GET', $this->generateUrl('contact_complete'));
-        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('homepage')));
     }
 }

--- a/tests/Eccube/Tests/Web/EntryControllerTest.php
+++ b/tests/Eccube/Tests/Web/EntryControllerTest.php
@@ -193,7 +193,7 @@ class EntryControllerTest extends AbstractWebTestCase
         $client = $this->client;
         $client->request('GET', $this->generateUrl('entry_complete'));
 
-        $this->assertTrue($client->getResponse()->isSuccessful());
+        $this->assertTrue($client->getResponse()->isRedirect($this->generateUrl('homepage')));
     }
 
     public function testActivate()

--- a/tests/Eccube/Tests/Web/ForgotControllerTest.php
+++ b/tests/Eccube/Tests/Web/ForgotControllerTest.php
@@ -98,11 +98,7 @@ class ForgotControllerTest extends AbstractWebTestCase
         $client = $this->client;
         $crawler = $client->request('GET', $this->generateUrl('forgot_complete'));
 
-        $this->expected = 'パスワード発行メールの送信 完了';
-        $this->actual = $crawler->filter('div.ec-pageHeader > h1')->text();
-        $this->verify();
-
-        $this->assertTrue($client->getResponse()->isSuccessful());
+        $this->assertTrue($client->getResponse()->isRedirect($this->generateUrl('homepage')));
     }
 
     public function testResetWithDenied()

--- a/tests/Eccube/Tests/Web/Mypage/WithdrawControllerTest.php
+++ b/tests/Eccube/Tests/Web/Mypage/WithdrawControllerTest.php
@@ -87,6 +87,6 @@ class WithdrawControllerTest extends AbstractWebTestCase
             'GET',
             $this->generateUrl('mypage_withdraw_complete')
         );
-        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('homepage')));
     }
 }

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -66,11 +66,9 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
 
     public function testComplete()
     {
-        $this->container->get('session')->set('eccube.front.shopping.order.id', 111);
         $this->client->request('GET', $this->generateUrl('shopping_complete'));
 
-        $this->assertTrue($this->client->getResponse()->isSuccessful());
-        $this->assertNull($this->container->get('session')->get('eccube.front.shopping.order.id'));
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('homepage')));
     }
 
     public function testShoppingError()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- 各完了画面が直接URLを指定すると表示できるため、遷移チェックを行う用に修正
- 対象は、問い合わせ、会員登録、商品購入、会員退会、パスワードリマインダ
- 不正な遷移の場合は、トップページにリダイレクトする

## テスト（Test)
- Travis-CIが通ることを確認

## 相談（Discussion）
- 購入完了画面は、購入確認画面(/shopping/order)を経由した場合は、他のサイト(決済など)から戻ってきても表示できるようにしています。
