### PR TITLE
Order と Cart をマージする処理を追加

### DIFF
--- a/src/Eccube/Controller/CartController.php
+++ b/src/Eccube/Controller/CartController.php
@@ -214,7 +214,7 @@ class CartController extends AbstractController
         $this->eventDispatcher->dispatch(EccubeEvents::FRONT_CART_BUYSTEP_INITIALIZE, $event);
 
         $this->cartService->setPrimary($index);
-        $this->cartService->lock();
+        // $this->cartService->lock();
         $this->cartService->save();
 
         // FRONT_CART_BUYSTEP_COMPLETE

--- a/src/Eccube/Controller/CartController.php
+++ b/src/Eccube/Controller/CartController.php
@@ -214,7 +214,6 @@ class CartController extends AbstractController
         $this->eventDispatcher->dispatch(EccubeEvents::FRONT_CART_BUYSTEP_INITIALIZE, $event);
 
         $this->cartService->setPrimary($index);
-        // $this->cartService->lock();
         $this->cartService->save();
 
         // FRONT_CART_BUYSTEP_COMPLETE

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -553,9 +553,9 @@ class ShoppingController extends AbstractShoppingController
      */
     public function login(Request $request, AuthenticationUtils $authenticationUtils)
     {
-        if (!$this->cartService->isLocked()) {
-            return $this->redirectToRoute('cart');
-        }
+        // if (!$this->cartService->isLocked()) {
+        //     return $this->redirectToRoute('cart');
+        // }
 
         if ($this->isGranted('IS_AUTHENTICATED_FULLY')) {
             return $this->redirectToRoute('shopping');
@@ -617,12 +617,12 @@ class ShoppingController extends AbstractShoppingController
     public function checkToCart(Request $request)
     {
         // カートチェック
-        if (!$this->cartService->isLocked()) {
-            log_info('カートが存在しません');
+        // if (!$this->cartService->isLocked()) {
+        //     log_info('カートが存在しません');
 
-            // カートが存在しない、カートがロックされていない時はエラー
-            return $this->redirectToRoute('cart');
-        }
+        //     // カートが存在しない、カートがロックされていない時はエラー
+        //     return $this->redirectToRoute('cart');
+        // }
 
         // カートチェック
         if (count($this->cartService->getCart()->getCartItems()) <= 0) {
@@ -686,6 +686,12 @@ class ShoppingController extends AbstractShoppingController
 
         // 受注関連情報を最新状態に更新
         $this->entityManager->refresh($Order);
+
+        // 同一 preOrderId はカートの情報で Order を上書き
+        // preOrderId が異なる
+        // かつ 同一販売種別(CartAllocator にて判定できる？)
+        // かつ 同一会員の購入処理中 Order が存在する場合はマージする
+        // 明細は CartComparetor で比較する
 
         $this->parameterBag->set('Order', $Order);
 

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -553,10 +553,6 @@ class ShoppingController extends AbstractShoppingController
      */
     public function login(Request $request, AuthenticationUtils $authenticationUtils)
     {
-        // if (!$this->cartService->isLocked()) {
-        //     return $this->redirectToRoute('cart');
-        // }
-
         if ($this->isGranted('IS_AUTHENTICATED_FULLY')) {
             return $this->redirectToRoute('shopping');
         }
@@ -616,14 +612,6 @@ class ShoppingController extends AbstractShoppingController
      */
     public function checkToCart(Request $request)
     {
-        // カートチェック
-        // if (!$this->cartService->isLocked()) {
-        //     log_info('カートが存在しません');
-
-        //     // カートが存在しない、カートがロックされていない時はエラー
-        //     return $this->redirectToRoute('cart');
-        // }
-
         // カートチェック
         if (count($this->cartService->getCart()->getCartItems()) <= 0) {
             log_info('カートに商品が入っていないためショッピングカート画面にリダイレクト');

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -675,12 +675,6 @@ class ShoppingController extends AbstractShoppingController
         // 受注関連情報を最新状態に更新
         $this->entityManager->refresh($Order);
 
-        // 同一 preOrderId はカートの情報で Order を上書き
-        // preOrderId が異なる
-        // かつ 同一販売種別(CartAllocator にて判定できる？)
-        // かつ 同一会員の購入処理中 Order が存在する場合はマージする
-        // 明細は CartComparetor で比較する
-
         $this->parameterBag->set('Order', $Order);
 
         return new Response();

--- a/src/Eccube/EventListener/SecurityListener.php
+++ b/src/Eccube/EventListener/SecurityListener.php
@@ -14,7 +14,9 @@
 namespace Eccube\EventListener;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Entity\Customer;
 use Eccube\Entity\Member;
+use Eccube\Service\CartService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
@@ -23,9 +25,14 @@ class SecurityListener implements EventSubscriberInterface
 {
     protected $em;
 
-    public function __construct(EntityManagerInterface $em)
-    {
+    protected $cartService;
+
+    public function __construct(
+        EntityManagerInterface $em,
+        CartService $cartService
+    ) {
         $this->em = $em;
+        $this->cartService = $cartService;
     }
 
     /**
@@ -41,6 +48,8 @@ class SecurityListener implements EventSubscriberInterface
             $user->setLoginDate(new \DateTime());
             $this->em->persist($user);
             $this->em->flush();
+        } elseif ($user instanceof Customer) {
+            $this->cartService->mergeFromOrders();
         }
     }
 

--- a/src/Eccube/EventListener/SecurityListener.php
+++ b/src/Eccube/EventListener/SecurityListener.php
@@ -49,7 +49,7 @@ class SecurityListener implements EventSubscriberInterface
             $this->em->persist($user);
             $this->em->flush();
         } elseif ($user instanceof Customer) {
-            $this->cartService->mergeFromOrders();
+            $this->cartService->mergeFromOrders($user);
         }
     }
 

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -496,4 +496,29 @@ class OrderRepository extends AbstractRepository
 
         return $result;
     }
+
+    /**
+     * 会員が保持する最新の購入処理中の Order を取得する.
+     *
+     * @param Customer
+     * @return Order
+     */
+    public function getExistsOrdersByCustomer(\Eccube\Entity\Customer $Customer)
+    {
+        $qb = $this->createQueryBuilder('o');
+        $Order = $qb
+            ->select('o')
+            ->where('o.Customer = :Customer')
+            ->setParameter('Customer', $Customer)
+            ->orderBy('o.id', 'DESC')
+            ->getQuery()
+            ->setMaxResults(1)
+            ->getOneOrNullResult();
+
+        if ($Order && $Order->getOrderStatus()->getId() == OrderStatus::PROCESSING) {
+            return $Order;
+        }
+
+        return null;
+    }
 }

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -346,22 +346,27 @@ class CartService
         return $this->session->set('carts', $this->carts);
     }
 
+    /**
+     * @deprecated
+     */
     public function unlock()
     {
         $this->getCart()
             ->setLock(false);
-            // ->setPreOrderId(null);
     }
 
+    /**
+     * @deprecated
+     */
     public function lock()
     {
         $this->getCart()
             ->setLock(true);
-            // ->setPreOrderId(null);
     }
 
     /**
      * @return bool
+     * @deprecated
      */
     public function isLocked()
     {

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -127,10 +127,8 @@ class CartService
     {
         if (is_null($this->carts)) {
             $this->carts = $this->session->get('carts', []);
-            // $this->loadItems(); // TODO deprecated
         }
 
-        // TODO loadItems() の代替
         foreach ($this->carts as &$Cart) {
 
             /** @var CartItem $item */
@@ -258,7 +256,6 @@ class CartService
             } else {
                 $Cart = new Cart();
                 $Cart->addCartItem($item);
-                    //->setPreOrderId(sha1(StringUtil::random(32))); // TODO
                 $Carts[$cartId] = $Cart;
             }
         }
@@ -403,7 +400,6 @@ class CartService
         if (!empty($removed)) {
             $removedCart = $removed[0];
             $removedCart
-                // ->setPreOrderId(null)
                 ->setLock(false)
                 ->setTotalPrice(0)
                 ->clearCartItems();

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -259,8 +259,8 @@ class CartService
             }
         }
 
-        $this->session->set('carts', $Carts);
         // 配列のkeyを0からにする
+        $this->session->set('carts', array_values($Carts));
         $this->carts = array_values($Carts);
     }
 

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -151,16 +151,18 @@ class CartService
     public function mergeFromOrders()
     {
         $Order = $this->orderRepository->getExistsOrdersByCustomer($this->tokenStorage->getToken()->getUser());
+        if ($Order) {
+            $Carts = $this->getCarts();
+            $ExistsCart = $this->orderHelper->convertToCart($Order);
 
-        $Carts = $this->getCarts();
-        $ExistsCart = $this->orderHelper->convertToCart($Order);
-        $allCartItems = [];
-        foreach ($Carts as $Cart) {
-            $allCartItems = $this->mergeCartitems($Cart->getCartItems(), $allCartItems);
+            $allCartItems = [];
+            foreach ($Carts as $Cart) {
+                $allCartItems = $this->mergeCartitems($Cart->getCartItems(), $allCartItems);
+            }
+
+            $CartItems = $this->mergeCartitems($ExistsCart->getItems(), $allCartItems);
+            $this->restoreCarts($CartItems);
         }
-
-        $CartItems = $this->mergeCartitems($ExistsCart->getItems(), $allCartItems);
-        $this->restoreCarts($CartItems);
     }
 
     /**

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -15,6 +15,7 @@ namespace Eccube\Service;
 
 use Eccube\Entity\Cart;
 use Eccube\Entity\CartItem;
+use Eccube\Entity\Customer;
 use Eccube\Entity\ItemHolderInterface;
 use Eccube\Entity\ProductClass;
 use Eccube\Repository\ProductClassRepository;
@@ -146,11 +147,12 @@ class CartService
     /**
      * 会員が保持する購入処理中の受注と、カートをマージする.
      *
+     * @param Customer $Customer
      * @return void
      */
-    public function mergeFromOrders()
+    public function mergeFromOrders(Customer $Customer)
     {
-        $Order = $this->orderRepository->getExistsOrdersByCustomer($this->tokenStorage->getToken()->getUser());
+        $Order = $this->orderRepository->getExistsOrdersByCustomer($Customer);
         if ($Order) {
             $Carts = $this->getCarts();
             $ExistsCart = $this->orderHelper->convertToCart($Order);

--- a/src/Eccube/Service/OrderHelper.php
+++ b/src/Eccube/Service/OrderHelper.php
@@ -192,7 +192,9 @@ class OrderHelper
         /** @var OrderItem $OrderItem */
         foreach ($Order->getProductOrderItems() as $OrderItem) {
             $CartItem = new CartItem();
-            $CartItem->setProductClass($OrderItem->getProductClass());
+            $ProductClass = $OrderItem->getProductClass();
+            $this->entityManager->refresh($ProductClass);
+            $CartItem->setProductClass($ProductClass);
             $CartItem->setPrice($OrderItem->getPriceIncTax());
             $CartItem->setQuantity($OrderItem->getQuantity());
             $Cart->addCartItem($CartItem);

--- a/src/Eccube/Service/OrderHelper.php
+++ b/src/Eccube/Service/OrderHelper.php
@@ -142,13 +142,15 @@ class OrderHelper
      *
      * @return Order
      */
-    public function createProcessingOrder(Customer $Customer, CustomerAddress $CustomerAddress, $CartItems)
+    public function createProcessingOrder(Customer $Customer, CustomerAddress $CustomerAddress, $CartItems, $preOrderId = null)
     {
         $OrderStatus = $this->orderStatusRepository->find(OrderStatus::PROCESSING);
         $Order = new Order($OrderStatus);
 
-        // pre_order_idを生成
-        $Order->setPreOrderId($this->createPreOrderId());
+        if (!$preOrderId) {
+            // pre_order_idを生成
+            $Order->setPreOrderId($this->createPreOrderId());
+        }
 
         // 顧客情報の設定
         $this->setCustomer($Order, $Customer);

--- a/tests/Eccube/Tests/Repository/OrderRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryTest.php
@@ -15,7 +15,7 @@ namespace Eccube\Tests\Repository;
 
 use Eccube\Entity\Customer;
 use Eccube\Entity\Order;
-use Eccube\Repository\Master\OrderStatusRepository;
+use Eccube\Entity\Master\OrderStatus;
 use Eccube\Repository\OrderRepository;
 use Eccube\Tests\EccubeTestCase;
 
@@ -31,16 +31,13 @@ class OrderRepositoryTest extends EccubeTestCase
     /** @var Order */
     protected $Order;
 
-    /** @var OrderStatusRepository */
-    protected $orderStatusRepo;
     /** @var OrderRepository */
-    protected $orderRepo;
+    protected $orderRepository;
 
     public function setUp()
     {
         parent::setUp();
-        $this->orderStatusRepo = $this->container->get(OrderStatusRepository::class);
-        $this->orderRepo = $this->container->get(OrderRepository::class);
+        $this->orderRepository = $this->container->get(OrderRepository::class);
 
         $this->createProduct();
         $this->Customer = $this->createCustomer();
@@ -52,9 +49,9 @@ class OrderRepositoryTest extends EccubeTestCase
     public function testChangeStatusWithCommitted()
     {
         $orderId = $this->Order->getId();
-        $Status = $this->orderStatusRepo->find(5);
+        $Status = $this->entityManager->find(OrderStatus::class, OrderStatus::DELIVERED);
 
-        $this->orderRepo->changeStatus($orderId, $Status);
+        $this->orderRepository->changeStatus($orderId, $Status);
 
         $this->assertNotNull($this->Order->getShippingDate());
         $this->expected = 5;
@@ -65,9 +62,9 @@ class OrderRepositoryTest extends EccubeTestCase
     public function testChangeStatusWithPayment()
     {
         $orderId = $this->Order->getId();
-        $Status = $this->orderStatusRepo->find(6);
+        $Status = $this->entityManager->find(OrderStatus::class, OrderStatus::PAID);
 
-        $this->orderRepo->changeStatus($orderId, $Status);
+        $this->orderRepository->changeStatus($orderId, $Status);
 
         $this->assertNotNull($this->Order->getPaymentDate());
         $this->expected = 6;
@@ -78,9 +75,9 @@ class OrderRepositoryTest extends EccubeTestCase
     public function testChangeStatusWithOther()
     {
         $orderId = $this->Order->getId();
-        $Status = $this->orderStatusRepo->find(1);
+        $Status = $this->entityManager->find(OrderStatus::class, OrderStatus::NEW);
 
-        $this->orderRepo->changeStatus($orderId, $Status);
+        $this->orderRepository->changeStatus($orderId, $Status);
 
         $this->assertNull($this->Order->getShippingDate());
         $this->assertNull($this->Order->getPaymentDate());
@@ -92,7 +89,7 @@ class OrderRepositoryTest extends EccubeTestCase
         $this->createOrder($this->Customer);
         $this->createOrder($Customer2);
 
-        $qb = $this->orderRepo->getQueryBuilderByCustomer($this->Customer);
+        $qb = $this->orderRepository->getQueryBuilderByCustomer($this->Customer);
         $Orders = $qb->getQuery()->getResult();
 
         $this->expected = 2;

--- a/tests/Eccube/Tests/Repository/OrderRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryTest.php
@@ -102,4 +102,26 @@ class OrderRepositoryTest extends EccubeTestCase
         $this->assertInstanceOf('\Doctrine\Common\Collections\Collection', $this->Order->getShippings());
         $this->assertEquals(1, $this->Order->getShippings()->count());
     }
+
+    public function testGetExistsOrdersByCustomer()
+    {
+        $Order2 = $this->createOrder($this->Customer);
+        $Status = $this->entityManager->find(OrderStatus::class, OrderStatus::PROCESSING);
+
+        $this->orderRepository->changeStatus($Order2->getId(), $Status);
+
+        $this->actual = $Order2;
+        $this->expected = $this->orderRepository->getExistsOrdersByCustomer($this->Customer);
+        $this->verify();
+    }
+
+    public function testGetExistsOrdersByCustomerWithNull()
+    {
+        $Order2 = $this->createOrder($this->Customer);
+        $Status = $this->entityManager->find(OrderStatus::class, OrderStatus::NEW);
+
+        $this->orderRepository->changeStatus($Order2->getId(), $Status);
+
+        $this->assertNull($this->orderRepository->getExistsOrdersByCustomer($this->Customer));
+    }
 }

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -42,8 +42,10 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
 
     public function testRoutingShoppingLogin()
     {
-        $this->client->request('GET', '/shopping/login');
-        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('cart')));
+        $crawler = $this->client->request('GET', '/shopping/login');
+        $this->expected = 'ログイン';
+        $this->actual = $crawler->filter('.ec-pageHeader h1')->text();
+        $this->verify();
     }
 
     public function testShoppingIndexWithCartUnlock()

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
@@ -34,9 +34,10 @@ class ShoppingControllerWithNonmemberTest extends AbstractShoppingControllerTest
 
     public function testRoutingShoppingLogin()
     {
-        $client = $this->client;
-        $client->request('GET', '/shopping/login');
-        $this->assertTrue($client->getResponse()->isRedirect($this->generateUrl('cart')));
+        $crawler = $this->client->request('GET', '/shopping/login');
+        $this->expected = 'ログイン';
+        $this->actual = $crawler->filter('.ec-pageHeader h1')->text();
+        $this->verify();
     }
 
     public function testIndexWithCartUnlock()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- 複数配送画面で、 Order の内容が変更された場合に Cart へ同期する
- 会員ログインした場合に、購入処理中の Order があれば、 Cart にマージする。以下のようなフローが該当する
    1.  会員で購入処理まで進んで複数配送設定する
    2. 一旦ログアウトし、別の商品をカートに入れて再度ご注文内容設定画面へ遷移する
    3.  カートの商品情報(個数とか)はマージされる
    4. 配送先は非会員時に設定した配送先が表示される

## 方針(Policy)
+ Order の内容が変更された場合に Cart へ同期する処理は、複数配送画面の submit 時に実装する
+ 購入処理中の Order を Cart にマージする処理は、ログイン成功時に実装する

## 実装に関する補足(Appendix)

- たまに、マージされるはずの商品が消えてしまう場合がある。再現性が不明
- Order に Shipping が設定されていた場合、 Shipping もマージする必要があるかも

## テスト（Test)
+ ユニットテストを実装

## 相談（Discussion）
+ マージの処理が不安定


