### PR TITLE
#261 【ご注文手続き】お届け日のプルダウンに曜日も出したい

### DIFF
--- a/src/Eccube/Form/Type/Shopping/ShippingType.php
+++ b/src/Eccube/Form/Type/Shopping/ShippingType.php
@@ -164,8 +164,18 @@ class ShippingType extends AbstractType
                         new \DateTime($minDate + $this->eccubeConfig['eccube_deliv_date_end_max'].' day')
                     );
 
+                    // 曜日設定用
+                    $dateFormatter = \IntlDateFormatter::create(
+                        'ja_JP@calendar=japanese',
+                        \IntlDateFormatter::FULL,
+                        \IntlDateFormatter::FULL,
+                        'Asia/Tokyo',
+                        \IntlDateFormatter::TRADITIONAL,
+                        'E'
+                    );
+
                     foreach ($period as $day) {
-                        $deliveryDurations[$day->format('Y/m/d')] = $day->format('Y/m/d');
+                        $deliveryDurations[$day->format('Y/m/d')] = $day->format('Y/m/d').'('.$dateFormatter->format($day).')';
                     }
                 }
 

--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -115,7 +115,7 @@ file that was distributed with this source code.
                         </div>
                         <div class="ec-definitions--soft">
                             <dt>{{'mypage.history.detail.label.shipping_date'|trans}} : </dt>
-                            <dd>{{ Shipping.shipping_delivery_date|date_format|default('admin.shipping.edit.719'|trans) }}</dd>
+                            <dd>{{ Shipping.shipping_delivery_date|date_day_with_weekday|default('admin.shipping.edit.719'|trans) }}</dd>
                         </div>
                         <div class="ec-definitions--soft">
                             <dt>{{'mypage.history.detail.label.shipping_time'|trans}} : </dt>

--- a/src/Eccube/Resource/template/default/Shopping/confirm.twig
+++ b/src/Eccube/Resource/template/default/Shopping/confirm.twig
@@ -295,7 +295,7 @@ $(function() {
                             </div>
                             <div class="ec-select ec-select__delivery">
                                 <label>お届け日</label>
-                                {{ Order.Shippings[idx].shipping_delivery_date? Order.Shippings[idx].shipping_delivery_date|date_day :"指定なし" }}
+                                {{ Order.Shippings[idx].shipping_delivery_date? Order.Shippings[idx].shipping_delivery_date|date_day_with_weekday :"指定なし" }}
                                 {{ form_widget(form.Shippings[idx].shipping_delivery_date, {'type': 'hidden'}) }}
                             </div>
                             <div class="ec-select ec-select__time">

--- a/src/Eccube/Twig/Extension/IntlExtension.php
+++ b/src/Eccube/Twig/Extension/IntlExtension.php
@@ -28,6 +28,7 @@ class IntlExtension extends AbstractExtension
             new TwigFilter('date_day', [$this, 'date_day'], ['needs_environment' => true]),
             new TwigFilter('date_min', [$this, 'date_min'], ['needs_environment' => true]),
             new TwigFilter('date_sec', [$this, 'date_sec'], ['needs_environment' => true]),
+            new TwigFilter('date_day_with_weekday', [$this, 'date_day_with_weekday'], ['needs_environment' => true]),
         ];
     }
 
@@ -89,5 +90,31 @@ class IntlExtension extends AbstractExtension
         }
 
         return \twig_localized_date_filter($env, $date, 'medium', 'medium');
+    }
+
+    /**
+     * @param Environment $env
+     * @param $date
+     *
+     * @return bool|string
+     */
+    public function date_day_with_weekday(Environment $env, $date)
+    {
+        if (!$date) {
+            return '';
+        }
+
+        $date_day = \twig_localized_date_filter($env, $date, 'medium', 'none');
+        // 曜日
+        $dateFormatter = \IntlDateFormatter::create(
+            'ja_JP@calendar=japanese',
+            \IntlDateFormatter::FULL,
+            \IntlDateFormatter::FULL,
+            'Asia/Tokyo',
+            \IntlDateFormatter::TRADITIONAL,
+            'E'
+        );
+
+        return $date_day.'('.$dateFormatter->format($date).')';
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
・注文手続き画面でのお届け日プルダウンに曜日表記を追加
・購入確認画面でのお届け日表示に曜日追加
・マイページ/購入履歴表示画面でのお届け日表示に曜日追加

## 方針(Policy)
曜日表示参考は以下URL参照。
https://gist.github.com/hidenorigoto/2327195#file-intldateformatter-php-L30
・プルダウンの日付表示はForm/Type/Shopping/ShippingType.php
・Twigでの表示はTwig/Extension/IntlExtension.php
で対応

## 実装に関する補足(Appendix)
なし

## テスト（Test)
・テスト手順
1.お届け日選択可能な商品を選択
2.カート画面遷移 ⇒ 注文手続き画面表示
3.注文手続き画面 ⇒ 購入確認画面
4. 購入確認画面 ⇒ 注文手続き画面
5. 購入確認画面 ⇒ 注文完了
6. マイページ/購入履歴表示

## 相談（Discussion）
なし
