### PR TITLE
【マイページ】赤伝(マイナス数量の商品)を含む受注は、再注文ボタンを「非表示」にする

### DIFF
--- a/src/Eccube/Controller/Mypage/MypageController.php
+++ b/src/Eccube/Controller/Mypage/MypageController.php
@@ -207,19 +207,17 @@ class MypageController extends AbstractController
             throw new NotFoundHttpException();
         }
 
-        $StockFind = true;
-        foreach ($Order->getShippings() as $shipping) {
-            foreach ($shipping->getProductOrderItems() as $orderItem) {
-                if ($orderItem->isProduct() && $orderItem->getProductClass()->getStockFind() == false) {
-                    $StockFind = false;
-                    break;
-                }
+        $stockFind = true;
+        foreach ($Order->getOrderItems() as $orderItem) {
+            if ($orderItem->isProduct() && $orderItem->getProductClass()->getStockFind() == false) {
+                $stockFind = false;
+                break;
             }
         }
 
         return [
             'Order' => $Order,
-            'StockFind' => $StockFind
+            'stockFind' => $stockFind
         ];
     }
 

--- a/src/Eccube/Controller/Mypage/MypageController.php
+++ b/src/Eccube/Controller/Mypage/MypageController.php
@@ -17,6 +17,7 @@ use Eccube\Controller\AbstractController;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Customer;
 use Eccube\Entity\CustomerFavoriteProduct;
+use Eccube\Entity\Order;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
 use Eccube\Exception\CartException;
@@ -199,14 +200,26 @@ class MypageController extends AbstractController
         );
         $this->eventDispatcher->dispatch(EccubeEvents::FRONT_MYPAGE_MYPAGE_HISTORY_INITIALIZE, $event);
 
+        /** @var Order $Order */
         $Order = $event->getArgument('Order');
 
         if (!$Order) {
             throw new NotFoundHttpException();
         }
 
+        $StockFind = true;
+        foreach ($Order->getShippings() as $shipping) {
+            foreach ($shipping->getProductOrderItems() as $orderItem) {
+                if ($orderItem->isProduct() && $orderItem->getProductClass()->getStockFind() == false) {
+                    $StockFind = false;
+                    break;
+                }
+            }
+        }
+
         return [
             'Order' => $Order,
+            'StockFind' => $StockFind
         ];
     }
 

--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -180,8 +180,11 @@ file that was distributed with this source code.
                     </dl>
                     {% endif %}
                     <div class="ec-totalBox__total">{{'common.label.cart_total'|trans}}<span class="ec-totalBox__price">{{ Order.payment_total|price }}</span><span class="ec-totalBox__taxLabel">{{'shopping.label.tax_incl'|trans}}</span></div>
+                    {% if StockFind %}
                     <a href="{{ url('mypage_order', {'order_no': Order.order_no }) }}" class="ec-blockBtn--action load-overlay" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">{{'mypage.history.detail.re_order'|trans}}</a>
-
+                    {% else %}
+                        <button class="ec-blockBtn--action" disabled="disabled">ただいま品切れ中です</button>
+                    {% endif %}
                 </div>
                 {% if remessage %}
                     <p class="ec-color-accent">

--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -180,10 +180,8 @@ file that was distributed with this source code.
                     </dl>
                     {% endif %}
                     <div class="ec-totalBox__total">{{'common.label.cart_total'|trans}}<span class="ec-totalBox__price">{{ Order.payment_total|price }}</span><span class="ec-totalBox__taxLabel">{{'shopping.label.tax_incl'|trans}}</span></div>
-                    {% if StockFind %}
+                    {% if stockFind %}
                     <a href="{{ url('mypage_order', {'order_no': Order.order_no }) }}" class="ec-blockBtn--action load-overlay" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">{{'mypage.history.detail.re_order'|trans}}</a>
-                    {% else %}
-                        <button class="ec-blockBtn--action" disabled="disabled">ただいま品切れ中です</button>
                     {% endif %}
                 </div>
                 {% if remessage %}

--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -181,7 +181,7 @@ file that was distributed with this source code.
                     {% endif %}
                     <div class="ec-totalBox__total">{{'common.label.cart_total'|trans}}<span class="ec-totalBox__price">{{ Order.payment_total|price }}</span><span class="ec-totalBox__taxLabel">{{'shopping.label.tax_incl'|trans}}</span></div>
                     {% if stockFind %}
-                    <a href="{{ url('mypage_order', {'order_no': Order.order_no }) }}" class="ec-blockBtn--action load-overlay" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">{{'mypage.history.detail.re_order'|trans}}</a>
+                        <a href="{{ url('mypage_order', {'order_no': Order.order_no }) }}" class="ec-blockBtn--action load-overlay" {{ csrf_token_for_anchor() }} data-method="put" data-confirm="false">{{'mypage.history.detail.re_order'|trans}}</a>
                     {% endif %}
                 </div>
                 {% if remessage %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
  - Can not re-order when one of product imposible

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
- After order successfull
Case 1:
- Reduce quantity of one product
- Into history, review that Order and check button re-Order ( invisible )
Case 2:
- Increase quantity of  all products
- Into history, review that Order and check button re-Order ( visible )

## 相談（Discussion）



