### PR TITLE
【受注一覧】出荷完了メール送信済みの場合に、アイコンが表示されない

### DIFF
--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -1284,6 +1284,7 @@ return [
     'admin.order.index.th_delivery_address' => 'お届け先',
     'admin.order.index.not_payment' => '未入金',
     'admin.order.index.not_shipping' => '未発送',
+    'admin.order.index.send_mail_date' => '%date% に送信済みです',
     'admin.order.mail.339' => '受注管理',
     'admin.order.mail.340' => 'メール通知',
     'admin.order.mail.341' => '取得に失敗しました',

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -1284,7 +1284,7 @@ return [
     'admin.order.index.th_delivery_address' => 'お届け先',
     'admin.order.index.not_payment' => '未入金',
     'admin.order.index.not_shipping' => '未発送',
-    'admin.order.index.send_mail_date' => '%date% に送信済みです',
+    'admin.order.index.send_mail_date' => '%date% に出荷メール送信済みです',
     'admin.order.mail.339' => '受注管理',
     'admin.order.mail.340' => 'メール通知',
     'admin.order.mail.341' => '取得に失敗しました',

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -588,7 +588,7 @@ file that was distributed with this source code.
                                                     {% endif %}
                                                 </td>
                                                 <td class="align-middle text-center">
-                                                    {% if Order.is_multiple %}
+                                                    {% if Shipping.Shipped %}
                                                         <a href="{{ url('admin_shipping_edit', { id: Order.id }) }}">
                                                             {% if Shipping.shipping_date %}
                                                                 {{ Shipping.shipping_date|date_day }}
@@ -596,6 +596,10 @@ file that was distributed with this source code.
                                                                 {{ 'admin.order.index.not_shipping'|trans }}
                                                             {% endif %}
                                                         </a>
+                                                        {% if Shipping.mail_send_date %}
+                                                            {% set send_mail_date = Shipping.mail_send_date|date_day %}
+                                                            <i class="fa fa-envelope fa-lg text-secondary" aria-hidden="true" data-toggle="tooltip" data-placement="top" data-original-title="{{ 'admin.order.index.send_mail_date'|trans({'%date%': send_mail_date}) }}"></i>
+                                                        {% endif %}
                                                     {% else %}
                                                         {{ Shipping.shipping_date ? Shipping.shipping_date|date_day : 'admin.order.index.not_shipping'|trans }}
                                                     {% endif %}

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -600,7 +600,7 @@ file that was distributed with this source code.
                                                         {{ Shipping.shipping_date ? Shipping.shipping_date|date_day : 'admin.order.index.not_shipping'|trans }}
                                                     {% endif %}
                                                     {% if Shipping.mail_send_date %}
-                                                        {% set send_mail_date = Shipping.mail_send_date|date_day %}
+                                                        {% set send_mail_date = Shipping.mail_send_date|date_min %}
                                                         <i class="fa fa-envelope fa-lg text-secondary" aria-hidden="true" data-toggle="tooltip" data-placement="top" data-original-title="{{ 'admin.order.index.send_mail_date'|trans({'%date%': send_mail_date}) }}"></i>
                                                     {% endif %}
                                                 </td>

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -588,7 +588,7 @@ file that was distributed with this source code.
                                                     {% endif %}
                                                 </td>
                                                 <td class="align-middle text-center">
-                                                    {% if Shipping.Shipped %}
+                                                    {% if Order.is_multiple %}
                                                         <a href="{{ url('admin_shipping_edit', { id: Order.id }) }}">
                                                             {% if Shipping.shipping_date %}
                                                                 {{ Shipping.shipping_date|date_day }}
@@ -596,12 +596,12 @@ file that was distributed with this source code.
                                                                 {{ 'admin.order.index.not_shipping'|trans }}
                                                             {% endif %}
                                                         </a>
-                                                        {% if Shipping.mail_send_date %}
-                                                            {% set send_mail_date = Shipping.mail_send_date|date_day %}
-                                                            <i class="fa fa-envelope fa-lg text-secondary" aria-hidden="true" data-toggle="tooltip" data-placement="top" data-original-title="{{ 'admin.order.index.send_mail_date'|trans({'%date%': send_mail_date}) }}"></i>
-                                                        {% endif %}
                                                     {% else %}
                                                         {{ Shipping.shipping_date ? Shipping.shipping_date|date_day : 'admin.order.index.not_shipping'|trans }}
+                                                    {% endif %}
+                                                    {% if Shipping.mail_send_date %}
+                                                        {% set send_mail_date = Shipping.mail_send_date|date_day %}
+                                                        <i class="fa fa-envelope fa-lg text-secondary" aria-hidden="true" data-toggle="tooltip" data-placement="top" data-original-title="{{ 'admin.order.index.send_mail_date'|trans({'%date%': send_mail_date}) }}"></i>
                                                     {% endif %}
                                                 </td>
                                                 <td class="align-middle text-center">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
add icon email when sent email shipped

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
case 1 - create order
           - still not show icon email
case 2 - send email about shipping
           - check icon email
case 3 - check with multi_shipping



