### PR TITLE
モーダルとtooltipの競合を修正

### DIFF
--- a/html/template/admin/assets/js/function.js
+++ b/html/template/admin/assets/js/function.js
@@ -27,7 +27,7 @@ mainNavArea();
 //Bootstrap ツールチップ
 var toolTip = function() {
     $(function() {
-        $('[data-toggle="tooltip"]').tooltip();
+        $('[data-tooltip="true"]').tooltip()
     })
 };
 

--- a/src/Eccube/Resource/template/admin/Content/block.twig
+++ b/src/Eccube/Resource/template/admin/Content/block.twig
@@ -92,7 +92,7 @@ file that was distributed with this source code.
                                                 <div class="row">
                                                     <div class="col-6 text-right">
                                                         <a href="{{ url('admin_content_block_edit', {id: Block.id}) }}"
-                                                           class="btn btn-ec-actionIcon mr-3" data-toggle="tooltip"
+                                                           class="btn btn-ec-actionIcon mr-3" data-tooltip="true"
                                                            data-placement="top"
                                                            title="{{ 'admin.content.block_edit.14'|trans }}">
                                                             <i class="fa fa-pencil fa-lg text-secondary"></i>
@@ -103,7 +103,7 @@ file that was distributed with this source code.
                                                             <a href="#"
                                                                data-toggle="modal"
                                                                data-target="#confirmModal-{{ Block.id }}"
-                                                               class="btn btn-ec-actionIcon mr-3" data-toggle="tooltip"
+                                                               class="btn btn-ec-actionIcon mr-3" data-tooltip="true"
                                                                data-placement="top"
                                                                title="{{ 'admin.content.block_edit.17'|trans }}">
                                                                 <i class="fa fa-close fa-lg text-secondary"></i>

--- a/src/Eccube/Resource/template/admin/Content/file.twig
+++ b/src/Eccube/Resource/template/admin/Content/file.twig
@@ -177,11 +177,11 @@ file that was distributed with this source code.
                                                     <td class="align-middle text-right pr-3">
                                                         <div class="row justify-content-end">
                                                             <div class="col-auto text-center">
-                                                                <a href="{{ url('admin_content_file_view') }}?file={{ file.file_path|e('url') }}" target="_blank" class="btn btn-ec-actionIcon action-view" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{ 'admin.content.file.36'|trans }}"><i class="fa fa-eye fa-lg text-secondary" aria-hidden="true"></i></a>
+                                                                <a href="{{ url('admin_content_file_view') }}?file={{ file.file_path|e('url') }}" target="_blank" class="btn btn-ec-actionIcon action-view" data-tooltip="true" data-placement="top" title="" data-original-title="{{ 'admin.content.file.36'|trans }}"><i class="fa fa-eye fa-lg text-secondary" aria-hidden="true"></i></a>
                                                             </div>
 
                                                             <div class="col-auto text-center">
-                                                                <a href="{{ url('admin_content_file_download') }}?select_file={{ file.file_path|e('url') }}" class="btn btn-ec-actionIcon action-download" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{ 'admin.content.file.37'|trans }}"><i class="fa fa-cloud-download fa-lg text-secondary" aria-hidden="true"></i></a>
+                                                                <a href="{{ url('admin_content_file_download') }}?select_file={{ file.file_path|e('url') }}" class="btn btn-ec-actionIcon action-download" data-tooltip="true" data-placement="top" title="" data-original-title="{{ 'admin.content.file.37'|trans }}"><i class="fa fa-cloud-download fa-lg text-secondary" aria-hidden="true"></i></a>
                                                             </div>
 
                                                             <div class="col-auto text-center">

--- a/src/Eccube/Resource/template/admin/Content/layout.twig
+++ b/src/Eccube/Resource/template/admin/Content/layout.twig
@@ -248,7 +248,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.content.layout.block_edit'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.content.layout.block_edit'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col-4 text-right"><a data-toggle="collapse" href="#layoutBlockEdit" aria-expanded="false" aria-controls="layoutBlockEdit"><i class="fa fa-angle-up fa-lg"></i></a></div>
                             </div>

--- a/src/Eccube/Resource/template/admin/Content/page.twig
+++ b/src/Eccube/Resource/template/admin/Content/page.twig
@@ -102,7 +102,7 @@ file that was distributed with this source code.
                                     </td>
                                     <td class="align-middle pr-3">
                                         <div class="row justify-content-end">
-                                            <div class="col-auto text-center" data-toggle="tooltip" data-placement="top" title="{{ 'admin.content.page.delete'|trans }}">
+                                            <div class="col-auto text-center" data-tooltip="true" data-placement="top" title="{{ 'admin.content.page.delete'|trans }}">
                                                 {% if Page.edit_type == constant('Eccube\\Entity\\Page::EDIT_TYPE_USER') %}
                                                     <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_{{ Page.id }}">
                                                         <i class="fa fa-close fa-lg text-secondary"

--- a/src/Eccube/Resource/template/admin/Content/page_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/page_edit.twig
@@ -146,7 +146,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip">
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip">
                                         <span class="card-title">{{ 'admin.content.page_edit.layout_setting'|trans }}</span>
                                         <i class="fa fa-question-circle fa-lg ml-1"></i>
                                     </div>
@@ -181,7 +181,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip">
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip">
                                         <span class="card-title">{{ 'admin.content.page_edit.meta_setting'|trans }}</span>
                                         <i class="fa fa-question-circle fa-lg ml-1"></i>
                                     </div>

--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -49,7 +49,7 @@ file that was distributed with this source code.
                                 {% if Customer.id %}
                                     <div class="row mb-2">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.customer.edit.95'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -242,7 +242,7 @@ file that was distributed with this source code.
                             <div class="card-header">
                                 <div class="row">
                                     <div class="col-8">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                              title="Tooltip">
                                         <span class="card-title">
                                             {{ 'admin.customer.edit.sipping'|trans }}
@@ -342,7 +342,7 @@ file that was distributed with this source code.
                             <div class="card-header">
                                 <div class="row">
                                     <div class="col-8">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                              title="Tooltip">
                                         <span class="card-title">
                                             {{ 'admin.customer.edit.99'|trans }}
@@ -418,7 +418,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                          title="Tooltip">
                                         <span class="card-title">{{ 'admin.customer.edit.109'|trans }}</span>
                                         <i class="fa fa-question-circle fa-lg ml-1"></i>

--- a/src/Eccube/Resource/template/admin/Customer/index.twig
+++ b/src/Eccube/Resource/template/admin/Customer/index.twig
@@ -367,7 +367,7 @@ file that was distributed with this source code.
                                             <td class="align-middle pr-3">
                                                 <div class="row justify-content-end">
                                                     {% if Customer.Status.id == constant('Eccube\\Entity\\Master\\CustomerStatus::PROVISIONAL') %}
