### PR TITLE
TaxRuleControllerTest の修正

### DIFF
--- a/codeception/acceptance/EA07BasicinfoCest.php
+++ b/codeception/acceptance/EA07BasicinfoCest.php
@@ -226,7 +226,7 @@ class EA07BasicinfoCest
         $TaxManagePage
             ->入力_消費税率(1, '10')
             ->入力_適用日(date('Y'), date('n'), date('j'))
-            ->入力_適用時(date('G'), date('i'))
+            ->入力_適用時(date('G'), (int) date('i'))
             ->共通税率設定_登録();
         $I->see('10%', $TaxManagePage->一覧_税率(2));
 

--- a/src/Eccube/Form/Type/Admin/TaxRuleType.php
+++ b/src/Eccube/Form/Type/Admin/TaxRuleType.php
@@ -61,7 +61,7 @@ class TaxRuleType extends AbstractType
             ->add('apply_date', DateTimeType::class, [
                 'date_widget' => 'choice',
                 'input' => 'datetime',
-                'format' => 'yyyy-MM-dd hh:mm',
+                'format' => 'yyyy-MM-dd HH:mm',
                 'years' => range(date('Y'), date('Y') + 10),
                 'placeholder' => [
                     'year' => '----', 'month' => '--', 'day' => '--',

--- a/tests/Eccube/Tests/Web/Admin/Setting/Shop/TaxRuleControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/Shop/TaxRuleControllerTest.php
@@ -75,7 +75,9 @@ class TaxRuleControllerTest extends AbstractAdminWebTestCase
                 ],
                 'time' => [
                     'hour' => $now->format('G'),
-                    'minute' => $now->format('i'),
+                    // Symfony specification of without leading zero
+                    // https://symfony.com/doc/3.4/reference/forms/types/datetime.html#minutes
+                    'minute' => (int)$now->format('i'),
                 ],
             ],
         ];
@@ -123,5 +125,45 @@ class TaxRuleControllerTest extends AbstractAdminWebTestCase
             $this->generateUrl('admin_setting_shop_tax_delete', ['id' => $tid])
         );
         $this->assertSame(404, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testEditWithTime()
+    {
+        $TaxRule = $this->createTaxRule();
+        $tid = $TaxRule->getId();
+        $now = new \DateTime();
+        $form = [
+            '_token' => 'dummy',
+            'tax_rate' => 10,
+            'rounding_type' => rand(1, 3),
+            'apply_date' => [
+                'date' => [
+                    'year' => $now->format('Y'),
+                    'month' => $now->format('n'),
+                    'day' => $now->format('j'),
+                ],
+                'time' => [
+                    'hour' => 23,
+                    'minute' => 1,
+                ],
+            ],
+        ];
+
+        $this->client->request(
+            'POST',
+            $this->generateUrl('admin_setting_shop_tax'),
+            [
+                'tax_rule' => $form,
+                'tax_rule_id' => "$tid",
+                'mode' => 'edit_inline',
+            ]
+        );
+
+        $redirectUrl = $this->generateUrl('admin_setting_shop_tax');
+        $this->assertTrue($this->client->getResponse()->isRedirect($redirectUrl));
+
+        $this->expected = $form['tax_rate'];
+        $this->actual = $TaxRule->getTaxRate();
+        $this->verify();
     }
 }

--- a/tests/Eccube/Tests/Web/Admin/Setting/Shop/TaxRuleControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/Shop/TaxRuleControllerTest.php
@@ -77,7 +77,7 @@ class TaxRuleControllerTest extends AbstractAdminWebTestCase
                     'hour' => $now->format('G'),
                     // Symfony specification of without leading zero
                     // https://symfony.com/doc/3.4/reference/forms/types/datetime.html#minutes
-                    'minute' => (int)$now->format('i'),
+                    'minute' => (int) $now->format('i'),
                 ],
             ],
         ];


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
TaxRuleControllerTest が 0 分〜 9分の間にエラーとなっていたのを修正

## 方針(Policy)
- format を修正
- テストケースを Symfony DateTimeType の仕様に合わせる
    - http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax

## 実装に関する補足(Appendix)
- format は、おそらくそのままでも動作に問題ないと思われるが、念のために修正
- Symfony DateTimeType は、先頭ゼロを付与するとエラーになってしまうため int にキャストする
   - https://symfony.com/doc/3.4/reference/forms/types/datetime.html#minutes

## テスト（Test)
テストの実行時刻に係わらず再現するテストケースを追加

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



