### PR TITLE
Itemのエラー用商品名はthrowInvalidItemExceptionで生成しているためprocessor個別の関数を削除

### DIFF
--- a/src/Eccube/Service/PurchaseFlow/Processor/SaleLimitMultipleValidator.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/SaleLimitMultipleValidator.php
@@ -14,7 +14,6 @@
 namespace Eccube\Service\PurchaseFlow\Processor;
 
 use Eccube\Entity\ItemHolderInterface;
-use Eccube\Entity\ProductClass;
 use Eccube\Repository\ProductClassRepository;
 use Eccube\Service\PurchaseFlow\ItemHolderValidator;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
@@ -66,18 +65,5 @@ class SaleLimitMultipleValidator extends ItemHolderValidator
                 }
             }
         }
-    }
-
-    protected function formatProductName(ProductClass $ProductClass)
-    {
-        $productName = $ProductClass->getProduct()->getName();
-        if ($ProductClass->hasClassCategory1()) {
-            $productName .= ' - '.$ProductClass->getClassCategory1()->getName();
-        }
-        if ($ProductClass->hasClassCategory2()) {
-            $productName .= ' - '.$ProductClass->getClassCategory2()->getName();
-        }
-
-        return $productName;
     }
 }

--- a/src/Eccube/Service/PurchaseFlow/Processor/StockMultipleValidator.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/StockMultipleValidator.php
@@ -14,7 +14,6 @@
 namespace Eccube\Service\PurchaseFlow\Processor;
 
 use Eccube\Entity\ItemHolderInterface;
-use Eccube\Entity\ProductClass;
 use Eccube\Repository\ProductClassRepository;
 use Eccube\Service\PurchaseFlow\ItemHolderValidator;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
@@ -69,18 +68,5 @@ class StockMultipleValidator extends ItemHolderValidator
                 }
             }
         }
-    }
-
-    protected function formatProductName(ProductClass $ProductClass)
-    {
-        $productName = $ProductClass->getProduct()->getName();
-        if ($ProductClass->hasClassCategory1()) {
-            $productName .= ' - '.$ProductClass->getClassCategory1()->getName();
-        }
-        if ($ProductClass->hasClassCategory2()) {
-            $productName .= ' - '.$ProductClass->getClassCategory2()->getName();
-        }
-
-        return $productName;
     }
 }


### PR DESCRIPTION
Itemのエラー用商品名はthrowInvalidItemExceptionで生成しているため、使用していないprocessor個別の関数を削除

