### PR TITLE
MySQLだとDoctrineのDateTimeTzが使えなくて+9h表示されちゃうので

### DIFF
--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -88,6 +88,7 @@ class Kernel extends BaseKernel
         // DateTime/DateTimeTzのタイムゾーンを設定.
         UTCDateTimeType::setTimeZone($this->container->getParameter('timezone'));
         UTCDateTimeTzType::setTimeZone($this->container->getParameter('timezone'));
+        date_default_timezone_set($this->container->getParameter('timezone'));
 
         // Activate to $app
         $app = Application::getInstance(['debug' => $this->isDebug()]);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
ref: #3274
https://www.doctrine-project.org/projects/doctrine-dbal/en/2.7/reference/known-vendor-issues.html#mysql

## 相談（Discussion）
とりあえずこの実装でMySQLでも+9hはされなくなるが、この解決方法で良いかどうかは要相談




