### PR TITLE
帳票の入力内容が保存できない問題の修正

### DIFF
--- a/src/Eccube/Entity/OrderPdf.php
+++ b/src/Eccube/Entity/OrderPdf.php
@@ -43,49 +43,49 @@ if (!class_exists('\Eccube\Entity\OrderPdf')) {
         /**
          * @var string
          *
-         * @ORM\Column(name="title", type="string")
+         * @ORM\Column(name="title", type="string", nullable=true)
          */
         private $title;
 
         /**
          * @var string
          *
-         * @ORM\Column(name="message1", type="string")
+         * @ORM\Column(name="message1", type="string", nullable=true)
          */
         private $message1;
 
         /**
          * @var string
          *
-         * @ORM\Column(name="message2", type="string")
+         * @ORM\Column(name="message2", type="string", nullable=true)
          */
         private $message2;
 
         /**
          * @var string
          *
-         * @ORM\Column(name="message3", type="string")
+         * @ORM\Column(name="message3", type="string", nullable=true)
          */
         private $message3;
 
         /**
          * @var string
          *
-         * @ORM\Column(name="note1", type="string")
+         * @ORM\Column(name="note1", type="string", nullable=true)
          */
         private $note1;
 
         /**
          * @var string
          *
-         * @ORM\Column(name="note2", type="string")
+         * @ORM\Column(name="note2", type="string", nullable=true)
          */
         private $note2;
 
         /**
          * @var string
          *
-         * @ORM\Column(name="note3", type="string")
+         * @ORM\Column(name="note3", type="string", nullable=true)
          */
         private $note3;
 

--- a/src/Eccube/Repository/OrderPdfRepository.php
+++ b/src/Eccube/Repository/OrderPdfRepository.php
@@ -44,26 +44,22 @@ class OrderPdfRepository extends AbstractRepository
          */
         $Member = $arrData['admin'];
 
-        try {
-            $OrderPdf = $this->find($Member);
-            if (!$OrderPdf) {
-                $OrderPdf = new OrderPdf();
-            }
-
-            $OrderPdf->setMemberId($Member->getId())
-                ->setTitle($arrData['title'])
-                ->setMessage1($arrData['message1'])
-                ->setMessage2($arrData['message2'])
-                ->setMessage3($arrData['message3'])
-                ->setNote1($arrData['note1'])
-                ->setNote2($arrData['note2'])
-                ->setNote3($arrData['note3'])
-                ->setVisible(true);
-            $this->getEntityManager()->persist($OrderPdf);
-            $this->getEntityManager()->flush($OrderPdf);
-        } catch (\Exception $e) {
-            return false;
+        $OrderPdf = $this->find($Member);
+        if (!$OrderPdf) {
+            $OrderPdf = new OrderPdf();
         }
+
+        $OrderPdf->setMemberId($Member->getId())
+            ->setTitle($arrData['title'])
+            ->setMessage1($arrData['message1'])
+            ->setMessage2($arrData['message2'])
+            ->setMessage3($arrData['message3'])
+            ->setNote1($arrData['note1'])
+            ->setNote2($arrData['note2'])
+            ->setNote3($arrData['note3'])
+            ->setVisible(true);
+        $this->getEntityManager()->persist($OrderPdf);
+        $this->getEntityManager()->flush($OrderPdf);
 
         return true;
     }

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
@@ -19,6 +19,7 @@ use Eccube\Entity\Order;
 use Eccube\Entity\OrderPdf;
 use Eccube\Repository\Master\OrderStatusRepository;
 use Eccube\Repository\OrderRepository;
+use Eccube\Repository\OrderPdfRepository;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 use Faker\Generator;
 use Symfony\Component\DomCrawler\Crawler;
@@ -35,11 +36,15 @@ class OrderPdfControllerTest extends AbstractAdminWebTestCase
     /** @var OrderRepository */
     protected $orderRepo;
 
+    /** @var OrderPdfRepository */
+    protected $orderPdfRepository;
+
     public function setUp()
     {
         parent::setUp();
         $this->orderStatusRepo = $this->container->get(OrderStatusRepository::class);
         $this->orderRepo = $this->container->get(OrderRepository::class);
+        $this->orderPdfRepository = $this->container->get(OrderPdfRepository::class);
     }
 
     /**
@@ -342,6 +347,63 @@ class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $this->actual = $client->getResponse()->headers->get('Content-Type');
         $this->expected = 'application/pdf';
         $this->verify();
+    }
+
+    /**
+     * Render order pdf download.
+     */
+    public function testDownloadWithPreviousInputSuccessWithWeb()
+    {
+        $Order = $this->createOrderForSearch();
+        $Shippings = $Order->getShippings();
+        $shippingId = $Shippings[0]->getId();
+
+        /**
+         * @var Client
+         */
+        $client = $this->client;
+
+        $adminTest = $this->createMember();
+        $this->loginTo($adminTest);
+
+        $crawler = $client->request('POST', $this->generateUrl('admin_order_export_pdf'),
+            [
+                '_token' => 'dummy',
+                'ids' => [$shippingId],
+            ]
+        );
+
+        /**
+         * @var \Symfony\Component\DomCrawler\Form
+         */
+        $form = $this->getForm($crawler);
+        // fields set to empty.
+        $form->setValues([
+            'order_pdf[title]' => '',
+            'order_pdf[message1]' => '',
+            'order_pdf[message2]' => '',
+            'order_pdf[message3]' => '',
+            'order_pdf[note1]' => '',
+            'order_pdf[note2]' => '',
+            'order_pdf[note3]' => '',
+            'order_pdf[default]' => '1'
+        ]);
+
+        $client->submit($form);
+
+        $this->actual = $client->getResponse()->headers->get('Content-Type');
+        $this->expected = 'application/pdf';
+        $this->verify();
+
+        $OrderPdf = $this->orderPdfRepository->find($adminTest->getId());
+
+        $this->assertNull($OrderPdf->getTitle());
+        $this->assertNull($OrderPdf->getMessage1());
+        $this->assertNull($OrderPdf->getMessage2());
+        $this->assertNull($OrderPdf->getMessage3());
+        $this->assertNull($OrderPdf->getNote1());
+        $this->assertNull($OrderPdf->getNote2());
+        $this->assertNull($OrderPdf->getNote3());
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
納品書出力時に「入力内容を保存する」にチェックを入れても保存できない問題の修正

## 方針(Policy)
- OrderPdfRepository では try/catch しない
- title, message, notes に nullable=true 追加

## 実装に関する補足(Appendix)
- NOT NULL 制約に抵触しても、 Exception を黙殺していたのでエラーにならなかった

## テスト（Test)
title, message, note の各項目が空でも登録確認できるテストケースを追加

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



