### PR TITLE
#141 【当サイトについて】項目名の部分が太文字(bold)になっていない (特商法も同様）

### DIFF
--- a/src/Eccube/Resource/template/default/Help/about.twig
+++ b/src/Eccube/Resource/template/default/Help/about.twig
@@ -21,20 +21,26 @@ file that was distributed with this source code.
             <div class="ec-borderedDefs">
                 {% if BaseInfo.shop_name|default is not empty %}
                     <dl id="help_about_box__shop_name">
-                        <dt>{{'common.label.shop_name'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'common.label.shop_name'|trans}}</label>
+                        </dt>
                         <dd>{{ BaseInfo.shop_name }}</dd>
                     </dl>
                 {% endif %}
                 {% if BaseInfo.company_name|default is not empty %}
                     <dl id="help_about_box__company_name">
-                        <dt>{{'common.label.company_name'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'common.label.company_name'|trans}}</label>
+                        </dt>
                         <dd>{{ BaseInfo.company_name }}</dd>
                     </dl>
                 {% endif %}
 
                 {% if BaseInfo.postal_code|default is not empty %}
                     <dl id="help_about_box__zip">
-                        <dt>{{'common.label.address'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'common.label.address'|trans}}</label>
+                        </dt>
                         <dd>〒{{ BaseInfo.postal_code }}<br />
                             {{ BaseInfo.pref }}{{ BaseInfo.addr01 }}{{ BaseInfo.addr02 }}
                         </dd>
@@ -43,28 +49,36 @@ file that was distributed with this source code.
 
                 {% if BaseInfo.phone_number|default is not empty %}
                     <dl id="help_about_box__tel">
-                        <dt>{{'common.label.phone_number'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'common.label.phone_number'|trans}}</label>
+                        </dt>
                         <dd>{{ BaseInfo.phone_number }}</dd>
                     </dl>
                 {% endif %}
 
                 {% if BaseInfo.business_hour|default is not empty %}
                     <dl id="help_about_box__business_hour">
-                        <dt>{{'common.label.business_hour'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'common.label.business_hour'|trans}}</label>
+                        </dt>
                         <dd>{{ BaseInfo.business_hour }}</dd>
                     </dl>
                 {% endif %}
 
                 {% if BaseInfo.good_traded|default is not empty %}
                     <dl id="help_about_box__good_traded">
-                        <dt>{{'common.label.good_traded'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'common.label.good_traded'|trans}}</label>
+                        </dt>
                         <dd>{{ BaseInfo.good_traded|nl2br }}</dd>
                     </dl>
                 {% endif %}
 
                 {% if BaseInfo.message|default is not empty %}
                     <dl id="help_about_box__message">
-                        <dt>{{'admin.mail.order.203'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'admin.mail.order.203'|trans}}</label>
+                        </dt>
                         <dd>{{ BaseInfo.message|nl2br }}</dd>
                     </dl>
                 {% endif %}

--- a/src/Eccube/Resource/template/default/Help/tradelaw.twig
+++ b/src/Eccube/Resource/template/default/Help/tradelaw.twig
@@ -19,63 +19,87 @@ file that was distributed with this source code.
             <div class="ec-off1Grid__cell">
                 <div class="ec-borderedDefs">
                     <dl id="trade_company">
-                        <dt>{{'tradelaw.label.seller'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'tradelaw.label.seller'|trans}}</label>
+                        </dt>
                         <dd></dd>
                     </dl>
 
                     <dl id="trade_manager">
-                        <dt>{{'tradelaw.label.operation_director'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'tradelaw.label.operation_director'|trans}}</label>
+                        </dt>
                         <dd></dd>
                     </dl>
 
                     <dl id="trade_zip">
-                        <dt>{{'tradelaw.label.company_address'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'tradelaw.label.company_address'|trans}}</label>
+                        </dt>
                         <dd><br />
                         </dd>
                     </dl>
 
                     <dl id="trade_tel">
-                        <dt>{{'tradelaw.label.company_phone'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'tradelaw.label.company_phone'|trans}}</label>
+                        </dt>
                         <dd></dd>
                     </dl>
 
                     <dl id="trade_email">
-                        <dt>{{'tradelaw.label.email'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'tradelaw.label.email'|trans}}</label>
+                        </dt>
                         <dd><a href="mailto:"></a></dd>
                     </dl>
 
                     <dl id="trade_url">
-                        <dt>URL</dt>
+                        <dt>
+                            <label class="ec-label">URL</label>
+                        </dt>
                         <dd><a href=""></a></dd>
                     </dl>
 
                     <dl id="trade_term01">
-                        <dt>{{'tradelaw.label.required_fee'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'tradelaw.label.required_fee'|trans}}</label>
+                        </dt>
                         <dd></dd>
                     </dl>
 
                     <dl id="trade_term02">
-                        <dt>{{'tradelaw.label.required_fee'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'tradelaw.label.required_fee'|trans}}</label>
+                        </dt>
                         <dd></dd>
                     </dl>
 
                     <dl id="trade_term03">
-                        <dt>{{'tradelaw.label.howo_to_pay'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'tradelaw.label.howo_to_pay'|trans}}</label>
+                        </dt>
                         <dd></dd>
                     </dl>
 
                     <dl id="trade_term04">
-                        <dt>{{'tradelaw.label.payment_due'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'tradelaw.label.payment_due'|trans}}</label>
+                        </dt>
                         <dd></dd>
                     </dl>
 
                     <dl id="trade_term05">
-                        <dt>{{'tradelaw.label.delivery_timing'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'tradelaw.label.delivery_timing'|trans}}</label>
+                        </dt>
                         <dd></dd>
                     </dl>
 
                     <dl id="trade_term06">
-                        <dt>{{'tradelaw.label.return_exchange_policy'|trans}}</dt>
+                        <dt>
+                            <label class="ec-label">{{'tradelaw.label.return_exchange_policy'|trans}}</label>
+                        </dt>
                         <dd></dd>
                     </dl>
                 </div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 当サイトについて、特商法の項目名が太文字指定されていない。

## 方針(Policy)
+ お問い合わせを参考に、各テンプレの項目を<label class="ec-label">～</label>で囲む。

## テスト（Test)
+ 当サイトについて、特商法の両ページに対して全項目を表示さえ目視で太文字表示を確認。
