### PR TITLE
fix 一覧系画面の削除モーダルの修正

### DIFF
--- a/codeception/_support/Page/Admin/CategoryManagePage.php
+++ b/codeception/_support/Page/Admin/CategoryManagePage.php
@@ -66,7 +66,14 @@ class CategoryManagePage extends AbstractAdminPageStyleGuide
 
     public function 一覧_削除($rowNum)
     {
-        $this->tester->click("body > div > div.c-contentsArea > div.c-contentsArea__cols > div.c-contentsArea__primaryCol > div > div > div > div > ul > li:nth-child(${rowNum}) > div > div.col-auto.text-right > a:nth-child(4)");
+        $this->tester->click("body > div > div.c-contentsArea > div.c-contentsArea__cols > div.c-contentsArea__primaryCol > div > div > div > div > ul > li:nth-child(${rowNum}) > div > div.col-auto.text-right > div > a");
+        return $this;
+    }
+
+    public function acceptModal()
+    {
+        $this->tester->waitForElementVisible("#delete_modal");
+        $this->tester->click("#delete_modal > div > div > div.modal-footer > a");
         return $this;
     }
 

--- a/codeception/_support/Page/Admin/ClassCategoryManagePage.php
+++ b/codeception/_support/Page/Admin/ClassCategoryManagePage.php
@@ -62,15 +62,14 @@ class ClassCategoryManagePage extends AbstractAdminPageStyleGuide
     public function 一覧_削除($rowNum)
     {
         $rowNum += 1;
-        $this->tester->click("ul.list-group > li:nth-child(${rowNum}) a:nth-child(4)");
+        $this->tester->click("ul.list-group > li:nth-child(${rowNum}) > div > div.col-auto.text-right > div > a");
         return $this;
     }
 
-    public function acceptModal($rowNum)
+    public function acceptModal()
     {
-        $rowNum += 1;
-        $this->tester->waitForElementVisible("ul.list-group > li:nth-child(${rowNum}) div.modal");
-        $this->tester->click("ul.list-group > li:nth-child(${rowNum}) div.modal a.btn-ec-delete");
+        $this->tester->waitForElementVisible("#delete_modal");
+        $this->tester->click("#delete_modal > div > div > div.modal-footer > a");
         return $this;
     }
 

--- a/codeception/_support/Page/Admin/ClassNameManagePage.php
+++ b/codeception/_support/Page/Admin/ClassNameManagePage.php
@@ -78,15 +78,14 @@ class ClassNameManagePage extends AbstractAdminPageStyleGuide
     public function 一覧_削除($rowNum)
     {
         $rowNum += 1;
-        $this->tester->click("ul.list-group > li:nth-child(${rowNum}) a:nth-child(4)");
+        $this->tester->click("ul.list-group > li:nth-child(${rowNum}) > div > div.col-auto.text-right > div > a");
         return $this;
     }
 
-    public function acceptModal($rowNum)
+    public function acceptModal()
     {
-        $rowNum += 1;
-        $this->tester->waitForElementVisible("ul.list-group > li:nth-child(${rowNum}) div.modal");
-        $this->tester->click("ul.list-group > li:nth-child(${rowNum}) div.modal a.btn-ec-delete");
+        $this->tester->waitForElementVisible("#delete_modal");
+        $this->tester->click("#delete_modal > div > div > div.modal-footer > a");
         return $this;
     }
 

--- a/codeception/_support/Page/Admin/DeliveryManagePage.php
+++ b/codeception/_support/Page/Admin/DeliveryManagePage.php
@@ -37,7 +37,11 @@ class DeliveryManagePage extends AbstractAdminPageStyleGuide
 
     public function 一覧_削除($rowNum)
     {
-        $this->tester->click("#page_admin_setting_shop_delivery > div > div.c-contentsArea > form > div > div > div.c-primaryCol > div > div > div > ul > li:nth-child($rowNum) > div > div.col-auto.text-right > a:nth-child(3)");
+        $this->tester->click("#page_admin_setting_shop_delivery > div > div.c-contentsArea > form > div > div > div.c-primaryCol > div > div > div > ul > li:nth-child($rowNum) > div > div.col-auto.text-right > div > a");
+
+        // accept modal
+        $this->tester->waitForElementVisible("#delete_modal");
+        $this->tester->click("#delete_modal > div > div > div.modal-footer > a");
         return $this;
     }
 

--- a/codeception/_support/Page/Admin/PaymentManagePage.php
+++ b/codeception/_support/Page/Admin/PaymentManagePage.php
@@ -49,9 +49,11 @@ class PaymentManagePage extends AbstractAdminPageStyleGuide
     public function 一覧_削除($rowNum)
     {
         $rowNum = $rowNum + 1;
-        $this->tester->click(".c-contentsArea__primaryCol .list-group-flush .list-group-item:nth-child(${rowNum}) > div > div.col-3.text-right > div > div:nth-child(3) > a");
+        $this->tester->click(".c-contentsArea__primaryCol .list-group-flush .list-group-item:nth-child(${rowNum}) > div > div.col-3.text-right > div > a");
+
         // accept modal
-        $this->tester->click(".c-contentsArea__primaryCol .list-group-flush .list-group-item:nth-child(${rowNum}) > div > div.col-3.text-right > div > div:nth-child(3) > div > div > div > div.modal-footer > a:nth-child(2)");
+        $this->tester->waitForElementVisible("#delete_modal");
+        $this->tester->click("#delete_modal > div > div > div.modal-footer > a");
     }
 
     public function 新規入力()

--- a/codeception/acceptance/EA03ProductCest.php
+++ b/codeception/acceptance/EA03ProductCest.php
@@ -468,7 +468,7 @@ class EA03ProductCest
         $I->see('規格を保存しました。', ClassNameManagePage::$登録完了メッセージ);
         // remove added class
         ClassNameManagePage::go($I)->一覧_削除(1)
-            ->acceptModal(1);
+            ->acceptModal();
     }
 
     public function product_規格削除(\AcceptanceTester $I)
@@ -482,7 +482,7 @@ class EA03ProductCest
             ->規格作成();
 
         ClassNameManagePage::go($I)->一覧_削除(1)
-            ->acceptModal(1);
+            ->acceptModal();
 
         $I->see('規格を削除しました。', ClassNameManagePage::$登録完了メッセージ);
     }
@@ -569,7 +569,7 @@ class EA03ProductCest
 
         // delete test
         $ProductClassCategoryPage->一覧_削除(1)
-            ->acceptModal(1);
+            ->acceptModal();
 
         $I->see('分類を削除しました。', ClassCategoryManagePage::$登録完了メッセージ);
     }
@@ -617,12 +617,12 @@ class EA03ProductCest
         $I->see('カテゴリを保存しました。', CategoryManagePage::$登録完了メッセージ);
 
         // カテゴリ削除 (children)
