### PR TITLE
#272 【購入手続き画面】お支払い方法の選択肢のラベルが２重で表示されている

### DIFF
--- a/src/Eccube/Resource/template/default/Shopping/index.twig
+++ b/src/Eccube/Resource/template/default/Shopping/index.twig
@@ -340,7 +340,7 @@ file that was distributed with this source code.
                     <div class="ec-blockRadio">
                         {% for key, child in form.Payment %}
                             {% set Payment = form.Payment.vars.choices[key].data %}
-                            <label>{{ form_widget(child, {'attr': {'class': 'payment' }}) }}<span>{{ child.vars.label }}</span></label>
+                            <label>{{ form_widget(child, {'attr': {'class': 'payment' }}) }}</label>
                             {% if Payment.payment_image is not null %}
                                 <img src="{{ asset(Payment.payment_image, 'save_image') }}">
                             {% endif %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ ラジオボタンと同時に不要なお支払い方法のラベルが出力されている。

## 方針(Policy)
+ form_widgetでラベルごと出力されているが、twig側でさらに支払い方法を出力している為。twig側は不要なため対象タグを削除。

## テスト（Test)
+ お支払い方法選択画面でお支払い方法が二重で表示されていない事を確認。

