### PR TITLE
#23 【配送方法登録・編集】お届け時間設定で新規作成->編集->キャンセルで入力値が消える。消えないようにしたい。

### DIFF
--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
@@ -168,6 +168,9 @@ file that was distributed with this source code.
                 current.find('.display-label').text(value);
                 current.find('.mode-view').removeClass('d-none');
                 current.find('.mode-edit').addClass('d-none');
+                current.find('[data-origin-value]').each(function(e) {
+                    $(this).attr('data-origin-value', value);
+                });
             });
             // 編集キャンセル
             $('#delivery-time-group').on('click', 'button.action-edit-cancel', function (e) {

--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
@@ -102,6 +102,7 @@ file that was distributed with this source code.
                 // お届け時間名を入れる
                 var inputId = '#delivery_delivery_times_' + index + '_delivery_time';
                 $(inputId).val(deliveryTimeName);
+                $(inputId).attr('data-origin-value', deliveryTimeName);
 
                 // 入力欄を初期化
                 $('#add-delivery-time-value').val('');


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ お届け時間編集で新規行を追加、追加行を修正、キャンセルすると元々追加した内容が消える。
 - 一度編集確定後、再度編集、キャンセルでも同様の事象が発生している。
 
## 方針(Policy)
+ 新規追加行に対して編集キャンセルした場合、最終確定していた値を復元させる。
 - 新規追加時、編集確定時にdata-origin-value属性へ確定値を設定していなかった為、設定するように修正。

## テスト（Test)
+ 以下のテストを実施し確認
 - 新規追加 > 編集 > 値変更しキャンセル > 新規追加時点の値が設定される
 - 新規追加 > 編集 > [確定] > 編集 > 値変更しキャンセル > [確定]時点の値が設定される