-        $CategoryPage->一覧_削除(2);
-        $I->acceptPopup();
+        $CategoryPage->一覧_削除(2)
+            ->acceptModal();
 
         // Delete category root
-        CategoryManagePage::go($I)->一覧_削除(2);
-        $I->acceptPopup();
+        CategoryManagePage::go($I)->一覧_削除(2)
+            ->acceptModal();
     }
 
     public function product_カテゴリ表示順の変更(\AcceptanceTester $I)

--- a/codeception/acceptance/EA07BasicinfoCest.php
+++ b/codeception/acceptance/EA07BasicinfoCest.php
@@ -174,8 +174,6 @@ class EA07BasicinfoCest
 
         DeliveryManagePage::go($I)
             ->一覧_削除(1);
-
-        $I->acceptPopup();
     }
 
     public function basicinfo_配送方法一覧順序変更(\AcceptanceTester $I)

--- a/src/Eccube/Resource/template/admin/Product/category.twig
+++ b/src/Eccube/Resource/template/admin/Product/category.twig
@@ -242,19 +242,18 @@ file that was distributed with this source code.
                                                         </a>
                                                         {% if Category.Children|length > 0 or Category.hasProductCategories %}
                                                             {# TODO: Need fix css for tooltip to work (currently using `disabled` class) #}
-                                                            <a class="btn btn-ec-actionIcon mr-3 disabled"
+                                                            <a class="btn btn-ec-actionIcon disabled"
                                                                data-toggle="tooltip" data-placement="top"
                                                                title="{{ 'admin.product.category.text01'|trans }}">
                                                                 <i class="fa fa-close fa-lg text-secondary"></i>
                                                             </a>
                                                         {% else %}
-                                                            <a class="btn btn-ec-actionIcon mr-3"
-                                                               href="{{ url('admin_product_category_delete', {id: Category.id}) }}"
-                                                               data-toggle="tooltip" data-placement="top"
-                                                               title="{{ 'admin.product.category.410'|trans }}" {{ csrf_token_for_anchor() }}
-                                                               data-method="delete">
-                                                                <i class="fa fa-close fa-lg text-secondary"></i>
-                                                            </a>
+                                                          {# TODO `data-target`の設定 #}
+                                                          <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.category.410'|trans }}">
+                                                              <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#categoryDeleteConfirm_{{ Category.id }}">
+                                                                  <i class="fa fa-close fa-lg"></i>
+                                                              </a>
+                                                          </div>
                                                         {% endif %}
                                                     </div>
                                                 </div>
@@ -273,6 +272,38 @@ file that was distributed with this source code.
                                                 </form>
                                             {% endif %}
                                         </li>
+                                      {# TODO `id`, `aria-labelledby`の設定 #}
+                                        <div class="modal fade" id="categoryDeleteConfirm_{{ Category.id }}" tabindex="-1"
+                                             role="dialog"
+                                             aria-labelledby="categoryDeleteConfirmModal_{{ Category.id }}" aria-hidden="true">
+                                            <div class="modal-dialog" role="document">
+                                                <div class="modal-content">
+                                                    <div class="modal-header">
+                                                        <h5 class="modal-title font-weight-bold">
+                                                          {{ 'admin.class_category.modal.header'|trans }}</h5>
+                                                        <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                                                    </div>
+                                                    <div class="modal-body text-left">
+                                                        <p class="text-left">
+                                                          {{ 'admin.class_category.modal.body'|trans }}</p>
+                                                    </div>
+                                                    <div class="modal-footer">
+                                                        <button class="btn btn-ec-sub" type="button"
+                                                                data-dismiss="modal">
+                                                          {{ 'admin.product.category.cancel'|trans }}
+                                                        </button>
+                                                        <a
+                                                            href="{{ url('admin_product_category_delete', {id: Category.id}) }}"
+                                                            class="btn btn-ec-delete"
+                                                            data-confirm="false"
+                                                            {{ csrf_token_for_anchor() }}
+                                                            data-method="delete">
+                                                          {{ 'admin.product.category.410'|trans }}
+                                                        </a>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
                                     {% endfor %}
                                 {% endif %}
                             </ul>

--- a/src/Eccube/Resource/template/admin/Product/category.twig
+++ b/src/Eccube/Resource/template/admin/Product/category.twig
@@ -248,7 +248,6 @@ file that was distributed with this source code.
                                                                 <i class="fa fa-close fa-lg text-secondary"></i>
                                                             </a>
                                                         {% else %}
-                                                          {# TODO `data-target`の設定 #}
                                                           <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.category.410'|trans }}">
                                                               <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#categoryDeleteConfirm_{{ Category.id }}">
                                                                   <i class="fa fa-close fa-lg"></i>
@@ -272,7 +271,6 @@ file that was distributed with this source code.
                                                 </form>
                                             {% endif %}
                                         </li>
-                                      {# TODO `id`, `aria-labelledby`の設定 #}
                                         <div class="modal fade" id="categoryDeleteConfirm_{{ Category.id }}" tabindex="-1"
                                              role="dialog"
                                              aria-labelledby="categoryDeleteConfirmModal_{{ Category.id }}" aria-hidden="true">

--- a/src/Eccube/Resource/template/admin/Product/category.twig
+++ b/src/Eccube/Resource/template/admin/Product/category.twig
@@ -113,6 +113,12 @@ file that was distributed with this source code.
                 current.find('.mode-view').addClass('d-none');
                 current.find('.mode-edit').removeClass('d-none');
             });
+
+            // 削除モーダルのhref変更
+            $('#delete_modal').on('shown.bs.modal', function(event) {
+                var target = $(event.relatedTarget);
+                $(this).find('[data-method="delete"]').attr('href', target.data('url'));
+            });
         });
     </script>
 {% endblock %}
@@ -240,20 +246,11 @@ file that was distributed with this source code.
                                                            title="{{ 'admin.product.category.rename'|trans }}">
                                                             <i class="fa fa-pencil fa-lg text-secondary"></i>
                                                         </a>
-                                                        {% if Category.Children|length > 0 or Category.hasProductCategories %}
-                                                            {# TODO: Need fix css for tooltip to work (currently using `disabled` class) #}
-                                                            <a class="btn btn-ec-actionIcon disabled"
-                                                               data-toggle="tooltip" data-placement="top"
-                                                               title="{{ 'admin.product.category.text01'|trans }}">
+                                                        <div class="d-inline-block mr-3" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.category.410'|trans }}">
+                                                            <a class="btn btn-ec-actionIcon{% if Category.Children|length > 0 or Category.hasProductCategories %} disabled{% endif %}" data-toggle="modal" data-target="#delete_modal" data-url="{{ url('admin_product_category_delete', {id: Category.id}) }}">
                                                                 <i class="fa fa-close fa-lg text-secondary"></i>
                                                             </a>
-                                                        {% else %}
-                                                          <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.category.410'|trans }}">
-                                                              <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#categoryDeleteConfirm_{{ Category.id }}">
-                                                                  <i class="fa fa-close fa-lg"></i>
-                                                              </a>
-                                                          </div>
-                                                        {% endif %}
+                                                        </div>
                                                     </div>
                                                 </div>
                                                 <form class="form-row d-none mode-edit" method="POST" action="{{ (Parent and Parent.id) ? url('admin_product_category_show', {'parent_id': Parent.id}) : url('admin_product_category') }}">
@@ -271,40 +268,40 @@ file that was distributed with this source code.
                                                 </form>
                                             {% endif %}
                                         </li>
-                                        <div class="modal fade" id="categoryDeleteConfirm_{{ Category.id }}" tabindex="-1"
-                                             role="dialog"
-                                             aria-labelledby="categoryDeleteConfirmModal_{{ Category.id }}" aria-hidden="true">
-                                            <div class="modal-dialog" role="document">
-                                                <div class="modal-content">
-                                                    <div class="modal-header">
-                                                        <h5 class="modal-title font-weight-bold">
-                                                          {{ 'admin.class_category.modal.header'|trans }}</h5>
-                                                        <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
-                                                    </div>
-                                                    <div class="modal-body text-left">
-                                                        <p class="text-left">
-                                                          {{ 'admin.class_category.modal.body'|trans }}</p>
-                                                    </div>
-                                                    <div class="modal-footer">
-                                                        <button class="btn btn-ec-sub" type="button"
-                                                                data-dismiss="modal">
-                                                          {{ 'admin.product.category.cancel'|trans }}
-                                                        </button>
-                                                        <a
-                                                            href="{{ url('admin_product_category_delete', {id: Category.id}) }}"
-                                                            class="btn btn-ec-delete"
-                                                            data-confirm="false"
-                                                            {{ csrf_token_for_anchor() }}
-                                                            data-method="delete">
-                                                          {{ 'admin.product.category.410'|trans }}
-                                                        </a>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
                                     {% endfor %}
                                 {% endif %}
                             </ul>
+                            <div class="modal fade" id="delete_modal" tabindex="-1"
+                                 role="dialog"
+                                 aria-labelledby="delete_modal" aria-hidden="true">
+                                <div class="modal-dialog" role="document">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title font-weight-bold">
+                                                {{ 'admin.class_category.modal.header'|trans }}</h5>
+                                            <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                                        </div>
+                                        <div class="modal-body text-left">
+                                            <p class="text-left">
+                                                {{ 'admin.class_category.modal.body'|trans }}</p>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button class="btn btn-ec-sub" type="button"
+                                                    data-dismiss="modal">
+                                                {{ 'admin.product.category.cancel'|trans }}
+                                            </button>
+                                            <a
+                                                    href="#"
+                                                    class="btn btn-ec-delete"
+                                                    data-confirm="false"
+                                                    {{ csrf_token_for_anchor() }}
+                                                    data-method="delete">
+                                                {{ 'admin.product.category.410'|trans }}
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/Eccube/Resource/template/admin/Product/class_category.twig
+++ b/src/Eccube/Resource/template/admin/Product/class_category.twig
@@ -116,6 +116,12 @@ file that was distributed with this source code.
                 current.find('.mode-view').addClass('d-none');
                 current.find('.mode-edit').removeClass('d-none');
             });
