### PR TITLE
プラグインジェネレータを最新化

### DIFF
--- a/src/Eccube/Command/PluginGenerateCommand.php
+++ b/src/Eccube/Command/PluginGenerateCommand.php
@@ -113,7 +113,7 @@ class PluginGenerateCommand extends Command
         $this->createDirectories($pluginDir);
         $this->createConfig($pluginDir, $name, $code, $version);
         $this->createEvent($pluginDir, $code);
-        $this->createMessages($pluginDir, $code);
+        $this->createMessages($pluginDir);
         $this->createNav($pluginDir, $code);
         $this->createTwigBlock($pluginDir, $code);
         $this->createConfigController($pluginDir, $code);
@@ -174,12 +174,18 @@ class PluginGenerateCommand extends Command
     protected function createConfig($pluginDir, $name, $code, $version)
     {
         $source = <<<EOL
-name: $name
-code: $code
-version: $version
+{
+  "name": "ec-cube/$code",
+  "version": "$version",
+  "description": "$name",
+  "type": "eccube-plugin",
+  "extra": {
+    "code": "$code"
+  }
+}
 EOL;
 
-        $this->fs->dumpFile($pluginDir.'/config.yml', $source);
+        $this->fs->dumpFile($pluginDir.'/composer.json', $source);
     }
 
     /**
@@ -287,9 +293,9 @@ namespace Plugin\\${code}\\Controller\\Admin;
 use Eccube\\Controller\\AbstractController;
 use Plugin\\${code}\\Form\\Type\\Admin\\ConfigType;
 use Plugin\\${code}\\Repository\\ConfigRepository;
-use Sensio\\Bundle\\FrameworkExtraBundle\\Configuration\\Route;
 use Sensio\\Bundle\\FrameworkExtraBundle\\Configuration\\Template;
 use Symfony\\Component\\HttpFoundation\\Request;
+use Symfony\\Component\\Routing\\Annotation\\Route;
 
 class ConfigController extends AbstractController
 {
@@ -307,8 +313,9 @@ class ConfigController extends AbstractController
     {
         \$this->configRepository = \$configRepository;
     }
+
     /**
-     * @Route("/%eccube_admin_route%/${snakecased}/config", name="plugin_${code}_config")
+     * @Route("/%eccube_admin_route%/${snakecased}/config", name="${snakecased}_admin_config")
      * @Template("@${code}/admin/config.twig")
      */
     public function index(Request \$request)
@@ -323,7 +330,7 @@ class ConfigController extends AbstractController
             \$this->entityManager->flush(\$Config);
             \$this->addSuccess('登録しました。', 'admin');
 
-            return \$this->redirectToRoute('plugin_${code}_config');
+            return \$this->redirectToRoute('${snakecased}_admin_config');
         }
 
         return [
@@ -331,6 +338,7 @@ class ConfigController extends AbstractController
         ];
     }
 }
+
 EOL;
 
         $this->fs->dumpFile($pluginDir.'/Controller/Admin/ConfigController.php', $source);
@@ -394,6 +402,7 @@ class Config
         return \$this;
     }
 }
+
 EOL;
 
         $this->fs->dumpFile($pluginDir.'/Entity/Config.php', $source);
@@ -406,7 +415,6 @@ namespace Plugin\\${code}\\Repository;
 use Eccube\\Repository\\AbstractRepository;
 use Plugin\\${code}\\Entity\\Config;
 use Symfony\\Bridge\\Doctrine\\RegistryInterface;
-use Symfony\\Component\\HttpKernel\\KernelInterface;
 
 /**
  * ConfigRepository
@@ -428,6 +436,7 @@ class ConfigRepository extends AbstractRepository
 
     /**
      * @param int \$id
+     *
      * @return null|Config
      */
     public function get(\$id = 1)
@@ -463,7 +472,7 @@ class ConfigType extends AbstractType
         \$builder->add('name', TextType::class, [
             'constraints' => [
                 new NotBlank(),
-                new Length(['max' => 255]),                
+                new Length(['max' => 255]),
             ],
         ]);
     }
@@ -484,7 +493,7 @@ EOL;
         $this->fs->dumpFile($pluginDir.'/Form/Type/Admin/ConfigType.php', $source);
 
         $source = <<<EOL
-{% extends '@admin/styleguide_frame.twig' %}
+{% extends '@admin/default_frame.twig' %}
 
 {% set menus = ['store', 'plugin', 'plugin_list'] %}
 
@@ -546,6 +555,7 @@ EOL;
         </div>
     </form>
 {% endblock %}
+
 EOL;
         $this->fs->dumpFile($pluginDir.'/Resource/template/admin/config.twig', $source);
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

https://github.com/EC-CUBE/ec-cube/issues/3516

プラグインジェネレータを最新化
- twigテンプレート
- ルーティング
- 命名規則
- cs-fixer

## 方針(Policy)
問題があった部分の最新化のみ対応

## 実装に関する補足(Appendix)

## テスト（Test)
ローカルで
- プラグインジェネレート
- プラグインインストール
- プラグイン有効化
- プラグインの管理画面にて設定登録
ができることを確認

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更
