### PR TITLE
fix 住所入力フォームで「番地」にまで「市町村名」が自動入力されるようになっていたのを修正

### DIFF
--- a/src/Eccube/Form/Type/AddressType.php
+++ b/src/Eccube/Form/Type/AddressType.php
@@ -114,7 +114,7 @@ class AddressType extends AbstractType
                     new Assert\Length(['max' => $this->config['eccube_address2_len']]),
                 ],
                 'attr' => [
-                    'class' => 'p-locality p-street-address',
+                    'class' => 'p-extended-address',
                     'placeholder' => 'common.address_sample_02',
                 ],
             ],


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
住所入力フォームで「番地」にまで「市町村名」が自動入力されるようになっていたのを修正

## 関連
以下のバックポート
https://github.com/EC-CUBE/ec-cube/pull/2417