### PR TITLE
フロント画面商品一覧の件数を20件刻みに変更

### DIFF
--- a/codeception/acceptance/EF02ProductCest.php
+++ b/codeception/acceptance/EF02ProductCest.php
@@ -71,7 +71,7 @@ class EF02ProductCest
         $listPage = new ProductListPage($I);
         // ソート条件の選択リストを変更する 価格順->新着順
         $listPage
-            ->表示件数設定(30)
+            ->表示件数設定(40)
             ->表示順設定('新着順');
 
         // 変更されたソート条件に従い、商品がソートされる
@@ -104,14 +104,14 @@ class EF02ProductCest
         // 各商品のサムネイルが表示される
         $config = Fixtures::get('test_config');
         $productNum = $config['fixture_product_num'] + 2;
-        $itemNum = ($productNum >= 15) ? 15 : $productNum;
+        $itemNum = ($productNum >= 20) ? 20 : $productNum;
         $I->assertEquals($itemNum, $listPage->一覧件数取得());
 
         // 表示件数の選択リストを変更する
-        $listPage->表示件数設定(30);
+        $listPage->表示件数設定(40);
 
         // 変更された表示件数分が1画面に表示される
-        $expected = ($productNum >= 30) ? 30 : $productNum;
+        $expected = ($productNum >= 40) ? 40 : $productNum;
         $I->assertEquals($expected, $listPage->一覧件数取得());
     }
 

--- a/src/Eccube/Resource/doctrine/import_csv/mtb_product_list_max.csv
+++ b/src/Eccube/Resource/doctrine/import_csv/mtb_product_list_max.csv
@@ -1,4 +1,4 @@
 id,name,sort_no,discriminator_type
-"15","15件","0","productlistmax"
-"30","30件","1","productlistmax"
-"50","50件","2","productlistmax"
+"20","20件","0","productlistmax"
+"40","40件","1","productlistmax"
+"60","60件","2","productlistmax"


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
フロント画面の商品一覧は画面の横幅によって２個または４個の商品が１行に並ぶ。
変更前と15個/30個/50個では最終行に空白ができてしまう。

表示件数を2と4の公倍数の20件ごととすることでどの画面幅でも最後まで商品が埋まるようにした。

kj確認済み

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト
軽微な既存機能の仕様変更にあたるかと思います。

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更
