### PR TITLE
#28 【支払方法設定】受注に紐付いている支払い方法を削除した時のエラーメッセージがおかしい

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/Shop/PaymentController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/PaymentController.php
@@ -227,7 +227,7 @@ class PaymentController extends AbstractController
         } catch (ForeignKeyConstraintViolationException $e) {
             $this->entityManager->rollback();
 
-            $message = trans('admin.delete.failed.foreign_key', ['%name%' => trans('payment.text.name')]);
+            $message = trans('admin.delete.failed.foreign_key', ['%name%' => $TargetPayment->getMethod()]);
             $this->addError($message, 'admin');
         }
 


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ 関連するデータがあるため「」を削除できませんでした。　と表示される。

## 方針(Policy)
+ 削除できない支払方法名を用い　関連するデータがあるため「銀行振込」を削除できませんでした。　と表示されるように修正する。

## テスト（Test)
+ 以下の試験を実施し、目視で確認
 - 受注に紐づく支払い方法を削除 = エラーメッセージが正しく表示される
 - 受注に紐づかない支払い方法を削除 = 正しく削除される

