### PR TITLE
【issueリスト165】検索件数のデフォルトを50件に変更

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -62,7 +62,7 @@ parameters:
     eccube_smtext_len: 100
     eccube_tax_rule_priority: ['product_id','product_class_id','pref_id','country_id']
     eccube_url_len: 1024
-    eccube_default_page_count: 10
+    eccube_default_page_count: 50
     eccube_admin_product_stock_status: 3
     eccube_info_url: 'https://www.ec-cube.net/info/4/'
     eccube_customer_reset_expire: 10

--- a/codeception/_support/Page/Admin/OrderManagePage.php
+++ b/codeception/_support/Page/Admin/OrderManagePage.php
@@ -236,4 +236,9 @@ class OrderManagePage extends AbstractAdminPageStyleGuide
     {
         return $this->tester->grabTextFrom("#search_result > tbody > tr:nth-child(${rowNum}) > td:nth-child(4) > span");
     }
+
+    public function 件数変更($num) {
+        $this->tester->selectOption("#form_bulk > div.row.justify-content-between.mb-2 > div.col-5.text-right > div:nth-child(1) > select", '/admin/order/page/1?page_count=' . $num);
+        return $this;
+    }
 }

--- a/codeception/acceptance/EA04OrderCest.php
+++ b/codeception/acceptance/EA04OrderCest.php
@@ -234,6 +234,7 @@ class EA04OrderCest
         $I->resetEmails();
 
         OrderManagePage::go($I)
+            ->件数変更(10)
             ->一覧_全選択()
             ->一括メール送信();
 

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
@@ -151,29 +151,26 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $this->verify('検索結果件数の確認テスト');
 
         // デフォルトの表示件数確認テスト
-        $this->expected = '10件';
-        $this->actual = $crawler->filter('select.custom-select > option:nth-child(1)')->text();
+        $this->expected = '50件';
+        $this->actual = $crawler->filter('select.custom-select > option:selected')->text();
         $this->verify('デフォルトの表示件数確認テスト');
 
-        // TODO
-        $this->markTestIncomplete('表示件数のプルダウン実装後に修正');
-
-        // 表示件数20件テスト
-        $crawler = $this->client->request('GET', $this->generateUrl('admin_product_page', ['page_no' => 1]), ['page_count' => 20]);
-        $this->expected = '20件';
-        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
-        $this->verify('表示件数20件テスト');
+        // 表示件数100件テスト
+        $crawler = $this->client->request('GET', $this->generateUrl('admin_product_page', ['page_no' => 1]), ['page_count' => 100]);
+        $this->expected = '100件';
+        $this->actual = $crawler->filter('select.custom-select > option:selected')->text();
+        $this->verify('表示件数100件テスト');
 
         // 表示件数入力値は正しくない場合はデフォルトの表示件数になるテスト
         $crawler = $this->client->request('GET', $this->generateUrl('admin_product_page', ['page_no' => 1]), ['page_count' => 999999]);
-        $this->expected = '13 件';
-        $this->actual = $crawler->filter('#result_list__header h3 strong')->text();
+        $this->expected = '検索結果：13件が該当しました';
+        $this->actual = $crawler->filter('#search_form > div:nth-child(4) > span')->text();
         $this->verify('表示件数入力値は正しくない場合はデフォルトの表示件数になるテスト');
 
         // 表示件数はSESSIONから取得するテスト
         $crawler = $this->client->request('GET', $this->generateUrl('admin_product_page', ['page_no' => 1]), ['status' => 1]);
-        $this->expected = '20件';
-        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        $this->expected = '100件';
+        $this->actual = $crawler->filter('select.custom-select > option:selected')->text();
         $this->verify('表示件数はSESSIONから取得するテスト');
     }
 
@@ -202,29 +199,26 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $this->verify('検索結果件数の確認テスト');
 
         // デフォルトの表示件数確認テスト
-        $this->expected = '10件';
-        $this->actual = $crawler->filter('select.custom-select > option:nth-child(1)')->text();
+        $this->expected = '50件';
+        $this->actual = $crawler->filter('select.custom-select > option:selected')->text();
         $this->verify('デフォルトの表示件数確認テスト');
 
