### PR TITLE
129,134フロントから購入時にお届け日、時間バグ修正

### DIFF
--- a/src/Eccube/Form/Type/Shopping/ShippingType.php
+++ b/src/Eccube/Form/Type/Shopping/ShippingType.php
@@ -179,6 +179,7 @@ class ShippingType extends AbstractType
                             'required' => false,
                             'placeholder' => '指定なし',
                             'mapped' => false,
+                            'data' => $Shipping->getShippingDeliveryDate() ? $Shipping->getShippingDeliveryDate()->format('Y/m/d') : null,
                         ]
                     );
             }
@@ -192,10 +193,17 @@ class ShippingType extends AbstractType
                     return;
                 }
 
+                $ShippingDeliveryTime = null;
                 $DeliveryTimes = [];
                 $Delivery = $Shipping->getDelivery();
                 if ($Delivery) {
                     $DeliveryTimes = $Delivery->getDeliveryTimes();
+                    foreach ($DeliveryTimes as $deliveryTime) {
+                        if ($deliveryTime->getId() == $Shipping->getTimeId()) {
+                            $ShippingDeliveryTime = $deliveryTime;
+                            break;
+                        }
+                    }
                 }
 
                 $form = $event->getForm();
@@ -210,6 +218,7 @@ class ShippingType extends AbstractType
                         'required' => false,
                         'placeholder' => '指定なし',
                         'mapped' => false,
+                        'data' => $ShippingDeliveryTime,
                     ]
                 );
             }
@@ -232,10 +241,20 @@ class ShippingType extends AbstractType
                 $Shipping->setShippingDeliveryName($Delivery->getName());
             }
             $form = $event->getForm();
+            $DeliveryDate = $form['shipping_delivery_date']->getData();
+            if ($DeliveryDate) {
+                $Shipping->setShippingDeliveryDate(new \DateTime($DeliveryDate));
+            } else {
+                $Shipping->setShippingDeliveryDate(null);
+            }
+
             $DeliveryTime = $form['DeliveryTime']->getData();
             if ($DeliveryTime) {
                 $Shipping->setShippingDeliveryTime($DeliveryTime->getDeliveryTime());
                 $Shipping->setTimeId($DeliveryTime->getId());
+            } else {
+                $Shipping->setShippingDeliveryTime(null);
+                $Shipping->setTimeId(null);
             }
         });
     }

--- a/src/Eccube/Resource/template/default/Shopping/confirm.twig
+++ b/src/Eccube/Resource/template/default/Shopping/confirm.twig
@@ -295,7 +295,7 @@ $(function() {
                             </div>
                             <div class="ec-select ec-select__delivery">
                                 <label>お届け日</label>
-                                {{ Order.Shippings[idx].shipping_delivery_date? Order.Shippings[idx].shipping_delivery_date|date_format :"指定なし" }}
+                                {{ Order.Shippings[idx].shipping_delivery_date? Order.Shippings[idx].shipping_delivery_date|date_day :"指定なし" }}
                                 {{ form_widget(form.Shippings[idx].shipping_delivery_date, {'type': 'hidden'}) }}
                             </div>
                             <div class="ec-select ec-select__time">

--- a/src/Eccube/Resource/template/default/Shopping/confirm.twig
+++ b/src/Eccube/Resource/template/default/Shopping/confirm.twig
@@ -295,7 +295,7 @@ $(function() {
                             </div>
                             <div class="ec-select ec-select__delivery">
                                 <label>お届け日</label>
-                                {{ Order.Shippings[idx].shipping_delivery_date?:"指定なし" }}
+                                {{ Order.Shippings[idx].shipping_delivery_date? Order.Shippings[idx].shipping_delivery_date|date_format :"指定なし" }}
                                 {{ form_widget(form.Shippings[idx].shipping_delivery_date, {'type': 'hidden'}) }}
                             </div>
                             <div class="ec-select ec-select__time">


### PR DESCRIPTION
129【ご注文確認画面】ご注文画面からご注文手続き画面へ戻る際の情報の引き継ぎが一部できていない
134【ご注文手続き】お届け時間・お届け日が画面リロードで保持されない
上記の対応