### PR TITLE
購入完了画面に注文番号の表示（3系から）

### DIFF
--- a/src/Eccube/Resource/template/default/Shopping/complete.twig
+++ b/src/Eccube/Resource/template/default/Shopping/complete.twig
@@ -65,7 +65,12 @@ file that was distributed with this source code.
             <div class="ec-reportHeading">
                 <h2>{{ 'front.shopping.complete_message__title'|trans }}</h2>
             </div>
-            <p class="ec-reportDescription">{{ 'front.shopping.complete_message__body'|trans }}</p>
+            <p class="ec-reportDescription">
+                {{ 'front.shopping.complete_message__body'|trans }}
+                {% if Order.id %}
+                    <br /><br /><strong>ご注文番号：{{ Order.orderNo }}</strong>
+                {% endif %}
+            </p>
 
             {% if Order.complete_message is not empty %}
                 {{ Order.complete_message|raw }}


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
以下の3系のPRから取り込み
refs https://github.com/EC-CUBE/ec-cube/pull/2192

ただしidではなく注文番号(OrderNo)を表示に変更している
