### PR TITLE
#249 購入確認画面でポイントに消費税がついた表示となってしまっている

### DIFF
--- a/src/Eccube/Resource/template/default/Shopping/confirm.twig
+++ b/src/Eccube/Resource/template/default/Shopping/confirm.twig
@@ -237,7 +237,14 @@ $(function() {
                                 {% if orderDetail.productClass is not null and orderDetail.productClass.classCategory2 %}
                                     <p>{{ orderDetail.productClass.classCategory2.className.name }}：{{ orderDetail.productClass.classCategory2 }}</p>
                                 {% endif %}
-                                <p>{{ orderDetail.priceIncTax|price }} × {{ orderDetail.quantity|number_format }}<span class="ec-imageGrid__contentTotal">小計：{{ orderDetail.totalPrice|price }}</span></p>
+                                <p>
+                                    {% if orderDetail.orderItemType.id == constant('Eccube\\Entity\\Master\\OrderItemType::PRODUCT') %}
+                                        {{ orderDetail.priceIncTax|price }}
+                                    {% else %}
+                                        {{ orderDetail.price|price }}
+                                    {% endif %}
+                                     × {{ orderDetail.quantity|number_format }}<span class="ec-imageGrid__contentTotal">小計：{{ orderDetail.totalPrice|price }}</span>
+                                </p>
                             </div>
                         </div>
                     </li>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
購入確認画面でポイント値引き額が税込み表示となっているため、
入力ポイントを表示する

## 方針(Policy)
なし

## 実装に関する補足(Appendix)
OrderItemTypeが商品のもの以外は税込み表示とするため
それ以外はorderDetail.priceIncTaxでなくorderDetail.priceで対応

## テスト（Test)
・複数お届けでポイント利用の場合、ポイント利用が購入金額以上
・単一お届けでポイント利用の場合、ポイント利用が購入金額以上
・単一お届けでポイント利用の場合、ポイント利用が購入金額以内
・単一お届けでポイント利用の場合、ポイント利用が購入金額以内
・画面遷移テスト（カート⇒ご注文手続き⇒購入確認⇒ご注文手続き⇒購入確認）

## 相談（Discussion）
OrderItemTypeの値によって、金額表示の切り分けをtwigで行っているが、問題なし？