+
+            // 削除モーダルのhref変更
+            $('#delete_modal').on('shown.bs.modal', function(event) {
+                var target = $(event.relatedTarget);
+                $(this).find('[data-method="delete"]').attr('href', target.data('url'));
+            });
         });
     </script>
 {% endblock %}
@@ -175,36 +181,14 @@ file that was distributed with this source code.
                                                 <a class="btn btn-ec-actionIcon mr-3 action-edit" href="" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_category.432'|trans }}">
                                                     <i class="fa fa-pencil fa-lg text-secondary"></i>
                                                 </a>
-                                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}">
-                                                    <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_{{ ClassCategory.id }}">
+                                                <div class="d-inline-block mr-3" data-toggle="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}">
+                                                    {# TODO: 削除不可の時はdisabledクラスを付与する #}
+                                                    <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_modal" data-url="{{ url('admin_product_class_category_delete', {'class_name_id' : ClassName.id, 'id': ClassCategory.id}) }}">
                                                         <i class="fa fa-close fa-lg text-secondary"></i>
                                                     </a>
-                                                    <div class="modal fade" id="delete_{{ ClassCategory.id }}" tabindex="-1"
-                                                         role="dialog"
-                                                         aria-labelledby="delete_{{ ClassCategory.id }}" aria-hidden="true">
-                                                        <div class="modal-dialog" role="document">
-                                                            <div class="modal-content">
-                                                                <div class="modal-header">
-                                                                    <h5 class="modal-title font-weight-bold">
-                                                                      {{ 'admin.class_category.modal.header'|trans }}</h5>
-                                                                    <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
-                                                                </div>
-                                                                <div class="modal-body text-left">
-                                                                    <p class="text-left">
-                                                                      {{ 'admin.class_category.modal.body'|trans }}</p>
-                                                                </div>
-                                                                <div class="modal-footer">
-                                                                    <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}</button>
-                                                                    <a class="btn btn-ec-delete" href="{{ url('admin_product_class_category_delete', {'class_name_id' : ClassName.id, 'id': ClassCategory.id}) }}" {{ csrf_token_for_anchor() }}
-                                                                       data-method="delete" data-confirm="false">{{ 'common.label.delete'|trans }}</a>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
-
                                         <form class="form-row d-none mode-edit" method="post" action="{{ url('admin_product_class_category_edit', {'class_name_id': ClassName.id, 'id': ClassCategory.id}) }}">
                                             {{ form_widget(forms[ClassCategory.id]._token) }}
                                             <div class="col-3 mr-2">
@@ -218,10 +202,32 @@ file that was distributed with this source code.
                                                 <button class="btn btn-ec-sub action-edit-cancel" type="button">{{ 'admin.common.label.cancel'|trans }}</button>
                                             </div>
                                         </form>
-
                                     </li>
                                 {% endfor %}
                             </ul>
+                            <div class="modal fade" id="delete_modal" tabindex="-1"
+                                 role="dialog"
+                                 aria-labelledby="delete_modal" aria-hidden="true">
+                                <div class="modal-dialog" role="document">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title font-weight-bold">
+                                                {{ 'admin.class_category.modal.header'|trans }}</h5>
+                                            <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                                        </div>
+                                        <div class="modal-body text-left">
+                                            <p class="text-left">
+                                                {{ 'admin.class_category.modal.body'|trans }}</p>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}</button>
+                                            <a class="btn btn-ec-delete" href="#" {{ csrf_token_for_anchor() }}
+                                               data-method="delete" data-confirm="false">{{ 'common.label.delete'|trans }}</a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
                         </div>
                     </div>
                 </div>

