### PR TITLE
プラグインから独自にログファイルを出力できるようにログ関数を作成、monologの設定を修正

### DIFF
--- a/app/config/eccube/packages/prod/monolog.yml
+++ b/app/config/eccube/packages/prod/monolog.yml
@@ -16,7 +16,7 @@ monolog:
             action_level: error
             passthru_level: info
             handler: front_rotating_file
-            channels: ['front']
+            channels: ['front', 'app', 'php']
         front_rotating_file:
             type: rotating_file
             max_files: 60
@@ -28,7 +28,7 @@ monolog:
             action_level: error
             passthru_level: info
             handler: admin_rotating_file
-            channels: ['admin']
+            channels: ['admin', 'app', 'php']
         admin_rotating_file:
             type: rotating_file
             max_files: 60

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -108,6 +108,7 @@ services:
           - '@monolog.logger.front'
           - '@monolog.logger.admin'
         lazy: true
+        public: true
 
     eccube.log.formatter.line:
         class: Monolog\Formatter\LineFormatter

--- a/src/Eccube/Resource/functions/log.php
+++ b/src/Eccube/Resource/functions/log.php
@@ -11,82 +11,82 @@
  * file that was distributed with this source code.
  */
 
-if (!function_exists('log_emergency')) {
-    function log_emergency($message, array $context = [])
-    {
-        $app = \Eccube\Application::getInstance();
-        if (isset($app['eccube.logger'])) {
-            $app['eccube.logger']->emergency($message, $context);
-        }
+function log_emergency($message, array $context = [])
+{
+    $app = \Eccube\Application::getInstance();
+    if (isset($app['eccube.logger'])) {
+        $app['eccube.logger']->emergency($message, $context);
     }
 }
 
-if (!function_exists('log_alert')) {
-    function log_alert($message, array $context = [])
-    {
-        $app = \Eccube\Application::getInstance();
-        if (isset($app['eccube.logger'])) {
-            $app['eccube.logger']->alert($message, $context);
-        }
+function log_alert($message, array $context = [])
+{
+    $app = \Eccube\Application::getInstance();
+    if (isset($app['eccube.logger'])) {
+        $app['eccube.logger']->alert($message, $context);
     }
 }
 
-if (!function_exists('log_critical')) {
-    function log_critical($message, array $context = [])
-    {
-        $app = \Eccube\Application::getInstance();
-        if (isset($app['eccube.logger'])) {
-            $app['eccube.logger']->critical($message, $context);
-        }
+function log_critical($message, array $context = [])
+{
+    $app = \Eccube\Application::getInstance();
+    if (isset($app['eccube.logger'])) {
+        $app['eccube.logger']->critical($message, $context);
     }
 }
 
-if (!function_exists('log_error')) {
-    function log_error($message, array $context = [])
-    {
-        $app = \Eccube\Application::getInstance();
-        if (isset($app['eccube.logger'])) {
-            $app['eccube.logger']->error($message, $context);
-        }
+function log_error($message, array $context = [])
+{
+    $app = \Eccube\Application::getInstance();
+    if (isset($app['eccube.logger'])) {
+        $app['eccube.logger']->error($message, $context);
     }
 }
 
-if (!function_exists('log_warning')) {
-    function log_warning($message, array $context = [])
-    {
-        $app = \Eccube\Application::getInstance();
-        if (isset($app['eccube.logger'])) {
-            $app['eccube.logger']->warning($message, $context);
-        }
+function log_warning($message, array $context = [])
+{
+    $app = \Eccube\Application::getInstance();
+    if (isset($app['eccube.logger'])) {
+        $app['eccube.logger']->warning($message, $context);
     }
 }
 
-if (!function_exists('log_notice')) {
-    function log_notice($message, array $context = [])
-    {
-        $app = \Eccube\Application::getInstance();
-        if (isset($app['eccube.logger'])) {
-            $app['eccube.logger']->notice($message, $context);
-        }
+function log_notice($message, array $context = [])
+{
+    $app = \Eccube\Application::getInstance();
+    if (isset($app['eccube.logger'])) {
+        $app['eccube.logger']->notice($message, $context);
     }
 }
 
-if (!function_exists('log_info')) {
-    function log_info($message, array $context = [])
-    {
-        $app = \Eccube\Application::getInstance();
-        if (isset($app['eccube.logger'])) {
-            $app['eccube.logger']->info($message, $context);
-        }
+function log_info($message, array $context = [])
+{
+    $app = \Eccube\Application::getInstance();
+    if (isset($app['eccube.logger'])) {
+        $app['eccube.logger']->info($message, $context);
     }
 }
 
-if (!function_exists('log_debug')) {
-    function log_debug($message, array $context = [])
-    {
-        $app = \Eccube\Application::getInstance();
-        if (isset($app['eccube.logger'])) {
-            $app['eccube.logger']->debug($message, $context);
-        }
+function log_debug($message, array $context = [])
+{
+    $app = \Eccube\Application::getInstance();
+    if (isset($app['eccube.logger'])) {
+        $app['eccube.logger']->debug($message, $context);
     }
+}
+
+/**
+ * プラグイン用ログ出力関数
+ *
+ * @param $channel 設定されたchannel名
+ *
+ * @return \Symfony\Bridge\Monolog\Logger
+ */
+function logs($channel)
+{
+    $app = \Eccube\Application::getInstance();
+
+    $container = $app->getParentContainer();
+
+    return $container->get('monolog.logger.'.$channel);
 }


### PR DESCRIPTION
プラグインから独自にログファイルを出力できるようにログ関数を作成

## 利用方法
プラグインでの利用方法

1. `[プラグインディレクトリ]/Resource/config/services.yaml` というファイルを作成する。
2. 作成したservices.yamlに対して以下の内容を記述する。  
```yml
monolog:
    channels: ['プラグインコード名']
    handlers:
        プラグインコード名:
            type: fingers_crossed
            action_level: error
            passthru_level: info
            handler: プラグインコード名_rotating_file
            channels: ['プラグインコード名']
            channels: ['!event', '!doctrine']
        プラグインコード名_rotating_file:
            type: rotating_file
            max_files: 60
            path: '%kernel.logs_dir%/%kernel.environment%/出力したファイル名.log'
            formatter: eccube.log.formatter.line
            level: debug
```
3. プラグインからは以下のように呼び出す
```
logs('プラグインコード名')->info('ああああああ');
```
4. ログの内容が出力されているかどうか確認
```
[EC-CUBEのディレクトリ]/var/log/[prodまたはdev等]/出力したファイル名-YYYY-MM-DD.log
```
5. ログフォーマッットの記述を変更したい時は以下を設定する。
```yml
services:
    プラグインコード名.log.formatter.line:
        class: Monolog\Formatter\LineFormatter
        arguments:
            - "[%%datetime%%] %%level_name%% [%%extra.session_id%%] %%message%% [%%extra.ip%%, %%extra.referrer%%, %%extra.user_agent%%]\n"

monolog:
    channels: ['プラグインコード名']
    handlers:
        プラグインコード名:
            type: fingers_crossed
            action_level: error
            passthru_level: info
            handler: プラグインコード名_rotating_file
            channels: ['プラグインコード名']
            channels: ['!event', '!doctrine']
        プラグインコード名_rotating_file:
            type: rotating_file
            max_files: 60
            path: '%kernel.logs_dir%/%kernel.environment%/出力したファイル名.log'
            formatter: プラグインコード名.log.formatter.line
            level: debug
```
上記のargumentsにある設定で出力する内容が変更可能。
```
logs('プラグインコード名')->info('ああああああ');
```
と出力した場合、`%%message%% ` に `ああああああ` が出力される。

