### PR TITLE
スマホで子カテゴリを選択できない不具合の対応

### DIFF
--- a/html/template/default/assets/js/script.js
+++ b/html/template/default/assets/js/script.js
@@ -43,7 +43,15 @@ $(function() {
     // スマホのドロワーメニュー内の下層カテゴリ表示
     // TODO FIXME スマホのカテゴリ表示方法
     $('.ec-itemNav ul a').click(function() {
-        $(this).siblings().slideToggle();
+        let child = $(this).siblings();
+        if(child.length > 0 ){
+            if(child.is(':visible')){ 
+                return true;                
+            }else{
+                child.slideToggle();
+                return false;
+            }
+        }
     })
 });
 

--- a/html/template/default/assets/js/script.js
+++ b/html/template/default/assets/js/script.js
@@ -43,7 +43,7 @@ $(function() {
     // スマホのドロワーメニュー内の下層カテゴリ表示
     // TODO FIXME スマホのカテゴリ表示方法
     $('.ec-itemNav ul a').click(function() {
-        let child = $(this).siblings();
+        var child = $(this).siblings();
         if(child.length > 0 ){
             if(child.is(':visible')){ 
                 return true;                


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
スマホで子カテゴリがある親カテゴリをタップすると、子カテゴリが展開されない。（アコーディオンが展開されながら遷移しちゃう）問題の対応

## 方針(Policy)
展開されていなかったら展開。展開されていたら遷移する

## 相談（Discussion）
とりあえずこの動きで良いですかね？

