### PR TITLE
商品一覧で数量を0 or 空にしてカートに入れるとモーダルが解除されないのを修正

### DIFF
--- a/src/Eccube/Resource/template/default/Product/list.twig
+++ b/src/Eccube/Resource/template/default/Product/list.twig
@@ -41,18 +41,20 @@ file that was distributed with this source code.
 
 
         $('.add-cart').on('click', function(e) {
-            e.preventDefault();
             var $form = $(this).parents('li').find('form');
 
             // 個数フォームのチェック
             var $quantity = $form.parent().find('.quantity');
             if ($quantity.val() < 1) {
-                $quantity[0].setCustomValidity("{{ 'front.product.invalid_quantity'|trans }}");
+                $quantity[0].setCustomValidity('{{ 'front.product.invalid_quantity'|trans }}');
+                setTimeout(function () {
+                    loadingOverlay('hide');
+                }, 100);
                 return true;
             } else {
-                $quantity[0].setCustomValidity("");
+                $quantity[0].setCustomValidity('');
             }
-
+            e.preventDefault();
             $.ajax({
                 url: $form.attr('action'),
                 type: $form.attr('method'),


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
商品一覧で数量を0 or 空にしてカートに入れるとモーダルが解除されないのを修正

## 方針(Policy)
setTimeout で、モーダルを解除するよう修正

## テスト（Test)
HTML5バリデーションエラーが表示され、モーダルが解除されるのを確認

## 相談（Discussion）
商品一覧からのカートインの codeception が無いので作成した方がよいかも

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



