### PR TITLE
注文完了時にメッセージを表示できるように対応

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -313,14 +313,15 @@ class ShoppingController extends AbstractShoppingController
     {
         // 受注IDを取得
         $orderId = $this->session->get($this->sessionOrderKey);
-        $Order = null;
-        if ($orderId) {
-            $Order = $this->orderRepository->find($orderId);
+
+        if (empty($orderId)) {
+            return $this->redirectToRoute('homepage');
         }
+
+        $Order = $this->orderRepository->find($orderId);
 
         $event = new EventArgs(
             [
-                'orderId' => $orderId,
                 'Order' => $Order,
             ],
             $request
@@ -336,12 +337,11 @@ class ShoppingController extends AbstractShoppingController
         $this->session->remove($this->sessionKey);
         $this->session->remove($this->sessionCustomerAddressKey);
 
-        log_info('購入処理完了', [$orderId]);
+        log_info('購入処理完了', [$Order->getId()]);
 
         $hasNextCart = !empty($this->cartService->getCarts());
 
         return [
-            'orderId' => $orderId,
             'Order' => $Order,
             'hasNextCart' => $hasNextCart,
         ];

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -29,6 +29,7 @@ use Eccube\Form\Type\Front\ShoppingShippingType;
 use Eccube\Form\Type\Shopping\CustomerAddressType;
 use Eccube\Form\Type\Shopping\OrderType;
 use Eccube\Repository\CustomerAddressRepository;
+use Eccube\Repository\OrderRepository;
 use Eccube\Service\CartService;
 use Eccube\Service\OrderHelper;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
@@ -91,6 +92,7 @@ class ShoppingController extends AbstractShoppingController
         CartService $cartService,
         ShoppingService $shoppingService,
         CustomerAddressRepository $customerAddressRepository,
+        OrderRepository $orderRepository,
         ParameterBag $parameterBag
     ) {
         $this->BaseInfo = $BaseInfo;
@@ -98,6 +100,7 @@ class ShoppingController extends AbstractShoppingController
         $this->cartService = $cartService;
         $this->shoppingService = $shoppingService;
         $this->customerAddressRepository = $customerAddressRepository;
+        $this->orderRepository = $orderRepository;
         $this->parameterBag = $parameterBag;
     }
 
@@ -310,10 +313,15 @@ class ShoppingController extends AbstractShoppingController
     {
         // 受注IDを取得
         $orderId = $this->session->get($this->sessionOrderKey);
+        $Order = null;
+        if ($orderId) {
+            $Order = $this->orderRepository->find($orderId);
+        }
 
         $event = new EventArgs(
             [
                 'orderId' => $orderId,
+                'Order' => $Order,
             ],
             $request
         );
@@ -334,6 +342,7 @@ class ShoppingController extends AbstractShoppingController
 
         return [
             'orderId' => $orderId,
+            'Order' => $Order,
             'hasNextCart' => $hasNextCart,
         ];
     }

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -358,7 +358,7 @@ class Order extends \Eccube\Entity\AbstractEntity implements PurchaseInterface, 
      *
      * プラグインから注文完了時にメッセージを表示したい場合, このフィールドにセットすることで, 注文完了画面で表示されます。
      * 複数のプラグインから利用されるため, appendCompleteMesssage()で追加してください.
-     * 表示する際にHTMLは利用可能ですが、Javascriptはエスケープされます。
+     * 表示する際にHTMLは利用可能です。
      *
      * @var string|null
      *

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -354,6 +354,12 @@ class Order extends \Eccube\Entity\AbstractEntity implements PurchaseInterface, 
     private $currency_code;
 
     /**
+     * 注文完了画面に表示するメッセージ
+     *
+     * プラグインから注文完了時にメッセージを表示したい場合, このフィールドにセットすることで, 注文完了画面で表示されます。
+     * 複数のプラグインから利用されるため, appendCompleteMesssage()で追加してください.
+     * 表示する際にHTMLエスケープは行いません。
+     *
      * @var string|null
      *
      * @ORM\Column(name="complete_message", type="text", nullable=true)
@@ -361,6 +367,11 @@ class Order extends \Eccube\Entity\AbstractEntity implements PurchaseInterface, 
     private $complete_message;
 
     /**
+     * 注文完了メールに表示するメッセージ
+     *
+     * プラグインから注文完了メールにメッセージを表示したい場合, このフィールドにセットすることで, 注文完了メールで表示されます。
+     * 複数のプラグインから利用されるため, appendCompleteMailMesssage()で追加してください.
+     *
      * @var string|null
      *
      * @ORM\Column(name="complete_mail_message", type="text", nullable=true)

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -354,6 +354,20 @@ class Order extends \Eccube\Entity\AbstractEntity implements PurchaseInterface, 
     private $currency_code;
 
     /**
+     * @var string|null
+     *
+     * @ORM\Column(name="complete_message", type="text", nullable=true)
+     */
+    private $complete_message;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(name="complete_mail_message", type="text", nullable=true)
+     */
+    private $complete_mail_message;
+
+    /**
      * @var \Doctrine\Common\Collections\Collection
      *
      * @ORM\OneToMany(targetEntity="Eccube\Entity\OrderItem", mappedBy="Order", cascade={"persist","remove"})
@@ -1349,6 +1363,70 @@ class Order extends \Eccube\Entity\AbstractEntity implements PurchaseInterface, 
     public function setCurrencyCode($currencyCode = null)
     {
         $this->currency_code = $currencyCode;
+
+        return $this;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getCompleteMessage()
+    {
+        return $this->complete_message;
+    }
+
+    /**
+     * @param null|string $complete_message
+     *
+     * @return $this
+     */
+    public function setCompleteMessage($complete_message = null)
+    {
+        $this->complete_message = $complete_message;
+
+        return $this;
+    }
+
+    /**
+     * @param null|string $complete_message
+     *
+     * @return $this
+     */
+    public function appendCompleteMessage($complete_message = null)
+    {
+        $this->complete_message .= $complete_message;
+
+        return $this;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getCompleteMailMessage()
+    {
+        return $this->complete_mail_message;
+    }
+
+    /**
+     * @param null|string $complete_mail_message
+     *
+     * @return
+     */
+    public function setCompleteMailMessage($complete_mail_message = null)
+    {
+        $this->complete_mail_message = $complete_mail_message;
+
+        return $this;
+    }
+
+    /**
+     * @param null|string $complete_mail_message
+     *
+     * @return
+     */
+    public function appendCompleteMailMessage($complete_mail_message = null)
+    {
+        $this->complete_mail_message .= $complete_mail_message;
 
         return $this;
     }

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -358,7 +358,7 @@ class Order extends \Eccube\Entity\AbstractEntity implements PurchaseInterface, 
      *
      * プラグインから注文完了時にメッセージを表示したい場合, このフィールドにセットすることで, 注文完了画面で表示されます。
      * 複数のプラグインから利用されるため, appendCompleteMesssage()で追加してください.
-     * 表示する際にHTMLエスケープは行いません。
+     * 表示する際にHTMLは利用可能ですが、Javascriptはエスケープされます。
      *
      * @var string|null
      *

--- a/src/Eccube/Resource/template/admin/Mail/order.twig
+++ b/src/Eccube/Resource/template/admin/Mail/order.twig
@@ -91,4 +91,8 @@ FAX番号 ：{{ Shipping.fax01 }}-{{ Shipping.fax02 }}-{{ Shipping.fax03 }}
 {% endfor %}
 {% endfor %}
 
+{% if Order.complete_mail_message is not empty %}
+{{ Order.complete_mail_message }}
+{% endif %}
+
 {{ footer }}

--- a/src/Eccube/Resource/template/default/Mail/order.twig
+++ b/src/Eccube/Resource/template/default/Mail/order.twig
@@ -88,4 +88,8 @@ file that was distributed with this source code.
 {% endfor %}
 {% endfor %}
 
+{% if Order.complete_mail_message is not empty %}
+{{ Order.complete_mail_message }}
+{% endif %}
+
 {{ footer }}

--- a/src/Eccube/Resource/template/default/Shopping/complete.twig
+++ b/src/Eccube/Resource/template/default/Shopping/complete.twig
@@ -67,7 +67,7 @@ file that was distributed with this source code.
             </div>
             <p class="ec-reportDescription">{{'shopping.text.message.sent_email'|trans}}<br>{{'shopping.text.message.in_case'|trans}}<br>{{'shopping.text.message.thank_you_with_us'|trans}}</p>
             {% if Order.complete_message is not empty %}
-                {{ Order.complete_message|e('js') }}
+                {{ Order.complete_message|raw }}
             {% endif %}
             <div class="ec-off4Grid">
                 {% if hasNextCart %}

--- a/src/Eccube/Resource/template/default/Shopping/complete.twig
+++ b/src/Eccube/Resource/template/default/Shopping/complete.twig
@@ -66,8 +66,8 @@ file that was distributed with this source code.
                 <h2>{{'shopping.text.message.thank_you_order'|trans}}</h2>
             </div>
             <p class="ec-reportDescription">{{'shopping.text.message.sent_email'|trans}}<br>{{'shopping.text.message.in_case'|trans}}<br>{{'shopping.text.message.thank_you_with_us'|trans}}</p>
-            {% if Order is not null and Order.complete_message is not empty %}
-                {{ Order.complete_message|raw }}
+            {% if Order.complete_message is not empty %}
+                {{ Order.complete_message|e('js') }}
             {% endif %}
             <div class="ec-off4Grid">
                 {% if hasNextCart %}

--- a/src/Eccube/Resource/template/default/Shopping/complete.twig
+++ b/src/Eccube/Resource/template/default/Shopping/complete.twig
@@ -66,6 +66,9 @@ file that was distributed with this source code.
                 <h2>{{'shopping.text.message.thank_you_order'|trans}}</h2>
             </div>
             <p class="ec-reportDescription">{{'shopping.text.message.sent_email'|trans}}<br>{{'shopping.text.message.in_case'|trans}}<br>{{'shopping.text.message.thank_you_with_us'|trans}}</p>
+            {% if Order is not null and Order.complete_message is not empty %}
+                {{ Order.complete_message|raw }}
+            {% endif %}
             <div class="ec-off4Grid">
                 {% if hasNextCart %}
                     <div class="ec-off4Grid__cell"><a class="ec-blockBtn--primary" href="{{ url('cart') }}">購入を続ける</a></div> {# TODO 未翻訳 #}}

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -49,7 +49,9 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
 
     public function testComplete()
     {
-        $this->container->get('session')->set('eccube.front.shopping.order.id', 111);
+        $Customer = $this->createCustomer();
+        $Order = $this->createOrder($Customer);
+        $this->container->get('session')->set('eccube.front.shopping.order.id', $Order->getId());
         $this->client->request('GET', $this->generateUrl('shopping_complete'));
 
         $this->assertTrue($this->client->getResponse()->isSuccessful());


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- プラグインなどから、注文完了時にメッセージを表示できるように対応
- 注文完了画面および注文完了メールでメッセージを挿入できる

## 実装に関する補足(Appendix)
- Orderに, complete_message/complete_mail_messageを追加
- 複数のプラグインから利用されるため、メッセージをセットする場合は
  - appendCompleteMessage
  - appendCompleteMailMessage
- を使用すること

## テスト（Test)
- travis-ciにパスすることを確認




