### PR TITLE
まれに在庫切れによってテストが失敗するのを修正

### DIFF
--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -422,7 +422,7 @@ class Generator
                 ->setCreateDate(new \DateTime()) // FIXME
                 ->setUpdateDate(new \DateTime())
                 ->setCreator($Member)
-                ->setStock($faker->randomNumber(3));
+                ->setStock($faker->numberBetween(100, 999));
             $this->entityManager->persist($ProductStock);
             $this->entityManager->flush($ProductStock);
             $ProductClass = new ProductClass();


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
- まれに予期せぬ在庫切れでテストが失敗していたので修正
- `Generator`で生成する商品の在庫を999以下から100-999の間に変更
  - 受注明細の個数は99以下で生成される
