### PR TITLE
お届け先選択で「会員の住所」を選択できるようにする

### DIFF
--- a/codeception/acceptance/EF03OrderCest.php
+++ b/codeception/acceptance/EF03OrderCest.php
@@ -422,7 +422,7 @@ class EF03OrderCest
             ->登録する();
 
         // 新規お届け先が追加されていることを確認
-        $I->see($nameSei, '#form_shipping_multiple_0_shipping_0_customer_address > option:nth-child(3)');
+        $I->see($nameSei, '#form_shipping_multiple_0_shipping_0_customer_address > option:nth-child(2)');
 
         // -------- EF0305-UC06-T01_複数配送 - 同じ商品種別（同一配送先） --------
         // 複数配送設定

--- a/codeception/acceptance/EF03OrderCest.php
+++ b/codeception/acceptance/EF03OrderCest.php
@@ -422,7 +422,7 @@ class EF03OrderCest
             ->登録する();
 
         // 新規お届け先が追加されていることを確認
-        $I->see($nameSei, '#form_shipping_multiple_0_shipping_0_customer_address > option:nth-child(2)');
+        $I->see($nameSei, '#form_shipping_multiple_0_shipping_0_customer_address > option:nth-child(3)');
 
         // -------- EF0305-UC06-T01_複数配送 - 同じ商品種別（同一配送先） --------
         // 複数配送設定

--- a/codeception/acceptance/EF05MypageCest.php
+++ b/codeception/acceptance/EF05MypageCest.php
@@ -171,13 +171,14 @@ class EF05MypageCest
         $I->see('お届け先編集', 'div.ec-pageHeader h1');
     }
 
-    public function mypage_お届け先編集作成(\AcceptanceTester $I)
+    public function mypage_お届け先編集作成変更(\AcceptanceTester $I)
     {
-        $I->wantTo('EF0506-UC01-T02 Mypage お届け先編集作成');
+        $I->wantTo('EF0506-UC01-T02 Mypage お届け先編集作成変更');
         $createCustomer = Fixtures::get('createCustomer');
         $customer = $createCustomer();
         $I->loginAsMember($customer->getEmail(), 'password');
 
+        // お届先作成
         // TOPページ>マイページ>お届け先編集
         MyPage::go($I)
             ->お届け先編集()
@@ -203,16 +204,9 @@ class EF05MypageCest
         CustomerAddressListPage::at($I);
 
         // 一覧に追加されている
-        $I->see('大阪市北区', 'div.ec-addressList div:nth-child(2) div.ec-addressList__address');
-    }
+        $I->see('大阪市北区', 'div.ec-addressList div:nth-child(1) div.ec-addressList__address');
 
-    public function mypage_お届け先編集変更(\AcceptanceTester $I)
-    {
-        $I->wantTo('EF0506-UC02-T01 Mypage お届け先編集変更');
-        $createCustomer = Fixtures::get('createCustomer');
-        $customer = $createCustomer();
-        $I->loginAsMember($customer->getEmail(), 'password');
-
+        // お届先編集
         // TOPページ>マイページ>お届け先編集
         MyPage::go($I)
             ->お届け先編集()
@@ -265,14 +259,13 @@ class EF05MypageCest
             ->入力_電話番号3('111')
             ->登録する();
 
-        $I->see('大阪市西区', 'div.ec-addressList div:nth-child(2) div.ec-addressList__address');
+        $I->see('大阪市西区', 'div.ec-addressList div:nth-child(1) div.ec-addressList__address');
 
         CustomerAddressListPage::at($I)
             ->削除(1);
 
         // 確認
-        $I->see('大阪市西区', 'div.ec-addressList div:nth-child(1) div.ec-addressList__address');
-        $I->dontSee($customer->getAddr01(), 'div.ec-addressList div:nth-child(1) div.ec-addressList__address');
+        $I->see('0 件', 'div.ec-layoutRole div.ec-layoutRole__contents p.ec-para-nomal strong');
     }
 
     public function mypage_退会手続き未実施(\AcceptanceTester $I)

--- a/src/Eccube/Controller/Admin/Customer/CustomerEditController.php
+++ b/src/Eccube/Controller/Admin/Customer/CustomerEditController.php
@@ -14,7 +14,6 @@
 namespace Eccube\Controller\Admin\Customer;
 
 use Eccube\Controller\AbstractController;
-use Eccube\Entity\CustomerAddress;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
 use Eccube\Form\Type\Admin\CustomerType;
@@ -67,7 +66,6 @@ class CustomerEditController extends AbstractController
         // 新規登録
         } else {
             $Customer = $this->customerRepository->newCustomer();
-            $CustomerAddress = new CustomerAddress();
             $Customer->setBuyTimes(0);
             $Customer->setBuyTotal(0);
         }
@@ -94,32 +92,6 @@ class CustomerEditController extends AbstractController
                 log_info('会員登録開始', [$Customer->getId()]);
 
                 $encoder = $this->encoderFactory->getEncoder($Customer);
-
-                if ($Customer->getId() === null) {
-                    $Customer->setSalt($encoder->createSalt());
-                    $Customer->setSecretKey($this->customerRepository->getUniqueSecretKey());
-
-                    $CustomerAddress->setName01($Customer->getName01())
-                        ->setName02($Customer->getName02())
-                        ->setKana01($Customer->getKana01())
-                        ->setKana02($Customer->getKana02())
-                        ->setCompanyName($Customer->getCompanyName())
-                        ->setZip01($Customer->getZip01())
-                        ->setZip02($Customer->getZip02())
-                        ->setZipcode($Customer->getZip01().$Customer->getZip02())
-                        ->setPref($Customer->getPref())
-                        ->setAddr01($Customer->getAddr01())
-                        ->setAddr02($Customer->getAddr02())
-                        ->setTel01($Customer->getTel01())
-                        ->setTel02($Customer->getTel02())
-                        ->setTel03($Customer->getTel03())
-                        ->setFax01($Customer->getFax01())
-                        ->setFax02($Customer->getFax02())
-                        ->setFax03($Customer->getFax03())
-                        ->setCustomer($Customer);
-
-                    $this->entityManager->persist($CustomerAddress);
-                }
 
                 if ($Customer->getPassword() === $this->eccubeConfig['eccube_default_password']) {
                     $Customer->setPassword($previous_password);

--- a/src/Eccube/Controller/EntryController.php
+++ b/src/Eccube/Controller/EntryController.php
@@ -14,7 +14,6 @@
 namespace Eccube\Controller;
 
 use Eccube\Entity\BaseInfo;
-use Eccube\Entity\CustomerAddress;
 use Eccube\Entity\Master\CustomerStatus;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
@@ -159,12 +158,7 @@ class EntryController extends AbstractController
                         ->setSecretKey($secretKey)
                         ->setPoint(0);
 
-                    $CustomerAddress = new CustomerAddress();
-                    $CustomerAddress
-                        ->setFromCustomer($Customer);
-
                     $this->entityManager->persist($Customer);
-                    $this->entityManager->persist($CustomerAddress);
                     $this->entityManager->flush();
 
                     log_info('会員登録完了');
@@ -173,7 +167,6 @@ class EntryController extends AbstractController
                         [
                             'form' => $form,
                             'Customer' => $Customer,
-                            'CustomerAddress' => $CustomerAddress,
                         ],
                         $request
                     );

