### PR TITLE
PluginManagerでレポジトリを取得するため, doctrineのタグは除外する

### DIFF
--- a/src/Eccube/DependencyInjection/Compiler/PluginPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/PluginPass.php
@@ -16,13 +16,25 @@ namespace Eccube\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * プラグインのコンポーネント定義を制御するクラス.
+ */
 class PluginPass implements CompilerPassInterface
 {
     /**
-     * You can modify the container here before it is dumped to PHP code.
+     * プラグインのコンポーネント定義を制御する.
+     *
+     * 無効状態のプラグインに対し, 付与されているサービスタグをクリアすることで,
+     * プラグインが作成しているEventListener等の拡張機構が呼び出されないようにする.
+     *
+     * サービスタグが収集されるタイミング(一般的にPassConfig::TYPE_BEFORE_OPTIMIZATIONの0)より先に実行される必要があります.
+     *
+     * @param ContainerBuilder $container
      */
     public function process(ContainerBuilder $container)
     {
+        // 無効状態のプラグインコード一覧を取得.
+        // 無効なプラグインの一覧はEccubeExtensionで定義している.
         $plugins = $container->getParameter('eccube.plugins.disabled');
 
         if (empty($plugins)) {

--- a/src/Eccube/DependencyInjection/Compiler/PluginPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/PluginPass.php
@@ -40,7 +40,14 @@ class PluginPass implements CompilerPassInterface
                 $namespace = 'Plugin\\'.$plugin.'\\';
 
                 if (false !== \strpos($class, $namespace)) {
-                    $definition->clearTags();
+                    foreach ($definition->getTags() as $tag => $attr) {
+                        // PluginManagerからレポジトリを取得する場合があるため,
+                        // doctrine.repository_serviceタグはスキップする.
+                        if ($tag === 'doctrine.repository_service') {
+                            continue;
+                        }
+                        $definition->clearTag($tag);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- プラグインが無効状態の場合、PluginPassですべてのタグを無効化している
- そのため、PluginManager::enableでコンテナからレポジトリを取得できてない
- PluginPassで、`doctrine.repository_service`タグは除外するように修正

## 参考

https://symfony.com/doc/4.1/service_container/tags.html
https://symfony.com/doc/current/reference/dic_tags.html