### PR TITLE
#169 【共通】メール本文のフォントサイズ表示(12ptうんたらかんたら)はいらないので削除

### DIFF
--- a/src/Eccube/Resource/template/admin/Mail/entry_confirm.twig
+++ b/src/Eccube/Resource/template/admin/Mail/entry_confirm.twig
@@ -9,8 +9,6 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 #}
 　※本メールは自動配信メールです。
-　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
-　最適にご覧になれます。
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 　※本メールは、

--- a/src/Eccube/Resource/template/default/Mail/contact_mail.twig
+++ b/src/Eccube/Resource/template/default/Mail/contact_mail.twig
@@ -9,8 +9,6 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 #}
 　※本メールは自動配信メールです。
-　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
-　最適にご覧になれます。
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 　※本メールは、

--- a/src/Eccube/Resource/template/default/Mail/customer_withdraw_mail.twig
+++ b/src/Eccube/Resource/template/default/Mail/customer_withdraw_mail.twig
@@ -9,8 +9,6 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 #}
 　※本メールは自動配信メールです。
-　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
-　最適にご覧になれます。
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 　※本メールは、

--- a/src/Eccube/Resource/template/default/Mail/entry_complete.twig
+++ b/src/Eccube/Resource/template/default/Mail/entry_complete.twig
@@ -9,8 +9,6 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 #}
 　※本メールは自動配信メールです。
-　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
-　最適にご覧になれます。
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 　※本メールは、

--- a/src/Eccube/Resource/template/default/Mail/entry_confirm.twig
+++ b/src/Eccube/Resource/template/default/Mail/entry_confirm.twig
@@ -9,8 +9,6 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 #}
 　※本メールは自動配信メールです。
-　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
-　最適にご覧になれます。
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 　※本メールは、

--- a/src/Eccube/Resource/template/default/Mail/forgot_mail.twig
+++ b/src/Eccube/Resource/template/default/Mail/forgot_mail.twig
@@ -9,8 +9,6 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 #}
 　※本メールは自動配信メールです。
-　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
-　最適にご覧になれます。
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 　※本メールは、

--- a/src/Eccube/Resource/template/default/Mail/reset_complete_mail.twig
+++ b/src/Eccube/Resource/template/default/Mail/reset_complete_mail.twig
@@ -9,8 +9,6 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 #}
 　※本メールは自動配信メールです。
-　等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
-　最適にご覧になれます。
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 　※本メールは、


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
メールテンプレートの
「等幅フォント(MSゴシック12ポイント、Osaka-等幅など)で
　最適にご覧になれます。」の削除

## 方針(Policy)
なし

## 実装に関する補足(Appendix)
なし

## テスト（Test)
なし

## 相談（Discussion）
なし