### PR TITLE
AppVeyor を動くよう修正

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,20 +2,21 @@
 # http://www.appveyor.com/docs/appveyor-yml
 
 # Set build version format here instead of in the admin panel.
-version: 3.0.x-{build}
+version: 3.x-{build}
 
 clone_folder: c:\projects\ec-cube
 
 cache:
   - '%LOCALAPPDATA%\Composer\files'
-  
+  - vendor
+
 # Fix line endings in Windows. (runs before repo cloning)
 init:
   - git config --global core.autocrlf input
 
 environment:
   global:
-    USER: "root" 
+    USER: "root"
     DBNAME: "myapp_test"
     DBPASS: "Password12!"
     DBUSER: "root"
@@ -26,44 +27,38 @@ environment:
     provider: mysql
 
 services:
-  - iis  
   - mysql
 
 # Install scripts. (runs after repo cloning)
 install:
+  - cp phpunit.xml.dist phpunit.xml
+  # see https://github.com/phpmd/phpmd/blob/master/appveyor.yml#L10-L13
+  - cinst -y OpenSSL.Light
+  - SET PATH=C:\Program Files\OpenSSL;%PATH%
+  - sc config wuauserv start= auto
+  - net start wuauserv
   # Set MySQL.
   - cp tests/my.cnf c:\
   - SET PATH=C:\Program Files\MySql\MySQL Server 5.7\bin\;%PATH%
   #- cinst mysql
   #- SET PATH=C:\tools\mysql\current\bin\;%PATH%
   # Set PHP.
-  - cinst php --version 7.0.9 --allow-empty-checksums
-  - SET PATH=C:\tools\php\;%PATH%
-  - copy C:\tools\php\php.ini-production C:\tools\php\php.ini
-  - echo date.timezone="Asia/Tokyo" >> C:\tools\php\php.ini
-  - echo extension_dir=ext >> C:\tools\php\php.ini
-  - echo extension=php_openssl.dll >> C:\tools\php\php.ini
-  - echo extension=php_gd2.dll >> C:\tools\php\php.ini
-  - echo extension=php_mbstring.dll >> C:\tools\php\php.ini
-  - echo extension=php_pgsql.dll >> C:\tools\php\php.ini
-  - echo extension=php_pdo_mysql.dll >> C:\tools\php\php.ini
-  - echo extension=php_pdo_pgsql.dll >> C:\tools\php\php.ini
-  - echo extension=php_curl.dll >> C:\tools\php\php.ini
-  - echo extension=php_fileinfo.dll >> C:\tools\php\php.ini
-  - echo output_buffering = Off >> C:\tools\php\php.ini
-  - echo default_charset = UTF-8 >> C:\tools\php\php.ini
-  - echo mbstring.language = Japanese >> C:\tools\php\php.ini
-  - echo mbstring.encoding_translation = On >> C:\tools\php\php.ini
-  - echo mbstring.http_input = UTF-8 >> C:\tools\php\php.ini
-  - echo mbstring.http_output = pass >> C:\tools\php\php.ini
-  - echo mbstring.internal_encoding = UTF-8 >> C:\tools\php\php.ini
-  - echo memory_limit = 512M >> C:\tools\php\php.ini
+  - cinst php --version 7.1.20 --allow-empty-checksums
+  - SET PATH=C:\tools\php71\;%PATH%
+  - copy C:\tools\php71\php.ini-production C:\tools\php71\php.ini
+  - echo date.timezone="Asia/Tokyo" >> C:\tools\php71\php.ini
+  - echo extension_dir=ext >> C:\tools\php71\php.ini
+  - echo extension=php_openssl.dll >> C:\tools\php71\php.ini
+  - echo extension=php_gd2.dll >> C:\tools\php71\php.ini
+  - echo extension=php_mbstring.dll >> C:\tools\php71\php.ini
+  - echo extension=php_pgsql.dll >> C:\tools\php71\php.ini
+  - echo extension=php_pdo_mysql.dll >> C:\tools\php71\php.ini
+  - echo extension=php_pdo_pgsql.dll >> C:\tools\php71\php.ini
+  - echo extension=php_curl.dll >> C:\tools\php71\php.ini
+  - echo extension=php_fileinfo.dll >> C:\tools\php71\php.ini
+  - echo memory_limit = 512M >> C:\tools\php71\php.ini
   - php -r "readfile('http://getcomposer.org/installer');" | php
   - php composer.phar install --dev --no-interaction -o
-
-# cache:
-  # - C:\ProgramData\chocolatey\bin -> appveyor.yml
-  # - C:\ProgramData\chocolatey\lib -> appveyor.yml
 
 # Don't actually build.
 build: off
@@ -72,4 +67,4 @@ before_test:
   - php eccube_install.php mysql none
 
 test_script:
-  - vendor\bin\phpunit.bat
+  - vendor\bin\phpunit.bat -c phpunit.xml


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
AppVeyor を動くよう修正

## 方針(Policy)
- PHP7.1 で実行するよう修正

## 実装に関する補足(Appendix)
- `cp phpunit.xml.dist phpunit.xml` を実行しないと、何故か phpunit.xml.dist が削除されてしまう

## テスト（Test)
AppVeyor が動作することを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更


