### PR TITLE
#371 【マイページ】お届け先一覧で削除ボタンが表示されない

### DIFF
--- a/src/Eccube/Resource/template/default/Mypage/delivery.twig
+++ b/src/Eccube/Resource/template/default/Mypage/delivery.twig
@@ -41,7 +41,11 @@ file that was distributed with this source code.
                         <div class="ec-addressList">
                             {% for CustomerAddress in Customer.CustomerAddresses %}
                                 <div class="ec-addressList__item">
-                                    <a class="ec-addressList__remove" href="{{ url('mypage_delivery_delete', { id : CustomerAddress.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete"></a>
+                                    <a class="ec-addressList__remove ec-icon" href="{{ url('mypage_delivery_delete', { id : CustomerAddress.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete">
+                                        <div class="ec-icon">
+                                            <img src="{{ asset('assets/icon/cross-dark.svg') }}" alt="close">
+                                        </div>
+                                    </a>
                                     <div class="ec-addressList__address">
                                         <div>{{ CustomerAddress.name01 }}&nbsp;{{ CustomerAddress.name02 }}</div>
                                         <div>〒{{ CustomerAddress.postal_code }}　{{ CustomerAddress.Pref }}{{ CustomerAddress.addr01 }}{{ CustomerAddress.addr02 }}</div>

--- a/src/Eccube/Resource/template/default/Mypage/delivery.twig
+++ b/src/Eccube/Resource/template/default/Mypage/delivery.twig
@@ -43,7 +43,7 @@ file that was distributed with this source code.
                                 <div class="ec-addressList__item">
                                     <a class="ec-addressList__remove ec-icon" href="{{ url('mypage_delivery_delete', { id : CustomerAddress.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete">
                                         <div class="ec-icon">
-                                            <img src="{{ asset('assets/icon/cross-dark.svg') }}" alt="close">
+                                            <img src="{{ asset('assets/icon/cross.svg') }}" alt="close">
                                         </div>
                                     </a>
                                     <div class="ec-addressList__address">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
マイページ / お届け先一覧で削除ボタンの設置ができていない。

## 方針(Policy)
削除用の×ボタンを設置しました。

## 実装に関する補足(Appendix)
なし

## テスト（Test)
削除ボタンを押下して選択したお届け先が削除される。

## 相談（Discussion）
なし