### PR TITLE
#277 【ご注文手続き】ご利用ポイントに購入金額以上のポイントを指定するとエラーになる

### DIFF
--- a/src/Eccube/Form/Type/Shopping/OrderType.php
+++ b/src/Eccube/Form/Type/Shopping/OrderType.php
@@ -176,6 +176,10 @@ class OrderType extends AbstractType
                 // XXX 非会員購入の際, use_point が null で submit される？
                 if ($Order->getUsePoint() === null) {
                     $Order->setUsePoint(0);
+                } else {
+                    if ($Order->getTotal() != 0 && $Order->getUsePoint() > $Order->getTotal()) {
+                        $Order->setUsePoint($Order->getTotal());
+                    }
                 }
                 $Payment = $Order->getPayment();
                 $Order->setPaymentMethod($Payment ? $Payment->getMethod() : null);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
ご利用ポイントが購入金額以上を指定した場合、
合計購入金額分のポイント利用になる。
ポイントで全額支払った場合は、0円での購入となる。

## 方針(Policy)
なし

## 実装に関する補足(Appendix)
ポイント利用が購入金額以上を指定した場合の制御処理をForm/Shopping/OrderTypeで行っている。
POSTされたポイントがそのままPointProcessorで使用されるためFormTypeで実施した方がわかりやすいと考えております。

## テスト（Test)
・複数お届けでポイント利用の場合、ポイント利用が購入金額以上
・単一お届けでポイント利用の場合、ポイント利用が購入金額以上
・単一お届けでポイント利用の場合、ポイント利用が購入金額以内
・単一お届けでポイント利用の場合、ポイント利用が購入金額以内
・画面遷移テスト（カート⇒ご注文手続き⇒購入確認⇒ご注文手続き⇒購入確認）
・画面遷移テスト（カート⇒ご注文手続き⇒購入確認⇒ご注文手続き⇒カート⇒ご注文手続き⇒購入確認）

## 相談（Discussion）
注文手続き画面でのポイント指定リロード時と注文手続きから購入確認画面への遷移時、どちらも
実装したポイント利用制御処理が実行されるため、
購入金額をポイント利用が超えている場合とポイント利用で金額が0円になっている場合はポイント制御処理を行わないようにしています。
処理としては現状問題なく動いておりますが、実装上正しい処理の仕方はありますでしょうか？
