### PR TITLE
非会員購入の注文者情報入力画面のインデントがイケていなかったので修正

### DIFF
--- a/src/Eccube/Resource/template/default/Shopping/nonmember.twig
+++ b/src/Eccube/Resource/template/default/Shopping/nonmember.twig
@@ -19,162 +19,161 @@ file that was distributed with this source code.
 {% endblock javascript %}
 
 {% block main %}
-
-<div class="ec-customerRole">
-    <div class="ec-pageHeader">
-        <h1>{{ 'front.shopping.nonmember'|trans }}</h1>
-    </div>
-    <div class="ec-cartRole">
-        <div class="ec-cartRole__progress">
-            <ul class="ec-progress">
-                {% set step = 1 %}
-                <li class="ec-progress__item">
-                    <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
-                    </div>
-                    <div class="ec-progress__label">{{ 'front.cart.nav__cart_items'|trans }}
-                    </div>
-                </li>
-                {% if is_granted('ROLE_USER') == false %}
-                    <li class="ec-progress__item is-complete">
+    <div class="ec-customerRole">
+        <div class="ec-pageHeader">
+            <h1>{{ 'front.shopping.nonmember'|trans }}</h1>
+        </div>
+        <div class="ec-cartRole">
+            <div class="ec-cartRole__progress">
+                <ul class="ec-progress">
+                    {% set step = 1 %}
+                    <li class="ec-progress__item">
                         <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
                         </div>
-                        <div class="ec-progress__label">{{ 'front.cart.nav__customer_info'|trans }}
+                        <div class="ec-progress__label">{{ 'front.cart.nav__cart_items'|trans }}
                         </div>
                     </li>
-                {% endif %}
-                <li class="ec-progress__item">
-                    <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
-                    </div>
-                    <div class="ec-progress__label">{{ 'front.cart.nav__order'|trans }}
-                    </div>
-                </li>
-                <li class="ec-progress__item">
-                    <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
-                    </div>
-                    <div class="ec-progress__label">{{ 'front.cart.nav__confirm'|trans }}
-                    </div>
-                </li>
-                <li class="ec-progress__item">
-                    <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
-                    </div>
-                    <div class="ec-progress__label">{{ 'front.cart.nav__complete'|trans }}
-                    </div>
-                </li>
-            </ul>
-        </div>
-    </div>
-
-    <div class="ec-off1Grid">
-        <div class="ec-off1Grid__cell">
-            <form method="post" action="{{ url('shopping_nonmember') }}" class="h-adr">
-            <span class="p-country-name" style="display:none;">Japan</span>
-            {{ form_widget(form._token) }}
-            <div class="ec-borderedDefs">
-                <dl>
-                    <dt>
-                        {{ form_label(form.name, 'common.name', { 'label_attr': { 'class': 'ec-label' }}) }}
-                    </dt>
-                    <dd>
-                        <div class="ec-halfInput{{ has_errors(form.name.name01, form.name.name02) ? ' error'}}">
-                            {{ form_widget(form.name.name01, { 'attr': { 'placeholder': 'common.last_name' }}) }}
-                            {{ form_widget(form.name.name02, { 'attr': { 'placeholder': 'common.first_name' }}) }}
-                            {{ form_errors(form.name.name01) }}
-                            {{ form_errors(form.name.name02) }}
-                        </div>
-                    </dd>
-                </dl>
-                <dl>
-                    <dt>
-                        {{ form_label(form.kana, 'common.kana', { 'label_attr': { 'class': 'ec-label' }}) }}
-                    </dt>
-                    <dd>
-                        <div class="ec-halfInput{{ has_errors(form.kana.kana01, form.kana.kana02) ? ' error'}}">
-                            {{ form_widget(form.kana.kana01, { 'attr': { 'placeholder': 'common.first_name_kana' }}) }}
-                            {{ form_widget(form.kana.kana02, { 'attr': { 'placeholder': 'common.first_name_kana' }}) }}
-                            {{ form_errors(form.kana.kana01) }}
-                            {{ form_errors(form.kana.kana02) }}
-                        </div>
-                    </dd>
-                </dl>
-                <dl>
-                    <dt>
-                        {{ form_label(form.company_name, 'common.company_name', { 'label_attr': { 'class': 'ec-label' }}) }}
-                    </dt>
-                    <dd>
-                        <div class="ec-halfInput{{ has_errors(form.company_name) ? ' error' }}">
-                            {{ form_widget(form.company_name) }}
-                            {{ form_errors(form.company_name) }}
-                        </div>
-                    </dd>
-                </dl>
-                <dl>
-                    <dt>
-                        {{ form_label(form.address, 'common.address', { 'label_attr': { 'class': 'ec-label' }}) }}
-                    </dt>
-                    <dd>
-                        <div class="ec-zipInput{{ has_errors(form.postal_code) ? ' error' }}"><span>{{ 'common.postal_symbol'|trans }}</span>
-                            {{ form_widget(form.postal_code) }}
-                            <div class="ec-zipInputHelp">
-                                <div class="ec-zipInputHelp__icon">
-                                    <div class="ec-icon"><img
-                                                src="{{ asset('assets/icon/question-white.svg') }}" alt="">
-                                    </div>
-                                </div><a href="http://www.post.japanpost.jp/zipcode/" target="_blank"><span>{{ 'common.search_postal_code'|trans }}</span></a>
+                    {% if is_granted('ROLE_USER') == false %}
+                        <li class="ec-progress__item is-complete">
+                            <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
                             </div>
