### PR TITLE
【受注詳細】注文確認メールが、受注詳細のメール配信履歴に表示されない。

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -406,6 +406,7 @@ class ShoppingController extends AbstractShoppingController
             // メール送信
             log_info('[注文処理] 注文メールの送信を行います.', [$Order->getId()]);
             $this->mailService->sendOrderMail($Order);
+            $this->entityManager->flush();
 
             log_info('[注文処理] 注文処理が完了しました. 購入完了画面へ遷移します.', [$Order->getId()]);
 

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -406,7 +406,6 @@ class ShoppingController extends AbstractShoppingController
             // メール送信
             log_info('[注文処理] 注文メールの送信を行います.', [$Order->getId()]);
             $this->mailService->sendOrderMail($Order);
-            $this->entityManager->flush();
 
             log_info('[注文処理] 注文処理が完了しました. 購入完了画面へ遷移します.', [$Order->getId()]);
 

--- a/src/Eccube/Repository/MailHistoryRepository.php
+++ b/src/Eccube/Repository/MailHistoryRepository.php
@@ -55,4 +55,22 @@ class MailHistoryRepository extends AbstractRepository
             ])
             ->getSingleResult();
     }
+
+    /**
+     * @param MailHistory $MailHistory
+     * @return bool
+     */
+    public function flush(MailHistory $MailHistory)
+    {
+        try {
+            $this->getEntityManager()->flush($MailHistory);
+
+            return true;
+        } catch (\Exception $exception) {
+            $this->getEntityManager()->rollback();
+            log_error($exception->getMessage());
+        }
+
+        return false;
+    }
 }

--- a/src/Eccube/Service/MailService.php
+++ b/src/Eccube/Service/MailService.php
@@ -410,6 +410,7 @@ class MailService
         }
 
         $this->mailHistoryRepository->save($MailHistory);
+        $this->mailHistoryRepository->flush($MailHistory);
 
         log_info('受注メール送信完了', ['count' => $count]);
 


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
 - 【受注詳細】注文確認メールが、受注詳細のメール配信履歴に表示されない。

期待結果：3系同様に表示されること。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

  - 注文確認メールが、受注詳細のメール配信履歴に表示されていません。
  - また、マイページの受注詳細のメール配信履歴にも表示されていません。
期待結果：3系同様に表示されること。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