--- a/src/Eccube/Resource/template/admin/Product/class_category.twig
+++ b/src/Eccube/Resource/template/admin/Product/class_category.twig
@@ -175,27 +175,29 @@ file that was distributed with this source code.
                                                 <a class="btn btn-ec-actionIcon mr-3 action-edit" href="" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_category.432'|trans }}">
                                                     <i class="fa fa-pencil fa-lg text-secondary"></i>
                                                 </a>
-                                                <a class="btn btn-ec-actionIcon mr-3" data-tooltip="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}" data-toggle="modal" data-target="#delete_{{ ClassCategory.id }}">
-                                                    <i class="fa fa-close fa-lg text-secondary"></i>
-                                                </a>
-                                                <div class="modal fade" id="delete_{{ ClassCategory.id }}" tabindex="-1"
-                                                     role="dialog"
-                                                     aria-labelledby="delete_{{ ClassCategory.id }}" aria-hidden="true">
-                                                    <div class="modal-dialog" role="document">
-                                                        <div class="modal-content">
-                                                            <div class="modal-header">
-                                                                <h5 class="modal-title font-weight-bold">
-                                                                    {{ 'admin.class_category.modal.header'|trans }}</h5>
-                                                                <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
-                                                            </div>
-                                                            <div class="modal-body text-left">
-                                                                <p class="text-left">
-                                                                    {{ 'admin.class_category.modal.body'|trans }}</p>
-                                                            </div>
-                                                            <div class="modal-footer">
-                                                                <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}</button>
-                                                                <a class="btn btn-ec-delete" href="{{ url('admin_product_class_category_delete', {'class_name_id' : ClassName.id, 'id': ClassCategory.id}) }}" {{ csrf_token_for_anchor() }}
-                                                                   data-method="delete" data-confirm="false">{{ 'common.label.delete'|trans }}</a>
+                                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}">
+                                                    <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_{{ ClassCategory.id }}">
+                                                        <i class="fa fa-close fa-lg text-secondary"></i>
+                                                    </a>
+                                                    <div class="modal fade" id="delete_{{ ClassCategory.id }}" tabindex="-1"
+                                                         role="dialog"
+                                                         aria-labelledby="delete_{{ ClassCategory.id }}" aria-hidden="true">
+                                                        <div class="modal-dialog" role="document">
+                                                            <div class="modal-content">
+                                                                <div class="modal-header">
+                                                                    <h5 class="modal-title font-weight-bold">
+                                                                      {{ 'admin.class_category.modal.header'|trans }}</h5>
+                                                                    <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                                                                </div>
+                                                                <div class="modal-body text-left">
+                                                                    <p class="text-left">
+                                                                      {{ 'admin.class_category.modal.body'|trans }}</p>
+                                                                </div>
+                                                                <div class="modal-footer">
+                                                                    <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}</button>
+                                                                    <a class="btn btn-ec-delete" href="{{ url('admin_product_class_category_delete', {'class_name_id' : ClassName.id, 'id': ClassCategory.id}) }}" {{ csrf_token_for_anchor() }}
+                                                                       data-method="delete" data-confirm="false">{{ 'common.label.delete'|trans }}</a>
+                                                                </div>
                                                             </div>
                                                         </div>
                                                     </div>

--- a/src/Eccube/Resource/template/admin/Product/class_name.twig
+++ b/src/Eccube/Resource/template/admin/Product/class_name.twig
@@ -81,7 +81,8 @@ file that was distributed with this source code.
             // 最初と最後の↑↓を再描画
             var redrawDisableAllows = function() {
                 var items = $('.sortable-item');
-                items.find('a').removeClass('disabled');
+                items.find('a.up').removeClass('disabled');
+                items.find('a.down').removeClass('disabled');
                 items.first().find('a.up').addClass('disabled');
                 items.last().find('a.down').addClass('disabled');
             };
@@ -126,8 +127,15 @@ file that was distributed with this source code.
                 current.find('.mode-view').addClass('d-none');
                 current.find('.mode-edit').removeClass('d-none');
             });
+
+            // 削除モーダルのhref変更
+            $('#delete_modal').on('shown.bs.modal', function(event) {
+                var target = $(event.relatedTarget);
+                $(this).find('[data-method="delete"]').attr('href', target.data('url'));
+            });
         });
     </script>
+
 {% endblock %}
 
 {% block main %}
@@ -173,42 +181,13 @@ file that was distributed with this source code.
                                                 <a class="btn btn-ec-actionIcon mr-3 action-edit" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.class_name.441'|trans }}">
                                                     <i class="fa fa-pencil fa-lg text-secondary"></i>
                                                 </a>
-                                                {% set classCategories = ClassName.ClassCategories|length %}
-                                                <a class="btn btn-ec-actionIcon mr-3 {% if classCategories > 0 %}disabled{% endif %}" data-tooltip="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}"
-                                                   {% if classCategories == 0 %}data-toggle="modal" data-target="#delete_{{ ClassName.id }}"{% endif %}>
-                                                    <i class="fa fa-close fa-lg text-secondary"></i>
-                                                </a>
-
-                                                {% if classCategories == 0 %}
-                                                    <div class="modal fade" id="delete_{{ ClassName.id }}" tabindex="-1"
-                                                         role="dialog"
-                                                         aria-labelledby="delete_{{ ClassName.id }}" aria-hidden="true">
-                                                        <div class="modal-dialog" role="document">
-                                                            <div class="modal-content">
-                                                                <div class="modal-header">
-                                                                    <h5 class="modal-title font-weight-bold">
-                                                                        {{ 'admin.class_name.modal.header'|trans }}</h5>
-                                                                    <button class="close" type="button"
-                                                                            data-dismiss="modal"
-                                                                            aria-label="Close"><span
-                                                                                aria-hidden="true">×</span>
-                                                                    </button>
-                                                                </div>
-                                                                <div class="modal-body text-left">
-                                                                    <p class="text-left">
-                                                                        {{ 'admin.class_name.modal.body'|trans }}</p>
-                                                                </div>
-                                                                <div class="modal-footer">
-                                                                    <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}
-                                                                    </button>
-                                                                    <a class="btn btn-ec-delete" href="{{ url('admin_product_class_name_delete', {'id' : ClassName.id}) }}" {{ csrf_token_for_anchor() }}
-                                                                       data-method="delete" data-confirm="false">{{ 'common.label.delete'|trans }}</a>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                {% endif %}
-
+                                                <div class="d-inline-block mr-3" data-toggle="tooltip" data-placement="top" title="{{ 'common.label.delete'|trans }}">
+                                                    {% set classCategories = ClassName.ClassCategories|length %}
+                                                    <a class="btn btn-ec-actionIcon{% if classCategories > 0 %} disabled{% endif %}"
+                                                       {% if classCategories == 0 %}data-toggle="modal" data-target="#delete_modal" data-url="{{ url('admin_product_class_name_delete', {'id' : ClassName.id}) }}" {% endif %}>
+                                                        <i class="fa fa-close fa-lg text-secondary"></i>
+                                                    </a>
+                                                </div>
                                             </div>
                                         </div>
 
