### PR TITLE
IE、FireFoxでカテゴリなどの階層表示の幅がずれていたため修正

### DIFF
--- a/html/template/admin/assets/js/file_manager.js
+++ b/html/template/admin/assets/js/file_manager.js
@@ -346,9 +346,9 @@
 
         if (children.length) {
             if (currentPath.indexOf(path) !== 0) {
-                ul.addClass('collapse');
+                ul.addClass('collapse list-unstyled');
             } else {
-                ul.addClass('collapsed');
+                ul.addClass('collapsed list-unstyled');
             }
 
             ul.attr('id', path.replace('/', '_'));

--- a/src/Eccube/Resource/template/admin/Content/file.twig
+++ b/src/Eccube/Resource/template/admin/Content/file.twig
@@ -233,13 +233,13 @@ file that was distributed with this source code.
                             <div class="collapse show ec-cardCollapse" id="folderDirectory">
                                 <div class="card-body">
                                     <div class="c-directoryTree--folder mb-3">
-                                        <ul id="directory_userdata"> {# TODO フォルダ構成 #}
+                                        <ul id="directory_userdata" class="list-unstyled"> {# TODO フォルダ構成 #}
                                             <li>
                                                 <label class="collapsed" data-toggle="collapse" href="#directory_userdata" aria-expanded="false" aria-controls="directory_userdata">user_data</label>
-                                                <ul class="collapse" style="">
+                                                <ul class="collapse list-unstyled" style="">
                                                     <li>
                                                         <label class="collapsed" data-toggle="collapse" href="#directory_pdf" aria-expanded="false" aria-controls="directory_pdf"><a href="/content/file">pdf</a></label>
-                                                        <ul class="collapse" id="directory_pdf">
+                                                        <ul class="collapse list-unstyled" id="directory_pdf">
                                                             <li>
                                                                 <label><a href="/content/file">フォルダA</a></label>
                                                             </li>
@@ -248,7 +248,7 @@ file that was distributed with this source code.
                                                             </li>
                                                             <li>
                                                                 <label class="collapsed" data-toggle="collapse" href="#directory_eBook" aria-expanded="false" aria-controls="directory_eBook"><span class="font-weight-bold">電子書籍</span></label>
-                                                                <ul class="collapse" id="directory_eBook">
+                                                                <ul class="collapse list-unstyled" id="directory_eBook">
                                                                     <li>
                                                                         <label><span>実用書</span></label>
                                                                     </li>

--- a/src/Eccube/Resource/template/admin/Product/category.twig
+++ b/src/Eccube/Resource/template/admin/Product/category.twig
@@ -322,7 +322,7 @@ file that was distributed with this source code.
                     <a href="{{ url('admin_product_category_show', { parent_id : Category.id }) }}"{%if (Category.id == TargetId) %} class="font-weight-bold"{% endif %}>{{ Category.name }}
                         ({{ Category.children|length }})</a></span>
                 {% if Category.children|length > 0 %}
-                    <ul class="collapse {% if Category.id in Ids %}show{% endif %}"
+                    <ul class="collapse list-unstyled {% if Category.id in Ids %}show{% endif %}"
                         id="directory_category{{ Category.id }}">
                         {% for ChildCategory in Category.children %}
                             {{ selfMacro.tree(ChildCategory, TargetId, level, Ids) }}
@@ -343,7 +343,7 @@ file that was distributed with this source code.
                         <div class="c-directoryTree mb-3">
                             {% import _self as renderMacro %}
                             {% for TopCategory in TopCategories %}
-                                <ul>
+                                <ul class="list-unstyled">
                                     {{ renderMacro.tree(TopCategory, TargetCategory.Parent.id | default(null), 0, Ids) }}
                                 </ul>
                             {% endfor %}

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -791,7 +791,7 @@ file that was distributed with this source code.
                                     <li class="c-directoryTree--registerItem category-li">
                                         <input type="checkbox" id="admin_product_category_{{ Category.id }}" name="admin_product[Category][]" value="{{ Category.id }}" {% if Category.id in ChoicedIds %}checked{% endif %}>
                                         <label for="admin_product_category_{{ Category.id }}">{{ Category.name }}</label>
-                                        <ul class="pl-0">
+                                        <ul class="list-unstyled">
                                             {% for child,ChildCategory in Category.children %}
                                                 {{ selfMacro.tree(ChoicedIds, ChildCategory, form) }}
                                             {% endfor %}
@@ -802,7 +802,7 @@ file that was distributed with this source code.
                                 <div class="c-directoryTree--register rounded border mb-3 p-3">
                                     {% import _self as renderMacro %}
                                     {% for TopCategory in TopCategories %}
-                                        <ul class="pl-0">
+                                        <ul class="list-unstyled">
                                             {{ renderMacro.tree(ChoicedCategoryIds, TopCategory, form.Category) }}
                                         </ul>
                                     {% endfor %}


### PR DESCRIPTION
以下の管理画面を修正

* 商品登録画面
* カテゴリ管理画面
* ファイル管理画面