### PR TITLE
発送日の更新をステートマシン外で行うように修正

### DIFF
--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -484,9 +484,24 @@ class OrderController extends AbstractController
                 log_info('対応状況一括変更スキップ');
                 $result = ['message' => sprintf('%s:  ステータス変更をスキップしました', $Shipping->getId())];
             } else {
-                // TODO: 出荷済み処理の場合は場合分けをして出荷に出荷日を入れる処理が必要
                 if ($this->orderStateMachine->can($Order, $OrderStatus)) {
-                    $this->orderStateMachine->apply($Order, $OrderStatus);
+                    if ($OrderStatus->getId() == OrderStatus::DELIVERED) {
+                        if (!$Shipping->isShipped()) {
+                            $Shipping->setShippingDate(new \DateTime());
+                        }
+                        $allShipped = true;
+                        foreach ($Order->getShippings() as $Ship) {
+                            if (!$Ship->isShipped()) {
+                                $allShipped = false;
+                                break;
+                            }
+                        }
+                        if ($allShipped) {
+                            $this->orderStateMachine->apply($Order, $OrderStatus);
+                        }
+                    } else {
+                        $this->orderStateMachine->apply($Order, $OrderStatus);
+                    }
 
                     if ($request->get('notificationMail')) { // for SimpleStatusUpdate
                         $this->mailService->sendShippingNotifyMail($Shipping);

--- a/src/Eccube/Service/OrderStateMachine.php
+++ b/src/Eccube/Service/OrderStateMachine.php
@@ -104,7 +104,7 @@ class OrderStateMachine implements EventSubscriberInterface
             'workflow.order.transition.pay' => ['updatePaymentDate'],
             'workflow.order.transition.cancel' => [['rollbackStock'], ['rollbackUsePoint']],
             'workflow.order.transition.back_to_in_progress' => [['commitStock'], ['commitUsePoint']],
-            'workflow.order.transition.ship' => [['commitAddPoint'], ['updateShippingDate']],
+            'workflow.order.transition.ship' => [['commitAddPoint']],
             'workflow.order.transition.return' => [['rollbackUsePoint'], ['rollbackAddPoint']],
             'workflow.order.transition.cancel_return' => [['commitUsePoint'], ['commitAddPoint']],
         ];
@@ -124,23 +124,6 @@ class OrderStateMachine implements EventSubscriberInterface
         /* @var Order $Order */
         $Order = $event->getSubject()->getOrder();
         $Order->setPaymentDate(new \DateTime());
-    }
-
-    /**
-     * 発送日を更新する.
-     *
-     * @param Event $event
-     */
-    public function updateShippingDate(Event $event)
-    {
-        // TODO: 出荷に出荷日を入れる処理は出荷ごとに実行される可能性があるのでステートマシン外で処理する必要がある
-        /* @var Order $Order */
-        $Order = $event->getSubject()->getOrder();
-        foreach ($Order->getShippings() as $Shipping) {
-            if (!$Shipping->getShippingDate()) {
-                $Shipping->setShippingDate(new \DateTime());
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- 発送日の更新処理を修正

## 方針(Policy)
以下の仕様で修正しています。

- 受注一覧
  - 一括変更で発送済に変更
    - 選択された出荷に出荷日を設定する
    - すべての出荷に出荷日が設定された場合、ステータスを発送済に更新する
    - 未出荷の出荷がある場合, ステータスは変更されない
  - 出荷済ボタンを実行
    - 選択された出荷に出荷日を設定する
    - すべての出荷に出荷日が設定された場合、ステータスを発送済に更新する
    - 未出荷の出荷がある場合, ステータスは変更されない
- 受注編集でステータスを発送済に変更
  - 単一/複数配送かかわらず、すべての出荷に出荷日が設定される
  - ステータスは発送済に変更される
- 複数配送編集の出荷済ボタンを実行
  -  選択された出荷に出荷日を設定する
  - すべての出荷に出荷日が設定された場合、ステータスを発送済に更新する
  - 未出荷の出荷がある場合, ステータスは変更されない

## テスト（Test)

- 既存のテストにパスすることを確認


