### PR TITLE
【共通】【注文フロー】送料を含めて金額でポイント付与されている

### DIFF
--- a/src/Eccube/Service/PurchaseFlow/Processor/PointProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PointProcessor.php
@@ -203,9 +203,11 @@ class PointProcessor extends ItemHolderValidator implements ItemHolderPreprocess
             }
 
             // TODO: ポイントは税抜き分しか割引されない、ポイント明細は税抜きのままでいいのか？
+            $point = 0;
             if ($item->isPoint()) {
                 $point = round($item->getPrice() * ($pointRate / 100)) * $item->getQuantity();
-            } else {
+            // Only calc point on product
+            } elseif ($item->isProduct()) {
                 // ポイント = 単価 * ポイント付与率 * 数量
                 $point = round($item->getPriceIncTax() * ($pointRate / 100)) * $item->getQuantity();
             }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
   - 送料に対してポイント付与されないこと

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
 - phpUnit
1．任意の商品をショッピングカートに入れてレジに進む
2．「ご注文内容のご確認」画面まで遷移
3．画面右側にある加算予定ポイントを確認すると送料を含めた金額でポイント付与されることを確認（NG）


## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