-                            {{ form_errors(form.postal_code) }}
+                            <div class="ec-progress__label">{{ 'front.cart.nav__customer_info'|trans }}
+                            </div>
+                        </li>
+                    {% endif %}
+                    <li class="ec-progress__item">
+                        <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
                         </div>
+                        <div class="ec-progress__label">{{ 'front.cart.nav__order'|trans }}
+                        </div>
+                    </li>
+                    <li class="ec-progress__item">
+                        <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
+                        </div>
+                        <div class="ec-progress__label">{{ 'front.cart.nav__confirm'|trans }}
+                        </div>
+                    </li>
+                    <li class="ec-progress__item">
+                        <div class="ec-progress__number">{{ step }}{% set step = step + 1 %}
+                        </div>
+                        <div class="ec-progress__label">{{ 'front.cart.nav__complete'|trans }}
+                        </div>
+                    </li>
+                </ul>
+            </div>
+        </div>
 
-                        <div class="ec-select{{ has_errors(form.address.pref) ? ' error' }}">
-                            {{ form_widget(form.address.pref) }}
-                            {{ form_errors(form.address.pref) }}
-                        </div>
-                        <div class="ec-input{{ has_errors(form.address.addr01) ? ' error' }}">
-                            {{ form_widget(form.address.addr01, { 'attr': { 'placeholder': 'common.address_sample_01' }}) }}
-                            {{ form_errors(form.address.addr01) }}
-                        </div>
-                        <div class="ec-input{{ has_errors(form.address.addr02) ? ' error' }}">
-                            {{ form_widget(form.address.addr02,  { 'attr': { 'placeholder': 'common.address_sample_02' }}) }}
-                            {{ form_errors(form.address.addr02) }}
-                        </div>
-                    </dd>
-                </dl>
-                <dl>
-                    <dt>
-                        {{ form_label(form.phone_number, 'common.phone_number', { 'label_attr': { 'class': 'ec-label' }}) }}
-                    </dt>
-                    <dd>
-                        <div class="ec-telInput{{ has_errors(form.phone_number) ? ' error' }}">
-                            {{ form_widget(form.phone_number) }}
-                            {{ form_errors(form.phone_number) }}
-                        </div>
-                    </dd>
-                </dl>
-                <dl>
-                    <dt>
-                        {{ form_label(form.email, 'common.mail_address', { 'label_attr': { 'class': 'ec-label' }}) }}
-                    </dt>
-                    <dd>
-                        <div class="ec-input{{ has_errors(form.email.first) ? ' error' }}">
-                            {{ form_widget(form.email.first, { 'attr': { 'placeholder': 'common.mail_address_sample' }}) }}
-                            {{ form_errors(form.email.first) }}
-                        </div>
-                        <div class="ec-input{{ has_errors(form.email.second) ? ' error' }}">
-                            {{ form_widget(form.email.second, { 'attr': { 'placeholder': 'common.repeated_confirm' }}) }}
-                            {{ form_errors(form.email.second) }}
-                        </div>
-                    </dd>
-                </dl>
-            </div>
-            <div class="ec-RegisterRole__actions">
-                <div class="ec-off4Grid">
-                    <div class="ec-off4Grid__cell">
-                        <button type="submit" class="ec-blockBtn--action">{{ 'common.next'|trans }}</button>
-                        <a class="ec-blockBtn--cancel" href="{{ url('cart') }}">{{ 'common.back'|trans }}</a>
+        <div class="ec-off1Grid">
+            <div class="ec-off1Grid__cell">
+                <form method="post" action="{{ url('shopping_nonmember') }}" class="h-adr">
+                    <span class="p-country-name" style="display:none;">Japan</span>
+                    {{ form_widget(form._token) }}
+                    <div class="ec-borderedDefs">
+                        <dl>
+                            <dt>
+                                {{ form_label(form.name, 'common.name', { 'label_attr': { 'class': 'ec-label' }}) }}
+                            </dt>
+                            <dd>
+                                <div class="ec-halfInput{{ has_errors(form.name.name01, form.name.name02) ? ' error'}}">
+                                    {{ form_widget(form.name.name01, { 'attr': { 'placeholder': 'common.last_name' }}) }}
+                                    {{ form_widget(form.name.name02, { 'attr': { 'placeholder': 'common.first_name' }}) }}
+                                    {{ form_errors(form.name.name01) }}
+                                    {{ form_errors(form.name.name02) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl>
+                            <dt>
+                                {{ form_label(form.kana, 'common.kana', { 'label_attr': { 'class': 'ec-label' }}) }}
+                            </dt>
+                            <dd>
+                                <div class="ec-halfInput{{ has_errors(form.kana.kana01, form.kana.kana02) ? ' error'}}">
+                                    {{ form_widget(form.kana.kana01, { 'attr': { 'placeholder': 'common.first_name_kana' }}) }}
+                                    {{ form_widget(form.kana.kana02, { 'attr': { 'placeholder': 'common.first_name_kana' }}) }}
+                                    {{ form_errors(form.kana.kana01) }}
+                                    {{ form_errors(form.kana.kana02) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl>
+                            <dt>
+                                {{ form_label(form.company_name, 'common.company_name', { 'label_attr': { 'class': 'ec-label' }}) }}
+                            </dt>
+                            <dd>
+                                <div class="ec-halfInput{{ has_errors(form.company_name) ? ' error' }}">
+                                    {{ form_widget(form.company_name) }}
+                                    {{ form_errors(form.company_name) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl>
+                            <dt>
+                                {{ form_label(form.address, 'common.address', { 'label_attr': { 'class': 'ec-label' }}) }}
+                            </dt>
+                            <dd>
+                                <div class="ec-zipInput{{ has_errors(form.postal_code) ? ' error' }}"><span>{{ 'common.postal_symbol'|trans }}</span>
+                                    {{ form_widget(form.postal_code) }}
+                                    <div class="ec-zipInputHelp">
+                                        <div class="ec-zipInputHelp__icon">
+                                            <div class="ec-icon"><img
+                                                        src="{{ asset('assets/icon/question-white.svg') }}" alt="">
+                                            </div>
+                                        </div><a href="http://www.post.japanpost.jp/zipcode/" target="_blank"><span>{{ 'common.search_postal_code'|trans }}</span></a>
+                                    </div>
+                                    {{ form_errors(form.postal_code) }}
+                                </div>
+
+                                <div class="ec-select{{ has_errors(form.address.pref) ? ' error' }}">
+                                    {{ form_widget(form.address.pref) }}
+                                    {{ form_errors(form.address.pref) }}
+                                </div>
+                                <div class="ec-input{{ has_errors(form.address.addr01) ? ' error' }}">
+                                    {{ form_widget(form.address.addr01, { 'attr': { 'placeholder': 'common.address_sample_01' }}) }}
+                                    {{ form_errors(form.address.addr01) }}
+                                </div>
+                                <div class="ec-input{{ has_errors(form.address.addr02) ? ' error' }}">
+                                    {{ form_widget(form.address.addr02,  { 'attr': { 'placeholder': 'common.address_sample_02' }}) }}
+                                    {{ form_errors(form.address.addr02) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl>
+                            <dt>
+                                {{ form_label(form.phone_number, 'common.phone_number', { 'label_attr': { 'class': 'ec-label' }}) }}
+                            </dt>
+                            <dd>
+                                <div class="ec-telInput{{ has_errors(form.phone_number) ? ' error' }}">
+                                    {{ form_widget(form.phone_number) }}
+                                    {{ form_errors(form.phone_number) }}
+                                </div>
+                            </dd>
+                        </dl>
+                        <dl>
+                            <dt>
+                                {{ form_label(form.email, 'common.mail_address', { 'label_attr': { 'class': 'ec-label' }}) }}
+                            </dt>
+                            <dd>
+                                <div class="ec-input{{ has_errors(form.email.first) ? ' error' }}">
+                                    {{ form_widget(form.email.first, { 'attr': { 'placeholder': 'common.mail_address_sample' }}) }}
+                                    {{ form_errors(form.email.first) }}
+                                </div>
+                                <div class="ec-input{{ has_errors(form.email.second) ? ' error' }}">
+                                    {{ form_widget(form.email.second, { 'attr': { 'placeholder': 'common.repeated_confirm' }}) }}
+                                    {{ form_errors(form.email.second) }}
+                                </div>
+                            </dd>
+                        </dl>
                     </div>
-                </div>
+                    <div class="ec-RegisterRole__actions">
+                        <div class="ec-off4Grid">
+                            <div class="ec-off4Grid__cell">
+                                <button type="submit" class="ec-blockBtn--action">{{ 'common.next'|trans }}</button>
+                                <a class="ec-blockBtn--cancel" href="{{ url('cart') }}">{{ 'common.back'|trans }}</a>
+                            </div>
+                        </div>
+                    </div>
+                </form>
             </div>
-        </form>
         </div>
     </div>
-</div>
 {% endblock %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
非会員購入の注文者情報入力画面のインデントがイケていなかったので修正
インデントと空行の調整のみ

## 方針(Policy)
インデントの調整のみ

## 実装に関する補足(Appendix)
?w=1をつけて確認をお願いします。

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



