### PR TITLE
【会員登録】会員登録完了後に送信されるメール本文に記載されているURLがhttpから始まっていない

### DIFF
--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -899,7 +899,7 @@ return [
     'admin.customer.edit.98' => '番地・ビル名（例：1-3-5）',
     'admin.customer.edit.99' => '購入履歴',
     'admin.customer.edit.100' => '注文日時',
-    'admin.customer.edit.101' => '注文番号',
+    'admin.customer.edit.101' => '受注番号',
     'admin.customer.edit.102' => '購入金額',
     'admin.customer.edit.103' => '出荷日',
     'admin.customer.edit.104' => '支払方法',

--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -373,7 +373,7 @@ file that was distributed with this source code.
                                                     <td class="align-middle pl-3">{{ Order.order_date|date_format }}</td>
                                                     <td class="align-middle">
                                                         <a href="{{ url('admin_order_edit', { 'id' : Order.id }) }}">
-                                                            {{ Order.order_no }}
+                                                            {{ Order.id }}
                                                         </a>
                                                     </td>
                                                     <td class="align-middle">


### PR DESCRIPTION
# 概要(Overview・Refs Issue)
- フロント会員登録時のアクティベーションメール内のURLが絶対パス表記になっていない為（クリックできない）、絶対パス表記へと変更する。

### 方針(Policy)
このPullRequestを作るにあたって考慮したものや除外した内容
 - CustomerController::resend()の方は絶対パス表記となっていた為、今回の対処としてはコードを一致させる事としたが、generateUrlをオーバーライドするなり、ユーティリティ化する等も考えられる。

### テスト（Test)
- 動作確認実施（フロントより新規会員登録を実行、配信されるメールを確認）
