### PR TITLE
カートの削除コマンドを追加

### DIFF
--- a/src/Eccube/Command/DeleteCartsCommand.php
+++ b/src/Eccube/Command/DeleteCartsCommand.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class DeleteCartsCommand extends Command
+{
+    protected static $defaultName = 'eccube:delete-carts';
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var SymfonyStyle
+     */
+    protected $io;
+
+    /**
+     * @var string
+     */
+    protected $locale;
+
+    /**
+     * @var \DateTimeZone
+     */
+    protected $timezone;
+
+    /**
+     * @var \IntlDateFormatter
+     */
+    protected $formatter;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $entityManager;
+
+    public function __construct(ContainerInterface $container, EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+
+        $this->container = $container;
+        $this->entityManager = $entityManager;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Delete Carts from the database')
+            ->addArgument('date', InputArgument::REQUIRED, '指定した日付以前のカート情報を削除します.');
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        if (null !== $input->getArgument('date')) {
+            return;
+        }
+
+        $this->io->title('Delete Cart Command Interactive Wizard');
+        $this->io->text([
+            'If you prefer to not use this interactive wizard, provide the',
+            'arguments required by this command as follows:',
+            '',
+            ' $ php bin/console eccube:delete-cart yyyy/mm/dd',
+            '',
+            'Now we\'ll ask you for the value of all the missing command arguments.',
+            '',
+        ]);
+
+        $now = new \DateTime('now', $this->timezone);
+
+        $dateStr = $this->formatter->format($now->getTimestamp());
+        $dateStr = $this->io->ask('date', $dateStr);
+
+        $input->setArgument('date', $dateStr);
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->io = new SymfonyStyle($input, $output);
+        $this->locale = $this->container->getParameter('locale');
+        $this->timezone = new \DateTimeZone($this->container->getParameter('timezone'));
+        $this->formatter = $this->createIntlFormatter();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $dateStr = $input->getArgument('date');
+        $timestamp = $this->formatter->parse($dateStr);
+        $dateTime = new \DateTime("@$timestamp", $this->timezone);
+
+        //$this->deleteCarts($dateTime);
+
+        $this->io->success('Delete carts successful.');
+    }
+
+    protected function deleteCarts(\DateTime $dateTime)
+    {
+        $batchSize = 20;
+        $i = 0;
+
+        $q = $this->entityManager->createQuery('SELECT c FROM Eccube\Entity\Cart c WHERE c.update_date <= :date');
+        $q->setParameter('date', $dateTime);
+
+        $iterableResult = $q->iterate();
+        while (($row = $iterableResult->next()) !== false) {
+            $this->entityManager->remove($row[0]);
+            if (($i % $batchSize) === 0) {
+                $this->flush(); // Executes all deletions.
+                $this->clear(); // Detaches all objects from Doctrine!
+            }
+            ++$i;
+        }
+        $this->entityManager->flush();
+
+        return;
+    }
+
+    protected function createIntlFormatter()
+    {
+        return \IntlDateFormatter::create(
+            $this->locale,
+            \IntlDateFormatter::MEDIUM,
+            \IntlDateFormatter::NONE,
+            $this->timezone,
+            \IntlDateFormatter::GREGORIAN
+        );
+    }
+}

--- a/src/Eccube/Command/DeleteCartsCommand.php
+++ b/src/Eccube/Command/DeleteCartsCommand.php
@@ -128,8 +128,8 @@ class DeleteCartsCommand extends Command
             while (($row = $iterableResult->next()) !== false) {
                 $this->entityManager->remove($row[0]);
                 if (($i % $batchSize) === 0) {
-                    $this->flush(); // Executes all deletions.
-                    $this->clear(); // Detaches all objects from Doctrine!
+                    $this->entityManager->flush(); // Executes all deletions.
+                    $this->entityManager->clear(); // Detaches all objects from Doctrine!
                 }
                 ++$i;
             }

