### PR TITLE
アクセス制限でのNavの表示項目制御がIDとURLを混合していて正しく制御できていなかったのでURLでの判定に統一

### DIFF
--- a/src/Eccube/EventListener/TwigInitializeListener.php
+++ b/src/Eccube/EventListener/TwigInitializeListener.php
@@ -27,6 +27,7 @@ use SunCat\MobileDetectBundle\DeviceDetector\MobileDetector;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
 class TwigInitializeListener implements EventSubscriberInterface
@@ -72,6 +73,11 @@ class TwigInitializeListener implements EventSubscriberInterface
     private $mobileDetector;
 
     /**
+     * @var UrlGeneratorInterface
+     */
+    private $router;
+
+    /**
      * TwigInitializeListener constructor.
      *
      * @param Environment $twig
@@ -82,6 +88,7 @@ class TwigInitializeListener implements EventSubscriberInterface
      * @param EccubeConfig $eccubeConfig
      * @param Context $context
      * @param MobileDetector $mobileDetector
+     * @param UrlGeneratorInterface $router
      */
     public function __construct(
         Environment $twig,
@@ -91,7 +98,8 @@ class TwigInitializeListener implements EventSubscriberInterface
         AuthorityRoleRepository $authorityRoleRepository,
         EccubeConfig $eccubeConfig,
         Context $context,
-        MobileDetector $mobileDetector
+        MobileDetector $mobileDetector,
+        UrlGeneratorInterface $router
     ) {
         $this->twig = $twig;
         $this->baseInfoRepository = $baseInfoRepository;
@@ -101,6 +109,7 @@ class TwigInitializeListener implements EventSubscriberInterface
         $this->eccubeConfig = $eccubeConfig;
         $this->requestContext = $context;
         $this->mobileDetector = $mobileDetector;
+        $this->router = $router;
     }
 
     /**
@@ -174,15 +183,53 @@ class TwigInitializeListener implements EventSubscriberInterface
         $this->twig->addGlobal('menus', $menus);
 
         // メニューの権限制御.
+        $eccubeNav = $this->eccubeConfig['eccube_nav'];
+
         $Member = $this->requestContext->getCurrentUser();
-        $AuthorityRoles = [];
         if ($Member instanceof Member) {
-            $AuthorityRoles = $this->authorityRoleRepository->findBy(['Authority' => $this->requestContext->getCurrentUser()->getAuthority()]);
+            $AuthorityRoles = $this->authorityRoleRepository->findBy(['Authority' => $Member->getAuthority()]);
+            $baseUrl = $event->getRequest()->getBaseUrl() . '/' . $this->eccubeConfig['eccube_admin_route'];
+            $eccubeNav = $this->getDisplayEccubeNav($eccubeNav, $AuthorityRoles, $baseUrl);
         }
-        $roles = array_map(function (AuthorityRole $AuthorityRole) use ($event) {
-            return $event->getRequest()->getBaseUrl().'/'.$this->eccubeConfig['eccube_admin_route'].$AuthorityRole->getDenyUrl();
-        }, $AuthorityRoles);
-        $this->twig->addGlobal('AuthorityRoles', $roles);
+        $this->twig->addGlobal('eccubeNav', $eccubeNav);
+    }
+
+    /**
+     * URLに対する権限有無チェックして表示するNavを返す
+     *
+     * @param array $parentNav
+     * @param AuthorityRole[] $AuthorityRoles
+     * @param string $baseUrl
+     *
+     * @return array
+     */
+    private function getDisplayEccubeNav($parentNav, $AuthorityRoles, $baseUrl)
+    {
+        foreach ($parentNav as $key => $childNav) {
+            if (array_key_exists('children', $childNav) && count($childNav['children']) > 0) {
+                // 子のメニューがある場合は子の権限チェック
+                $parentNav[$key]['children'] = $this->getDisplayEccubeNav($childNav['children'], $AuthorityRoles, $baseUrl);
+
+                if (count($parentNav[$key]['children']) <= 0) {
+                    // 子が存在しない場合は配列から削除
+                    unset($parentNav[$key]);
+                }
+            } elseif (array_key_exists('url', $childNav)) {
+                // 子のメニューがなく、URLが設定されている場合は権限があるURLか確認
+                $param = array_key_exists('param', $childNav) ? $childNav['param'] : [];
+                $url = $this->router->generate($childNav['url'], $param);
+                foreach ($AuthorityRoles as $AuthorityRole) {
+                    $denyUrl = str_replace('/', '\/', $baseUrl . $AuthorityRole->getDenyUrl());
+                    if (preg_match("/^({$denyUrl})/i", $url)) {
+                        // 権限がないURLの場合は配列から削除
+                        unset($parentNav[$key]);
+                        break;
+                    }
+                }
+            }
+        }
+
+        return $parentNav;
     }
 
     /**

--- a/src/Eccube/Resource/template/admin/nav.twig
+++ b/src/Eccube/Resource/template/admin/nav.twig
@@ -10,78 +10,76 @@ file that was distributed with this source code.
 #}
 <nav>
     <ul class="c-mainNavArea__nav">
+        <!-- ホーム -->
         <li class="c-mainNavArea__navItem">
-            <a class="c-mainNavArea__navItemTitle"
-               href="{{ url('admin_homepage') }}"><i class="fa fa-home fa-fw"
-                                                     aria-hidden="true"></i><span>{{ 'admin.home'|trans }}</span></a>
+            <a class="c-mainNavArea__navItemTitle" href="{{ url('admin_homepage') }}">
+                <i class="fa fa-home fa-fw" aria-hidden="true"></i>
+                <span>{{ 'admin.home'|trans }}</span>
+            </a>
         </li>
-        {% for key1, level1 in eccube_config.eccube_nav if app.request.baseUrl ~ '/' ~ eccube_config.eccube_admin_route ~ '/' ~ key1 not in AuthorityRoles %}
+        {% for key1, level1 in eccubeNav %}
             <li class="c-mainNavArea__navItem">
                 {% if level1.children is defined and level1.children|length > 0 %}
                     <a class="c-mainNavArea__navItemTitle{{ active_menus(menus)[0] != key1 ? ' collapsed' }}"
                        data-toggle="collapse" href="#nav-{{ key1 }}"
                        aria-expanded="{{ active_menus(menus)[0] == key1 ? 'true' : 'false' }}"
-                       aria-controls="nav-{{ key1 }}"><i class="fa {{ level1.icon }} fa-fw"
-                                                         aria-hidden="true"></i><span>{{ level1.name|trans }}</span></a>
-                    <ul class="collapse {% if active_menus(menus)[0] == key1 %} show{% endif %}"
-                        id="nav-{{ key1 }}">
-                        {% for key2, level2 in level1.children if app.request.baseUrl ~ '/' ~ eccube_config.eccube_admin_route ~ '/' ~ key1 ~ '/' ~ key2 not in AuthorityRoles %}
-                            {% if level2.url is defined and path(level2.url, level2.param is defined ? level2.param : []) in AuthorityRoles %}
-                            {% else %}
+                       aria-controls="nav-{{ key1 }}">
+                        <i class="fa {{ level1.icon }} fa-fw" aria-hidden="true"></i>
+                        <span>{{ level1.name|trans }}</span>
+                    </a>
+                    <ul class="collapse {% if active_menus(menus)[0] == key1 %} show{% endif %}" id="nav-{{ key1 }}">
+                        {% for key2, level2 in level1.children %}
+                            <li>
                                 {% if level2.children is defined and level2.children|length > 0 %}
-                                    <li>
-                                        <a class="c-mainNavArea__navItemSubTitle{{ active_menus(menus)[1] != key2 ? ' collapsed' }}"
-                                           data-toggle="collapse" href="#nav-{{ key2 }}"
-                                           aria-expanded="{{ active_menus(menus)[1] != key2 ? 'true' : 'false' }}"
-                                           aria-controls="nav-{{ key2 }}"><span>{{ level2.name|trans }}</span></a>
-                                        <ul class="collapse{{ active_menus(menus)[1] == key2 ? ' show' }}"
-                                            id="nav-{{ key2 }}">
-                                            {% for key3, level3 in level2.children %}
-                                                {% if level3.url is defined and path(level3.url, level3.param is defined ? level3.param : []) in AuthorityRoles %}
-                                                {% else %}
-                                                    <li>
-                                                        <a href="{{ url(level3.url, level3.param is defined ? level3.param : []) }}"{{ active_menus(menus)[2] == key3 ? ' class="is-active"' }}>{{ level3.name|trans }}</a>
-                                                    </li>
-                                                {% endif %}
-                                            {% endfor %}
-                                        </ul>
-                                    </li>
+                                    <a class="c-mainNavArea__navItemSubTitle{{ active_menus(menus)[1] != key2 ? ' collapsed' }}"
+                                       data-toggle="collapse" href="#nav-{{ key2 }}"
+                                       aria-expanded="{{ active_menus(menus)[1] != key2 ? 'true' : 'false' }}"
+                                       aria-controls="nav-{{ key2 }}">
+                                        <span>{{ level2.name|trans }}</span>
+                                    </a>
+                                    <ul class="collapse{{ active_menus(menus)[1] == key2 ? ' show' }}" id="nav-{{ key2 }}">
+                                        {% for key3, level3 in level2.children %}
+                                            <li>
+                                                <a href="{{ url(level3.url, level3.param is defined ? level3.param : []) }}"{{ active_menus(menus)[2] == key3 ? ' class="is-active"' }}>
+                                                    <span>{{ level3.name|trans }}</span>
+                                                </a>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
                                 {% else %}
-                                    <li>
-                                        <a href="{{ url(level2.url, level2.param is defined ? level2.param : []) }}"{{ active_menus(menus)[1] == key2 ? ' class="is-active"' }}>{{ level2.name|trans }}</a>
-                                    </li>
+                                    <a href="{{ url(level2.url, level2.param is defined ? level2.param : []) }}"{{ active_menus(menus)[1] == key2 ? ' class="is-active"' }}>
+                                        <span>{{ level2.name|trans }}</span>
+                                    </a>
                                 {% endif %}
-                            {% endif %}
+                            </li>
                         {% endfor %}
                     </ul>
                 {% else %}
-                    {% if level1.url is defined and path(level1.url, level1.param is defined ? level1.param : []) in AuthorityRoles == false %}
-                        <a class="c-mainNavArea__navItemTitle"
-                           href="{{ url(level1.url, level1.param is defined ? level1.param : []) }}"><i
-                                    class="fa {{ level1.icon }}"
-                                    aria-hidden="true"></i><span>{{ level1.name|trans }}</span></a>
-                    {% else %}
-                        <div class="c-mainNavArea__navItemTitle"><i class="fa {{ level1.icon }} fa-fw"
-                                                                    aria-hidden="true"></i><span>{{ level1.name|trans }}</span>
-                        </div>
-                    {% endif %}
+                    <a class="c-mainNavArea__navItemTitle" href="{{ url(level1.url, level1.param is defined ? level1.param : []) }}">
+                        <i class="fa {{ level1.icon }}" aria-hidden="true"></i>
+                        <span>{{ level1.name|trans }}</span>
+                    </a>
                 {% endif %}
             </li>
         {% endfor %}
+        <!-- 情報 -->
         <li class="c-mainNavArea__navItem">
             <a class="c-mainNavArea__navItemTitle collapsed" data-toggle="collapse" href="#others" aria-expanded="false"
-               aria-controls="others"><i class="fa fa-info-circle fa-fw"
-                                         aria-hidden="true"></i><span>{{ 'admin.info'|trans }}</span></a>
+               aria-controls="others">
+                <i class="fa fa-info-circle fa-fw" aria-hidden="true"></i>
+                <span>{{ 'admin.info'|trans }}</span>
+            </a>
             <ul class="collapse" id="others">
                 <li>
-                    <a href="{{ eccube_config.eccube_official_site_url }}"
-                       target="_blank">{{ 'admin.info.official_site'|trans }}</a>
+                    <a href="{{ eccube_config.eccube_official_site_url }}" target="_blank">
+                        <span>{{ 'admin.info.official_site'|trans }}</span>
+                    </a>
                 </li>
                 <li>
-                    <a href="{{ eccube_config.eccube_community_site_url }}"
-                       target="_blank">{{ 'admin.info.community'|trans }}</a>
+                    <a href="{{ eccube_config.eccube_community_site_url }}" target="_blank">
+                        <span>{{ 'admin.info.community'|trans }}</span>
+                    </a>
                 </li>
-
             </ul>
         </li>
     </ul>

--- a/src/Eccube/Twig/Extension/EccubeExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeExtension.php
@@ -326,24 +326,4 @@ class EccubeExtension extends AbstractExtension
 
         return $html;
     }
-
-    /**
-     * URLに対する権限有無チェック
-     *
-     * @param $target
-     * @param $AuthorityRoles
-     *
-     * @return boolean
-     */
-    public function isAuthorizedUrl($target, $AuthorityRoles)
-    {
-        foreach ($AuthorityRoles as $authorityRole) {
-            $denyUrl = str_replace('/', '\/', $authorityRole);
-            if (preg_match("/^({$denyUrl})/i", $target)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
 }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
Navについて以下の問題点があったので解決している
- IDとURL混同してアクセス制限の判定を行なっていた
  - 子要素が全てアクセス不可でも項目が表示される可能性があった
  - 逆にアクセス制限がされていない子要素が表示されない可能性があった
  - URLでの判定が正解なので統一
- 実装が不十分でURLの前方一致で判定ができていなかった
  - 関連: https://github.com/EC-CUBE/ec-cube/pull/3376
- twigの実装が複雑になっていたのでリファクタリング
- その他 `<span>` タグなど抜けているものがあったので修正

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->
`nav.twig` 内では処理が複雑になりすぎてしまうので、 `TwigInitializeListener.php` 内で有効なNavのリストを作成するように修正

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
プラグインには影響なし