### PR TITLE
受注管理一覧の検索条件では「発送メール送信済」ではなく「発送メール未送信」が検索したい

### DIFF
--- a/src/Eccube/Form/Type/Admin/SearchOrderType.php
+++ b/src/Eccube/Form/Type/Admin/SearchOrderType.php
@@ -14,7 +14,7 @@
 namespace Eccube\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -98,9 +98,16 @@ class SearchOrderType extends AbstractType
                 'label' => 'searchorder.label.tracking_number',
                 'required' => false,
             ])
-            ->add('shipping_mail_send', CheckboxType::class, [
+            ->add('shipping_mail_send', ChoiceType::class, [
                 'label' => 'searchorder.label.shipping_mail_send',
                 'required' => false,
+                'placeholder' => false,
+                'expanded' => true,
+                'multiple' => false,
+                'choices' => [
+                    'searchorder.label.shipping_mail_send' => 1,
+                    'searchorder.label.shipping_mail_not_send' => 0
+                ]
             ])
             ->add('payment', PaymentType::class, [
                 'label' => 'searchorder.label.payment_method',

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -433,9 +433,12 @@ class OrderRepository extends AbstractRepository
         }
 
         // 発送メール送信済かどうか.
-        if (isset($searchData['shipping_mail_send']) && $searchData['shipping_mail_send']) {
-            $qb
-                ->andWhere('s.mail_send_date IS NOT NULL');
+        if (isset($searchData['shipping_mail_send'])) {
+            if ($searchData['shipping_mail_send']) {
+                $qb->andWhere('s.mail_send_date IS NOT NULL');
+            } else {
+                $qb->andWhere('s.mail_send_date IS NULL');
+            }
         }
 
         // 送り状番号.

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -2717,6 +2717,7 @@ return [
     'searchorder.label.purchased_amount_max' => '購入金額(上限)',
     'searchorder.label.purchased_products' => '購入商品名',
     'searchorder.label.shipping_mail_send' => '発送メール送信済',
+    'searchorder.label.shipping_mail_not_send' => '発送メール未送信',
     'searchorder.label.tracking_number' => '送り状番号',
     'searchorder.label.shipping_delivery_date' => 'お届け予定日',
     'searchorder.label.shipping_delivery_date_start' => 'お届け予定日(開始)',

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -365,7 +365,7 @@ file that was distributed with this source code.
                         <div class="form-row">
                             <div class="col-12">
                                 <p class="col-form-label">{{ 'searchorder.label.shipping_mail_send'|trans }}</p>
-                                {{ form_widget(searchForm.shipping_mail_send) }}
+                                {{ form_widget(searchForm.shipping_mail_send, {'label_attr': { 'class': 'radio-inline'}}) }}
                                 {{ form_errors(searchForm.shipping_mail_send) }}
                             </div>
                         </div>
@@ -393,7 +393,7 @@ file that was distributed with this source code.
                 {% endfor %}
 
                 <div class="d-block text-center">
-                    <button class="btn btn-ec-regular" type="button">{{ 'admin.order.index.btn_clear_criteria'|trans }}</button>
+                    <button class="btn btn-ec-regular" type="reset">{{ 'admin.order.index.btn_clear_criteria'|trans }}</button>
                 </div>
             </div>
             <div class="c-outsideBlock__contents">

--- a/src/Eccube/Resource/template/admin/search_items.twig
+++ b/src/Eccube/Resource/template/admin/search_items.twig
@@ -23,7 +23,16 @@ file that was distributed with this source code.
             {%- elseif php_is_a(child.vars.data, '\DateTime') -%}
                 {{ child.vars.data|date_day }}
             {%- else -%}
-                {{ child.vars.data }}
+                {% if child.vars.choices is defined %}
+                    {# FIXME: display label in case radio input #}
+                    {%- for choice in child.vars.choices -%}
+                        {%- if choice is selectedchoice(child.vars.value) -%}
+                            {{ choice.label|trans }}
+                        {%- endif %}
+                    {%- endfor -%}
+                {% else %}
+                    {{ child.vars.data }}
+                {%  endif %}
             {%- endif -%}
         </li>
     {% endfor %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
   Change search condition from "Sent shipped mail" to "Still not send"

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
   For more experience,  add more condition for admin : sent & still not send

## テスト（Test)
-   check on radio button : "Sent" check search result, only show Sent Order
-   check on radio button : "Not Send" check search result, only show  Order which not send email
-   UN check on radio button , show all Order ( include Sent & Not Send )





