### PR TITLE
購入フローでログインしたタイミングで複数カートになった場合、ログイン後にカート画面に戻す対応

### DIFF
--- a/codeception/acceptance/EF03OrderCest.php
+++ b/codeception/acceptance/EF03OrderCest.php
@@ -527,8 +527,6 @@ class EF03OrderCest
         ProductDetailPage::go($I, 2)
             ->カートに入れる(1);
 
-        $I->wait(3);
-
         $I->acceptPopup();
 
         CartPage::go($I)
@@ -563,8 +561,6 @@ class EF03OrderCest
                 ->規格選択([$ProductClass->getClassCategory1()])
                 ->カートに入れる(1);
         }
-
-        $I->wait(3);
 
         $I->acceptPopup();
 

--- a/codeception/acceptance/EF03OrderCest.php
+++ b/codeception/acceptance/EF03OrderCest.php
@@ -521,11 +521,12 @@ class EF03OrderCest
         $createCustomer = Fixtures::get('createCustomer');
         $customer = $createCustomer();
         $I->loginAsMember($customer->getEmail(), 'password');
-        $BaseInfo = Fixtures::get('baseinfo');
 
         // 商品詳細パーコレータ カートへ
         ProductDetailPage::go($I, 2)
             ->カートに入れる(1);
+
+        $I->wait(3);
 
         $I->acceptPopup();
 
@@ -536,18 +537,13 @@ class EF03OrderCest
         $I->logoutAsMember();
 
         $createProduct = Fixtures::get('createProduct');
-
         $Product = $createProduct();
 
+
         $entityManager = Fixtures::get('entityManager');
-
-        $SaleType = $entityManager->find(\Eccube\Entity\Master\SaleType::class, 2);
-
-        $Product->getProductClasses()[0]->setSaleType($SaleType);
-
         $ProductClass = $Product->getProductClasses()[0];
+        $SaleType = $entityManager->find(\Eccube\Entity\Master\SaleType::class, 2);
         $ProductClass->setSaleType($SaleType);
-
         $entityManager->persist($ProductClass);
         $entityManager->flush();
 
@@ -562,6 +558,7 @@ class EF03OrderCest
                 ->カートに入れる(1);
         }
 
+        $I->wait(3);
         $I->acceptPopup();
 
         CartPage::go($I)
@@ -569,8 +566,6 @@ class EF03OrderCest
 
         // ログイン
         ShoppingLoginPage::at($I)->ログイン($customer->getEmail());
-
-        $I->resetEmails();
 
         $I->see('同時購入できない商品がカートに含まれています', '.ec-alert-warning__text');
     }

--- a/src/Eccube/Controller/CartController.php
+++ b/src/Eccube/Controller/CartController.php
@@ -67,7 +67,7 @@ class CartController extends AbstractController
      * @Route("/cart", name="cart")
      * @Template("Cart/index.twig")
      */
-    public function index()
+    public function index(Request $request)
     {
         // カートを取得して明細の正規化を実行
         $Carts = $this->cartService->getCarts();
@@ -90,6 +90,9 @@ class CartController extends AbstractController
 
             return $total;
         }, 0);
+
+        // カートが分割された時のセッション情報を削除
+        $request->getSession()->remove('cart.divide');
 
         return [
             'totalPrice' => $totalPrice,

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -614,6 +614,7 @@ class ShoppingController extends AbstractShoppingController
             $divide = $request->getSession()->get('cart.divide');
             if ($divide) {
                 log_info('種別が異なる商品がカートと結合されたためカート画面にリダイレクト');
+                $request->getSession()->remove('cart.divide');
 
                 return $this->redirectToRoute('cart');
             }

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -611,6 +611,12 @@ class ShoppingController extends AbstractShoppingController
     {
         $Cart = $this->cartService->getCart();
         if ($Cart && count($Cart->getCartItems()) > 0) {
+            $divide = $request->getSession()->get('cart.divide');
+            if ($divide) {
+                log_info('種別が異なる商品がカートと結合されたためカート画面にリダイレクト');
+
+                return $this->redirectToRoute('cart');
+            }
             return new Response();
         }
         log_info('カートに商品が入っていないためショッピングカート画面にリダイレクト');

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -617,6 +617,7 @@ class ShoppingController extends AbstractShoppingController
 
                 return $this->redirectToRoute('cart');
             }
+
             return new Response();
         }
         log_info('カートに商品が入っていないためショッピングカート画面にリダイレクト');

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -614,7 +614,6 @@ class ShoppingController extends AbstractShoppingController
             $divide = $request->getSession()->get('cart.divide');
             if ($divide) {
                 log_info('種別が異なる商品がカートと結合されたためカート画面にリダイレクト');
-                $request->getSession()->remove('cart.divide');
 
                 return $this->redirectToRoute('cart');
             }

