### PR TITLE
#156 【会員登録】フリガナの入力ボックスエラーのエラー文言がわかりにくい

### DIFF
--- a/src/Eccube/Form/Type/KanaType.php
+++ b/src/Eccube/Form/Type/KanaType.php
@@ -59,7 +59,7 @@ class KanaType extends AbstractType
                 'constraints' => [
                     new Assert\Regex([
                         'pattern' => '/^[ァ-ヶｦ-ﾟー]+$/u',
-                        'message' => 'form.type.notkanastyle',
+                        'message' => trans('form.type.notkanastyle'),
                     ]),
                     new Assert\Length([
                         'max' => $this->eccubeConfig['eccube_kana_len'],
@@ -73,7 +73,7 @@ class KanaType extends AbstractType
                 'constraints' => [
                     new Assert\Regex([
                         'pattern' => '/^[ァ-ヶｦ-ﾟー]+$/u',
-                        'message' => 'form.type.notkanastyle',
+                        'message' => trans('form.type.notkanastyle'),
                     ]),
                     new Assert\Length([
                         'max' => $this->eccubeConfig['eccube_kana_len'],

--- a/src/Eccube/Form/Type/KanaType.php
+++ b/src/Eccube/Form/Type/KanaType.php
@@ -59,6 +59,7 @@ class KanaType extends AbstractType
                 'constraints' => [
                     new Assert\Regex([
                         'pattern' => '/^[ァ-ヶｦ-ﾟー]+$/u',
+                        'message' => 'form.type.notkanastyle',
                     ]),
                     new Assert\Length([
                         'max' => $this->eccubeConfig['eccube_kana_len'],
@@ -72,6 +73,7 @@ class KanaType extends AbstractType
                 'constraints' => [
                     new Assert\Regex([
                         'pattern' => '/^[ァ-ヶｦ-ﾟー]+$/u',
+                        'message' => 'form.type.notkanastyle',
                     ]),
                     new Assert\Length([
                         'max' => $this->eccubeConfig['eccube_kana_len'],

--- a/src/Eccube/Resource/locale/messages.en.php
+++ b/src/Eccube/Resource/locale/messages.en.php
@@ -412,6 +412,7 @@ return [
     'form.type.customer.password.too_long' => 'This password is too long. It should have {{ limit }} character or more.|This password is too long. It should have {{ limit }} characters or more.',
     'form.type.admin.nottelstyle' => 'Please enter only a half-width number or a hyphen for the telephone number. . ',
     'form.type.admin.notkanastyle' => 'Please enter your name (phonetic) in katakana. ',
+    'form.type.notkanastyle' => 'Please enter in katakana. ',
     'form.type.select.notselect' => 'Not entered. ',
     'form.type.select.selectis_future_or_now_date' => 'You can not select future or now dates. ',
     'cart.over.stock' => 'Inventory of the selected product (%product%) is insufficient.

--- a/src/Eccube/Resource/locale/messages.ja.php
+++ b/src/Eccube/Resource/locale/messages.ja.php
@@ -487,6 +487,7 @@ return [
     'form.type.customer.company.nothasspace' => '会社名にスペース、タブ、改行は含めないで下さい。',
     'form.type.admin.nottelstyle' => '電話番号は半角数字かハイフンのみを入力してください。',
     'form.type.admin.notkanastyle' => 'お名前(フリガナ)はカタカナで入力してください。',
+    'form.type.notkanastyle' => 'カタカナで入力してください。',
     'form.type.select.notselect' => '入力されていません。',
     'form.type.select.classcategory' => '項目が選択されていません。',
     'form.type.add.quantity' => '1以上で入力してください。',


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- フロント 会員登録 カナ姓名において、カナ以外の文字を入力した場合のエラーメッセージが「有効な値を入力してください」と表示される為、メッセージを「カタカナで入力してください。」に変更する。

## 方針(Policy)
- KanaType内の正規表現チェックで、エラーメッセージが未設定であった為、日・英のメッセージに対応するメッセージを追加、チェック時に指定。

## テスト（Test)
- フロント：会員登録：カナ姓 > 英数記号を入力
- フロント：会員登録：カナ姓 > 半角カナ入力
- フロント：会員登録：カナ姓 > 全角かな入力
- フロント：会員登録：カナ姓 > 全角カナ入力
- フロント：会員登録：カナ名 > 英数記号を入力
- フロント：会員登録：カナ名 > 半角カナ入力
- フロント：会員登録：カナ名 > 全角かな入力
- フロント：会員登録：カナ名 > 全角カナ入力

- 管理：会員登録：カナ姓 > 英数記号を入力
- 管理：会員登録：カナ姓 > 半角カナ入力
- 管理：会員登録：カナ姓 > 全角かな入力
- 管理：会員登録：カナ姓 > 全角カナ入力
- 管理：会員登録：カナ名 > 英数記号を入力
- 管理：会員登録：カナ名 > 半角カナ入力
- 管理：会員登録：カナ名 > 全角かな入力
- 管理：会員登録：カナ名 > 全角カナ入力