### PR TITLE
form_widgetに `type: 'hidden'` を指定しても非表示にならない

### DIFF
--- a/src/Eccube/Resource/template/default/Form/form_div_layout.twig
+++ b/src/Eccube/Resource/template/default/Form/form_div_layout.twig
@@ -46,9 +46,23 @@ file that was distributed with this source code.
 {%- endblock textarea_widget -%}
 
 {%- block radio_widget -%}
-    <label for="{{ id }}">{{ parent() }}
-        <span>{{ label is not same as(false) ? (translation_domain is same as(false) ? label : label|trans({}, translation_domain)) }}</span>
-    </label>
+    {% if type is defined and type == 'hidden' %}
+        {{ block('form_widget_simple') }}
+    {% else %}
+        <label for="{{ id }}">{{ parent() }}
+            <span>{{ label is not same as(false) ? (translation_domain is same as(false) ? label : label|trans({}, translation_domain)) }}</span>
+        </label>
+    {% endif %}
 {%- endblock radio_widget -%}
+
+{%- block checkbox_widget -%}
+    {% if type is defined and type == 'hidden' %}
+        {{ block('form_widget_simple') }}
+    {% else %}
+        <label for="{{ id }}">{{ parent() }}
+            <span>{{ label is not same as(false) ? (translation_domain is same as(false) ? label : label|trans({}, translation_domain)) }}</span>
+        </label>
+    {% endif %}
+{%- endblock checkbox_widget -%}
 
 


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
  - form_widgetに `type: 'hidden'` を指定しても非表示にならない
  - Disable radio & check when have attributue : "hide"

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
- add hide attribute for checkbox
- it not enable on screen



