### PR TITLE
送料無料条件の判定をお届け先ごとに行うように修正

### DIFF
--- a/app/config/eccube/packages/purchaseflow.yaml
+++ b/app/config/eccube/packages/purchaseflow.yaml
@@ -52,6 +52,7 @@ services:
             - #
                 - '@Eccube\Service\PurchaseFlow\Processor\PaymentTotalLimitValidator'
                 - '@Eccube\Service\PurchaseFlow\Processor\DeliveryFeeProcessor'
+                - '@Eccube\Service\PurchaseFlow\Processor\DeliveryFeeFreeByShippingProcessor'
                 - '@Eccube\Service\PurchaseFlow\Processor\PaymentTotalNegativeValidator'
                 - '@Eccube\Service\PurchaseFlow\Processor\UsePointProcessor'
                 - '@Eccube\Service\PurchaseFlow\Processor\AddPointProcessor'

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -1414,7 +1414,7 @@ class Order extends \Eccube\Entity\AbstractEntity implements PurchaseInterface, 
     /**
      * Get shippings.
      *
-     * @return \Doctrine\Common\Collections\Collection
+     * @return \Doctrine\Common\Collections\Collection|Shipping[]
      */
     public function getShippings()
     {

--- a/src/Eccube/Entity/Shipping.php
+++ b/src/Eccube/Entity/Shipping.php
@@ -992,7 +992,7 @@ class Shipping extends \Eccube\Entity\AbstractEntity
     /**
      * Get orderItems.
      *
-     * @return \Doctrine\Common\Collections\Collection
+     * @return \Doctrine\Common\Collections\Collection|OrderItem[]
      */
     public function getOrderItems()
     {

--- a/src/Eccube/Service/OrderHelper.php
+++ b/src/Eccube/Service/OrderHelper.php
@@ -331,13 +331,6 @@ class OrderHelper
         $Delivery = current($Deliveries);
         $Shipping->setDelivery($Delivery);
         $Shipping->setShippingDeliveryName($Delivery->getName());
-
-        // TODO 配送料の取得方法はこれで良いか要検討
-        $deliveryFee = $this->deliveryFeeRepository->findOneBy(['Delivery' => $Delivery, 'Pref' => $Shipping->getPref()]);
-        if ($deliveryFee) {
-            $Shipping->setShippingDeliveryFee($deliveryFee->getFee());
-            $Shipping->setFeeId($deliveryFee->getId());
-        }
     }
 
     private function setDefaultPayment(Order $Order)

--- a/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeeFreeByShippingProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeeFreeByShippingProcessor.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\PurchaseFlow\Processor;
+
+use Eccube\Entity\BaseInfo;
+use Eccube\Entity\Cart;
+use Eccube\Entity\ItemHolderInterface;
+use Eccube\Entity\Order;
+use Eccube\Service\PurchaseFlow\ItemHolderProcessor;
+use Eccube\Service\PurchaseFlow\ProcessResult;
+use Eccube\Service\PurchaseFlow\PurchaseContext;
+
+/**
+ * 送料無料条件.
+ * お届け先ごとに条件判定を行う.
+ */
+class DeliveryFeeFreeByShippingProcessor implements ItemHolderProcessor
+{
+    /**
+     * @var BaseInfo
+     */
+    protected $BaseInfo;
+
+    /**
+     * DeliveryFeeProcessor constructor.
+     *
+     * @param BaseInfo $BaseInfo
+     */
+    public function __construct(BaseInfo $BaseInfo)
+    {
+        $this->BaseInfo = $BaseInfo;
+    }
+
+    /**
+     * @param ItemHolderInterface $itemHolder
+     * @param PurchaseContext $context
+     *
+     * @return ProcessResult
+     */
+    public function process(ItemHolderInterface $itemHolder, PurchaseContext $context)
+    {
+        if (!($this->BaseInfo->getDeliveryFreeAmount() || $this->BaseInfo->getDeliveryFreeQuantity())) {
+            return ProcessResult::success();
+        }
+
+        // Orderの場合はお届け先ごとに判定する.
+        if ($itemHolder instanceof Order) {
+            /** @var Order $Order */
+            $Order = $itemHolder;
+            foreach ($Order->getShippings() as $Shipping) {
+                $isFree = false;
+                $total = 0;
+                $quantity = 0;
+                foreach ($Shipping->getProductOrderItems() as $Item) {
+                    $total += $Item->getPriceIncTax() * $Item->getQuantity();
+                    $quantity += $Item->getQuantity();
+                }
+                // 送料無料（金額）を超えている
+                if ($this->BaseInfo->getDeliveryFreeAmount()) {
+                    if ($total >= $this->BaseInfo->getDeliveryFreeAmount()) {
+                        $isFree = true;
+                    }
+                }
+                // 送料無料（個数）を超えている
+                if ($this->BaseInfo->getDeliveryFreeQuantity()) {
+                    if ($quantity >= $this->BaseInfo->getDeliveryFreeQuantity()) {
+                        $isFree = true;
+                    }
+                }
+                if ($isFree) {
+                    foreach ($Shipping->getOrderItems() as $Item) {
+                        if ($Item->isDeliveryFee()) {
+                            $Item->setQuantity(0);
+                        }
+                    }
+                }
+            }
+        }
+
+        if ($itemHolder instanceof Cart) {
+
+        }
+
+        return ProcessResult::success();
+    }
+}

--- a/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeeProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeeProcessor.php
@@ -21,6 +21,8 @@ use Eccube\Entity\Master\TaxType;
 use Eccube\Entity\Order;
 use Eccube\Entity\OrderItem;
 use Eccube\Entity\Shipping;
+use Eccube\Repository\DeliveryFeeRepository;
+use Eccube\Repository\TaxRuleRepository;
 use Eccube\Service\PurchaseFlow\ItemHolderProcessor;
 use Eccube\Service\PurchaseFlow\ProcessResult;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
@@ -36,14 +38,32 @@ class DeliveryFeeProcessor implements ItemHolderProcessor
     protected $entityManager;
 
     /**
+     * @var TaxRuleRepository
+     */
+    protected $taxRuleRepository;
+
+    /**
+     * @var DeliveryFeeRepository
+     */
+    protected $deliveryFeeRepository;
+
+    /**
      * DeliveryFeeProcessor constructor.
      *
-     * @param $entityManager
+     * @param EntityManagerInterface $entityManager
+     * @param TaxRuleRepository $taxRuleRepository
+     * @param DeliveryFeeRepository $deliveryFeeRepository
      */
-    public function __construct(EntityManagerInterface $entityManager)
-    {
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        TaxRuleRepository $taxRuleRepository,
+        DeliveryFeeRepository $deliveryFeeRepository
+    ) {
         $this->entityManager = $entityManager;
+        $this->taxRuleRepository = $taxRuleRepository;
+        $this->deliveryFeeRepository = $deliveryFeeRepository;
     }
+
 
     /**
      * @param ItemHolderInterface $itemHolder
@@ -85,21 +105,30 @@ class DeliveryFeeProcessor implements ItemHolderProcessor
     {
         $DeliveryFeeType = $this->entityManager
             ->find(OrderItemType::class, OrderItemType::DELIVERY_FEE);
-        // TODO
         $TaxInclude = $this->entityManager
             ->find(TaxDisplayType::class, TaxDisplayType::INCLUDED);
         $Taxion = $this->entityManager
             ->find(TaxType::class, TaxType::TAXATION);
+        $TaxRule = $this->taxRuleRepository->getByRule();
 
         /** @var Order $Order */
         $Order = $itemHolder;
         /* @var Shipping $Shipping */
         foreach ($Order->getShippings() as $Shipping) {
+            // 送料の計算
+            $DeliveryFee = $this->deliveryFeeRepository->findOneBy([
+                'Delivery' => $Shipping->getDelivery(),
+                'Pref' => $Shipping->getPref(),
+            ]);
+            $Shipping->setShippingDeliveryFee($DeliveryFee->getFee());
+            $Shipping->setFeeId($DeliveryFee->getId());
+
             $OrderItem = new OrderItem();
             $OrderItem->setProductName(trans('deliveryfeeprocessor.label.shippint_charge'))
                 ->setPrice($Shipping->getShippingDeliveryFee())
                 ->setPriceIncTax($Shipping->getShippingDeliveryFee())
-                ->setTaxRate(8)
+                ->setTaxRule($TaxRule)
+                ->setTaxRate($TaxRule->getTaxRate())
                 ->setQuantity(1)
                 ->setOrderItemType($DeliveryFeeType)
                 ->setShipping($Shipping)


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- 送料無料条件をお届け先ごとに行うように修正

## 実装に関する補足(Appendix)
- カートではお届け先がわからないため、注文手続き画面とは別のProcessorで実装しています。
- OrderHelperで実装していた送料計算ロジックはDeliveryFeeProcessorへ移動しました。



