### PR TITLE
#95 【商品登録（規格設定）】エラーが２つでる

### DIFF
--- a/src/Eccube/Form/Type/Admin/ProductClassEditType.php
+++ b/src/Eccube/Form/Type/Admin/ProductClassEditType.php
@@ -231,10 +231,6 @@ class ProductClassEditType extends AbstractType
             ]);
             $this->addErrors('sale_limit', $form, $errors);
 
-            foreach ($errors as $error) {
-                $form['sale_limit']->addError(new FormError($error->getMessage()));
-            }
-
             // 販売価格
             $errors = $this->validator->validate($data['price02'], [
                 new Assert\NotBlank(),


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 販売制限数 に 0 を入力して登録・更新した場合、「1以上でなければなりません。」のエラーメッセージが1行に対して2つ(2行)表示される。

## 方針(Policy)
+ ProductClassEditType内のバリデーションロジック内で 販売制限数でエラーが発生した場合に addErrorsが2回実行される実装となっていた為。

## 実装に関する補足(Appendix)
+ 不要なaddErrorsを削除。

## テスト（Test)
+ 販売制限数 = 0 を設定して登録/修正
+ 販売制限数 = 11桁 を入力して登録/修正
