### PR TITLE
buttonタグをaタグに変更

### DIFF
--- a/src/Eccube/Resource/template/admin/Customer/index.twig
+++ b/src/Eccube/Resource/template/admin/Customer/index.twig
@@ -337,8 +337,8 @@ file that was distributed with this source code.
                                     <div class="d-inline-block">
                                         <div class="btn-group" role="group">
                                             {# TODO CSVダウンロード・項目設定 #}
-                                            <button class="btn btn-ec-regular" type="button" onclick='location.href="{{ url('admin_customer_export') }}"'><i class="fa fa-cloud-download mr-1 text-secondary"></i><span>{{ 'admin.customer.index.137'|trans }}</span></button>
-                                            <button class="btn btn-ec-regular" type="button" onclick='location.href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_CUSTOMER') }) }}"'><i class="fa fa-cog mr-1 text-secondary"></i><span>{{ 'admin.customer.index.139'|trans }}</span></button>
+                                            <a href="{{ url('admin_customer_export') }}" class="btn btn-ec-regular"><i class="fa fa-cloud-download mr-1 text-secondary"></i><span>{{ 'admin.customer.index.137'|trans }}</span></a>
+                                            <a href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_CUSTOMER') }) }}" class="btn btn-ec-regular"><i class="fa fa-cog mr-1 text-secondary"></i><span>{{ 'admin.customer.index.139'|trans }}</span></a>
                                         </div>
                                     </div>
                                 </div>

--- a/src/Eccube/Resource/template/admin/Product/category.twig
+++ b/src/Eccube/Resource/template/admin/Product/category.twig
@@ -151,16 +151,14 @@ file that was distributed with this source code.
                 </div>
                 <div class="col-6 text-right">
                     <div class="btn-group" role="group">
-                        <button class="btn btn-ec-regular" type="button"
-                                onclick="location.href='{{ url('admin_product_category_export') }}'">
+                        <a href="{{ url('admin_product_category_export') }}" class="btn btn-ec-regular">
                             <i class="fa fa-cloud-download mr-1 text-secondary"></i>
                             <span>{{ 'admin.product.category.405'|trans }}</span>
-                        </button>
-                        <button class="btn btn-ec-regular" type="button"
-                                onclick="location.href='{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_CATEGORY') }) }}'">
+                        </a>
+                        <a href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_CATEGORY') }) }}" class="btn btn-ec-regular">
                             <i class="fa fa-cog mr-1 text-secondary"></i>
                             <span>{{ 'admin.product.index.486'|trans }}</span>
-                        </button>
+                        </a>
                     </div>
                 </div>
             </div>
@@ -185,9 +183,9 @@ file that was distributed with this source code.
                                                     {{ form_errors(form.name) }}
                                                 </div>
                                                 <div class="col-auto">
-                                                    <button class="btn btn-ec-regular" type="submit">
+                                                    <a class="btn btn-ec-regular">
                                                         {{ 'admin.product.category.403'|trans }}
-                                                    </button>
+                                                    </a>
                                                 </div>
                                             </div>
                                             {# エンティティ拡張の自動出力 #}
@@ -263,10 +261,10 @@ file that was distributed with this source code.
                                                         {{ form_errors(forms[Category.id].name) }}
                                                     </div>
                                                     <div class="col-auto align-items-center">
-                                                        <button class="btn btn-ec-conversion" type="submit">{{ 'admin.common.label.ok'|trans }}</button>
+                                                        <a class="btn btn-ec-conversion">{{ 'admin.common.label.ok'|trans }}</a>
                                                     </div>
                                                     <div class="col-auto align-items-center">
-                                                        <button class="btn btn-ec-sub action-edit-cancel" type="button">{{ 'admin.common.label.cancel'|trans }}</button>
+                                                        <a class="btn btn-ec-sub action-edit-cancel">{{ 'admin.common.label.cancel'|trans }}</a>
                                                     </div>
                                                 </form>
                                             {% endif %}

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -343,17 +343,12 @@ file that was distributed with this source code.
                                     </div>
                                     <div class="d-inline-block">
                                         <div class="btn-group" role="group">
-                                            {# TODO onclickは適切ではないのでaタグで実装できるようにする #}
-                                            <button class="btn btn-ec-regular" type="button"
-                                                    onclick='location.href="{{ url('admin_product_export') }}"'><i
-                                                        class="fa fa-cloud-download mr-1 text-secondary"></i><span>{{ 'admin.product.index.484'|trans }}</span>
-                                            </button>
-                                            {# TODO onclickは適切ではないのでaタグで実装できるようにする #}
-                                            <button class="btn btn-ec-regular" type="button"
-                                                    onclick='location.href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_PRODUCT') }) }}"'>
-                                                <i
-                                                        class="fa fa-cog mr-1 text-secondary"></i><span>{{ 'admin.product.index.486'|trans }}</span>
-                                            </button>
+                                            <a href="{{ url('admin_product_export') }}" class="btn btn-ec-regular">
+                                                <i class="fa fa-cloud-download mr-1 text-secondary"></i><span>{{ 'admin.product.index.484'|trans }}</span>
+                                            </a>
+                                            <a href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_PRODUCT') }) }}" class="btn btn-ec-regular">
+                                                <i class="fa fa-cog mr-1 text-secondary"></i><span>{{ 'admin.product.index.486'|trans }}</span>
+                                            </a>
                                         </div>
                                     </div>
                                 </div>