-        // TODO
-        $this->markTestIncomplete('表示件数のプルダウン実装後に修正');
-
-        // 表示件数20件テスト
-        $crawler = $this->client->request('GET', $this->generateUrl('admin_product_page', ['page_no' => 1]), ['page_count' => 40]);
-        $this->expected = '40件';
-        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
-        $this->verify('表示件数40件テスト');
+        // 表示件数100件テスト
+        $crawler = $this->client->request('GET', $this->generateUrl('admin_product_page', ['page_no' => 1]), ['page_count' => 100]);
+        $this->expected = '100件';
+        $this->actual = $crawler->filter('select.custom-select > option:selected')->text();
+        $this->verify('表示件数100件テスト');
 
         // 表示件数入力値は正しくない場合はデフォルトの表示件数になるテスト
         $crawler = $this->client->request('GET', $this->generateUrl('admin_product_page', ['page_no' => 1]), ['page_count' => 999999]);
-        $this->expected = '1 件';
-        $this->actual = $crawler->filter('#result_list__header h3 strong')->text();
+        $this->expected = '検索結果：1件が該当しました';
+        $this->actual = $crawler->filter('#search_form > div:nth-child(4) > span')->text();
         $this->verify('表示件数入力値は正しくない場合はデフォルトの表示件数になるテスト');
 
         // 表示件数はSESSIONから取得するテスト
         $crawler = $this->client->request('GET', $this->generateUrl('admin_product_page', ['page_no' => 1]), ['status' => 1]);
-        $this->expected = '40件';
-        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        $this->expected = '100件';
+        $this->actual = $crawler->filter('select.custom-select > option:selected')->text();
         $this->verify('表示件数はSESSIONから取得するテスト');
     }
 
@@ -250,30 +244,27 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $this->verify('検索結果件数の確認テスト');
 
         // デフォルトの表示件数確認テスト
-        $this->expected = '10件';
-        $this->actual = $crawler->filter('select.custom-select > option:nth-child(1)')->text();
+        $this->expected = '50件';
+        $this->actual = $crawler->filter('select.custom-select > option:selected')->text();
         $this->verify('デフォルトの表示件数確認テスト');
 
-        // TODO
-        $this->markTestIncomplete('表示件数のプルダウン実装後に修正');
-
-        // 表示件数20件テスト
-        $crawler = $this->client->request('GET', $this->generateUrl('admin_product_page', ['page_no' => 1]), ['page_count' => 30]);
-        $this->expected = '30件';
-        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        // 表示件数100件テスト
+        $crawler = $this->client->request('GET', $this->generateUrl('admin_product_page', ['page_no' => 1]), ['page_count' => 100]);
+        $this->expected = '100件';
+        $this->actual = $crawler->filter('select.custom-select > option:selected')->text();
         $this->verify();
 
         // 表示件数入力値は正しくない場合はデフォルトのの表示件数になるテスト
         $crawler = $this->client->request('GET', $this->generateUrl('admin_product_page', ['page_no' => 1]), ['page_count' => 999999]);
-        $this->expected = '1 件';
-        $this->actual = $crawler->filter('#result_list__header h3 strong')->text();
+        $this->expected = '検索結果：1件が該当しました';
+        $this->actual = $crawler->filter('#search_form > div:nth-child(4) > span')->text();
         $this->verify();
 
         // 表示件数はSESSIONから取得するテスト
         $crawler = $this->client->request('GET', $this->generateUrl('admin_product_page', ['page_no' => 1]), ['status' => 1]);
 
-        $this->expected = '30件';
-        $this->actual = $crawler->filter('li#result_list__pagemax_menu a')->text();
+        $this->expected = '100件';
+        $this->actual = $crawler->filter('select.custom-select > option:selected')->text();
         $this->verify();
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
選択肢は現状と同じ（10件～100件まで10件刻み）として、50件をデフォルト
テストを通るように修正

