### PR TITLE
スマホでアクセスした場合に, スマホ用レイアウトが無い場合は PC 用にフォールバックするよう修正

### DIFF
--- a/src/Eccube/Twig/Extension/TwigIncludeExtension.php
+++ b/src/Eccube/Twig/Extension/TwigIncludeExtension.php
@@ -28,7 +28,7 @@ class TwigIncludeExtension extends AbstractExtension
     {
         return [
             new \Twig_Function('include_dispatch', [$this, 'include_dispatch'],
-                array('needs_context' => true, 'is_safe' => array('all'))),
+                ['needs_context' => true, 'is_safe' => ['all']]),
         ];
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
スマホでアクセスした場合に, スマホ用レイアウトが無い場合は PC 用にフォールバックするよう修正

## 方針(Policy)
`PageRepository::getByUrl()` が `NoResultException` をスローした場合、 PC 用の Page を返すよう修正

## 実装に関する補足(Appendix)
SQL のみで対応する場合は、以下のようなクエリをコールすれば、1発で済む。

```sql

SELECT
  d0_.id AS id_0,
  d0_.page_name AS page_name_1,
  d0_.url AS url_2,
  d0_.file_name AS file_name_3,
  d0_.edit_type AS edit_type_4,
  d0_.author AS author_5,
  d0_.description AS description_6,
  d0_.keyword AS keyword_7,
  d0_.update_url AS update_url_8,
  d0_.create_date AS create_date_9,
  d0_.update_date AS update_date_10,
  d0_.meta_robots AS meta_robots_11,
  d0_.meta_tags AS meta_tags_12,
  d1_.page_id AS page_id_13,
  d1_.layout_id AS layout_id_14,
  d1_.sort_no AS sort_no_15,
  d2_.id AS id_16,
  d2_.layout_name AS layout_name_17,
  d2_.create_date AS create_date_18,
  d2_.update_date AS update_date_19,
  d3_.page_id AS page_id_20,
  d3_.section AS section_21,
  d3_.block_id AS block_id_22,
  d3_.layout_id AS layout_id_23,
  d3_.block_row AS block_row_24,
  d3_.anywhere AS anywhere_25,
  d4_.id AS id_26,
  d4_.block_name AS block_name_27,
  d4_.file_name AS file_name_28,
  d4_.use_controller AS use_controller_29,
  d4_.deletable AS deletable_30,
  d4_.create_date AS create_date_31,
  d4_.update_date AS update_date_32,
  d0_.discriminator_type AS discriminator_type_33,
  d0_.device_type_id AS device_type_id_34,
  d0_.master_page_id AS master_page_id_35,
  d1_.discriminator_type AS discriminator_type_36,
  d1_.page_id AS page_id_37,
  d1_.layout_id AS layout_id_38,
  d2_.discriminator_type AS discriminator_type_39,
  d2_.device_type_id AS device_type_id_40,
  d3_.discriminator_type AS discriminator_type_41,
  d3_.block_id AS block_id_42,
  d3_.page_id AS page_id_43,
  d3_.layout_id AS layout_id_44,
  d4_.discriminator_type AS discriminator_type_45,
  d4_.device_type_id AS device_type_id_46
FROM dtb_page d0_
LEFT JOIN dtb_page_layout d1_
  ON d0_.id = d1_.page_id
  AND d1_.discriminator_type IN ('pagelayout')
LEFT JOIN (SELECT
  *
FROM dtb_layout
WHERE device_type_id IN (SELECT
  COALESCE(MIN(device_type_id),
  10)
FROM dtb_layout
WHERE device_type_id = 2)) d2_ -- device_type_id を指定
  ON 
  d1_.layout_id = d2_.id
  AND d2_.discriminator_type IN ('layout')
LEFT JOIN dtb_block_position d3_
  ON d2_.id = d3_.layout_id
  AND d3_.discriminator_type IN ('blockposition')
LEFT JOIN dtb_block d4_
  ON d3_.block_id = d4_.id
  AND d4_.discriminator_type IN ('block')
WHERE (d0_.url = 'homepage')
AND d0_.discriminator_type IN ('page')
ORDER BY d3_.block_row ASC
```
ORM での実装は難しいと思われる

## テスト（Test)
ユニットテストが通るのを確認