### PR TITLE
メッセージが日本語で表示できていなかったところを修正

### DIFF
--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -262,7 +262,7 @@ front.product.add_favorite_alrady: お気に入りに追加済です。
 front.product.out_of_stock: ただいま品切れ中です。
 front.product.out_of_stock_label: (品切れ中)
 front.product.added_to_favorite: お気に入りに追加済です。
-front.product.nomal_price: 通常価格
+front.product.normal_price: 通常価格
 front.product.sale_price: 販売価格
 front.product.code: 商品コード
 front.product.related_category: 関連カテゴリ
@@ -291,7 +291,7 @@ front.cart.no_items: 現在カート内に商品はございません。
 front.cart.delivery_fee_free__now: 現在送料無料です。
 front.cart.delivery_fee_free__price_and_quantity: あと「<strong>%price%</strong>」または「<strong>%quantity%個</strong>」のお買い上げで<strong class="ec-color-red">送料無料</strong>になります。
 front.cart.delivery_fee_free__price: あと「<strong>%price%</strong>」のお買い上げで<strong class="ec-color-red">送料無料</strong>になります。
-front.cart.delivery_fee_free__quantity: '<strong>%quantity%個</strong>」のお買い上げで<strong class="ec-color-red">送料無料</strong>になります。'
+front.cart.delivery_fee_free__quantity: あと「<strong>%quantity%個</strong>」のお買い上げで<strong class="ec-color-red">送料無料</strong>になります。
 
 #------------------------------------------------------------------------------------
 # ショッピング

--- a/src/Eccube/Resource/template/default/Cart/index.twig
+++ b/src/Eccube/Resource/template/default/Cart/index.twig
@@ -183,21 +183,21 @@ file that was distributed with this source code.
                             {% if is_delivery_free[cartKey] %}
                                 {{ 'front.cart.delivery_fee_free__now'|trans }}
                             {% else %}
-                                {{ 'front.cart.delivery_fee_free__price_and_quantity'|trans({ '%price%': least[cartKey]|price, '%quantity%': quantity[cartKey]|number_format }) }}
+                                {{ 'front.cart.delivery_fee_free__price_and_quantity'|trans({ '%price%': least[cartKey]|price, '%quantity%': quantity[cartKey]|number_format })|raw }}
                             {% endif %}
                         {% elseif BaseInfo.delivery_free_amount %}
                             <br/>
                             {% if is_delivery_free[cartKey] %}
                                 {{ 'front.cart.delivery_fee_free__now'|trans }}
                             {% else %}
-                                {{ 'front.cart.delivery_fee_free__price'|trans({ '%price%': least[cartKey]|price }) }}
+                                {{ 'front.cart.delivery_fee_free__price'|trans({ '%price%': least[cartKey]|price })|raw }}
                             {% endif %}
                         {% elseif BaseInfo.delivery_free_quantity %}
                             <br/>
                             {% if is_delivery_free[cartKey] %}
-                                {{ 'front.cart.delivery_fee_free__price'|trans() }}
+                                {{ 'front.cart.delivery_fee_free__now'|trans }}
                             {% else %}
-                                {{ 'front.cart.delivery_fee_free__quantity'|trans({ '%quantity%': quantity[cartKey]|price }) }}
+                                {{ 'front.cart.delivery_fee_free__quantity'|trans({ '%quantity%': quantity[cartKey]|number_format })|raw }}
                             {% endif %}
                         {% endif %}
                     </div>

--- a/src/Eccube/Resource/template/default/Contact/index.twig
+++ b/src/Eccube/Resource/template/default/Contact/index.twig
@@ -49,7 +49,7 @@ file that was distributed with this source code.
                             <dd>
                                 <div class="ec-halfInput{{ has_errors(form.kana.kana01, form.kana.kana02) ? ' error' }}">
                                     {{ form_widget(form.kana.kana01, {'attr': { 'placeholder': 'common.last_name_kana' }}) }}
-                                    {{ form_widget(form.kana.kana02, {'attr': { 'placeholder': 'common.first_naee_kana' }}) }}
+                                    {{ form_widget(form.kana.kana02, {'attr': { 'placeholder': 'common.first_name_kana' }}) }}
                                     {{ form_errors(form.kana.kana01) }}
                                     {{ form_errors(form.kana.kana02) }}
                                 </div>

--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -226,7 +226,7 @@ file that was distributed with this source code.
                     {% if Product.hasProductClass -%}
                         <div class="ec-productRole__priceRegular">
                             {% if Product.getPrice01Min is not null and Product.getPrice01IncTaxMin == Product.getPrice01IncTaxMax %}
-                                <span class="ec-productRole__priceRegularPrice">{{ 'front.product.nomal_price'|trans }}：<span class="price01-default">{{ Product.getPrice01IncTaxMin|price }}</span></span>
+                                <span class="ec-productRole__priceRegularPrice">{{ 'front.product.normal_price'|trans }}：<span class="price01-default">{{ Product.getPrice01IncTaxMin|price }}</span></span>
                                 <span class="ec-productRole__priceRegularTax">{{ 'common.tax_include'|trans }}</span>
                             {% elseif Product.getPrice01Min is not null and Product.getPrice01Max is not null %}
                                 <span class="ec-productRole__priceRegularPrice">{{ 'front.product.normal_price'|trans }}：<span class="price01-default">{{ Product.getPrice01IncTaxMin|price }}～ {{ Product.getPrice01IncTaxMax|price }}</span></span>
@@ -235,7 +235,7 @@ file that was distributed with this source code.
                         </div>
                     {% else %}
                         {% if Product.getPrice01Max is not null %}
-                            <span class="ec-productRole__priceRegularPrice">{{ 'front.product.nomal_price'|trans }}：{{ Product.getPrice01IncTaxMin|price }}</span>
+                            <span class="ec-productRole__priceRegularPrice">{{ 'front.product.normal_price'|trans }}：{{ Product.getPrice01IncTaxMin|price }}</span>
                             <span class="ec-productRole__priceRegularTax">{{ 'common.tax_include'|trans }}</span>
                         {% endif %}
                     {% endif %}
@@ -250,7 +250,7 @@ file that was distributed with this source code.
                             {% else %}
                                 <div class="ec-price">
                                     <span class="ec-price__price price02-default">{{ Product.getPrice02IncTaxMin|price }} ～ {{ Product.getPrice02IncTaxMax|price }}</span>
-                                    <span class="ec-price__tax">{{ 'common.tax_includel'|trans }}</span>
+                                    <span class="ec-price__tax">{{ 'common.tax_include'|trans }}</span>
                                 </div>
                             {% endif %}
                         {% else %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- メッセージidがそのまま表示されていたところ
- メッセージに含まれるHTMLタグが、そのまま文字列として出力されてしまっていたところ
を修正しました。

## 方針(Policy)
なし

## 実装に関する補足(Appendix)
なし

## テスト（Test)
変更箇所について表示の確認を行いました。

## 相談（Discussion）
なし
