### PR TITLE
fix バリデーションエラー時に支払い方法画像が消えてしまうのを修正

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/Shop/PaymentController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/PaymentController.php
@@ -101,11 +101,11 @@ class PaymentController extends AbstractController
 
         $form = $builder->getForm();
 
-        $form->setData($Payment);
-        $form->handleRequest($request);
-
         // 既に画像保存されてる場合は取得する
         $oldPaymentImage = $Payment->getPaymentImage();
+
+        $form->setData($Payment);
+        $form->handleRequest($request);
 
         // 登録ボタン押下
         if ($form->isSubmitted() && $form->isValid()) {


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
以下の対応が4.0移行時にバグってしまっていたので修正
https://github.com/EC-CUBE/ec-cube/pull/2366

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
handleRequest実行までに$oldPaymentImageを保持しないとpostの内容で上書きされてしまうので意味がない
