### PR TITLE
管理画面からプラグイン有効にしたときに、ルーティングのキャッシュが生成されなくてエラーとなる問題への対応。

### DIFF
--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -245,7 +245,7 @@ class PluginController extends AbstractController
      *
      * @return RedirectResponse
      */
-    public function enable(Plugin $Plugin)
+    public function enable(Plugin $Plugin, CacheUtil $cacheUtil)
     {
         $this->isTokenValid();
 
@@ -268,8 +268,12 @@ class PluginController extends AbstractController
             $this->addSuccess('admin.plugin.enable.complete', 'admin');
         }
 
-        // 有効化できた場合はキャッシュを再生成する
-        return $this->redirectToRoute('admin_store_clear_cache');
+        // キャッシュを削除してリダイレクト
+        // リダイレクトにredirectToRoute関数を使用していないのは、削除したキャッシュが再生成されてしまうため。
+        $url = $this->generateUrl('admin_store_plugin');
+        $cacheUtil->clearCache();
+
+        return $this->redirect($url);
     }
 
     /**
@@ -282,7 +286,7 @@ class PluginController extends AbstractController
      *
      * @return RedirectResponse
      */
-    public function disable(Plugin $Plugin)
+    public function disable(Plugin $Plugin, CacheUtil $cacheUtil)
     {
         $this->isTokenValid();
 
@@ -308,28 +312,12 @@ class PluginController extends AbstractController
             return $this->redirectToRoute('admin_store_plugin');
         }
 
-        // 無効化できた場合はキャッシュを再生成する
-        return $this->redirectToRoute('admin_store_clear_cache');
-    }
-
-    /**
-     * プラグイン有効状態切り替え後にキャッシュを削除するためのルーティング
-     *
-     * このルーティングが必要な理由：
-     * プラグイン有効化のリクエスト内でキャッシュを削除しても、有効になる前の情報でキャッシュが再生成されてしまう。
-     * それを回避するために、このルーティングにリダイレクトして、プラグイン有効状態であらためてキャッシュ再生成する。
-     *
-     * @Route("/%eccube_admin_route%/store/plugin/clearcache", name="admin_store_clear_cache")
-     *
-     * @param Request     $request
-     *
-     * @return RedirectResponse
-     */
-    public function clearCache(Request $request, CacheUtil $cacheUtil)
-    {
+        // キャッシュを削除してリダイレクト
+        // リダイレクトにredirectToRoute関数を使用していないのは、削除したキャッシュが再生成されてしまうため。
+        $url = $this->generateUrl('admin_store_plugin');
         $cacheUtil->clearCache();
 
-        return $this->redirectToRoute('admin_store_plugin');
+        return $this->redirect($url);
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
管理画面からプラグインを有効化したときに、プラグインが追加するルーティングが見つからなくてエラーとなる問題への対応です。

## 方針(Policy)
キャッシュを削除した状態でリダイレクトするようにしました。
キャッシュをクリアするルーティングを利用していましたが、意味がなかったんので削除しました。

## 実装に関する補足(Appendix)
redirectToRoute関数を実行すると、内部でgenerateUrl関数を呼び出し、キャッシュが再生成されていしまいます。
それを回避するために、generateUrl→キャッシュ削除→redirect という処理の流れになっています。

## テスト（Test)
プラグインを有効化してエラーにならなくなることを確認。


