### PR TITLE
日時データのテストに失敗する問題の対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install: &php_setup |
   echo "opcache.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   echo "apc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  echo "date.timezone=Asia/Tokyo" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:
   - &composer_install composer install --dev --no-interaction -o --apcu-autoloader


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- phpunitと、ec-cubeのtimezoneがずれているため、時間帯によっては日時を確認するテストに失敗する場合がある
- php.iniでtimezoneをAsia/Tokyoに固定するように対応
