### PR TITLE
注文手続画面へ遷移時に、注文者情報をマイページの住所で更新するように変更

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -127,6 +127,12 @@ class ShoppingController extends AbstractShoppingController
             $this->cartService->save();
         }
 
+        // マイページで会員情報が更新されていれば, Orderの注文者情報も更新する.
+        if ($Customer->getId()) {
+            $this->orderHelper->updateCustomerInfo($Order, $Customer);
+            $this->entityManager->flush();
+        }
+
         $form = $this->createForm(OrderType::class, $Order);
 
         return [

--- a/src/Eccube/Service/OrderHelper.php
+++ b/src/Eccube/Service/OrderHelper.php
@@ -277,6 +277,19 @@ class OrderHelper
         $this->session->remove(self::SESSION_NON_MEMBER_ADDRESSES);
     }
 
+    /**
+     * 会員情報の更新日時が受注の作成日時よりも新しければ, 受注の注文者情報を更新する.
+     *
+     * @param Order $Order
+     * @param Customer $Customer
+     */
+    public function updateCustomerInfo(Order $Order, Customer $Customer)
+    {
+        if ($Order->getCreateDate() < $Customer->getUpdateDate()) {
+            $this->setCustomer($Order, $Customer);
+        }
+    }
+
     private function createPreOrderId()
     {
         // ランダムなpre_order_idを作成

--- a/tests/Eccube/Tests/Service/OrderHelperTest.php
+++ b/tests/Eccube/Tests/Service/OrderHelperTest.php
@@ -13,13 +13,60 @@
 
 namespace Eccube\Tests\Service;
 
+use Eccube\Entity\Customer;
+use Eccube\Entity\Order;
 use Eccube\Service\OrderHelper;
 use Eccube\Tests\EccubeTestCase;
 
 class OrderHelperTest extends EccubeTestCase
 {
+    /**
+     * @var OrderHelper
+     */
+    protected $helper;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->helper = $this->container->get(OrderHelper::class);
+    }
+
     public function testNewInstance()
     {
         $this->assertInstanceOf(OrderHelper::class, $this->helper = $this->container->get(OrderHelper::class));
+    }
+
+    /**
+     * 受注の作成日時より会員の更新日時が古い場合は注文者情報を更新しない.
+     */
+    public function testUpdateCustomerInfoOldCustomer()
+    {
+        $Order = new Order();
+        $Order->setCreateDate((new \DateTime('today')));
+
+        $Customer = new Customer();
+        $Customer->setUpdateDate((new \DateTime('yesterday')));
+        $Customer->setName01('hoge');
+
+        $this->helper->updateCustomerInfo($Order, $Customer);
+        self::assertNull($Order->getName01());
+    }
+
+    /**
+     * 受注の作成日時より会員の更新日時が新しい場合は注文者情報を更新する.
+     */
+    public function testUpdateCustomerInfoNewCustomer()
+    {
+        $Order = new Order();
+        $Order->setCreateDate((new \DateTime('yesterday')));
+
+        $Customer = new Customer();
+        $Customer->setUpdateDate((new \DateTime('today')));
+        $Customer->setName01('hoge');
+
+        $this->helper->updateCustomerInfo($Order, $Customer);
+        self::assertNotNull($Order->getName01());
+        self::assertSame($Order->getName01(), $Customer->getName01());
     }
 }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

以下の問題を修正
- 会員で注文手続き画面へ遷移
- マイページで会員情報を変更
- 注文手続き画面を再表示

注文手続き画面の注文者情報が、更新前の情報が表示されている。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

注文手続画面遷移時に、受注の作成日より会員の更新日が新しい場合は、注文者情報を更新するように修正しました

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
- OrderHelperのテストを追加

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

CUBE-1816

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



