### PR TITLE
カテゴリー数が多いと商品一覧が遅くなる問題を修正

### DIFF
--- a/src/Eccube/Form/Type/SearchProductBlockType.php
+++ b/src/Eccube/Form/Type/SearchProductBlockType.php
@@ -51,8 +51,21 @@ class SearchProductBlockType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $Categories = $this->app['eccube.repository.category']
-            ->getList(null, true);
+        $Categories = array();
+        $AllCategories = $this->app['eccube.repository.category']
+            ->getList();
+        foreach ($AllCategories as $Category) {
+            $Parent = $Category->getParent();
+            if (!$Parent) {
+                $Categories[] = $Category;
+                continue;
+            }
+            $Parent = $Parent->getParent();
+            if (!$Parent) {
+                $Categories[] = $Category;
+                continue;
+            }
+        }
 
         $builder->add('category_id', 'entity', array(
             'class' => 'Eccube\Entity\Category',

--- a/src/Eccube/Form/Type/SearchProductType.php
+++ b/src/Eccube/Form/Type/SearchProductType.php
@@ -54,8 +54,21 @@ class SearchProductType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $Categories = $this->app['eccube.repository.category']
-            ->getList(null, true);
+        $Categories = array();
+        $AllCategories = $this->app['eccube.repository.category']
+            ->getList();
+        foreach ($AllCategories as $Category) {
+            $Parent = $Category->getParent();
+            if (!$Parent) {
+                $Categories[] = $Category;
+                continue;
+            }
+            $Parent = $Parent->getParent();
+            if (!$Parent) {
+                $Categories[] = $Category;
+                continue;
+            }
+        }
 
         $builder->add('mode', 'hidden', array(
             'data' => 'search',

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -102,7 +102,7 @@ class ProductRepository extends EntityRepository
         // category
         $categoryJoin = false;
         if (!empty($searchData['category_id']) && $searchData['category_id']) {
-            $Categories = $searchData['category_id']->getSelfAndDescendants();
+            $Categories = array($searchData['category_id']);
             if ($Categories) {
                 $qb
                     ->innerJoin('p.ProductCategories', 'pct')


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ カテゴリーが4階層3000件のケースで発生。カテゴリー数分クエリが発行されているため、パフォーマンスが劇的に低下していた。
+ https://xoops.ec-cube.net/modules/newbb/viewtopic.php?topic_id=20345&forum=10

## 方針(Policy)
+ クエリ発行回数を減らすために全カテゴリー情報を取得してphp側で処理するよう修正。

## 実装に関する補足(Appendix)
+ 

## テスト（Test)
+ 商品一覧、商品検索

## 相談（Discussion）
+ 
