### PR TITLE
受注管理画面のみが文字化けしてしまうのを修正

### DIFF
--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -137,7 +137,6 @@ class OrderController extends AbstractController
      * @param ProductStockRepository $productStockRepository
      * @param OrderRepository $orderRepository
      * @param OrderPdfRepository $orderPdfRepository
-     * @param OrderPdfService $orderPdfService
      * @param ValidatorInterface $validator
      * @param OrderStateMachine $orderStateMachine ;
      */
@@ -153,7 +152,6 @@ class OrderController extends AbstractController
         ProductStockRepository $productStockRepository,
         OrderRepository $orderRepository,
         OrderPdfRepository $orderPdfRepository,
-        OrderPdfService $orderPdfService,
         ValidatorInterface $validator,
         OrderStateMachine $orderStateMachine,
         MailService $mailService
@@ -169,7 +167,6 @@ class OrderController extends AbstractController
         $this->productStockRepository = $productStockRepository;
         $this->orderRepository = $orderRepository;
         $this->orderPdfRepository = $orderPdfRepository;
-        $this->orderPdfService = $orderPdfService;
         $this->validator = $validator;
         $this->orderStateMachine = $orderStateMachine;
         $this->mailService = $mailService;
@@ -660,7 +657,7 @@ class OrderController extends AbstractController
      *
      * @return Response
      */
-    public function exportPdfDownload(Request $request)
+    public function exportPdfDownload(Request $request, OrderPdfService $orderPdfService)
     {
         /**
          * @var FormBuilder
@@ -683,7 +680,7 @@ class OrderController extends AbstractController
         $arrData = $form->getData();
 
         // 購入情報からPDFを作成する
-        $status = $this->orderPdfService->makePdf($arrData);
+        $status = $orderPdfService->makePdf($arrData);
 
         // 異常終了した場合の処理
         if (!$status) {
@@ -697,7 +694,7 @@ class OrderController extends AbstractController
 
         // ダウンロードする
         $response = new Response(
-            $this->orderPdfService->outputPdf(),
+            $orderPdfService->outputPdf(),
             200,
             ['content-type' => 'application/pdf']
         );
@@ -706,9 +703,9 @@ class OrderController extends AbstractController
 
         // レスポンスヘッダーにContent-Dispositionをセットし、ファイル名を指定
         if ($downloadKind == 1) {
-            $response->headers->set('Content-Disposition', 'attachment; filename="'.$this->orderPdfService->getPdfFileName().'"');
+            $response->headers->set('Content-Disposition', 'attachment; filename="'.$orderPdfService->getPdfFileName().'"');
         } else {
-            $response->headers->set('Content-Disposition', 'inline; filename="'.$this->orderPdfService->getPdfFileName().'"');
+            $response->headers->set('Content-Disposition', 'inline; filename="'.$orderPdfService->getPdfFileName().'"');
         }
 
         log_info('OrderPdf download success!', ['Order ID' => implode(',', $request->get('ids', []))]);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
以下 Codeception の環境の admin01 にて再現する、受注管理画面のみが文字化けしてしまうのを修正。
https://github.com/EC-CUBE/eccube-codeception/pull/153

## 方針(Policy)
コンストラクタインジェクションを使用すると文字化けしてしまうため、メソッドインジェクションに変更

## 実装に関する補足(Appendix)
OrderPdfService が継承している、 TCPDF のコンストラクタで `mb_internal_encoding('ASCII')` をコールしているのが原因だが、どういう状況で再現するかは不明

## テスト（Test)
- 受注管理画面が文字化けしないのを確認
- https://github.com/EC-CUBE/eccube-codeception/pull/153 のテストが通るのを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



