### PR TITLE
#176 【メール設定】出荷通知メールに伝票番号が必要

### DIFF
--- a/src/Eccube/Resource/template/admin/Mail/shipping_notify.twig
+++ b/src/Eccube/Resource/template/admin/Mail/shipping_notify.twig
@@ -12,6 +12,13 @@ file that was distributed with this source code.
 
 {{ header }}
 
+{% if Shipping.tracking_number %}
+お問合せ伝票番号：{{ Shipping.tracking_number }}
+{% if Shipping.Delivery.confirm_url %}
+お問合せURL：{{ Shipping.Delivery.confirm_url }}
+{% endif %}
+{% endif %}
+
 ************************************************
 　ご注文商品明細
 ************************************************

--- a/src/Eccube/Resource/template/admin/Mail/shipping_notify.twig
+++ b/src/Eccube/Resource/template/admin/Mail/shipping_notify.twig
@@ -13,9 +13,9 @@ file that was distributed with this source code.
 {{ header }}
 
 {% if Shipping.tracking_number %}
-お問合せ伝票番号：{{ Shipping.tracking_number }}
+お問い合わせ番号：{{ Shipping.tracking_number }}
 {% if Shipping.Delivery.confirm_url %}
-お問合せURL：{{ Shipping.Delivery.confirm_url }}
+お問い合わせURL：{{ Shipping.Delivery.confirm_url }}
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
177 【配送方法登録】配送業者の URL を、出荷完了メールと連携させる必要がある

## 概要(Overview・Refs Issue)
出荷通知メールに伝票番号と配送業者に設定したURLを表示する

## 方針(Policy)
伝票番号は配送データに入力されていない場合は非表示とする
配送業者URLが設定されていない場合は非表示とする

## 実装に関する補足(Appendix)
なし

## テスト（Test)
出荷通知実行時に送信メールに記載がある
設定されていない場合は非表示で送信される

## 相談（Discussion）
出荷通知メールの項目名を
「お問合せ伝票番号」「お問合せURL」としておりますが
よろしいかどうか判断お願いいたします。
合わせて記載の場所の確認願います。
