### PR TITLE
販売種別が異なる場合にカートへの追加が失敗する不具合を修正

### DIFF
--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -400,20 +400,19 @@ class ProductController extends AbstractController
         $this->cartService->addProduct($addCartData['product_class_id'], $addCartData['quantity']);
 
         // 明細の正規化
-        $flow = $this->purchaseFlow;
-        $Cart = $this->cartService->getCart();
-        $result = $flow->calculate($Cart, new PurchaseContext($Cart, $this->getUser()));
-
-        // 復旧不可のエラーが発生した場合は追加した明細を削除.
-        if ($result->hasError()) {
-            $this->cartService->removeProduct($addCartData['product_class_id']);
-            foreach ($result->getErrors() as $error) {
-                $errorMessages[] = $error->getMessage();
+        $Carts = $this->cartService->getCarts();
+        foreach ($Carts as $Cart) {
+            $result = $this->purchaseFlow->calculate($Cart, new PurchaseContext($Cart, $this->getUser()));
+            // 復旧不可のエラーが発生した場合は追加した明細を削除.
+            if ($result->hasError()) {
+                $this->cartService->removeProduct($addCartData['product_class_id']);
+                foreach ($result->getErrors() as $error) {
+                    $errorMessages[] = $error->getMessage();
+                }
             }
-        }
-
-        foreach ($result->getWarning() as $warning) {
-            $errorMessages[] = $warning->getMessage();
+            foreach ($result->getWarning() as $warning) {
+                $errorMessages[] = $warning->getMessage();
+            }
         }
 
         $this->cartService->save();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- 販売種別が異なる商品をカートへ追加した場合に、「カートの追加に失敗しました」アラートが表示される
- カート分割後、purchaseFlowを通す必要があるが、最初のカートしか実行されていなかった
- そのため、total_priceがnullになり、INSERTに失敗していた
- すべてのカートにpurchaseFlowを実行するように修正