-                                                        <div class="col-auto text-center" data-toggle="tooltip" data-placement="top" title="{{ 'admin.customer.index.label.resend_registmail'|trans }}">
+                                                        <div class="col-auto text-center" data-tooltip="true" data-placement="top" title="{{ 'admin.customer.index.label.resend_registmail'|trans }}">
                                                             <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#discontinuance_cus_{{ Customer.id }}">
                                                                 <i class="fa fa-send fa-lg text-secondary" aria-hidden="true"></i>
                                                             </a>
@@ -395,7 +395,7 @@ file that was distributed with this source code.
                                                             </div>
                                                         </div>
                                                     {% endif %}
-                                                    <div class="col-auto text-center" data-toggle="tooltip"
+                                                    <div class="col-auto text-center" data-tooltip="true"
                                                          data-placement="top"
                                                          title="{{ 'admin.customer.index.delete'|trans }}">
                                                         <a class="btn btn-ec-actionIcon" data-toggle="modal"

--- a/src/Eccube/Resource/template/admin/Order/csv_shipping.twig
+++ b/src/Eccube/Resource/template/admin/Order/csv_shipping.twig
@@ -65,7 +65,7 @@ file that was distributed with this source code.
             <div class="c-primaryCol">
                 <div class="card rounded border-0 mb-4">
                     <div class="card-header">
-                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="" data-original-title="Tooltip">
+                        <div class="d-inline-block" data-tooltip="true" data-placement="top" title="" data-original-title="Tooltip">
                             <span>{{'admin.shipping.csv_shipping.title_csv_upload'|trans}}</span>
                             <i class="fa fa-question-circle fa-lg fa-lg ml-1"></i>
                         </div>
@@ -98,7 +98,7 @@ file that was distributed with this source code.
                     <div class="card-header">
                         <div class="row justify-content-between">
                             <div class="col-6">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="" data-original-title="Tooltip">
+                                <div class="d-inline-block" data-tooltip="true" data-placement="top" title="" data-original-title="Tooltip">
                                     <span class="align-middle">{{ 'admin.shipping.csv_shipping.title_csv_format'|trans }}</span>
                                     <i class="fa fa-question-circle fa-lg fa-lg ml-1"></i>
                                 </div>

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -177,7 +177,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.edit.label.order'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.edit.label.order'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col-4 text-right"><a data-toggle="collapse" href="#orderOverview" aria-expanded="false" aria-controls="orderOverview"><i class="fa fa-angle-up fa-lg"></i></a></div>
                             </div>
@@ -191,7 +191,7 @@ file that was distributed with this source code.
                                             <div class="col">{{ Order.order_no }}</div>
                                         </div>
                                         <div class="row mb-3 form-group">
-                                            <label class="col-3 col-form-label">{{ 'admin.order.index.298'|trans }}<i class="fa fa-question-circle fa-lg ml-1" data-toggle="tooltip" data-placement="top" title="Tooltip"></i></label>
+                                            <label class="col-3 col-form-label">{{ 'admin.order.index.298'|trans }}<i class="fa fa-question-circle fa-lg ml-1" data-tooltip="true" data-placement="top" title="Tooltip"></i></label>
                                             <div class="col">
                                                 {% if Order.id is not empty %}
                                                     {{ form_widget(form.OrderStatus) }}
@@ -270,7 +270,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-2">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.edit.label.customer_info'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.edit.label.customer_info'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col">{% if id %}<span class="mr-5">{% if form.Customer.vars.value is empty %}{{ 'admin.order.edit.256'|trans }}{% else %}<a href="{{ url('admin_customer_edit', {'id': form.Customer.vars.value}) }}">{{ form.Customer.vars.value }}</a>{% endif %}</span>{{ Order.full_name }} ({{ Order.full_name_kana }}) 〒{{ Order.postal_code }} {{ Order.pref }}{{ Order.addr01 }}{{ Order.addr02 }} {{ Order.email }}{% endif %}</div>
                                 <div class="col-1 text-right"><a class="d-block" data-toggle="collapse" href="#ordererInfo" aria-expanded="false" aria-controls="ordererInfo"><i class="fa {{ id ? 'fa-angle-down' : 'fa-angle-up' }} fa-lg"></i></a></div>
@@ -304,7 +304,7 @@ file that was distributed with this source code.
                                 <div class="row">
                                     <div class="col-6">
                                         <div class="row">
-                                            <label class="col-3">{{ 'admin.order.edit.customer_id'|trans }}<i class="fa fa-question-circle fa-lg ml-1" data-toggle="tooltip" data-placement="top" title="Tooltip"></i></label>
+                                            <label class="col-3">{{ 'admin.order.edit.customer_id'|trans }}<i class="fa fa-question-circle fa-lg ml-1" data-tooltip="true" data-placement="top" title="Tooltip"></i></label>
                                             <div class="col">
                                                 <p id="order_CustomerId">{% if form.Customer.vars.value is empty %}{{ 'admin.order.edit.256'|trans }}{% else %}<a href="{{ url('admin_customer_edit', {'id': form.Customer.vars.value}) }}">{{ form.Customer.vars.value }}</a>{% endif %}</p>
                                                 {{ form_widget(form.Customer) }}
@@ -412,7 +412,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.shipping.edit.730'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.shipping.edit.730'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col-4 text-right"><a data-toggle="collapse" href="#shippingInfo" aria-expanded="false" aria-controls="shippingInfo"><i class="fa fa-angle-up fa-lg"></i></a></div>
                             </div>
@@ -576,7 +576,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.edit.label.product_info'|trans }}<i class="fa fa-question-circle fa-lg ml-1"></i></span></div>
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.edit.label.product_info'|trans }}<i class="fa fa-question-circle fa-lg ml-1"></i></span></div>
                                 </div>
                                 <div class="col-4 text-right"><a data-toggle="collapse" href="#orderItem" aria-expanded="false" aria-controls="orderItem"><i class="fa fa-angle-up fa-lg"></i></a></div>
                             </div>
@@ -823,7 +823,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.common.label.memo'|trans }}<i class="fa fa-question-circle fa-lg ml-1"></i></span></div>
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.common.label.memo'|trans }}<i class="fa fa-question-circle fa-lg ml-1"></i></span></div>
                                 </div>
                                 <div class="col-4 text-right"><a data-toggle="collapse" href="#freeArea" aria-expanded="false" aria-controls="freeArea"><i class="fa fa-angle-up fa-lg"></i></a></div>
                             </div>

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -578,11 +578,11 @@ file that was distributed with this source code.
                                                 </td>
                                                 <td class="align-middle text-center">
                                                     {% if Order.message is not empty %}
-                                                        <a class="btn btn-ec-actionIcon" href="{{ url('admin_order_edit', { id : Order.id }) }}#order_message" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{ Order.message }}" aria-describedby="tooltip819464">
+                                                        <a class="btn btn-ec-actionIcon" href="{{ url('admin_order_edit', { id : Order.id }) }}#order_message" data-tooltip="true" data-placement="top" title="" data-original-title="{{ Order.message }}" aria-describedby="tooltip819464">
                                                             <i class="fa fa-commenting fa-lg text-secondary" aria-hidden="true"></i>
                                                         </a>
                                                     {% elseif Order.note is not empty %}
