### PR TITLE
配送業者の名称が初期値になってしまうのを修正

### DIFF
--- a/src/Eccube/Form/Type/Shopping/ShippingType.php
+++ b/src/Eccube/Form/Type/Shopping/ShippingType.php
@@ -14,6 +14,7 @@
 namespace Eccube\Form\Type\Shopping;
 
 use Eccube\Common\EccubeConfig;
+use Eccube\Entity\Delivery;
 use Eccube\Entity\Shipping;
 use Eccube\Repository\DeliveryFeeRepository;
 use Eccube\Repository\DeliveryRepository;
@@ -232,10 +233,18 @@ class ShippingType extends AbstractType
         );
 
         // POSTされないデータをエンティティにセットする.
-        // TODO Calculatorで行うのが適切.
+        // TODO PurchaseFlow で行うのが適切.
         $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
+            /** @var Shipping $Shipping */
             $Shipping = $event->getData();
             $form = $event->getForm();
+            /** @var Delivery $Delivery */
+            $Delivery = $form['Delivery']->getData();
+            if ($Delivery) {
+                $Shipping->setShippingDeliveryName($Delivery->getName());
+            } else {
+                $Shipping->setShippingDeliveryName(null);
+            }
             $DeliveryDate = $form['shipping_delivery_date']->getData();
             if ($DeliveryDate) {
                 $Shipping->setShippingDeliveryDate(new \DateTime($DeliveryDate));

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -13,7 +13,9 @@
 
 namespace Eccube\Tests\Web;
 
+use Eccube\Entity\Delivery;
 use Eccube\Entity\Master\OrderStatus;
+use Eccube\Entity\Master\SaleType;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\PaymentRepository;
 use Eccube\Repository\Master\OrderStatusRepository;
@@ -487,5 +489,85 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
 
         // Title
         $this->assertContains('お届け先の追加', $crawler->html());
+    }
+
+    /**
+     * カート→購入確認画面→完了画面(配送業者を変更する)
+     */
+    public function testCompleteWithChangeDeliveryName()
+    {
+        $Customer = $this->createCustomer();
+        $SaleTypeNormal = $this->entityManager->find(SaleType::class, SaleType::SALE_TYPE_NORMAL);
+        $Delivery = $this->entityManager->find(Delivery::class, 2);
+        $Delivery->setSaleType($SaleTypeNormal);
+        $this->entityManager->flush($Delivery);
+
+        // カート画面
+        $this->scenarioCartIn($Customer);
+
+        // 手続き画面
+        $crawler = $this->scenarioConfirm($Customer);
+        $this->expected = 'ご注文手続き';
+        $this->actual = $crawler->filter('.ec-pageHeader h1')->text();
+        $this->verify();
+
+        // 確認画面
+        $crawler = $this->scenarioComplete(
+            $Customer,
+            $this->generateUrl('shopping_confirm'),
+            [
+                [
+                    'Delivery' => $Delivery->getId(),
+                    'DeliveryTime' => null,
+                ]
+            ]
+        );
+        $this->expected = 'ご注文内容のご確認';
+        $this->actual = $crawler->filter('.ec-pageHeader h1')->text();
+        $this->verify();
+
+        // 完了画面
+        $crawler = $this->scenarioComplete(
+            $Customer,
+            $this->generateUrl('shopping_checkout'),
+            [
+                [
+                    'Delivery' => $Delivery->getId(),
+                    'DeliveryTime' => null,
+                ]
+            ]
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('shopping_complete')));
+
+        $BaseInfo = $this->baseInfoRepository->get();
+        $mailCollector = $this->getMailCollector(false);
+        $Messages = $mailCollector->getMessages();
+        $Message = $Messages[0];
+
+        $this->expected = '['.$BaseInfo->getShopName().'] ご注文ありがとうございます';
+        $this->actual = $Message->getSubject();
+        $this->verify();
+
+        // 生成された受注のチェック
+        $Order = $this->container->get(OrderRepository::class)->findOneBy(
+            [
+                'Customer' => $Customer,
+            ]
+        );
+
+        $OrderNew = $this->container->get(OrderStatusRepository::class)->find(OrderStatus::NEW);
+        $this->expected = $OrderNew;
+        $this->actual = $Order->getOrderStatus();
+        $this->verify();
+
+        $this->expected = $Customer->getName01();
+        $this->actual = $Order->getName01();
+        $this->verify();
+
+        $Shipping = $Order->getShippings()->first();
+
+        $this->expected = $Delivery->getName();
+        $this->actual = $Shipping->getShippingDeliveryName();
+        $this->verify();
     }
 }

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -20,6 +20,7 @@ use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\PaymentRepository;
 use Eccube\Repository\Master\OrderStatusRepository;
 use Eccube\Repository\OrderRepository;
+use Eccube\Tests\Fixture\Generator;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -498,7 +499,7 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
     {
         $Customer = $this->createCustomer();
         $SaleTypeNormal = $this->entityManager->find(SaleType::class, SaleType::SALE_TYPE_NORMAL);
-        $Delivery = $this->entityManager->find(Delivery::class, 2);
+        $Delivery = $this->container->get(Generator::class)->createDelivery();
         $Delivery->setSaleType($SaleTypeNormal);
         $this->entityManager->flush($Delivery);
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
Myページの注文履歴詳細で配送業者の名称が初期値になってしまうのを修正

## 方針(Policy)
- ShippingType で配送業者名称を設定するよう修正

## テスト（Test)
ユニットテストを追加


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



