### PR TITLE
#148 【パスワードの再発行】inputのtypeをemailに変更

### DIFF
--- a/src/Eccube/Form/Type/Front/ForgotType.php
+++ b/src/Eccube/Form/Type/Front/ForgotType.php
@@ -15,7 +15,7 @@ namespace Eccube\Form\Type\Front;
 
 use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -44,7 +44,7 @@ class ForgotType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('login_email', TextType::class, [
+        $builder->add('login_email', EmailType::class, [
             'attr' => [
                 'max_length' => $this->eccubeConfig['eccube_stext_len'],
             ],


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ パスワード再発行画面のメールアドレスがTextTypeが適用されている為、EmailTypeに変更する。

## 方針(Policy)
+ 概要に記載の通り。

## テスト（Test)
+ 修正後、HTMLを確認しtype="email" となっている事、HTML５標準のバリデーションが効いている事を手動でテスト、確認。
