### PR TITLE
Travis上でPHP-CS-Fixerを実行するようにする

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,44 +23,59 @@ cache:
 php:
   - 7.2
 
-before_install:
-  ## see https://github.com/symfony/symfony/blob/e0bdc0c35e9afdb3bee8af172f90e9648c4012fc/.travis.yml#L92-L97
-  - phpenv config-rm xdebug.ini || true
-  - echo "opcache.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - echo "apc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - wget -c -nc --retry-connrefused --tries=0 http://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip
-  - unzip -o -q chromedriver_linux64.zip
-  - sudo mv -f ./chromedriver /usr/local/bin/
-  - sudo chmod +x /usr/local/bin/chromedriver
-  - gem install mailcatcher
+## see https://github.com/symfony/symfony/blob/e0bdc0c35e9afdb3bee8af172f90e9648c4012fc/.travis.yml#L92-L97
+before_install: &php_setup |
+  phpenv config-rm xdebug.ini || true
+  echo "opcache.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  echo "apc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:
-  - composer install --dev --no-interaction -o --apcu-autoloader
-  - echo "APP_ENV=codeception" > .env
-  - bin/console doctrine:database:create
-  - bin/console doctrine:schema:create
-  - bin/console eccube:fixtures:load
+  - &composer_install composer install --dev --no-interaction -o --apcu-autoloader
+
+eccube_setup: &eccube_setup |
+  echo "APP_ENV=codeception" > .env
+  bin/console doctrine:database:create
+  bin/console doctrine:schema:create
+  bin/console eccube:fixtures:load
 
 jobs:
   include:
-    - stage: Unit Test
-      env:
-        - DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
+    - stage: Inspection
+      php: 7.1
+      env: DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
+      script: vendor/bin/php-cs-fixer fix --config=.php_cs.dist --dry-run
+    - &unit_test
+      stage: Unit Test
+      before_install:
+        - *php_setup
+        - gem install mailcatcher
+      install:
+        - *composer_install
+        - *eccube_setup
+      env: DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
       script:
         - ./bin/phpunit --exclude-group cache-clear
         - ./bin/phpunit --group cache-clear
-    - env:
-      - DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
-      script:
-        - ./bin/phpunit --exclude-group cache-clear
-        - ./bin/phpunit --group cache-clear
-    - stage: E2E Test
+    - <<: *unit_test
+      env: DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
+    - &e2e_test
+      stage: E2E Test
+      before_install:
+        - *php_setup
+        - wget -c -nc --retry-connrefused --tries=0 http://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip
+        - unzip -o -q chromedriver_linux64.zip
+        - sudo mv -f ./chromedriver /usr/local/bin/
+        - sudo chmod +x /usr/local/bin/chromedriver
+        - gem install mailcatcher
+      install:
+        - *composer_install
+        - *eccube_setup
       env: GROUP=admin01 APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
       script: ./codeception.sh -g ${GROUP}
-    - env: GROUP=admin02 APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
-      script: ./codeception.sh -g ${GROUP}
-    - env: GROUP=admin03 APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
-      script: ./codeception.sh -g ${GROUP}
-    - env: GROUP=front APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
-      script: ./codeception.sh -g ${GROUP}
+    - <<: *e2e_test
+      env: GROUP=admin02 APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
+    - <<: *e2e_test
+      env: GROUP=admin03 APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
+    - <<: *e2e_test
+      env: GROUP=front APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025

--- a/src/Eccube/Controller/Admin/Order/MailController.php
+++ b/src/Eccube/Controller/Admin/Order/MailController.php
@@ -100,7 +100,7 @@ class MailController extends AbstractController
                     $data = $form->getData();
 
                     $twig = $MailTemplate->getFileName();
