### PR TITLE
名前とカナの入力チェックエラーメッセージを修正

### DIFF
--- a/src/Eccube/Form/Type/KanaType.php
+++ b/src/Eccube/Form/Type/KanaType.php
@@ -58,6 +58,7 @@ class KanaType extends AbstractType
                 'constraints' => array(
                     new Assert\Regex(array(
                         'pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u",
+                        'message' => 'form.type.kana.lastname.nothasspace'
                     )),
                     new Assert\Length(array(
                         'max' => $this->config['kana_len'],
@@ -71,6 +72,7 @@ class KanaType extends AbstractType
                 'constraints' => array(
                     new Assert\Regex(array(
                         'pattern' => "/^[ァ-ヶｦ-ﾟー]+$/u",
+                        'message' => 'form.type.kana.firstname.nothasspace'
                     )),
                     new Assert\Length(array(
                         'max' => $this->config['kana_len'],

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -104,7 +104,7 @@ class NameType extends AbstractType
                     )),
                     new Assert\Regex(array(
                         'pattern' => '/^[^\s ]+$/u',
-                        'message' => 'form.type.name.firstname.nothasspace'
+                        'message' => 'form.type.name.lastname.nothasspace'
                     ))
                 ),
             ),
@@ -118,7 +118,7 @@ class NameType extends AbstractType
                     )),
                     new Assert\Regex(array(
                         'pattern' => '/^[^\s ]+$/u',
-                        'message' => 'form.type.name.lastname.nothasspace'
+                        'message' => 'form.type.name.firstname.nothasspace'
                     ))
                 ),
             ),

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -38,7 +38,9 @@ form.member.repeated.confirm: 確認のためもう一度入力してくださ�
 form.type.graph.invalid: 半角英数字で入力してください。
 
 form.type.name.firstname.nothasspace: お名前(名)にスペース、タブ、改行は含めないで下さい。
-form.type.name.lastname.nothasspace: お名前(性)にスペース、タブ、改行は含めないで下さい。
+form.type.name.lastname.nothasspace: お名前(姓)にスペース、タブ、改行は含めないで下さい。
+form.type.kana.firstname.nothasspace: フリガナ(メイ)にスペース、タブ、改行は含めないで下さい。
+form.type.kana.lastname.nothasspace: フリガナ(セイ)にスペース、タブ、改行は含めないで下さい。
 form.type.customer.company.nothasspace: 会社名にスペース、タブ、改行は含めないで下さい。
 
 form.type.admin.nottelstyle: 電話番号は半角数字かハイフンのみを入力してください。


### PR DESCRIPTION
名前とカナにスペースやタブ等がセットされた時の入力チェックエラーメッセージに誤りがあったため修正
