### PR TITLE
【お客様情報の入力】確認のメールアドレスが不一致だった場合に、エラーが表示される場所は、下段のほうがよい

### DIFF
--- a/src/Eccube/Form/Type/RepeatedEmailType.php
+++ b/src/Eccube/Form/Type/RepeatedEmailType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\OptionsResolver\Options;
 
 class RepeatedEmailType extends AbstractType
 {
@@ -47,6 +48,9 @@ class RepeatedEmailType extends AbstractType
             ],
             'error_bubbling' => false,
             'trim' => true,
+            'error_mapping' => function (Options $options) {
+                return ['.' => $options['second_name']];
+            }
         ]);
     }
 

--- a/src/Eccube/Form/Type/RepeatedEmailType.php
+++ b/src/Eccube/Form/Type/RepeatedEmailType.php
@@ -50,7 +50,7 @@ class RepeatedEmailType extends AbstractType
             'trim' => true,
             'error_mapping' => function (Options $options) {
                 return ['.' => $options['second_name']];
-            }
+            },
         ]);
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ PullRequestの目的、関連するIssue番号など
    - 【お客様情報の入力】確認のメールアドレスが不一致だった場合に、エラーが表示される場所は、下段のほうがよい

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外した内容
  - none

## 実装に関する補足(Appendix)
+ コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと

## テスト（Test)
+  none



