### PR TITLE
 #257 商品規格の並び方が管理画面/フロントで異なる

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -590,7 +590,7 @@ class EditController extends AbstractController
             foreach ($Products as $Product) {
                 /* @var $builder \Symfony\Component\Form\FormBuilderInterface */
                 $builder = $this->formFactory->createNamedBuilder('', AddCartType::class, null, [
-                    'product' => $Product,
+                    'product' => $this->productRepository->findWithSortedClassCategories($Product->getId()),
                 ]);
                 $addCartForm = $builder->getForm();
                 $forms[$Product->getId()] = $addCartForm->createView();

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -165,7 +165,7 @@ class ProductController extends AbstractController
                 AddCartType::class,
                 null,
                 [
-                    'product' => $Product,
+                    'product' => $this->productRepository->findWithSortedClassCategories($Product->getId()),
                     'allow_extra_fields' => true,
                 ]
             );


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
管理画面とフロントで合わせる。

規格管理一覧画面の並び順は、sort_no (dtb_class_category) の降順となっておりました為、
規格の並び順が sort_no の降順でない箇所について、修正を行います。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

対象画面(規格が選択できる箇所)
　1. フロント > 商品一覧画面の、各商品(規格が設定されている商品のみ)
　2. フロント > 商品詳細画面(規格が設定されている商品のみ)
　3. 管理 > 受注登録、編集画面の、商品追加(モーダルで表示される箇所)

上記3画面の内、対象画面2については、
Controller側の処理(ParamConverter)で sort_no の降順でソートが実行されておりました。
(規格管理画面と同じ並び順になっておりました)
→対応済み状態と判断し、修正対象外としています。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

対象画面2と同一のソート処理となるよう、対象画面1と3に実装しております。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

テスト実施ブラウザ
IE11
Chrome 67
Firefox 61

前提条件

1.商品
　ディナーフォーク(規格1,規格2を設定済)
2. 規格管理画面の並び順
規格1(材質)
　・プラチナ
　・金
　・銀
規格2(サイズ)
　・120
　・150
　・170

対象画面(方針に記載)
・フロント > 商品一覧(対象画面1)
・管理 > 受注登録、編集(対象画面3)

テスト内容と期待結果
対象画面に表示される対象商品において、次の操作を行った場合に、
規格管理画面で設定した並び順で表示されることを確認しております。

操作
　1. 初期表示(規格1、2未選択状態)の、規格1の表示(並び順)が一致
　2. 規格1「プラチナ」を選択した場合の、規格2の表示(並び順)が一致
　3. 規格1「金」を選択した場合の、規格2の表示(並び順)が一致

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
なし