### PR TITLE
#226 【管理画面/会員編集】管理画面で退会にステータスを変更した場合、メールアドレスがランダムなものに変更されない

### DIFF
--- a/src/Eccube/Controller/Admin/Customer/CustomerEditController.php
+++ b/src/Eccube/Controller/Admin/Customer/CustomerEditController.php
@@ -16,8 +16,10 @@ namespace Eccube\Controller\Admin\Customer;
 use Eccube\Controller\AbstractController;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
+use Eccube\Entity\Master\CustomerStatus;
 use Eccube\Form\Type\Admin\CustomerType;
 use Eccube\Repository\CustomerRepository;
+use Eccube\Util\StringUtil;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
@@ -60,6 +62,8 @@ class CustomerEditController extends AbstractController
             if (is_null($Customer)) {
                 throw new NotFoundHttpException();
             }
+
+            $oldStatusId = $Customer->getStatus()->getId();
             // 編集用にデフォルトパスワードをセット
             $previous_password = $Customer->getPassword();
             $Customer->setPassword($this->eccubeConfig['eccube_default_password']);
@@ -101,6 +105,12 @@ class CustomerEditController extends AbstractController
                         $Customer->setSecretKey($this->customerRepository->getUniqueSecretKey());
                     }
                     $Customer->setPassword($encoder->encodePassword($Customer->getPassword(), $Customer->getSalt()));
+                }
+
+                // 退会ステータスに更新の場合、ダミーのアドレスに更新
+                $newStatusId = $Customer->getStatus()->getId();
+                if ($oldStatusId != $newStatusId && $newStatusId == CustomerStatus::WITHDRAWING) {
+                    $Customer->setEmail(StringUtil::random(60).'@dummy.dummy');
                 }
 
                 $this->entityManager->persist($Customer);

--- a/src/Eccube/Controller/Mypage/WithdrawController.php
+++ b/src/Eccube/Controller/Mypage/WithdrawController.php
@@ -19,6 +19,7 @@ use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
 use Eccube\Repository\Master\CustomerStatusRepository;
 use Eccube\Service\MailService;
+use Eccube\Util\StringUtil;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
@@ -96,6 +97,7 @@ class WithdrawController extends AbstractController
                     // 退会ステータスに変更
                     $CustomerStatus = $this->customerStatusRepository->find(CustomerStatus::WITHDRAWING);
                     $Customer->setStatus($CustomerStatus);
+                    $Customer->setEmail(StringUtil::random(60).'@dummy.dummy');
 
                     $this->entityManager->flush();
 


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
・管理画面/会員編集 退会ステータスに変更した場合に会員Eメールをダミーに変更する
・マイページ/退会手続きを実行した場合に会員Eメールをダミーに変更する

## 方針(Policy)
退会ステータス更新時に
３系と同様にrandom(60) + dummy@dummyのメールアドレスを
会員データに設定する

## 実装に関する補足(Appendix)
管理画面/会員編集で退会ステータスから退会ステータス（変更なし）で登録した場合は、
メールアドレスは変更しないよう設定

## テスト（Test)
・マイページ/会員手続き実行
・管理画面/会員編集でステータス変更テスト（仮会員 ⇒ 本会員）
・管理画面/会員編集でステータス変更テスト（本会員 ⇒ 退会）
・管理画面/会員編集でステータス変更テスト（退会 ⇒ 退会）
・管理画面/会員編集でステータス変更テスト（本会員 ⇒ 本会員）

## 相談（Discussion）
なし