--- a/src/Eccube/Resource/template/admin/Product/tag.twig
+++ b/src/Eccube/Resource/template/admin/Product/tag.twig
@@ -140,9 +140,9 @@ file that was distributed with this source code.
                                             {{ form_errors(form.name) }}
                                         </div>
                                         <div class="col-auto align-items-center">
-                                            <button class="btn btn-ec-regular" type="submit">
+                                            <a class="btn btn-ec-regular">
                                                 {{ 'admin.product.tag.create'|trans }}
-                                            </button>
+                                            </a>
                                         </div>
                                     </form>
                                 </li>
@@ -192,20 +192,20 @@ file that was distributed with this source code.
                                                     <div class="modal-header">
                                                         <h5 class="modal-title font-weight-bold">
                                                             {{ 'admin.product.tag.delete.confirm.title'|trans }}</h5>
-                                                        <button class="close" type="button"
+                                                        <a class="close"
                                                                 data-dismiss="modal"
                                                                 aria-label="Close"><span
                                                                     aria-hidden="true">×</span>
-                                                        </button>
+                                                        </a>
                                                     </div>
                                                     <div class="modal-body text-left">
                                                         <p class="text-left">
                                                             {{ 'admin.product.tag.delete.confirm.message'|trans }}</p>
                                                     </div>
                                                     <div class="modal-footer">
-                                                        <button class="btn btn-ec-sub" type="button"
+                                                        <a class="btn btn-ec-sub"
                                                                 data-dismiss="modal">{{ 'admin.product.index.cancel'|trans }}
-                                                        </button>
+                                                        </a>
                                                         <a
                                                                 href="{{ url('admin_product_tag_delete', {'id' : Tag.id}) }}"
                                                                 class="btn btn-ec-delete"
@@ -226,10 +226,10 @@ file that was distributed with this source code.
                                                 {{ form_errors(forms[Tag.id].name) }}
                                             </div>
                                             <div class="col-auto align-items-center">
-                                                <button class="btn btn-ec-conversion" type="submit">{{ 'admin.product.tag.ok'|trans }}</button>
+                                                <a class="btn btn-ec-conversion">{{ 'admin.product.tag.ok'|trans }}</a>
                                             </div>
                                             <div class="col-auto align-items-center">
-                                                <button class="btn btn-ec-sub action-edit-cancel" type="button">{{ 'admin.product.tag.cancel'|trans }}</button>
+                                                <a class="btn btn-ec-sub action-edit-cancel">{{ 'admin.product.tag.cancel'|trans }}</a>
                                             </div>
                                         </form>
                                     </li>

--- a/src/Eccube/Resource/template/default/Help/privacy.twig
+++ b/src/Eccube/Resource/template/default/Help/privacy.twig
@@ -24,6 +24,8 @@ file that was distributed with this source code.
                     個人情報保護の重要性に鑑み、「個人情報の保護に関する法律」及び本プライバシーポリシーを遵守し、お客さまのプライバシー保護に努めます。
                 </p><br>
             </div>
+        </div>
+        <div class="ec-off1Grid">
             <div class="ec-off1Grid__cell">
                 <div class="ec-heading-bold">個人情報の定義</div>
                 <p>お客さま個人に関する情報(以下「個人情報」といいます)であって、お客さまのお名前、住所、電話番号など当該お客さま個人を識別することができる情報をさします。他の情報と組み合わせて照合することにより個人を識別することができる情報も含まれます。</p>


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
close EC-CUBE/Eccube-Styleguide-Admin#138

## 方針(Policy)

Issue 対応に伴い button[type=submit] を a タグに変更しています。

- button[type=submit]については、button タグのままとする。
- jQuery 等での処理で　フォーム送信記述入れる

のどちらが良いでしょうか？

前者であれば PR 差し戻しで対応します。

後者であれば JS によるフォーム処理実装、別途お願いします。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



