### PR TITLE
複数配送設定時のPurchaseFlowのハンドリングを調整

### DIFF
--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -1457,10 +1457,8 @@ class Order extends \Eccube\Entity\AbstractEntity implements PurchaseInterface, 
     {
         $Shippings = [];
         foreach ($this->getOrderItems() as $OrderItem) {
-            $Shipping = $OrderItem->getShipping();
-            if (is_object($Shipping)) {
-                $name = $Shipping->getName01(); // XXX lazy loading
-                $Shippings[$Shipping->getId()] = $Shipping;
+            if ($Shipping = $OrderItem->getShipping()) {
+                $Shippings[\spl_object_id($Shipping)] = $Shipping;
             }
         }
         $Result = new \Doctrine\Common\Collections\ArrayCollection();

--- a/src/Eccube/Entity/Shipping.php
+++ b/src/Eccube/Entity/Shipping.php
@@ -245,7 +245,7 @@ class Shipping extends \Eccube\Entity\AbstractEntity
     /**
      * @var \Doctrine\Common\Collections\Collection
      *
-     * @ORM\OneToMany(targetEntity="Eccube\Entity\OrderItem", mappedBy="Shipping")
+     * @ORM\OneToMany(targetEntity="Eccube\Entity\OrderItem", mappedBy="Shipping", cascade={"persist"})
      */
     private $OrderItems;
 

--- a/src/Eccube/Resource/template/default/Shopping/shipping_multiple.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping_multiple.twig
@@ -65,6 +65,36 @@ $(function() {
 
 {% block main %}
     <h1 class="page-heading">お届け先の複数指定</h1>
+    {# TODO エラーメッセージ #}
+    <div id="confirm_flow_box" class="row">
+        <div id="confirm_flow_box__body" class="col-md-12">
+            {% for error in app.session.flashbag.get('eccube.front.error')  %}
+                <div id="confirm_flow_box__message" class="message">
+                    <p class="errormsg bg-danger">
+                        <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>{{ error|trans|nl2br }}
+                    </p>
+                </div>
+            {% endfor %}
+            {% set productStr = app.session.flashbag.get('eccube.front.request.product') %}
+            {% for error in app.session.flashbag.get('eccube.front.request.error')  %}
+                {% set idx = loop.index0 %}
+                {% if productStr[idx] is defined %}
+                    <div id="cart_box__message--{{ loop.index }}" class="message">
+                        <p class="errormsg bg-danger">
+                            <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>
+                            {{ error|trans({'%product%':productStr[idx]})|nl2br }}
+                        </p>
+                    </div>
+                {% else %}
+                    <div id="confirm_flow_box__message--{{ loop.index }}" class="message">
+                        <p class="errormsg bg-danger">
+                            <svg class="cb cb-warning"><use xlink:href="#cb-warning" /></svg>{{ error|trans|nl2br }}
+                        </p>
+                    </div>
+                {% endif %}
+            {% endfor %}
+        </div><!-- /.col -->
+    </div><!-- /.row -->
     <div id="multiple_wrap" class="container-fluid">
         <form id="shipping-multiple-form" method="post" action="{{ url('shopping_shipping_multiple') }}">
             {{ form_widget(form._token) }}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
以下のようにハンドリングを調整

- Warning時は変更を永続化せず、同一画面上でエラー内容を表示する
- Error時は購入エラーとしてカートへ戻す

その他微調整
- Order::getShippingではshipping idで重複を除外しているが、ここでは永続化前のShippingを渡す必要があるため、object_idで除外するように修正
- https://github.com/EC-CUBE/ec-cube/compare/experimental/sf...chihiro-adachi:dev-purchase-error?expand=1#diff-f71d9274f9c9a50a73fc3b24d4f3b7e8L1463 





