### PR TITLE
#270 【ご注文手続き】配送情報に表示されている送料の小計が正しく表示されていない

### DIFF
--- a/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeePreprocessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeePreprocessor.php
@@ -102,7 +102,7 @@ class DeliveryFeePreprocessor implements ItemHolderPreprocessor
         $DeliveryFeeType = $this->entityManager
             ->find(OrderItemType::class, OrderItemType::DELIVERY_FEE);
         $TaxInclude = $this->entityManager
-            ->find(TaxDisplayType::class, TaxDisplayType::INCLUDED);
+            ->find(TaxDisplayType::class, TaxDisplayType::EXCLUDED);
         $Taxion = $this->entityManager
             ->find(TaxType::class, TaxType::TAXATION);
         $TaxRule = $this->taxRuleRepository->getByRule();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 注文確認画面で表示されている送料の小計が税抜き額で表示されている。

## 方針(Policy)
+ カートからの流れで送料商品を追加しているが、課税区分が INCLUDED(税込み）で送料商品が追加されている為。EXCLUDED(税別）を指定するよう修正。

## テスト（Test)
+ 100円送料の設定でカートから確認画面へ遷移し、送料商品が 108 × 1 = 108 で算定・表示されている事を確認。
