### PR TITLE
Pull Request時はカバレッジを計測しないようにする

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -162,7 +162,7 @@ tools:
 
     external_code_coverage:
         runs: 1
-        timeout: 36000 #The timeout must be in the interval [60,36000].
+        timeout: 3600
 
     #php_code_sniffer:
     #    enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,8 +80,8 @@ jobs:
       env: GROUP=admin03 APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
     - <<: *e2e_test
       env: GROUP=front APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
-    - &coverage
-      stage: Code Coverage
+    - stage: Code Coverage
+      if: type != pull_request
       env: DATABASE_URL=sqlite:///%kernel.project_dir%/var/eccube.db DATABASE_SERVER_VERSION=3 COVERAGE=1
       before_install:
         - *php_setup


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ カバレッジ計測のテスト実行に時間がかかるため、Pull Request時にはカバレッジ計測をせずにマージされたビルドで実行するようにする

## 参考
+ 個人のTravisビルドではカバレッジ計測される
    + https://travis-ci.org/kiy0taka/ec-cube/builds/410717122
+ Pull Request時はカバレッジ計測されない
    + https://travis-ci.com/EC-CUBE/ec-cube/builds/80598181