### PR TITLE
#67 【レイアウト管理】ブロック名が「...」で省略される

### DIFF
--- a/codeception/_support/Page/Admin/LayoutEditPage.php
+++ b/codeception/_support/Page/Admin/LayoutEditPage.php
@@ -32,9 +32,6 @@ class LayoutEditPage extends AbstractAdminPageStyleGuide
 
     public function ブロックを移動($blockName, $dest, $timeout = 10)
     {
-        if (mb_strlen($blockName) > 10) {
-            $blockName = mb_substr($blockName, 0, 10).'…';
-        }
         $this->tester->waitForElementVisible(['xpath' => "//div[contains(@id, 'detail_box__layout_item')][div[div[1][a[text()='${blockName}']]]]"], $timeout);
         $this->tester->dragAndDrop(['xpath' => "//div[contains(@id, 'detail_box__layout_item')][div[div[1][a[text()='${blockName}']]]]"], $dest);
         return $this;

--- a/src/Eccube/Resource/template/admin/Content/layout.twig
+++ b/src/Eccube/Resource/template/admin/Content/layout.twig
@@ -443,7 +443,7 @@ file that was distributed with this source code.
                                                                    data-id="{{ UnusedBlock.id }}"
                                                                    data-name="{{ UnusedBlock.name }}"
                                                                    title="{{ UnusedBlock.name }}"
-                                                                >{{ UnusedBlock.name|length > 10 ? UnusedBlock.name|slice(0, 10) ~ '…' : UnusedBlock.name }}</a>
+                                                                >{{ UnusedBlock.name }}</a>
                                                             </div>
                                                             <div class="col-auto text-right">
                                                                 <input type="hidden" class="name" name="name_{{ loop_index }}"

--- a/src/Eccube/Resource/template/admin/Content/layout_block.twig
+++ b/src/Eccube/Resource/template/admin/Content/layout_block.twig
@@ -17,7 +17,7 @@ file that was distributed with this source code.
                data-id="{{ BlockPosition.Block.id }}"
                data-name="{{ BlockPosition.Block.name }}"
                title="{{ BlockPosition.Block.name }}"
-            >{{ BlockPosition.Block.name|length > 10 ? BlockPosition.Block.name|slice(0, 10) ~ '…' : BlockPosition.Block.name }}</a>
+            >{{ BlockPosition.Block.name }}</a>
         </div>
         <div class="col-auto text-right">
             <div class="d-inline-block px-3 sort{% if loop.first %} first{% endif %}">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ Twig上で10桁足切りしているため。

## 方針(Policy)
+ ブロック名はすべてフル桁で表示するという方針となった為、足切り箇所を削除

## テスト（Test)
+ 10桁以上のブロック名もつブロックを作成し、レイアウト管理より表示を目視で確認。（配置、未配置）
