### PR TITLE
#99 【マイページ/お届け先編集】お届け先の表示ズレ

### DIFF
--- a/codeception/_support/Page/Front/CustomerAddressEditPage.php
+++ b/codeception/_support/Page/Front/CustomerAddressEditPage.php
@@ -34,7 +34,7 @@ class CustomerAddressEditPage extends AbstractFrontPage
     public static function at($I)
     {
         $page = new self($I);
-        $page->tester->see('マイページ/お届け先編集', 'div.ec-pageHeader h1');
+        $page->tester->see('マイページ/お届け先一覧', 'div.ec-pageHeader h1');
         return $page;
     }
 

--- a/codeception/_support/Page/Front/CustomerAddressListPage.php
+++ b/codeception/_support/Page/Front/CustomerAddressListPage.php
@@ -34,7 +34,7 @@ class CustomerAddressListPage extends AbstractFrontPage
     public static function at($I)
     {
         $page = new self($I);
-        $page->tester->see('マイページ/お届け先編集', 'div.ec-pageHeader h1');
+        $page->tester->see('マイページ/お届け先一覧', 'div.ec-pageHeader h1');
         return $page;
     }
 

--- a/codeception/_support/Page/Front/MyPage.php
+++ b/codeception/_support/Page/Front/MyPage.php
@@ -50,7 +50,7 @@ class MyPage extends AbstractFrontPage
         $page->tester->see('ご注文履歴', self::ORDER_HISTORY);
         $page->tester->see('お気に入り一覧', self::FAVORITE);
         $page->tester->see('会員情報編集', self::USER_INFO);
-        $page->tester->see('お届け先編集', self::ADDRESS);
+        $page->tester->see('お届け先一覧', self::ADDRESS);
         $page->tester->see('退会手続き', self::WITHDRAW);
         return $page;
     }

--- a/codeception/acceptance/EF05MypageCest.php
+++ b/codeception/acceptance/EF05MypageCest.php
@@ -162,10 +162,10 @@ class EF05MypageCest
         $customer = $createCustomer();
         $I->loginAsMember($customer->getEmail(), 'password');
 
-        // TOPページ>マイページ>お届け先編集
+        // TOPページ>マイページ>お届け先一覧
         MyPage::go($I)->お届け先編集();
 
-        $I->see('お届け先編集', 'div.ec-pageHeader h1');
+        $I->see('お届け先一覧', 'div.ec-pageHeader h1');
     }
 
     public function mypage_お届け先編集作成変更(\AcceptanceTester $I)

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -354,7 +354,7 @@ return [
     'mypage.label.customer_info' => '会員情報編集',
     'mypage.label.customer_info_complete' => '会員情報編集(完了)',
     'mypage.label.btn.edit' => '変更する',
-    'mypage.label.edit_address' => 'お届け先編集',
+    'mypage.label.edit_address' => 'お届け先一覧',
     'mypage.label.add_address' => '新規お届け先を追加する',
     'mypage.label.btn.register' => '登録する',
     'mypage.label.cancel_membership' => '退会手続き',


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ No 99:【マイページ/お届け先編集】お届け先の表示ズレ

## 方針(Policy)
+ messages.jaの日本語表記に表記ゆれがあった為、左記ファイルを修正
　お届け先編集 -> お届け先一覧

## 実装に関する補足(Appendix)
+ messages.jaのみ修正

## テスト（Test)
+ 目視で確認

## 相談（Discussion）
+ この画面自体は上記変更で問題ないが、mypage_delivery_edit （編集画面）も　お届け先一覧が表示されたままとなるが（ページボタンの上部）問題ないか？

