### PR TITLE
#45 【EC-CUBE ログ表示】ログを日付順か最終更新日時でソートして表示されてほしい

### DIFF
--- a/src/Eccube/Form/Type/Admin/LogType.php
+++ b/src/Eccube/Form/Type/Admin/LogType.php
@@ -53,7 +53,11 @@ class LogType extends AbstractType
     {
         $files = [];
         $finder = new Finder();
-        $finder->name('*.log')->depth('== 0');
+        $finder->name('*.log')
+            ->depth('== 0')
+            ->sort(function (\SplFileInfo $a, \SplFileInfo $b) {
+                return strcmp($b->getMTime(), $a->getMTime());
+            });
         $dirs = $this->kernel->getLogDir().DIRECTORY_SEPARATOR.$this->kernel->getEnvironment();
         foreach ($finder->in($dirs) as $file) {
             $files[$file->getFilename()] = $file->getFilename();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ ログファイル抽出時、特にソートの指定がなされていない為。

## 方針(Policy)
+ ファイル抽出時、finderのソート関数を設定し、最終更新日の降順でソートするように修正する。

## テスト（Test)
+ eccube/var/dev/log 配下に以下のファイルが配置されている場合、想定通りで表示される事を確認。
（site.log > site-2018-07-17.log > site-2018-07-16.log の順)
  - site.log(2018/07/18 20:30) 
  - site-2018-07-17.log(2018/07/17 20:30)
  - site-2018-07-16.log(2018/07/16 20:30)
+ 上記の状態より、site-2018-07-16.logをテキストエディタで更新、最終更新日を最新化した状態で、画面をリロードし、想定通りで表示される事を確認。
（site-2018-07-16.log > site.log > site-2018-07-16.log の順)

