### PR TITLE
お届け時間(dtb_delivery_time)にvisibleとcreate_dateとupdate_dateを追加

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/Shop/DeliveryController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/DeliveryController.php
@@ -214,6 +214,7 @@ class DeliveryController extends AbstractController
                     }
                 }
                 foreach ($DeliveryData['DeliveryTimes'] as $DeliveryTime) {
+                    $DeliveryTime->setVisible(true);
                     $DeliveryTime->setDelivery($Delivery);
                 }
 

--- a/src/Eccube/Entity/DeliveryTime.php
+++ b/src/Eccube/Entity/DeliveryTime.php
@@ -66,6 +66,27 @@ if (!class_exists('\Eccube\Entity\DeliveryTime')) {
         protected $sort_no;
 
         /**
+         * @var boolean
+         *
+         * @ORM\Column(name="visible", type="boolean", options={"default":true})
+         */
+        private $visible;
+
+        /**
+         * @var \DateTime
+         *
+         * @ORM\Column(name="create_date", type="datetimetz")
+         */
+        private $create_date;
+
+        /**
+         * @var \DateTime
+         *
+         * @ORM\Column(name="update_date", type="datetimetz")
+         */
+        private $update_date;
+
+        /**
          * Get id.
          *
          * @return int
@@ -145,6 +166,78 @@ if (!class_exists('\Eccube\Entity\DeliveryTime')) {
         public function getSortNo()
         {
             return $this->sort_no;
+        }
+
+        /**
+         * Set visible
+         *
+         * @param boolean $visible
+         *
+         * @return DeliveryTime
+         */
+        public function setVisible($visible)
+        {
+            $this->visible = $visible;
+
+            return $this;
+        }
+
+        /**
+         * Is the visibility visible?
+         *
+         * @return boolean
+         */
+        public function isVisible()
+        {
+            return $this->visible;
+        }
+
+        /**
+         * Set createDate.
+         *
+         * @param \DateTime $createDate
+         *
+         * @return DeliveryTime
+         */
+        public function setCreateDate($createDate)
+        {
+            $this->create_date = $createDate;
+
+            return $this;
+        }
+
+        /**
+         * Get createDate.
+         *
+         * @return \DateTime
+         */
+        public function getCreateDate()
+        {
+            return $this->create_date;
+        }
+
+        /**
+         * Set updateDate.
+         *
+         * @param \DateTime $updateDate
+         *
+         * @return DeliveryTime
+         */
+        public function setUpdateDate($updateDate)
+        {
+            $this->update_date = $updateDate;
+
+            return $this;
+        }
+
+        /**
+         * Get updateDate.
+         *
+         * @return \DateTime
+         */
+        public function getUpdateDate()
+        {
+            return $this->update_date;
         }
     }
 }

--- a/src/Eccube/Resource/doctrine/import_csv/dtb_delivery_time.csv
+++ b/src/Eccube/Resource/doctrine/import_csv/dtb_delivery_time.csv
@@ -1,3 +1,3 @@
-id,delivery_id,delivery_time,sort_no,discriminator_type
-"1","1","午前","1","deliverytime"
-"2","1","午後","2","deliverytime"
+id,delivery_id,delivery_time,sort_no,create_date,update_date,visible,discriminator_type
+"1","1","午前","1","2017-03-07 10:14:52","2017-03-07 10:14:52","1","deliverytime"
+"2","1","午後","2","2017-03-07 10:14:52","2017-03-07 10:14:52","1","deliverytime"

--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -762,7 +762,8 @@ class Generator
             $DeliveryTime
                 ->setDelivery($Delivery)
                 ->setDeliveryTime($faker->word)
-                ->setSortNo($i + 1);
+                ->setSortNo($i + 1)
+                ->setVisible(true);
             $this->entityManager->persist($DeliveryTime);
             $this->entityManager->flush($DeliveryTime);
             $Delivery->addDeliveryTime($DeliveryTime);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
配送時間が変更した時に対応するためお届け時間(dtb_delivery_time)にvisibleとcreate_dateとupdate_dateを追加しました。
支払い方法、配送方法を含めて表示/非表示の機能の実装はできていません。

## 方針(Policy)
dbのschemaを確定させることを優先、実装は残課題とする。

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト
