### PR TITLE
複数ブラウザ間でショッピングカートが同期されない問題を修正

### DIFF
--- a/codeception/_support/Page/Front/CartPage.php
+++ b/codeception/_support/Page/Front/CartPage.php
@@ -37,6 +37,13 @@ class CartPage extends AbstractFrontPage
         return $page;
     }
 
+    public static function at($I)
+    {
+        $page = new self($I);
+        $page->tester->see('ショッピングカート', ['css' => 'div.ec-pageHeader h1']);
+        return $page;
+    }
+
     public function 商品名($index)
     {
         return $this->tester->grabTextFrom(["xpath" => "//div[@class='ec-cartRole']//ul[@class='ec-cartRow'][position()=${index}]//div[@class='ec-cartRow__name']"]);
@@ -45,6 +52,11 @@ class CartPage extends AbstractFrontPage
     public function 商品数量($index)
     {
         return $this->tester->grabTextFrom(["xpath" => "//div[@class='ec-cartRole']//ul[@class='ec-cartRow'][position()=${index}]//div[@class='ec-cartRow__amount']"]);
+    }
+
+    public function 明細数()
+    {
+        return count($this->tester->grabMultiple(['css' => 'ul.ec-cartRow']));
     }
 
     public function 商品数量増やす($index)

--- a/codeception/_support/Page/Front/ProductDetailPage.php
+++ b/codeception/_support/Page/Front/ProductDetailPage.php
@@ -31,6 +31,11 @@ class ProductDetailPage extends AbstractFrontPage
         parent::__construct($I);
     }
 
+    /**
+     * @param $I
+     * @param $id
+     * @return ProductDetailPage
+     */
     public static function go($I, $id)
     {
         $page = new self($I);
@@ -69,12 +74,22 @@ class ProductDetailPage extends AbstractFrontPage
     }
 
     /**
-     * @param $num|int
+     * @param $num |int
+     * @param null $category1
+     * @param null $category2
      * @return ProductDetailPage
      */
-    public function カートに入れる($num)
+    public function カートに入れる($num, $category1 = null, $category2= null)
     {
         $this->tester->fillField(['id' => 'quantity'], $num);
+        if (!is_null($category1)) {
+            $this->tester->selectOption(['id' => 'classcategory_id1'], $category1);
+            if (!is_null($category2)) {
+                $category2_id = current(array_keys($category2));
+                $this->tester->waitForElement(['xpath' => "//*[@id='classcategory_id2']/option[@value='${category2_id}']"]);
+                $this->tester->selectOption(['id' => 'classcategory_id2'], $category2);
+            }
+        }
         $this->tester->click(['id' => 'add-cart']);
         $this->tester->wait(1);
         return $this;
@@ -91,9 +106,12 @@ class ProductDetailPage extends AbstractFrontPage
         return $this->tester->grabTextFrom(["xpath" => "//*[@id=\"ec-modal-header\"]"]);
     }
 
+    /**
+     * @return CartPage
+     */
     public function カートへ進む()
     {
         $this->tester->click("div.ec-modal-box > div > a");
-        return new CartPage($this->tester);
+        return CartPage::at($this->tester);
     }
 }

--- a/codeception/acceptance/EF03OrderCest.php
+++ b/codeception/acceptance/EF03OrderCest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Codeception\Util\Fixtures;
+use Eccube\Entity\Customer;
 use Page\Front\CartPage;
 use Page\Front\CustomerAddressAddPage;
 use Page\Front\MultipleShippingPage;
@@ -898,5 +899,106 @@ class EF03OrderCest
         // 完了画面 -> topへ
         ShoppingCompletePage::at($I)->TOPへ();
         $I->see('新着情報', '.ec-news__title');
+    }
+
+    public function order_複数ブラウザでログインしてカートに追加する(\AcceptanceTester $I)
+    {
+        $I->logoutAsMember();
+        $I->saveSessionSnapshot('not_login');
+
+        $createCustomer = Fixtures::get('createCustomer');
+        /** @var Customer $customer */
+        $customer = $createCustomer();
+
+        // ブラウザ1ログイン
+        $I->loginAsMember($customer->getEmail(), 'password');
+        $I->saveSessionSnapshot('browser1');
+
+        // ブラウザ2ログイン
+        $I->loadSessionSnapshot('not_login');
+        $I->loginAsMember($customer->getEmail(), 'password');
+        $I->saveSessionSnapshot('browser2');
+
+        /*
+         * ブラウザ1でカートに商品を入れる
+         */
+        $I->loadSessionSnapshot('browser1');
+
+        $CartPage = ProductDetailPage::go($I, 2)
+            ->カートに入れる(1)
+            ->カートへ進む();
+
+        $I->assertEquals(1, $CartPage->明細数());
+        $I->assertEquals('パーコレーター', $CartPage->商品名(1));
+
+        /*
+         * ブラウザ2にのカートにも反映されている
+         */
+        $I->loadSessionSnapshot('browser2');
+
+        $CartPage = CartPage::go($I);
+
+        $I->assertEquals(1, $CartPage->明細数());
+        $I->assertEquals('パーコレーター', $CartPage->商品名(1));
+    }
+
+
+    public function order_複数ブラウザ_片方でログインしてカートに追加しもう一方にログインして別の商品を追加する(\AcceptanceTester $I)
+    {
+        $I->logoutAsMember();
+        $I->saveSessionSnapshot('not_login');
+
+        $createCustomer = Fixtures::get('createCustomer');
+        /** @var Customer $customer */
+        $customer = $createCustomer();
+
+        // ブラウザ1ログイン
+        $I->loginAsMember($customer->getEmail(), 'password');
+        $I->saveSessionSnapshot('browser1');
+
+        /*
+         * ブラウザ1でカートに商品を入れる
+         */
+        $I->loadSessionSnapshot('browser1');
+
+        $CartPage = ProductDetailPage::go($I, 2)
+            ->カートに入れる(1)
+            ->カートへ進む();
+
+        $I->assertEquals(1, $CartPage->明細数());
+        $I->assertContains('パーコレーター', $CartPage->商品名(1));
+
+        /*
+         * ブラウザ2で未ログインのまま別の商品を入れる
+         */
+        $I->loadSessionSnapshot('not_login');
+        $CartPage = ProductDetailPage::go($I, 1)
+            ->カートに入れる(1, ['1' => '金'], ['4' => '120mm'])
+            ->カートへ進む();
+
+        $I->assertEquals(1, $CartPage->明細数());
+        $I->assertContains('ディナーフォーク', $CartPage->商品名(1));
+
+        /*
+         * ブラウザ2でログインするとブラウザ1のカートとマージされている
+         */
+        $I->loginAsMember($customer->getEmail(), 'password');
+
+        $CartPage = CartPage::go($I);
+        $I->assertEquals(2, $CartPage->明細数());
+        $itemNames = $I->grabMultiple(['css' => '.ec-cartRow__name a']);
+        $I->assertContains('ディナーフォーク', $itemNames);
+        $I->assertContains('パーコレーター', $itemNames);
+
+        /*
+         * ブラウザ1のカートもマージされている
+         */
+        $I->loadSessionSnapshot('browser1');
+
+        $CartPage = CartPage::go($I);
+        $I->assertEquals(2, $CartPage->明細数());
+        $itemNames = $I->grabMultiple(['css' => '.ec-cartRow__name a']);
+        $I->assertContains('ディナーフォーク', $itemNames);
+        $I->assertContains('パーコレーター', $itemNames);
     }
 }

