### PR TITLE
OrderStatusMachineでOrderStatusのidが変更される問題の対応

### DIFF
--- a/app/config/eccube/packages/order_state_machine.php
+++ b/app/config/eccube/packages/order_state_machine.php
@@ -11,8 +11,8 @@
  * file that was distributed with this source code.
  */
 
-use Eccube\Entity\Order;
 use Eccube\Entity\Master\OrderStatus as Status;
+use Eccube\Service\OrderStateMachineContext;
 
 $container->loadFromExtension('framework', [
     'workflows' => [
@@ -20,10 +20,10 @@ $container->loadFromExtension('framework', [
             'type' => 'state_machine',
             'marking_store' => [
                 'type' => 'single_state',
-                'arguments' => 'OrderStatus.id',
+                'arguments' => 'status',
             ],
             'supports' => [
-                Order::class,
+                OrderStateMachineContext::class,
             ],
             'initial_place' => (string) Status::NEW,
             'places' => [

--- a/src/Eccube/Controller/Admin/Order/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Order/CsvImportController.php
@@ -164,8 +164,6 @@ class CsvImportController extends AbstractCsvImportController
             }
             $OrderStatus = $this->entityManager->find(OrderStatus::class, OrderStatus::DELIVERED);
             if ($allShipped) {
-                // XXX 先行の行で OrderStateMachine が OrderStatus::id を変更している場合があるので refresh する
-                $this->entityManager->refresh($Order);
                 if ($this->orderStateMachine->can($Order, $OrderStatus)) {
                     $this->orderStateMachine->apply($Order, $OrderStatus);
                 } else {

--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -257,9 +257,6 @@ class EditController extends AbstractController
                             $TargetOrder->setOrderStatus($OldStatus);
                             // FormTypeでステータスの遷移チェックは行っているのでapplyのみ実行.
                             $this->orderStateMachine->apply($TargetOrder, $NewStatus);
-                            // FIXME ステートマシンがmtb_order_statusを更新しようとするので, refreshしておく.
-                            $this->entityManager->refresh($OldStatus);
-                            $this->entityManager->refresh($NewStatus);
                         }
 
                         $this->entityManager->persist($TargetOrder);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 関連 https://github.com/EC-CUBE/ec-cube/pull/3374
+ OrderStatusをdetach/refreshしなくていいように変更

## 方針(Policy)
+ Orderを直接StateMachineに渡していたため`OrderStatus.id`が変更されていたが、Orderとステータスを持つオブジェクトをStateMachineに渡すようにして`OrderStatus.id`が変更されないように対応

## テスト（Test)
+ 既存のテストが通ることを確認
