### PR TITLE
【受注一覧】「入金済み」ステータスの受注が「対応中」に変更せずに「キャンセル」へ変更可能となっている

### DIFF
--- a/app/config/eccube/packages/order_state_machine.php
+++ b/app/config/eccube/packages/order_state_machine.php
@@ -48,7 +48,7 @@ $container->loadFromExtension('framework', [
                     'to' => (string) Status::IN_PROGRESS,
                 ],
                 'cancel' => [
-                    'from' => [(string) Status::NEW, (string) Status::IN_PROGRESS, (string) Status::PAID],
+                    'from' => [(string) Status::NEW, (string) Status::IN_PROGRESS],
                     'to' => (string) Status::CANCEL,
                 ],
                 'back_to_in_progress' => [

--- a/tests/Eccube/Tests/Service/OrderStateMachineTest.php
+++ b/tests/Eccube/Tests/Service/OrderStateMachineTest.php
@@ -64,7 +64,7 @@ class OrderStateMachineTest extends EccubeTestCase
             [OrderStatus::PAID,         OrderStatus::NEW,           false],
             [OrderStatus::PAID,         OrderStatus::PAID,          false],
             [OrderStatus::PAID,         OrderStatus::IN_PROGRESS,   true],
-            [OrderStatus::PAID,         OrderStatus::CANCEL,        true],
+            [OrderStatus::PAID,         OrderStatus::CANCEL,        false],
             [OrderStatus::PAID,         OrderStatus::DELIVERED,     true],
             [OrderStatus::PAID,         OrderStatus::RETURNED,      false],
 


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
  - エラーとなり、注文状況が更新されないこと

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
1．受注一覧画面で対象の受注のステータスを「入金済み」に変更する
　2．「入金済み」ステータスの受注を「キャンセル」へ変更する
　3．エラーが表示されずに、ステータスが「キャンセル」となっている（NG）



