### PR TITLE
mtb_customer_order_statusに初期データを追加

### DIFF
--- a/src/Eccube/Resource/doctrine/import_csv/mtb_customer_order_status.csv
+++ b/src/Eccube/Resource/doctrine/import_csv/mtb_customer_order_status.csv
@@ -7,3 +7,5 @@ id,name,sort_no,discriminator_type
 "4","注文受付","5","customerorderstatus"
 "5","発送済み","6","customerorderstatus"
 "8","注文未完了","7","customerorderstatus"
+"9","注文受付","8","customerorderstatus"
+"10","返品","9","customerorderstatus"


### PR DESCRIPTION
対応中、返品の定義がなかったためデータを追加
