### PR TITLE
twig拡張の3系から4系への移行がうまくできていなかった部分の対応

### DIFF
--- a/src/Eccube/Twig/Extension/EccubeExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeExtension.php
@@ -44,14 +44,7 @@ class EccubeExtension extends AbstractExtension
             new TwigFunction('has_errors', [$this, 'hasErrors']),
             new TwigFunction('active_menus', [$this, 'getActiveMenus']),
             new TwigFunction('class_categories_as_json', [$this, 'getClassCategoriesAsJson']),
-            new TwigFunction('php_*', function () {
-                $arg_list = func_get_args();
-                $function = array_shift($arg_list);
-                if (is_callable($function)) {
-                    return call_user_func_array($function, $arg_list);
-                }
-                trigger_error('Called to an undefined function : php_'.$function, E_USER_WARNING);
-            }, ['pre_escape' => 'html', 'is_safe' => ['html']]),
+            new TwigFunction('php_*', [$this, 'getPhpFunctions'], ['pre_escape' => 'html', 'is_safe' => ['html']]),
         ];
     }
 

--- a/src/Eccube/Twig/Extension/EccubeExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeExtension.php
@@ -174,30 +174,6 @@ class EccubeExtension extends AbstractExtension
     }
 
     /**
-     * product_idで指定したProductを取得
-     * Productが取得できない場合、または非公開の場合、商品情報は表示させない。
-     * デバッグ環境以外ではProductが取得できなくでもエラー画面は表示させず無視される。
-     *
-     * @param $id
-     *
-     * @return Product|null
-     */
-    public function getProduct($id)
-    {
-        try {
-            $Product = $this->app['eccube.repository.product']->get($id);
-
-            if ($Product->getStatus()->getId() == Disp::DISPLAY_SHOW) {
-                return $Product;
-            }
-        } catch (\Exception $e) {
-            return null;
-        }
-
-        return null;
-    }
-
-    /**
      * Twigでphp関数を使用できるようにする。
      *
      * @return mixed|null

--- a/src/Eccube/Twig/Extension/EccubeExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeExtension.php
@@ -199,9 +199,9 @@ class EccubeExtension extends AbstractExtension
     public function getProduct($id)
     {
         try {
-            $Product = $this->productRepository->find($id);
+            $Product = $this->productRepository->findWithSortedClassCategories($id);
 
-            if ($Product && $Product->getStatus()->getId() == ProductStatus::DISPLAY_SHOW) {
+            if ($Product->getStatus()->getId() == ProductStatus::DISPLAY_SHOW) {
                 return $Product;
             }
         } catch (\Exception $e) {

--- a/tests/Eccube/Tests/Twig/Extension/EccubeExtensionTest.php
+++ b/tests/Eccube/Tests/Twig/Extension/EccubeExtensionTest.php
@@ -14,6 +14,7 @@
 namespace Eccube\Tests\Twig\Extension;
 
 use Eccube\Common\EccubeConfig;
+use Eccube\Repository\ProductRepository;
 use Eccube\Twig\Extension\EccubeExtension;
 use Eccube\Tests\EccubeTestCase;
 
@@ -28,7 +29,8 @@ class EccubeExtensionTest extends EccubeTestCase
     {
         parent::setUp();
         $EccubeConfig = $this->container->get(EccubeConfig::class);
-        $this->Extension = new EccubeExtension($EccubeConfig);
+        $productRepository = $this->container->get(ProductRepository::class);
+        $this->Extension = new EccubeExtension($EccubeConfig, $productRepository);
     }
 
     public function testGetClassCategoriesAsJson()


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
以下の２点修正
- twig内でphp関数を使えるようにする関数の実装が重複していたので他の関数の実装と合わせる
- getProduct関数のsymfony対応

## twig拡張 `getProduct` の使い方

twig内で `product(id)` とするとProductのEntityが取得できる。
例えば以下のように使用するとid=1の商品情報をdumpできる。

```twig
{{ dump(product(1)) }}
```
