### PR TITLE
PaymentResult#getErrors()の修正

### DIFF
--- a/src/Eccube/Service/Payment/PaymentResult.php
+++ b/src/Eccube/Service/Payment/PaymentResult.php
@@ -23,7 +23,7 @@ class PaymentResult
     /**
      * @var array
      */
-    private $errors;
+    private $errors = [];
 
     /**
      * @var boolean

--- a/src/Eccube/Service/Payment/PaymentResult.php
+++ b/src/Eccube/Service/Payment/PaymentResult.php
@@ -70,7 +70,7 @@ class PaymentResult
      */
     public function getErrors()
     {
-        return [];
+        return $this->errors;
     }
 
     /**


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
`PaymentResult#getErrors()` が常に空配列を返していたので修正。
