### PR TITLE
関係のないプラグインが無効化される問題を修正

### DIFF
--- a/src/Eccube/DependencyInjection/Compiler/PluginPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/PluginPass.php
@@ -37,7 +37,7 @@ class PluginPass implements CompilerPassInterface
             $class = $definition->getClass();
 
             foreach ($plugins as $plugin) {
-                $namespace = 'Plugin\\'.$plugin;
+                $namespace = 'Plugin\\'.$plugin.'\\';
 
                 if (false !== \strpos($class, $namespace)) {
                     $definition->clearTags();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- 文字列の評価が前方一致のため関係のないプラグインが無効化される
- 例えばSample だと SamplePaymentも無効化される
- namespaceの区切りまで評価するように修正


