### PR TITLE
#68 【レイアウト管理】未使用ブロックをセクションに入れるとメニューのアイコンがずれる

### DIFF
--- a/src/Eccube/Resource/template/admin/Content/layout.twig
+++ b/src/Eccube/Resource/template/admin/Content/layout.twig
@@ -446,7 +446,7 @@ file that was distributed with this source code.
                                                                 >{{ UnusedBlock.name|length > 10 ? UnusedBlock.name|slice(0, 10) ~ '…' : UnusedBlock.name }}</a>
                                                             </div>
                                                             <div class="col-auto text-right">
-                                                                <div class="d-inline-block px-3 sort">
+                                                                <div class="d-inline-block px-3">
                                                                     <input type="hidden" class="name" name="name_{{ loop_index }}"
                                                                         value="{{ UnusedBlock.name }}"/>
                                                                     <input type="hidden" class="id" name="block_id_{{ loop_index }}"

--- a/src/Eccube/Resource/template/admin/Content/layout.twig
+++ b/src/Eccube/Resource/template/admin/Content/layout.twig
@@ -446,17 +446,19 @@ file that was distributed with this source code.
                                                                 >{{ UnusedBlock.name|length > 10 ? UnusedBlock.name|slice(0, 10) ~ '…' : UnusedBlock.name }}</a>
                                                             </div>
                                                             <div class="col-auto text-right">
-                                                                <input type="hidden" class="name" name="name_{{ loop_index }}"
-                                                                       value="{{ UnusedBlock.name }}"/>
-                                                                <input type="hidden" class="id" name="block_id_{{ loop_index }}"
-                                                                       value="{{ UnusedBlock.id }}"/>
-                                                                <input type="hidden" class="target-id"
-                                                                       name="section_{{ loop_index }}"
-                                                                       value="{{ unused_target_id }}"/>
-                                                                <input type="hidden" class="block-row"
-                                                                       name="block_row_{{ loop_index }}"
-                                                                       value="{{ UnusedBlock.id }}"/>
-                                                                <div class="block-context-menu d-inline-block px-3"><i class="fa fa-ellipsis-v fa-lg text-secondary"></i></div>
+                                                                <div class="d-inline-block px-3 sort">
+                                                                    <input type="hidden" class="name" name="name_{{ loop_index }}"
+                                                                        value="{{ UnusedBlock.name }}"/>
+                                                                    <input type="hidden" class="id" name="block_id_{{ loop_index }}"
+                                                                        value="{{ UnusedBlock.id }}"/>
+                                                                    <input type="hidden" class="target-id"
+                                                                        name="section_{{ loop_index }}"
+                                                                        value="{{ unused_target_id }}"/>
+                                                                    <input type="hidden" class="block-row"
+                                                                        name="block_row_{{ loop_index }}"
+                                                                        value="{{ UnusedBlock.id }}"/>
+                                                                    <div class="block-context-menu d-inline-block px-3"><i class="fa fa-ellipsis-v fa-lg text-secondary"></i></div>
+                                                                </div>
                                                             </div>
                                                         </div>
                                                     </div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 未使用ブロック -> セクション / セクション -> 未使用ブロックへの移動でアイコンが右寄りになる。

## 方針(Policy)
+ 未使用ブロック・セクション上のブロックで出力タグが異なっていた為。セクション上のブロックに出力されているタグに合わせて修正。

## テスト（Test)
+ 未使用ブロック -> セクション / セクション -> 未使用ブロックへの移動を行い、目視でずれていない事を確認。
