### PR TITLE
テンプレートイベントの修正

### DIFF
--- a/src/Eccube/Twig/Environment.php
+++ b/src/Eccube/Twig/Environment.php
@@ -14,7 +14,6 @@
 namespace Eccube\Twig;
 
 use Eccube\Event\TemplateEvent;
-use Eccube\Request\Context;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class Environment extends \Twig_Environment
@@ -29,16 +28,10 @@ class Environment extends \Twig_Environment
      */
     protected $eventDispatcher;
 
-    /**
-     * @var Context
-     */
-    protected $requestContext;
-
-    public function __construct(\Twig_Environment $twig, EventDispatcherInterface $eventDispatcher, Context $context)
+    public function __construct(\Twig_Environment $twig, EventDispatcherInterface $eventDispatcher)
     {
         $this->twig = $twig;
         $this->eventDispatcher = $eventDispatcher;
-        $this->requestContext = $context;
     }
 
     public function render($name, array $context = [])

--- a/src/Eccube/Twig/Environment.php
+++ b/src/Eccube/Twig/Environment.php
@@ -51,14 +51,8 @@ class Environment extends \Twig_Environment
         // プラグインにはテンプレートファイル名, 文字列化されたtwigファイル, パラメータを渡す.
         $event = new TemplateEvent($name, $source, $context);
 
-        $eventName = $name;
-        if ($this->requestContext->isAdmin()) {
-            // 管理画面の場合, event名に`Admin/`を付ける.
-            $eventName = 'Admin/'.$name;
-        }
-
         // テンプレートフックポイントの実行.
-        $this->eventDispatcher->dispatch($eventName, $event);
+        $this->eventDispatcher->dispatch($name, $event);
 
         // プラグインで変更された文字列から, テンプレートオブジェクトを生成.
         $template = $this->twig->createTemplate($event->getSource());


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- 管理画面のテンプレートは`@admin`の名前空間がつくようになっている
- 管理画面のテンプレートかどうかの判別は不要になったため該当処理を削除