@@ -235,6 +214,33 @@ file that was distributed with this source code.
                                     </li>
                                 {% endfor %}
                             </ul>
+                            <div class="modal fade" id="delete_modal" tabindex="-1"
+                                 role="dialog"
+                                 aria-labelledby="delete_modal" aria-hidden="true">
+                                <div class="modal-dialog" role="document">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title font-weight-bold">
+                                                {{ 'admin.class_name.modal.header'|trans }}</h5>
+                                            <button class="close" type="button"
+                                                    data-dismiss="modal"
+                                                    aria-label="Close"><span
+                                                        aria-hidden="true">×</span>
+                                            </button>
+                                        </div>
+                                        <div class="modal-body text-left">
+                                            <p class="text-left">
+                                                {{ 'admin.class_name.modal.body'|trans }}</p>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}
+                                            </button>
+                                            <a class="btn btn-ec-delete" href="#" {{ csrf_token_for_anchor() }}
+                                               data-method="delete" data-confirm="false">{{ 'common.label.delete'|trans }}</a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/Eccube/Resource/template/admin/Product/tag.twig
+++ b/src/Eccube/Resource/template/admin/Product/tag.twig
@@ -120,6 +120,12 @@ file that was distributed with this source code.
                 current.find('.mode-view').addClass('d-none');
                 current.find('.mode-edit').removeClass('d-none');
             });
+
+            // 削除モーダルのhref変更
+            $('#delete_modal').on('shown.bs.modal', function(event) {
+                var target = $(event.relatedTarget);
+                $(this).find('[data-method="delete"]').attr('href', target.data('url'));
+            });
         });
     </script>
 {% endblock %}
@@ -164,49 +170,13 @@ file that was distributed with this source code.
                                                 <a class="btn btn-ec-actionIcon mr-3 action-edit" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.tag.edit'|trans }}">
                                                     <i class="fa fa-pencil fa-lg text-secondary"></i>
                                                 </a>
-                                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.tag.delete'|trans }}">
-                                                    <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#confirmModal-{{ Tag.id }}">
+                                                <div class="d-inline-block mr-3" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.tag.delete'|trans }}">
+                                                    <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_modal" data-url="{{ url('admin_product_tag_delete', {'id' : Tag.id}) }}">
                                                         <i class="fa fa-close fa-lg text-secondary"></i>
                                                     </a>
                                                 </div>
                                             </div>
                                         </div>
-
-                                        <div class="modal fade" id="confirmModal-{{ Tag.id }}" tabindex="-1"
-                                             role="dialog"
-                                             aria-labelledby="confirmModal-{{ Tag.id }}" aria-hidden="true">
-                                            <div class="modal-dialog" role="document">
-                                                <div class="modal-content">
-                                                    <div class="modal-header">
-                                                        <h5 class="modal-title font-weight-bold">
-                                                            {{ 'admin.product.tag.delete.confirm.title'|trans }}</h5>
-                                                        <button class="close" type="button"
-                                                                data-dismiss="modal"
-                                                                aria-label="Close"><span
-                                                                    aria-hidden="true">×</span>
-                                                        </button>
-                                                    </div>
-                                                    <div class="modal-body text-left">
-                                                        <p class="text-left">
-                                                            {{ 'admin.product.tag.delete.confirm.message'|trans }}</p>
-                                                    </div>
-                                                    <div class="modal-footer">
-                                                        <button class="btn btn-ec-sub" type="button"
-                                                                data-dismiss="modal">{{ 'admin.product.index.cancel'|trans }}
-                                                        </button>
-                                                        <a
-                                                                href="{{ url('admin_product_tag_delete', {'id' : Tag.id}) }}"
-                                                                class="btn btn-ec-delete"
-                                                                data-confirm="false"
-                                                                {{ csrf_token_for_anchor() }}
-                                                                data-method="delete">
-                                                            {{ 'admin.product.index.delete'|trans }}
-                                                        </a>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-
                                         <form class="form-row d-none mode-edit" method="post" action="{{ url('admin_product_tag') }}">
                                             {{ form_widget(forms[Tag.id]._token) }}
                                             <div class="col-auto align-items-center">
@@ -223,6 +193,40 @@ file that was distributed with this source code.
                                     </li>
                                 {% endfor %}
                             </ul>
+                            <div class="modal fade" id="delete_modal" tabindex="-1"
+                                 role="dialog"
+                                 aria-labelledby="delete_modal" aria-hidden="true">
+                                <div class="modal-dialog" role="document">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title font-weight-bold">
+                                                {{ 'admin.product.tag.delete.confirm.title'|trans }}</h5>
+                                            <button class="close" type="button"
+                                                    data-dismiss="modal"
+                                                    aria-label="Close"><span
+                                                        aria-hidden="true">×</span>
+                                            </button>
+                                        </div>
+                                        <div class="modal-body text-left">
+                                            <p class="text-left">
+                                                {{ 'admin.product.tag.delete.confirm.message'|trans }}</p>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button class="btn btn-ec-sub" type="button"
+                                                    data-dismiss="modal">{{ 'admin.product.index.cancel'|trans }}
+                                            </button>
+                                            <a
+                                                    href="#"
+                                                    class="btn btn-ec-delete"
+                                                    data-confirm="false"
+                                                    {{ csrf_token_for_anchor() }}
+                                                    data-method="delete">
+                                                {{ 'admin.product.index.delete'|trans }}
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/Eccube/Resource/template/admin/Product/tag.twig
+++ b/src/Eccube/Resource/template/admin/Product/tag.twig
@@ -161,7 +161,7 @@ file that was distributed with this source code.
                                                 <a class="btn btn-ec-actionIcon mr-3 action-down{% if loop.last %} disabled{% endif %}" href="#" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.tag.down'|trans }}">
                                                     <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                                 </a>
-                                                <a class="btn btn-ec-actionIcon action-edit" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.tag.edit'|trans }}">
+                                                <a class="btn btn-ec-actionIcon mr-3 action-edit" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.tag.edit'|trans }}">
                                                     <i class="fa fa-pencil fa-lg text-secondary"></i>
                                                 </a>
                                                 <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.tag.delete'|trans }}">

