### PR TITLE
注文履歴(値引きあり)をマイページで開くとエラーになっていた不具合を修正

### DIFF
--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -178,7 +178,7 @@ file that was distributed with this source code.
                     </dl>
                     {% if Order.discount > 0 %}
                         <dl class="ec-totalBox__spec">
-                            <dt>{{ 'common.discount'|price }}</dt>
+                            <dt>{{ 'common.discount'|trans }}</dt>
                             <dd>{{ (0 - Order.discount)|price }}</dd>
                         </dl>
                     {% endif %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
値引きがある注文履歴をマイページで開くとエラーになっていた不具合を修正しました。

## 方針(Policy)
なし

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
なし

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
該当する受注の詳細が表示できるようになったことを確認。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
なし



