### PR TITLE
販売価格の変更を検知するプロセッサを追加

### DIFF
--- a/app/config/eccube/packages/purchaseflow.yaml
+++ b/app/config/eccube/packages/purchaseflow.yaml
@@ -17,6 +17,7 @@ services:
                 - '@Eccube\Service\PurchaseFlow\Processor\DeliverySettingValidator'
                 - '@Eccube\Service\PurchaseFlow\Processor\StockValidator'
                 - '@Eccube\Service\PurchaseFlow\Processor\ProductStatusValidator'
+                - '@Eccube\Service\PurchaseFlow\Processor\PriceChangeValidator'
 
     eccube.purchase.flow.cart.holder_processors:
         class: Doctrine\Common\Collections\ArrayCollection
@@ -43,6 +44,7 @@ services:
                 - '@Eccube\Service\PurchaseFlow\Processor\DisplayStatusValidator'
                 - '@Eccube\Service\PurchaseFlow\Processor\DeliverySettingValidator'
                 - '@Eccube\Service\PurchaseFlow\Processor\ProductStatusValidator'
+                - '@Eccube\Service\PurchaseFlow\Processor\PriceChangeValidator'
 
     eccube.purchase.flow.shopping.holder_processors:
         class: Doctrine\Common\Collections\ArrayCollection

