### PR TITLE
【受注登録】購入処理中の受注データに対して、受注登録の「受注情報を登録」で受注日が登録されてしまう

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -623,7 +623,7 @@ file that was distributed with this source code.
                                     </div>
                                     <div class="col-5 text-right">
                                         <button type="submit" class="btn btn-ec-regular mr-2" name="mode" value="calc" data-link="order-product" id="calculate"
-                                        {% if Order.OrderStatus.id == constant('Eccube\\Entity\\Master\\OrderStatus::PROCESSING') %}disabled="disabled"{% endif %}>
+                                        {% if Order.OrderStatus is not null and Order.OrderStatus.id == constant('Eccube\\Entity\\Master\\OrderStatus::PROCESSING') %}disabled="disabled"{% endif %}>
                                             {{ 'admin.order.edit.267'|trans }}
                                         </button>
                                     </div>
@@ -895,7 +895,7 @@ file that was distributed with this source code.
                         <div class="row align-items-center justify-content-end">
                             <div class="col-auto">
                                 <button type="submit" class="btn btn-ec-conversion px-5" name="mode" value="register"
-                                    {% if Order.OrderStatus.id == constant('Eccube\\Entity\\Master\\OrderStatus::PROCESSING') %}disabled="disabled"{% endif %}>
+                                    {% if Order.OrderStatus is not null and Order.OrderStatus.id == constant('Eccube\\Entity\\Master\\OrderStatus::PROCESSING') %}disabled="disabled"{% endif %}>
                                     {{ 'admin.order.edit.287'|trans }}
                                 </button>
                             </div>

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -622,7 +622,10 @@ file that was distributed with this source code.
                                         {{ form_errors(form.OrderItemsErrors) }}
                                     </div>
                                     <div class="col-5 text-right">
-                                        <button type="submit" class="btn btn-ec-regular mr-2" name="mode" value="calc" data-link="order-product" id="calculate">{{ 'admin.order.edit.267'|trans }}</button>
+                                        <button type="submit" class="btn btn-ec-regular mr-2" name="mode" value="calc" data-link="order-product" id="calculate"
+                                        {% if Order.OrderStatus.id == constant('Eccube\\Entity\\Master\\OrderStatus::PROCESSING') %}disabled="disabled"{% endif %}>
+                                            {{ 'admin.order.edit.267'|trans }}
+                                        </button>
                                     </div>
                                 </div>
                                 <table id="table-form-field" class="table table-striped table-sm mb-0  text-nowrap"
@@ -891,7 +894,10 @@ file that was distributed with this source code.
                     <div class="col-6">
                         <div class="row align-items-center justify-content-end">
                             <div class="col-auto">
-                                <button type="submit" class="btn btn-ec-conversion px-5" name="mode" value="register">{{ 'admin.order.edit.287'|trans }}</button>
+                                <button type="submit" class="btn btn-ec-conversion px-5" name="mode" value="register"
+                                    {% if Order.OrderStatus.id == constant('Eccube\\Entity\\Master\\OrderStatus::PROCESSING') %}disabled="disabled"{% endif %}>
+                                    {{ 'admin.order.edit.287'|trans }}
+                                </button>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
＜期待動作＞対応状況が、購入処理中の場合は、受注日の更新はしない

    -  修正方針

            - 購入処理中は編集できないようにする

            - 登録ボタンが押せない

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
- When Order have status is processing, don't enable that button 


