### PR TITLE
ShoppingControllerでエラー発生時のログ出力不具合修正

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -855,7 +855,6 @@ class ShoppingController extends AbstractShoppingController
 
                 $this->entityManager->getConnection()->rollback();
 
-                $this->log($e);
                 $this->addError($e->getMessage());
 
                 return $this->redirectToRoute('shopping_error');


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
- `$this->log($e)`は存在しないメソッドなので削除
- catchの最初で`log_error`関数でログ出力しているのでエラーログは出力される
