### PR TITLE
プラグインの有効無効判定が動作していなかった問題を修正

### DIFF
--- a/src/Eccube/DependencyInjection/Compiler/PluginPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/PluginPass.php
@@ -37,7 +37,7 @@ class PluginPass implements CompilerPassInterface
             $class = $definition->getClass();
 
             foreach ($plugins as $plugin) {
-                $namespace = 'Plugin\\'.$plugin['code'];
+                $namespace = 'Plugin\\'.$plugin;
 
                 if (false !== \strpos($class, $namespace)) {
                     $definition->clearTags();

--- a/src/Eccube/DependencyInjection/EccubeExtension.php
+++ b/src/Eccube/DependencyInjection/EccubeExtension.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class EccubeExtension extends Extension implements PrependExtensionInterface
@@ -36,8 +37,13 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
      */
     public function prepend(ContainerBuilder $container)
     {
+        $pluginDir = $container->getParameter('kernel.project_dir').'/app/Plugin';
+        $pluginDirs = $this->getPluginDirectories($pluginDir);
+
         $container->setParameter('eccube.plugins.enabled', []);
-        $container->setParameter('eccube.plugins.disabled', []);
+        // ファイル設置のみの場合は, 無効なプラグインとみなす.
+        // DB接続後, 有効無効の判定を行う.
+        $container->setParameter('eccube.plugins.disabled', $pluginDirs);
 
         // FIXME WebTestCase で DATABASE_URL が取得できず落ちる
         if (!array_key_exists('APP_ENV', $_ENV) || $_ENV['APP_ENV'] == 'test') {
@@ -67,13 +73,19 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
         $stmt = $conn->query('select * from dtb_plugin');
         $plugins = $stmt->fetchAll();
 
-        $enabled = array_filter($plugins, function ($plugin) {
-            return true === (bool) $plugin['enabled'];
-        });
+        $enabled = [];
+        foreach ($plugins as $plugin) {
+            if ($plugin['enabled']) {
+                $enabled[] = $plugin['code'];
+            }
+        }
 
-        $disabled = array_filter($plugins, function ($plugin) {
-            return false === (bool) $plugin['enabled'];
-        });
+        $disabled = [];
+        foreach ($pluginDirs as $dir) {
+            if (!in_array($dir, $enabled)) {
+                $disabled[] = $dir;
+            }
+        }
 
         // 他で使いまわすため, パラメータで保持しておく.
         $container->setParameter('eccube.plugins.enabled', $enabled);
@@ -88,8 +100,7 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
     {
         $paths = [];
 
-        foreach ($enabled as $plugin) {
-            $code = $plugin['code'];
+        foreach ($enabled as $code) {
             $dir = $pluginDir.'/'.$code.'/Resource/template';
             if (file_exists($dir)) {
                 $paths[$dir] = $code;
@@ -107,8 +118,7 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
     {
         $paths = [];
 
-        foreach ($enabled as $plugin) {
-            $code = $plugin['code'];
+        foreach ($enabled as $code) {
             $dir = $pluginDir.'/'.$code.'/Resource/locale';
             if (file_exists($dir)) {
                 $paths[] = $dir;
@@ -143,5 +153,20 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
         );
 
         return empty($tables) ? false : true;
+    }
+
+    protected function getPluginDirectories($pluginDir)
+    {
+        $finder = (new Finder())
+            ->in($pluginDir)
+            ->depth(0)
+            ->directories();
+
+        $dirs = [];
+        foreach ($finder as $dir) {
+            $dirs[] = $dir->getBaseName();
+        }
+
+        return $dirs;
     }
 }

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -131,7 +131,7 @@ class Kernel extends BaseKernel
         $plugins = $container->getParameter('eccube.plugins.enabled');
         $pluginDir = $this->getProjectDir().'/app/Plugin';
         foreach ($plugins as $plugin) {
-            $dir = $pluginDir.'/'.$plugin['code'].'/Controller';
+            $dir = $pluginDir.'/'.$plugin.'/Controller';
             if (file_exists($dir)) {
                 $builder = $routes->import($dir, '/', 'annotation');
                 $builder->setSchemes($scheme);

--- a/tests/Eccube/Tests/Twig/Extension/EccubeBlockExtensionTest.php
+++ b/tests/Eccube/Tests/Twig/Extension/EccubeBlockExtensionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Twig\Extension;
+
+use Eccube\Tests\EccubeTestCase;
+use Eccube\Twig\Extension\EccubeBlockExtension;
+use org\bovigo\vfs\vfsStream;
+
+class EccubeBlockExtensionTest extends EccubeTestCase
+{
+    protected $templateDir;
+
+    protected $blockTwigs = [
+        'test_block.twig',
+        'test_block2.twig',
+    ];
+
+    /**
+     * @var \Twig_Environment
+     */
+    protected $twig;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $root = vfsStream::setup();
+        $this->templateDir = $root->url();
+
+        foreach ($this->blockTwigs as $twig_file) {
+            // Preventing undefined errors
+            file_put_contents($this->templateDir.'/'.$twig_file, '');
+        }
+
+        $loader = new \Twig_Loader_Filesystem([
+            $this->templateDir,
+        ]);
+        $this->twig = new \Twig_Environment($loader);
+        $this->twig->addExtension(new EccubeBlockExtension($this->twig, $this->blockTwigs));
+    }
+
+    /**
+     * 任意のブロックをユーザー定義関数で出力するテスト.
+     */
+    public function testEccubeBlockFunctions()
+    {
+        $file = $this->templateDir.'/'.$this->blockTwigs[0];
+        $source = '{% block exampleblock %}<div id="exampleblock">test</div>{% endblock %}';
+
+        file_put_contents($file, $source);
+        $template = $this->twig->createTemplate("<div id='test'>{{ eccube_block_exampleblock() }}</div>");
+
+        $this->expected = "<div id='test'><div id=\"exampleblock\">test</div></div>";
+        $this->actual = $template->render([]);
+
+        $this->verify();
+    }
+
+    /**
+     * 任意のブロックをユーザー定義関数で出力するテスト.
+     *
+     * 引数付き
+     */
+    public function testEccubeBlockFunctionsWithParams()
+    {
+        $file = $this->templateDir.'/'.$this->blockTwigs[1];
+        $source = '{% block exampleblock2 %}<div id="exampleblock">{{ variable }}</div>{% endblock %}';
+
+        file_put_contents($file, $source);
+
+        $template = $this->twig->createTemplate(
+            "<div id='test'>{{ eccube_block_exampleblock2({'variable': 'example'}) }}</div>"
+        );
+
+        $this->expected = "<div id='test'><div id=\"exampleblock\">example</div></div>";
+        $this->actual = $template->render(['variable' => 'example']);
+
+        $this->verify();
+    }
+}

--- a/tests/Eccube/Tests/Twig/Extension/FunctionsTest.php
+++ b/tests/Eccube/Tests/Twig/Extension/FunctionsTest.php
@@ -14,16 +14,9 @@
 namespace Eccube\Tests\Twig\Extension;
 
 use Eccube\Tests\EccubeTestCase;
-use org\bovigo\vfs\vfsStream;
 
 class FunctionsTest extends EccubeTestCase
 {
-    protected $templateDir;
-    protected $blockTwigs = [
-        'test_block.twig',
-        'test_block2.twig',
-    ];
-
     /**
      * @var \Twig_Environment
      */
@@ -33,31 +26,7 @@ class FunctionsTest extends EccubeTestCase
     {
         parent::setUp();
 
-        $client = self::createClient();
-        $root = vfsStream::setup();
-        $this->templateDir = $root->url();
-
-        // Rewrite to parameters using reflection
-        $container = $client->getContainer();
-        $parameters = $container->getParameterBag()->all();
-        $parameters['eccube_twig_block_templates'] = $this->blockTwigs;
-
-        $refClass = new \ReflectionClass($container);
-        $refProp = $refClass->getProperty('parameters');
-        $refProp->setAccessible(true);
-        $refProp->setValue($container, $parameters);
-
-        // Initialize to the Twig loader
-        $this->twig = $client->getContainer()->get('twig');
-        $paths = $this->twig->getLoader()->getPaths();
-        $paths[] = $this->templateDir;
-        $this->twig->setLoader(new \Twig_Loader_Filesystem($paths));
-        $this->twig->setCache(false);
-
-        foreach ($this->blockTwigs as $twig_file) {
-            // Preventing undefined errors
-            file_put_contents($this->templateDir.'/'.$twig_file, '');
-        }
+        $this->twig = $this->container->get('twig');
     }
 
     /**
@@ -70,44 +39,6 @@ class FunctionsTest extends EccubeTestCase
         $this->expected = "<div id='test'>aaa</div>";
         $this->actual = $template->render([]);
 
-        $this->verify();
-    }
-
-    /**
-     * 任意のブロックをユーザー定義関数で出力するテスト.
-     */
-    public function testEccubeBlockFunctions()
-    {
-        $file = $this->templateDir.'/'.$this->blockTwigs[0];
-        $source = '{% block exampleblock %}<div id="exampleblock">test</div>{% endblock %}';
-
-        file_put_contents($file, $source);
-        $template = $this->twig->createTemplate("<div id='test'>{{ eccube_block_exampleblock() }}</div>");
-
-        $this->expected = "<div id='test'><div id=\"exampleblock\">test</div></div>";
-        $this->actual = $template->render([]);
-
-        $this->verify();
-    }
-
-    /**
-     * 任意のブロックをユーザー定義関数で出力するテスト.
-     *
-     * 引数付き
-     */
-    public function testEccubeBlockFunctionsWithParams()
-    {
-        $file = $this->templateDir.'/'.$this->blockTwigs[1];
-        $source = '{% block exampleblock2 %}<div id="exampleblock">{{ variable }}</div>{% endblock %}';
-
-        file_put_contents($file, $source);
-
-        $template = $this->twig->createTemplate(
-            "<div id='test'>{{ eccube_block_exampleblock2({'variable': 'example'}) }}</div>"
-        );
-
-        $this->expected = "<div id='test'><div id=\"exampleblock\">example</div></div>";
-        $this->actual = $template->render(['variable' => 'example']);
         $this->verify();
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- プラグインの有効無効判定が動作していなかった問題を修正
- dtb_pluginに登録されていないプラグインが読み込まれていた
- dtb_pluginに登録されていないプラグインは無効扱いとし、ロードしないように修正




