### PR TITLE
【マスターデータ管理】説明と挙動が一致していない

### DIFF
--- a/src/Eccube/Form/Type/Admin/MasterdataDataType.php
+++ b/src/Eccube/Form/Type/Admin/MasterdataDataType.php
@@ -69,10 +69,6 @@ class MasterdataDataType extends AbstractType
             if (strlen($data['id']) && strlen($data['name']) == 0) {
                 $form['name']->addError(new FormError(trans('This value should not be blank.')));
             }
-
-            if (strlen($data['name']) && strlen($data['id']) == 0) {
-                $form['id']->addError(new FormError(trans('This value should not be blank.')));
-            }
         });
     }
 

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/MasterdataControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/MasterdataControllerTest.php
@@ -116,36 +116,6 @@ class MasterdataControllerTest extends AbstractAdminWebTestCase
     }
 
     /**
-     * New id is null
-     *
-     * @see https://github.com/EC-CUBE/ec-cube/issues/1884
-     */
-    public function testNewIdIsNull()
-    {
-        $formData = $this->createFormData($this->entityTest);
-        $editForm = $this->createFormDataEdit($this->entityTest);
-        $id = count($editForm['data']) + 1;
-        $editForm['data'][$id]['id'] = null;
-        $editForm['data'][$id]['name'] = 'test';
-
-        $crawler = $this->client->request(
-            'POST',
-            $this->generateUrl('admin_setting_system_masterdata_edit'),
-            [
-                'admin_system_masterdata' => $formData,
-                'admin_system_masterdata_edit' => $editForm,
-            ]
-        );
-        $html = $crawler->html();
-        $this->assertContains('入力されていません。', $html);
-
-        // Cannot save
-        $entityName = str_replace('-', '\\', $formData['masterdata']);
-        $actual = $this->entityManager->getRepository($entityName)->find($id);
-        $this->assertTrue(empty($actual));
-    }
-
-    /**
      * Add new name test
      *
      * @see https://github.com/EC-CUBE/ec-cube/issues/1884
@@ -173,34 +143,6 @@ class MasterdataControllerTest extends AbstractAdminWebTestCase
         $entityName = str_replace('-', '\\', $formData['masterdata']);
         $actual = $this->entityManager->getRepository($entityName)->find($id);
         $this->assertTrue(empty($actual));
-    }
-
-    /**
-     * Edit id is null
-     *
-     * @see https://github.com/EC-CUBE/ec-cube/issues/1884
-     */
-    public function testEditIdIsNull()
-    {
-        $formData = $this->createFormData($this->entityTest);
-        $editForm = $this->createFormDataEdit($this->entityTest);
-        $id = $editForm['data'][1]['id'];
-        $editForm['data'][1]['id'] = null;
-
-        $crawler = $this->client->request(
-            'POST',
-            $this->generateUrl('admin_setting_system_masterdata_edit'),
-            [
-                'admin_system_masterdata' => $formData,
-                'admin_system_masterdata_edit' => $editForm,
-            ]
-        );
-        $html = $crawler->html();
-        $this->assertContains('入力されていません。', $html);
-
-        $entityName = str_replace('-', '\\', $formData['masterdata']);
-        $actual = $this->entityManager->getRepository($entityName)->find($id);
-        $this->assertFalse(empty($actual));
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ マスタデータ管理において、idが空の場合に必須入力バリデーションがかかってしまい、削除ができていない

## 方針(Policy)
+ FormType側で名前が入力されていて、かつ、idが未入力の場合に必須入力のバリデーションがかかっていた為、当該チェック部を削除

## テスト（Test)
+ 以下のテストを実施
 - id未入力かつ名前入力 = 登録済みのidが空にされた場合は削除される
 - 名前未入力かつid入力 = 名前部に「入力されていません。」のエラーメッセージが表示される

