### PR TITLE
#106 【商品登録】タグがsort_noで並べ替えられていない

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -431,11 +431,7 @@ class ProductController extends AbstractController
         }
         $form['Category']->setData($categories);
 
-        $Tags = [];
-        $ProductTags = $Product->getProductTag();
-        foreach ($ProductTags as $ProductTag) {
-            $Tags[] = $ProductTag->getTag();
-        }
+        $Tags = $Product->getTags();
         $form['Tag']->setData($Tags);
 
         if ('POST' === $request->getMethod()) {


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ No 106【商品登録】タグがsort_noで並べ替えられていない

## 方針(Policy)
+ 商品単位に選択されているタグ（ProductTag)をソートせずにDB登録順のまま抽出していた為、フロントと同様の並び替えメソッドを通してTagを抽出するように修正。

## 実装に関する補足(Appendix)
+ 特になし

## テスト（Test)
+ タグ管理より登録タグの並び順を変更し、テスト実施

