### PR TITLE
cache:clearコマンドでpluginディレクトリが対象外となっていたため追加

### DIFF
--- a/src/Eccube/Util/Cache.php
+++ b/src/Eccube/Util/Cache.php
@@ -23,9 +23,9 @@
 
 namespace Eccube\Util;
 
+use Eccube\Application;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
-use Eccube\Application;
 
 /**
  * キャッシュ関連のユーティリティクラス.
@@ -74,6 +74,8 @@ class Cache
                 $finder = Finder::create()->in($cacheDir.'/translator');
                 $filesystem->remove($finder);
             }
+            // プラグインキャッシュファイルの削除
+            $app->removePluginConfigCache();
         }
 
         if (function_exists('opcache_reset')) {

--- a/src/Eccube/Util/Cache.php
+++ b/src/Eccube/Util/Cache.php
@@ -75,7 +75,10 @@ class Cache
                 $filesystem->remove($finder);
             }
             // プラグインキャッシュファイルの削除
-            $app->removePluginConfigCache();
+            $pluginCacheFile = $app['config']['plugin_temp_realdir'].'/config_cache.php';
+            if (file_exists($pluginCacheFile)) {
+                unlink($pluginCacheFile);
+            }
         }
 
         if (function_exists('opcache_reset')) {

--- a/tests/Eccube/Tests/Util/CacheTest.php
+++ b/tests/Eccube/Tests/Util/CacheTest.php
@@ -41,6 +41,8 @@ class CacheTest extends \PHPUnit_Framework_TestCase
                 file_put_contents($this->app['config']['root_dir'].'/app/cache/'.$dir.'/'.$i, 'test');
             }
         }
+
+        $this->app['config']['plugin_temp_realdir'] = $this->app['config']['root_dir'].'/app/cache/plugin';
     }
 
     public function testClearAll()
@@ -77,5 +79,17 @@ class CacheTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertTrue($this->root->hasChild('app/cache/.gitkeep'), '.gitkeep は存在するはず');
         $this->assertTrue($this->root->hasChild('app/cache/.dummykeep'), '.dummykeep は存在するはず');
+    }
+
+    public function testClearPluginCache()
+    {
+        mkdir($this->app['config']['plugin_temp_realdir'], 0777, true);
+        file_put_contents($this->app['config']['plugin_temp_realdir'].'/config_cache.php', '<?php return array();');
+
+        $this->assertTrue(file_exists($this->app['config']['plugin_temp_realdir'].'/config_cache.php'));
+
+        Cache::clear($this->app, false);
+
+        $this->assertFalse(file_exists($this->app['config']['plugin_temp_realdir'].'/config_cache.php'));
     }
 }


### PR DESCRIPTION
php app/console cache:clear コマンド実行時にpluginディレクトリに作成されているキャッシュファイルが削除されていなかったため対応
