### PR TITLE
UpdateDate, CreateDateの更新処理をSaveEventSubscriberに統一

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -580,7 +580,6 @@ class ProductController extends AbstractController
                     $this->entityManager->persist($ProductTag);
                 }
 
-                $Product->setUpdateDate(new \DateTime());
                 $this->entityManager->flush();
 
                 log_info('商品登録完了', [$id]);

--- a/src/Eccube/Repository/CustomerFavoriteProductRepository.php
+++ b/src/Eccube/Repository/CustomerFavoriteProductRepository.php
@@ -42,8 +42,6 @@ class CustomerFavoriteProductRepository extends AbstractRepository
             $CustomerFavoriteProduct = new \Eccube\Entity\CustomerFavoriteProduct();
             $CustomerFavoriteProduct->setCustomer($Customer);
             $CustomerFavoriteProduct->setProduct($Product);
-            $CustomerFavoriteProduct->setCreateDate(new \DateTime());
-            $CustomerFavoriteProduct->setUpdateDate(new \DateTime());
 
             $em = $this->getEntityManager();
             $em->persist($CustomerFavoriteProduct);

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -415,10 +415,7 @@ class PluginService
                 ->setClassName(isset($meta['event']) ? $meta['event'] : '')
                 ->setVersion($meta['version'])
                 ->setSource($source)
-                ->setCode($meta['code'])
-                // TODO 日付の自動設定
-                ->setCreateDate(new \DateTime())
-                ->setUpdateDate(new \DateTime());
+                ->setCode($meta['code']);
 
             $em->persist($p);
             $em->flush();


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
UpdateDate, CreateDateの更新処理をSaveEventSubscriberに統一
それぞれのController等で行なっていたUpdateDate, CreateDateの更新は不要なので処理を削除

refs https://github.com/EC-CUBE/ec-cube/pull/1704

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->
UpdateDate, CreateDateの更新処理をSaveEventSubscriberに統一

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
UpdateDateの更新はLifecycleEventのpreUpdateで行なっています。
このイベントはテーブルの書き換えが発生しない限りイベントが実行されないので、変更前の動作と以下の点で挙動が異なります。
- 商品情報を何も変更しないで保存した場合
  - 修正後はイベントが実行されないのでUpdateDateは更新されません。
- 商品規格情報を更新した場合
  - 商品情報とEntityが異なるため商品情報のUpdateDateは更新されません。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
ローカルで以下の動作でUpdateDate, CreateDateが更新されることを確認
- 管理画面から商品情報を編集
- コマンドラインからプラグインをインストール（画面からのインストールも同じ関数を使用している）
- フロント画面からお気に入り登録


