### PR TITLE
規格を初期化した商品がカートに投入できない不具合の修正

### DIFF
--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -164,7 +164,7 @@ class ProductController extends AbstractController
                 AddCartType::class,
                 null,
                 [
-                    'product' => $this->productRepository->findWithSortedClassCategories($Product->getId(), true),
+                    'product' => $this->productRepository->findWithSortedClassCategories($Product->getId()),
                     'allow_extra_fields' => true,
                 ]
             );

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -164,7 +164,7 @@ class ProductController extends AbstractController
                 AddCartType::class,
                 null,
                 [
-                    'product' => $this->productRepository->findWithSortedClassCategories($Product->getId()),
+                    'product' => $this->productRepository->findWithSortedClassCategories($Product->getId(), true),
                     'allow_extra_fields' => true,
                 ]
             );

--- a/src/Eccube/Form/DataTransformer/EntityToIdTransformer.php
+++ b/src/Eccube/Form/DataTransformer/EntityToIdTransformer.php
@@ -50,7 +50,7 @@ class EntityToIdTransformer implements DataTransformerInterface
 
     public function reverseTransform($id)
     {
-        if (!$id) {
+        if ('' === $id || null === $id) {
             return null;
         }
 

--- a/src/Eccube/Form/Type/AddCartType.php
+++ b/src/Eccube/Form/Type/AddCartType.php
@@ -83,7 +83,7 @@ class AddCartType extends AbstractType
                 $builder
                     ->create('ProductClass', HiddenType::class, [
                         'data_class' => null,
-                        'data' => count($ProductClasses) === 1 ? $ProductClasses->first() : null,
+                        'data' => $Product->hasProductClass() ?  null : $ProductClasses->first(),
                         'constraints' => [
                             new Assert\NotBlank(),
                         ],

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -59,10 +59,10 @@ class ProductRepository extends AbstractRepository
      * Find the Product with sorted ClassCategories.
      *
      * @param integer $productId
-     * @param bool $visibleOnly product_class.visibleがtrueのものだけを対象にするかどうか.
+     *
      * @return Product
      */
-    public function findWithSortedClassCategories($productId, $visibleOnly = false)
+    public function findWithSortedClassCategories($productId)
     {
         $qb = $this->createQueryBuilder('p');
         $qb->addSelect(['pc', 'cc1', 'cc2', 'pi', 'pt'])
@@ -72,15 +72,13 @@ class ProductRepository extends AbstractRepository
             ->leftJoin('p.ProductImage', 'pi')
             ->leftJoin('p.ProductTag', 'pt')
             ->where('p.id = :id')
+            ->andWhere('pc.visible = :visible')
+            ->setParameter('id', $productId)
+            ->setParameter('visible', true)
             ->orderBy('cc1.sort_no', 'DESC')
             ->addOrderBy('cc2.sort_no', 'DESC');
-        if ($visibleOnly) {
-            $qb
-                ->andWhere('pc.visible = :visible')
-                ->setParameter('visible', true);
-        }
+
         $product = $qb
-            ->setParameter('id', $productId)
             ->getQuery()
             ->getSingleResult();
 

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -65,12 +65,11 @@ class ProductRepository extends AbstractRepository
     public function findWithSortedClassCategories($productId, $visibleOnly = false)
     {
         $qb = $this->createQueryBuilder('p');
-        $qb->addSelect(['pc', 'cc1', 'cc2', 'pi', 'ps', 'pt'])
+        $qb->addSelect(['pc', 'cc1', 'cc2', 'pi', 'pt'])
             ->innerJoin('p.ProductClasses', 'pc')
             ->leftJoin('pc.ClassCategory1', 'cc1')
             ->leftJoin('pc.ClassCategory2', 'cc2')
             ->leftJoin('p.ProductImage', 'pi')
-            ->innerJoin('pc.ProductStock', 'ps')
             ->leftJoin('p.ProductTag', 'pt')
             ->where('p.id = :id')
             ->orderBy('cc1.sort_no', 'DESC')

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -59,10 +59,10 @@ class ProductRepository extends AbstractRepository
      * Find the Product with sorted ClassCategories.
      *
      * @param integer $productId
-     *
+     * @param bool $visibleOnly product_class.visibleがtrueのものだけを対象にするかどうか.
      * @return Product
      */
-    public function findWithSortedClassCategories($productId)
+    public function findWithSortedClassCategories($productId, $visibleOnly = false)
     {
         $qb = $this->createQueryBuilder('p');
         $qb->addSelect(['pc', 'cc1', 'cc2', 'pi', 'ps', 'pt'])
@@ -75,10 +75,13 @@ class ProductRepository extends AbstractRepository
             ->where('p.id = :id')
             ->orderBy('cc1.sort_no', 'DESC')
             ->addOrderBy('cc2.sort_no', 'DESC');
+        if ($visibleOnly) {
+            $qb
+                ->andWhere('pc.visible = :visible')
+                ->setParameter('visible', true);
+        }
         $product = $qb
-            ->setParameters([
-                'id' => $productId,
-            ])
+            ->setParameter('id', $productId)
             ->getQuery()
             ->getSingleResult();
 

--- a/tests/Eccube/Tests/Repository/ProductRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryTest.php
@@ -25,7 +25,7 @@ class ProductRepositoryTest extends AbstractProductRepositoryTestCase
 
         $this->entityManager->clear();
 
-        $Result = $this->productRepository->findWithSortedClassCategories($Product->getId(), true);
+        $Result = $this->productRepository->findWithSortedClassCategories($Product->getId());
 
         // visible = trueのみ取得する, 合計3件.
         self::assertCount(3, $Result->getProductClasses());

--- a/tests/Eccube/Tests/Repository/ProductRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Repository;
+
+class ProductRepositoryTest extends AbstractProductRepositoryTestCase
+{
+    public function testFindWithSortedClassCategories()
+    {
+        $Product = $this->createProduct(null, 3);
+        $Result = $this->productRepository->findWithSortedClassCategories($Product->getId());
+
+        // visible = falseも取得するため, 合計4件.
+        self::assertCount(4, $Result->getProductClasses());
+
+        $this->entityManager->clear();
+
+        $Result = $this->productRepository->findWithSortedClassCategories($Product->getId(), true);
+
+        // visible = trueのみ取得する, 合計3件.
+        self::assertCount(3, $Result->getProductClasses());
+    }
+}


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)

管理画面にて規格設定の初期化を行った商品をカートへ追加できず、カートの追加に失敗した旨のメッセージが表示される。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

以下の再現手順が修正されていることを確認

- 管理画面を表示する
- 規格設定なしの商品を登録する
- 該当の商品に規格設定を設定する
- 該当の商品の規格設定を初期化する
- フロント画面を表示する
- 該当の商品をカートへ入れる
- カートへ追加できず、カートの追加に失敗した旨のメッセージが表示される(NG)

## 相談

- ProductRepository::findWithSortedClassCategoriesに引数を追加しています。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