--- a/src/Eccube/EventListener/SecurityListener.php
+++ b/src/Eccube/EventListener/SecurityListener.php
@@ -60,6 +60,10 @@ class SecurityListener implements EventSubscriberInterface
                 $this->purchaseFlow->calculate($Cart, new PurchaseContext($Cart, $user));
             }
             $this->cartService->save();
+            if (count($this->cartService->getCarts()) > 1) {
+                // カートが分割されていればメッセージを表示
+                $event->getRequest()->getSession()->set('cart.divide', true);
+            }
         }
     }
 

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -508,6 +508,8 @@ return [
     'cart.product.not.status' => '現時点で購入できない商品が含まれておりました。該当商品をカートから削除しました。',
     'cart.product.not.saletype' => '「%product%」はまだ配送の準備ができておりません。
 恐れ入りますがお問い合わせページよりお問い合わせください。',
+    'cart.product.divide' => '同時購入できない商品がカートに含まれています。
+お手数ですが、個別に購入手続きをお願い致します。',
     'shopping.multiple.delivery' => '配送方法が異なる商品が含まれているため、お届け先は複数となります。',
     'shopping.multiple.quantity.diff' => '数量の合計が、カゴの中の数量と異なっています。',
     'shopping.delivery.not.saletype' => '配送の準備ができていない商品が含まれております。

--- a/src/Eccube/Resource/template/default/Cart/index.twig
+++ b/src/Eccube/Resource/template/default/Cart/index.twig
@@ -16,7 +16,7 @@ file that was distributed with this source code.
 
     <div class="ec-role">
         <div class="ec-pageHeader">
-            <h1>{{'shopping.label.cart'|trans}}</h1>
+            <h1>{{ 'shopping.label.cart'|trans }}</h1>
         </div>
     </div>
 
@@ -27,14 +27,14 @@ file that was distributed with this source code.
                 <li class="ec-progress__item is-complete">
                     <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
                     </div>
-                    <div class="ec-progress__label">{{'shopping.label.your_cart'|trans}}
+                    <div class="ec-progress__label">{{ 'shopping.label.your_cart'|trans }}
                     </div>
                 </li>
                 {% if is_granted('ROLE_USER') == false %}
                     <li class="ec-progress__item">
                         <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
                         </div>
-                        <div class="ec-progress__label">{{'shopping.label.customer_info'|trans}}
+                        <div class="ec-progress__label">{{ 'shopping.label.customer_info'|trans }}
                         </div>
                     </li>
                 {% endif %}
@@ -47,13 +47,13 @@ file that was distributed with this source code.
                 <li class="ec-progress__item">
                     <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
                     </div>
-                    <div class="ec-progress__label">{{'shopping.label.confirm_order'|trans}}
+                    <div class="ec-progress__label">{{ 'shopping.label.confirm_order'|trans }}
                     </div>
                 </li>
                 <li class="ec-progress__item">
                     <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
                     </div>
-                    <div class="ec-progress__label">{{'shopping.label.order_completed'|trans}}
+                    <div class="ec-progress__label">{{ 'shopping.label.order_completed'|trans }}
                     </div>
                 </li>
             </ul>
@@ -112,6 +112,15 @@ file that was distributed with this source code.
                     {% endif %}
                 </p>
             </div>
+            {% if Carts|length > 1 %}
+                <div class="ec-cartRole__error">
+                    <div class="ec-alert-warning">
+                        <div class="ec-alert-warning__text">
+                            {{ 'cart.product.divide'|trans|nl2br }}
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
 
             <form name="form" id="form_cart" class="ec-cartRole" method="post" action="{{ url('cart') }}">
 
@@ -127,13 +136,13 @@ file that was distributed with this source code.
                         </div>
                     {% endfor %}
 
-                <div class="ec-cartRole__cart">
-                    <div class="ec-cartTable">
-                        <ol class="ec-cartHeader">
-                            <li class="ec-cartHeader__label">{{'shopping.label.del'|trans}}</li>
-                            <li class="ec-cartHeader__label">{{'shopping.label.products'|trans}}</li>
-                            <li class="ec-cartHeader__label">{{'shopping.label.qty'|trans}}</li>
-                            <li class="ec-cartHeader__label">{{'shopping.label.subtotal'|trans}}</li>
+                    <div class="ec-cartRole__cart">
+                        <div class="ec-cartTable">
+                            <ol class="ec-cartHeader">
+                                <li class="ec-cartHeader__label">{{ 'shopping.label.del'|trans }}</li>
+                                <li class="ec-cartHeader__label">{{ 'shopping.label.products'|trans }}</li>
+                                <li class="ec-cartHeader__label">{{ 'shopping.label.qty'|trans }}</li>
+                                <li class="ec-cartHeader__label">{{ 'shopping.label.subtotal'|trans }}</li>
                             </ol>
                             {% for CartItem in Cart.CartItems %}
                                 {% set ProductClass = CartItem.ProductClass %}
@@ -187,35 +196,35 @@ file that was distributed with this source code.
                                     </li>
                                 </ul>
                             {% endfor %}
+                        </div>
                     </div>
-                </div>
-                <div class="ec-cartRole__actions">
-                    <div class="ec-cartRole__total">{{'shopping.label.total'|trans}}：<span class="ec-cartRole__totalAmount">{{ Cart.totalPrice|price }}</span>
+                    <div class="ec-cartRole__actions">
+                        <div class="ec-cartRole__total">{{ 'shopping.label.total'|trans }}：<span class="ec-cartRole__totalAmount">{{ Cart.totalPrice|price }}</span>
+                        </div>
+                        <a class="ec-blockBtn--action" href="{{ path('cart_buystep', {'index':loop.index0}) }}">{{ 'shopping.label.btn.checkout'|trans }}</a>
+                        {% if loop.last %}
+                            <a class="ec-blockBtn--cancel" href="{{ path('homepage') }}">{{ 'shopping.label.btn.continue'|trans }}</a>
+                        {% endif %}
                     </div>
-                    <a class="ec-blockBtn--action" href="{{ path('cart_buystep', {'index':loop.index0}) }}">{{'shopping.label.btn.checkout'|trans}}</a>
-                    {% if loop.last %}
-                        <a class="ec-blockBtn--cancel" href="{{ path('homepage') }}">{{'shopping.label.btn.continue'|trans}}</a>
-                    {% endif %}
-                </div>
                 {% endfor %}
             </form>
         {% else %}
             {% for error in app.session.flashbag.get('eccube.front.cart.0.request.error') %}
-                    <div class="ec-cartRole__error">
-                        <div class="ec-alert-warning">
-                            <div class="ec-alert-warning__icon"><img src="{{ asset('assets/icon/exclamation-white.svg') }}"></div>
-                            <div class="ec-alert-warning__text">
-                                {{ error|trans|nl2br }}
-                            </div>
+                <div class="ec-cartRole__error">
+                    <div class="ec-alert-warning">
+                        <div class="ec-alert-warning__icon"><img src="{{ asset('assets/icon/exclamation-white.svg') }}"></div>
+                        <div class="ec-alert-warning__text">
+                            {{ error|trans|nl2br }}
                         </div>
                     </div>
+                </div>
             {% endfor %}
             <div class="ec-role">
                 <div class="ec-off3Grid">
                     <div class="ec-off3Grid__cell">
                         <div class="ec-alert-warning">
                             <div class="ec-alert-warning__icon"><img src="{{ asset('assets/icon/exclamation-white.svg') }}"></div>
-                            <div class="ec-alert-warning__text">{{'shopping.text.error.no_item_in_cart'|trans}}</div>
+                            <div class="ec-alert-warning__text">{{ 'shopping.text.error.no_item_in_cart'|trans }}</div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
購入フローでログインしたタイミングで複数カートになった場合、ログイン後にカート画面に戻す対応
カート画面では複数カートに分かれたらメッセージを表示させる。

## 概要(Overview・Refs Issue)
以下の順序で種別が異なる商品がカートにセットされたらカート画面へ戻す対応

1. 会員状態で販売種別Aの商品をカートに入れる
1. 購入フローに進む
1. 購入せずにログアウトする
1. 非会員状態でカートに販売種別Bの商品をカートに入れる
1. レジに進む
1. ログインする
1. 種別が異なる商品があるためカートが複数になる
1. カート画面に戻る

## テスト（Test)
codeceptionの対応