-                                                        <a class="btn btn-ec-actionIcon" href="{{ url('admin_order_edit', { id : Order.id }) }}#order_note" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{ Order.note }}" aria-describedby="tooltip819464">
+                                                        <a class="btn btn-ec-actionIcon" href="{{ url('admin_order_edit', { id : Order.id }) }}#order_note" data-tooltip="true" data-placement="top" title="" data-original-title="{{ Order.note }}" aria-describedby="tooltip819464">
                                                             <i class="fa fa-commenting fa-lg text-secondary" aria-hidden="true"></i>
                                                         </a>
                                                     {% endif %}
@@ -601,7 +601,7 @@ file that was distributed with this source code.
                                                     {% endif %}
                                                     {% if Shipping.mail_send_date %}
                                                         {% set send_mail_date = Shipping.mail_send_date|date_min %}
-                                                        <i class="fa fa-envelope fa-lg text-secondary" aria-hidden="true" data-toggle="tooltip" data-placement="top" data-original-title="{{ 'admin.order.index.send_mail_date'|trans({'%date%': send_mail_date}) }}"></i>
+                                                        <i class="fa fa-envelope fa-lg text-secondary" aria-hidden="true" data-tooltip="true" data-placement="top" data-original-title="{{ 'admin.order.index.send_mail_date'|trans({'%date%': send_mail_date}) }}"></i>
                                                     {% endif %}
                                                 </td>
                                                 <td class="align-middle text-center">
@@ -629,7 +629,7 @@ file that was distributed with this source code.
                                                             </a>
                                                         </div>
                                                         <div class="col-auto text-center">
-                                                            <a class="btn btn-ec-actionIcon pdf-print" href="{{ url('admin_order_export_pdf') }}?ids[]={{ Shipping.id }}" data-toggle="tooltip" data-placement="top" title data-original-title="{{ 'admin.order.index.btn_form'|trans }}">
+                                                            <a class="btn btn-ec-actionIcon pdf-print" href="{{ url('admin_order_export_pdf') }}?ids[]={{ Shipping.id }}" data-tooltip="true" data-placement="top" title data-original-title="{{ 'admin.order.index.btn_form'|trans }}">
                                                                 <i class="fa fa-table fa-lg text-secondary" aria-hidden="true"></i>
                                                             </a>
                                                         </div>
@@ -639,7 +639,7 @@ file that was distributed with this source code.
                                                                data-update-status-id="{{ constant('Eccube\\Entity\\Master\\OrderStatus::DELIVERED') }}"
                                                                data-update-status-url="{{ url('admin_shipping_update_order_status', { id: Shipping.id}) }}"
                                                                data-preview-notify-mail-url="{{ url('admin_shipping_preview_notify_mail', { id: Shipping.id}) }}"
-                                                               data-toggle="tooltip" data-placement="top" title data-original-title="{{ '出荷済にする'|trans }}">
+                                                               data-tooltip="true" data-placement="top" title data-original-title="{{ '出荷済にする'|trans }}">
                                                                 <i class="fa fa-check fa-lg text-secondary" aria-hidden="true"></i>
                                                             </a>
                                                         </div>

