### PR TITLE
ダミーデータ生成時の受注番号を変更

### DIFF
--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -552,7 +552,7 @@ class Generator
             ->setNote($faker->realText())
             ->setAddPoint(0)    // TODO
             ->setUsePoint(0)    // TODO
-            ->setOrderNo(sha1(StringUtil::random()))
+            ->setOrderNo($faker->numberBetween(100, 999).'-'.$faker->numberBetween(1000000, 9999999).'-'.$faker->numberBetween(1000000, 9999999))
         ;
 
         $this->entityManager->persist($Order);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
bin/console eccube:fixtures:generate で生成するダミーデータについて。
受注番号を実際のサイトのようになるように変更。

例） 382-5760706-5029950

## 方針(Policy)
実際のサイトの受注番号の桁数

## 実装に関する補足(Appendix)
なし

## テスト（Test)
生成されることを確認

## 相談（Discussion）
なし
