### PR TITLE
#286 【ご注文履歴詳細】受注管理から登録した値引きが表示されていない

### DIFF
--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -167,6 +167,12 @@ file that was distributed with this source code.
                         <dt>{{'shopping.label.shipping_charge'|trans}}</dt>
                         <dd>{{ Order.delivery_fee_total|price }}</dd>
                     </dl>
+                    {% if Order.discount > 0 %}
+                    <dl class="ec-totalBox__spec">
+                        <dt>内値引き</dt>
+                        <dd>{{ (0 - Order.discount)|price }}</dd>
+                    </dl>
+                    {% endif %}
                     <div class="ec-totalBox__total">{{'common.label.cart_total'|trans}}<span class="ec-totalBox__price">{{ Order.payment_total|price }}</span><span class="ec-totalBox__taxLabel">{{'shopping.label.tax_incl'|trans}}</span></div>
                     <a href="{{ url('mypage_order', {'order_no': Order.order_no }) }}" class="ec-blockBtn--action load-overlay" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">{{'mypage.history.detail.re_order'|trans}}</a>
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
フロント/注文履歴詳細画面に値引き額が表示されていない

## 方針(Policy)
注文確認画面で表示されるのと同様に表示されるよう対応

## 実装に関する補足(Appendix)
なし

## テスト（Test)
・管理画面からの注文（値引きあり）
・管理画面からの注文（値引きなし）
・フロントからの注文（値引きあり）
・フロントからの注文（値引きなし）

## 相談（Discussion）
なし
