### PR TITLE
IP制限がフロントでも効いていたので修正

### DIFF
--- a/src/Eccube/EventListener/IpAddrListener.php
+++ b/src/Eccube/EventListener/IpAddrListener.php
@@ -14,6 +14,7 @@
 namespace Eccube\EventListener;
 
 use Eccube\Common\EccubeConfig;
+use Eccube\Request\Context;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -25,9 +26,15 @@ class IpAddrListener implements EventSubscriberInterface
      */
     protected $eccubeConfig;
 
-    public function __construct(EccubeConfig $eccubeConfig)
+    /**
+     * @var Context
+     */
+    protected $requestContext;
+
+    public function __construct(EccubeConfig $eccubeConfig, Context $requestContext)
     {
         $this->eccubeConfig = $eccubeConfig;
+        $this->requestContext = $requestContext;
     }
 
     public function onKernelRequest(GetResponseEvent $event)
@@ -42,8 +49,10 @@ class IpAddrListener implements EventSubscriberInterface
             return;
         }
 
-        if (array_search($event->getRequest()->getClientIp(), $allowHosts) === false) {
-            throw new AccessDeniedHttpException();
+        if ($this->requestContext->isAdmin()) {
+            if (array_search($event->getRequest()->getClientIp(), $allowHosts) === false) {
+                throw new AccessDeniedHttpException();
+            }
         }
     }
 


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
- IPアドレス制限を有効にすると、管理画面だけでなくフロントでも有効になっていた
- 管理画面のみ実行されるように修正




