### PR TITLE
[出荷CSV登録時]出荷日の時間を00:00:00に固定

### DIFF
--- a/src/Eccube/Controller/Admin/Shipping/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Shipping/CsvImportController.php
@@ -139,6 +139,7 @@ class CsvImportController extends AbstractCsvImportController
                     continue;
                 }
 
+                $shippingDate->setTime(0, 0, 0);
                 $Shipping->setShippingDate($shippingDate);
             }
         }

--- a/tests/Eccube/Tests/Web/Admin/Shipping/CsvImportControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Shipping/CsvImportControllerTest.php
@@ -34,7 +34,7 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         $this->entityManager->refresh($Shipping);
 
         self::assertEquals('1234', $Shipping->getTrackingNumber());
-        self::assertEquals(\DateTime::createFromFormat('Y-m-d', '2018-01-23'), $Shipping->getShippingDate());
+        self::assertEquals($this->parseDate('2018-01-23'), $Shipping->getShippingDate());
     }
 
     public function testLoadCsv_FlippedColumns()
@@ -51,7 +51,7 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         $this->entityManager->refresh($Shipping);
 
         self::assertEquals('1234', $Shipping->getTrackingNumber());
-        self::assertEquals(\DateTime::createFromFormat('Y-m-d', '2018-01-23'), $Shipping->getShippingDate());
+        self::assertEquals($this->parseDate('2018-01-23'), $Shipping->getShippingDate());
     }
 
     /**
@@ -160,10 +160,18 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
 
         $this->entityManager->refresh($Shipping1);
         self::assertEquals('1234', $Shipping1->getTrackingNumber());
-        self::assertEquals(\DateTime::createFromFormat('Y-m-d', '2018-01-11'), $Shipping1->getShippingDate());
+        self::assertEquals($this->parseDate('2018-01-11'), $Shipping1->getShippingDate());
 
         $this->entityManager->refresh($Shipping2);
         self::assertEquals('5678', $Shipping2->getTrackingNumber());
-        self::assertEquals(\DateTime::createFromFormat('Y-m-d', '2018-02-22'), $Shipping2->getShippingDate());
+        self::assertEquals($this->parseDate('2018-02-22'), $Shipping2->getShippingDate());
+    }
+
+    private function parseDate($value)
+    {
+        $result = \DateTime::createFromFormat('Y-m-d', $value);
+        $result->setTime(0, 0, 0);
+
+        return $result;
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 出荷CSV登録時、出荷日の時間がシステム時間になっていたので「00:00:00」に固定するよう変更

## 関連
https://github.com/EC-CUBE/ec-cube/pull/3264

## テスト（Test)
+ たまに失敗していたテストが失敗しなくなる
