### PR TITLE
コントローラのないtwigの拡張ができない問題の対応

### DIFF
--- a/src/Eccube/Resource/template/default/block.twig
+++ b/src/Eccube/Resource/template/default/block.twig
@@ -11,13 +11,9 @@ file that was distributed with this source code.
 {% for Block in Blocks %}
     <!-- ▼{{ Block.name }} -->
     {% if Block.use_controller %}
-        {% if app.config.http_cache.enabled %}
-            {{ render_esi(path('block_' ~ Block.file_name)) }}
-        {% else %}
-            {{ render(path('block_' ~ Block.file_name)) }}
-        {% endif %}
+        {{ render(path('block_' ~ Block.file_name)) }}
     {% else %}
-        {{ include('Block/' ~ Block.file_name~ '.twig', ignore_missing = true) }}
+        {{ include_dispatch('Block/' ~ Block.file_name ~ '.twig') }}
     {% endif %}
     <!-- ▲{{ Block.name }} -->
 {% endfor %}

--- a/src/Eccube/Twig/Extension/TwigIncludeExtension.php
+++ b/src/Eccube/Twig/Extension/TwigIncludeExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+
+class TwigIncludeExtension extends AbstractExtension
+{
+    protected $twig;
+
+    public function __construct(\Eccube\Twig\Environment $twig)
+    {
+        $this->twig = $twig;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new \Twig_Function('include_dispatch', [$this, 'include_dispatch'],
+                array('needs_context' => true, 'is_safe' => array('all'))),
+        ];
+    }
+
+    public function include_dispatch($context, $template, $variables = [])
+    {
+        if (!empty($variables)) {
+            $context = array_merge($context, $variables);
+        }
+
+        return $this->twig->render($template, $context);
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- Block/category.twig  など、コントローラを経由しないtwigを拡張できないため、フックポイントを呼び出すように対応

