### PR TITLE
feat 管理画面（受注一覧・商品一覧）、フロント画面（商品一覧）のN+1問題対応

### DIFF
--- a/src/Eccube/DataCollector/EccubeDataCollector.php
+++ b/src/Eccube/DataCollector/EccubeDataCollector.php
@@ -120,8 +120,18 @@ class EccubeDataCollector extends DataCollector
             $enabled = $this->container->getParameter('eccube.plugins.enabled');
             $disabled = $this->container->getParameter('eccube.plugins.disabled');
 
+            $Plugins = $this->pluginRepository->findAll();
             foreach (array_merge($enabled, $disabled) as $code) {
-                $Plugin = $this->pluginRepository->findOneBy(['code' => $code]);
+                $Plugin = null;
+
+                /** @var Plugin $Plugin */
+                foreach ($Plugins as $p) {
+                    if ($code == $p->getCode()) {
+                        $Plugin = $p;
+                        break;
+                    }
+                }
+
                 if (!$Plugin) {
                     $Plugin = new Plugin();
                     $Plugin->setCode($code);

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -251,6 +251,9 @@ class OrderRepository extends AbstractRepository
     {
         $qb = $this->createQueryBuilder('o')
             ->select('o, s')
+            ->addSelect('oi', 'p')
+            ->leftJoin('o.OrderItems', 'oi')
+            ->leftJoin('o.Pref', 'p')
             ->innerJoin('o.Shippings', 's');
 
         // order_id_start
@@ -427,7 +430,6 @@ class OrderRepository extends AbstractRepository
         // buy_product_name
         if (isset($searchData['buy_product_name']) && StringUtil::isNotBlank($searchData['buy_product_name'])) {
             $qb
-                ->leftJoin('o.OrderItems', 'oi')
                 ->andWhere('oi.product_name LIKE :buy_product_name')
                 ->setParameter('buy_product_name', '%'.$searchData['buy_product_name'].'%');
         }

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -177,7 +177,11 @@ class ProductRepository extends AbstractRepository
     public function getQueryBuilderBySearchDataForAdmin($searchData)
     {
         $qb = $this->createQueryBuilder('p')
-            ->innerJoin('p.ProductClasses', 'pc');
+            ->addSelect('pc', 'pi', 'tr', 'ps')
+            ->innerJoin('p.ProductClasses', 'pc')
+            ->leftJoin('p.ProductImage', 'pi')
+            ->leftJoin('pc.TaxRule', 'tr')
+            ->leftJoin('pc.ProductStock', 'ps');
 
         // id
         if (isset($searchData['id']) && StringUtil::isNotBlank($searchData['id'])) {

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -65,12 +65,13 @@ class ProductRepository extends AbstractRepository
     public function findWithSortedClassCategories($productId)
     {
         $qb = $this->createQueryBuilder('p');
-        $qb->addSelect(['pc', 'cc1', 'cc2', 'pi', 'ps'])
+        $qb->addSelect(['pc', 'cc1', 'cc2', 'pi', 'ps', 'pt'])
             ->innerJoin('p.ProductClasses', 'pc')
             ->leftJoin('pc.ClassCategory1', 'cc1')
             ->leftJoin('pc.ClassCategory2', 'cc2')
             ->leftJoin('p.ProductImage', 'pi')
             ->innerJoin('pc.ProductStock', 'ps')
+            ->leftJoin('p.ProductTag', 'pt')
             ->where('p.id = :id')
             ->orderBy('cc1.sort_no', 'DESC')
             ->addOrderBy('cc2.sort_no', 'DESC');


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
管理画面 受注一覧・商品一覧、フロント画面の商品一覧のN+1問題対応

ローカルでの検証結果は以下

### 変更前

画面 | 50件 | 1000件
-- | -- | --
管理画面：商品一覧 | Database Queries1022<br>Query time717.86 ms | Database Queries10022<br>Query time6691.96 ms
管理画面：受注一覧 | Database Queries104<br>Query time104.97 ms | Database Queries1069<br>Query time1001.84 ms
管理画面：会員一覧 | Database Queries14<br>Query time17.15 ms | Database Queries14<br>Query time33.14 ms
フロント画面：商品一覧 | Database Queries345<br>Query time375.17 ms | ※Database Queries1242<br>Query time1244.07 ms


※フロント画面：商品一覧の1000件はエラーで表示できなかったので200件でテスト

### 改善後

画面 | 50件 | 1000件
-- | -- | --
管理画面：商品一覧 | Database Queries22<br>Query time86.96 ms | Database Queries22<br>Query time369.28 ms
管理画面：受注一覧 | Database Queries22<br>Query time57.33 ms | Database Queries22<br>Query time251.93 ms
管理画面：会員一覧 | 改善なし | 改善なし
フロント画面：商品一覧 | Database Queries295<br>Query time349.10 ms | Database Queries1045<br>Query time1231.53 ms

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->
明示的にjoinする。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
- 管理画面：会員一覧はもともとクエリ数が少なかったので対応なし。
- フロント画面：商品一覧はTaxRuleがLazyLoadされておりクエリ数が多くなっているが、EventSubscriberとGroupByで改善が難しくなっており対応できていない。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
なし

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
フロント画面：商品一覧についていい方法があれば教えてください。

