### PR TITLE
fix 出荷管理画面 出荷メール・出荷完了処理にてメッセージが２重で表示される問題を修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/confirmationModal_js.twig
+++ b/src/Eccube/Resource/template/admin/Order/confirmationModal_js.twig
@@ -60,7 +60,7 @@
                     }
             }
             $('.modal-title', modal).text(updater.modalTitle);
-            $('.modal-body > p', modal).text("{{ 'admin.shipping.index.827'|trans }}");
+            $('.modal-body > p.modal-message', modal).text("{{ 'admin.shipping.index.827'|trans }}");
             $('button', modal).hide();
             $('#bulk-options').hide();
             $('.progress', modal).show();
@@ -115,7 +115,7 @@
         },
         always: function (result) {
             $('.progress', this.modal).hide();
-            $('.modal-body > p', this.modal).text("{{ 'admin.shipping.index.828'|trans }}");
+            $('.modal-body > p.modal-message', this.modal).text("{{ 'admin.shipping.index.828'|trans }}");
             $('#bulkChangeComplete').show();
         },
         getPromises: function (progress, url, data) {
@@ -196,7 +196,7 @@
         always: {
             value: function (result) {
                 ConfirmationModal.prototype.always.call(this, result);
-                $('.modal-body > p', this.modal).text("{{ 'admin.shipping.index.828'|trans }}" + this.notifierCompleteMessage);
+                $('.modal-body > p.modal-message', this.modal).text("{{ 'admin.shipping.index.828'|trans }}" + this.notifierCompleteMessage);
             }
         },
         getPromises: {

--- a/src/Eccube/Resource/template/admin/Order/shipping.twig
+++ b/src/Eccube/Resource/template/admin/Order/shipping.twig
@@ -130,6 +130,10 @@ file that was distributed with this source code.
             return false;
         });
 
+        // モーダル注意文言の削除
+        $('#bulkChange').on('click', function () {
+            $('.warning-message').css('display', 'none');
+        })
     </script>
 
 {{ include('@admin/Order/confirmationModal_js.twig') }}
@@ -186,7 +190,7 @@ file that was distributed with this source code.
                     </div>
                     <div class="modal-body">
                         <p class="mb-4 modal-message"></p>
-                        <p class="mb-4">{{ 'admin.shipping.index.838'|trans }}</p>
+                        <p class="mb-4 warning-message">{{ 'admin.shipping.index.838'|trans }}</p>
                         <ul id="bulkErrors"></ul>
                         <div id="bulk-options">
                             <div class="font-weight-bold mb-2 notificationMail">{{ 'admin.shipping.index.812'|trans }}</div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
fix 出荷管理画面 出荷メール・出荷完了処理にてメッセージが２重で表示される問題を修正

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->
- confirmationModal_js.twig で扱うメッセージにはmodal-messagクラスを付与
- shipping.twigで扱うメッセージにはwarning-messageクラスを付与
