### PR TITLE
#349【受注一覧】受注をキャンセルした場合に在庫が戻らない

### DIFF
--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -32,6 +32,7 @@ use Eccube\Repository\Master\SexRepository;
 use Eccube\Repository\OrderPdfRepository;
 use Eccube\Repository\OrderRepository;
 use Eccube\Repository\PaymentRepository;
+use Eccube\Repository\ProductStockRepository;
 use Eccube\Service\CsvExportService;
 use Eccube\Service\MailService;
 use Eccube\Service\OrderPdfService;
@@ -99,6 +100,11 @@ class OrderController extends AbstractController
     /** @var OrderPdfRepository */
     protected $orderPdfRepository;
 
+    /**
+     * @var ProductStockRepository
+     */
+    protected $productStockRepository;
+
     /** @var OrderPdfService */
     protected $orderPdfService;
 
@@ -128,6 +134,7 @@ class OrderController extends AbstractController
      * @param OrderStatusRepository $orderStatusRepository
      * @param PageMaxRepository $pageMaxRepository
      * @param ProductStatusRepository $productStatusRepository
+     * @param ProductStockRepository $productStockRepository
      * @param OrderRepository $orderRepository
      * @param OrderPdfRepository $orderPdfRepository
      * @param OrderPdfService $orderPdfService
@@ -143,6 +150,7 @@ class OrderController extends AbstractController
         OrderStatusRepository $orderStatusRepository,
         PageMaxRepository $pageMaxRepository,
         ProductStatusRepository $productStatusRepository,
+        ProductStockRepository $productStockRepository,
         OrderRepository $orderRepository,
         OrderPdfRepository $orderPdfRepository,
         OrderPdfService $orderPdfService,
@@ -158,6 +166,7 @@ class OrderController extends AbstractController
         $this->orderStatusRepository = $orderStatusRepository;
         $this->pageMaxRepository = $pageMaxRepository;
         $this->productStatusRepository = $productStatusRepository;
+        $this->productStockRepository = $productStockRepository;
         $this->orderRepository = $orderRepository;
         $this->orderPdfRepository = $orderPdfRepository;
         $this->orderPdfService = $orderPdfService;
@@ -506,7 +515,19 @@ class OrderController extends AbstractController
                     } else {
                         $result['mail'] = false;
                     }
-                    $this->entityManager->flush();
+                    // 対応中・キャンセルの更新時は商品在庫を増減させているので商品情報を更新
+                    if ($OrderStatus->getId() == OrderStatus::IN_PROGRESS || $OrderStatus->getId() == OrderStatus::CANCEL) {
+                        foreach ($Order->getOrderItems() as $OrderItem) {
+                            $ProductClass = $OrderItem->getProductClass();
+                            if ($OrderItem->isProduct() && !$ProductClass->isStockUnlimited()) {
+                                $this->entityManager->flush($ProductClass);
+                                $ProductStock = $this->productStockRepository->findOneBy(['ProductClass' => $ProductClass]);
+                                $this->entityManager->flush($ProductStock);
+                            }
+                        }
+                    }
+                    $this->entityManager->flush($Order);
+                    $this->entityManager->flush($Shipping);
 
                     // 会員の場合、購入回数、購入金額などを更新
                     if ($Customer = $Order->getCustomer()) {

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -506,8 +506,7 @@ class OrderController extends AbstractController
                     } else {
                         $result['mail'] = false;
                     }
-                    $this->entityManager->flush($Shipping);
-                    $this->entityManager->flush($Order);
+                    $this->entityManager->flush();
 
                     // 会員の場合、購入回数、購入金額などを更新
                     if ($Customer = $Order->getCustomer()) {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
受注一覧から一括受注ステータス更新で
対応中 ⇒ キャンセル
キャンセル ⇒ 対応中
ステータス更新した際に商品在庫が増減していない

## 方針(Policy)
受注編集のように
$this->entityManager->flush();
でEntityを指定せずにflushするよう修正

## 実装に関する補足(Appendix)
なし

## テスト（Test)
ステータスが対応中の選択した受注をキャンセルへ更新したときに受注明細の商品在庫が増えている。
ステータスがキャンセルの選択した受注を対応中へ更新したときに受注明細の商品在庫が減っている。

## 相談（Discussion）
なし