--- a/src/Eccube/Resource/template/admin/Product/tag.twig
+++ b/src/Eccube/Resource/template/admin/Product/tag.twig
@@ -161,12 +161,14 @@ file that was distributed with this source code.
                                                 <a class="btn btn-ec-actionIcon mr-3 action-down{% if loop.last %} disabled{% endif %}" href="#" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.tag.down'|trans }}">
                                                     <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                                 </a>
-                                                <a class="btn btn-ec-actionIcon mr-3 action-edit" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.tag.edit'|trans }}">
+                                                <a class="btn btn-ec-actionIcon action-edit" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.tag.edit'|trans }}">
                                                     <i class="fa fa-pencil fa-lg text-secondary"></i>
                                                 </a>
-                                                <a class="btn btn-ec-actionIcon mr-3" data-toggle="modal" data-target="#confirmModal-{{ Tag.id }}" data-tooltip="tooltip" data-placement="top" title="{{ 'admin.product.tag.delete'|trans }}">
-                                                    <i class="fa fa-close fa-lg text-secondary"></i>
-                                                </a>
+                                                <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.product.tag.delete'|trans }}">
+                                                    <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#confirmModal-{{ Tag.id }}">
+                                                        <i class="fa fa-close fa-lg text-secondary"></i>
+                                                    </a>
+                                                </div>
                                             </div>
                                         </div>
 

--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery.twig
@@ -87,6 +87,12 @@ file that was distributed with this source code.
                     moveSortNo();
                 }
             });
+
+            // 削除モーダルのhref変更
+            $('#delete_modal').on('shown.bs.modal', function(event) {
+                var target = $(event.relatedTarget);
+                $(this).find('[data-method="delete"]').attr('href', target.data('url'));
+            });
         });
     </script>
 {% endblock %}
@@ -117,51 +123,51 @@ file that was distributed with this source code.
                                                         <a href="#" class="btn btn-ec-actionIcon mr-3 action-down {% if loop.last %}disabled{% endif %}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.common.label.move.down'|trans }}">
                                                             <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                                         </a>
