### PR TITLE
ログインしている状態で種別が異なる商品がカートにセットされているとカートから削除できない不具合修正

### DIFF
--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -244,17 +244,15 @@ class CartService
 
     protected function restoreCarts($cartItems)
     {
-        if (empty($cartItems)) {
-            foreach ($this->getCarts() as $Cart) {
-                foreach ($Cart->getCartItems() as $i) {
-                    $this->entityManager->remove($i);
-                    $this->entityManager->flush($i);
-                }
-                $this->entityManager->remove($Cart);
-                $this->entityManager->flush($Cart);
+        foreach ($this->getCarts() as $Cart) {
+            foreach ($Cart->getCartItems() as $i) {
+                $this->entityManager->remove($i);
+                $this->entityManager->flush($i);
             }
-            $this->carts = [];
+            $this->entityManager->remove($Cart);
+            $this->entityManager->flush($Cart);
         }
+        $this->carts = [];
 
         /** @var Cart[] $Carts */
         $Carts = [];


### PR DESCRIPTION
ログインされている時、種別が異なる商品がセットされているとカードが削除できなかったため修正
ログインされていなくても正常に削除できることを確認