### PR TITLE
Composer経由でプラグインのインストール/アンインストール

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "doctrine/lexer": "^1.0",
         "doctrine/migrations": "^1.8",
         "doctrine/orm": "^2.6",
+        "ec-cube/plugin-installer": "0.0.3",
         "egulias/email-validator": "^2.1",
         "friendsofphp/php-cs-fixer": "^2.10",
         "guzzlehttp/guzzle": "^6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "381e29e4bbf38550909d97f35561fa7a",
+    "content-hash": "33ba1c22ea694f224a433ea8fadbc106",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1642,6 +1642,39 @@
                 "productivity"
             ],
             "time": "2017-10-20T08:47:57+00:00"
+        },
+        {
+            "name": "ec-cube/plugin-installer",
+            "version": "0.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/EC-CUBE/eccube-plugin-installer.git",
+                "reference": "ee1e90abf940c22a93e3aaaa1a5c5f93487f5e82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/EC-CUBE/eccube-plugin-installer/zipball/ee1e90abf940c22a93e3aaaa1a5c5f93487f5e82",
+                "reference": "ee1e90abf940c22a93e3aaaa1a5c5f93487f5e82",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Eccube\\Composer\\EccubePluginInstallerPlugin"
+            },
+            "autoload": {
+                "psr-0": {
+                    "Eccube": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "EC-CUBE plugin installer.",
+            "time": "2018-08-14T05:05:32+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -4913,17 +4946,6 @@
         {
             "name": "symfony/lts",
             "version": "v3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/lts.git",
-                "reference": "3a4e88df038e3197e6b66d091d2495fd7d255c0b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/lts/zipball/3a4e88df038e3197e6b66d091d2495fd7d255c0b",
-                "reference": "3a4e88df038e3197e6b66d091d2495fd7d255c0b",
-                "shasum": ""
-            },
             "conflict": {
                 "symfony/asset": ">=4",
                 "symfony/browser-kit": ">=4",

--- a/src/Eccube/Command/ComposerRemoveCommand.php
+++ b/src/Eccube/Command/ComposerRemoveCommand.php
@@ -1,35 +1,23 @@
 <?php
+
 /*
  * This file is part of EC-CUBE
  *
- * Copyright(c) 2000-2018 LOCKON CO.,LTD. All Rights Reserved.
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
  *
  * http://www.lockon.co.jp/
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 namespace Eccube\Command;
-
 
 use Eccube\Service\Composer\ComposerApiService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ComposerRemoveCommand extends Command
 {
@@ -53,6 +41,6 @@ class ComposerRemoveCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->composerService->execRemove($input->getArgument('package'));
+        $this->composerService->execRemove($input->getArgument('package'), $output);
     }
 }

--- a/src/Eccube/Command/ComposerRemoveCommand.php
+++ b/src/Eccube/Command/ComposerRemoveCommand.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2018 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Command;
+
+
+use Eccube\Service\Composer\ComposerApiService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class ComposerRemoveCommand extends Command
+{
+    protected static $defaultName = 'eccube:composer:remove';
+
+    /**
+     * @var ComposerApiService
+     */
+    private $composerService;
+
+    public function __construct(ComposerApiService $composerService)
+    {
+        parent::__construct();
+        $this->composerService = $composerService;
+    }
+
+    protected function configure()
+    {
+        $this->addArgument('package', InputArgument::REQUIRED);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->composerService->execRemove($input->getArgument('package'));
+    }
+}

--- a/src/Eccube/Command/ComposerRequireCommand.php
+++ b/src/Eccube/Command/ComposerRequireCommand.php
@@ -1,35 +1,23 @@
 <?php
+
 /*
  * This file is part of EC-CUBE
  *
- * Copyright(c) 2000-2018 LOCKON CO.,LTD. All Rights Reserved.
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
  *
  * http://www.lockon.co.jp/
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 namespace Eccube\Command;
-
 
 use Eccube\Service\Composer\ComposerApiService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ComposerRequireCommand extends Command
 {
@@ -54,6 +42,6 @@ class ComposerRequireCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->composerService->execRequire($input->getArgument('package'));
+        $this->composerService->execRequire($input->getArgument('package'), $output);
     }
 }

--- a/src/Eccube/Command/ComposerRequireCommand.php
+++ b/src/Eccube/Command/ComposerRequireCommand.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2018 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Command;
+
+
+use Eccube\Service\Composer\ComposerApiService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class ComposerRequireCommand extends Command
+{
+    protected static $defaultName = 'eccube:composer:require';
+
+    /**
+     * @var ComposerApiService
+     */
+    private $composerService;
+
+    public function __construct(ComposerApiService $composerService)
+    {
+        parent::__construct();
+        $this->composerService = $composerService;
+    }
+
+    protected function configure()
+    {
+        $this->addArgument('package', InputArgument::REQUIRED)
+            ->addArgument('version', InputArgument::OPTIONAL);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->composerService->execRequire($input->getArgument('package'));
+    }
+}

--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -212,17 +212,18 @@ class OwnerStoreController extends AbstractController
     /**
      * Api Install plugin by composer connect with package repo
      *
-     * @Route("/install/{pluginCode}/{eccubeVersion}/{version}" , name="admin_store_plugin_api_install")
+     * @Route("/install", name="admin_store_plugin_api_install")
      *
      * @param Request $request
-     * @param string $pluginCode
-     * @param string $eccubeVersion
-     * @param string $version
      *
      * @return RedirectResponse
      */
-    public function apiInstall(Request $request, $pluginCode, $eccubeVersion, $version)
+    public function apiInstall(Request $request)
     {
+        $pluginCode = $request->get('pluginCode');
+        $eccubeVersion = $request->get('eccubeVersion');
+        $version = $request->get('version');
+
         // Check plugin code
         $url = $this->eccubeConfig['eccube_package_repo_url'].'/search/packages.json'.'?eccube_version='.$eccubeVersion.'&plugin_code='.$pluginCode.'&version='.$version;
         list($json, $info) = $this->getRequestApi($url);

--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -18,6 +18,7 @@ use Eccube\Common\EccubeConfig;
 use Eccube\Exception\PluginException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Class ComposerApiService
@@ -47,6 +48,8 @@ class ComposerApiService implements ComposerServiceInterface
      * @param string $pluginName format foo/bar or foo/bar:1.0.0 or "foo/bar 1.0.0"
      *
      * @return array
+     *
+     * @throws PluginException
      */
     public function execInfo($pluginName)
     {
@@ -62,10 +65,11 @@ class ComposerApiService implements ComposerServiceInterface
      * Run execute command
      *
      * @param string $packageName format "foo/bar foo/bar:1.0.0"
+     * @param null|OutputInterface $output
      *
      * @throws PluginException
      */
-    public function execRequire($packageName)
+    public function execRequire($packageName, $output = null)
     {
         $packageName = explode(' ', trim($packageName));
         $this->runCommand([
@@ -77,17 +81,18 @@ class ComposerApiService implements ComposerServiceInterface
             '--ignore-platform-reqs' => true,
             '--update-with-dependencies' => true,
             '--no-scripts' => true,
-        ]);
+        ], $output);
     }
 
     /**
      * Run remove command
      *
      * @param string $packageName format "foo/bar foo/bar:1.0.0"
+     * @param null|OutputInterface $output
      *
      * @throws PluginException
      */
-    public function execRemove($packageName)
+    public function execRemove($packageName, $output = null)
     {
         $packageName = explode(' ', trim($packageName));
         $this->runCommand([
@@ -97,7 +102,7 @@ class ComposerApiService implements ComposerServiceInterface
             '--no-interaction' => true,
             '--profile' => true,
             '--no-scripts' => true,
-        ]);
+        ], $output);
     }
 
     /**
@@ -105,7 +110,9 @@ class ComposerApiService implements ComposerServiceInterface
      *
      * @param string $packageName
      * @param string $callback
-     * @param null   $typeFilter
+     * @param null $typeFilter
+     *
+     * @throws PluginException
      */
     public function foreachRequires($packageName, $callback, $typeFilter = null)
     {
@@ -124,9 +131,11 @@ class ComposerApiService implements ComposerServiceInterface
      * Run get config information
      *
      * @param string $key
-     * @param null   $value
+     * @param null $value
      *
      * @return array|mixed
+     *
+     * @throws PluginException
      */
     public function execConfig($key, $value = null)
     {
@@ -147,6 +156,8 @@ class ComposerApiService implements ComposerServiceInterface
      * Get config list
      *
      * @return array
+     *
+     * @throws PluginException
      */
     public function getConfig()
     {
@@ -171,30 +182,35 @@ class ComposerApiService implements ComposerServiceInterface
     /**
      * Run composer command
      *
-     * @throws PluginException
-     *
      * @param array $commands
+     * @param null $output
      *
      * @return string
+     *
+     * @throws PluginException
      */
-    public function runCommand($commands)
+    public function runCommand($commands, $output = null)
     {
         $this->init();
         $commands['--working-dir'] = $this->workingDir;
         $commands['--no-ansi'] = 1;
         $input = new ArrayInput($commands);
-        $output = new BufferedOutput();
+        $output = $output ?: new BufferedOutput();
 
         $exitCode = $this->consoleApplication->run($input, $output);
 
-        $log = $output->fetch();
-        if ($exitCode) {
-            log_error($log);
-            throw new PluginException($log);
-        }
-        log_info($log, $commands);
+        if ($output instanceof BufferedOutput) {
+            $log = $output->fetch();
+            if ($exitCode) {
+                log_error($log);
+                throw new PluginException($log);
+            }
+            log_info($log, $commands);
 
-        return $log;
+            return $log;
+        } elseif ($exitCode) {
+            throw new PluginException();
+        }
     }
 
     /**
@@ -217,6 +233,8 @@ class ComposerApiService implements ComposerServiceInterface
      * Get version of composer
      *
      * @return null|string
+     *
+     * @throws PluginException
      */
     public function composerVersion()
     {

--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -183,7 +183,7 @@ class ComposerApiService implements ComposerServiceInterface
      * Run composer command
      *
      * @param array $commands
-     * @param null $output
+     * @param null|OutputInterface $output
      *
      * @return string
      *
@@ -219,7 +219,7 @@ class ComposerApiService implements ComposerServiceInterface
     private function init()
     {
         set_time_limit(0);
-        @ini_set('memory_limit', '-1');
+        ini_set('memory_limit', '-1');
         // Config for some environment
         putenv('COMPOSER_HOME='.$this->eccubeConfig['plugin_realdir'].'/.composer');
         $consoleApplication = new Application();

--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -76,6 +76,7 @@ class ComposerApiService implements ComposerServiceInterface
             '--prefer-dist' => true,
             '--ignore-platform-reqs' => true,
             '--update-with-dependencies' => true,
+            '--no-scripts' => true,
         ]);
     }
 
@@ -95,6 +96,7 @@ class ComposerApiService implements ComposerServiceInterface
             '--ignore-platform-reqs' => true,
             '--no-interaction' => true,
             '--profile' => true,
+            '--no-scripts' => true,
         ]);
     }
 