-                                                      {# TODO `data-target`の設定 #}
-                                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.common.label.delete'|trans }}">
-                                                            <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#deliveryDeleteConfirm_{{ Delivery.Id }}">
+                                                        <div class="d-inline-block mr-3" data-toggle="tooltip" data-placement="top" title="{{ 'admin.common.label.delete'|trans }}">
+                                                            <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_modal" data-url="{{ url('admin_setting_shop_delivery_delete', {id: Delivery.Id} ) }}">
                                                                 <i class="fa fa-close fa-lg"></i>
                                                             </a>
                                                         </div>
                                                     </div>
                                                 </div>
                                             </li>
-                                            <div class="modal fade" id="deliveryDeleteConfirm_{{ Delivery.Id }}" tabindex="-1"
-                                                 role="dialog"
-                                                 aria-labelledby="deliveryDeleteConfirmModal_{{ Delivery.Id }}" aria-hidden="true">
-                                                <div class="modal-dialog" role="document">
-                                                    <div class="modal-content">
-                                                        <div class="modal-header">
-                                                          {# TODO モーダルのタイトルの設定 #}
-                                                            <h5 class="modal-title font-weight-bold">
-                                                                配送方法を削除します</h5>
-                                                            <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
-                                                        </div>
-                                                        <div class="modal-body text-left">
-                                                          {# TODO モーダルの文章の設定 #}
-                                                            <p class="text-left">
-                                                                この配送方法を削除しますか？</p>
-                                                        </div>
-                                                        <div class="modal-footer">
-                                                            <button class="btn btn-ec-sub" type="button"
-                                                                    data-dismiss="modal">
-                                                                {{ 'admin.common.label.cancel'|trans }}
-                                                            </button>
-                                                            <a
-                                                                href="{{ url('admin_setting_shop_delivery_delete', {id: Delivery.Id} ) }}"
-                                                                class="btn btn-ec-delete"
-                                                                data-confirm="false"
-                                                                {{ csrf_token_for_anchor() }}
-                                                                data-method="delete">
-                                                              {{ 'admin.common.label.delete'|trans }}
-                                                            </a>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
                                         {% endfor %}
                                     {% endif %}
                                 </ul>
+                                <div class="modal fade" id="delete_modal" tabindex="-1"
+                                     role="dialog"
+                                     aria-labelledby="delete_modal" aria-hidden="true">
+                                    <div class="modal-dialog" role="document">
+                                        <div class="modal-content">
+                                            <div class="modal-header">
+                                                {# TODO モーダルのタイトルの設定 #}
+                                                <h5 class="modal-title font-weight-bold">
+                                                    配送方法を削除します</h5>
+                                                <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                                            </div>
+                                            <div class="modal-body text-left">
+                                                {# TODO モーダルの文章の設定 #}
+                                                <p class="text-left">
+                                                    この配送方法を削除しますか？</p>
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button class="btn btn-ec-sub" type="button"
+                                                        data-dismiss="modal">
+                                                    {{ 'admin.common.label.cancel'|trans }}
+                                                </button>
+                                                <a
+                                                        href="#"
+                                                        class="btn btn-ec-delete"
+                                                        data-confirm="false"
+                                                        {{ csrf_token_for_anchor() }}
+                                                        data-method="delete">
+                                                    {{ 'admin.common.label.delete'|trans }}
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
                             </div>
                         </div>
                     </div>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery.twig
@@ -126,7 +126,6 @@ file that was distributed with this source code.
                                                     </div>
                                                 </div>
                                             </li>
-                                          {# TODO `id`, `aria-labelledby`の設定 #}
                                             <div class="modal fade" id="deliveryDeleteConfirm_{{ Delivery.Id }}" tabindex="-1"
                                                  role="dialog"
                                                  aria-labelledby="deliveryDeleteConfirmModal_{{ Delivery.Id }}" aria-hidden="true">

--- a/src/Eccube/Resource/template/admin/Setting/Shop/delivery.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/delivery.twig
@@ -117,12 +117,49 @@ file that was distributed with this source code.
                                                         <a href="#" class="btn btn-ec-actionIcon mr-3 action-down {% if loop.last %}disabled{% endif %}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.common.label.move.down'|trans }}">
                                                             <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                                         </a>
-                                                        <a href="{{ url('admin_setting_shop_delivery_delete', {id: Delivery.Id} ) }}" class="btn btn-ec-actionIcon mr-3" data-toggle="tooltip" data-placement="top" title="{{ 'admin.common.label.delete'|trans }}" {{ csrf_token_for_anchor() }} data-method="delete">
-                                                            <i class="fa fa-close fa-lg text-secondary"></i>
-                                                        </a>
+                                                      {# TODO `data-target`の設定 #}
+                                                        <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.common.label.delete'|trans }}">
+                                                            <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#deliveryDeleteConfirm_{{ Delivery.Id }}">
+                                                                <i class="fa fa-close fa-lg"></i>
+                                                            </a>
+                                                        </div>
                                                     </div>
                                                 </div>
                                             </li>
+                                          {# TODO `id`, `aria-labelledby`の設定 #}
+                                            <div class="modal fade" id="deliveryDeleteConfirm_{{ Delivery.Id }}" tabindex="-1"
+                                                 role="dialog"
+                                                 aria-labelledby="deliveryDeleteConfirmModal_{{ Delivery.Id }}" aria-hidden="true">
+                                                <div class="modal-dialog" role="document">
+                                                    <div class="modal-content">
+                                                        <div class="modal-header">
+                                                          {# TODO モーダルのタイトルの設定 #}
+                                                            <h5 class="modal-title font-weight-bold">
+                                                                配送方法を削除します</h5>
+                                                            <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                                                        </div>
+                                                        <div class="modal-body text-left">
+                                                          {# TODO モーダルの文章の設定 #}
+                                                            <p class="text-left">
+                                                                この配送方法を削除しますか？</p>
+                                                        </div>
+                                                        <div class="modal-footer">
+                                                            <button class="btn btn-ec-sub" type="button"
+                                                                    data-dismiss="modal">
+                                                                {{ 'admin.common.label.cancel'|trans }}
+                                                            </button>
+                                                            <a
+                                                                href="{{ url('admin_setting_shop_delivery_delete', {id: Delivery.Id} ) }}"
+                                                                class="btn btn-ec-delete"
+                                                                data-confirm="false"
+                                                                {{ csrf_token_for_anchor() }}
+                                                                data-method="delete">
+                                                              {{ 'admin.common.label.delete'|trans }}
+                                                            </a>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
                                         {% endfor %}
                                     {% endif %}
                                 </ul>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
@@ -102,6 +102,20 @@ file that was distributed with this source code.
                     moveSortNo();
                 }
             });
+
+            // 表示・非表示
+            $('.check-display').click(function(){
+                var id = $(this).attr('id');
+                if($('.display-show-toggle-' + id).hasClass('fa-eye')){
+                    $('.display-show-toggle-' + id).addClass('fa-eye-slash');
+                    $('.display-show-toggle-' + id).removeClass('fa-eye');
+                    $('#' + id).css('background-color','#FAF1F1');
+                }else{
+                    $('.display-show-toggle-' + id).addClass('fa-eye');
+                    $('.display-show-toggle-' + id).removeClass('fa-eye-slash');
+                    $('#' + id).css('background-color','');
+                }
+            });
         });
     </script>
 {% endblock %}
@@ -148,6 +162,10 @@ file that was distributed with this source code.
                                             </a>
                                             <a class="btn btn-ec-actionIcon mr-3 action-down{{ loop.last ? ' disabled' }}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.609'|trans }}">
                                                 <i class="fa fa-arrow-down fa-lg text-secondary"></i>
+                                            </a>
+                                            {# TODO クラス名, id名の設定 #}
+                                            <a class="btn btn-ec-actionIcon check-display" id="{{ Payment.id }}" data-toggle="tooltip" data-placement="top" title="表示">
+                                                <i class="fa fa-eye display-show-toggle-{{ Payment.id }} fa-lg text-secondary"></i>
                                             </a>
                                             <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.607'|trans }}">
                                                 <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_{{ Payment.id }}">

--- a/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
@@ -143,45 +143,39 @@ file that was distributed with this source code.
                                         </span>
                                         </div>
                                         <div class="col-3 text-right">
-                                            <div class="row">
-                                                <div class="col text-center" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.608'|trans }}">
-                                                    <a class="btn btn-ec-actionIcon mr-3 action-up{{ loop.first ? ' disabled' }}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.608'|trans }}">
-                                                        <i class="fa fa-arrow-up fa-lg text-secondary"></i>
-                                                    </a>
-                                                </div>
-                                                <div class="col text-center" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.609'|trans }}">
-                                                    <a class="btn btn-ec-actionIcon mr-3 action-down{{ loop.last ? ' disabled' }}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.609'|trans }}">
-                                                        <i class="fa fa-arrow-down fa-lg text-secondary"></i>
-                                                    </a>
-                                                </div>
-                                                <div class="col text-center" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.607'|trans }}">
-                                                    <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_{{ Payment.id }}">
-                                                        <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
-                                                    </a>
-                                                    <div class="modal fade" id="delete_{{ Payment.id }}" tabindex="-1"
-                                                         role="dialog"
-                                                         aria-labelledby="delete_{{ Payment.id }}" aria-hidden="true">
-                                                        <div class="modal-dialog" role="document">
-                                                            <div class="modal-content">
-                                                                <div class="modal-header">
-                                                                    <h5 class="modal-title font-weight-bold">
-                                                                        {{ 'admin.setting.shop.payment.modal.header'|trans }}</h5>
-                                                                    <button class="close" type="button"
-                                                                            data-dismiss="modal"
-                                                                            aria-label="Close"><span
-                                                                                aria-hidden="true">×</span>
-                                                                    </button>
-                                                                </div>
-                                                                <div class="modal-body text-left">
-                                                                    <p class="text-left">
-                                                                        {{ 'admin.setting.shop.payment.modal.body'|trans }}</p>
-                                                                </div>
-                                                                <div class="modal-footer">
-                                                                    <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}
-                                                                    </button>
-                                                                    <a class="btn btn-ec-delete" href="{{ url('admin_setting_shop_payment_delete', {'id' : Payment.id}) }}" {{ csrf_token_for_anchor() }}
-                                                                       data-method="delete" data-confirm="false">{{ 'common.label.delete'|trans }}</a>
-                                                                </div>
+                                            <a class="btn btn-ec-actionIcon mr-3 action-up{{ loop.first ? ' disabled' }}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.608'|trans }}">
+                                                <i class="fa fa-arrow-up fa-lg text-secondary"></i>
+                                            </a>
+                                            <a class="btn btn-ec-actionIcon mr-3 action-down{{ loop.last ? ' disabled' }}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.609'|trans }}">
+                                                <i class="fa fa-arrow-down fa-lg text-secondary"></i>
+                                            </a>
+                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.607'|trans }}">
+                                                <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_{{ Payment.id }}">
+                                                    <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
+                                                </a>
+                                                <div class="modal fade" id="delete_{{ Payment.id }}" tabindex="-1"
+                                                     role="dialog"
+                                                     aria-labelledby="delete_{{ Payment.id }}" aria-hidden="true">
+                                                    <div class="modal-dialog" role="document">
+                                                        <div class="modal-content">
+                                                            <div class="modal-header">
+                                                                <h5 class="modal-title font-weight-bold">
+                                                                    {{ 'admin.setting.shop.payment.modal.header'|trans }}</h5>
+                                                                <button class="close" type="button"
+                                                                        data-dismiss="modal"
+                                                                        aria-label="Close"><span
+                                                                            aria-hidden="true">×</span>
+                                                                </button>
+                                                            </div>
+                                                            <div class="modal-body text-left">
+                                                                <p class="text-left">
+                                                                    {{ 'admin.setting.shop.payment.modal.body'|trans }}</p>
+                                                            </div>
+                                                            <div class="modal-footer">
+                                                                <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}
+                                                                </button>
+                                                                <a class="btn btn-ec-delete" href="{{ url('admin_setting_shop_payment_delete', {'id' : Payment.id}) }}" {{ csrf_token_for_anchor() }}
+                                                                   data-method="delete" data-confirm="false">{{ 'common.label.delete'|trans }}</a>
                                                             </div>
                                                         </div>
                                                     </div>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
@@ -117,6 +117,12 @@ file that was distributed with this source code.
                     $('#' + id).css('background-color','');
                 }
             });
+
+            // 削除モーダルのhref変更
+            $('#delete_modal').on('shown.bs.modal', function(event) {
+                var target = $(event.relatedTarget);
+                $(this).find('[data-method="delete"]').attr('href', target.data('url'));
+            });
         });
     </script>
 {% endblock %}
