### PR TITLE
#46 システム情報はシステム情報設定の一番下にする

### DIFF
--- a/app/config/eccube/packages/eccube_nav.yaml
+++ b/app/config/eccube/packages/eccube_nav.yaml
@@ -106,9 +106,6 @@ parameters:
             name: admin.nav.setting.system
             has_child: true
             child:
-                - id: system_index
-                  name: admin.nav.setting.system.system_index
-                  url: admin_setting_system_system
                 - id: member
                   name: admin.nav.setting.system.member
                   url: admin_setting_system_member
@@ -124,6 +121,9 @@ parameters:
                 - id: masterdata
                   name: admin.nav.setting.system.masterdata
                   url: admin_setting_system_masterdata
+                - id: system_index
+                  name: admin.nav.setting.system.system_index
+                  url: admin_setting_system_system
     - id: store
       name: admin.nav.store
       has_child: true


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ No46 の通り、システム情報メニューはシステム情報カテゴリの最下位に移動

## 方針(Policy)
+ eccube.navi.yamlの修正のみで対応

## テスト（Test)
+ 変更後、目視で確認

