### PR TITLE
APP_ENV=prod の場合に DATABASE_SERVER_VERSION を指定すると、カートに商品が入らなくなる問題の修正

### DIFF
--- a/src/Eccube/EventListener/TransactionListener.php
+++ b/src/Eccube/EventListener/TransactionListener.php
@@ -13,6 +13,7 @@
 
 namespace Eccube\EventListener;
 
+use Doctrine\Dbal\Connection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -73,7 +74,12 @@ class TransactionListener implements EventSubscriberInterface
             return;
         }
 
-        $this->em->getConnection()->setAutoCommit(false);
+        /** @var Connection $Connection */
+        $Connection = $this->em->getConnection();
+        if (!$Connection->isConnected()) {
+            $Connection->connect();
+        }
+        $Connection->setAutoCommit(false);
         $this->em->beginTransaction();
         log_debug('Begin Transaction.');
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
`Connection::setAutoCommit(false)` をコールする前にデータベース接続が確立していないと、最終的なコミットが無効となってしまう模様。

`DATABASE_SERVER_VERSION` を指定していない場合は、 内部的にデータベースのバージョンを取得する際に接続を確立するために動作していた。

## 方針(Policy)
`Eccube\EventListener\TransactionListener` にて、 `Connection::setAutoCommit(false)` をコールする前に、 データベース接続を確立するよう修正。

## テスト（Test)
デバッグツールバーのログ出力にて、トランザクションがコミットされているのを確認

## 相談（Discussion）
- プラグインにて例外がスローされた場合に、意図した通り正常にロールバックされるか要確認
- https://github.com/EC-CUBE/ec-cube/issues/1518#issuecomment-234825735

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更