-                    if (!$twig)  {
+                    if (!$twig) {
                         $twig = 'Mail/order.twig';
                     }
 
@@ -128,7 +128,7 @@ class MailController extends AbstractController
                     $MailTemplate = $form->get('template')->getData();
 
                     $twig = $MailTemplate->getFileName();
-                    if (!$twig)  {
+                    if (!$twig) {
                         $twig = 'Mail/order.twig';
                     }
 

--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -13,8 +13,6 @@
 
 namespace Eccube\Controller\Admin\Store;
 
-use Doctrine\ORM\EntityManager;
-use Eccube\Application;
 use Eccube\Common\Constant;
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\Plugin;
@@ -37,7 +35,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class OwnerStoreController extends AbstractController
 {
-
     /**
      * @var PluginRepository
      */
@@ -62,6 +59,7 @@ class OwnerStoreController extends AbstractController
 
     /**
      * OwnerStoreController constructor.
+     *
      * @param PluginRepository $pluginRepository
      * @param PluginService $pluginService
      * @param ComposerProcessService $composerProcessService
@@ -81,19 +79,19 @@ class OwnerStoreController extends AbstractController
 
         // TODO: Check the flow of the composer service below
         $memoryLimit = $this->systemService->getMemoryLimit();
-        if($memoryLimit == -1 or $memoryLimit >= $this->eccubeConfig['eccube_composer_memory_limit']){
+        if ($memoryLimit == -1 or $memoryLimit >= $this->eccubeConfig['eccube_composer_memory_limit']) {
             $this->composerService = $composerApiService;
-        }else{
+        } else {
             $this->composerService = $composerProcessService;
         }
     }
-
 
     /**
      * Owner's Store Plugin Installation Screen - Search function
      *
      * @Route("/search", name="admin_store_plugin_owners_search")
      * @Template("@admin/Store/plugin_search.twig")
+     *
      * @param Request     $request
      *
      * @return array
@@ -175,6 +173,7 @@ class OwnerStoreController extends AbstractController
      *
      * @Route("/install/{id}/confirm", requirements={"id" = "\d+"}, name="admin_store_plugin_install_confirm")
      * @Template("@admin/Store/plugin_confirm.twig")
+     *
      * @param Request     $request
      * @param string      $id
      *
@@ -301,6 +300,7 @@ class OwnerStoreController extends AbstractController
      *
      * @Route("/delete/{id}/confirm", requirements={"id" = "\d+"}, name="admin_store_plugin_delete_confirm")
      * @Template("Store/plugin_confirm_uninstall.twig")
+     *
      * @param Plugin      $Plugin
      *
      * @return array|RedirectResponse
@@ -351,6 +351,7 @@ class OwnerStoreController extends AbstractController
      *
      * @Method("DELETE")
      * @Route("/delete/{id}/uninstall", requirements={"id" = "\d+"}, name="admin_store_plugin_api_uninstall")
+     *
      * @param Plugin      $Plugin
      *
      * @return RedirectResponse
@@ -412,6 +413,7 @@ class OwnerStoreController extends AbstractController
      *
      * @Route("/upgrade/{id}/confirm", requirements={"id" = "\d+"}, name="admin_store_plugin_update_confirm")
      * @Template("@admin/Store/plugin_confirm.twig")
+     *
      * @param Plugin      $plugin
      *
      * @return Response

--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -62,6 +62,7 @@ class PluginController extends AbstractController
 
     /**
      * PluginController constructor.
+     *
      * @param PluginRepository $pluginRepository
      * @param PluginService $pluginService
      * @param BaseInfo $baseInfo
@@ -73,7 +74,6 @@ class PluginController extends AbstractController
         $this->pluginEventHandlerRepository = $eventHandlerRepository;
         $this->BaseInfo = $baseInfo;
     }
-
 
     /**
      * インストール済プラグイン画面
@@ -89,7 +89,7 @@ class PluginController extends AbstractController
 
         // ファイル設置プラグインの取得.
         $unregisterdPlugins = $this->getUnregisteredPlugins($Plugins);
-        $unregisterdPluginsConfigPages = array();
+        $unregisterdPluginsConfigPages = [];
         foreach ($unregisterdPlugins as $unregisterdPlugin) {
             try {
                 $code = $unregisterdPlugin['code'];
@@ -172,6 +172,7 @@ class PluginController extends AbstractController
      *
      * @Method("POST")
      * @Route("/%eccube_admin_route%/store/plugin/{id}/update", requirements={"id" = "\d+"}, name="admin_store_plugin_update")
+     *
      * @param Request     $request
      * @param Plugin      $Plugin
      *
@@ -217,7 +218,7 @@ class PluginController extends AbstractController
                     $fs = new Filesystem();
                     $fs->remove($tmpDir);
                 }
-                log_error("plugin install failed.", array('original-message' => $er->getMessage()));
+                log_error('plugin install failed.', ['original-message' => $er->getMessage()]);
                 $message = 'admin.plugin.install.fail';
             }
         } else {
@@ -237,6 +238,7 @@ class PluginController extends AbstractController
      *
      * @Method("PUT")
      * @Route("/%eccube_admin_route%/store/plugin/{id}/enable", requirements={"id" = "\d+"}, name="admin_store_plugin_enable")
+     *
      * @param Plugin      $Plugin
      *
      * @return RedirectResponse
@@ -272,6 +274,7 @@ class PluginController extends AbstractController
      *
      * @Method("PUT")
      * @Route("/%eccube_admin_route%/store/plugin/{id}/disable", requirements={"id" = "\d+"}, name="admin_store_plugin_disable")
+     *
      * @param Plugin      $Plugin
      *
      * @return RedirectResponse
@@ -308,6 +311,7 @@ class PluginController extends AbstractController
      *
      * @Method("DELETE")
      * @Route("/%eccube_admin_route%/store/plugin/{id}/uninstall", requirements={"id" = "\d+"}, name="admin_store_plugin_uninstall")
+     *
      * @param Plugin      $Plugin
      *
      * @return RedirectResponse
@@ -389,6 +393,7 @@ class PluginController extends AbstractController
      *
      * @Route("/%eccube_admin_route%/store/plugin/install", name="admin_store_plugin_install")
      * @Template("@admin/Store/plugin_install.twig")
+     *
      * @param Request     $request
      *
      * @return array|RedirectResponse

--- a/src/Eccube/Controller/Block/CartController.php
+++ b/src/Eccube/Controller/Block/CartController.php
@@ -81,5 +81,4 @@ class CartController extends AbstractController
             return $this->purchaseFlow->calculate($Cart, $purchaseContext);
         }, $Carts);
     }
-
 }

--- a/src/Eccube/Controller/NonMemberShoppingController.php
+++ b/src/Eccube/Controller/NonMemberShoppingController.php
@@ -21,7 +21,6 @@ use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
 use Eccube\Exception\CartException;
 use Eccube\Form\Type\Front\NonMemberType;
-use Eccube\Form\Type\Front\ShoppingShippingType;
 use Eccube\Repository\Master\PrefRepository;
 use Eccube\Service\CartService;
 use Eccube\Service\OrderHelper;

--- a/src/Eccube/Controller/ShippingMultipleController.php
+++ b/src/Eccube/Controller/ShippingMultipleController.php
@@ -91,7 +91,6 @@ class ShippingMultipleController extends AbstractShoppingController
         $this->orderHelper = $orderHelper;
     }
 
-
     /**
      * 複数配送処理
      *
@@ -302,7 +301,6 @@ class ShippingMultipleController extends AbstractShoppingController
             // 合計金額の再計算
             $flowResult = $this->executePurchaseFlow($Order);
             if ($flowResult->hasWarning()) {
-
                 return [
                     'form' => $form->createView(),
                     'OrderItems' => $OrderItemsForFormBuilder,
@@ -311,7 +309,6 @@ class ShippingMultipleController extends AbstractShoppingController
                 ];
             }
             if ($flowResult->hasError()) {
-
                 return $this->redirectToRoute('cart');
             }
 

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -1471,7 +1471,7 @@ class Order extends \Eccube\Entity\AbstractEntity implements PurchaseInterface, 
 
         usort($Shippings, function (Shipping $a, Shipping $b) {
             $result = strnatcmp($a->getName01(), $b->getName01());
-            if($result === 0) {
+            if ($result === 0) {
                 return strnatcmp($a->getName02(), $b->getName02());
             } else {
                 return $result;

--- a/src/Eccube/Form/Type/Admin/MemberType.php
+++ b/src/Eccube/Form/Type/Admin/MemberType.php
@@ -11,7 +11,6 @@
  * file that was distributed with this source code.
  */
 
-
 namespace Eccube\Form\Type\Admin;
 
 use Eccube\Common\EccubeConfig;

--- a/src/Eccube/Form/Type/Admin/SearchOrderType.php
+++ b/src/Eccube/Form/Type/Admin/SearchOrderType.php
@@ -15,7 +15,6 @@ namespace Eccube\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
-use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;

--- a/src/Eccube/Form/Type/Admin/SecurityType.php
+++ b/src/Eccube/Form/Type/Admin/SecurityType.php
@@ -99,7 +99,7 @@ class SecurityType extends AbstractType
                         ]
                     );
                     if ($errors->count() != 0) {
-                        $form['admin_allow_hosts']->addError(new FormError(trans('security.text.error.not_ipv4', array('%ip%' => $ip))));
+                        $form['admin_allow_hosts']->addError(new FormError(trans('security.text.error.not_ipv4', ['%ip%' => $ip])));
                     }
                 }
 

