### PR TITLE
#271 【マスターデータ管理】重複したidで登録ができてしまう

### DIFF
--- a/src/Eccube/Form/Type/Admin/MasterdataEditType.php
+++ b/src/Eccube/Form/Type/Admin/MasterdataEditType.php
@@ -41,7 +41,7 @@ class MasterdataEditType extends AbstractType
                 $data = $event->getData();
 
                 // IDのみを配列化
-                $ids = array();
+                $ids = [];
                 foreach ($data['data'] as $key => $value) {
                     if (isset($value['id'])) {
                         $ids[$key] = $value['id'];
@@ -60,7 +60,7 @@ class MasterdataEditType extends AbstractType
                                 $form['data'][$key]['id']->addError(new FormError(trans('admin.setting.system.masterdata.680')));
                             }
                         }
-                    } 
+                    }
                 }
             });
     }

--- a/src/Eccube/Form/Type/Admin/MasterdataEditType.php
+++ b/src/Eccube/Form/Type/Admin/MasterdataEditType.php
@@ -17,6 +17,9 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 
 class MasterdataEditType extends AbstractType
 {
@@ -32,7 +35,34 @@ class MasterdataEditType extends AbstractType
                 'allow_delete' => true,
                 'prototype' => true,
             ])
-            ->add('masterdata_name', HiddenType::class);
+            ->add('masterdata_name', HiddenType::class)
+            ->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
+                $form = $event->getForm();
+                $data = $event->getData();
+
+                // IDのみを配列化
+                $ids = array();
+                foreach ($data['data'] as $key => $value) {
+                    if (isset($value['id'])) {
+                        $ids[$key] = $value['id'];
+                    }
+                }
+
+                if (count($ids) > 0) {
+                    // 重複IDチェック
+                    $idCount = array_count_values($ids);
+                    foreach ($idCount as $id => $count) {
+                        // 同じIDの数が2つ以上の場合は重複
+                        if ($count >= 2) {
+                            $keys = array_keys($ids, $id);
+                            // 重複した全ての入力項目にエラーを出力
+                            foreach ($keys as $key) {
+                                $form['data'][$key]['id']->addError(new FormError(trans('admin.setting.system.masterdata.680')));
+                            }
+                        }
+                    } 
+                }
+            });
     }
 
     /**


### PR DESCRIPTION

## 概要(Overview・Refs Issue)
重複したIDを登録した場合にエラーとならず、上書き登録されてしまうため、
重複IDがあった場合は、入力ID項目ごとにエラーを表示する

## テスト（Test)
・同じIDの入力が1つ or 2つ存在した場合のエラー表示テスト
・重複IDがない場合
