### PR TITLE
確認するボタン押下すると、2回目でシステムエラーになる

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -299,7 +299,7 @@ class ShoppingController extends AbstractShoppingController
         log_info('[注文確認] フォームエラーのため, 注文手続画面を表示します.', [$Order->getId()]);
 
         // FIXME @Templateの差し替え.
-        $request->attributes->set('_template', new Template(['template' => 'shopping/index.twig']));
+        $request->attributes->set('_template', new Template(['template' => 'Shopping/index.twig']));
 
         return [
             'form' => $form->createView(),


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
 - ご注文手続き画面のポイント入力部分に空白を入れて、確認するボタン押下すると、1回目は正常に「入力されていません」というエラー文言が表示されるのですが、そのまま2回目に確認ボタンを押下するとシステムエラーになります。


## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
 - 確認するボタン押下すると、2回目でシステムエラーになる

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



