### PR TITLE
eccube:fixtures:generateコマンドで、--products=0でも動作するように修正。

### DIFF
--- a/src/Eccube/Command/GenerateDummyDataCommand.php
+++ b/src/Eccube/Command/GenerateDummyDataCommand.php
@@ -92,7 +92,7 @@ EOF
         $numberOfCustomer = $input->getOption('customers');
 
         $Customers = [];
-        $Products = $this->productRepository->findAll();
+        $Products = [];
 
         $faker = Faker::create($locale);
         for ($i = 0; $i < $numberOfCustomer; $i++) {
@@ -149,7 +149,13 @@ EOF
         ];
         foreach ($Customers as $Customer) {
             $Delivery = $Deliveries[$faker->numberBetween(0, count($Deliveries) - 1)];
-            $Product = $Products[$faker->numberBetween(0, count($Products) - 1)];
+            if (count($Products) > 0) {
+                $Product = $Products[$faker->numberBetween(0, count($Products) - 1)];
+            } else {
+                $orderBy = ['ASC', 'DESC'];
+                $orderByKey = $faker->numberBetween(0, 1);
+                $Product = $this->productRepository->findOneBy([], ['id' => $orderBy[$orderByKey]]);
+            }
             $charge = $faker->randomNumber(4);
             $discount = $faker->randomNumber(4);
             for ($i = 0; $i < $numberOfOrder; $i++) {

--- a/src/Eccube/Command/GenerateDummyDataCommand.php
+++ b/src/Eccube/Command/GenerateDummyDataCommand.php
@@ -16,6 +16,7 @@ namespace Eccube\Command;
 use Doctrine\ORM\EntityManager;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Repository\DeliveryRepository;
+use Eccube\Repository\ProductRepository;
 use Eccube\Tests\Fixture\Generator;
 use Faker\Factory as Faker;
 use Symfony\Component\Console\Command\Command;
@@ -42,12 +43,18 @@ class GenerateDummyDataCommand extends Command
      */
     protected $deliveryRepository;
 
-    public function __construct(Generator $generator = null, EntityManager $entityManager = null, DeliveryRepository $deliveryRepository = null)
+    /**
+     * @var ProductRepository
+     */
+    protected $productRepository;
+
+    public function __construct(Generator $generator = null, EntityManager $entityManager = null, DeliveryRepository $deliveryRepository = null, ProductRepository $productRepository = null)
     {
         parent::__construct();
         $this->generator = $generator;
         $this->entityManager = $entityManager;
         $this->deliveryRepository = $deliveryRepository;
+        $this->productRepository = $productRepository;
     }
 
     protected function configure()
@@ -85,7 +92,7 @@ EOF
         $numberOfCustomer = $input->getOption('customers');
 
         $Customers = [];
-        $Products = [];
+        $Products = $this->productRepository->findAll();
 
         $faker = Faker::create($locale);
         for ($i = 0; $i < $numberOfCustomer; $i++) {
@@ -142,7 +149,7 @@ EOF
         ];
         foreach ($Customers as $Customer) {
             $Delivery = $Deliveries[$faker->numberBetween(0, count($Deliveries) - 1)];
-            $Product = $Products[$faker->numberBetween(0, $numberOfProducts - 1)];
+            $Product = $Products[$faker->numberBetween(0, count($Products) - 1)];
             $charge = $faker->randomNumber(4);
             $discount = $faker->randomNumber(4);
             for ($i = 0; $i < $numberOfOrder; $i++) {


### PR DESCRIPTION

## 概要(Overview・Refs Issue)
eccube:fixtures:generateコマンドで、--products=0だとエラーになっていたのを修正。
また、既存の商品も含めて受注を生成するようにしました。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->
なし

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
なし

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
--products=0でも動作することを確認しました。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
なし

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