--- a/src/Eccube/Form/Type/Admin/TagType.php
+++ b/src/Eccube/Form/Type/Admin/TagType.php
@@ -13,7 +13,6 @@
 
 namespace Eccube\Form\Type\Admin;
 
-use Eccube\Application;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;

--- a/src/Eccube/Form/Type/CustomerType.php
+++ b/src/Eccube/Form/Type/CustomerType.php
@@ -13,7 +13,6 @@
 
 namespace Eccube\Form\Type;
 
-use Eccube\Application;
 use Eccube\Form\Type\Master\CustomerStatusType;
 use Eccube\Form\Type\Master\JobType;
 use Eccube\Form\Type\Master\SexType;

--- a/src/Eccube/Form/Type/ShippingMultipleItemType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleItemType.php
@@ -51,6 +51,7 @@ class ShippingMultipleItemType extends AbstractType
 
     /**
      * ShippingMultipleItemType constructor.
+     *
      * @param array $eccubeConfig
      * @param Session $session
      * @param AuthorizationCheckerInterface $authorizationChecker
@@ -95,8 +96,9 @@ class ShippingMultipleItemType extends AbstractType
                     /** @var Customer $Customer */
                     $Customer = $this->tokenStorage->getToken()->getUser();
                     $CustomerAddresses = $Customer->getCustomerAddresses();
