### PR TITLE
HEADメソッドで商品一覧にアクセスされると500エラーが発生するため、500エラーを発生させない対応

### DIFF
--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -95,7 +95,7 @@ class ProductController
         $pagination = $app['paginator']()->paginate(
             $qb,
             !empty($searchData['pageno']) ? $searchData['pageno'] : 1,
-            $searchData['disp_number']->getId()
+            !empty($searchData['disp_number']) ? $searchData['disp_number']->getId() : 15
         );
 
         // addCart form

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -95,7 +95,9 @@ class ProductController
         $pagination = $app['paginator']()->paginate(
             $qb,
             !empty($searchData['pageno']) ? $searchData['pageno'] : 1,
-            !empty($searchData['disp_number']) ? $searchData['disp_number']->getId() : 15
+            !empty($searchData['disp_number'])
+                ? $searchData['disp_number']->getId()
+                : $app['eccube.repository.master.product_list_max']->findOneBy(array(), array('id' => 'ASC'))->getId()
         );
 
         // addCart form


### PR DESCRIPTION
HEADメソッドで商品一覧にアクセスされると500エラーが発生するため、500エラーを発生させない対応

## 実装に関する補足(Appendix)
index_dev.phpをつけるとまだエラーが発生するが、本番環境で500エラーを発生させなくするために対応する。
