### PR TITLE
日本語テンプレートへの変換スクリプトを追加

### DIFF
--- a/bin/template_jp.php
+++ b/bin/template_jp.php
@@ -1,0 +1,81 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * 日本語テンプレート生成スクリプト
+ *
+ * メッセージIDを通常の日本語に置換します.
+ * {{ 'message_id'|trans }}は{{ 'メッセージID'|trans }}のように置換されます.
+ *
+ * symfonyのライブラリを使用しているため, composer install後に実行してください.
+ *
+ * composer install
+ * bin/template_jp.php
+ *
+ */
+require_once __DIR__.'/../vendor/autoload.php';
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Yaml\Yaml;
+
+define('PROJECT_DIR', realpath(__DIR__.'/../'));
+define('LOCALE_DIR', realpath(PROJECT_DIR.'/src/Eccube/Resource/locale'));
+define('TEMPLATE_DIR', realpath(PROJECT_DIR.'/src/Eccube/Resource/template'));
+
+$messagesFile = LOCALE_DIR.'/messages.ja.yaml';
+$messages = Yaml::parse(file_get_contents($messagesFile));
+
+$directories = [
+    TEMPLATE_DIR.'/default',
+    TEMPLATE_DIR.'/install',
+    TEMPLATE_DIR.'/toolbar',
+];
+
+$files = Finder::create()
+    ->in($directories)
+    ->name('*.twig')
+    ->files();
+
+$templates = [];
+/** @var SplFileInfo $file */
+foreach ($files as $file) {
+    $template = new \stdClass();
+    $template->realpath = $file->getRealPath();
+    $template->content = file_get_contents($file->getRealPath());
+    $templates[] = $template;
+}
+
+foreach ($templates as $template) {
+    $replaced = $template->content;
+    foreach ($messages as $messageId => $messageText) {
+        $pattern = "/'".$messageId."'/";
+        $replacement = "'".$messageText."'";
+        $result = \preg_replace($pattern, $replacement, $replaced);
+        if (null === $result) {
+            echoLn('preg_replace is failed.');
+            echoLn('  file: '.$template->realpath);
+            echoLn('  message id: '.$messageId);
+            echoLn('  message text: '.$messageText);
+
+            eixt(1);
+        }
+        $replaced = $result;
+    }
+
+    if ($replaced === $template->content) {
+        // ヒットなし
+        echoLn('SKIP: '.$template->realpath);
+        continue;
+    }
+
+    // 上書き
+    echoLn('FIX: '.$template->realpath);
+    file_put_contents($template->realpath, $replaced);
+}
+
+function echoLn($message)
+{
+    echo $message.PHP_EOL;
+    @ob_flush();
+}
+

--- a/bin/template_jp.php
+++ b/bin/template_jp.php
@@ -48,7 +48,7 @@ foreach ($files as $file) {
 foreach ($templates as $template) {
     $replaced = $template->content;
     foreach ($messages as $messageId => $messageText) {
-        $pattern = "/'".$messageId."'/";
+        $pattern = "/('|\")".$messageId."('|\")/";   // 'message_id' or "message_id"を置換
         $replacement = "'".$messageText."'";
         $result = \preg_replace($pattern, $replacement, $replaced);
         if (null === $result) {

--- a/src/Eccube/Resource/template/default/Block/search_product.twig
+++ b/src/Eccube/Resource/template/default/Block/search_product.twig
@@ -17,7 +17,7 @@ file that was distributed with this source code.
         </div>
         <div class="ec-headerSearch__keyword">
             <div class="ec-input">
-                {{ form_widget(form.name, {'attr': { 'placeholder' : "common.search_keyword" }} ) }}
+                {{ form_widget(form.name, {'attr': { 'placeholder' : 'common.search_keyword' }} ) }}
                 <button class="ec-headerSearch__keywordBtn" type="submit">
                     <div class="ec-icon">
                         <img src="{{ asset('assets/icon/search-dark.svg') }}" alt="">


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

twigファイル内のメッセージIDを日本語に置換するスクリプトです

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

### 実行方法

composer install後、以下で実行します。

`bin/template_jp.php`

置換後そのままファイルを上書きしますのでご注意ください。

### 置換内容

`{{ 'message_id'|trans }}` は `{{ 'メッセージID'|trans }}`のように置換します。
trans等のフィルタはそのまま残し, メッセージIDのみ置換されます。

パラメータ付きの場合は以下のようになります。

`{{ 'count_message_id'|trans({'%count%': count}) }}` -> `{{ '%count%件'|trans({'%count%': count}) }}` 

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

- 変換後、画面表示を行い文言が表示されているかを確認.

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



