### PR TITLE
新着情報管理で、管理画面とフロントで並び順が異なる不具合と、表示が5件より多い場合の表示制御の不具合を修正

### DIFF
--- a/codeception/acceptance/_bootstrap.php
+++ b/codeception/acceptance/_bootstrap.php
@@ -343,7 +343,7 @@ Fixtures::add('findCustomers', $findCustomers);
 /** 新着情報を検索するクロージャ */
 Fixtures::add('findNews', function() use ($entityManager) {
     return $entityManager->getRepository(\Eccube\Entity\News::class)
-        ->findBy(['visible' => true], ['publish_date' => 'DESC']);
+        ->findBy(['visible' => true], ['publish_date' => 'DESC', 'id' => 'DESC']);
 });
 
 /** 新着情報を登録するクロージャ */

--- a/src/Eccube/Repository/NewsRepository.php
+++ b/src/Eccube/Repository/NewsRepository.php
@@ -79,7 +79,8 @@ class NewsRepository extends AbstractRepository
         $qb->where('n.publish_date <= :date')
             ->andWhere('n.visible = TRUE')
             ->setParameter('date', new \DateTime())
-            ->orderBy('n.publish_date', 'DESC');
+            ->orderBy('n.publish_date', 'DESC')
+            ->addOrderBy('n.id', 'DESC');
 
         return $qb->getQuery()->getResult();
     }

--- a/src/Eccube/Resource/template/admin/Content/news.twig
+++ b/src/Eccube/Resource/template/admin/Content/news.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 
 {% set menus = ['content', 'news'] %}
 
-{% block title %}新着情報管理{% endblock %}
+{% block title %}新着情報一覧{% endblock %}
 {% block sub_title %}コンテンツ管理{% endblock %}
 
 {% block stylesheet %}
@@ -63,7 +63,7 @@ file that was distributed with this source code.
                                                     <div class="modal-dialog" role="document">
                                                         <div class="modal-content">
                                                             <div class="modal-header">
-                                                                <h5 class="modal-title font-weight-bold">削除します</h5>
+                                                                <h5 class="modal-title font-weight-bold">新着情報を削除します</h5>
                                                                 <button class="close" type="button"
                                                                         data-dismiss="modal"
                                                                         aria-label="Close"><span
@@ -71,7 +71,7 @@ file that was distributed with this source code.
                                                                 </button>
                                                             </div>
                                                             <div class="modal-body text-left">
-                                                                <p class="text-left">この操作は後で元に戻すことはできません。 「ニュース」を削除してもよろしいですか？</p>
+                                                                <p class="text-left">この操作は後で元に戻すことはできません。 「{{ News.title }}」を削除してもよろしいですか？</p>
                                                             </div>
                                                             <div class="modal-footer">
                                                                 <button class="btn btn-ec-sub" type="button" data-dismiss="modal">キャンセル</button>

--- a/src/Eccube/Resource/template/admin/Content/news_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/news_edit.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 
 {% set menus = ['content', 'news'] %}
 
-{% block title %}新着情報管理{% endblock %}
+{% block title %}新着情報設定{% endblock %}
 {% block sub_title %}コンテンツ管理{% endblock %}
 
 {% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
@@ -52,7 +52,7 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <span class="card-title">新着情報登録・編集</span></div>
+                                    <span class="card-title">新着情報</span></div>
                                 <div class="col-4 text-right">
                                     <a data-toggle="collapse" href="#newsForm"
                                                                  aria-expanded="true" aria-controls="newsForm"><i class="fa fa-lg fa-angle-up"></i></a></div>
@@ -61,7 +61,7 @@ file that was distributed with this source code.
                         <div class="ec-cardCollapse collapse show" id="newsForm" style="">
                             <div class="card-body">
                                 <div class="row">
-                                    <div class="col-3"><span>日付</span></div>
+                                    <div class="col-3"><span>公開日時</span></div>
                                     <div class="col mb-2">
                                         <div class="row">
                                             <div class="col-2 pr-2">
@@ -135,7 +135,7 @@ file that was distributed with this source code.
                                 <div class="c-conversionArea__leftBlockItem">
                                     <a class="c-beseLink" href="{{ url('admin_content_news') }}">
                                         <i class="fa fa-backward" aria-hidden="true"></i>
-                                        <span>新着情報管理</span></a>
+                                        <span>新着情報一覧</span></a>
                                 </div>
                             </div>
                             <div class="col-6">
@@ -146,11 +146,7 @@ file that was distributed with this source code.
                                     </div>
                                     <div class="col-auto">
                                         <button class="btn btn-ec-conversion px-5" type="submit">
-                                            {% if(News.id) %}
-                                                更新
-                                            {% else %}
-                                                登録
-                                            {% endif %}
+                                            登録
                                         </button>
                                     </div>
                                 </div>

--- a/src/Eccube/Resource/template/default/Block/news.twig
+++ b/src/Eccube/Resource/template/default/Block/news.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
 {% block javascript %}
 <script>
     $(function() {
-        $('.news__items').each(function() {
+        $('.ec-news__items').each(function() {
             var listLenght = $(this).find('li').length;
             if (listLenght > 5) {
                 $(this).find('li:gt(4)').each(function() {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
新着情報です。
・管理画面とフロントで並び順が異なる不具合を修正しました(OrderByを追加)
・表示する新着情報が5件より多い場合に「もっと見る」が表示されていない不具合を修正
・細かい文言の油揺れや間違いを修正しました。

https://github.com/EC-CUBE/ec-cube/pull/3590 の対応の続きです。

## 方針(Policy)
なし

## 実装に関する補足(Appendix)
なし

## テスト（Test)
・並び順を確認しました。
・文言については変更が反映できていることを各ページで確認しました。

## 相談（Discussion）

