### PR TITLE
fix ページ管理 右上のページ検索は画面内検索のためformタグを削除

### DIFF
--- a/src/Eccube/Resource/template/admin/Content/page.twig
+++ b/src/Eccube/Resource/template/admin/Content/page.twig
@@ -60,18 +60,16 @@ file that was distributed with this source code.
                         </a>
                     </div>
                     <div class="col-3">
-                        <form class="mb-2">
-                            <div class="form-row">
-                                <div class="col">
-                                    <div class="input-group mb-3">
-                                        <div class="input-group-prepend">
-                                            <span class="input-group-text" id="basic-addon1"><i class="fa fa-search"></i></span>
-                                        </div>
-                                        <input id="search-page" class="form-control" type="search" aria-label="Search">
+                        <div class="form-row">
+                            <div class="col">
+                                <div class="input-group mb-3">
+                                    <div class="input-group-prepend">
+                                        <span class="input-group-text" id="basic-addon1"><i class="fa fa-search"></i></span>
                                     </div>
+                                    <input id="search-page" class="form-control" type="search" aria-label="Search">
                                 </div>
                             </div>
-                        </form>
+                        </div>
                     </div>
                 </div>
                 <div class="card rounded border-0 mb-4">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
ページ管理の右上のページ検索は画面内検索のためformタグを削除
formがあったためテキストフォームでエンターを押すとpostされてページが再読み込みされる状態となっていた

## 補足
インデントの調整をしているため `?w=1` で差分確認をお願いします。
https://github.com/EC-CUBE/ec-cube/pull/3529/files?w=1