### PR TITLE
#142 【お問い合わせ】問い合わせ内容が確認画面で改行されない

### DIFF
--- a/src/Eccube/Resource/template/default/Contact/confirm.twig
+++ b/src/Eccube/Resource/template/default/Contact/confirm.twig
@@ -82,7 +82,7 @@ file that was distributed with this source code.
                                 {{ form_label(form.contents, 'お問い合わせ内容', {'label_attr': {'class': 'ec-label'}}) }}
                             </dt>
                             <dd>
-                                {{ form.contents.vars.data }}
+                                {{ form.contents.vars.data|nl2br }}
                                 {{ form_widget(form.contents, { type : 'hidden' }) }}
                             </dd>
                         </dl>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 複数行のお問い合わせ本文が、確認画面で改行されずに表示されている。

## 方針(Policy)
+ nl2brフィルタで改行されるよう改修。

## テスト（Test)
+ お問い合わせ入力よりお問い合わせ本文を複数行入力し、目視で確認。

## 相談（Discussion）
+ 改行自体は問題ありませんが、line-heightが大きすぎるのか本文部の行間が見た目として大きい気がします。別途スタイル調整が必要かもしれません。