@@ -168,44 +174,44 @@ file that was distributed with this source code.
                                             <a class="btn btn-ec-actionIcon mr-3 check-display" id="{{ Payment.id }}" data-toggle="tooltip" data-placement="top" title="表示">
                                                 <i class="fa fa-eye display-show-toggle-{{ Payment.id }} fa-lg text-secondary"></i>
                                             </a>
-                                            <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.607'|trans }}">
-                                                <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_{{ Payment.id }}">
-                                                    <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
+                                            <div class="d-inline-block mr-3" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.607'|trans }}">
+                                                <a class="btn btn-ec-actionIcon" data-toggle="modal" data-target="#delete_modal" data-url="{{ url('admin_setting_shop_payment_delete', {'id' : Payment.id}) }}">
+                                                    <i class="fa fa-close fa-lg text-secondary"></i>
                                                 </a>
-                                                <div class="modal fade" id="delete_{{ Payment.id }}" tabindex="-1"
-                                                     role="dialog"
-                                                     aria-labelledby="delete_{{ Payment.id }}" aria-hidden="true">
-                                                    <div class="modal-dialog" role="document">
-                                                        <div class="modal-content">
-                                                            <div class="modal-header">
-                                                                <h5 class="modal-title font-weight-bold">
-                                                                    {{ 'admin.setting.shop.payment.modal.header'|trans }}</h5>
-                                                                <button class="close" type="button"
-                                                                        data-dismiss="modal"
-                                                                        aria-label="Close"><span
-                                                                            aria-hidden="true">×</span>
-                                                                </button>
-                                                            </div>
-                                                            <div class="modal-body text-left">
-                                                                <p class="text-left">
-                                                                    {{ 'admin.setting.shop.payment.modal.body'|trans }}</p>
-                                                            </div>
-                                                            <div class="modal-footer">
-                                                                <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}
-                                                                </button>
-                                                                <a class="btn btn-ec-delete" href="{{ url('admin_setting_shop_payment_delete', {'id' : Payment.id}) }}" {{ csrf_token_for_anchor() }}
-                                                                   data-method="delete" data-confirm="false">{{ 'common.label.delete'|trans }}</a>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
                                             </div>
                                         </div>
                                     </div>
                                 </li>
                             {% endfor %}
-
                         </ul>
+                        <div class="modal fade" id="delete_modal" tabindex="-1"
+                             role="dialog"
+                             aria-labelledby="delete_modal" aria-hidden="true">
+                            <div class="modal-dialog" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <h5 class="modal-title font-weight-bold">
+                                            {{ 'admin.setting.shop.payment.modal.header'|trans }}</h5>
+                                        <button class="close" type="button"
+                                                data-dismiss="modal"
+                                                aria-label="Close"><span
+                                                    aria-hidden="true">×</span>
+                                        </button>
+                                    </div>
+                                    <div class="modal-body text-left">
+                                        <p class="text-left">
+                                            {{ 'admin.setting.shop.payment.modal.body'|trans }}</p>
+                                    </div>
+                                    <div class="modal-footer">
+                                        <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'common.label.cancel'|trans }}
+                                        </button>
+                                        <a class="btn btn-ec-delete" href="#" {{ csrf_token_for_anchor() }}
+                                           data-method="delete" data-confirm="false">{{ 'common.label.delete'|trans }}</a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
                     </div>
                 </div>
                 <p>{{ 'admin.setting.shop.payment.notice'|trans }}</p>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/payment.twig
@@ -103,6 +103,7 @@ file that was distributed with this source code.
                 }
             });
 
+            {# TODO: 表示・非表示を登録できるようにする #}
             // 表示・非表示
             $('.check-display').click(function(){
                 var id = $(this).attr('id');
@@ -163,8 +164,8 @@ file that was distributed with this source code.
                                             <a class="btn btn-ec-actionIcon mr-3 action-down{{ loop.last ? ' disabled' }}" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.609'|trans }}">
                                                 <i class="fa fa-arrow-down fa-lg text-secondary"></i>
                                             </a>
-                                            {# TODO クラス名, id名の設定 #}
-                                            <a class="btn btn-ec-actionIcon check-display" id="{{ Payment.id }}" data-toggle="tooltip" data-placement="top" title="表示">
+                                            {# TODO クラス名、id名の設定、メッセージID化、登録機能 #}
+                                            <a class="btn btn-ec-actionIcon mr-3 check-display" id="{{ Payment.id }}" data-toggle="tooltip" data-placement="top" title="表示">
                                                 <i class="fa fa-eye display-show-toggle-{{ Payment.id }} fa-lg text-secondary"></i>
                                             </a>
                                             <div class="d-inline-block" data-toggle="tooltip" data-placement="top" title="{{ 'admin.setting.shop.payment.607'|trans }}">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
一覧系画面の削除モーダルの修正です。

以下のPRに変更を加えました。
https://github.com/EC-CUBE/ec-cube/pull/3497
元のプルリクはクローズします。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->
+ 以下の問題があった
    - モーダルが出るページとalartが出るページがある
    - モーダルのhtmlソースの配置がバラバラ
    - tooltipとmodalの競合回避箇所のhtmlの構造が統一できていなかった
    - 項目の順序変更の処理と競合してliタグ内にモーダルのソースを配置できない

+ 以下の方針で修正した
    - モーダルで統一
    - モーダルは１個を共通で使う
    - モーダルのhtmlソースの配置をulタグの下に統一
    - tooltipとmodalの実装を統一

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
e2eテストを修正

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
