### PR TITLE
管理画面：会員登録：エラーの表示を修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -73,8 +73,14 @@ file that was distributed with this source code.
                                             <div class="col">
                                                 {{ form_widget(form.name.name02) }}
                                             </div>
-                                            {{ form_errors(form.name.name01) }}
-                                            {{ form_errors(form.name.name02) }}
+                                        </div>
+                                        <div class="row">
+                                            <div class="col">
+                                                {{ form_errors(form.name.name01) }}
+                                            </div>
+                                            <div class="col">
+                                                {{ form_errors(form.name.name02) }}
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
@@ -91,8 +97,14 @@ file that was distributed with this source code.
                                             <div class="col">
                                                 {{ form_widget(form.kana.kana02) }}
                                             </div>
-                                            {{ form_errors(form.kana.kana01) }}
-                                            {{ form_errors(form.kana.kana02) }}
+                                        </div>
+                                        <div class="row">
+                                            <div class="col">
+                                                {{ form_errors(form.kana.kana01) }}
+                                            </div>
+                                            <div class="col">
+                                                {{ form_errors(form.kana.kana02) }}
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
@@ -115,12 +127,15 @@ file that was distributed with this source code.
                                                 <div class="col-auto pr-0 align-self-center"><span>{{ 'admin.common.postal_symbol'|trans }}</span></div>
                                                 <div class="col-2">
                                                     {{ form_widget(form.postal_code) }}
-                                                </div>
 
-                                                {{ form_errors(form.postal_code) }}
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col">
+                                                    {{ form_errors(form.postal_code) }}
+                                                </div>
                                             </div>
                                         </div>
-
                                         <div class="mb-3">
                                             <div class="row justify-content-start">
                                                 <div class="col-auto">

--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -125,6 +125,7 @@ file that was distributed with this source code.
                                             <div class="row justify-content-start">
                                                 <div class="col-auto">
                                                     {{ form_widget(form.address.pref) }}
+                                                    {{ form_errors(form.address.pref) }}
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- 都道府県のエラーメッセージが表示されていない不具合を修正
- エラーの表示がずれていた問題を修正

## before

![image](https://user-images.githubusercontent.com/8196725/44249719-1c307a80-a22c-11e8-9a5b-754d518b1611.png)

## after

![image](https://user-images.githubusercontent.com/8196725/44249730-2a7e9680-a22c-11e8-96bf-2865eb6771fd.png)

