### PR TITLE
【出荷登録】出荷内容の「販売価格」列のレイアウトが崩れている

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/shipping.twig
+++ b/src/Eccube/Resource/template/admin/Order/shipping.twig
@@ -613,7 +613,7 @@ file that was distributed with this source code.
                                                     <td class="align-middle">
                                                         <div class="col-12">
                                                             {{ OrderItem.price|price }}
-                                                            {{ form_widget(orderItemForm.price, { 'type': 'hidden' }) }}
+                                                            {{ form_widget(orderItemForm.price, { 'type': 'hidden', 'money_pattern': '{{}}' }) }}
                                                             {{ form_errors(orderItemForm.price) }}
                                                         </div>
                                                     </td>


### PR DESCRIPTION

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
  - When edit shipping price , ex : admin/shipping/53/edit
  - Have duplicate currency symbol in column, should remove 1.

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
- check shipping price : admin/shipping/53/edit
- only have one currency in column price.