--- a/src/Eccube/Controller/Block/CartController.php
+++ b/src/Eccube/Controller/Block/CartController.php
@@ -16,9 +16,6 @@ namespace Eccube\Controller\Block;
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\Cart;
 use Eccube\Service\CartService;
-use Eccube\Service\PurchaseFlow\PurchaseContext;
-use Eccube\Service\PurchaseFlow\PurchaseFlow;
-use Eccube\Service\PurchaseFlow\PurchaseFlowResult;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -29,17 +26,10 @@ class CartController extends AbstractController
      */
     protected $cartService;
 
-    /**
-     * @var PurchaseFlow
-     */
-    protected $purchaseFlow;
-
     public function __construct(
-        CartService $cartService,
-        PurchaseFlow $cartPurchaseFlow
+        CartService $cartService
     ) {
         $this->cartService = $cartService;
-        $this->purchaseFlow = $cartPurchaseFlow;
     }
 
     /**
@@ -81,15 +71,5 @@ class CartController extends AbstractController
                 'Carts' => $Carts,
             ]);
         }
-    }
-
-    protected function execPurchaseFlow($Carts)
-    {
-        /** @var PurchaseFlowResult[] $flowResults */
-        $flowResults = array_map(function ($Cart) {
-            $purchaseContext = new PurchaseContext($Cart, $this->getUser());
-
-            return $this->purchaseFlow->validate($Cart, $purchaseContext);
-        }, $Carts);
     }
 }

--- a/src/Eccube/EventListener/SecurityListener.php
+++ b/src/Eccube/EventListener/SecurityListener.php
@@ -62,7 +62,7 @@ class SecurityListener implements EventSubscriberInterface
             $this->em->persist($user);
             $this->em->flush();
         } elseif ($user instanceof Customer) {
-            $this->cartService->mergeFromPersistedCart($user);
+            $this->cartService->mergeFromPersistedCart();
             foreach ($this->cartService->getCarts() as $Cart) {
                 $this->purchaseFlow->validate($Cart, new PurchaseContext($Cart, $user));
             }

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -163,6 +163,7 @@ class CartService
     public function getSessionCarts()
     {
         $cartKeys = $this->session->get('cart_keys', []);
+
         return $this->cartRepository->findBy(['cart_key' => $cartKeys], ['id' => 'DESC']);
     }
 

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -169,10 +169,8 @@ class CartService
 
     /**
      * 会員が保持する永続化されたカートと、非会員時のカートをマージする.
-     *
-     * @param Customer $Customer
      */
-    public function mergeFromPersistedCart(Customer $Customer)
+    public function mergeFromPersistedCart()
     {
         $CartItems = [];
         foreach ($this->getPersistedCarts() as $Cart) {

--- a/src/Eccube/Twig/Extension/TwigIncludeExtension.php
+++ b/src/Eccube/Twig/Extension/TwigIncludeExtension.php
@@ -28,7 +28,7 @@ class TwigIncludeExtension extends AbstractExtension
     {
         return [
             new \Twig_Function('include_dispatch', [$this, 'include_dispatch'],
-                array('needs_context' => true, 'is_safe' => array('all'))),
+                ['needs_context' => true, 'is_safe' => ['all']]),
         ];
     }
 


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
- 2つのブラウザでそれぞれログイン後、別のブラウザで追加されたカートが同期されなかった

1. 2つのブラウザA,Bでログインする
1. Aのブラウザで商品を追加する
1. Bのブラウザでカート画面に行ってもカートが空のまま

- 関連 https://github.com/EC-CUBE/ec-cube/pull/3435

## 実装に関する補足(Appendix)
- ログイン時に永続化された`cart_key`を保持し続けていたため、他のセッションで追加された`cart_key`が反映されていなかった
- ログイン後でもカートを取得するときは、ログインユーザに紐付いたすべてのカートを取得し直すように修正

## テスト（Test)
セッションを切り替えることで2つのブラウザで操作するテストケースを `EF03OrderCest` に再現しています。
