### PR TITLE
Fix license identifiers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "project",
     "homepage": "http://www.ec-cube.net/",
     "license": [
-       "GPL-2.0",
-       "Commercial"
+       "GPL-2.0-only",
+       "proprietary"
     ],
     "support": {
         "issues": "https://github.com/EC-CUBE/ec-cube/issues"


### PR DESCRIPTION
Fixed identifiers according to https://spdx.org/licenses/ to prevent errors on the packagist.org updates