### PR TITLE
#265 【カテゴリ管理】画面右のツリーで選択中の項目をわかるように表示する

### DIFF
--- a/src/Eccube/Resource/template/admin/Product/category.twig
+++ b/src/Eccube/Resource/template/admin/Product/category.twig
@@ -293,7 +293,7 @@ file that was distributed with this source code.
                        aria-expanded="{% if Category.id in Ids %}true{% endif %}"
                        aria-controls="directory_category{{ Category.id }}"></label>
                 <span>
-                    <a href="{{ url('admin_product_category_show', { parent_id : Category.id }) }}">{{ Category.name }}
+                    <a href="{{ url('admin_product_category_show', { parent_id : Category.id }) }}"{%if (Category.id == TargetId) %} class="font-weight-bold"{% endif %}>{{ Category.name }}
                         ({{ Category.children|length }})</a></span>
                 {% if Category.children|length > 0 %}
                     <ul class="collapse {% if Category.id in Ids %}show{% endif %}"


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
選択中のカテゴリを、ボールド表示するようにする。

## 方針(Policy)
・選択中のカテゴリのみ、ボールド表示する
　→下位カテゴリの場合で、上位カテゴリはボールド表示しない。

## 実装に関する補足(Appendix)
ツリー生成のmacro内で、選択中のカテゴリID(TargetId)の場合に、
font-weight-boldのclassを付与する形で実装しております。

## テスト（Test)

テスト実施ブラウザ
IE11
Chrome 67
Firefox 61

テスト内容と期待結果
1,2,3の各操作を行った場合に、
画面右側のツリー内のカテゴリ一覧の内、選択したカテゴリがボールドとなる

対象操作
1.画面左側のカテゴリ一覧を選択した場合
2.画面右側ツリー部分で、最上位カテゴリを選択した場合
3.画面右側ツリー部分で、下位カテゴリを選択した場合

操作詳細
1-1.画面左側のカテゴリ一覧より「インテリア」を選択
1-2.画面右側のツリー内のカテゴリ「インテリア」がボールド表示となる

2-1.「キッチンツール」を選択
2-2.「キッチンツール」がボールド表示となる

3-1.「キッチンツール」の+を押し、下位カテゴリを開く
3-2.下位カテゴリ「食器」を選択
3-3.画面右側のツリー内のカテゴリ「食器」がボールド表示となる

## 相談（Discussion）
なし