### PR TITLE
Packagistにexperimental/sfブランチが登録されない問題の修正

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "type": "project",
     "homepage": "https://www.ec-cube.net/",
     "license": [
-       "GPL-2.0",
-       "Commercial"
+       "GPL-2.0-only"
     ],
     "support": {
         "issues": "https://github.com/EC-CUBE/ec-cube/issues"


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- Packagistにexperimental/sfが登録されない
- ライセンス表記について、以下のエラーが発生している
- GPLの記述方法が変わったため

```
Reading composer.json of ec-cube/ec-cube (experimental/sf)
Importing branch experimental/sf (dev-experimental/sf)
Skipped branch experimental/sf, Invalid package information: 
License ["GPL-2.0","Commercial"] is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.
```

## 参考
https://spdx.org/licenses/