### PR TITLE
親スコープの変数を利用できるように修正

### DIFF
--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -19,7 +19,6 @@ use Eccube\Entity\ExportCsvRow;
 use Eccube\Entity\Master\CsvType;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Entity\Order;
-use Eccube\Entity\OrderItem;
 use Eccube\Entity\OrderPdf;
 use Eccube\Entity\Shipping;
 use Eccube\Event\EccubeEvents;

--- a/src/Eccube/Twig/Extension/EccubeBlockExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeBlockExtension.php
@@ -32,18 +32,19 @@ class EccubeBlockExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
-            new TwigFunction('eccube_block_*', function ($name, array $parameters = []) {
-                $sources = $this->blockTemplates;
-                foreach ($sources as $source) {
-                    $template = $this->twig->loadTemplate($source);
-                    if ($template->hasBlock($name, $parameters)) {
-                        echo $template->renderBlock($name, $parameters);
-
-                        return;
+            new TwigFunction('eccube_block_*', function ($context, $name, array $parameters = []) {
+                if (!empty($parameters)) {
+                    $context = array_merge($context, $parameters);
+                }
+                $files = $this->blockTemplates;
+                foreach ($files as $file) {
+                    $template = $this->twig->loadTemplate($file);
+                    if ($template->hasBlock($name, $context)) {
+                        return $template->renderBlock($name, $context);
                     }
                 }
                 @trigger_error($name.' block is not found', E_USER_WARNING);
-            }, ['pre_escape' => 'html', 'is_safe' => ['html']]),
+            }, ['needs_context' => true, 'pre_escape' => 'html', 'is_safe' => ['html']]),
         ];
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ TwigBlockで親スコープの変数を利用できるように修正

## 方針(Policy)

以下のブロックを作成した場合, 

```twig
{% block hoge %}
  {{ Product.name }} 
{% endblock  %}
```

従来は

```twig
{{ eccube_block_hoge({ Product: Product}) }}
```

のように埋め込み先で変数を引き回す必要がありましたが、親の変数も参照出来るようになります。

以下の記述で表示可能です。

```twig
{{ eccube_block_hoge() }}
```

## 実装に関する補足(Appendix)

- プラグインの無効時は処理を行わずスキップします。

## テスト（Test)

- 既存のテストにパスすることを確認

## 相談（Discussion）

- テンプレートの介入方法が複数あるため整理が必要



