### PR TITLE
プラグインの削除時に不正なproxyが生成される問題を修正

### DIFF
--- a/src/Eccube/Service/EntityProxyService.php
+++ b/src/Eccube/Service/EntityProxyService.php
@@ -236,6 +236,7 @@ class EntityProxyService
      * - 本体でuseされているTrait -> PointTrait
      *
      * @param $name
+     *
      * @return array|Token[]
      */
     private function convertTraitNameToTokens($name)

--- a/tests/Eccube/Tests/Service/EntityProxyServiceTest.php
+++ b/tests/Eccube/Tests/Service/EntityProxyServiceTest.php
@@ -221,6 +221,33 @@ EOT
 
         self::assertNull($entityTokens->getNextTokenOfKind(0, [CT::T_USE_TRAIT]), 'Traitのuse句が削除されているはず');
     }
+
+    public function testRemoveTraitWhenImportedTrait()
+    {
+        $entityTokens = Tokens::fromCode(<<< EOT
+<?php
+
+use Eccube\\Entity\\PointTrait;
+
+class EntityProxyServiceTest_Entity extends \\Eccube\\Entity\\AbstractEntity
+{
+    use PointTrait, \\Eccube\\Tests\\Service\\EntityProxyServiceTest_Trait;
+}
+EOT
+        );
+        $method = new \ReflectionMethod(EntityProxyService::class, 'removeTrait');
+        $method->setAccessible(true);
+        $method->invoke($this->entityProxyService, $entityTokens, '\\Eccube\\Tests\\Service\\EntityProxyServiceTest_Trait');
+
+        $traitTokens = [
+            [CT::T_USE_TRAIT],
+            [T_STRING, 'PointTrait'],
+            ';',
+        ];
+
+        self::assertNotNull($entityTokens->findSequence($traitTokens), 'PointTraitが残るはず');
+
+    }
 }
 
 /**

--- a/tests/Eccube/Tests/Service/EntityProxyServiceTest.php
+++ b/tests/Eccube/Tests/Service/EntityProxyServiceTest.php
@@ -246,7 +246,6 @@ EOT
         ];
 
         self::assertNotNull($entityTokens->findSequence($traitTokens), 'PointTraitが残るはず');
-
     }
 }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- プラグインの削除時に不正なproxyが生成される問題を修正
- 本体側で使用されているtraitが削除される, もしくはFQCNに変換されるケースがある
- EntityProxyServiceのtrait名の変換処理で、本体のtraitを考慮するように修正

## テスト（Test)
- Travis-CIにパスすることを確認