-                    $Addresses = array_reduce($CustomerAddresses->toArray(), function(array $result, CustomerAddress $CustomerAddress) {
+                    $Addresses = array_reduce($CustomerAddresses->toArray(), function (array $result, CustomerAddress $CustomerAddress) {
                         $result[$CustomerAddress->getShippingMultipleDefaultName()] = $CustomerAddress->getId();
+
                         return $result;
                     }, []);
 
@@ -111,7 +113,7 @@ class ShippingMultipleItemType extends AbstractType
                     if ($this->session->has('eccube.front.shopping.nonmember.customeraddress')) {
                         $customerAddresses = $this->session->get('eccube.front.shopping.nonmember.customeraddress');
                         $customerAddresses = unserialize($customerAddresses);
-                        $addresses = array_map(function(CustomerAddress $CustomerAddress) {
+                        $addresses = array_map(function (CustomerAddress $CustomerAddress) {
                             return $CustomerAddress->getShippingMultipleDefaultName();
                         }, $customerAddresses);
 
@@ -136,7 +138,7 @@ class ShippingMultipleItemType extends AbstractType
 
                 $choices = $form['customer_address']->getConfig()->getOption('choices');
 
-                /** @var CustomerAddress $CustomerAddress */
+                /* @var CustomerAddress $CustomerAddress */
                 foreach ($choices as $address => $id) {
                     if ($address === $data->getShippingMultipleDefaultName()) {
                         $form['customer_address']->setData($id);

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -508,6 +508,7 @@ class OrderRepository extends AbstractRepository
      * 会員が保持する最新の購入処理中の Order を取得する.
      *
      * @param Customer
+     *
      * @return Order
      */
     public function getExistsOrdersByCustomer(\Eccube\Entity\Customer $Customer)

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -2188,8 +2188,6 @@ return [
     'admin.store.unregisterd_plugin_table.950' => '設定',
     'admin.store.install.label' => 'プラグイン (zip、tar、tar.gz形式)',
 
-
-
     //asdasdasdas
     'application.text.error.access' => '',
     'application.text.error.access.message' => 'お探しのページはアクセスができない状況にあるか、移動もしくは削除された可能性があります。',

--- a/src/Eccube/Resource/locale/validators.ja.php
+++ b/src/Eccube/Resource/locale/validators.ja.php
@@ -16,6 +16,6 @@ return [
     'This value should be the user\'s current password.' => '現在のパスワードが正しくありません。',
     'Invalid twig format. {{ error }}' => 'Twigのフォーマットが正しくありません。{{ error }}',
     'form.type.float.invalid' => '数字と小数点のみ入力できます。',
-    'admin.system.member.form.not.blank'=> '入力されていません。',
+    'admin.system.member.form.not.blank' => '入力されていません。',
     'form.type.numeric.invalid' => '数字で入力してください。',
 ];

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -22,12 +22,9 @@ use Eccube\Repository\ProductClassRepository;
 use Eccube\Repository\OrderRepository;
 use Eccube\Service\Cart\CartItemAllocator;
 use Eccube\Service\Cart\CartItemComparator;
-use Eccube\Service\OrderHelper;
-use Eccube\Util\StringUtil;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\EntityManagerInterface;
 
 class CartService
@@ -130,7 +127,6 @@ class CartService
         }
 
         foreach ($this->carts as &$Cart) {
-
             /** @var CartItem $item */
             foreach ($Cart->getItems() as $item) {
                 /** @var ProductClass $ProductClass */
@@ -146,7 +142,6 @@ class CartService
      * 会員が保持する購入処理中の受注と、カートをマージする.
      *
      * @param Customer $Customer
-     * @return void
      */
     public function mergeFromOrders(Customer $Customer)
     {
@@ -340,6 +335,7 @@ class CartService
         if ($Carts) {
             $this->carts = $Carts;
         }
+
         return $this->session->set('carts', $this->carts);
     }
 
@@ -363,6 +359,7 @@ class CartService
 
     /**
      * @return bool
+     *
      * @deprecated
      */
     public function isLocked()

--- a/src/Eccube/Service/Composer/ComposerProcessService.php
+++ b/src/Eccube/Service/Composer/ComposerProcessService.php
@@ -40,6 +40,7 @@ class ComposerProcessService implements ComposerServiceInterface
 
     /**
      * ComposerProcessService constructor.
+     *
      * @param EccubeConfig $eccubeConfig
      * @param EntityManagerInterface $entityManager
      * @param SystemService $systemService

--- a/src/Eccube/Service/MailService.php
+++ b/src/Eccube/Service/MailService.php
@@ -390,7 +390,9 @@ class MailService
      * @param Order $Order 受注情報
      * @param $formData 入力内容
      * @param string $twig テンプレートファイル名
+     *
      * @return $this
+     *
      * @throws \Twig_Error_Loader
      * @throws \Twig_Error_Runtime
      * @throws \Twig_Error_Syntax

--- a/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeeProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeeProcessor.php
@@ -64,7 +64,6 @@ class DeliveryFeeProcessor implements ItemHolderProcessor
         $this->deliveryFeeRepository = $deliveryFeeRepository;
     }
 
-
     /**
      * @param ItemHolderInterface $itemHolder
      * @param PurchaseContext     $context

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -208,8 +208,7 @@ class ShoppingService
         OrderService $orderService,
         BaseInfo $BaseInfo,
         AuthorizationCheckerInterface $authorizationChecker
-    )
-    {
+    ) {
         $this->mailTemplateRepository = $mailTemplateRepository;
         $this->mailService = $mailService;
         $this->eventDispatcher = $eventDispatcher;

--- a/tests/Eccube/Tests/Entity/OrderTest.php
+++ b/tests/Eccube/Tests/Entity/OrderTest.php
@@ -144,7 +144,7 @@ class OrderTest extends EccubeTestCase
         $Order = new Order();
         $ItemProduct = $this->entityManager->find(OrderItemType::class, OrderItemType::PRODUCT);
 
-        foreach(range(1,$times) as $i){
+        foreach (range(1, $times) as $i) {
             $Shipping = new Shipping();
 
             $OrderItem = new OrderItem();
@@ -177,6 +177,5 @@ class OrderTest extends EccubeTestCase
         $this->expected = $quantity * $times;
         $this->actual = $OrderItem->getQuantity();
         $this->verify();
-
     }
 }

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DeliveryFeeFreeByShippingProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DeliveryFeeFreeByShippingProcessorTest.php
@@ -1,24 +1,14 @@
 <?php
+
 /*
  * This file is part of EC-CUBE
  *
- * Copyright(c) 2000-2018 LOCKON CO.,LTD. All Rights Reserved.
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
  *
  * http://www.lockon.co.jp/
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 namespace Eccube\Tests\Service\PurchaseFlow\Processor;
@@ -46,7 +36,6 @@ class DeliveryFeeFreeByShippingProcessorTest extends EccubeTestCase
         $this->DeliveryFeeType = $this->entityManager->find(OrderItemType::class, OrderItemType::DELIVERY_FEE);
     }
 
-
     /**
      * 送料無料条件が設定されていない場合
      */
@@ -69,6 +58,7 @@ class DeliveryFeeFreeByShippingProcessorTest extends EccubeTestCase
      * 送料無料条件(金額)が設定されている場合
      *
      * @dataProvider deliveryFreeAmountProvider
+     *
      * @param $amount int 受注金額
      * @param $expectedFee int 期待する送料
      */
@@ -101,6 +91,7 @@ class DeliveryFeeFreeByShippingProcessorTest extends EccubeTestCase
      * 送料無料条件(数量)が設定されている場合
      *
      * @dataProvider deliveryFreeQuantityProvider
+     *
      * @param $quantity int 数量
      * @param $expectedFee int 期待する送料
      */
@@ -184,6 +175,7 @@ class DeliveryFeeFreeByShippingProcessorTest extends EccubeTestCase
         $BaseInfo = new BaseInfo();
         $BaseInfo->setDeliveryFreeAmount($deliveryFeeAmount);
         $BaseInfo->setDeliveryFreeQuantity($deliveryFeeQuantity);
+
         return $BaseInfo;
     }
 
@@ -195,6 +187,7 @@ class DeliveryFeeFreeByShippingProcessorTest extends EccubeTestCase
         $prop->setAccessible(true);
         $prop->setValue($Shipping, $id);
         $Shipping->setName01("name_${id}");
+
         return $Shipping;
     }
 
@@ -206,6 +199,7 @@ class DeliveryFeeFreeByShippingProcessorTest extends EccubeTestCase
         $OrderItem->setQuantity($quantity);
         $OrderItem->setShipping($Shipping);
         $Shipping->addOrderItem($OrderItem);
+
         return $OrderItem;
     }
 
@@ -217,6 +211,7 @@ class DeliveryFeeFreeByShippingProcessorTest extends EccubeTestCase
         $OrderItem->setQuantity(1);
         $OrderItem->setShipping($Shipping);
         $Shipping->addOrderItem($OrderItem);
+
         return $OrderItem;
     }
 }

--- a/tests/Eccube/Tests/Web/Admin/Setting/Shop/MailControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/Shop/MailControllerTest.php
@@ -24,8 +24,8 @@ class MailControllerTest extends AbstractAdminWebTestCase
     public function tearDown()
     {
         $themeDir = $this->container->getParameter('eccube_theme_front_dir');
-        if (file_exists($themeDir . '/Mail/order.twig')) {
-            unlink($themeDir . '/Mail/order.twig');
+        if (file_exists($themeDir.'/Mail/order.twig')) {
+            unlink($themeDir.'/Mail/order.twig');
         }
         parent::tearDown();
     }

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleNonmemberTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleNonmemberTest.php
@@ -12,6 +12,7 @@
  */
 
 namespace Eccube\Tests\Web;
+
 use Eccube\Entity\Order;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\OrderRepository;
@@ -1317,7 +1318,7 @@ class ShoppingControllerWithMultipleNonmemberTest extends AbstractShoppingContro
         $this->client->request('POST', $this->generateUrl('product_add_cart', ['id' => '1']), [
             'ProductClass' => '1',
             'quantity' => $maxAddress,
-            '_token' => 'dummy'
+            '_token' => 'dummy',
         ]);
         $this->scenarioCartIn();
 

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
@@ -13,7 +13,6 @@
 
 namespace Eccube\Tests\Web;
 
-use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\Master\OrderStatusRepository;
@@ -1573,7 +1572,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
         );
 
         // FIXME ユニットテストではステータスが変わらない
-        /** @var OrderStatus $OrderNew */
+        /* @var OrderStatus $OrderNew */
 //        $OrderNew = $this->orderStatusRepository->find(OrderStatus::NEW);
 //        $this->expected = $OrderNew->getId();
 //        $this->actual = $Order->getOrderStatus()->getId();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ UnitTestを実行する前にPHP-CS-Fixerを実行するように修正
+ PHP-CS-Fixerで変更が必要な場合はTravisのテストが失敗する