--- a/src/Eccube/Resource/template/admin/Order/mail.twig
+++ b/src/Eccube/Resource/template/admin/Order/mail.twig
@@ -69,7 +69,7 @@ $(function() {
                 <div class="card-header">
                     <div class="row">
                         <div class="col-8">
-                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.mail.349'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                            <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span class="card-title">{{ 'admin.order.mail.349'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                         </div>
                         <div class="col-4 text-right"><a data-toggle="collapse" href="#mailTo" aria-expanded="false" aria-controls="mailTo"><i class="fa fa-angle-up fa-lg"></i></a></div>
                     </div>
@@ -149,7 +149,7 @@ $(function() {
                     <div class="card-body">
                         <div class="row mb-2">
                             <div class="col-3">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'admin.order.mail.358'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i><span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></div>
+                                <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span>{{ 'admin.order.mail.358'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i><span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></div>
                             </div>
                             <div class="col">
                                 {{ form_widget(form.template, {'id': 'template-change'}) }}

--- a/src/Eccube/Resource/template/admin/Order/mail_all.twig
+++ b/src/Eccube/Resource/template/admin/Order/mail_all.twig
@@ -62,7 +62,7 @@ $(function() {
                         <div class="card-body">
                             <div class="row mb-2">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'admin.order.mail.358'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i><span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></div>
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span>{{ 'admin.order.mail.358'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i><span class="badge badge-primary ml-1">{{ 'common.text.message.required'|trans }}</span></div>
                                 </div>
                                 <div class="col">
                                     {{ form_widget(form.template, {'id': 'template-change'}) }}

--- a/src/Eccube/Resource/template/admin/Order/shipping.twig
+++ b/src/Eccube/Resource/template/admin/Order/shipping.twig
@@ -275,7 +275,7 @@ file that was distributed with this source code.
                             <div class="card-header">
                                 <div class="row">
                                     <div class="col-8">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                              title="Tooltip">
                                             <span class="card-title">{{ 'admin.shipping.edit.description_title'|trans }}{{ loop.index }}</span>
                                             <i class="fa fa-question-circle fa-lg ml-1" aria-hidden="true"></i>
@@ -506,7 +506,7 @@ file that was distributed with this source code.
                                                            data-update-status-id="{{ constant('Eccube\\Entity\\Master\\OrderStatus::DELIVERED') }}"
                                                            data-update-status-url="{{ url('admin_shipping_update_order_status', { id: shippingForm.vars.value.id}) }}"
                                                            data-preview-notify-mail-url="{{ url('admin_shipping_preview_notify_mail', { id: shippingForm.vars.value.id}) }}"
-                                                           data-toggle="tooltip" data-placement="top" title data-original-title="{{ '出荷済にする'|trans }}">
+                                                           data-tooltip="true" data-placement="top" title data-original-title="{{ '出荷済にする'|trans }}">
                                                             <i class="fa fa-check fa-lg text-secondary" aria-hidden="true"></i>
                                                             出荷完了にする
                                                         </button>

--- a/src/Eccube/Resource/template/admin/Product/category.twig
+++ b/src/Eccube/Resource/template/admin/Product/category.twig
@@ -225,32 +225,32 @@ file that was distributed with this source code.
                                                     </div>
                                                     <div class="col-auto text-right">
                                                         <a class="btn btn-ec-actionIcon action-up mr-3 {% if loop.first %} disabled {% endif %}" href=""
-                                                           data-toggle="tooltip" data-placement="top"
+                                                           data-tooltip="true" data-placement="top"
                                                            title="{{ 'admin.product.category.up'|trans }}">
                                                             <i class="fa fa-arrow-up fa-lg text-secondary"></i>
                                                         </a>
                                                         <a class="btn btn-ec-actionIcon action-down mr-3 {% if loop.last %} disabled {% endif %}" href=""
-                                                           data-toggle="tooltip" data-placement="top"
+                                                           data-tooltip="true" data-placement="top"
                                                            title="{{ 'admin.product.category.down'|trans }}">
                                                             <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                                         </a>
                                                         <a class="btn btn-ec-actionIcon mr-3 action-edit"
                                                            href="{{ url('admin_product_category_edit', {id: Category.id}) }}"
-                                                           data-toggle="tooltip" data-placement="top"
+                                                           data-tooltip="true" data-placement="top"
                                                            title="{{ 'admin.product.category.rename'|trans }}">
                                                             <i class="fa fa-pencil fa-lg text-secondary"></i>
                                                         </a>
                                                         {% if Category.Children|length > 0 or Category.hasProductCategories %}
                                                             {# TODO: Need fix css for tooltip to work (currently using `disabled` class) #}
                                                             <a class="btn btn-ec-actionIcon mr-3 disabled"
-                                                               data-toggle="tooltip" data-placement="top"
+                                                               data-tooltip="true" data-placement="top"
                                                                title="{{ 'admin.product.category.text01'|trans }}">
                                                                 <i class="fa fa-close fa-lg text-secondary"></i>
                                                             </a>
                                                         {% else %}
                                                             <a class="btn btn-ec-actionIcon mr-3"
                                                                href="{{ url('admin_product_category_delete', {id: Category.id}) }}"
-                                                               data-toggle="tooltip" data-placement="top"
+                                                               data-tooltip="true" data-placement="top"
                                                                title="{{ 'admin.product.category.410'|trans }}" {{ csrf_token_for_anchor() }}
                                                                data-method="delete">
                                                                 <i class="fa fa-close fa-lg text-secondary"></i>

--- a/src/Eccube/Resource/template/admin/Product/class_category.twig
+++ b/src/Eccube/Resource/template/admin/Product/class_category.twig
@@ -166,13 +166,13 @@ file that was distributed with this source code.
                                             <div class="col-auto d-flex align-items-center"><i class="fa fa-bars text-ec-gray"></i></div>
                                             <div class="col d-flex align-items-center">{{ ClassCategory.name }}</div>
                                             <div class="col-auto text-right">
-                                                <a class="btn btn-ec-actionIcon mr-3 action-up {% if loop.first %}disabled{% endif %}" href="" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_category.430'|trans }}">
+                                                <a class="btn btn-ec-actionIcon mr-3 action-up {% if loop.first %}disabled{% endif %}" href="" data-tooltip="true" data-placement="top" title="{{ 'admin.product.class_category.430'|trans }}">
                                                     <i class="fa fa-arrow-up fa-lg text-secondary"></i>
                                                 </a>
-                                                <a class="btn btn-ec-actionIcon mr-3 action-down {% if loop.last %}disabled{% endif %}" href="" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_category.431'|trans }}">
+                                                <a class="btn btn-ec-actionIcon mr-3 action-down {% if loop.last %}disabled{% endif %}" href="" data-tooltip="true" data-placement="top" title="{{ 'admin.product.class_category.431'|trans }}">
                                                     <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                                 </a>
-                                                <a class="btn btn-ec-actionIcon mr-3 action-edit" href="" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_category.432'|trans }}">
+                                                <a class="btn btn-ec-actionIcon mr-3 action-edit" href="" data-tooltip="true" data-placement="top" title="{{ 'admin.product.class_category.432'|trans }}">
                                                     <i class="fa fa-pencil fa-lg text-secondary"></i>
                                                 </a>
                                                 <a class="btn btn-ec-actionIcon mr-3" data-tooltip="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}" data-toggle="modal" data-target="#delete_{{ ClassCategory.id }}">

--- a/src/Eccube/Resource/template/admin/Product/class_name.twig
+++ b/src/Eccube/Resource/template/admin/Product/class_name.twig
@@ -161,13 +161,13 @@ file that was distributed with this source code.
                                                 <a href="{{ url('admin_product_class_category', {class_name_id : ClassName.id }) }}">{{ ClassName.name }}［{{ 'admin.product.class_name.444'|trans }}{{ ClassName.backend_name }}］ ({{ ClassName.ClassCategories|length }})</a>
                                             </div>
                                             <div class="col-auto text-right">
-                                                <a class="btn btn-ec-actionIcon mr-3 up {% if loop.first %}disabled{% endif %}" href="" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_name.439'|trans }}">
+                                                <a class="btn btn-ec-actionIcon mr-3 up {% if loop.first %}disabled{% endif %}" href="" data-tooltip="true" data-placement="top" title="{{ 'admin.product.class_name.439'|trans }}">
                                                     <i class="fa fa-arrow-up fa-lg text-secondary"></i>
                                                 </a>
-                                                <a class="btn btn-ec-actionIcon mr-3 down {% if loop.last %}disabled{% endif %}" href="" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_name.440'|trans }}">
+                                                <a class="btn btn-ec-actionIcon mr-3 down {% if loop.last %}disabled{% endif %}" href="" data-tooltip="true" data-placement="top" title="{{ 'admin.product.class_name.440'|trans }}">
                                                     <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                                 </a>
-                                                <a class="btn btn-ec-actionIcon mr-3 action-edit" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_name.441'|trans }}">
+                                                <a class="btn btn-ec-actionIcon mr-3 action-edit" data-tooltip="true" data-placement="top" title="{{ 'admin.product.class_name.441'|trans }}">
                                                     <i class="fa fa-pencil fa-lg text-secondary"></i>
                                                 </a>
                                                 {% set classCategories = ClassName.ClassCategories|length %}

--- a/src/Eccube/Resource/template/admin/Product/csv_category.twig
+++ b/src/Eccube/Resource/template/admin/Product/csv_category.twig
@@ -63,7 +63,7 @@ file that was distributed with this source code.
             <div class="c-primaryCol">
                 <div class="card rounded border-0 mb-4">
                     <div class="card-header">
-                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'admin.product.csv_category.csv_file_upload'|trans }}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
+                        <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span>{{ 'admin.product.csv_category.csv_file_upload'|trans }}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
                     </div>
                     <div id="ex-csv_category-upload" class="card-body">
                         <div class="row">
@@ -91,7 +91,7 @@ file that was distributed with this source code.
                     <div class="card-header">
                         <div class="row justify-content-between">
                             <div class="col-6">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span class="align-middle">{{ 'admin.product.csv_category.category_csv_format'|trans }}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
+                                <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span class="align-middle">{{ 'admin.product.csv_category.category_csv_format'|trans }}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
                             </div>
                             <div class="col-4 text-right">
                                 <a href="{{ url('admin_product_csv_template', {'type': 'category'}) }}" class="btn btn-ec-regular" id="download-button">{{ 'admin.product.csv_category.download'|trans }}</a>

--- a/src/Eccube/Resource/template/admin/Product/csv_product.twig
+++ b/src/Eccube/Resource/template/admin/Product/csv_product.twig
@@ -57,7 +57,7 @@ file that was distributed with this source code.
             <div class="c-primaryCol">
                 <div class="card rounded border-0 mb-4">
                     <div class="card-header">
-                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.csv_product.upload_header.tooltip'|trans }}"><span>{{ 'admin.product.csv_product.upload_header'|trans }}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
+                        <div class="d-inline-block" data-tooltip="true" data-placement="top" title="{{ 'admin.product.csv_product.upload_header.tooltip'|trans }}"><span>{{ 'admin.product.csv_product.upload_header'|trans }}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
                     </div>
                     <div id="ex-csv_product-upload" class="card-body">
                         <div class="row">
@@ -82,7 +82,7 @@ file that was distributed with this source code.
                     <div class="card-header">
                         <div class="row justify-content-between">
                             <div class="col-6">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.csv_product.format_header.tooltip'|trans }}"><span class="align-middle">{{ 'admin.product.csv_product.format_header'|trans }}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
+                                <div class="d-inline-block" data-tooltip="true" data-placement="top" title="{{ 'admin.product.csv_product.format_header.tooltip'|trans }}"><span class="align-middle">{{ 'admin.product.csv_product.format_header'|trans }}</span><i class="fa fa-question-circle fa-lg fa-lg ml-1"></i></div>
                             </div>
                             <div class="col-4 text-right">
                                 <a href="{{ url('admin_product_csv_template', {'type': 'product'}) }}" class="btn btn-ec-regular" id="download-button">{{ 'admin.product.csv_product.download_template_button'|trans }}</a>

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -217,7 +217,7 @@ file that was distributed with this source code.
                     </div>
                     <div class="col-6">
                         <div class="mb-2">
-                            <label class="col-form-label" data-toggle="tooltip" data-placement="top" title="Tooltip">
+                            <label class="col-form-label" data-tooltip="true" data-placement="top" title="Tooltip">
                                 {{ 'admin.product.index.473'|trans }}
                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
                             </label>
@@ -412,14 +412,14 @@ file that was distributed with this source code.
                                             </td>
                                             <td class="align-middle pr-3" colspan="3">
                                                 <div class="row">
-                                                    <div class="col text-center" data-toggle="tooltip"
+                                                    <div class="col text-center" data-tooltip="true"
                                                          data-placement="top"
                                                          title="{{ 'admin.product.index.display'|trans }}"><a class="btn btn-ec-actionIcon"
                                                                                                               href="{{ url('product_detail', {id:Product.id}) }}"
                                                                                                               target="_blank"><i
                                                                     class="fa fa-eye fa-lg text-secondary"
                                                                     aria-hidden="true"></i></a></div>
-                                                    <div class="col text-center" data-toggle="tooltip"
+                                                    <div class="col text-center" data-tooltip="true"
                                                          data-placement="top"
                                                          title="{{ 'admin.product.index.duplicate'|trans }}">
                                                         <a href="#" class="btn btn-ec-actionIcon"
@@ -462,7 +462,7 @@ file that was distributed with this source code.
                                                             </div>
                                                         </div>
                                                     </div>
-                                                    <div class="col text-center" data-toggle="tooltip"
+                                                    <div class="col text-center" data-tooltip="true"
                                                          data-placement="top"
                                                          title="{{ 'admin.product.index.abolition'|trans }}"><a class="btn btn-ec-actionIcon" data-toggle="modal"
                                                                                                                 data-target="#discontinuance_{{ Product.id }}"><i

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -289,7 +289,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                          title="Tooltip">
                                     <span class="card-title">
                                         {{ 'admin.product.product.basic_configuration'|trans }}
@@ -309,7 +309,7 @@ file that was distributed with this source code.
                             <div class="card-body">
                                 <div class="row">
                                     <div class="col-3">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                              title="Tooltip">
                                             <span>{{ 'admin.product.product.500'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -323,7 +323,7 @@ file that was distributed with this source code.
                                 </div>
                                 <div class="row">
                                     <div class="col-3">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                              title="Tooltip">
                                             <span>{{ 'admin.product.product.name'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -340,7 +340,7 @@ file that was distributed with this source code.
                                 {% if has_class == false %}
                                     <div class="row">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.sale_type'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -356,7 +356,7 @@ file that was distributed with this source code.
                                 {% endif %}
                                 <div class="row">
                                     <div class="col-3">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                              title="Tooltip">
                                             <span>{{ 'admin.product.product.image'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -384,7 +384,7 @@ file that was distributed with this source code.
                                 </div>
                                 <div class="row">
                                     <div class="col-3">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                              title="Tooltip">
                                             <span>{{ 'admin.product.product.description'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -407,7 +407,7 @@ file that was distributed with this source code.
                                 <div class="collapse ec-collapse" id="addComment">
                                     <div class="row bg-ec-formGray pt-3 mb-2">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.description_list'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -424,7 +424,7 @@ file that was distributed with this source code.
                                 {% if has_class == false %}
                                     <div class="row">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.price02'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -442,7 +442,7 @@ file that was distributed with this source code.
                                     </div>
                                     <div class="row">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.price01'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -457,7 +457,7 @@ file that was distributed with this source code.
                                     </div>
                                     <div class="row">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.stock'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -489,7 +489,7 @@ file that was distributed with this source code.
                                 {% endif %}
                                 <div class="row">
                                     <div class="col-3">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                              title="Tooltip">
                                             <span>{{ 'admin.product.product.search_word'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -508,7 +508,7 @@ file that was distributed with this source code.
                                 {% if has_class == false %}
                                     <div class="row">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.code'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -523,7 +523,7 @@ file that was distributed with this source code.
                                     </div>
                                     <div class="row">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.sale_limit'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -538,7 +538,7 @@ file that was distributed with this source code.
                                     </div>
                                     <div class="row">
                                         <div class="col-3">
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                            <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                                  title="Tooltip">
                                                 <span>{{ 'admin.product.product.delivery_duration'|trans }}</span>
                                                 <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -555,7 +555,7 @@ file that was distributed with this source code.
                                     {% if BaseInfo.option_product_delivery_fee %}
                                         <div class="row">
                                             <div class="col-3">
-                                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                                <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                                      title="Tooltip">
                                                     <span>{{ 'admin.product.product.delivery_fee'|trans }}</span>
                                                     <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -572,7 +572,7 @@ file that was distributed with this source code.
                                     {% if BaseInfo.option_product_tax_rule %}
                                         <div class="row">
                                             <div class="col-3">
-                                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                                <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                                      title="Tooltip">
                                                     <span>{{ 'admin.product.product.tax_rate'|trans }}</span>
                                                     <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -637,7 +637,7 @@ file that was distributed with this source code.
                             <div class="card-header">
                                 <div class="row">
                                     <div class="col-8">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                              title="Tooltip">
                                         <span class="card-title">
                                             {{ 'admin.product.product.511'|trans }}
@@ -656,7 +656,7 @@ file that was distributed with this source code.
                             <div class="collapse show ec-cardCollapse" id="standardConfig">
                                 <div class="card-body">
                                     {% if has_class == true %}
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                        <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                              title="Tooltip">
                                             <span>{{ 'admin.product.product.text03'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -699,7 +699,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                          title="Tooltip">
                                         <span class="card-title">{{ 'admin.product.product.508'|trans }}</span>
                                         <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -751,7 +751,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                          title="Tooltip">
                                         <span class="card-title">{{ 'admin.product.product.category'|trans }}</span>
                                         <i class="fa fa-question-circle fa-lg ml-1"></i>
@@ -820,7 +820,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                          title="Tooltip">
                                         <span class="card-title">
                                             {{ 'admin.product.product.tag'|trans }}
@@ -930,7 +930,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                          title="Tooltip">
                                         <span class="card-title">
                                             {{ 'admin.product.product.523'|trans }}

--- a/src/Eccube/Resource/template/admin/Product/tag.twig
+++ b/src/Eccube/Resource/template/admin/Product/tag.twig
@@ -152,13 +152,13 @@ file that was distributed with this source code.
                                             <div class="col d-flex align-items-center"><a>{{ Tag.name }}</a>
                                             </div>
                                             <div class="col-auto text-right">
-                                                <a class="btn btn-ec-actionIcon mr-3 action-up{% if loop.first %} disabled{% endif %}" href="#" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.tag.up'|trans }}">
+                                                <a class="btn btn-ec-actionIcon mr-3 action-up{% if loop.first %} disabled{% endif %}" href="#" data-tooltip="true" data-placement="top" title="{{ 'admin.product.tag.up'|trans }}">
                                                     <i class="fa fa-arrow-up fa-lg text-secondary"></i>
                                                 </a>
-                                                <a class="btn btn-ec-actionIcon mr-3 action-down{% if loop.last %} disabled{% endif %}" href="#" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.tag.down'|trans }}">
+                                                <a class="btn btn-ec-actionIcon mr-3 action-down{% if loop.last %} disabled{% endif %}" href="#" data-tooltip="true" data-placement="top" title="{{ 'admin.product.tag.down'|trans }}">
                                                     <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                                 </a>
-                                                <a class="btn btn-ec-actionIcon mr-3 action-edit" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.tag.edit'|trans }}">
+                                                <a class="btn btn-ec-actionIcon mr-3 action-edit" data-tooltip="true" data-placement="top" title="{{ 'admin.product.tag.edit'|trans }}">
                                                     <i class="fa fa-pencil fa-lg text-secondary"></i>
                                                 </a>
                                                 <a class="btn btn-ec-actionIcon mr-3" data-toggle="modal" data-target="#confirmModal-{{ Tag.id }}" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.product.tag.delete'|trans }}">

--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery.twig
@@ -108,13 +108,13 @@ file that was distributed with this source code.
                                                         </a>
                                                     </div>
                                                     <div class="col-auto text-right">
-                                                        <a href="#" class="btn btn-ec-actionIcon mr-3 action-up {% if loop.first %}disabled{% endif %}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.common.label.move.up'|trans }}">
+                                                        <a href="#" class="btn btn-ec-actionIcon mr-3 action-up {% if loop.first %}disabled{% endif %}" data-tooltip="true" data-placement="top" title="{{ 'admin.common.label.move.up'|trans }}">
                                                             <i class="fa fa-arrow-up fa-lg text-secondary"></i>
                                                         </a>
-                                                        <a href="#" class="btn btn-ec-actionIcon mr-3 action-down {% if loop.last %}disabled{% endif %}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.common.label.move.down'|trans }}">
+                                                        <a href="#" class="btn btn-ec-actionIcon mr-3 action-down {% if loop.last %}disabled{% endif %}" data-tooltip="true" data-placement="top" title="{{ 'admin.common.label.move.down'|trans }}">
                                                             <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                                         </a>
-                                                        <a href="{{ url('admin_setting_shop_delivery_delete', {id: Delivery.Id} ) }}" class="btn btn-ec-actionIcon mr-3" data-toggle="tooltip" data-placement="top" title="{{ 'admin.common.label.delete'|trans }}" {{ csrf_token_for_anchor() }} data-method="delete">
+                                                        <a href="{{ url('admin_setting_shop_delivery_delete', {id: Delivery.Id} ) }}" class="btn btn-ec-actionIcon mr-3" data-tooltip="true" data-placement="top" title="{{ 'admin.common.label.delete'|trans }}" {{ csrf_token_for_anchor() }} data-method="delete">
                                                             <i class="fa fa-close fa-lg text-secondary"></i>
                                                         </a>
                                                     </div>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery_edit.twig
@@ -221,7 +221,7 @@ file that was distributed with this source code.
                             </div>
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                          title="Tooltip">
                                         <span>{{ 'admin.setting.shop.delivery_edit.slip_number_url'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
@@ -294,7 +294,7 @@ file that was distributed with this source code.
                                 <li class="list-group-item">
                                     <div class="row justify-content-start">
                                         <div class="col-2">
-                                            <div class="d-inline-block align-middle" data-toggle="tooltip"
+                                            <div class="d-inline-block align-middle" data-tooltip="true"
                                                  data-placement="top" title="Tooltip"><span
                                                         class="card-title">{{ 'admin.setting.shop.delivery_edit.delivery_fees_all_pref'|trans }}</span><i
                                                         class="fa fa-question-circle fa-lg ml-1"></i></div>
@@ -330,7 +330,7 @@ file that was distributed with this source code.
                         <div id="ex-delivery-shop" class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                          title="Tooltip">
                                     <span class="card-title">{{ 'admin.setting.shop.delivery_edit.note'|trans }}<i
                                                 class="fa fa-question-circle fa-lg ml-1"></i></span></div>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery_time_prototype.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery_time_prototype.twig
@@ -17,19 +17,19 @@ file that was distributed with this source code.
             <a class="display-label">{% if form.vars.value == '' %}__value__{% else %}{{ form.vars.value }}{% endif %}</a>
         </div>
         <div class="col-auto text-right">
-            <a class="btn btn-ec-actionIcon mr-3 action-up" href="" data-toggle="tooltip"
+            <a class="btn btn-ec-actionIcon mr-3 action-up" href="" data-tooltip="true"
                data-placement="top" title="{{ 'admin.setting.shop.delivery_edit.delivery_time_up'|trans }}">
                 <i class="fa fa-arrow-up fa-lg text-secondary"></i>
             </a>
-            <a class="btn btn-ec-actionIcon mr-3 action-down" href="" data-toggle="tooltip"
+            <a class="btn btn-ec-actionIcon mr-3 action-down" href="" data-tooltip="true"
                data-placement="top" title="{{ 'admin.setting.shop.delivery_edit.delivery_time_down'|trans }}">
                 <i class="fa fa-arrow-down fa-lg text-secondary"></i>
             </a>
-            <a class="btn btn-ec-actionIcon mr-3 action-edit" href="" data-toggle="tooltip"
+            <a class="btn btn-ec-actionIcon mr-3 action-edit" href="" data-tooltip="true"
                data-placement="top" title="{{ 'admin.setting.shop.delivery_edit.delivery_time_edit'|trans }}">
                 <i class="fa fa-pencil fa-lg text-secondary"></i>
             </a>
-            <a class="btn btn-ec-actionIcon mr-3 remove-delivery-time-item" href="" data-toggle="tooltip"
+            <a class="btn btn-ec-actionIcon mr-3 remove-delivery-time-item" href="" data-tooltip="true"
                data-placement="top" title="{{ 'admin.setting.shop.delivery_edit.delivery_time_remove'|trans }}">
                 <i class="fa fa-close fa-lg text-secondary"></i>
             </a>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
@@ -144,17 +144,17 @@ file that was distributed with this source code.
                                         </div>
                                         <div class="col-3 text-right">
                                             <div class="row">
-                                                <div class="col text-center" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.608'|trans }}">
-                                                    <a class="btn btn-ec-actionIcon mr-3 action-up{{ loop.first ? ' disabled' }}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.608'|trans }}">
+                                                <div class="col text-center" data-tooltip="true" data-placement="top" title="{{ 'admin.setting.shop.payment.608'|trans }}">
+                                                    <a class="btn btn-ec-actionIcon mr-3 action-up{{ loop.first ? ' disabled' }}" data-tooltip="true" data-placement="top" title="{{ 'admin.setting.shop.payment.608'|trans }}">
                                                         <i class="fa fa-arrow-up fa-lg text-secondary"></i>
                                                     </a>
                                                 </div>
-                                                <div class="col text-center" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.609'|trans }}">
-                                                    <a class="btn btn-ec-actionIcon mr-3 action-down{{ loop.last ? ' disabled' }}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.609'|trans }}">
+                                                <div class="col text-center" data-tooltip="true" data-placement="top" title="{{ 'admin.setting.shop.payment.609'|trans }}">
+                                                    <a class="btn btn-ec-actionIcon mr-3 action-down{{ loop.last ? ' disabled' }}" data-tooltip="true" data-placement="top" title="{{ 'admin.setting.shop.payment.609'|trans }}">
                                                         <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                                     </a>
                                                 </div>
-                                                <div class="col text-center" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.607'|trans }}">
+                                                <div class="col text-center" data-tooltip="true" data-placement="top" title="{{ 'admin.setting.shop.payment.607'|trans }}">
                                                     <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_{{ Payment.id }}">
                                                         <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
                                                     </a>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/payment_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/payment_edit.twig
@@ -173,7 +173,7 @@ file that was distributed with this source code.
 
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'paymentregister.label.logo_image.tooltip'|trans }}">
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="{{ 'paymentregister.label.logo_image.tooltip'|trans }}">
                                         <span>{{ 'paymentregister.label.logo_image'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i>
                                     </div>
                                 </div>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/shop_master.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/shop_master.twig
@@ -180,7 +180,7 @@ file that was distributed with this source code.
                         <div id="ex-shop-delivery" class="card-body">
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'common.label.option_delivery_fee_free_amount'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span>{{ 'common.label.option_delivery_fee_free_amount'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col-4 mb-2">
                                     {{ form_widget(form.delivery_free_amount) }}
@@ -190,7 +190,7 @@ file that was distributed with this source code.
                             </div>
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'common.label.option_delivery_free_quantity'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span>{{ 'common.label.option_delivery_free_quantity'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col-4 mb-2">
                                     {{ form_widget(form.delivery_free_quantity) }}
@@ -257,7 +257,7 @@ file that was distributed with this source code.
                         <div id="ex-shop-tax" class="card-body">
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'shopmaster.label.option_product_tax_rule'|trans }}</span></div>
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span>{{ 'shopmaster.label.option_product_tax_rule'|trans }}</span></div>
                                 </div>
                                 <div class="col mb-2">
                                     {{ form_widget(form.option_product_tax_rule) }}
@@ -278,7 +278,7 @@ file that was distributed with this source code.
                             </div>
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'shopmaster.label.basic_point_rate'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span>{{ 'shopmaster.label.basic_point_rate'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col mb-2">
                                     <div class="input-group col-4 pl-0">
@@ -292,7 +292,7 @@ file that was distributed with this source code.
                             </div>
                             <div class="row">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip"><span>{{ 'shopmaster.label.point_conversion_rate'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip"><span>{{ 'shopmaster.label.point_conversion_rate'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i></div>
                                 </div>
                                 <div class="col mb-2">
                                     <div class="input-group col-4 pl-0">

--- a/src/Eccube/Resource/template/admin/Setting/Shop/tax_rule.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/tax_rule.twig
@@ -177,11 +177,11 @@ file that was distributed with this source code.
                                         <td class="align-middle action">
                                             <div class="col-12 col-sm-10 col-md-8 col-lg-6 pull-right">
                                                 <div class="row pr-2">
-                                                    <div class="col-6 text-center pr-0"><a class="btn btn-ec-actionIcon edit-button" data-toggle="tooltip" data-id="{{ TaxRule.id }}" data-placement="top" title="{{ 'common.label.edit'|trans }}"><i class="fa fa-pencil fa-lg text-secondary" aria-hidden="true"></i></a></div>
+                                                    <div class="col-6 text-center pr-0"><a class="btn btn-ec-actionIcon edit-button" data-tooltip="true" data-id="{{ TaxRule.id }}" data-placement="top" title="{{ 'common.label.edit'|trans }}"><i class="fa fa-pencil fa-lg text-secondary" aria-hidden="true"></i></a></div>
 
                                                     <div class="col-6 text-center">
                                                         {% if not TaxRule.default_tax_rule %}
-                                                            <a class="btn btn-ec-actionIcon" data-toggle="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}" href="{{ url('admin_setting_shop_tax_delete', { id : TaxRule.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete">
+                                                            <a class="btn btn-ec-actionIcon" data-tooltip="true" data-placement="top" title="{{ 'common.label.delete'|trans }}" href="{{ url('admin_setting_shop_tax_delete', { id : TaxRule.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete">
                                                                 <i class="fa fa-times fa-lg text-secondary" aria-hidden="true"></i></a>
                                                         {% endif %}
                                                     </div>

--- a/src/Eccube/Resource/template/admin/Setting/System/member.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/member.twig
@@ -96,7 +96,7 @@ file that was distributed with this source code.
                                                 <div class="col-auto text-center">
                                                     <a class="btn btn-ec-actionIcon action-edit"
                                                        href="{{ url('admin_setting_system_member_edit', { 'id' : Member.id }) }}"
-                                                       data-toggle="tooltip"
+                                                       data-tooltip="true"
                                                        data-placement="top"
                                                        data-original-title="{{ 'admin.setting.system.member.691'|trans }}">
                                                         <i class="fa fa-pencil fa-lg text-secondary" aria-hidden="true"></i>
@@ -105,7 +105,7 @@ file that was distributed with this source code.
                                                 <div class="col-auto text-center">
                                                     <a class="btn btn-ec-actionIcon action-up {% if loop.first %} disabled {% endif %}"
                                                        href="{{ url('admin_setting_system_member_up', {id: Member.id}) }}"
-                                                       data-toggle="tooltip"
+                                                       data-tooltip="true"
                                                        data-method="put"
                                                        data-placement="top"
                                                        data-original-title="{{ 'admin.setting.system.member.694'|trans }}">
@@ -115,7 +115,7 @@ file that was distributed with this source code.
                                                 <div class="col-auto text-center">
                                                     <a class="btn btn-ec-actionIcon action-down {% if loop.last %} disabled {% endif %}"
                                                        href="{{ url('admin_setting_system_member_down', {id: Member.id}) }}"
-                                                       data-toggle="tooltip"
+                                                       data-tooltip="true"
                                                        data-method="put"
                                                        data-placement="top"
                                                        data-original-title="{{ 'admin.setting.system.member.695'|trans }}">
@@ -125,7 +125,7 @@ file that was distributed with this source code.
                                                 <div class="col-auto text-center">
                                                     {% if Member.id == app.user.id %}
                                                         <a class="btn btn-ec-actionIcon action-delete disabled"
-                                                           data-toggle="tooltip" data-placement="top"
+                                                           data-tooltip="true" data-placement="top"
                                                            data-original-title="{{ 'admin.setting.system.member.692'|trans }}">
                                                             <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
                                                         </a>

--- a/src/Eccube/Resource/template/admin/Setting/System/security.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/security.twig
@@ -39,7 +39,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip">
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip">
                                         <span class="card-title">{{ 'admin.setting.system.security.704'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i>
                                     </div>
                                 </div>
@@ -52,7 +52,7 @@ file that was distributed with this source code.
                             <div class="card-body">
                                 <div class="row mb-2">
                                     <div class="col-3">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip">
+                                        <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip">
                                             <span>{{ form_label(form.admin_route_dir) }}</span><i class="fa fa-question-circle fa-lg ml-1"></i>
                                         </div>
                                     </div>
@@ -63,7 +63,7 @@ file that was distributed with this source code.
                                 </div>
                                 <div class="row mb-2">
                                     <div class="col-3">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip">
+                                        <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip">
                                             <span>{{ form_label(form.admin_allow_hosts) }}</span><i class="fa fa-question-circle fa-lg ml-1"></i>
                                         </div>
                                     </div>
@@ -82,7 +82,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row mb-2">
                                 <div class="col-8">
-                                    <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip">
+                                    <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip">
                                         <span class="card-title">{{ 'admin.setting.system.security.709'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i>
                                     </div>
                                 </div>
@@ -95,7 +95,7 @@ file that was distributed with this source code.
                             <div class="card-body">
                                 <div class="row">
                                     <div class="col-3">
-                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip">
+                                        <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip">
                                             <span><label class="col-form-label col-sm-2 form-control-label">{{ form.force_ssl.vars.label|trans }}</label></span><i class="fa fa-question-circle fa-lg ml-1"></i>
                                         </div>
                                     </div>

--- a/src/Eccube/Resource/template/admin/Store/authentication_setting.twig
+++ b/src/Eccube/Resource/template/admin/Store/authentication_setting.twig
@@ -33,7 +33,7 @@ file that was distributed with this source code.
                                 <div class="col-sm-2">
                                     <div class="d-inline-block">
                                         <span>認証キー</span>
-                                        <i class="fa fa-question-circle fa-lg" data-toggle="tooltip" data-placement="top" title="Tooltip"></i>
+                                        <i class="fa fa-question-circle fa-lg" data-tooltip="true" data-placement="top" title="Tooltip"></i>
                                     </div>
                                 </div>
                                 <div class="col-sm-6">

--- a/src/Eccube/Resource/template/admin/index.twig
+++ b/src/Eccube/Resource/template/admin/index.twig
@@ -211,7 +211,7 @@ file that was distributed with this source code.
                     <div class="col-8 mb-4">
                         <div id="chart-statistics" class="card rounded border-0 h-100">
                             <div class="card-header">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip">
+                                <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip">
                                     <span class="card-title">{{ 'admin.index.summary.sales.situation'|trans }}</span>
                                     <i class="fa fa-question-circle fa-lg ml-1" aria-hidden="true"></i>
                                 </div>
@@ -278,7 +278,7 @@ file that was distributed with this source code.
                     <div class="col mb-4">
                         <div id="shop-statistical" class="card rounded border-0 h-100">
                             <div class="card-header">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top"
+                                <div class="d-inline-block" data-tooltip="true" data-placement="top"
                                      title="Tooltip">
                                     <span class="card-title">{{ 'admin.index.summary.shop.situation'|trans }}</span>
                                     <i class="fa fa-question-circle fa-lg ml-1" aria-hidden="true"></i>
@@ -336,7 +336,7 @@ file that was distributed with this source code.
                     <div class="col mb-4">
                         <div id="ec-cube-plugin" class="card rounded border-0 h-100">
                             <div class="card-header">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip">
+                                <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip">
                                     <span class="card-title">{{ 'admin.index.recommended.plugin'|trans }}</span>
                                 </div>
                             </div>
@@ -348,7 +348,7 @@ file that was distributed with this source code.
                     <div class="col mb-4">
                         <div id="ec-cube-news" class="card rounded border-0 h-100">
                             <div class="card-header">
-                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="Tooltip">
+                                <div class="d-inline-block" data-tooltip="true" data-placement="top" title="Tooltip">
                                     <span class="card-title">{{ 'admin.index.161'|trans }}</span>
                                 </div>
                             </div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#3334 を全体に適用しています

## 実装に関する補足(Appendix)

#3334のコメントにあるとおり、`data-tooltip="true"`で定義しています。

## テスト（Test)

- 既存のテストにパスすることを確認

## 相談（Discussion）

今回の修正の影響ではないですが、jquery uiを使用している画面でtooptipをマウスオーバーすると、以下のエラーが発生し、ツールチップが表示されません。jquery uiのバージョンが古いのかなという気がします。

※ #3527 にチケット作成済です。

```
Uncaught TypeError: r.getClientRects is not a function
    at w.fn.init.offset (jquery-3.3.1.min.js:2)
    at Object.getWithinInfo (jquery-ui.min.js:6)
    at w.fn.init.e.fn.position (jquery-ui.min.js:6)
    at e.(anonymous function).(anonymous function)._open (https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js:13:10346)
    at e.(anonymous function).(anonymous function)._open (https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js:6:7987)
    at e.(anonymous function).(anonymous function)._updateContent (https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js:13:9680)
    at e.(anonymous function).(anonymous function)._updateContent (https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js:6:7987)
    at e.(anonymous function).(anonymous function).open (https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js:13:9414)
    at e.(anonymous function).(anonymous function).open (https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js:6:7987)
    at HTMLDivElement.r (jquery-ui.min.js:6)
```

