### PR TITLE
#267 【配送方法登録・編集】お届け時間設定の名前を編集後にボタンを再度押せなくなる

### DIFF
--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
@@ -158,6 +158,8 @@ file that was distributed with this source code.
                 var current = $(this).parents("li");
                 current.find('.mode-view').addClass('d-none');
                 current.find('.mode-edit').removeClass('d-none');
+                current.find('.action-edit-submit').attr('disabled', false);
+                current.find('.action-edit-cancel').attr('disabled', false);
             });
 
             // 編集決定


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ お届け時間明細部の編集・キャンセルボタンを一度押すと、disable属性がついてしまい、リロードするまで二度通せなくなる。

## 方針(Policy)
+ 概要の通り、クリック後、何かのjsライブラリでdisabled属性がついている。（見たところladda系）。取り急ぎ、本修正については、編集・キャンセルクリック後に再表示するタイミングで付与されているdisabled属性をfalseとする事で対応しています。

## テスト（Test)
+ お届け時間一覧より編集クリック > 編集確定の為編集ボタンクリック > 再度、編集モードとし、編集・キャンセルボタンがクリックできる事。
+ お届け時間一覧より編集クリック > キャンセル確定の為キャンセルボタンクリック > 再度、編集モードとし、編集・キャンセルボタンがクリックできる事。

## 相談（Discussion）
+ 別件となりますが、編集モードにした場合 data-style="expand-right" data-loading="" が適用され、ボタンの幅が広がってしまう現象も確認しています。今回、JSで対処はしているものの、本来的には勝手にdisabledなどがつかないスタイル・テーマを適用すべきではないかと考えています。
