### PR TITLE
#143 【プライバシーポリシー】文言の表示崩れ

### DIFF
--- a/src/Eccube/Resource/template/default/Help/privacy.twig
+++ b/src/Eccube/Resource/template/default/Help/privacy.twig
@@ -24,6 +24,8 @@ file that was distributed with this source code.
                     個人情報保護の重要性に鑑み、「個人情報の保護に関する法律」及び本プライバシーポリシーを遵守し、お客さまのプライバシー保護に努めます。
                 </p><br>
             </div>
+        </div>
+        <div class="ec-off1Grid">
             <div class="ec-off1Grid__cell">
                 <div class="ec-heading-bold">個人情報の定義</div>
                 <p>お客さま個人に関する情報(以下「個人情報」といいます)であって、お客さまのお名前、住所、電話番号など当該お客さま個人を識別することができる情報をさします。他の情報と組み合わせて照合することにより個人を識別することができる情報も含まれます。</p>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
プライバシーポリシーのレイアウト崩れ

## 方針(Policy)
twigのみ修正

## 実装に関する補足(Appendix)
なし

## テスト（Test)
なし

## 相談（Discussion）
レイアウト調整はできたのですが、今の３系と全く同じ見た目にはなっていないので
正しいタグ構成かどうか確認をお願いいたします。