--- a/src/Eccube/Controller/Block/CartController.php
+++ b/src/Eccube/Controller/Block/CartController.php
@@ -49,8 +49,9 @@ class CartController extends AbstractController
     public function index()
     {
         $Carts = $this->cartService->getCarts();
-        // TODO ここで集計しないほうがよい？
-        $this->execPurchaseFlow($Carts);
+
+        // 二重に実行され, 注文画面でのエラーハンドリングができないので
+        // ここではpurchaseFlowは実行しない
 
         $totalQuantity = array_reduce($Carts, function ($total, $Cart) {
             /* @var Cart $Cart */

--- a/src/Eccube/Controller/ShippingMultipleController.php
+++ b/src/Eccube/Controller/ShippingMultipleController.php
@@ -26,6 +26,8 @@ use Eccube\Form\Type\ShippingMultipleType;
 use Eccube\Repository\Master\OrderItemTypeRepository;
 use Eccube\Repository\Master\PrefRepository;
 use Eccube\Repository\OrderRepository;
+use Eccube\Service\PurchaseFlow\PurchaseContext;
+use Eccube\Service\PurchaseFlow\PurchaseFlow;
 use Eccube\Service\ShoppingService;
 use Eccube\Service\CartService;
 use Eccube\Service\OrderHelper;
@@ -57,6 +59,11 @@ class ShippingMultipleController extends AbstractShoppingController
     protected $cartService;
 
     /**
+     * @var PurchaseFlow
+     */
+    protected $cartPurchaseFlow;
+
+    /**
      * @var OrderRepository
      */
     protected $orderRepository;
@@ -81,7 +88,8 @@ class ShippingMultipleController extends AbstractShoppingController
         OrderItemTypeRepository $orderItemTypeRepository,
         ShoppingService $shoppingService,
         CartService $cartService,
-        OrderHelper $orderHelper
+        OrderHelper $orderHelper,
+        PurchaseFlow $cartPurchaseFlow
     ) {
         $this->prefRepository = $prefRepository;
         $this->orderRepository = $orderRepository;
@@ -89,6 +97,7 @@ class ShippingMultipleController extends AbstractShoppingController
         $this->shoppingService = $shoppingService;
         $this->cartService = $cartService;
         $this->orderHelper = $orderHelper;
+        $this->cartPurchaseFlow = $cartPurchaseFlow;
     }
 
     /**
@@ -344,6 +353,7 @@ class ShippingMultipleController extends AbstractShoppingController
                 }
             }
 
+            $this->cartPurchaseFlow->calculate($Cart, new PurchaseContext());
             $this->cartService->save();
 
             return $this->redirectToRoute('shopping');

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -125,6 +125,9 @@ class ShoppingController extends AbstractShoppingController
         // 単価集計
         $flowResult = $this->executePurchaseFlow($Order);
 
+        // 明細が丸められる場合に, カートから注文画面へ遷移できなくなるため, 集計の結果を保存する
+        $this->entityManager->flush();
+
         // フォームを生成する
         $this->forwardToRoute('shopping_create_form');
 

--- a/src/Eccube/Entity/ProductClass.php
+++ b/src/Eccube/Entity/ProductClass.php
@@ -35,7 +35,7 @@ class ProductClass extends \Eccube\Entity\AbstractEntity
      *
      * @return string
      */
-    public function formatProductName()
+    public function formatedProductName()
     {
         $productName = $this->getProduct()->getName();
         if ($this->hasClassCategory1()) {

--- a/src/Eccube/Entity/ProductClass.php
+++ b/src/Eccube/Entity/ProductClass.php
@@ -31,6 +31,24 @@ class ProductClass extends \Eccube\Entity\AbstractEntity
     private $tax_rate = false;
 
     /**
+     * 商品規格名を含めた商品名を返す.
+     *
+     * @return string
+     */
+    public function formatProductName()
+    {
+        $productName = $this->getProduct()->getName();
+        if ($this->hasClassCategory1()) {
+            $productName .= ' - '.$this->getClassCategory1()->getName();
+        }
+        if ($this->hasClassCategory2()) {
+            $productName .= ' - '.$this->getClassCategory2()->getName();
+        }
+
+        return $productName;
+    }
+
+    /**
      * Is Enable
      *
      * @return bool

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -508,6 +508,7 @@ return [
     'cart.product.not.status' => '現時点で購入できない商品が含まれておりました。該当商品をカートから削除しました。',
     'cart.product.not.saletype' => '「%product%」はまだ配送の準備ができておりません。
 恐れ入りますがお問い合わせページよりお問い合わせください。',
+    'cart.product.price.change' => '「%product%」の販売価格が変更されました。',
     'shopping.multiple.delivery' => '配送方法が異なる商品が含まれているため、お届け先は複数となります。',
     'shopping.multiple.quantity.diff' => '数量の合計が、カゴの中の数量と異なっています。',
     'shopping.delivery.not.saletype' => '配送の準備ができていない商品が含まれております。

--- a/src/Eccube/Service/PurchaseFlow/Processor/PriceChangeValidator.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PriceChangeValidator.php
@@ -43,7 +43,7 @@ class PriceChangeValidator extends ValidatableItemProcessor
 
         $realPrice = $item->getProductClass()->getPrice02IncTax();
 
-        if ($price !== $realPrice) {
+        if ($price != $realPrice) {
             $this->throwInvalidItemException('cart.product.price.change', $item->getProductClass());
         }
     }

--- a/src/Eccube/Service/PurchaseFlow/Processor/PriceChangeValidator.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PriceChangeValidator.php
@@ -46,7 +46,7 @@ class PriceChangeValidator implements ItemProcessor
         $realPrice = $item->getProductClass()->getPrice02IncTax();
         if ($price != $realPrice) {
             $message = trans('cart.product.price.change',
-                ['%product%' => $item->getProductClass()->formatProductName()]);
+                ['%product%' => $item->getProductClass()->formatedProductName()]);
 
             if ($item instanceof OrderItem) {
                 $item->setPrice($item->getProductClass()->getPrice02());

--- a/src/Eccube/Service/PurchaseFlow/Processor/PriceChangeValidator.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PriceChangeValidator.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\PurchaseFlow\Processor;
+
+use Eccube\Entity\ItemInterface;
+use Eccube\Entity\OrderItem;
+use Eccube\Service\PurchaseFlow\PurchaseContext;
+use Eccube\Service\PurchaseFlow\ValidatableItemProcessor;
+
+/**
+ * 販売価格の変更検知.
+ */
+class PriceChangeValidator extends ValidatableItemProcessor
+{
+    /**
+     * @param ItemInterface $item
+     * @param PurchaseContext $context
+     *
+     * @throws \Eccube\Service\PurchaseFlow\InvalidItemException
+     */
+    protected function validate(ItemInterface $item, PurchaseContext $context)
+    {
+        if (!$item->isProduct()) {
+            return;
+        }
+
+        if ($item instanceof OrderItem) {
+            $price = $item->getPriceIncTax();
+        } else {
+            $price = $item->getPrice();
+        }
+
+        $realPrice = $item->getProductClass()->getPrice02IncTax();
+
+        if ($price !== $realPrice) {
+            $this->throwInvalidItemException('cart.product.price.change', $item->getProductClass());
+        }
+    }
+
+    protected function handle(ItemInterface $item, PurchaseContext $context)
+    {
+        $price = $item->getProductClass()->getPrice02IncTax();
+        $item->setPrice($price);
+    }
+}

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PriceChangeValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PriceChangeValidatorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Service;
+
+use Eccube\Entity\CartItem;
+use Eccube\Entity\Product;
+use Eccube\Entity\ProductClass;
+use Eccube\Service\PurchaseFlow\Processor\PriceChangeValidator;
+use Eccube\Service\PurchaseFlow\PurchaseContext;
+use Eccube\Tests\EccubeTestCase;
+
+class PriceChangeValidatorTest extends EccubeTestCase
+{
+    /**
+     * @var PriceChangeValidator
+     */
+    protected $validator;
+
+    /**
+     * @var CartItem
+     */
+    protected $cartItem;
+
+    /**
+     * @var Product
+     */
+    protected $Product;
+
+    /**
+     * @var ProductClass
+     */
+    protected $ProductClass;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->Product = $this->createProduct('テスト商品', 1);
+        $this->ProductClass = $this->Product->getProductClasses()[0];
+        $this->validator = $this->container->get(PriceChangeValidator::class);
+        $this->cartItem = new CartItem();
+        $this->cartItem->setProductClass($this->ProductClass);
+    }
+
+    public function testInstance()
+    {
+        self::assertInstanceOf(PriceChangeValidator::class, $this->validator);
+        self::assertSame($this->ProductClass, $this->cartItem->getProductClass());
+    }
+
+    public function testNoChange()
+    {
+        $this->ProductClass->setPrice02(100);
+        $this->cartItem->setPrice($this->ProductClass->getPrice02IncTax());
+        $result = $this->validator->process($this->cartItem, new PurchaseContext());
+        self::assertTrue($result->isSuccess());
+    }
+
+    public function testChange()
+    {
+        $this->ProductClass->setPrice02(100);
+        $this->cartItem->setPrice(50);
+        $result = $this->validator->process($this->cartItem, new PurchaseContext());
+        self::assertTrue($result->isWarning());
+        self::assertSame($this->ProductClass->getPrice02IncTax(), $this->cartItem->getPrice());
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- カートおよび注文画面で販売価格の変更を検知するように修正
- カートでは、販売価格変更時にエラーを表示し、変更後の価格に更新する
- 注文画面では変更検知のみ行い、カート画面に戻す

## テスト（Test)
- プロセッサのテストを追加しています




