### PR TITLE
マイページの複数配送対応

### DIFF
--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -1366,6 +1366,35 @@ class Order extends \Eccube\Entity\AbstractEntity implements PurchaseInterface, 
     }
 
     /**
+     * 同じ規格の商品の個数をまとめた受注明細を取得
+     *
+     * @return OrderItem[]
+     */
+    public function getAggregatedProductOrderItems()
+    {
+        $ProductOrderItems = $this->getProductOrderItems();
+
+        $orderItemArray = [];
+
+        /** @var ItemInterface $ProductOrderItem */
+        foreach ($ProductOrderItems as $ProductOrderItem) {
+            $productClassId = $ProductOrderItem->getProductClass()->getId();
+            if (array_key_exists($productClassId, $orderItemArray)) {
+                // 同じ規格の商品がある場合は個数をまとめる
+                /** @var ItemInterface $OrderItem */
+                $OrderItem = $orderItemArray[$productClassId];
+                $quantity = $OrderItem->getQuantity() + $ProductOrderItem->getQuantity();
+                $OrderItem->setQuantity($quantity);
+            } else {
+                // 新規規格の商品は新しく追加する
+                $orderItemArray[$productClassId] = $ProductOrderItem;
+            }
+        }
+
+        return array_values($orderItemArray);
+    }
+
+    /**
      * Add orderItem.
      *
      * @param \Eccube\Entity\OrderItem $OrderItem

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -1370,7 +1370,7 @@ class Order extends \Eccube\Entity\AbstractEntity implements PurchaseInterface, 
      *
      * @return OrderItem[]
      */
