### PR TITLE
[WIP] PurchaseFlow でエラーが発生した場合に遷移先を指定できるよう修正

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -136,7 +136,14 @@ class ShoppingController extends AbstractShoppingController
         // フォームを生成する
         $this->forwardToRoute('shopping_create_form');
 
-        if ($flowResult->hasWarning() || $flowResult->hasError()) {
+        if ($flowResult->hasWarning() || $flowResult->hasError()) { // XXX warning の場合は遷移させない？
+            foreach ($flowResult->getValidateErrorHandlers() as $errorHandler) {
+                return $this->redirectToRoute(
+                    $errorHandler->getRoute(),
+                    $errorHandler->getRouteParameters()
+                );
+            }
+
             return $this->redirectToRoute('cart');
         }
 

--- a/src/Eccube/Service/PurchaseFlow/Processor/PointProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PointProcessor.php
@@ -129,7 +129,7 @@ class PointProcessor extends ItemHolderValidator implements ItemHolderPreprocess
     }
 
     /**
-     * {@inheritdoc
+     * {@inheritdoc}
      */
     public function commit(ItemHolderInterface $target, PurchaseContext $context)
     {
@@ -137,7 +137,7 @@ class PointProcessor extends ItemHolderValidator implements ItemHolderPreprocess
     }
 
     /**
-     * {@inheritdoc
+     * {@inheritdoc}
      */
     public function rollback(ItemHolderInterface $itemHolder, PurchaseContext $context)
     {
@@ -148,6 +148,22 @@ class PointProcessor extends ItemHolderValidator implements ItemHolderPreprocess
 
         $Customer = $itemHolder->getCustomer();
         $Customer->setPoint($Customer->getPoint() + $itemHolder->getUsePoint());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRoute()
+    {
+        return 'shopping';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRouteParameters()
+    {
+        return [];
     }
 
     /*

--- a/src/Eccube/Service/PurchaseFlow/PurchaseFlow.php
+++ b/src/Eccube/Service/PurchaseFlow/PurchaseFlow.php
@@ -103,7 +103,11 @@ class PurchaseFlow
         foreach ($itemHolder->getItems() as $item) {
             foreach ($this->itemValidators as $itemValidator) {
                 $result = $itemValidator->execute($item, $context);
-                $flowResult->addProcessResult($result);
+                if ($itemValidator instanceof ValidateErrorHandlerInterface) {
+                    $flowResult->addProcessResult($result, $itemValidator);
+                } else {
+                    $flowResult->addProcessResult($result);
+                }
             }
         }
 
@@ -111,7 +115,11 @@ class PurchaseFlow
 
         foreach ($this->itemHolderValidators as $itemHolderValidator) {
             $result = $itemHolderValidator->execute($itemHolder, $context);
-            $flowResult->addProcessResult($result);
+            if ($itemHolderValidator instanceof ValidateErrorHandlerInterface) {
+                $flowResult->addProcessResult($result, $itemHolderValidator);
+            } else {
+                $flowResult->addProcessResult($result);
+            }
         }
 
         $this->calculateAll($itemHolder);

--- a/src/Eccube/Service/PurchaseFlow/PurchaseFlowResult.php
+++ b/src/Eccube/Service/PurchaseFlow/PurchaseFlowResult.php
@@ -23,6 +23,10 @@ class PurchaseFlowResult
     /** @var ProcessResult[] */
     private $processResults = [];
 
+    /** @var ValidateErrorHandlerInterface[] */
+    private $validateErrorHandlers = [];
+
+
     /**
      * PurcahseFlowResult constructor.
      *
@@ -33,9 +37,12 @@ class PurchaseFlowResult
         $this->itemHolder = $itemHolder;
     }
 
-    public function addProcessResult(ProcessResult $processResult)
+    public function addProcessResult(ProcessResult $processResult, ValidateErrorHandlerInterface $validateErrorHandler = null)
     {
         $this->processResults[] = $processResult;
+        if ($validateErrorHandler) {
+            $this->validateErrorHandlers[] = $validateErrorHandler;
+        }
     }
 
     /**
@@ -66,5 +73,13 @@ class PurchaseFlowResult
     public function hasWarning()
     {
         return !empty($this->getWarning());
+    }
+
+    /**
+     * @return ValidateErrorHandlerInterface[]
+     */
+    public function getValidateErrorHandlers()
+    {
+        return $this->validateErrorHandlers;
     }
 }

--- a/src/Eccube/Service/PurchaseFlow/ValidateErrorHandlerInterface.php
+++ b/src/Eccube/Service/PurchaseFlow/ValidateErrorHandlerInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\PurchaseFlow;
+
+/**
+ * PurchaseFlow でのエラーハンドラ.
+ *
+ * このインターフェイスを実装することで、 InvalidItemException がスローされた場合の遷移先を指定できます。
+ */
+interface ValidateErrorHandlerInterface
+{
+    /**
+     * @return string The name of the route
+     */
+    public function getRoute();
+
+    /**
+     * @return string[] An array of parameters
+     */
+    public function getRouteParameters();
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
PurchaseFlow でエラーが発生した場合に遷移先を指定できるよう修正。
注文手続き画面で、ポイント関連のエラーが発生した場合、カート画面に遷移してしまうのを防止

## 方針(Policy)
- ValidateErrorHandlerInterface を新規作成
- ValidateErrorHandlerInterface を Processor に実装しておくことで、 InvalidItemException がスローされた場合に遷移先を指定できる

## 実装に関する補足(Appendix)
- ValidateErrorHandlerInterface は PurchaseFlowResult で複数保持できるようにしているが、遷移可能なのは最初の1個所のみ

## テスト（Test)
TODO

## 相談（Discussion）
- 本来ならコントローラで制御したいが、カスタマイズ時に追加するのは Processor なので、 Processor のみで遷移先も制御できるようにした。
- PurchaseFlow の仕様変更を含んでいるが、追加のエラーハンドリングなので既存機能に大きな影響は無いと思われる

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