@@ -201,14 +203,14 @@ class ComposerApiService implements ComposerServiceInterface
     private function init()
     {
         set_time_limit(0);
-        @ini_set('memory_limit', '1536M');
+        @ini_set('memory_limit', '-1');
         // Config for some environment
         putenv('COMPOSER_HOME='.$this->eccubeConfig['plugin_realdir'].'/.composer');
         $consoleApplication = new Application();
         $consoleApplication->resetComposer();
         $consoleApplication->setAutoExit(false);
         $this->consoleApplication = $consoleApplication;
-        $this->workingDir = $this->workingDir ? $this->workingDir : $this->eccubeConfig['root_dir'];
+        $this->workingDir = $this->workingDir ? $this->workingDir : $this->eccubeConfig['kernel.project_dir'];
     }
 
     /**

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -449,7 +449,7 @@ class PluginService
             $em->getConnection()->commit();
         } catch (\Exception $e) {
             $em->getConnection()->rollback();
-            throw new PluginException($e->getMessage());
+            throw new PluginException($e->getMessage(), $e->getCode(), $e);
         }
 
         return $p;

--- a/symfony.lock
+++ b/symfony.lock
@@ -119,6 +119,9 @@
             "ref": "70062abc2cd58794d2a90274502f81b55cd9951b"
         }
     },
+    "ec-cube/plugin-installer": {
+        "version": "0.0.3"
+    },
     "egulias/email-validator": {
         "version": "1.2.14"
     },


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- 以下の方法でプラグインをインストールできます。

```
# ec-cubeインストールディレクトリに移動
$ cd ec-cube

# Composer リポジトリ (開発用) 設定を追加
$ composer config repositories.eccube '{
    "type": "composer",
    "url": "https://dev-package-api.ec-cube.net",
    "options": {
        "http": {
            "header": ["X-ECCUBE-KEY: key_1_1"]
        }
    }
}'

# プラグインのインストール
$ bin/console eccube:composer:require ec-cube/ProductReview

# プラグインの有効化
$ bin/console eccube:plugin:enable --code ProductReview

# プラグインの無効化
$ bin/console eccube:plugin:disable --code ProductReview

# プラグインの削除
$ bin/console eccube:composer:remove ec-cube/ProductReview
```

## 実装に関する補足(Appendix)
- `composer`コマンド内のSymfonyのバージョンとEC-CUBEのSymfonyバージョンが異なるため、`composer`コマンドを直接実行してプラグインをインストールすることはできません。
- 代わりに`eccube:composer:xxx`コマンドを実装しています。
