### PR TITLE
ec-cubeをサブディレクトリに配置した場合の対応

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -598,6 +598,8 @@ class ProductController extends AbstractController
                 if ($returnLink = $form->get('return_link')->getData()) {
                     try {
                         // $returnLinkはpathの形式で渡される. pathが存在するかをルータでチェックする.
+                        $pattern = '/^'.preg_quote($request->getBasePath(), '/').'/';
+                        $returnLink = preg_replace($pattern, '', $returnLink);
                         $result = $router->match($returnLink);
                         // パラメータのみ抽出
                         $params = array_filter($result, function ($key) {

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -189,6 +189,8 @@ class ShoppingController extends AbstractShoppingController
 
             try {
                 // リダイレクト先のチェック.
+                $pattern = '/^'.preg_quote($request->getBasePath(), '/').'/';
+                $redirectTo = preg_replace($pattern, '', $redirectTo);
                 $result = $router->match($redirectTo);
                 // パラメータのみ抽出
                 $params = array_filter($result, function ($key) {


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
- ec-cubeをサブディレクトリに配置した場合に, URL検証に失敗する不具合の修正
- router->matchメソッドが, `/xxx//eccube_sf/shopping/shipping_multiple`のようなパスを渡した場合に判別できなかかった
- 渡されたパスからbasePathを除くように修正

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

- 通常配置, サブディレクトリ配置ともに動作を確認



