### PR TITLE
ページ管理のmeta設定の入力チェック文字数を500文字に修正

### DIFF
--- a/src/Eccube/Form/Type/Admin/MainEditType.php
+++ b/src/Eccube/Form/Type/Admin/MainEditType.php
@@ -54,7 +54,7 @@ class MainEditType extends AbstractType
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Length(array(
-                        'max' => $app['config']['stext_len'],
+                        'max' => $app['config']['sltext_len'],
                     ))
                 )
             ))
@@ -95,7 +95,7 @@ class MainEditType extends AbstractType
                 'required' => false,
                 'constraints' => array(
                     new Assert\Length(array(
-                        'max' => $app['config']['stext_len'],
+                        'max' => $app['config']['sltext_len'],
                     ))
                 )
             ))
@@ -104,7 +104,7 @@ class MainEditType extends AbstractType
                 'required' => false,
                 'constraints' => array(
                     new Assert\Length(array(
-                        'max' => $app['config']['stext_len'],
+                        'max' => $app['config']['sltext_len'],
                     ))
                 )
             ))
@@ -113,7 +113,7 @@ class MainEditType extends AbstractType
                 'required' => false,
                 'constraints' => array(
                     new Assert\Length(array(
-                        'max' => $app['config']['stext_len'],
+                        'max' => $app['config']['sltext_len'],
                     ))
                 )
             ))
@@ -122,7 +122,7 @@ class MainEditType extends AbstractType
                 'required' => false,
                 'constraints' => array(
                     new Assert\Length(array(
-                        'max' => $app['config']['stext_len'],
+                        'max' => $app['config']['sltext_len'],
                     ))
                 )
             ))->add('meta_tags', 'textarea', array(

--- a/tests/Eccube/Tests/Form/Type/Admin/MainEditTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/MainEditTypeTest.php
@@ -72,7 +72,7 @@ class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInValidName_MaxLength()
     {
-        $this->formData['name'] = str_repeat('1', $this->app['config']['stext_len'] + 1);
+        $this->formData['name'] = str_repeat('1', $this->app['config']['sltext_len'] + 1);
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
@@ -206,7 +206,7 @@ class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInValidAuthor_MaxLength()
     {
-        $this->formData['author'] = str_repeat('1', $this->app['config']['stext_len'] + 1);;
+        $this->formData['author'] = str_repeat('1', $this->app['config']['sltext_len'] + 1);;
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
@@ -220,7 +220,7 @@ class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInValidDescription_MaxLength()
     {
-        $this->formData['description'] = str_repeat('1', $this->app['config']['stext_len'] + 1);;
+        $this->formData['description'] = str_repeat('1', $this->app['config']['sltext_len'] + 1);;
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
@@ -234,7 +234,7 @@ class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInValidKeyword_MaxLength()
     {
-        $this->formData['keyword'] = str_repeat('1', $this->app['config']['stext_len'] + 1);;
+        $this->formData['keyword'] = str_repeat('1', $this->app['config']['sltext_len'] + 1);;
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
@@ -248,7 +248,7 @@ class MainEditTestType extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInValidMetaRobots_MaxLength()
     {
-        $this->formData['meta_robots'] = str_repeat('1', $this->app['config']['stext_len'] + 1);;
+        $this->formData['meta_robots'] = str_repeat('1', $this->app['config']['sltext_len'] + 1);;
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }


### PR DESCRIPTION
ページ管理の下記項目の入力チェック文字数を500文字に修正
* 名称
* author
* description
* keyword
* robots
