### PR TITLE
メールプレビューは、メール本文を確認しやすいようにモーダルのサイズを大きくした。

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -641,7 +641,7 @@ file that was distributed with this source code.
 
                 <!-- 出荷済にする確認モーダル -->
                 <div class="modal fade" id="sentUpdateModal" tabindex="-1" role="dialog" aria-labelledby="sentUpdateModal" aria-hidden="true" data-keyboard="false" data-backdrop="static">
-                    <div class="modal-dialog" role="document">
+                    <div class="modal-dialog modal-lg" role="document">
                         <div class="modal-content">
                             <div class="modal-header">
                                 <h5 class="modal-title font-weight-bold"><!--confirmationModal_js.twig--></h5>

--- a/src/Eccube/Resource/template/admin/Order/shipping.twig
+++ b/src/Eccube/Resource/template/admin/Order/shipping.twig
@@ -188,7 +188,7 @@ file that was distributed with this source code.
         </div>
         <!-- 出荷済にするモーダル / 出荷メール送信モーダル -->
         <div class="modal fade" id="sentUpdateModal" tabindex="-1" role="dialog" aria-labelledby="sentUpdateModal" aria-hidden="true" data-keyboard="false" data-backdrop="static">
-            <div class="modal-dialog" role="document">
+            <div class="modal-dialog modal-lg" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title font-weight-bold"><!--confirmationModal_js.twig--></h5>

--- a/src/Eccube/Resource/template/admin/Setting/Shop/mail.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/mail.twig
@@ -204,8 +204,8 @@ file that was distributed with this source code.
 
     <!-- HTMLメールを確認するモーダル -->
     <div class="modal fade" id="htmlPreviewModal" tabindex="-1" role="dialog" aria-labelledby="htmlPreviewModal" aria-hidden="true" data-keyboard="false" data-backdrop="static">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content" style="width:600px;">
+        <div class="modal-dialog modal-lg" role="document">
+            <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title font-weight-bold">HTMLメールを確認する</h5>
                     <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
メールプレビューをモーダルで表示する画面にて。
メール本文を確認しやすいようにモーダルのサイズを大きくした。

対象のモーダル一覧
- 受注一覧
  - 一括操作 > メール送信
  - 出荷お知らせメール送信ボタン(紙飛行機アイコン)
  - 出荷済に更新ボタン(チェックマークアイコン)
- 出荷情報ページ
  - 出荷メール送信ボタン
  - 出荷済みにする送信ボタン
- メール設定
  - HTMLメールのプレビュー

## 方針(Policy)
bootstrapの `modal-lg` を使用。

## 実装に関する補足(Appendix)
なし

## テスト（Test)
上記の「対象のモーダル一覧」において、大きなサイズのモーダルが表示されることを確認。

## 相談（Discussion）
なし


## before

![image](https://user-images.githubusercontent.com/16891862/44613783-2964ef00-a854-11e8-8918-058facb00895.png)

## after

![image](https://user-images.githubusercontent.com/16891862/44613777-ef93e880-a853-11e8-8fe2-cecaaa84304b.png)
