### PR TITLE
data-toggleでtooltipとmodalが競合する問題に対応するためjsを修正

### DIFF
--- a/html/template/admin/assets/js/script.js
+++ b/html/template/admin/assets/js/script.js
@@ -17,7 +17,7 @@ mainNavArea();
 //Bootstrap ツールチップ
 var toolTip = function(){
     $(function () {
-        $('[data-toggle="tooltip"]').tooltip()
+        $('[data-tooltip="tooltip"]').tooltip()
     })
 };
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
モーダルで削除確認を表示する場合。
たとえば「削除ボタン」で `data-toggle="tooltip"` と `data-toggle="modal"` が競合する問題の対応。

## 方針(Policy)
- script.jsを修正しています。

## 実装に関する補足(Appendix)

管理画面の各画面について、
`data-toggle="tooltip"` → `data-tooltip="tooltip"` に置き換えていく必要があります。



