### PR TITLE
#302 【受注登録】対応状況でリストに出てこないステータスで変更するとシステムエラーが発生する

### DIFF
--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -420,11 +420,15 @@ class OrderType extends AbstractType
         $newStatus = $form['OrderStatus']->getData();
 
         // ステータスに変更があった場合のみチェックする.
-        if ($oldStatus->getId() != $newStatus->getId()) {
-            if (!$this->orderStateMachine->can($Order, $newStatus)) {
-                $form['OrderStatus']->addError(
-                    new FormError(sprintf('%sから%sには変更できません', $oldStatus->getName(), $newStatus->getName())));
+        if (!is_null($oldStatus) && !is_null($newStatus)) {
+            if ($oldStatus->getId() != $newStatus->getId()) {
+                if (!$this->orderStateMachine->can($Order, $newStatus)) {
+                    $form['OrderStatus']->addError(
+                        new FormError(sprintf('%sから%sには変更できません', $oldStatus->getName(), $newStatus->getName())));
+                }
             }
+        } else {
+            $form['OrderStatus']->addError(new FormError('ステータス変更できません。'));
         }
     }
 

--- a/src/Eccube/Service/PurchaseFlow/Processor/PointDiffProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PointDiffProcessor.php
@@ -150,6 +150,10 @@ class PointDiffProcessor extends ItemHolderValidator implements PurchaseProcesso
             return false;
         }
 
+        if (!$itemHolder->getOrderStatus()) {
+            return false;
+        }
+
         switch ($itemHolder->getOrderStatus()->getId()) {
             case OrderStatus::NEW:
             case OrderStatus::PAID:


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
＜再現手順＞
受注一覧から新規受付のデータを受注登録で開き、別タブで同じデータを受注登録で開く
新規受付から対応中で受注情報を登録する
もう１つのタブで、新規受付から入金済みで登録するとシステムエラーが発生する

＜期待動作＞
ステータス変更できない旨のエラーメッセージ表示

## 方針(Policy)
エラーメッセージとして「ステータス変更できません。」と表示する。

## 実装に関する補足(Appendix)
なし

## テスト（Test)
再現手順でエラーとならず、エラーメッセージ「ステータス変更できません。」と表示される。

## 相談（Discussion）
エラーメッセージとして「有効な値ではありません。」と一緒に表示されてしまうのは
よいでしょうか？