### PR TITLE
【PC】【注文フロー】お届け先を複数指定した際、商品の在庫数が注文時に指定した数量分減っていない

### DIFF
--- a/src/Eccube/Service/PurchaseFlow/Processor/StockReduceProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/StockReduceProcessor.php
@@ -13,11 +13,8 @@
 
 namespace Eccube\Service\PurchaseFlow\Processor;
 
-use Doctrine\DBAL\LockMode;
 use Eccube\Entity\ItemHolderInterface;
 use Eccube\Entity\Order;
-use Eccube\Entity\ProductStock;
-use Eccube\Repository\ProductStockRepository;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
 
 /**
@@ -25,21 +22,6 @@ use Eccube\Service\PurchaseFlow\PurchaseContext;
  */
 class StockReduceProcessor extends AbstractPurchaseProcessor
 {
-    /**
-     * @var ProductStockRepository
-     */
-    protected $productStockRepository;
-
-    /**
-     * StockReduceProcessor constructor.
-     *
-     * @param ProductStockRepository $productStockRepository
-     */
-    public function __construct(ProductStockRepository $productStockRepository)
-    {
-        $this->productStockRepository = $productStockRepository;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -72,13 +54,7 @@ class StockReduceProcessor extends AbstractPurchaseProcessor
         foreach ($itemHolder->getProductOrderItems() as $item) {
             // 在庫が無制限かチェックし、制限ありなら在庫数をチェック
             if (!$item->getProductClass()->isStockUnlimited()) {
-                // 在庫チェックあり
-                // 在庫に対してロック(select ... for update)を実行
-                /* @var ProductStock $productStock */
-                $productStock = $this->productStockRepository->find(
-                    $item->getProductClass()->getProductStock()->getId(), LockMode::PESSIMISTIC_WRITE
-                );
-
+                $productStock = $item->getProductClass()->getProductStock();
                 $stock = $callback($productStock->getStock(), $item->getQuantity());
                 $productStock->setStock($stock);
                 $item->getProductClass()->setStock($stock);


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
 - 商品の在庫数が注文時に指定した数量分減っていること

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
 - using lock in foreach => duplicated lock in same row => fail

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
1．管理画面を表示する
　2．任意の在庫数を設定する
　3．フロント画面を表示する
　4．任意の商品をカートへ入れる
　5．お届け先を複数指定して商品を購入する
　6．管理画面を表示する
　7．該当の商品の在庫数を確認する。
　8．在庫数が注文時に指定した数量分減っていない(NG)

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



