### PR TITLE
Webインストーラのデータベース初期化エラーハンドリング修正

### DIFF
--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -13,6 +13,9 @@
 
 namespace Eccube\Controller\Install;
 
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\CachedReader;
+use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
@@ -24,6 +27,7 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Tools\Setup;
 use Eccube\Common\Constant;
 use Eccube\Controller\AbstractController;
+use Eccube\Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Eccube\Form\Type\Install\Step1Type;
 use Eccube\Form\Type\Install\Step3Type;
 use Eccube\Form\Type\Install\Step4Type;
@@ -370,6 +374,7 @@ class InstallController extends AbstractController
             } catch (\Exception $e) {
                 log_error($e->getMessage());
                 $this->addError($e->getMessage());
+
                 return [
                     'form' => $form->createView(),
                 ];
@@ -519,7 +524,11 @@ class InstallController extends AbstractController
             $this->getParameter('kernel.project_dir').'/src/Eccube/Entity',
             $this->getParameter('kernel.project_dir').'/app/Customize/Entity',
         ];
-        $config = Setup::createAnnotationMetadataConfiguration($paths, true, null, null, false);
+        $config = Setup::createConfiguration(true);
+        $driver = new AnnotationDriver(new CachedReader(new AnnotationReader(), new ArrayCache()), $paths);
+        $driver->setTraitProxiesDirectory($this->getParameter('kernel.project_dir').'/app/proxy/entity');
+        $config->setMetadataDriverImpl($driver);
+
         $em = EntityManager::create($conn, $config);
 
         return $em;

--- a/src/Eccube/Resource/template/install/step5.twig
+++ b/src/Eccube/Resource/template/install/step5.twig
@@ -46,6 +46,15 @@ file that was distributed with this source code.
                                 <div class="note_box">
                                     <p>{{ 'install.database_skip_notice'|trans }}</p>
                                     {{ form_widget(form.no_update) }}
+
+                                    {% for error in app.session.flashbag.get('eccube.front.error')  %}
+                                        <div class="message">
+                                            <p class="errormsg bg-danger">
+                                                <span class="initialism form-error-icon badge badge-danger">ERROR</span>
+                                                <span class="form-error-message">{{ error|trans|nl2br }}</span>
+                                            </p>
+                                        </div>
+                                    {% endfor %}
                                 </div>
 
                                 <ul class="btn_area">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- Webインストーラのデータベース初期化で画面にエラーメッセージを表示するよう修正
- インストーラで proxy クラスのアノテーションをロードできない問題の修正

## 方針(Policy)
- Controller で try/catch をし、例外をスローした場合はエラーメッセージを表示する
- Proxy クラスが存在する場合は、 Proxy クラスのアノテーションをロードする

## テスト（Test)
500エラー画面にならず、画面にエラーが表示されるのを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更


