### PR TITLE
#372 【マイページ】お気に入り一覧から削除するとエラーが発生する

### DIFF
--- a/src/Eccube/Controller/Mypage/MypageController.php
+++ b/src/Eccube/Controller/Mypage/MypageController.php
@@ -16,7 +16,6 @@ namespace Eccube\Controller\Mypage;
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Customer;
-use Eccube\Entity\CustomerFavoriteProduct;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
 use Eccube\Exception\CartException;
@@ -345,11 +344,13 @@ class MypageController extends AbstractController
      *
      * @Route("/mypage/favorite/{id}/delete", name="mypage_favorite_delete", methods={"DELETE"}, requirements={"id" = "\d+"})
      */
-    public function delete(Request $request, CustomerFavoriteProduct $CustomerFavoriteProduct)
+    public function delete(Request $request, $id)
     {
         $this->isTokenValid();
 
         $Customer = $this->getUser();
+
+        $CustomerFavoriteProduct = $this->customerFavoriteProductRepository->findOneBy(['Customer' => $Customer, 'Product' => $id]);
 
         log_info('お気に入り商品削除開始', [$Customer->getId(), $CustomerFavoriteProduct->getId()]);
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
マイページ / お気に入り一覧画面から商品削除ボタンをクリックしたときにエラーとなる。

## 方針(Policy)
実行されるメソッドのパラメータが不正だったので修正

## 実装に関する補足(Appendix)
なし

## テスト（Test)
お気に入り一覧から選択商品が削除される

## 相談（Discussion）
なし