-    public function getAggregatedProductOrderItems()
+    public function getMergedProductOrderItems()
     {
         $ProductOrderItems = $this->getProductOrderItems();
 

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -1376,7 +1376,7 @@ class Order extends \Eccube\Entity\AbstractEntity implements PurchaseInterface, 
 
         $orderItemArray = [];
 
-        /** @var ItemInterface $ProductOrderItem */
+        /** @var OrderItem $ProductOrderItem */
         foreach ($ProductOrderItems as $ProductOrderItem) {
             $productClassId = $ProductOrderItem->getProductClass()->getId();
             if (array_key_exists($productClassId, $orderItemArray)) {
@@ -1387,7 +1387,15 @@ class Order extends \Eccube\Entity\AbstractEntity implements PurchaseInterface, 
                 $OrderItem->setQuantity($quantity);
             } else {
                 // 新規規格の商品は新しく追加する
-                $orderItemArray[$productClassId] = $ProductOrderItem;
+                $OrderItem = new OrderItem();
+                $OrderItem
+                    ->setProduct($ProductOrderItem->getProduct())
+                    ->setProductName($ProductOrderItem->getProductName())
+                    ->setClassCategoryName1($ProductOrderItem->getClassCategoryName1())
+                    ->setClassCategoryName2($ProductOrderItem->getClassCategoryName2())
+                    ->setPriceIncTax($ProductOrderItem->getPriceIncTax())
+                    ->setQuantity($ProductOrderItem->getQuantity());
+                $orderItemArray[$productClassId] = $OrderItem;
             }
         }
 

--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -121,9 +121,8 @@ file that was distributed with this source code.
                             <dt>{{'mypage.history.detail.label.shipping_time'|trans}} : </dt>
                             <dd>{{ Shipping.shipping_delivery_time|default('admin.shipping.edit.719'|trans) }}</dd>
                         </div>
-
-                </div>
                     {% endfor %}
+                </div>
                     <div class="ec-orderPayment">
                         <div class="ec-rectHeading">
                             <h2>{{'mypage.history.detail.title.payment'|trans}}</h2>

--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -73,7 +73,7 @@ file that was distributed with this source code.
                     </div>
                     {% for Shipping in Order.Shippings %}
                         <div class="ec-orderDelivery__title">{{'mypage.history.detail.label.shipping'|trans}}{% if Order.multiple %}({{ loop.index }}){% endif %}</div>
-                        {% for orderItem in Shipping.orderItems %}
+                        {% for orderItem in Shipping.productOrderItems %}
                             <div class="ec-orderDelivery__item">
                                 <div class="ec-imageGrid">
                                     <div class="ec-imageGrid__img">

--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -36,6 +36,8 @@ file that was distributed with this source code.
             {% include 'Mypage/navi.twig' %}
         </div>
 
+        {% set remessage = false %}
+
         <div class="ec-orderRole">
             <div class="ec-orderRole__detail">
                 <div class="ec-orderOrder">
@@ -64,50 +66,11 @@ file that was distributed with this source code.
                         </div>
                     {% endif %}
 
-                    <div class="ec-orderOrder__items">
-                        {% set remessage = '' %}
-                        {% for OrderItem in Order.OrderItems %}
-                            <div class="ec-imageGrid">
-                                <div class="ec-imageGrid__img">
-                                    {% if OrderItem.Product is null %}
-                                        <img src="{{ asset(''|no_image_product, 'save_image') }}" />
-                                    {% else %}
-                                        <a href="{{ url('product_detail', { id : OrderItem.Product.id } ) }}">
-                                            <img src="{{ asset(OrderItem.Product.MainListImage|no_image_product, 'save_image') }}" />
-                                        </a>
-                                    {% endif %}
-                                </div>
-                                <div class="ec-imageGrid__content">
-                                    <p>
-                                        {% if OrderItem.Product is null %}
-                                            {{ OrderItem.product_name }}
-                                        {% else %}
-                                            <a href="{{ url('product_detail', {'id': OrderItem.Product.id}) }}">
-                                                {{ OrderItem.product_name }}
-                                            </a>
-                                        {% endif %}
-                                    </p>
-                                    {% if OrderItem.classcategory_name1 is not empty %}
-                                        {{ OrderItem.classcategory_name1 }}
-                                    {% endif %}
-                                    {% if OrderItem.classcategory_name2 is not empty %}
-                                        / {{ OrderItem.classcategory_name2 }}
-                                    {% endif %}
-                                    <p>{{ OrderItem.price_inc_tax|price }} × {{ OrderItem.quantity|number_format }}</p>
-                                    {% if OrderItem.product and OrderItem.price_inc_tax != OrderItem.productClass.price02IncTax %}
-                                        <p class="ec-color-accent">【現在価格】{{ OrderItem.productClass.price02IncTax|price }}</p>
-                                        {% set remessage = true %}
-                                    {% endif %}
-                                </div>
-                            </div>
-                        {% endfor %}
-                    </div>
                 </div>
                 <div class="ec-orderDelivery">
                     <div class="ec-rectHeading">
                         <h2>{{'mypage.history.detail.title.delivery'|trans}}</h2>
                     </div>
-                    {% set OrderItem = Order.OrderItems.0 %}
                     {% for Shipping in Order.Shippings %}
                         <div class="ec-orderDelivery__title">{{'mypage.history.detail.label.shipping'|trans}}{% if Order.multiple %}({{ loop.index }}){% endif %}</div>
                         {% for orderItem in Shipping.orderItems %}
@@ -130,6 +93,12 @@ file that was distributed with this source code.
                                                 <br>{{ orderItem.productClass.classCategory2.className.name }}：{{ orderItem.productClass.classCategory2 }}
                                             {% endif %}
                                         {% endif %}
+                                        <p>{{ orderItem.price_inc_tax|price }} × {{ orderItem.quantity|number_format }}</p>
+                                        {% if orderItem.product and orderItem.price_inc_tax != orderItem.productClass.price02IncTax %}
+                                            <p class="ec-color-accent">【現在価格】{{ orderItem.productClass.price02IncTax|price }}</p>
+                                            {% set remessage = true %}
+                                        {% endif %}
+
                                     </div>
                                 </div>
                             </div>

--- a/src/Eccube/Resource/template/default/Mypage/index.twig
+++ b/src/Eccube/Resource/template/default/Mypage/index.twig
@@ -60,7 +60,7 @@ file that was distributed with this source code.
                                         {% if OrderItem.class_category_name1 is not empty %}
                                             / {{ OrderItem.class_category_name2 }}
                                         {% endif %}
-                                        <p class="ec-historyRole__detailPrice">{{ OrderItem.price_inc_tax|price }} ×{{ OrderItem.quantity }}</p>
+                                        <p class="ec-historyRole__detailPrice">{{ OrderItem.price_inc_tax|price }} × {{ OrderItem.quantity }}</p>
                                     </div>
                                 </div>
                             {% endfor %}

--- a/src/Eccube/Resource/template/default/Mypage/index.twig
+++ b/src/Eccube/Resource/template/default/Mypage/index.twig
@@ -43,7 +43,7 @@ file that was distributed with this source code.
                             </div>
                         </div>
                         <div class="ec-historyRole__detail">
-                            {% for OrderItem in Order.AggregatedProductOrderItems %}
+                            {% for OrderItem in Order.MergedProductOrderItems %}
                                 <div class="ec-imageGrid">
                                     <div class="ec-imageGrid__img">
                                         {% if OrderItem.Product is null %}

--- a/src/Eccube/Resource/template/default/Mypage/index.twig
+++ b/src/Eccube/Resource/template/default/Mypage/index.twig
@@ -43,7 +43,7 @@ file that was distributed with this source code.
                             </div>
                         </div>
                         <div class="ec-historyRole__detail">
-                            {% for OrderItem in Order.OrderItems %}
+                            {% for OrderItem in Order.AggregatedProductOrderItems %}
                                 <div class="ec-imageGrid">
                                     <div class="ec-imageGrid__img">
                                         {% if OrderItem.Product is null %}

--- a/tests/Eccube/Tests/Entity/OrderTest.php
+++ b/tests/Eccube/Tests/Entity/OrderTest.php
@@ -135,9 +135,10 @@ class OrderTest extends EccubeTestCase
 
     public function testGetMergedProductOrderItems()
     {
-        $quantity = '5';
-        $times = '2';
+        $quantity = '5';    // 配送先あたりの商品の個数
+        $times = '2';       // 複数配送の配送先数
 
+        // テストデータの準備
         $Product = new Product();
         $ProductClass = new ProductClass();
         $Order = new Order();
@@ -162,11 +163,20 @@ class OrderTest extends EccubeTestCase
             $Order->addOrderItem($OrderItem);
         }
 
+        // 実行
         $OrderItems = $Order->getMergedProductOrderItems();
+
+        // 2個目の明細が1個にまとめられているか
+        $this->expected = 1;
+        $this->actual = count($OrderItems);
+        $this->verify();
+
+        // まとめられた明細の商品の個数が全配送先の合計になっているか
         $OrderItem = $OrderItems[0];
 
         $this->expected = $quantity * $times;
         $this->actual = $OrderItem->getQuantity();
         $this->verify();
+
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ マイページの複数配送対応
    + マイページの注文一覧
        + 商品のみ表示させる。
        + 同じ規格の商品明細がまとまって表示されている。
    + マイページの注文詳細
        + 画面上部の購入明細一覧は非表示
        + お届け先別の明細には商品のみ表示
        + お届け先一覧の明細に「単価 * 送料」を表示
        + 送料・手数料・割引は画面右の合計欄にのみ表示
    + テストが通っていることを確認

## 実装に関する補足(Appendix)
+ OrderのEntityに同じ規格の商品の個数をまとめた受注明細を取得できる関数 `getAggregatedProductOrderItems` を追加

## テスト（Test)
+ テストが通っていることを確認

