### PR TITLE
issues #3392 コントローラー付きのブロックを設置するとエラーが発生します

### DIFF
--- a/src/Eccube/Resource/template/default/block.twig
+++ b/src/Eccube/Resource/template/default/block.twig
@@ -11,11 +11,7 @@ file that was distributed with this source code.
 {% for Block in Blocks %}
     <!-- ▼{{ Block.name }} -->
     {% if Block.use_controller %}
-        {% if app.config.http_cache.enabled %}
-            {{ render_esi(path('block_' ~ Block.file_name)) }}
-        {% else %}
-            {{ render(path('block_' ~ Block.file_name)) }}
-        {% endif %}
+        {{ render(path('block_' ~ Block.file_name)) }}
     {% else %}
         {{ include('Block/' ~ Block.file_name~ '.twig', ignore_missing = true) }}
     {% endif %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
レイアウト管理でブロックを設定するとエラーが発生する

## 方針(Policy)
https://github.com/EC-CUBE/ec-cube/issues/3392
コメントされている方法で対応いたしました。

## 実装に関する補足(Appendix)
なし

## テスト（Test)
各ブロックをレイアウトに設定し、表示

## 相談（Discussion）
なし