--- a/src/Eccube/Controller/NonMemberShoppingController.php
+++ b/src/Eccube/Controller/NonMemberShoppingController.php
@@ -166,11 +166,7 @@ class NonMemberShoppingController extends AbstractShoppingController
             }
 
             // 非会員用セッションを作成
-            $nonMember = [];
-            $nonMember['customer'] = $Customer;
-            $nonMember['pref'] = $Customer->getPref()->getId();
-            $this->session->set($this->sessionKey, $nonMember);
-
+            $this->session->set($this->sessionKey, $Customer);
             $this->session->set($this->sessionCustomerAddressKey, serialize([]));
 
             $event = new EventArgs(

--- a/src/Eccube/Controller/NonMemberShoppingController.php
+++ b/src/Eccube/Controller/NonMemberShoppingController.php
@@ -14,7 +14,6 @@
 namespace Eccube\Controller;
 
 use Eccube\Entity\Customer;
-use Eccube\Entity\CustomerAddress;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Entity\Order;
 use Eccube\Event\EccubeEvents;
@@ -139,26 +138,6 @@ class NonMemberShoppingController extends AbstractShoppingController
                 ->setAddr01($data['addr01'])
                 ->setAddr02($data['addr02']);
 
-            // 非会員複数配送用
-            $CustomerAddress = new CustomerAddress();
-            $CustomerAddress
-                ->setCustomer($Customer)
-                ->setName01($data['name01'])
-                ->setName02($data['name02'])
-                ->setKana01($data['kana01'])
-                ->setKana02($data['kana02'])
-                ->setCompanyName($data['company_name'])
-                ->setTel01($data['tel01'])
-                ->setTel02($data['tel02'])
-                ->setTel03($data['tel03'])
-                ->setZip01($data['zip01'])
-                ->setZip02($data['zip02'])
-                ->setZipCode($data['zip01'].$data['zip02'])
-                ->setPref($data['pref'])
-                ->setAddr01($data['addr01'])
-                ->setAddr02($data['addr02']);
-            $Customer->addCustomerAddress($CustomerAddress);
-
             // 受注情報を取得
             /** @var Order $Order */
             $Order = $this->shoppingService->getOrder(OrderStatus::PROCESSING);
@@ -170,7 +149,6 @@ class NonMemberShoppingController extends AbstractShoppingController
                     // 受注情報を作成
                     $Order = $this->orderHelper->createProcessingOrder(
                         $Customer,
-                        $Customer->getCustomerAddresses()->current(),
                         $cartService->getCart()->getCartItems()
                     );
                     $cartService->setPreOrderId($Order->getPreOrderId());
@@ -193,9 +171,7 @@ class NonMemberShoppingController extends AbstractShoppingController
             $nonMember['pref'] = $Customer->getPref()->getId();
             $this->session->set($this->sessionKey, $nonMember);
 
-            $customerAddresses = [];
-            $customerAddresses[] = $CustomerAddress;
-            $this->session->set($this->sessionCustomerAddressKey, serialize($customerAddresses));
+            $this->session->set($this->sessionCustomerAddressKey, serialize([]));
 
             $event = new EventArgs(
                 [

--- a/src/Eccube/Controller/ShippingMultipleController.php
+++ b/src/Eccube/Controller/ShippingMultipleController.php
@@ -175,15 +175,15 @@ class ShippingMultipleController extends AbstractShoppingController
                 foreach ($mulitples as $items) {
                     foreach ($items as $item) {
                         $CustomerAddress = $item['customer_address']->getData();
-                        $cusAddId = $CustomerAddress->getShippingMultipleDefaultName();
+                        $customerAddressName = $CustomerAddress->getShippingMultipleDefaultName();
 
                         $itemId = $OrderItem->getProductClass()->getId();
                         $quantity = $item['quantity']->getData();
 
-                        if (isset($arrOrderItemTemp[$cusAddId]) && array_key_exists($itemId, $arrOrderItemTemp[$cusAddId])) {
-                            $arrOrderItemTemp[$cusAddId][$itemId] = $arrOrderItemTemp[$cusAddId][$itemId] + $quantity;
+                        if (isset($arrOrderItemTemp[$customerAddressName]) && array_key_exists($itemId, $arrOrderItemTemp[$customerAddressName])) {
+                            $arrOrderItemTemp[$customerAddressName][$itemId] = $arrOrderItemTemp[$customerAddressName][$itemId] + $quantity;
                         } else {
-                            $arrOrderItemTemp[$cusAddId][$itemId] = $quantity;
+                            $arrOrderItemTemp[$customerAddressName][$itemId] = $quantity;
                         }
                     }
                 }
@@ -225,14 +225,14 @@ class ShippingMultipleController extends AbstractShoppingController
                 foreach ($mulitples as $items) {
                     foreach ($items as $item) {
                         $CustomerAddress = $item['customer_address']->getData();
-                        $cusAddId = $CustomerAddress->getShippingMultipleDefaultName();
+                        $customerAddressName = $CustomerAddress->getShippingMultipleDefaultName();
 
                         $Shipping = new Shipping();
                         $Shipping
                             ->setFromCustomerAddress($CustomerAddress)
                             ->setDelivery($Delivery);
 
-                        $ShippingList[$cusAddId][$saleTypeId] = $Shipping;
+                        $ShippingList[$customerAddressName][$saleTypeId] = $Shipping;
                     }
                 }
             }
@@ -257,20 +257,20 @@ class ShippingMultipleController extends AbstractShoppingController
                 foreach ($mulitples as $items) {
                     foreach ($items as $item) {
                         $CustomerAddress = $item['customer_address']->getData();
-                        $cusAddId = $CustomerAddress->getShippingMultipleDefaultName();
+                        $customerAddressName = $CustomerAddress->getShippingMultipleDefaultName();
 
                         // お届け先から商品の数量を取得
                         $quantity = 0;
-                        if (isset($arrOrderItemTemp[$cusAddId]) && array_key_exists($productClassId, $arrOrderItemTemp[$cusAddId])) {
-                            $quantity = $arrOrderItemTemp[$cusAddId][$productClassId];
-                            unset($arrOrderItemTemp[$cusAddId][$productClassId]);
+                        if (isset($arrOrderItemTemp[$customerAddressName]) && array_key_exists($productClassId, $arrOrderItemTemp[$customerAddressName])) {
+                            $quantity = $arrOrderItemTemp[$customerAddressName][$productClassId];
+                            unset($arrOrderItemTemp[$customerAddressName][$productClassId]);
                         } else {
                             // この配送先には送る商品がないのでスキップ（通常ありえない）
                             continue;
                         }
 
                         // 関連付けるお届け先のインスタンスを取得
-                        $Shipping = $ShippingList[$cusAddId][$saleTypeId];
+                        $Shipping = $ShippingList[$customerAddressName][$saleTypeId];
 
                         // インスタンスを生成して保存
                         $OrderItem = new OrderItem();

--- a/src/Eccube/Controller/ShippingMultipleController.php
+++ b/src/Eccube/Controller/ShippingMultipleController.php
@@ -174,7 +174,9 @@ class ShippingMultipleController extends AbstractShoppingController
                 $OrderItem = $mulitples->getData();
                 foreach ($mulitples as $items) {
                     foreach ($items as $item) {
-                        $cusAddId = $this->getCustomerAddressId($item['customer_address']->getData());
+                        $CustomerAddress = $item['customer_address']->getData();
+                        $cusAddId = $CustomerAddress->getShippingMultipleDefaultName();
+
                         $itemId = $OrderItem->getProductClass()->getId();
                         $quantity = $item['quantity']->getData();
 
@@ -222,8 +224,8 @@ class ShippingMultipleController extends AbstractShoppingController
 
                 foreach ($mulitples as $items) {
                     foreach ($items as $item) {
-                        $CustomerAddress = $this->getCustomerAddress($item['customer_address']->getData());
-                        $cusAddId = $this->getCustomerAddressId($item['customer_address']->getData());
+                        $CustomerAddress = $item['customer_address']->getData();
+                        $cusAddId = $CustomerAddress->getShippingMultipleDefaultName();
 
                         $Shipping = new Shipping();
                         $Shipping
@@ -254,7 +256,8 @@ class ShippingMultipleController extends AbstractShoppingController
 
                 foreach ($mulitples as $items) {
                     foreach ($items as $item) {
-                        $cusAddId = $this->getCustomerAddressId($item['customer_address']->getData());
+                        $CustomerAddress = $item['customer_address']->getData();
+                        $cusAddId = $CustomerAddress->getShippingMultipleDefaultName();
 
                         // お届け先から商品の数量を取得
                         $quantity = 0;
@@ -431,47 +434,5 @@ class ShippingMultipleController extends AbstractShoppingController
         return [
             'form' => $form->createView(),
         ];
-    }
-
-    /**
-     * フォームの情報からお届け先のインデックスを返す
-     *
-     * @param mixed $CustomerAddressData
-     *
-     * @return int
-     */
-    private function getCustomerAddressId($CustomerAddressData)
-    {
-        if ($CustomerAddressData instanceof CustomerAddress) {
-            return $CustomerAddressData->getId();
-        } else {
-            return $CustomerAddressData;
-        }
-    }
-
-    /**
-     * フォームの情報からお届け先のインスタンスを返す
-     *
-     * @param int $customerAddressId お届け先ID。非会員の場合はセッションに登録されたお届け先リストのインデックス。
-     *
-     * @return CustomerAddress
-     */
-    private function getCustomerAddress($customerAddressId)
-    {
-        // 会員の場合は登録されているお届け先を返す
-        if ($this->getUser()) {
-            return $this->entityManager->find(CustomerAddress::class, $customerAddressId);
-        }
-
-        // 非会員の場合はセッション中のお届け先リストから返す
-        $cusAddId = $customerAddressId;
-        $customerAddresses = $this->session->get($this->sessionCustomerAddressKey);
-        $customerAddresses = unserialize($customerAddresses);
-
-        $CustomerAddress = $customerAddresses[$cusAddId];
-        $pref = $this->prefRepository->find($CustomerAddress->getPref()->getId());
-        $CustomerAddress->setPref($pref);
-
-        return $CustomerAddress;
     }
 }

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -322,10 +322,8 @@ class ShoppingController extends AbstractShoppingController
 
         // 受注に関連するセッションを削除
         $this->session->remove($this->sessionOrderKey);
-
-        // 非会員用セッション情報を空の配列で上書きする(プラグイン互換性保持のために削除はしない)
-        $this->session->set($this->sessionKey, null);
-        $this->session->set($this->sessionCustomerAddressKey, []);
+        $this->session->remove($this->sessionKey);
+        $this->session->remove($this->sessionCustomerAddressKey);
 
         log_info('購入処理完了', [$orderId]);
 

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -324,7 +324,7 @@ class ShoppingController extends AbstractShoppingController
         $this->session->remove($this->sessionOrderKey);
 
         // 非会員用セッション情報を空の配列で上書きする(プラグイン互換性保持のために削除はしない)
-        $this->session->set($this->sessionKey, []);
+        $this->session->set($this->sessionKey, null);
         $this->session->set($this->sessionCustomerAddressKey, []);
 
         log_info('購入処理完了', [$orderId]);

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -651,7 +651,6 @@ class ShoppingController extends AbstractShoppingController
                 //$Order = $app['eccube.service.shopping']->createOrder($Customer);
                 $Order = $this->orderHelper->createProcessingOrder(
                     $Customer,
-                    $Customer->getCustomerAddresses()->current(),
                     $this->cartService->getCart()->getCartItems()
                 );
                 $this->cartService->setPreOrderId($Order->getPreOrderId());

--- a/src/Eccube/Form/Type/ShippingMultipleItemType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleItemType.php
@@ -95,15 +95,15 @@ class ShippingMultipleItemType extends AbstractType
                     // 会員の場合、CustomerAddressを設定
                     /** @var Customer $Customer */
                     $Customer = $this->tokenStorage->getToken()->getUser();
-                    $CustomerAddresses = $Customer->getCustomerAddresses();
-                    $Addresses = array_reduce($CustomerAddresses->toArray(), function (array $result, CustomerAddress $CustomerAddress) {
-                        $result[$CustomerAddress->getShippingMultipleDefaultName()] = $CustomerAddress->getId();
-
-                        return $result;
-                    }, []);
+                    $CustomerAddress = new CustomerAddress();
+                    $CustomerAddress->setFromCustomer($Customer);
+                    $CustomerAddresses = array_merge([$CustomerAddress], $Customer->getCustomerAddresses()->toArray());
 
                     $form->add('customer_address', ChoiceType::class, [
-                        'choices' => $Addresses,
+                        'choices' => $CustomerAddresses,
+                        'choice_label' => function ($Address, $key, $value) {
+                            return $Address->getShippingMultipleDefaultName();
+                        },
                         'constraints' => [
                             new Assert\NotBlank(),
                         ],
@@ -139,9 +139,9 @@ class ShippingMultipleItemType extends AbstractType
                 $choices = $form['customer_address']->getConfig()->getOption('choices');
 
                 /* @var CustomerAddress $CustomerAddress */
-                foreach ($choices as $address => $id) {
+                foreach ($choices as  $address) {
                     if ($address === $data->getShippingMultipleDefaultName()) {
-                        $form['customer_address']->setData($id);
+                        $form['customer_address']->setData($address);
                         break;
                     }
                 }

--- a/src/Eccube/Form/Type/ShippingMultipleItemType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleItemType.php
@@ -134,9 +134,7 @@ class ShippingMultipleItemType extends AbstractType
 
                 $form->add('customer_address', ChoiceType::class, [
                     'choices' => $CustomerAddresses,
-                    'choice_label' => function ($Address) {
-                        return $Address->getShippingMultipleDefaultName();
-                    },
+                    'choice_label' => 'shippingMultipleDefaultName',
                     'constraints' => [
                         new Assert\NotBlank(),
                     ],

--- a/src/Eccube/Form/Type/ShippingMultipleItemType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleItemType.php
@@ -121,7 +121,7 @@ class ShippingMultipleItemType extends AbstractType
                         $CustomerAddress = new CustomerAddress();
                         $CustomerAddress->setFromCustomer($NonMember);
 
-                        if ($CustomerAddresses = $this->session->get('eccube.front.shopping.nonmember.customeraddress', [])) {
+                        if ($CustomerAddresses = $this->session->get('eccube.front.shopping.nonmember.customeraddress')) {
                             $CustomerAddresses = unserialize($CustomerAddresses);
                             $CustomerAddresses = array_merge([$CustomerAddress], $CustomerAddresses);
                             foreach ($CustomerAddresses as $Address) {

--- a/src/Eccube/Form/Type/ShippingMultipleItemType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleItemType.php
@@ -156,7 +156,7 @@ class ShippingMultipleItemType extends AbstractType
 
                 /* @var CustomerAddress $CustomerAddress */
                 foreach ($choices as  $address) {
-                    if ($address === $data->getShippingMultipleDefaultName()) {
+                    if ($address->getShippingMultipleDefaultName() === $data->getShippingMultipleDefaultName()) {
                         $form['customer_address']->setData($address);
                         break;
                     }

--- a/src/Eccube/Form/Type/ShippingMultipleItemType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleItemType.php
@@ -13,9 +13,11 @@
 
 namespace Eccube\Form\Type;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Customer;
 use Eccube\Entity\CustomerAddress;
+use Eccube\Repository\Master\PrefRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -50,6 +52,16 @@ class ShippingMultipleItemType extends AbstractType
     protected $tokenStorage;
 
     /**
+     * @var PrefRepository
+     */
+    protected $prefRepository;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $entityManager;
+
+    /**
      * ShippingMultipleItemType constructor.
      *
      * @param array $eccubeConfig
@@ -61,12 +73,16 @@ class ShippingMultipleItemType extends AbstractType
         EccubeConfig $eccubeConfig,
         Session $session,
         AuthorizationCheckerInterface $authorizationChecker,
-        TokenStorageInterface $tokenStorage
+        TokenStorageInterface $tokenStorage,
+        PrefRepository $prefRepository,
+        EntityManagerInterface $entityManager
     ) {
         $this->eccubeConfig = $eccubeConfig;
         $this->session = $session;
         $this->authorizationChecker = $authorizationChecker;
         $this->tokenStorage = $tokenStorage;
+        $this->prefRepository = $prefRepository;
+        $this->entityManager = $entityManager;
     }
 
     /**
@@ -92,39 +108,39 @@ class ShippingMultipleItemType extends AbstractType
                 $form = $event->getForm();
 
                 if ($this->authorizationChecker->isGranted('IS_AUTHENTICATED_FULLY')) {
-                    // 会員の場合、CustomerAddressを設定
+                    // 会員の場合は、会員住所とお届け先住所をマージしてリストを作成
                     /** @var Customer $Customer */
                     $Customer = $this->tokenStorage->getToken()->getUser();
                     $CustomerAddress = new CustomerAddress();
                     $CustomerAddress->setFromCustomer($Customer);
                     $CustomerAddresses = array_merge([$CustomerAddress], $Customer->getCustomerAddresses()->toArray());
-
-                    $form->add('customer_address', ChoiceType::class, [
-                        'choices' => $CustomerAddresses,
-                        'choice_label' => function ($Address, $key, $value) {
-                            return $Address->getShippingMultipleDefaultName();
-                        },
-                        'constraints' => [
-                            new Assert\NotBlank(),
-                        ],
-                    ]);
                 } else {
-                    // 非会員の場合、セッションに設定されたCustomerAddressを設定
-                    if ($this->session->has('eccube.front.shopping.nonmember.customeraddress')) {
-                        $customerAddresses = $this->session->get('eccube.front.shopping.nonmember.customeraddress');
-                        $customerAddresses = unserialize($customerAddresses);
-                        $addresses = array_map(function (CustomerAddress $CustomerAddress) {
-                            return $CustomerAddress->getShippingMultipleDefaultName();
-                        }, $customerAddresses);
+                    $CustomerAddresses = [];
+                    // 非会員の場合は、セッションに保持されている注文者住所とお届け先住所をマージしてリストを作成
+                    if ($NonMember = $this->session->get('eccube.front.shopping.nonmember')) {
+                        $CustomerAddress = new CustomerAddress();
+                        $CustomerAddress->setFromCustomer($NonMember);
 
-                        $form->add('customer_address', ChoiceType::class, [
-                            'choices' => array_flip($addresses),
-                            'constraints' => [
-                                new Assert\NotBlank(),
-                            ],
-                        ]);
+                        if ($CustomerAddresses = $this->session->get('eccube.front.shopping.nonmember.customeraddress', [])) {
+                            $CustomerAddresses = unserialize($CustomerAddresses);
+                            $CustomerAddresses = array_merge([$CustomerAddress], $CustomerAddresses);
+                            foreach ($CustomerAddresses as $Address) {
+                                $Pref = $this->prefRepository->find($Address->getPref()->getId());
+                                $Address->setPref($Pref);
+                            }
+                        }
                     }
                 }
+
+                $form->add('customer_address', ChoiceType::class, [
+                    'choices' => $CustomerAddresses,
+                    'choice_label' => function ($Address, $key, $value) {
+                        return $Address->getShippingMultipleDefaultName();
+                    },
+                    'constraints' => [
+                        new Assert\NotBlank(),
+                    ],
+                ]);
             })
             ->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
                 /** @var \Eccube\Entity\Shipping $data */

--- a/src/Eccube/Form/Type/ShippingMultipleItemType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleItemType.php
@@ -134,7 +134,7 @@ class ShippingMultipleItemType extends AbstractType
 
                 $form->add('customer_address', ChoiceType::class, [
                     'choices' => $CustomerAddresses,
-                    'choice_label' => function ($Address, $key, $value) {
+                    'choice_label' => function ($Address) {
                         return $Address->getShippingMultipleDefaultName();
                     },
                     'constraints' => [

--- a/src/Eccube/Form/Type/Shopping/CustomerAddressType.php
+++ b/src/Eccube/Form/Type/Shopping/CustomerAddressType.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Form\Type\Shopping;
+
+use Eccube\Entity\Customer;
+use Eccube\Entity\CustomerAddress;
+use Eccube\Entity\Shipping;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class CustomerAddressType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        // 会員住所とお届け先住所をマージして選択肢を作成
+        /** @var Customer $Customer */
+        $Customer = $options['customer'];
+        $CustomerAddress = new CustomerAddress();
+        $CustomerAddress->setFromCustomer($Customer);
+        $Addresses = array_merge([$CustomerAddress], $Customer->getCustomerAddresses()->toArray());
+
+        // 注文のお届け先住所とマッチするものを初期選択とする
+        /** @var Shipping $Shipping */
+        $Shipping = $options['shipping'];
+        $Checked = null;
+        foreach ($Addresses as $Address) {
+            if ($Address->getShippingMultipleDefaultName() === $Shipping->getShippingMultipleDefaultName()) {
+                $Checked = $Address;
+            }
+        }
+
+        $builder->add('addresses', ChoiceType::class, [
+            'choices' => $Addresses,
+            'data' => $Checked,
+            'constraints' => [
+                new NotBlank(),
+            ],
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(['customer' => null, 'shipping' => null]);
+    }
+}

--- a/src/Eccube/Resource/template/default/Shopping/shipping.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping.twig
@@ -31,7 +31,7 @@ file that was distributed with this source code.
                             </div>
                         </div>
                     {% endif %}
-                    {% if error %}
+                    {% if has_errors(form.addresses) %}
                         <div class="ec-alert-warning">
                             <div class="ec-alert-warning__text">
                                 <div class="ec-alert-warning__icon"><img src="{{ asset('assets/icon/exclamation-white.svg') }}"/></div>
@@ -41,19 +41,20 @@ file that was distributed with this source code.
                     {% endif %}
                 </div>
 
-                {% if Customer.CustomerAddresses|length > 0 %}
                 <form method="post" action="{{ url('shopping_shipping', {'id': shippingId}) }}">
-
+                    {{ form_widget(form._token) }}
                     <div class="ec-addressList">
-                        {% for CustomerAddress in Customer.CustomerAddresses %}
+                        {% for choice in form.addresses.vars.choices %}
+                            {% set Address = choice.data %}
                         <div class="ec-addressList__item">
                             <div class="ec-addressList__remove">
-                                <input type="radio" id="address{{ CustomerAddress.id }}" class="no-style" name="address" value="{{ CustomerAddress.id }}" />
+                                {% set checked = choice is selectedchoice(form.addresses.vars.value) ? 'checked="checked"' : '' %}
+                                <input type="radio" id="address{{ choice.value }}" name="{{ form.addresses.vars.full_name }}" value="{{ choice.value }}" {{ checked }} />
                             </div>
                             <div class="ec-addressList__address">
-                                <div>{{ CustomerAddress.name01 }}&nbsp;{{ CustomerAddress.name02 }}</div>
-                                <div>〒{{ CustomerAddress.zip01 }}-{{ CustomerAddress.zip02 }} {{ CustomerAddress.Pref }}{{ CustomerAddress.addr01 }}{{ CustomerAddress.addr02 }}</div>
-                                <div>{{ CustomerAddress.tel01 }}-{{ CustomerAddress.tel02 }}-{{ CustomerAddress.tel03 }}</div>
+                                <div>{{ Address.name01 }}&nbsp;{{ Address.name02 }}</div>
+                                <div>〒{{ Address.zip01 }}-{{ Address.zip02 }} {{ Address.Pref }}{{ Address.addr01 }}{{ Address.addr02 }}</div>
+                                <div>{{ Address.tel01 }}-{{ Address.tel02 }}-{{ Address.tel03 }}</div>
                             </div>
                         </div>
                         {% endfor %}
@@ -69,7 +70,6 @@ file that was distributed with this source code.
                     </div>
 
                 </form>
-                {% endif %}
             </div>
         </div>
 

--- a/src/Eccube/Service/OrderHelper.php
+++ b/src/Eccube/Service/OrderHelper.php
@@ -20,7 +20,6 @@ use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Cart;
 use Eccube\Entity\CartItem;
 use Eccube\Entity\Customer;
-use Eccube\Entity\CustomerAddress;
 use Eccube\Entity\Master\OrderItemType;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Entity\Master\ShippingStatus;
@@ -137,12 +136,11 @@ class OrderHelper
      * 購入処理中の受注データを生成する.
      *
      * @param Customer $Customer
-     * @param CustomerAddress $CustomerAddress
      * @param array $CartItems
      *
      * @return Order
      */
-    public function createProcessingOrder(Customer $Customer, CustomerAddress $CustomerAddress, $CartItems, $preOrderId = null)
+    public function createProcessingOrder(Customer $Customer, $CartItems, $preOrderId = null)
     {
         $OrderStatus = $this->orderStatusRepository->find(OrderStatus::PROCESSING);
         $Order = new Order($OrderStatus);
@@ -166,7 +164,7 @@ class OrderHelper
         }, []);
 
         foreach ($OrderItemsGroupBySaleType as $OrderItems) {
-            $Shipping = $this->createShippingFromCustomerAddress($CustomerAddress);
+            $Shipping = $this->createShippingFromCustomer($Customer);
             $this->addOrderItems($Order, $Shipping, $OrderItems);
             $this->setDefaultDelivery($Shipping);
             $this->entityManager->persist($Shipping);
@@ -288,27 +286,27 @@ class OrderHelper
         }, $CartItems->toArray());
     }
 
-    private function createShippingFromCustomerAddress(CustomerAddress $CustomerAddress)
+    private function createShippingFromCustomer(Customer $Customer)
     {
         $Shipping = new Shipping();
         $Shipping
-            ->setName01($CustomerAddress->getName01())
-            ->setName02($CustomerAddress->getName02())
-            ->setKana01($CustomerAddress->getKana01())
-            ->setKana02($CustomerAddress->getKana02())
-            ->setCompanyName($CustomerAddress->getCompanyName())
-            ->setTel01($CustomerAddress->getTel01())
-            ->setTel02($CustomerAddress->getTel02())
-            ->setTel03($CustomerAddress->getTel03())
-            ->setFax01($CustomerAddress->getFax01())
-            ->setFax02($CustomerAddress->getFax02())
-            ->setFax03($CustomerAddress->getFax03())
-            ->setZip01($CustomerAddress->getZip01())
-            ->setZip02($CustomerAddress->getZip02())
-            ->setZipCode($CustomerAddress->getZip01().$CustomerAddress->getZip02())
-            ->setPref($CustomerAddress->getPref())
-            ->setAddr01($CustomerAddress->getAddr01())
-            ->setAddr02($CustomerAddress->getAddr02());
+            ->setName01($Customer->getName01())
+            ->setName02($Customer->getName02())
+            ->setKana01($Customer->getKana01())
+            ->setKana02($Customer->getKana02())
+            ->setCompanyName($Customer->getCompanyName())
+            ->setTel01($Customer->getTel01())
+            ->setTel02($Customer->getTel02())
+            ->setTel03($Customer->getTel03())
+            ->setFax01($Customer->getFax01())
+            ->setFax02($Customer->getFax02())
+            ->setFax03($Customer->getFax03())
+            ->setZip01($Customer->getZip01())
+            ->setZip02($Customer->getZip02())
+            ->setZipCode($Customer->getZip01().$Customer->getZip02())
+            ->setPref($Customer->getPref())
+            ->setAddr01($Customer->getAddr01())
+            ->setAddr02($Customer->getAddr02());
 
         $ShippingStatus = $this->shippingStatusRepository->find(ShippingStatus::PREPARED);
         $Shipping->setShippingStatus($ShippingStatus);

--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -271,26 +271,12 @@ class ShoppingService
      */
     public function getNonMember($sesisonKey)
     {
-        // 非会員でも一度会員登録されていればショッピング画面へ遷移
-        $nonMember = $this->session->get($sesisonKey);
-        if (is_null($nonMember)) {
-            return null;
-        }
-        if (!array_key_exists('customer', $nonMember) || !array_key_exists('pref', $nonMember)) {
-            return null;
-        }
+        if ($NonMember = $this->session->get($sesisonKey)) {
+            $Pref = $this->prefRepository->find($NonMember->getPref()->getId());
+            $NonMember->setPref($Pref);
 
-        $Customer = $nonMember['customer'];
-        $Customer->setPref($this->prefRepository->find($nonMember['pref']));
-
-        foreach ($Customer->getCustomerAddresses() as $CustomerAddress) {
-            $Pref = $CustomerAddress->getPref();
-            if ($Pref) {
-                $CustomerAddress->setPref($this->prefRepository->find($Pref->getId()));
-            }
+            return $NonMember;
         }
-
-        return $Customer;
     }
 
     /**

--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -260,13 +260,6 @@ class Generator
         $this->entityManager->persist($Customer);
         $this->entityManager->flush($Customer);
 
-        $CustomerAddress = new CustomerAddress();
-        $CustomerAddress->setCustomer($Customer);
-        $CustomerAddress->copyProperties($Customer);
-        $this->entityManager->persist($CustomerAddress);
-        $this->entityManager->flush($CustomerAddress);
-
-        $Customer->addCustomerAddress($CustomerAddress);
         $this->entityManager->flush($Customer);
 
         return $Customer;
@@ -363,18 +356,12 @@ class Generator
             ->setFax02(isset($fax[1]) ? $fax[1] : null)
             ->setFax03(isset($fax[2]) ? $fax[2] : null);
 
-        $CustomerAddress = new CustomerAddress();
-        $CustomerAddress->setCustomer($Customer);
-        $CustomerAddress->copyProperties($Customer);
-        $Customer->addCustomerAddress($CustomerAddress);
-
         $nonMember = [];
         $nonMember['customer'] = $Customer;
         $nonMember['pref'] = $Customer->getPref()->getId();
         $this->session->set($sessionKey, $nonMember);
 
         $customerAddresses = [];
-        $customerAddresses[] = $CustomerAddress;
         $this->session->set($sessionCustomerAddressKey, serialize($customerAddresses));
 
         return $Customer;

--- a/tests/Eccube/Tests/Web/Mypage/DeliveryControllerTest.php
+++ b/tests/Eccube/Tests/Web/Mypage/DeliveryControllerTest.php
@@ -28,6 +28,7 @@ class DeliveryControllerTest extends AbstractWebTestCase
     {
         parent::setUp();
         $this->Customer = $this->createCustomer();
+        $this->createCustomerAddress($this->Customer);
     }
 
     protected function createFormData()

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
@@ -474,7 +474,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                             'quantity' => 2,
                         ],
                         [
-                            'customer_address' => 2,
+                            'customer_address' => 1,
                             'quantity' => 2,
                         ],
                     ],
@@ -557,7 +557,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => 2,
+                            'customer_address' => 1,
                             'quantity' => 1,
                         ],
                     ],
@@ -569,7 +569,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => 2,
+                            'customer_address' => 1,
                             'quantity' => 1,
                         ],
                     ],
@@ -764,11 +764,11 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => 1,
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => 2,
+                            'customer_address' => 1,
                             'quantity' => 1,
                         ],
                     ],
@@ -776,11 +776,11 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => 1,
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => 2,
+                            'customer_address' => 1,
                             'quantity' => 1,
                         ],
                     ],
@@ -788,7 +788,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => 1,
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                     ],
@@ -877,11 +877,11 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => 1,
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => 2,
+                            'customer_address' => 1,
                             'quantity' => 1,
                         ],
                     ],
@@ -889,11 +889,11 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => 1,
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => 2,
+                            'customer_address' => 1,
                             'quantity' => 1,
                         ],
                     ],
@@ -901,7 +901,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => 3,
+                            'customer_address' => 2,
                             'quantity' => 1,
                         ],
                     ],
@@ -1113,7 +1113,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => 2,
+                            'customer_address' => 1,
                             'quantity' => 1,
                         ],
                     ],
@@ -1125,7 +1125,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => 2,
+                            'customer_address' => 1,
                             'quantity' => 1,
                         ],
                     ],
@@ -1133,7 +1133,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => 3,
+                            'customer_address' => 2,
                             'quantity' => 1,
                         ],
                     ],
@@ -1206,8 +1206,6 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
         $this->actual = $crawler->filter('div.ec-pageHeader h1')->text();
         $this->verify();
 
-        $arrCustomerAddress = $Customer->getCustomerAddresses();
-        $addressId = $arrCustomerAddress->first()->getId();
         // Before multi shipping
         // Only shipped to one address
         $multiForm = [

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
@@ -224,15 +224,13 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
             ],
         ]);
 
-        $arrCustomerAddress = $Customer->getCustomerAddresses();
-
         $multiForm = [
             '_token' => 'dummy',
             'shipping_multiple' => [
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                     ],
@@ -251,10 +249,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
         $Order = $this->orderRepository->findOneBy(['Customer' => $Customer]);
 
         // One shipping
-        $Shipping = $Order->getShippings();
-        $this->actual = count($Shipping);
-        $this->expected = count($arrCustomerAddress);
-        $this->verify();
+        $this->assertCount(1, $Order->getShippings());
     }
 
     /**
@@ -288,19 +283,17 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
             ],
         ]);
 
-        $arrCustomerAddress = $Customer->getCustomerAddresses();
-
         $multiForm = [
             '_token' => 'dummy',
             'shipping_multiple' => [
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                     ],
@@ -317,13 +310,9 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
         $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('shopping')));
 
         $Order = $this->orderRepository->findOneBy(['Customer' => $Customer]);
-        $Shipping = $Order->getShippings();
 
         // One shipping
-        $this->actual = count($Shipping);
-        $this->expected = count($arrCustomerAddress);
-
-        $this->verify();
+        $this->assertCount(1, $Order->getShippings());
     }
 
     /**
@@ -374,19 +363,17 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
             ],
         ]);
 
-        $arrCustomerAddress = $Customer->getCustomerAddresses();
-
         $multiForm = [
             '_token' => 'dummy',
             'shipping_multiple' => [
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                     ],
@@ -394,11 +381,11 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                     ],
@@ -417,10 +404,8 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
         $Order = $this->orderRepository->findOneBy(['Customer' => $Customer]);
         $Shipping = $Order->getShippings();
 
-        // one shipping
-        $this->actual = count($Shipping);
-        $this->expected = count($arrCustomerAddress);
-        $this->verify();
+        // One shipping
+        $this->assertCount(1, $Order->getShippings());
     }
 
     /**
@@ -452,8 +437,6 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
         $this->scenarioCartIn($Customer, $ProductClass2->getId());
         $this->scenarioCartIn($Customer, $ProductClass2->getId());
 
-        $this->scenarioCartIn($Customer);
-
         // 確認画面
         $crawler = $this->scenarioConfirm($Customer);
 
@@ -473,28 +456,26 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
             ],
         ]);
 
-        $arrCustomerAddress = $Customer->getCustomerAddresses();
-
         $multiForm = [
             '_token' => 'dummy',
             'shipping_multiple' => [
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
-                            'quantity' => 1,
+                            'customer_address' => 0,
+                            'quantity' => 2,
                         ],
                     ],
                 ],
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
-                            'quantity' => 1,
+                            'customer_address' => 0,
+                            'quantity' => 2,
                         ],
                         [
-                            'customer_address' => $arrCustomerAddress->last()->getId(),
-                            'quantity' => 1,
+                            'customer_address' => 2,
+                            'quantity' => 2,
                         ],
                     ],
                 ],
@@ -512,10 +493,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
         $Order = $this->orderRepository->findOneBy(['Customer' => $Customer]);
 
         // Two shipping
-        $Shipping = $Order->getShippings();
-        $this->actual = count($Shipping);
-        $this->expected = count($arrCustomerAddress);
-        $this->verify();
+        $this->assertCount(2, $Order->getShippings());
     }
 
     /**
@@ -569,19 +547,17 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
             ],
         ]);
 
-        $arrCustomerAddress = $Customer->getCustomerAddresses();
-
         $multiForm = [
             '_token' => 'dummy',
             'shipping_multiple' => [
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => $arrCustomerAddress->last()->getId(),
+                            'customer_address' => 2,
                             'quantity' => 1,
                         ],
                     ],
@@ -589,11 +565,11 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => $arrCustomerAddress->last()->getId(),
+                            'customer_address' => 2,
                             'quantity' => 1,
                         ],
                     ],
@@ -612,10 +588,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
         $Order = $this->orderRepository->findOneBy(['Customer' => $Customer]);
 
         // Two shipping
-        $Shipping = $Order->getShippings();
-        $this->actual = count($Shipping);
-        $this->expected = count($arrCustomerAddress);
-        $this->verify();
+        $this->assertCount(2, $Order->getShippings());
     }
 
     /**
@@ -674,31 +647,17 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
             ],
         ]);
 
-        $arrCustomerAddress = $Customer->getCustomerAddresses();
-
         $multiForm = [
             '_token' => 'dummy',
             'shipping_multiple' => [
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
-                            'quantity' => 1,
-                        ],
-                    ],
-                ],
-                [
-                    'shipping' => [
-                        [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
-                            'quantity' => 1,
-                        ],
-                        [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                     ],
@@ -706,7 +665,19 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
+                            'quantity' => 1,
+                        ],
+                        [
+                            'customer_address' => 0,
+                            'quantity' => 1,
+                        ],
+                    ],
+                ],
+                [
+                    'shipping' => [
+                        [
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                     ],
@@ -723,12 +694,9 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
         $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('shopping')));
 
         $Order = $this->orderRepository->findOneBy(['Customer' => $Customer]);
-        $Shipping = $Order->getShippings();
 
         // One shipping
-        $this->actual = count($Shipping);
-        $this->expected = count($arrCustomerAddress);
-        $this->verify();
+        $this->assertCount(1, $Order->getShippings());
     }
 
     /**
@@ -790,31 +758,17 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
             ],
         ]);
 
-        $arrCustomerAddress = $Customer->getCustomerAddresses();
-
         $multiForm = [
             '_token' => 'dummy',
             'shipping_multiple' => [
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 1,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => $arrCustomerAddress->last()->getId(),
-                            'quantity' => 1,
-                        ],
-                    ],
-                ],
-                [
-                    'shipping' => [
-                        [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
-                            'quantity' => 1,
-                        ],
-                        [
-                            'customer_address' => $arrCustomerAddress->last()->getId(),
+                            'customer_address' => 2,
                             'quantity' => 1,
                         ],
                     ],
@@ -822,7 +776,19 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 1,
+                            'quantity' => 1,
+                        ],
+                        [
+                            'customer_address' => 2,
+                            'quantity' => 1,
+                        ],
+                    ],
+                ],
+                [
+                    'shipping' => [
+                        [
+                            'customer_address' => 1,
                             'quantity' => 1,
                         ],
                     ],
@@ -839,12 +805,9 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
         $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('shopping')));
 
         $Order = $this->orderRepository->findOneBy(['Customer' => $Customer]);
-        $Shipping = $Order->getShippings();
 
         // Two shipping
-        $this->actual = count($Shipping);
-        $this->expected = count($arrCustomerAddress);
-        $this->verify();
+        $this->assertCount(2, $Order->getShippings());
     }
 
     /**
@@ -908,32 +871,17 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
             ],
         ]);
 
-        $arrCustomerAddress = $Customer->getCustomerAddresses();
-        $secondCustomerAddress = $arrCustomerAddress->get(1);
-
         $multiForm = [
             '_token' => 'dummy',
             'shipping_multiple' => [
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 1,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => $arrCustomerAddress->last()->getId(),
-                            'quantity' => 1,
-                        ],
-                    ],
-                ],
-                [
-                    'shipping' => [
-                        [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
-                            'quantity' => 1,
-                        ],
-                        [
-                            'customer_address' => $arrCustomerAddress->last()->getId(),
+                            'customer_address' => 2,
                             'quantity' => 1,
                         ],
                     ],
@@ -941,7 +889,19 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $secondCustomerAddress->getId(),
+                            'customer_address' => 1,
+                            'quantity' => 1,
+                        ],
+                        [
+                            'customer_address' => 2,
+                            'quantity' => 1,
+                        ],
+                    ],
+                ],
+                [
+                    'shipping' => [
+                        [
+                            'customer_address' => 3,
                             'quantity' => 1,
                         ],
                     ],
@@ -958,12 +918,9 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
         $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('shopping')));
 
         $Order = $this->orderRepository->findOneBy(['Customer' => $Customer]);
-        $Shipping = $Order->getShippings();
 
         // Three shipping
-        $this->actual = count($Shipping);
-        $this->expected = count($arrCustomerAddress);
-        $this->verify();
+        $this->assertCount(3, $Order->getShippings());
     }
 
     /**
@@ -1057,118 +1014,6 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
     /**
      * Test add multi shipping
      */
-    public function testAddMultiShippingWithQuantityNotEqual()
-    {
-        $Customer = $this->createCustomer();
-        $Customer->addCustomerAddress($this->createCustomerAddress($Customer));
-        $Customer->addCustomerAddress($this->createCustomerAddress($Customer));
-
-        // Product test 1 with type 1
-        $Product1 = $this->createProduct();
-        $ProductClass1 = $Product1->getProductClasses()->first();
-        $ProductClass1->setStock(111);
-
-        // Product test 2
-        $Product2 = $this->createProduct();
-        $ProductClass2 = $Product2->getProductClasses()->first();
-        $ProductClass2->setStock(111);
-
-        // Product test 3
-        $Product3 = $this->createProduct();
-        $ProductClass3 = $Product3->getProductClasses()->first();
-        $ProductClass3->setStock(111);
-
-        $this->entityManager->persist($ProductClass1);
-        $this->entityManager->persist($ProductClass2);
-        $this->entityManager->persist($ProductClass3);
-        $this->entityManager->flush();
-
-        // Item of product 1
-        $this->scenarioCartIn($Customer, $ProductClass1->getId());
-        $this->scenarioCartIn($Customer, $ProductClass1->getId());
-
-        // Item of product 2
-        $this->scenarioCartIn($Customer, $ProductClass2->getId());
-        $this->scenarioCartIn($Customer, $ProductClass2->getId());
-
-        // Item of product 3
-        $this->scenarioCartIn($Customer, $ProductClass3->getId());
-
-        // 確認画面
-        $crawler = $this->scenarioConfirm($Customer);
-        // お届け先指定画面
-        $this->scenarioRedirectTo($Customer, [
-            '_shopping_order' => [
-                'Shippings' => [
-                    0 => [
-                        'Delivery' => 1,
-                        'DeliveryTime' => 1,
-                    ],
-                ],
-                'Payment' => 1,
-                'message' => $this->getFaker()->realText(),
-                'mode' => 'shipping_multiple_change',
-                'param' => $crawler->filter('button.btn-shipping')->attr('data-id'),
-            ],
-        ]);
-
-        $arrCustomerAddress = $Customer->getCustomerAddresses();
-        $secondCustomerAddress = $arrCustomerAddress->next();
-
-        $multiForm = [
-            '_token' => 'dummy',
-            'shipping_multiple' => [
-                [
-                    'shipping' => [
-                        [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
-                            'quantity' => 2, // total not equal
-                        ],
-                        [
-                            'customer_address' => $arrCustomerAddress->last()->getId(),
-                            'quantity' => 1,
-                        ],
-                    ],
-                ],
-                [
-                    'shipping' => [
-                        [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
-                            'quantity' => 1,
-                        ],
-                        [
-                            'customer_address' => $arrCustomerAddress->last()->getId(),
-                            'quantity' => 1,
-                        ],
-                    ],
-                ],
-                [
-                    'shipping' => [
-                        [
-                            'customer_address' => $secondCustomerAddress->getId(),
-                            'quantity' => 1,
-                        ],
-                    ],
-                ],
-            ],
-        ];
-
-        $this->client->request(
-            'POST',
-            $this->generateUrl('shopping_shipping_multiple'),
-            ['form' => $multiForm]
-        );
-
-        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('shopping')));
-
-        $crawler = $this->client->request('GET', $this->generateUrl('shopping'));
-        $shipping = $crawler->filter('#shopping-form > div > div.ec-orderRole__detail > div.ec-orderDelivery')->text();
-        $this->assertContains('× 2', $shipping);
-    }
-
-    /**
-     * Test add multi shipping
-     */
     public function testAddMultiShippingWithShippingEarlier()
     {
         $Customer = $this->createCustomer();
@@ -1224,9 +1069,6 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
             ],
         ]);
 
-        $arrCustomerAddress = $Customer->getCustomerAddresses();
-        $secondCustomerAddress = $arrCustomerAddress->next();
-
         // Before multi shipping
         // Only shipped to one address
         $beforeForm = [
@@ -1235,7 +1077,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 2,
                         ],
                     ],
@@ -1243,7 +1085,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 2,
                         ],
                     ],
@@ -1251,7 +1093,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                     ],
@@ -1267,23 +1109,11 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => $arrCustomerAddress->last()->getId(),
-                            'quantity' => 1,
-                        ],
-                    ],
-                ],
-                [
-                    'shipping' => [
-                        [
-                            'customer_address' => $arrCustomerAddress->first()->getId(),
-                            'quantity' => 1,
-                        ],
-                        [
-                            'customer_address' => $arrCustomerAddress->last()->getId(),
+                            'customer_address' => 2,
                             'quantity' => 1,
                         ],
                     ],
@@ -1291,7 +1121,19 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                 [
                     'shipping' => [
                         [
-                            'customer_address' => $secondCustomerAddress->getId(),
+                            'customer_address' => 0,
+                            'quantity' => 1,
+                        ],
+                        [
+                            'customer_address' => 2,
+                            'quantity' => 1,
+                        ],
+                    ],
+                ],
+                [
+                    'shipping' => [
+                        [
+                            'customer_address' => 3,
                             'quantity' => 1,
                         ],
                     ],
@@ -1319,9 +1161,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
         $Shipping = $Order->getShippings();
 
         // Three shipping
-        $this->actual = count($Shipping);
-        $this->expected = count($arrCustomerAddress);
-        $this->verify();
+        $this->assertCount(3, $Shipping);
     }
 
     /**
@@ -1377,15 +1217,15 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
                     'shipping' => [
                         // number 3
                         [
-                            'customer_address' => $addressId,
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => $addressId,
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                         [
-                            'customer_address' => $addressId,
+                            'customer_address' => 0,
                             'quantity' => 1,
                         ],
                     ],

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
@@ -139,7 +139,7 @@ class ShoppingControllerWithNonmemberTest extends AbstractShoppingControllerTest
         $this->assertNotNull($this->container->get('session')->get('eccube.front.shopping.nonmember.customeraddress'));
 
         $this->expected = $formData['name']['name01'];
-        $this->actual = $Nonmember['customer']->getName01();
+        $this->actual = $Nonmember->getName01();
         $this->verify();
 
         $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('shopping')));


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- 現状(3.0)
  - 注文時は、お届け先のリストからのみ、お届け先を選択できる。
  - マイページで会員情報を変更した場合、「会員住所」と「お届け先リストの住所」が異なる状態になる。

- やりたいこと
  - 注文時に、「会員住所」＆「お届け先リストの住所」からお届け先を選択できる。
  - お届け先のデフォルトは「会員住所」となる。

# 方針

- 注文時に、「会員住所」＆「お届け先リストの住所」からお届け先を選択できる
- お届け先のデフォルトは「会員住所」となる。
- 会員登録時にお届け先リストには追加しない

## テスト（Test)
- travis-ciがパスすることを確認
