### PR TITLE
【注文手続画面】非会員の住所入力時の進捗バーが、表示中のページとずれている不具合修正

### DIFF
--- a/src/Eccube/Resource/template/default/Shopping/nonmember.twig
+++ b/src/Eccube/Resource/template/default/Shopping/nonmember.twig
@@ -26,13 +26,13 @@ file that was distributed with this source code.
     </div>
     <div class="ec-layoutRole__progress">
         <ul class="ec-progress">
-            <li class="ec-progress__item is-complete">
+            <li class="ec-progress__item">
                 <div class="ec-progress__number">1
                 </div>
                 <div class="ec-progress__label">{{'shopping.label.your_cart'|trans}}
                 </div>
             </li>
-            <li class="ec-progress__item">
+            <li class="ec-progress__item is-complete">
                 <div class="ec-progress__number">2
                 </div>
                 <div class="ec-progress__label">{{'shopping.label.customer_info'|trans}}


### PR DESCRIPTION
【注文手続画面】非会員の住所入力時の進捗バーが、表示中のページとずれている不具合修正