### PR TITLE
受注編集画面を複数配送に対応させる

### DIFF
--- a/codeception/_support/Page/Admin/OrderEditPage.php
+++ b/codeception/_support/Page/Admin/OrderEditPage.php
@@ -109,7 +109,7 @@ class OrderEditPage extends AbstractAdminPageStyleGuide
 
     public function 入力_配送業者($value)
     {
-        $this->tester->selectOption(['id' => 'order_Shippings_0_Delivery'], $value);
+        $this->tester->selectOption(['id' => 'order_Shipping_Delivery'], $value);
         return $this;
     }
 

--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -185,6 +185,11 @@ class EditController extends AbstractController
                 ]
             );
 
+        // 複数配送の場合は配送先の編集ができない
+        if ($TargetOrder->isMultiple()) {
+            $builder->remove('Shipping');
+        }
+
         $event = new EventArgs(
             [
                 'builder' => $builder,
@@ -196,6 +201,12 @@ class EditController extends AbstractController
         $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_ORDER_EDIT_INDEX_INITIALIZE, $event);
 
         $form = $builder->getForm();
+
+        // 単数配送の場合は配送先の編集ができる
+        if ($TargetOrder->isMultiple() == false) {
+            $form['Shipping']->setData($TargetOrder->getShippings()[0]);
+        }
+
         $form->handleRequest($request);
         $purchaseContext = new PurchaseContext($OriginOrder, $OriginOrder->getCustomer());
 

--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -239,11 +239,8 @@ class OrderType extends AbstractType
                 'prototype' => true,
                 'data' => $options['SortedItems'],
             ])
