### PR TITLE
cookie secureの値を動的に設定するように修正

### DIFF
--- a/app/config/eccube/packages/framework.yaml
+++ b/app/config/eccube/packages/framework.yaml
@@ -12,8 +12,6 @@ framework:
         save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
         name: '%env(ECCUBE_COOKIE_NAME)%'
         cookie_path: '%env(ECCUBE_COOKIE_PATH)%'
-        # TODO cookieが発行されないため、いったんfalseに変更
-        cookie_secure: false
         cookie_lifetime: '%env(ECCUBE_COOKIE_LIFETIME)%'
         gc_maxlifetime: '%env(ECCUBE_GC_MAXLIFETIME)%'
         cookie_httponly: true

--- a/src/Eccube/DependencyInjection/EccubeExtension.php
+++ b/src/Eccube/DependencyInjection/EccubeExtension.php
@@ -37,6 +37,34 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
      */
     public function prepend(ContainerBuilder $container)
     {
+        // FrameworkBundleの設定を動的に変更する.
+        $this->configureFramework($container);
+
+        // プラグインの有効無効判定および初期化を行う.
+        $this->configurePlugins($container);
+    }
+
+    protected function configureFramework(ContainerBuilder $container)
+    {
+        // SSL強制時は, cookie_secureをtrueにする
+        $forceSSL = $container->resolveEnvPlaceholders('%env(ECCUBE_FORCE_SSL)%', true);
+        // envから取得した内容が文字列のため, booleanに変換
+        if ('true' === $forceSSL) {
+            $forceSSL = true;
+        } elseif ('false' === $forceSSL) {
+            $forceSSL = false;
+        }
+
+        // framework.yamlでは制御できないため, ここで定義する.
+        $container->prependExtensionConfig('framework', [
+            'session' => [
+                'cookie_secure' => $forceSSL,
+            ],
+        ]);
+    }
+
+    protected function configurePlugins(ContainerBuilder $container)
+    {
         $pluginDir = $container->getParameter('kernel.project_dir').'/app/Plugin';
         $pluginDirs = $this->getPluginDirectories($pluginDir);
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- cookie secureはframework.yamlで設定する必要があるが、動的に変更することができない
- force sslの有効/無効に合わせて変更できるように対応しました

## テスト（Test)
- 既存のテストにパスすることを確認
- `bin/console debug:config framework`で.envの値に応じてcookie secureの設定が変わることを確認



