### PR TITLE
gitignoreの`/phpunit.xml` が重複していたので一方を削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ composer.phar
 !/html/template/install
 /html/user_data/*
 !/html/user_data/.gitkeep
-/phpunit.xml
 /src/Eccube/Resource/config/*.dist.php
 /tests/tmp/*
 /reports/*


### PR DESCRIPTION
gitignoreの`/phpunit.xml` が重複していたので一方を削除