--- a/src/Eccube/Command/DeleteCartsCommand.php
+++ b/src/Eccube/Command/DeleteCartsCommand.php
@@ -73,7 +73,7 @@ class DeleteCartsCommand extends Command
     {
         $this
             ->setDescription('Delete Carts from the database')
-            ->addArgument('date', InputArgument::REQUIRED, 'Deletes the cart before the specified date');
+            ->addArgument('date', InputArgument::REQUIRED, 'Deletes carts before the specified date');
     }
 
     protected function interact(InputInterface $input, OutputInterface $output)

--- a/src/Eccube/Command/DeleteCartsCommand.php
+++ b/src/Eccube/Command/DeleteCartsCommand.php
@@ -73,7 +73,7 @@ class DeleteCartsCommand extends Command
     {
         $this
             ->setDescription('Delete Carts from the database')
-            ->addArgument('date', InputArgument::REQUIRED, '指定した日付以前のカート情報を削除します.');
+            ->addArgument('date', InputArgument::REQUIRED, 'Deletes the cart before the specified date');
     }
 
     protected function interact(InputInterface $input, OutputInterface $output)
@@ -82,12 +82,13 @@ class DeleteCartsCommand extends Command
             return;
         }
 
+        $pattern = $this->formatter->getPattern();
         $this->io->title('Delete Cart Command Interactive Wizard');
         $this->io->text([
             'If you prefer to not use this interactive wizard, provide the',
             'arguments required by this command as follows:',
             '',
-            ' $ php bin/console eccube:delete-cart yyyy/mm/dd',
+            ' $ php bin/console eccube:delete-cart <'.$pattern.'>',
             '',
             'Now we\'ll ask you for the value of all the missing command arguments.',
             '',

--- a/src/Eccube/Entity/Cart.php
+++ b/src/Eccube/Entity/Cart.php
@@ -66,7 +66,7 @@ class Cart extends AbstractEntity implements PurchaseInterface, ItemHolderInterf
     /**
      * @var \Doctrine\Common\Collections\Collection|CartItem[]
      *
-     * @ORM\OneToMany(targetEntity="Eccube\Entity\CartItem", mappedBy="Cart", cascade={"persist","remove"})
+     * @ORM\OneToMany(targetEntity="Eccube\Entity\CartItem", mappedBy="Cart", cascade={"persist"})
      */
     private $CartItems;
 

--- a/src/Eccube/Entity/CartItem.php
+++ b/src/Eccube/Entity/CartItem.php
@@ -66,7 +66,7 @@ class CartItem extends \Eccube\Entity\AbstractEntity implements ItemInterface
      *
      * @ORM\ManyToOne(targetEntity="Eccube\Entity\Cart", inversedBy="CartItems")
      * @ORM\JoinColumns({
-     *   @ORM\JoinColumn(name="cart_id", referencedColumnName="id")
+     *   @ORM\JoinColumn(name="cart_id", referencedColumnName="id", onDelete="CASCADE")
      * })
      */
     private $Cart;

--- a/tests/Eccube/Tests/Command/DeleteCartsCommandTest.php
+++ b/tests/Eccube/Tests/Command/DeleteCartsCommandTest.php
@@ -45,6 +45,7 @@ class DeleteCartsCommandTest extends EccubeTestCase
         $CartItem->setProductClass($ProductClass);
         $CartItem->setQuantity(1);
         $CartItem->setPrice(1000);
+        $CartItem->setCart($Cart);
         $Cart->addCartItem($CartItem);
 
         $this->entityManager->persist($Cart);
@@ -79,6 +80,7 @@ class DeleteCartsCommandTest extends EccubeTestCase
         $CartItem->setProductClass($ProductClass);
         $CartItem->setQuantity(1);
         $CartItem->setPrice(1000);
+        $CartItem->setCart($Cart);
         $Cart->addCartItem($CartItem);
 
         $this->entityManager->persist($Cart);

--- a/tests/Eccube/Tests/Command/DeleteCartsCommandTest.php
+++ b/tests/Eccube/Tests/Command/DeleteCartsCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2018 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Tests\Command;
+
+use Eccube\Command\DeleteCartsCommand;
+use Eccube\Entity\Cart;
+use Eccube\Entity\CartItem;
+use Eccube\Entity\ProductClass;
+use Eccube\Tests\EccubeTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DeleteCartsCommandTest extends EccubeTestCase
+{
+
+    public function testDeleteCarts()
+    {
+        $Product = $this->createProduct();
+        /** @var ProductClass $ProductClass */
+        $ProductClass = $Product->getProductClasses()[0];
+        $Cart = new Cart();
+        $Cart->setTotalPrice(1000);
+        $Cart->setDeliveryFeeTotal(0);
+
+        $CartItem = new CartItem();
+        $CartItem->setProductClass($ProductClass);
+        $CartItem->setQuantity(1);
+        $CartItem->setPrice(1000);
+        $Cart->addCartItem($CartItem);
+
+        $this->entityManager->persist($Cart);
+        $this->entityManager->flush();
+
+        $id = $Cart->getId();
+
+        self::assertNotNull($this->entityManager->find(Cart::class, $id));
+
+        /** @var DeleteCartsCommand $command */
+        $command = $this->container->get(DeleteCartsCommand::class);
+
+        $tester = new CommandTester($command);
+        $tomorrow = new \DateTime('tomorrow');
+        $tester->execute(['date'=>$tomorrow->format('Y/m/d')]);
+
+        $this->entityManager->clear();
+
+        self::assertNull($this->entityManager->find(Cart::class, $id));
+    }
+}

--- a/tests/Eccube/Tests/Command/DeleteCartsCommandTest.php
+++ b/tests/Eccube/Tests/Command/DeleteCartsCommandTest.php
@@ -49,7 +49,7 @@ class DeleteCartsCommandTest extends EccubeTestCase
         $command = $this->container->get(DeleteCartsCommand::class);
 
         $tester = new CommandTester($command);
-        $tomorrow = new \DateTime('tomorrow');
+        $tomorrow = new \DateTime('+2day');
         $tester->execute(['date' => $tomorrow->format('Y/m/d')]);
 
         $this->entityManager->clear();

--- a/tests/Eccube/Tests/Command/DeleteCartsCommandTest.php
+++ b/tests/Eccube/Tests/Command/DeleteCartsCommandTest.php
@@ -1,24 +1,14 @@
 <?php
+
 /*
  * This file is part of EC-CUBE
  *
- * Copyright(c) 2000-2018 LOCKON CO.,LTD. All Rights Reserved.
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
  *
  * http://www.lockon.co.jp/
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 namespace Eccube\Tests\Command;
@@ -60,7 +50,7 @@ class DeleteCartsCommandTest extends EccubeTestCase
 
         $tester = new CommandTester($command);
         $tomorrow = new \DateTime('tomorrow');
-        $tester->execute(['date'=>$tomorrow->format('Y/m/d')]);
+        $tester->execute(['date' => $tomorrow->format('Y/m/d')]);
 
         $this->entityManager->clear();
 
@@ -95,7 +85,7 @@ class DeleteCartsCommandTest extends EccubeTestCase
 
         $tester = new CommandTester($command);
         $tomorrow = new \DateTime('yesterday');
-        $tester->execute(['date'=>$tomorrow->format('Y/m/d')]);
+        $tester->execute(['date' => $tomorrow->format('Y/m/d')]);
 
         $this->entityManager->clear();
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

カートの削除コマンドを追加

```
bin/console eccube:delete-carts <yyyy/mm/dd>
```

で、指定した日付以前のカート情報を削除する。

もしくは対話形式で日付を指定することも可能です。

```
bin/console eccube:delete-carts

Delete Cart Command Interactive Wizard
======================================

 If you prefer to not use this interactive wizard, provide the
 arguments required by this command as follows:
 
  $ php bin/console eccube:delete-cart yyyy/mm/dd
 
 Now we'll ask you for the value of all the missing command arguments.
 

 date [2018/06/12]:
 > 2018/06/30

```