-            ->add('Shippings', CollectionType::class, [
-                'entry_type' => ShippingType::class,
-                'allow_add' => true,
-                'allow_delete' => true,
-                'prototype' => true,
+            ->add('Shipping', ShippingType::class, [
+                'mapped' => false,
             ])
             ->add('OrderItemsErrors', TextType::class, [
                 'mapped' => false,

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -1134,6 +1134,7 @@ return [
     'admin.order.edit.label.customer_info.copy' => '注文者情報をコピー',
     'admin.order.edit.label.shipping.print' => '納品書出力',
     'admin.order.edit.label.shipping.add' => 'お届け先の追加',
+    'admin.order.edit.label.shipping.edit' => '複数配送の編集',
     'admin.order.edit.label.customer_info' => '注文者',
     'admin.order.edit.label.customer_info.edit' => '注文者の編集',
     'admin.order.edit.product.error' => '商品が追加されていません。',

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -385,21 +385,31 @@ file that was distributed with this source code.
                     {# 注文者 終了 #}
 
                     {# お届け先情報 開始 #}
-                    {% if not Order.isMultiple %}
-                        {% for shippingForm in form.Shippings %}
-                            {% set shippingIndex = shippingForm.vars.name %}
-                            <div class="card rounded border-0 mb-4 h-adr">
-                                <span class="p-country-name" style="display:none;">Japan</span>
-                                <div class="card-header">
-                                    <div class="row">
-                                        <div class="col-8">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.shipping.edit.730'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
-                                        </div>
-                                        <div class="col-4 text-right"><a data-toggle="collapse" href="#shippingInfo" aria-expanded="false" aria-controls="shippingInfo"><i class="fa fa-angle-up fa-lg"></i></a></div>
-                                    </div>
+                    <div class="card rounded border-0 mb-4 h-adr">
+                        <span class="p-country-name" style="display:none;">Japan</span>
+                        <div class="card-header">
+                            <div class="row">
+                                <div class="col-8">
+                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.shipping.edit.730'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
-                                <div class="collapse show ec-cardCollapse" id="shippingInfo">
-                                    <div class="card-body">
+                                <div class="col-4 text-right"><a data-toggle="collapse" href="#shippingInfo" aria-expanded="false" aria-controls="shippingInfo"><i class="fa fa-angle-up fa-lg"></i></a></div>
+                            </div>
+                        </div>
+                        <div class="collapse show ec-cardCollapse" id="shippingInfo">
+                            <div class="card-body">
+                                {% if Order.isMultiple %}
+                                    {# 複数配送の場合は配送先の表示のみ #}
+                                    <div class="mb-3">
+                                        <button type="button" id="shipping-add" class="btn btn-ec-regular">{{ 'admin.order.edit.label.shipping.edit'|trans }}</button>
+                                        複数配送を指定している場合は、こちらのボタンからそれぞれの配送設定の編集ができます。
+                                    </div>
+                                    {% for shippingForm in form.Shippings %}
+                                        お届け先{{ shippingForm.vars.name + 1 }}　{{ shippingForm.name.name01.vars.value }}{{ shippingForm.name.name02.vars.value }}　{{ shippingForm.address.addr01.vars.value }}{{ shippingForm.address.addr02.vars.value }}<br>
+                                    {% endfor %}
+                                {% else %}
+                                    {# 単数配送の場合は配送先の編集が可能 #}
+                                    {% for shippingForm in form.Shippings %}
+                                        {% set shippingIndex = shippingForm.vars.name %}
                                         <div class="row mb-3">
                                             <div class="col-6">
                                                 <button type="button" class="btn btn-ec-regular copy-customer" data-idx="{{ shippingIndex }}">{{ 'admin.order.edit.label.customer_info.copy'|trans }}</button>
@@ -540,11 +550,11 @@ file that was distributed with this source code.
                                                 {% endif %}
                                             </div>
                                         </div>
-                                    </div>
-                                </div>
+                                    {% endfor %}
+                                {% endif %}
                             </div>
-                        {% endfor %}
-                    {% endif %}
+                        </div>
+                    </div>
                     {# お届け先情報 終了 #}
 
                     {# 受注商品情報 開始 #}
@@ -562,23 +572,26 @@ file that was distributed with this source code.
                                 <input type="hidden" name="error-message">
                                 <div class="row justify-content-between mb-2">
                                     <div class="col-6">
-                                        <a class="btn btn-ec-regular mr-2 add" data-toggle="modal" data-target="#addProduct">{{ 'admin.order.edit.btn.add_product'|trans }}</a>
-                                        <div class="modal fade" id="addProduct" tabindex="-1" role="dialog" aria-labelledby="addProduct" aria-hidden="true">
-                                            <div class="modal-dialog modal-lg" role="document">
-                                                <div class="modal-content">
-                                                    <div class="modal-header">
-                                                        <h5 class="modal-title">{{ 'admin.order.edit.btn.add_product'|trans }}</h5>
-                                                        <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
-                                                    </div>
-                                                    <div class="modal-body">
-                                                        {{ form_widget(searchProductModalForm.id, { attr : {'class': 'mb-3',  placeholder : 'admin.order.edit.293' }}) }}
-                                                        {{ form_widget(searchProductModalForm.category_id) }}
-                                                        <button type="button" id="searchProductModalButton" class="btn btn-ec-conversion px-5 mb-4 mt-2">{{ 'admin.order.edit.294'|trans }}</button>
-                                                        <div id="searchProductModalList"></div>
+                                        {# 複数配送の場合は商品追加できない #}
+                                        {% if not Order.isMultiple %}
+                                            <a class="btn btn-ec-regular mr-2 add" data-toggle="modal" data-target="#addProduct">{{ 'admin.order.edit.btn.add_product'|trans }}</a>
+                                            <div class="modal fade" id="addProduct" tabindex="-1" role="dialog" aria-labelledby="addProduct" aria-hidden="true">
+                                                <div class="modal-dialog modal-lg" role="document">
+                                                    <div class="modal-content">
+                                                        <div class="modal-header">
+                                                            <h5 class="modal-title">{{ 'admin.order.edit.btn.add_product'|trans }}</h5>
+                                                            <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                                                        </div>
+                                                        <div class="modal-body">
+                                                            {{ form_widget(searchProductModalForm.id, { attr : {'class': 'mb-3',  placeholder : 'admin.order.edit.293' }}) }}
+                                                            {{ form_widget(searchProductModalForm.category_id) }}
+                                                            <button type="button" id="searchProductModalButton" class="btn btn-ec-conversion px-5 mb-4 mt-2">{{ 'admin.order.edit.294'|trans }}</button>
+                                                            <div id="searchProductModalList"></div>
+                                                        </div>
                                                     </div>
                                                 </div>
                                             </div>
-                                        </div>
+                                        {% endif %}
                                         <a class="btn btn-ec-regular mr-2" data-toggle="modal" data-target="#addOrderItemType">{{ 'admin.order.edit.btn.add_other_item'|trans }}</a>
                                         <div class="modal fade" id="addOrderItemType" tabindex="-1" role="dialog" aria-labelledby="addOrderItemType" aria-hidden="true">
                                             <div class="modal-dialog modal-lg" role="document">
@@ -660,8 +673,15 @@ file that was distributed with this source code.
                                             </td>
                                             <td class="align-middle">
                                                 <div class="col-6">
-                                                    {{ form_widget(orderItemForm.quantity) }}
-                                                    {{ form_errors(orderItemForm.quantity) }}
+                                                    {# 複数配送の場合は商品の個数を変更できない #}
+                                                    {% if Order.isMultiple and orderItemForm.vars.value.orderItemType.id == 1 %}
+                                                        {{ orderItemForm.vars.value.quantity }}
+                                                        {{ form_widget(orderItemForm.quantity, {'attr': {'class': 'd-none'}}) }}
+                                                        {{ form_errors(orderItemForm.quantity) }}
+                                                    {% else %}
+                                                        {{ form_widget(orderItemForm.quantity) }}
+                                                        {{ form_errors(orderItemForm.quantity) }}
+                                                    {% endif %}
                                                 </div>
                                             </td>
                                             <td class="align-middle">

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -166,7 +166,6 @@ file that was distributed with this source code.
         <div class="c-contentsArea__cols">
             <div class="c-contentsArea__primaryCol">
                 <div class="c-primaryCol">
-                    {# 注文概要 開始 #}
                     <div class="card rounded border-0 mb-4">
                         <div class="card-header">
                             <div class="row">
@@ -234,10 +233,7 @@ file that was distributed with this source code.
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    {# 注文概要 終了 #}
-
-                    {# 注文者 開始 #}
+                    </div><!-- .card.rounded -->
                     <div class="card rounded border-0 mb-4">
                         <div class="card-header">
                             <div class="row">
@@ -379,10 +375,7 @@ file that was distributed with this source code.
 
                             </div>
                         </div>
-                    </div>
-                    {# 注文者 終了 #}
-
-                    {# お届け先情報 開始 #}
+                    </div><!-- .card.rounded -->
                     <div class="card rounded border-0 mb-4 h-adr">
                         <span class="p-country-name" style="display:none;">Japan</span>
                         <div class="card-header">
@@ -544,10 +537,7 @@ file that was distributed with this source code.
                                 {% endif %}
                             </div>
                         </div>
-                    </div>
-                    {# お届け先情報 終了 #}
-
-                    {# 受注商品情報 開始 #}
+                    </div><!-- .card.rounded -->
                     <div id="order-product" class="card rounded border-0 mb-4">
                         <div class="card-header">
                             <div class="row">
@@ -791,10 +781,7 @@ file that was distributed with this source code.
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    {# 受注商品情報 終了 #}
-
-                    {# ショップ用メモ欄 開始 #}
+                    </div><!-- .card.rounded -->
                     <div class="card rounded border-0 mb-4">
                         <div class="card-header">
                             <div class="row">
@@ -809,10 +796,7 @@ file that was distributed with this source code.
                                 {{ form_widget(form.note, {'attr': {'rows': 8}}) }}
                             </div>
                         </div>
-                    </div>
-                    {# ショップ用メモ欄 終了 #}
-
-                    {# メール配信履歴 開始 #}
+                    </div><!-- .card.rounded -->
                     {% if id is not null %}
                         <div class="card rounded border-0 mb-4">
                             <div class="card-header">
@@ -863,10 +847,8 @@ file that was distributed with this source code.
                                     </div>
                                 </div>
                             </div>
-                        </div>
+                        </div><!-- .card.rounded -->
                     {% endif %}
-                    {# メール配信履歴 終了 #}
-
                 </div>
             </div>
         </div>

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -124,19 +124,17 @@ file that was distributed with this source code.
 
             // 注文者情報をコピー
             $('.copy-customer').on('click', function() {
-                var data = $(this).data();
-                var idx = data.idx;
-                $('#order_Shippings_' + idx + '_name_name01').val($('#order_name_name01').val());
-                $('#order_Shippings_' + idx + '_name_name02').val($('#order_name_name02').val());
-                $('#order_Shippings_' + idx + '_kana_kana01').val($('#order_kana_kana01').val());
-                $('#order_Shippings_' + idx + '_kana_kana02').val($('#order_kana_kana02').val());
-                $('#order_Shippings_' + idx + '_postal_code').val($('#order_postal_code').val());
-                $('#order_Shippings_' + idx + '_address_pref').val($('#order_address_pref').val());
-                $('#order_Shippings_' + idx + '_address_addr01').val($('#order_address_addr01').val());
-                $('#order_Shippings_' + idx + '_address_addr02').val($('#order_address_addr02').val());
-                $('#order_Shippings_' + idx + '_email').val($('#order_email').val());
-                $('#order_Shippings_' + idx + '_phone_number').val($('#order_phone_number').val());
-                $('#order_Shippings_' + idx + '_company_name').val($('#order_company_name').val());
+                $('#order_Shipping_name_name01').val($('#order_name_name01').val());
+                $('#order_Shipping_name_name02').val($('#order_name_name02').val());
+                $('#order_Shipping_kana_kana01').val($('#order_kana_kana01').val());
+                $('#order_Shipping_kana_kana02').val($('#order_kana_kana02').val());
+                $('#order_Shipping_postal_code').val($('#order_postal_code').val());
+                $('#order_Shipping_address_pref').val($('#order_address_pref').val());
+                $('#order_Shipping_address_addr01').val($('#order_address_addr01').val());
+                $('#order_Shipping_address_addr02').val($('#order_address_addr02').val());
+                $('#order_Shipping_email').val($('#order_email').val());
+                $('#order_Shipping_phone_number').val($('#order_phone_number').val());
+                $('#order_Shipping_company_name').val($('#order_company_name').val());
             });
         });
 
@@ -410,7 +408,7 @@ file that was distributed with this source code.
                                     {# 単数配送の場合は配送先の編集が可能 #}
                                     <div class="row mb-3">
                                         <div class="col-6">
-                                            <button type="button" class="btn btn-ec-regular copy-customer" data-idx="{{ form.Shipping.vars.name }}">{{ 'admin.order.edit.label.customer_info.copy'|trans }}</button>
+                                            <button type="button" class="btn btn-ec-regular copy-customer">{{ 'admin.order.edit.label.customer_info.copy'|trans }}</button>
                                             <button type="button" id="print" class="btn btn-ec-regular">{{ 'admin.order.edit.label.shipping.print'|trans }}</button>
                                         </div>
                                         <div class="col-6 text-right">

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -402,7 +402,10 @@ file that was distributed with this source code.
                                         複数配送を指定している場合は、こちらのボタンからそれぞれの配送設定の編集ができます。
                                     </div>
                                     {% for shipping in Order.Shippings %}
-                                        お届け先{{ loop.index }}　{{ shipping.name01 }} {{ shipping.name02 }}　 〒{{ shipping.postal_code }} {{ shipping.addr01 }} {{ shipping.addr02 }}　{{ shipping.shipping_date|date_sec }}<br>
+                                        <div class="col">
+                                            <span class="mr-5">お届け先{{ loop.index }}</span>
+                                            {{ shipping.full_name }} ({{ shipping.full_name_kana }}) {% if shipping.company_name is not null %}{{ shipping.company_name }} {% endif %}〒{{ shipping.postal_code }} {{ shipping.pref }}{{ shipping.addr01 }}{{ shipping.addr02 }} {{ shipping.phone_number }}{% if shipping.shipping_date is not null %} {{ shipping.shipping_date|date_sec }}{% endif %}
+                                        </div>
                                     {% endfor %}
                                 {% else %}
                                     {# 単数配送の場合は配送先の編集が可能 #}

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -168,6 +168,7 @@ file that was distributed with this source code.
         <div class="c-contentsArea__cols">
             <div class="c-contentsArea__primaryCol">
                 <div class="c-primaryCol">
+                    {# 注文概要 開始 #}
                     <div class="card rounded border-0 mb-4">
                         <div class="card-header">
                             <div class="row">
@@ -236,6 +237,9 @@ file that was distributed with this source code.
                             </div>
                         </div>
                     </div>
+                    {# 注文概要 終了 #}
+
+                    {# 注文者 開始 #}
                     <div class="card rounded border-0 mb-4">
                         <div class="card-header">
                             <div class="row">
@@ -378,459 +382,470 @@ file that was distributed with this source code.
                             </div>
                         </div>
                     </div>
-                </div>
-                {% if not Order.isMultiple %}
-                    {% for shippingForm in form.Shippings %}
-                        {% set shippingIndex = shippingForm.vars.name %}
-                        <div class="card rounded border-0 mb-4 h-adr">
-                            <span class="p-country-name" style="display:none;">Japan</span>
-                            <div class="card-header">
-                                <div class="row">
-                                    <div class="col-8">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.shipping.edit.730'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
-                                    </div>
-                                    <div class="col-4 text-right"><a data-toggle="collapse" href="#shippingInfo" aria-expanded="false" aria-controls="shippingInfo"><i class="fa fa-angle-up fa-lg"></i></a></div>
-                                </div>
-                            </div>
-                            <div class="collapse show ec-cardCollapse" id="shippingInfo">
-                                <div class="card-body">
-                                    <div class="row mb-3">
-                                        <div class="col-6">
-                                            <button type="button" class="btn btn-ec-regular copy-customer" data-idx="{{ shippingIndex }}">{{ 'admin.order.edit.label.customer_info.copy'|trans }}</button>
-                                            <button type="button" id="print" class="btn btn-ec-regular">{{ 'admin.order.edit.label.shipping.print'|trans }}</button>
-                                        </div>
-                                        <div class="col-6 text-right">
-                                            <button type="button" id="shipping-add" class="btn btn-ec-regular w-25">{{ 'admin.order.edit.label.shipping.add'|trans }}</button>
-                                        </div>
-                                    </div>
+                    {# 注文者 終了 #}
+
+                    {# お届け先情報 開始 #}
+                    {% if not Order.isMultiple %}
+                        {% for shippingForm in form.Shippings %}
+                            {% set shippingIndex = shippingForm.vars.name %}
+                            <div class="card rounded border-0 mb-4 h-adr">
+                                <span class="p-country-name" style="display:none;">Japan</span>
+                                <div class="card-header">
                                     <div class="row">
-                                        <div class="col-6">
-                                            <div class="row form-group">
-                                                <label class="col-3 col-form-label">{{ 'admin.common.label.name'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
-                                                <div class="col">
-                                                    <div class="row">
-                                                        <div class="col">
-                                                            {{ form_widget(shippingForm.name.name01, {attr: {placeholder: 'admin.common.label.family_name' }}) }}
-                                                            {{ form_errors(shippingForm.name.name01) }}
-                                                        </div>
-                                                        <div class="col">
-                                                            {{ form_widget(shippingForm.name.name02, {attr: {placeholder: 'admin.common.label.first_name' }}) }}
-                                                            {{ form_errors(shippingForm.name.name02) }}
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="row form-group">
-                                                <label class="col-3 col-form-label">{{ 'admin.common.label.kana'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
-                                                <div class="col">
-                                                    <div class="row">
-                                                        <div class="col">
-                                                            {{ form_widget(shippingForm.kana.kana01, {attr: {placeholder: 'admin.common.label.family_name_kana' }}) }}
-                                                            {{ form_errors(shippingForm.kana.kana01) }}
-                                                        </div>
-                                                        <div class="col">
-                                                            {{ form_widget(shippingForm.kana.kana02, {attr: {placeholder: 'admin.common.label.first_name_kana' }}) }}
-                                                            {{ form_errors(shippingForm.kana.kana02) }}
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="row form-group">
-                                                <label class="col-3 col-form-label">{{ 'admin.common.label.address'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
-                                                <div class="col">
-                                                    <div class="row mb-3">
-                                                        <div class="col form-inline">
-                                                            {{ 'admin.order.edit.261'|trans }}
-                                                            {{ form_widget(shippingForm.postal_code) }}
-                                                            {{ form_errors(shippingForm.postal_code) }}
-                                                        </div>
-                                                    </div>
-                                                    <div class="row mb-3">
-                                                        <div class="col">
-                                                            {{ form_widget(shippingForm.address.pref) }}
-                                                            {{ form_errors(shippingForm.address.pref) }}
-                                                        </div>
-                                                    </div>
-                                                    <div class="row mb-3">
-                                                        <div class="col">
-                                                            {{ form_widget(shippingForm.address.addr01, { attr : {placeholder : 'admin.order.edit.262' }}) }}
-                                                            {{ form_errors(shippingForm.address.addr01) }}
-                                                        </div>
-                                                    </div>
-                                                    <div class="row">
-                                                        <div class="col">
-                                                            {{ form_widget(shippingForm.address.addr02, { attr : { placeholder : 'admin.order.edit.263' }}) }}
-                                                            {{ form_errors(shippingForm.address.addr02) }}
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
+                                        <div class="col-8">
+                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.shipping.edit.730'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                         </div>
-                                        <div class="col-6">
-                                            <div class="row form-group">
-                                                <label class="col-3 col-form-label">{{ 'admin.common.label.tel'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
-                                                <div class="col">
-                                                    {{ form_widget(shippingForm.phone_number) }}
-                                                    {{ form_errors(shippingForm.phone_number) }}
-                                                </div>
-                                            </div>
-
-                                            <div class="row form-group">
-                                                <label class="col-3 col-form-label">{{ 'admin.common.label.company'|trans }}</label>
-                                                <div class="col">
-                                                    {{ form_widget(shippingForm.company_name) }}
-                                                    {{ form_errors(shippingForm.company_name) }}
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="col-12">
-                                            <hr>
-                                        </div>
-                                        <div class="col-6">
-                                            <div class="row mb-3 form-group">
-                                                <label class="col-3 col-form-label">{{ 'admin.common.label.tracking_number'|trans }}</label>
-                                                <div class="col">
-                                                    {{ form_widget(shippingForm.tracking_number) }}
-                                                    {{ form_errors(shippingForm.tracking_number) }}
-                                                </div>
-                                            </div>
-                                            <div class="row mb-3 form-group">
-                                                <label class="col-3 col-form-label">{{ 'admin.shipping.edit.delivery_provider'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
-                                                <div class="col">
-                                                    {{ form_widget(shippingForm.Delivery) }}
-                                                    {{ form_errors(shippingForm.Delivery) }}
-                                                </div>
-                                            </div>
-                                            <div class="row mb-3 form-group">
-                                                <label class="col-3 col-form-label">{{ 'admin.shipping.edit.note_title'|trans }}</label>
-                                                <div class="col">
-                                                    {{ form_widget(shippingForm.note) }}
-                                                    {{ form_errors(shippingForm.note) }}
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="col-6">
-                                            <div class="row mb-3 form-group">
-                                                <label class="col-3 col-form-label"><i class="fa fa-calendar-check-o fa-fw mr-1" aria-hidden="true"></i>{{ 'admin.shipping.edit.date_to_deliver'|trans }}</label>
-                                                <div class="col">
-                                                    {{ form_widget(shippingForm.shipping_delivery_date) }}
-                                                    {{ form_errors(shippingForm.shipping_delivery_date) }}
-                                                </div>
-                                            </div>
-                                            <div class="row mb-3 form-group">
-                                                <label class="col-3 col-form-label"><i class="fa fa-clock-o fa-fw mr-1" aria-hidden="true"></i>{{ 'admin.shipping.edit.specified_time_zone'|trans }}</label>
-                                                <div class="col">
-                                                    {{ form_widget(shippingForm.DeliveryTime) }}
-                                                    {{ form_errors(shippingForm.DeliveryTime) }}
-                                                </div>
-                                            </div>
-                                            {% if Order.isMultiple %}
-                                                <div class="row mb-3">
-                                                    <div class="col-3"><i class="fa fa-truck fa-fw mr-1" aria-hidden="true"></i>{{ 'admin.shipping.edit.ship_date'|trans }}</div>
-                                                    <div class="col">
-                                                        {{ Order.Shippings[shippingIndex].shipping_date|date_sec }}
-                                                    </div>
-                                                </div>
-                                            {% endif %}
-                                        </div>
+                                        <div class="col-4 text-right"><a data-toggle="collapse" href="#shippingInfo" aria-expanded="false" aria-controls="shippingInfo"><i class="fa fa-angle-up fa-lg"></i></a></div>
                                     </div>
                                 </div>
-                            </div>
-                        </div>
-
-                    {% endfor %}
-                {% endif %}
-
-                <div id="order-product" class="card rounded border-0 mb-4">
-                    <div class="card-header">
-                        <div class="row">
-                            <div class="col-8">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.edit.label.product_info'|trans }}<i class="fa fa-question-circle fa-lg ml-1"></i></span></div>
-                            </div>
-                            <div class="col-4 text-right"><a data-toggle="collapse" href="#orderItem" aria-expanded="false" aria-controls="orderItem"><i class="fa fa-angle-up fa-lg"></i></a></div>
-                        </div>
-                    </div>
-                    <div class="collapse show ec-cardCollapse" id="orderItem">
-                        <div class="card-body">
-                            <input type="hidden" name="error-message">
-                            <div class="row justify-content-between mb-2">
-                                <div class="col-6">
-                                    <a class="btn btn-ec-regular mr-2 add" data-toggle="modal" data-target="#addProduct">{{ 'admin.order.edit.btn.add_product'|trans }}</a>
-                                    <div class="modal fade" id="addProduct" tabindex="-1" role="dialog" aria-labelledby="addProduct" aria-hidden="true">
-                                        <div class="modal-dialog modal-lg" role="document">
-                                            <div class="modal-content">
-                                                <div class="modal-header">
-                                                    <h5 class="modal-title">{{ 'admin.order.edit.btn.add_product'|trans }}</h5>
-                                                    <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
-                                                </div>
-                                                <div class="modal-body">
-                                                    {{ form_widget(searchProductModalForm.id, { attr : {'class': 'mb-3',  placeholder : 'admin.order.edit.293' }}) }}
-                                                    {{ form_widget(searchProductModalForm.category_id) }}
-                                                    <button type="button" id="searchProductModalButton" class="btn btn-ec-conversion px-5 mb-4 mt-2">{{ 'admin.order.edit.294'|trans }}</button>
-                                                    <div id="searchProductModalList"></div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <a class="btn btn-ec-regular mr-2" data-toggle="modal" data-target="#addOrderItemType">{{ 'admin.order.edit.btn.add_other_item'|trans }}</a>
-                                    <div class="modal fade" id="addOrderItemType" tabindex="-1" role="dialog" aria-labelledby="addOrderItemType" aria-hidden="true">
-                                        <div class="modal-dialog modal-lg" role="document">
-                                            <div class="modal-content">
-                                                <div class="modal-header">
-                                                    <h5 class="modal-title">{{ 'admin.order.edit.btn.add_other_item'|trans }}</h5>
-                                                    <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
-                                                </div>
-                                                <div class="modal-body">
-                                                    <div id="searchOrderItemTypeList"></div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    {{ form_errors(form.OrderItemsErrors) }}
-                                </div>
-                                <div class="col-5 text-right">
-                                    <button type="submit" class="btn btn-ec-regular mr-2" name="mode" value="calc" data-link="order-product" id="calculate">{{ 'admin.order.edit.267'|trans }}</button>
-                                </div>
-                            </div>
-                            <table id="table-form-field" class="table table-striped table-sm mb-0  text-nowrap"
-                                   data-prototype="{% filter escape %}{{ include('@admin/Order/order_item_prototype.twig', {'orderItemForm': form.OrderItems.vars.prototype}) }}{% endfilter %}">
-                                <thead class="table-active">
-                                <tr>
-                                    <th class="pt-2 pb-2 pl-3">{{ 'admin.order.edit.label.product_name_code'|trans }}</th>
-                                    <th class="pt-2 pb-2">
-                                        <div class="col-8">{{ 'admin.common.label.price02'|trans }}</div>
-                                    </th>
-                                    <th class="pt-2 pb-2">
-                                        <div class="col-8">{{ 'admin.common.label.quantity'|trans }}</div>
-                                    </th>
-                                    <th class="pt-2 pb-2">
-                                        <div class="col-8">{{ 'admin.common.label.tax'|trans }}</div>
-                                    </th>
-                                    <th class="pt-2 pb-2">
-                                        <div class="col-8">{{ 'admin.common.label.tax_status'|trans }}</div>
-                                    </th>
-                                    <th class="pt-2 pb-2">
-                                        <div class="col-8">{{ 'admin.common.label.subtotal'|trans }}</div>
-                                    </th>
-                                    <th class="pt-2 pb-2 pr-3"></th>
-                                </tr>
-                                </thead>
-                                <tbody>
-                                {% for orderItemForm in form.OrderItems %}
-                                    <tr>
-                                        {{ form_widget(orderItemForm.Order) }}
-                                        <td class="align-middle w-25 pl-3">
-                                            <p class="mb-0 font-weight-bold">
-                                                {% if orderItemForm.vars.value.OrderItemType.isProduct %}
-                                                    {{ orderItemForm.vars.value.product_name }}
-                                                    {{ form_widget(orderItemForm.product_name, {'attr': {'class': 'd-none'}}) }}
-                                                {% else %}
-                                                    {{ form_widget(orderItemForm.product_name) }}
-                                                    {{ form_errors(orderItemForm.product_name) }}
-                                                {% endif %}
-                                            </p>
-                                            <span>
-                                                    {{ orderItemForm.vars.value.product_code }}
-                                                {% if orderItemForm.vars.value.class_category_name1 is not empty %}
-                                                    / (
-                                                    {{ orderItemForm.vars.value.class_name1 }}：
-                                                    {{ orderItemForm.vars.value.class_category_name1 }}
-                                                    {% if orderItemForm.vars.value.class_category_name2 is not empty %}
-                                                        /
-                                                        {{ orderItemForm.vars.value.class_name2 }}：
-                                                        {{ orderItemForm.vars.value.class_category_name2 }}
-                                                    {% endif %}
-                                                    )
-                                                {% endif %}
-                                            </span>
-                                            {{ form_errors(orderItemForm.product_name) }}
-                                        </td>
-                                        <td class="align-middle">
-                                            <div class="col-8">
-                                                {{ form_widget(orderItemForm.price, {'attr': {'class': 'input-price'}}) }}
-                                                {{ form_errors(orderItemForm.price) }}
-                                            </div>
-                                        </td>
-                                        <td class="align-middle">
+                                <div class="collapse show ec-cardCollapse" id="shippingInfo">
+                                    <div class="card-body">
+                                        <div class="row mb-3">
                                             <div class="col-6">
-                                                {{ form_widget(orderItemForm.quantity) }}
-                                                {{ form_errors(orderItemForm.quantity) }}
+                                                <button type="button" class="btn btn-ec-regular copy-customer" data-idx="{{ shippingIndex }}">{{ 'admin.order.edit.label.customer_info.copy'|trans }}</button>
+                                                <button type="button" id="print" class="btn btn-ec-regular">{{ 'admin.order.edit.label.shipping.print'|trans }}</button>
                                             </div>
-                                        </td>
-                                        <td class="align-middle">
-                                            <div class="col-8">
-                                                {{ orderItemForm.vars.value.tax_rate }}
-                                                {{ form_widget(orderItemForm.tax_rate, {'attr': {'class': 'd-none'}}) }}
-                                                {{ form_errors(orderItemForm.tax_rate) }}
+                                            <div class="col-6 text-right">
+                                                <button type="button" id="shipping-add" class="btn btn-ec-regular w-25">{{ 'admin.order.edit.label.shipping.add'|trans }}</button>
                                             </div>
-                                        </td>
-                                        <td class="align-middle">
-                                            <div class="col-8">
-                                                {{ orderItemForm.vars.value.tax_type }}
-                                            </div>
-                                        </td>
-                                        <td class="align-middle">
-                                            <div class="col-8">
-                                                <span>{{ orderItemForm.vars.value.total_price|price }}</span>
-                                                <small>（{{ 'admin.common.label.taxinc'|trans }}）</small>
-                                            </div>
-                                        </td>
-                                        <td class="align-middle text-right pr-3">
-                                            <div class="row justify-content-end">
-                                                <div class="col-auto text-center"><a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_{{ orderItemForm.vars.id }}" data-tooltip="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}"><i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i></a>
-                                                    <div class="modal fade" id="delete_{{ orderItemForm.vars.id }}" tabindex="-1" role="dialog" aria-labelledby="delete_{{ orderItemForm.vars.id }}" aria-hidden="true">
-                                                        <div class="modal-dialog" role="document">
-                                                            <div class="modal-content">
-                                                                <div class="modal-header">
-                                                                    <h5 class="modal-title font-weight-bold">{{ 'admin.order.edit.delete.modal.header'|trans }}</h5>
-                                                                    <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
-                                                                </div>
-                                                                <div class="modal-body text-left"><p class="text-left">{{ 'admin.order.edit.delete.modal.body'|trans }}</p></div>
-                                                                <div class="modal-footer">
-                                                                    <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}</button>
-                                                                    <a href="#order-product" class="btn delete btn-ec-delete">{{ 'common.label.delete'|trans }}</a>
-                                                                </div>
+                                        </div>
+                                        <div class="row">
+                                            <div class="col-6">
+                                                <div class="row form-group">
+                                                    <label class="col-3 col-form-label">{{ 'admin.common.label.name'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
+                                                    <div class="col">
+                                                        <div class="row">
+                                                            <div class="col">
+                                                                {{ form_widget(shippingForm.name.name01, {attr: {placeholder: 'admin.common.label.family_name' }}) }}
+                                                                {{ form_errors(shippingForm.name.name01) }}
+                                                            </div>
+                                                            <div class="col">
+                                                                {{ form_widget(shippingForm.name.name02, {attr: {placeholder: 'admin.common.label.first_name' }}) }}
+                                                                {{ form_errors(shippingForm.name.name02) }}
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div class="row form-group">
+                                                    <label class="col-3 col-form-label">{{ 'admin.common.label.kana'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
+                                                    <div class="col">
+                                                        <div class="row">
+                                                            <div class="col">
+                                                                {{ form_widget(shippingForm.kana.kana01, {attr: {placeholder: 'admin.common.label.family_name_kana' }}) }}
+                                                                {{ form_errors(shippingForm.kana.kana01) }}
+                                                            </div>
+                                                            <div class="col">
+                                                                {{ form_widget(shippingForm.kana.kana02, {attr: {placeholder: 'admin.common.label.first_name_kana' }}) }}
+                                                                {{ form_errors(shippingForm.kana.kana02) }}
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div class="row form-group">
+                                                    <label class="col-3 col-form-label">{{ 'admin.common.label.address'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
+                                                    <div class="col">
+                                                        <div class="row mb-3">
+                                                            <div class="col form-inline">
+                                                                {{ 'admin.order.edit.261'|trans }}
+                                                                {{ form_widget(shippingForm.postal_code) }}
+                                                                {{ form_errors(shippingForm.postal_code) }}
+                                                            </div>
+                                                        </div>
+                                                        <div class="row mb-3">
+                                                            <div class="col">
+                                                                {{ form_widget(shippingForm.address.pref) }}
+                                                                {{ form_errors(shippingForm.address.pref) }}
+                                                            </div>
+                                                        </div>
+                                                        <div class="row mb-3">
+                                                            <div class="col">
+                                                                {{ form_widget(shippingForm.address.addr01, { attr : {placeholder : 'admin.order.edit.262' }}) }}
+                                                                {{ form_errors(shippingForm.address.addr01) }}
+                                                            </div>
+                                                        </div>
+                                                        <div class="row">
+                                                            <div class="col">
+                                                                {{ form_widget(shippingForm.address.addr02, { attr : { placeholder : 'admin.order.edit.263' }}) }}
+                                                                {{ form_errors(shippingForm.address.addr02) }}
                                                             </div>
                                                         </div>
                                                     </div>
                                                 </div>
                                             </div>
-                                        </td>
-                                        {{ form_widget(orderItemForm.Order) }}
-                                        {{ form_widget(orderItemForm.Shipping) }}
-                                        {{ form_widget(orderItemForm.Product) }}
-                                        {{ form_widget(orderItemForm.ProductClass) }}
-                                        {{ form_widget(orderItemForm.product_name) }}
-                                        {{ form_widget(orderItemForm.product_code) }}
-                                        {{ form_widget(orderItemForm.class_name1) }}
-                                        {{ form_widget(orderItemForm.class_name2) }}
-                                        {{ form_widget(orderItemForm.class_category_name1) }}
-                                        {{ form_widget(orderItemForm.class_category_name2) }}
-                                        {{ form_widget(orderItemForm.tax_rule) }}
-                                        {{ form_widget(orderItemForm.tax_type) }}
-                                        {{ form_widget(orderItemForm.tax_display_type) }}
-                                        {{ form_widget(orderItemForm.order_item_type) }}
-                                    </tr>
-                                {% endfor %}
-                                </tbody>
-                            </table>
-                            <hr class="mt-0">
-                            {# TODO 小計,内値引き,内送料,内手数料の金額が明細と合わない #}
-                            <div class="row justify-content-end mb-3">
-                                <div class="col-auto"><span class="align-middle">{{ 'admin.order.edit.276'|trans }}</span></div>
-                                <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.subtotal|price }}</span></div>
-                            </div>
-                            <div class="row justify-content-end mb-3">
-                                <div class="col-auto"><span class="align-middle">{{ 'admin.order.edit.277'|trans }}</span></div>
-                                <div class="col-2 text-right"><span class="h4 align-middle text-danger font-weight-normal">- {{ Order.discount|price }}</span></div>
-                            </div>
-                            <div class="row justify-content-end mb-3">
-                                <div class="col-auto"><span class="align-middle">{{ 'admin.order.edit.279'|trans }}</span></div>
-                                <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.delivery_fee_total|price }}</span></div>
-                            </div>
-                            <div class="row justify-content-end mb-3">
-                                <div class="col-auto"><span class="align-middle">{{ 'admin.order.edit.280'|trans }}</span></div>
-                                <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.charge|price }}</span></div>
-                            </div>
-                            <div class="row justify-content-end mb-3">
-                                <div class="col-auto"><span class="align-middle">{{ 'admin.common.label.add_point'|trans }}</span></div>
-                                <div class="col-2 text-right">
-                                        <span class="h4 align-middle font-weight-normal">
-                                            {{ form_widget(form.add_point) }}
-                                            {{ form_errors(form.add_point) }}
-                                        </span>
-                                </div>
-                            </div>
-                            <div class="row justify-content-end mb-3">
-                                <div class="col-auto"><span class="align-middle">{{ 'admin.common.label.use_point'|trans }}</span></div>
-                                <div class="col-2 text-right">
-                                        <span class="h4 align-middle font-weight-normal">
-                                            {{ form_widget(form.use_point) }}
-                                            {{ form_errors(form.use_point) }}
-                                        </span>
-                                </div>
-                            </div>
+                                            <div class="col-6">
+                                                <div class="row form-group">
+                                                    <label class="col-3 col-form-label">{{ 'admin.common.label.tel'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
+                                                    <div class="col">
+                                                        {{ form_widget(shippingForm.phone_number) }}
+                                                        {{ form_errors(shippingForm.phone_number) }}
+                                                    </div>
+                                                </div>
 
-                            <hr>
-                            <div class="row justify-content-end mb-3">
-                                <div class="col-auto"><span class="align-middle">{{ 'admin.common.label.total'|trans }}</span></div>
-                                <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.total|price }}</span></div>
+                                                <div class="row form-group">
+                                                    <label class="col-3 col-form-label">{{ 'admin.common.label.company'|trans }}</label>
+                                                    <div class="col">
+                                                        {{ form_widget(shippingForm.company_name) }}
+                                                        {{ form_errors(shippingForm.company_name) }}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="col-12">
+                                                <hr>
+                                            </div>
+                                            <div class="col-6">
+                                                <div class="row mb-3 form-group">
+                                                    <label class="col-3 col-form-label">{{ 'admin.common.label.tracking_number'|trans }}</label>
+                                                    <div class="col">
+                                                        {{ form_widget(shippingForm.tracking_number) }}
+                                                        {{ form_errors(shippingForm.tracking_number) }}
+                                                    </div>
+                                                </div>
+                                                <div class="row mb-3 form-group">
+                                                    <label class="col-3 col-form-label">{{ 'admin.shipping.edit.delivery_provider'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
+                                                    <div class="col">
+                                                        {{ form_widget(shippingForm.Delivery) }}
+                                                        {{ form_errors(shippingForm.Delivery) }}
+                                                    </div>
+                                                </div>
+                                                <div class="row mb-3 form-group">
+                                                    <label class="col-3 col-form-label">{{ 'admin.shipping.edit.note_title'|trans }}</label>
+                                                    <div class="col">
+                                                        {{ form_widget(shippingForm.note) }}
+                                                        {{ form_errors(shippingForm.note) }}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="col-6">
+                                                <div class="row mb-3 form-group">
+                                                    <label class="col-3 col-form-label"><i class="fa fa-calendar-check-o fa-fw mr-1" aria-hidden="true"></i>{{ 'admin.shipping.edit.date_to_deliver'|trans }}</label>
+                                                    <div class="col">
+                                                        {{ form_widget(shippingForm.shipping_delivery_date) }}
+                                                        {{ form_errors(shippingForm.shipping_delivery_date) }}
+                                                    </div>
+                                                </div>
+                                                <div class="row mb-3 form-group">
+                                                    <label class="col-3 col-form-label"><i class="fa fa-clock-o fa-fw mr-1" aria-hidden="true"></i>{{ 'admin.shipping.edit.specified_time_zone'|trans }}</label>
+                                                    <div class="col">
+                                                        {{ form_widget(shippingForm.DeliveryTime) }}
+                                                        {{ form_errors(shippingForm.DeliveryTime) }}
+                                                    </div>
+                                                </div>
+                                                {% if Order.isMultiple %}
+                                                    <div class="row mb-3">
+                                                        <div class="col-3"><i class="fa fa-truck fa-fw mr-1" aria-hidden="true"></i>{{ 'admin.shipping.edit.ship_date'|trans }}</div>
+                                                        <div class="col">
+                                                            {{ Order.Shippings[shippingIndex].shipping_date|date_sec }}
+                                                        </div>
+                                                    </div>
+                                                {% endif %}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
-                            <div class="row justify-content-end mb-3">
-                                <div class="col-auto"><span class="align-middle">{{ 'admin.common.label.payment_total'|trans }}</span></div>
-                                <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.payment_total|price }}</span></div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="card rounded border-0 mb-4">
-                    <div class="card-header">
-                        <div class="row">
-                            <div class="col-8">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.common.label.memo'|trans }}<i class="fa fa-question-circle fa-lg ml-1"></i></span></div>
-                            </div>
-                            <div class="col-4 text-right"><a data-toggle="collapse" href="#freeArea" aria-expanded="false" aria-controls="freeArea"><i class="fa fa-angle-up fa-lg"></i></a></div>
-                        </div>
-                    </div>
-                    <div class="collapse show ec-cardCollapse" id="freeArea">
-                        <div class="card-body">
-                            {{ form_widget(form.note, {'attr': {'rows': 8}}) }}
-                        </div>
-                    </div>
-                </div>
-                {% if id is not null %}
-                    <div class="card rounded border-0 mb-4">
+                        {% endfor %}
+                    {% endif %}
+                    {# お届け先情報 終了 #}
+
+                    {# 受注商品情報 開始 #}
+                    <div id="order-product" class="card rounded border-0 mb-4">
                         <div class="card-header">
                             <div class="row">
-                                <div class="col-8"><span class="card-title">{{ 'admin.order.edit.label.mail_delivery_history'|trans }}</span></div>
-                                <div class="col-4 text-right"><a data-toggle="collapse" href="#mailHistory" aria-expanded="false" aria-controls="mailHistory"><i class="fa fa-angle-up fa-lg"></i></a></div>
+                                <div class="col-8">
+                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.edit.label.product_info'|trans }}<i class="fa fa-question-circle fa-lg ml-1"></i></span></div>
+                                </div>
+                                <div class="col-4 text-right"><a data-toggle="collapse" href="#orderItem" aria-expanded="false" aria-controls="orderItem"><i class="fa fa-angle-up fa-lg"></i></a></div>
                             </div>
                         </div>
-                        <div class="collapse show ec-cardCollapse" id="mailHistory">
+                        <div class="collapse show ec-cardCollapse" id="orderItem">
                             <div class="card-body">
-                                <table class="table table-striped">
+                                <input type="hidden" name="error-message">
+                                <div class="row justify-content-between mb-2">
+                                    <div class="col-6">
+                                        <a class="btn btn-ec-regular mr-2 add" data-toggle="modal" data-target="#addProduct">{{ 'admin.order.edit.btn.add_product'|trans }}</a>
+                                        <div class="modal fade" id="addProduct" tabindex="-1" role="dialog" aria-labelledby="addProduct" aria-hidden="true">
+                                            <div class="modal-dialog modal-lg" role="document">
+                                                <div class="modal-content">
+                                                    <div class="modal-header">
+                                                        <h5 class="modal-title">{{ 'admin.order.edit.btn.add_product'|trans }}</h5>
+                                                        <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                                                    </div>
+                                                    <div class="modal-body">
+                                                        {{ form_widget(searchProductModalForm.id, { attr : {'class': 'mb-3',  placeholder : 'admin.order.edit.293' }}) }}
+                                                        {{ form_widget(searchProductModalForm.category_id) }}
+                                                        <button type="button" id="searchProductModalButton" class="btn btn-ec-conversion px-5 mb-4 mt-2">{{ 'admin.order.edit.294'|trans }}</button>
+                                                        <div id="searchProductModalList"></div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <a class="btn btn-ec-regular mr-2" data-toggle="modal" data-target="#addOrderItemType">{{ 'admin.order.edit.btn.add_other_item'|trans }}</a>
+                                        <div class="modal fade" id="addOrderItemType" tabindex="-1" role="dialog" aria-labelledby="addOrderItemType" aria-hidden="true">
+                                            <div class="modal-dialog modal-lg" role="document">
+                                                <div class="modal-content">
+                                                    <div class="modal-header">
+                                                        <h5 class="modal-title">{{ 'admin.order.edit.btn.add_other_item'|trans }}</h5>
+                                                        <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                                                    </div>
+                                                    <div class="modal-body">
+                                                        <div id="searchOrderItemTypeList"></div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        {{ form_errors(form.OrderItemsErrors) }}
+                                    </div>
+                                    <div class="col-5 text-right">
+                                        <button type="submit" class="btn btn-ec-regular mr-2" name="mode" value="calc" data-link="order-product" id="calculate">{{ 'admin.order.edit.267'|trans }}</button>
+                                    </div>
+                                </div>
+                                <table id="table-form-field" class="table table-striped table-sm mb-0  text-nowrap"
+                                       data-prototype="{% filter escape %}{{ include('@admin/Order/order_item_prototype.twig', {'orderItemForm': form.OrderItems.vars.prototype}) }}{% endfilter %}">
                                     <thead class="table-active">
                                     <tr>
-                                        <th class="pt-2 pb-2 pl-3">{{ 'admin.order.edit.label.mail_delivery_date'|trans }}</th>
-                                        <th class="pt-2 pb-2 pr-3">{{ 'admin.order.edit.label.mail_delivery_title'|trans }}</th>
+                                        <th class="pt-2 pb-2 pl-3">{{ 'admin.order.edit.label.product_name_code'|trans }}</th>
+                                        <th class="pt-2 pb-2">
+                                            <div class="col-8">{{ 'admin.common.label.price02'|trans }}</div>
+                                        </th>
+                                        <th class="pt-2 pb-2">
+                                            <div class="col-8">{{ 'admin.common.label.quantity'|trans }}</div>
+                                        </th>
+                                        <th class="pt-2 pb-2">
+                                            <div class="col-8">{{ 'admin.common.label.tax'|trans }}</div>
+                                        </th>
+                                        <th class="pt-2 pb-2">
+                                            <div class="col-8">{{ 'admin.common.label.tax_status'|trans }}</div>
+                                        </th>
+                                        <th class="pt-2 pb-2">
+                                            <div class="col-8">{{ 'admin.common.label.subtotal'|trans }}</div>
+                                        </th>
+                                        <th class="pt-2 pb-2 pr-3"></th>
                                     </tr>
                                     </thead>
                                     <tbody>
-                                    {% for MailHistory in Order.MailHistories %}
+                                    {% for orderItemForm in form.OrderItems %}
                                         <tr>
-                                            <td class="pl-3">{{ MailHistory.send_date|date_min }}</td>
-                                            <td class="pr-3"><a class="text-primary" data-toggle="modal" data-target="#mail2">{{ MailHistory.mail_subject }}</a>
-                                                <div class="modal fade" id="mail2" tabindex="-1" role="dialog" aria-labelledby="mail2" aria-hidden="true">
-                                                    <div class="modal-dialog" role="document">
-                                                        <div class="modal-content">
-                                                            <div class="modal-header">
-                                                                <h5 class="modal-title">{{ MailHistory.mail_subject }}</h5>
-                                                                <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
-                                                            </div>
-                                                            <div class="modal-body">
-                                                                <p>
-                                                                    {{ MailHistory.mail_body|nl2br }}
-                                                                </p>
-                                                            </div>
-                                                            <div class="modal-footer">
-                                                                <button class="btn btn-ec-regular" type="button" data-dismiss="modal">{{ 'admin.common.label.close'|trans }}</button>
+                                            {{ form_widget(orderItemForm.Order) }}
+                                            <td class="align-middle w-25 pl-3">
+                                                <p class="mb-0 font-weight-bold">
+                                                    {% if orderItemForm.vars.value.OrderItemType.isProduct %}
+                                                        {{ orderItemForm.vars.value.product_name }}
+                                                        {{ form_widget(orderItemForm.product_name, {'attr': {'class': 'd-none'}}) }}
+                                                    {% else %}
+                                                        {{ form_widget(orderItemForm.product_name) }}
+                                                        {{ form_errors(orderItemForm.product_name) }}
+                                                    {% endif %}
+                                                </p>
+                                                <span>
+                                                        {{ orderItemForm.vars.value.product_code }}
+                                                    {% if orderItemForm.vars.value.class_category_name1 is not empty %}
+                                                        / (
+                                                        {{ orderItemForm.vars.value.class_name1 }}：
+                                                        {{ orderItemForm.vars.value.class_category_name1 }}
+                                                        {% if orderItemForm.vars.value.class_category_name2 is not empty %}
+                                                            /
+                                                            {{ orderItemForm.vars.value.class_name2 }}：
+                                                            {{ orderItemForm.vars.value.class_category_name2 }}
+                                                        {% endif %}
+                                                        )
+                                                    {% endif %}
+                                                </span>
+                                                {{ form_errors(orderItemForm.product_name) }}
+                                            </td>
+                                            <td class="align-middle">
+                                                <div class="col-8">
+                                                    {{ form_widget(orderItemForm.price, {'attr': {'class': 'input-price'}}) }}
+                                                    {{ form_errors(orderItemForm.price) }}
+                                                </div>
+                                            </td>
+                                            <td class="align-middle">
+                                                <div class="col-6">
+                                                    {{ form_widget(orderItemForm.quantity) }}
+                                                    {{ form_errors(orderItemForm.quantity) }}
+                                                </div>
+                                            </td>
+                                            <td class="align-middle">
+                                                <div class="col-8">
+                                                    {{ orderItemForm.vars.value.tax_rate }}
+                                                    {{ form_widget(orderItemForm.tax_rate, {'attr': {'class': 'd-none'}}) }}
+                                                    {{ form_errors(orderItemForm.tax_rate) }}
+                                                </div>
+                                            </td>
+                                            <td class="align-middle">
+                                                <div class="col-8">
+                                                    {{ orderItemForm.vars.value.tax_type }}
+                                                </div>
+                                            </td>
+                                            <td class="align-middle">
+                                                <div class="col-8">
+                                                    <span>{{ orderItemForm.vars.value.total_price|price }}</span>
+                                                    <small>（{{ 'admin.common.label.taxinc'|trans }}）</small>
+                                                </div>
+                                            </td>
+                                            <td class="align-middle text-right pr-3">
+                                                <div class="row justify-content-end">
+                                                    <div class="col-auto text-center"><a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_{{ orderItemForm.vars.id }}" data-tooltip="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}"><i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i></a>
+                                                        <div class="modal fade" id="delete_{{ orderItemForm.vars.id }}" tabindex="-1" role="dialog" aria-labelledby="delete_{{ orderItemForm.vars.id }}" aria-hidden="true">
+                                                            <div class="modal-dialog" role="document">
+                                                                <div class="modal-content">
+                                                                    <div class="modal-header">
+                                                                        <h5 class="modal-title font-weight-bold">{{ 'admin.order.edit.delete.modal.header'|trans }}</h5>
+                                                                        <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                                                                    </div>
+                                                                    <div class="modal-body text-left"><p class="text-left">{{ 'admin.order.edit.delete.modal.body'|trans }}</p></div>
+                                                                    <div class="modal-footer">
+                                                                        <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}</button>
+                                                                        <a href="#order-product" class="btn delete btn-ec-delete">{{ 'common.label.delete'|trans }}</a>
+                                                                    </div>
+                                                                </div>
                                                             </div>
                                                         </div>
                                                     </div>
                                                 </div>
                                             </td>
+                                            {{ form_widget(orderItemForm.Order) }}
+                                            {{ form_widget(orderItemForm.Shipping) }}
+                                            {{ form_widget(orderItemForm.Product) }}
+                                            {{ form_widget(orderItemForm.ProductClass) }}
+                                            {{ form_widget(orderItemForm.product_name) }}
+                                            {{ form_widget(orderItemForm.product_code) }}
+                                            {{ form_widget(orderItemForm.class_name1) }}
+                                            {{ form_widget(orderItemForm.class_name2) }}
+                                            {{ form_widget(orderItemForm.class_category_name1) }}
+                                            {{ form_widget(orderItemForm.class_category_name2) }}
+                                            {{ form_widget(orderItemForm.tax_rule) }}
+                                            {{ form_widget(orderItemForm.tax_type) }}
+                                            {{ form_widget(orderItemForm.tax_display_type) }}
+                                            {{ form_widget(orderItemForm.order_item_type) }}
                                         </tr>
                                     {% endfor %}
                                     </tbody>
                                 </table>
-                                <div class="text-center">
-                                    <a class="btn btn-ec-regular" href="{{ url('admin_order_mail', { id : Order.id }) }}">{{ 'admin.order.edit.label.mail'|trans }}</a>
+                                <hr class="mt-0">
+                                {# TODO 小計,内値引き,内送料,内手数料の金額が明細と合わない #}
+                                <div class="row justify-content-end mb-3">
+                                    <div class="col-auto"><span class="align-middle">{{ 'admin.order.edit.276'|trans }}</span></div>
+                                    <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.subtotal|price }}</span></div>
+                                </div>
+                                <div class="row justify-content-end mb-3">
+                                    <div class="col-auto"><span class="align-middle">{{ 'admin.order.edit.277'|trans }}</span></div>
+                                    <div class="col-2 text-right"><span class="h4 align-middle text-danger font-weight-normal">- {{ Order.discount|price }}</span></div>
+                                </div>
+                                <div class="row justify-content-end mb-3">
+                                    <div class="col-auto"><span class="align-middle">{{ 'admin.order.edit.279'|trans }}</span></div>
+                                    <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.delivery_fee_total|price }}</span></div>
+                                </div>
+                                <div class="row justify-content-end mb-3">
+                                    <div class="col-auto"><span class="align-middle">{{ 'admin.order.edit.280'|trans }}</span></div>
+                                    <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.charge|price }}</span></div>
+                                </div>
+                                <div class="row justify-content-end mb-3">
+                                    <div class="col-auto"><span class="align-middle">{{ 'admin.common.label.add_point'|trans }}</span></div>
+                                    <div class="col-2 text-right">
+                                            <span class="h4 align-middle font-weight-normal">
+                                                {{ form_widget(form.add_point) }}
+                                                {{ form_errors(form.add_point) }}
+                                            </span>
+                                    </div>
+                                </div>
+                                <div class="row justify-content-end mb-3">
+                                    <div class="col-auto"><span class="align-middle">{{ 'admin.common.label.use_point'|trans }}</span></div>
+                                    <div class="col-2 text-right">
+                                            <span class="h4 align-middle font-weight-normal">
+                                                {{ form_widget(form.use_point) }}
+                                                {{ form_errors(form.use_point) }}
+                                            </span>
+                                    </div>
+                                </div>
+
+                                <hr>
+                                <div class="row justify-content-end mb-3">
+                                    <div class="col-auto"><span class="align-middle">{{ 'admin.common.label.total'|trans }}</span></div>
+                                    <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.total|price }}</span></div>
+                                </div>
+                                <div class="row justify-content-end mb-3">
+                                    <div class="col-auto"><span class="align-middle">{{ 'admin.common.label.payment_total'|trans }}</span></div>
+                                    <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.payment_total|price }}</span></div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                {% endif %}
+                    {# 受注商品情報 終了 #}
 
+                    {# ショップ用メモ欄 開始 #}
+                    <div class="card rounded border-0 mb-4">
+                        <div class="card-header">
+                            <div class="row">
+                                <div class="col-8">
+                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.common.label.memo'|trans }}<i class="fa fa-question-circle fa-lg ml-1"></i></span></div>
+                                </div>
+                                <div class="col-4 text-right"><a data-toggle="collapse" href="#freeArea" aria-expanded="false" aria-controls="freeArea"><i class="fa fa-angle-up fa-lg"></i></a></div>
+                            </div>
+                        </div>
+                        <div class="collapse show ec-cardCollapse" id="freeArea">
+                            <div class="card-body">
+                                {{ form_widget(form.note, {'attr': {'rows': 8}}) }}
+                            </div>
+                        </div>
+                    </div>
+                    {# ショップ用メモ欄 終了 #}
+
+                    {# メール配信履歴 開始 #}
+                    {% if id is not null %}
+                        <div class="card rounded border-0 mb-4">
+                            <div class="card-header">
+                                <div class="row">
+                                    <div class="col-8"><span class="card-title">{{ 'admin.order.edit.label.mail_delivery_history'|trans }}</span></div>
+                                    <div class="col-4 text-right"><a data-toggle="collapse" href="#mailHistory" aria-expanded="false" aria-controls="mailHistory"><i class="fa fa-angle-up fa-lg"></i></a></div>
+                                </div>
+                            </div>
+                            <div class="collapse show ec-cardCollapse" id="mailHistory">
+                                <div class="card-body">
+                                    <table class="table table-striped">
+                                        <thead class="table-active">
+                                        <tr>
+                                            <th class="pt-2 pb-2 pl-3">{{ 'admin.order.edit.label.mail_delivery_date'|trans }}</th>
+                                            <th class="pt-2 pb-2 pr-3">{{ 'admin.order.edit.label.mail_delivery_title'|trans }}</th>
+                                        </tr>
+                                        </thead>
+                                        <tbody>
+                                        {% for MailHistory in Order.MailHistories %}
+                                            <tr>
+                                                <td class="pl-3">{{ MailHistory.send_date|date_min }}</td>
+                                                <td class="pr-3"><a class="text-primary" data-toggle="modal" data-target="#mail2">{{ MailHistory.mail_subject }}</a>
+                                                    <div class="modal fade" id="mail2" tabindex="-1" role="dialog" aria-labelledby="mail2" aria-hidden="true">
+                                                        <div class="modal-dialog" role="document">
+                                                            <div class="modal-content">
+                                                                <div class="modal-header">
+                                                                    <h5 class="modal-title">{{ MailHistory.mail_subject }}</h5>
+                                                                    <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                                                                </div>
+                                                                <div class="modal-body">
+                                                                    <p>
+                                                                        {{ MailHistory.mail_body|nl2br }}
+                                                                    </p>
+                                                                </div>
+                                                                <div class="modal-footer">
+                                                                    <button class="btn btn-ec-regular" type="button" data-dismiss="modal">{{ 'admin.common.label.close'|trans }}</button>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        {% endfor %}
+                                        </tbody>
+                                    </table>
+                                    <div class="text-center">
+                                        <a class="btn btn-ec-regular" href="{{ url('admin_order_mail', { id : Order.id }) }}">{{ 'admin.order.edit.label.mail'|trans }}</a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% endif %}
+                    {# メール配信履歴 終了 #}
+
+                </div>
             </div>
         </div>
         <div class="c-conversionArea">

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -403,154 +403,143 @@ file that was distributed with this source code.
                                         <button type="button" id="shipping-add" class="btn btn-ec-regular">{{ 'admin.order.edit.label.shipping.edit'|trans }}</button>
                                         複数配送を指定している場合は、こちらのボタンからそれぞれの配送設定の編集ができます。
                                     </div>
-                                    {% for shippingForm in form.Shippings %}
-                                        お届け先{{ shippingForm.vars.name + 1 }}　{{ shippingForm.name.name01.vars.value }}{{ shippingForm.name.name02.vars.value }}　{{ shippingForm.address.addr01.vars.value }}{{ shippingForm.address.addr02.vars.value }}<br>
+                                    {% for shipping in Order.Shippings %}
+                                        お届け先{{ loop.index }}　{{ shipping.name01 }} {{ shipping.name02 }}　 〒{{ shipping.postal_code }} {{ shipping.addr01 }} {{ shipping.addr02 }}　{{ shipping.shipping_date|date_sec }}<br>
                                     {% endfor %}
                                 {% else %}
                                     {# 単数配送の場合は配送先の編集が可能 #}
-                                    {% for shippingForm in form.Shippings %}
-                                        {% set shippingIndex = shippingForm.vars.name %}
-                                        <div class="row mb-3">
-                                            <div class="col-6">
-                                                <button type="button" class="btn btn-ec-regular copy-customer" data-idx="{{ shippingIndex }}">{{ 'admin.order.edit.label.customer_info.copy'|trans }}</button>
-                                                <button type="button" id="print" class="btn btn-ec-regular">{{ 'admin.order.edit.label.shipping.print'|trans }}</button>
-                                            </div>
-                                            <div class="col-6 text-right">
-                                                <button type="button" id="shipping-add" class="btn btn-ec-regular w-25">{{ 'admin.order.edit.label.shipping.add'|trans }}</button>
-                                            </div>
+                                    <div class="row mb-3">
+                                        <div class="col-6">
+                                            <button type="button" class="btn btn-ec-regular copy-customer" data-idx="{{ form.Shipping.vars.name }}">{{ 'admin.order.edit.label.customer_info.copy'|trans }}</button>
+                                            <button type="button" id="print" class="btn btn-ec-regular">{{ 'admin.order.edit.label.shipping.print'|trans }}</button>
                                         </div>
-                                        <div class="row">
-                                            <div class="col-6">
-                                                <div class="row form-group">
-                                                    <label class="col-3 col-form-label">{{ 'admin.common.label.name'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
-                                                    <div class="col">
-                                                        <div class="row">
-                                                            <div class="col">
-                                                                {{ form_widget(shippingForm.name.name01, {attr: {placeholder: 'admin.common.label.family_name' }}) }}
-                                                                {{ form_errors(shippingForm.name.name01) }}
-                                                            </div>
-                                                            <div class="col">
-                                                                {{ form_widget(shippingForm.name.name02, {attr: {placeholder: 'admin.common.label.first_name' }}) }}
-                                                                {{ form_errors(shippingForm.name.name02) }}
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div class="row form-group">
-                                                    <label class="col-3 col-form-label">{{ 'admin.common.label.kana'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
-                                                    <div class="col">
-                                                        <div class="row">
-                                                            <div class="col">
-                                                                {{ form_widget(shippingForm.kana.kana01, {attr: {placeholder: 'admin.common.label.family_name_kana' }}) }}
-                                                                {{ form_errors(shippingForm.kana.kana01) }}
-                                                            </div>
-                                                            <div class="col">
-                                                                {{ form_widget(shippingForm.kana.kana02, {attr: {placeholder: 'admin.common.label.first_name_kana' }}) }}
-                                                                {{ form_errors(shippingForm.kana.kana02) }}
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div class="row form-group">
-                                                    <label class="col-3 col-form-label">{{ 'admin.common.label.address'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
-                                                    <div class="col">
-                                                        <div class="row mb-3">
-                                                            <div class="col form-inline">
-                                                                {{ 'admin.order.edit.261'|trans }}
-                                                                {{ form_widget(shippingForm.postal_code) }}
-                                                                {{ form_errors(shippingForm.postal_code) }}
-                                                            </div>
-                                                        </div>
-                                                        <div class="row mb-3">
-                                                            <div class="col">
-                                                                {{ form_widget(shippingForm.address.pref) }}
-                                                                {{ form_errors(shippingForm.address.pref) }}
-                                                            </div>
-                                                        </div>
-                                                        <div class="row mb-3">
-                                                            <div class="col">
-                                                                {{ form_widget(shippingForm.address.addr01, { attr : {placeholder : 'admin.order.edit.262' }}) }}
-                                                                {{ form_errors(shippingForm.address.addr01) }}
-                                                            </div>
-                                                        </div>
-                                                        <div class="row">
-                                                            <div class="col">
-                                                                {{ form_widget(shippingForm.address.addr02, { attr : { placeholder : 'admin.order.edit.263' }}) }}
-                                                                {{ form_errors(shippingForm.address.addr02) }}
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="col-6">
-                                                <div class="row form-group">
-                                                    <label class="col-3 col-form-label">{{ 'admin.common.label.tel'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
-                                                    <div class="col">
-                                                        {{ form_widget(shippingForm.phone_number) }}
-                                                        {{ form_errors(shippingForm.phone_number) }}
-                                                    </div>
-                                                </div>
-
-                                                <div class="row form-group">
-                                                    <label class="col-3 col-form-label">{{ 'admin.common.label.company'|trans }}</label>
-                                                    <div class="col">
-                                                        {{ form_widget(shippingForm.company_name) }}
-                                                        {{ form_errors(shippingForm.company_name) }}
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="col-12">
-                                                <hr>
-                                            </div>
-                                            <div class="col-6">
-                                                <div class="row mb-3 form-group">
-                                                    <label class="col-3 col-form-label">{{ 'admin.common.label.tracking_number'|trans }}</label>
-                                                    <div class="col">
-                                                        {{ form_widget(shippingForm.tracking_number) }}
-                                                        {{ form_errors(shippingForm.tracking_number) }}
-                                                    </div>
-                                                </div>
-                                                <div class="row mb-3 form-group">
-                                                    <label class="col-3 col-form-label">{{ 'admin.shipping.edit.delivery_provider'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
-                                                    <div class="col">
-                                                        {{ form_widget(shippingForm.Delivery) }}
-                                                        {{ form_errors(shippingForm.Delivery) }}
-                                                    </div>
-                                                </div>
-                                                <div class="row mb-3 form-group">
-                                                    <label class="col-3 col-form-label">{{ 'admin.shipping.edit.note_title'|trans }}</label>
-                                                    <div class="col">
-                                                        {{ form_widget(shippingForm.note) }}
-                                                        {{ form_errors(shippingForm.note) }}
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="col-6">
-                                                <div class="row mb-3 form-group">
-                                                    <label class="col-3 col-form-label"><i class="fa fa-calendar-check-o fa-fw mr-1" aria-hidden="true"></i>{{ 'admin.shipping.edit.date_to_deliver'|trans }}</label>
-                                                    <div class="col">
-                                                        {{ form_widget(shippingForm.shipping_delivery_date) }}
-                                                        {{ form_errors(shippingForm.shipping_delivery_date) }}
-                                                    </div>
-                                                </div>
-                                                <div class="row mb-3 form-group">
-                                                    <label class="col-3 col-form-label"><i class="fa fa-clock-o fa-fw mr-1" aria-hidden="true"></i>{{ 'admin.shipping.edit.specified_time_zone'|trans }}</label>
-                                                    <div class="col">
-                                                        {{ form_widget(shippingForm.DeliveryTime) }}
-                                                        {{ form_errors(shippingForm.DeliveryTime) }}
-                                                    </div>
-                                                </div>
-                                                {% if Order.isMultiple %}
-                                                    <div class="row mb-3">
-                                                        <div class="col-3"><i class="fa fa-truck fa-fw mr-1" aria-hidden="true"></i>{{ 'admin.shipping.edit.ship_date'|trans }}</div>
+                                        <div class="col-6 text-right">
+                                            <button type="button" id="shipping-add" class="btn btn-ec-regular w-25">{{ 'admin.order.edit.label.shipping.add'|trans }}</button>
+                                        </div>
+                                    </div>
+                                    <div class="row">
+                                        <div class="col-6">
+                                            <div class="row form-group">
+                                                <label class="col-3 col-form-label">{{ 'admin.common.label.name'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
+                                                <div class="col">
+                                                    <div class="row">
                                                         <div class="col">
-                                                            {{ Order.Shippings[shippingIndex].shipping_date|date_sec }}
+                                                            {{ form_widget(form.Shipping.name.name01, {attr: {placeholder: 'admin.common.label.family_name' }}) }}
+                                                            {{ form_errors(form.Shipping.name.name01) }}
+                                                        </div>
+                                                        <div class="col">
+                                                            {{ form_widget(form.Shipping.name.name02, {attr: {placeholder: 'admin.common.label.first_name' }}) }}
+                                                            {{ form_errors(form.Shipping.name.name02) }}
                                                         </div>
                                                     </div>
-                                                {% endif %}
+                                                </div>
+                                            </div>
+                                            <div class="row form-group">
+                                                <label class="col-3 col-form-label">{{ 'admin.common.label.kana'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
+                                                <div class="col">
+                                                    <div class="row">
+                                                        <div class="col">
+                                                            {{ form_widget(form.Shipping.kana.kana01, {attr: {placeholder: 'admin.common.label.family_name_kana' }}) }}
+                                                            {{ form_errors(form.Shipping.kana.kana01) }}
+                                                        </div>
+                                                        <div class="col">
+                                                            {{ form_widget(form.Shipping.kana.kana02, {attr: {placeholder: 'admin.common.label.first_name_kana' }}) }}
+                                                            {{ form_errors(form.Shipping.kana.kana02) }}
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="row form-group">
+                                                <label class="col-3 col-form-label">{{ 'admin.common.label.address'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
+                                                <div class="col">
+                                                    <div class="row mb-3">
+                                                        <div class="col form-inline">
+                                                            {{ 'admin.order.edit.261'|trans }}
+                                                            {{ form_widget(form.Shipping.postal_code) }}
+                                                            {{ form_errors(form.Shipping.postal_code) }}
+                                                        </div>
+                                                    </div>
+                                                    <div class="row mb-3">
+                                                        <div class="col">
+                                                            {{ form_widget(form.Shipping.address.pref) }}
+                                                            {{ form_errors(form.Shipping.address.pref) }}
+                                                        </div>
+                                                    </div>
+                                                    <div class="row mb-3">
+                                                        <div class="col">
+                                                            {{ form_widget(form.Shipping.address.addr01, { attr : {placeholder : 'admin.order.edit.262' }}) }}
+                                                            {{ form_errors(form.Shipping.address.addr01) }}
+                                                        </div>
+                                                    </div>
+                                                    <div class="row">
+                                                        <div class="col">
+                                                            {{ form_widget(form.Shipping.address.addr02, { attr : { placeholder : 'admin.order.edit.263' }}) }}
+                                                            {{ form_errors(form.Shipping.address.addr02) }}
+                                                        </div>
+                                                    </div>
+                                                </div>
                                             </div>
                                         </div>
-                                    {% endfor %}
+                                        <div class="col-6">
+                                            <div class="row form-group">
+                                                <label class="col-3 col-form-label">{{ 'admin.common.label.tel'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
+                                                <div class="col">
+                                                    {{ form_widget(form.Shipping.phone_number) }}
+                                                    {{ form_errors(form.Shipping.phone_number) }}
+                                                </div>
+                                            </div>
+
+                                            <div class="row form-group">
+                                                <label class="col-3 col-form-label">{{ 'admin.common.label.company'|trans }}</label>
+                                                <div class="col">
+                                                    {{ form_widget(form.Shipping.company_name) }}
+                                                    {{ form_errors(form.Shipping.company_name) }}
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-12">
+                                            <hr>
+                                        </div>
+                                        <div class="col-6">
+                                            <div class="row mb-3 form-group">
+                                                <label class="col-3 col-form-label">{{ 'admin.common.label.tracking_number'|trans }}</label>
+                                                <div class="col">
+                                                    {{ form_widget(form.Shipping.tracking_number) }}
+                                                    {{ form_errors(form.Shipping.tracking_number) }}
+                                                </div>
+                                            </div>
+                                            <div class="row mb-3 form-group">
+                                                <label class="col-3 col-form-label">{{ 'admin.shipping.edit.delivery_provider'|trans }}<span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></label>
+                                                <div class="col">
+                                                    {{ form_widget(form.Shipping.Delivery) }}
+                                                    {{ form_errors(form.Shipping.Delivery) }}
+                                                </div>
+                                            </div>
+                                            <div class="row mb-3 form-group">
+                                                <label class="col-3 col-form-label">{{ 'admin.shipping.edit.note_title'|trans }}</label>
+                                                <div class="col">
+                                                    {{ form_widget(form.Shipping.note) }}
+                                                    {{ form_errors(form.Shipping.note) }}
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-6">
+                                            <div class="row mb-3 form-group">
+                                                <label class="col-3 col-form-label"><i class="fa fa-calendar-check-o fa-fw mr-1" aria-hidden="true"></i>{{ 'admin.shipping.edit.date_to_deliver'|trans }}</label>
+                                                <div class="col">
+                                                    {{ form_widget(form.Shipping.shipping_delivery_date) }}
+                                                    {{ form_errors(form.Shipping.shipping_delivery_date) }}
+                                                </div>
+                                            </div>
+                                            <div class="row mb-3 form-group">
+                                                <label class="col-3 col-form-label"><i class="fa fa-clock-o fa-fw mr-1" aria-hidden="true"></i>{{ 'admin.shipping.edit.specified_time_zone'|trans }}</label>
+                                                <div class="col">
+                                                    {{ form_widget(form.Shipping.DeliveryTime) }}
+                                                    {{ form_errors(form.Shipping.DeliveryTime) }}
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 {% endif %}
                             </div>
                         </div>
@@ -704,23 +693,35 @@ file that was distributed with this source code.
                                             </td>
                                             <td class="align-middle text-right pr-3">
                                                 <div class="row justify-content-end">
-                                                    <div class="col-auto text-center"><a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_{{ orderItemForm.vars.id }}" data-tooltip="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}"><i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i></a>
-                                                        <div class="modal fade" id="delete_{{ orderItemForm.vars.id }}" tabindex="-1" role="dialog" aria-labelledby="delete_{{ orderItemForm.vars.id }}" aria-hidden="true">
-                                                            <div class="modal-dialog" role="document">
-                                                                <div class="modal-content">
-                                                                    <div class="modal-header">
-                                                                        <h5 class="modal-title font-weight-bold">{{ 'admin.order.edit.delete.modal.header'|trans }}</h5>
-                                                                        <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
-                                                                    </div>
-                                                                    <div class="modal-body text-left"><p class="text-left">{{ 'admin.order.edit.delete.modal.body'|trans }}</p></div>
-                                                                    <div class="modal-footer">
-                                                                        <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}</button>
-                                                                        <a href="#order-product" class="btn delete btn-ec-delete">{{ 'common.label.delete'|trans }}</a>
+                                                    {# 複数配送の場合は商品を削除できない #}
+                                                    {% if Order.isMultiple and orderItemForm.vars.value.orderItemType.id == 1 %}
+                                                        <div class="col-auto text-center">
+                                                            <a class="btn btn-ec-actionIcon disabled">
+                                                                <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
+                                                            </a>
+                                                        </div>
+                                                    {% else %}
+                                                        <div class="col-auto text-center">
+                                                            <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_{{ orderItemForm.vars.id }}" data-tooltip="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}">
+                                                                <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
+                                                            </a>
+                                                            <div class="modal fade" id="delete_{{ orderItemForm.vars.id }}" tabindex="-1" role="dialog" aria-labelledby="delete_{{ orderItemForm.vars.id }}" aria-hidden="true">
+                                                                <div class="modal-dialog" role="document">
+                                                                    <div class="modal-content">
+                                                                        <div class="modal-header">
+                                                                            <h5 class="modal-title font-weight-bold">{{ 'admin.order.edit.delete.modal.header'|trans }}</h5>
+                                                                            <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                                                                        </div>
+                                                                        <div class="modal-body text-left"><p class="text-left">{{ 'admin.order.edit.delete.modal.body'|trans }}</p></div>
+                                                                        <div class="modal-footer">
+                                                                            <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}</button>
+                                                                            <a href="#order-product" class="btn delete btn-ec-delete">{{ 'common.label.delete'|trans }}</a>
+                                                                        </div>
                                                                     </div>
                                                                 </div>
                                                             </div>
                                                         </div>
-                                                    </div>
+                                                    {% endif %}
                                                 </div>
                                             </td>
                                             {{ form_widget(orderItemForm.Order) }}

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
@@ -44,7 +44,24 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         'delivery_fee_total' => '1',
         'charge' => '1',
         'Payment' => '1', // dtb_payment?
-        'Shippings' => [],
+        'Shipping' => [
+            'name' => [
+                'name01' => 'たかはし',
+                'name02' => 'しんいち',
+            ],
+            'kana' => [
+                'kana01' => 'タカハシ',
+                'kana02' => 'シンイチ',
+            ],
+            'postal_code' => '530-0001',
+            'address' => [
+                'pref' => '5',
+                'addr01' => '北区',
+                'addr02' => '梅田',
+            ],
+            'phone_number' => '012-345-6789',
+            'Delivery' => 1
+        ],
     ];
 
     public function setUp()

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
@@ -60,7 +60,7 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
                 'addr02' => '梅田',
             ],
             'phone_number' => '012-345-6789',
-            'Delivery' => 1
+            'Delivery' => 1,
         ],
     ];
 

--- a/tests/Eccube/Tests/Web/Admin/Order/AbstractEditControllerTestCase.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/AbstractEditControllerTestCase.php
@@ -54,7 +54,7 @@ abstract class AbstractEditControllerTestCase extends AbstractAdminWebTestCase
                 'tax_rule' => 1,
                 'product_name' => $Product->getName(),
                 'product_code' => $ProductClasses[0]->getCode(),
-                'order_item_type' => 1
+                'order_item_type' => 1,
             ];
         }
 
@@ -74,7 +74,7 @@ abstract class AbstractEditControllerTestCase extends AbstractAdminWebTestCase
                 'addr02' => $faker->streetAddress,
             ],
             'phone_number' => $faker->phoneNumber,
-            'Delivery' => 1
+            'Delivery' => 1,
         ];
 
         $order = [
@@ -165,7 +165,7 @@ abstract class AbstractEditControllerTestCase extends AbstractAdminWebTestCase
                 'addr02' => $Shipping->getAddr02(),
             ],
             'phone_number' => $Shipping->getPhoneNumber(),
-            'Delivery' => 1
+            'Delivery' => 1,
         ];
 
         //受注フォーム

--- a/tests/Eccube/Tests/Web/Admin/Order/AbstractEditControllerTestCase.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/AbstractEditControllerTestCase.php
@@ -15,6 +15,7 @@ namespace Eccube\Tests\Web\Admin\Order;
 
 use Eccube\Entity\Customer;
 use Eccube\Entity\Order;
+use Eccube\Entity\OrderItem;
 use Eccube\Entity\Product;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 
@@ -53,8 +54,28 @@ abstract class AbstractEditControllerTestCase extends AbstractAdminWebTestCase
                 'tax_rule' => 1,
                 'product_name' => $Product->getName(),
                 'product_code' => $ProductClasses[0]->getCode(),
+                'order_item_type' => 1
             ];
         }
+
+        $shipping = [
+            'name' => [
+                'name01' => $faker->lastName,
+                'name02' => $faker->firstName,
+            ],
+            'kana' => [
+                'kana01' => $faker->lastKanaName,
+                'kana02' => $faker->firstKanaName,
+            ],
+            'postal_code' => $faker->postcode,
+            'address' => [
+                'pref' => '5',
+                'addr01' => $faker->city,
+                'addr02' => $faker->streetAddress,
+            ],
+            'phone_number' => $faker->phoneNumber,
+            'Delivery' => 1
+        ];
 
         $order = [
             '_token' => 'dummy',
@@ -86,6 +107,7 @@ abstract class AbstractEditControllerTestCase extends AbstractAdminWebTestCase
             'OrderItems' => $OrderItems,
             'add_point' => 0,
             'use_point' => 0,
+            'Shipping' => $shipping,
         ];
 
         return $order;
@@ -103,6 +125,7 @@ abstract class AbstractEditControllerTestCase extends AbstractAdminWebTestCase
         //受注アイテム
         $orderItem = [];
         $OrderItemColl = $Order->getOrderItems();
+        /** @var OrderItem $OrderItem */
         foreach ($OrderItemColl as $OrderItem) {
             $Product = $OrderItem->getProduct();
             $ProductClass = $OrderItem->getProductClass();
@@ -115,6 +138,7 @@ abstract class AbstractEditControllerTestCase extends AbstractAdminWebTestCase
                 'tax_rule' => $OrderItem->getTaxRule(),
                 'product_name' => is_object($Product) ? $Product->getName() : '送料', // XXX v3.1 より 送料等, Product の無い明細が追加される
                 'product_code' => is_object($ProductClass) ? $ProductClass->getCode() : null,
+                'order_item_type' => $OrderItem->getOrderItemTypeId(),
             ];
         }
         $Customer = $Order->getCustomer();
@@ -122,6 +146,28 @@ abstract class AbstractEditControllerTestCase extends AbstractAdminWebTestCase
         if (is_object($Customer)) {
             $customer_id = $Customer->getId();
         }
+
+        $Shipping = $Order->getShippings()[0];
+
+        $shipping = [
+            'name' => [
+                'name01' => $Shipping->getName01(),
+                'name02' => $Shipping->getName02(),
+            ],
+            'kana' => [
+                'kana01' => $Shipping->getKana01(),
+                'kana02' => $Shipping->getKana02(),
+            ],
+            'postal_code' => $Shipping->getPostalCode(),
+            'address' => [
+                'pref' => $Shipping->getPref()->getId(),
+                'addr01' => $Shipping->getAddr01(),
+                'addr02' => $Shipping->getAddr02(),
+            ],
+            'phone_number' => $Shipping->getPhoneNumber(),
+            'Delivery' => 1
+        ];
+
         //受注フォーム
         $order = [
             '_token' => 'dummy',
@@ -153,6 +199,7 @@ abstract class AbstractEditControllerTestCase extends AbstractAdminWebTestCase
             'note' => $Order->getNote(),
             'add_point' => 0,
             'use_point' => 0,
+            'Shipping' => $shipping,
         ];
 
         return $order;


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 受注編集画面を複数配送に対応させる
  - 複数配送の場合はお届け先情報を１件１行で表示させる
  - 受注編集画面では新規商品の追加をさせない
  - 受注編集画面では商品の個数を変更させない

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、2系で同様の仕様があったため など

## 実装に関する補足(Appendix)
+ コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと

## テスト（Test)
+ テストを行っている範囲など、レビューアが安心できるような情報

## 相談（Discussion）
+ 相談したいことや意見を求めたいこと

