### PR TITLE
#157 【会員登録・編集会員管理】購入履歴＞対応状況の色表示を対応する

### DIFF
--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -360,6 +360,19 @@ file that was distributed with this source code.
                             </div>
                             <div class="collapse show ec-cardCollapse" id="orderHistory">
                                 {% if Customer.Orders|length > 0 %}
+                                    {# TODO IN_PROGRESS と RETURNED の色を決める #}
+                                    {% set cssClassStatus = {
+                                        (constant('Eccube\\Entity\\Master\\OrderStatus::NEW')): "badge-ec-blue",
+                                        (constant('Eccube\\Entity\\Master\\OrderStatus::PAY_WAIT')): "badge-ec-red",
+                                        (constant('Eccube\\Entity\\Master\\OrderStatus::BACK_ORDER')): "badge-ec-red",
+                                        (constant('Eccube\\Entity\\Master\\OrderStatus::CANCEL')): "badge-ec-glay",
+                                        (constant('Eccube\\Entity\\Master\\OrderStatus::DELIVERED')): "badge-ec-glay",
+                                        (constant('Eccube\\Entity\\Master\\OrderStatus::PAID')): "badge-ec-green",
+                                        (constant('Eccube\\Entity\\Master\\OrderStatus::PENDING')): "badge-ec-yellow",
+                                        (constant('Eccube\\Entity\\Master\\OrderStatus::PROCESSING')): "badge-ec-yellow",
+                                        (constant('Eccube\\Entity\\Master\\OrderStatus::IN_PROGRESS')): "badge-ec-yellow",
+                                        (constant('Eccube\\Entity\\Master\\OrderStatus::RETURNED')): "badge-ec-yellow"
+                                    } %}
                                     <div class="card-body">
                                         <table class="table table-striped table-sm">
                                             <thead class="table-active">
@@ -381,7 +394,7 @@ file that was distributed with this source code.
                                                         <span class="h5 font-weight-normal">{{ Order.total|price }}</span>
                                                     </td>
                                                     <td class="align-middle pr-3">
-                                                        <span class="badge badge-ec-glay">{{ Order.OrderStatus }}</span>
+                                                        <span class="badge {{ attribute(cssClassStatus, Order.OrderStatus.id) }}">{{ Order.OrderStatus }}</span>
                                                     </td>
                                                 </tr>
                                             {% endfor %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 会員編集 : 受注一覧のステータスが受注一覧 : ステータスのように色付けされていない。

## 方針(Policy)
+ 会員編集 : 受注一覧のステータスについても色付けする。

## テスト（Test)
+ 各ステータスで受注を作成し、目視で確認。
　（受注一覧内で記載されているTODOがある為、TODOはそのままコピーしています。）

## 相談（Discussion）
+ twigにて受注一覧で適用されているコードと同じコードを入れていますが、同じ処理が重複しています。twigのカスタム関数にすべきであるかどうか、レビューをお願いします。（TODOもあるので保守性は悪い。）
