### PR TITLE
管理画面の受注編集画面にて、更新ボタン押下時に明細のポイントの割引金額が更新されるように修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -165,6 +165,31 @@ file that was distributed with this source code.
                 }
             });
         });
+
+        {# ポイント機能が有効かつ会員の場合のみポイントの割引金額を変更する #}
+        {% if BaseInfo.isOptionPoint and Order.Customer is not null %}
+            // 再計算時のポイントの割引金額の更新
+            function updatePointItem() {
+                // ポイント換算レート
+                var pointConversionRate = {{ BaseInfo.point_conversion_rate }};
+                // 利用ポイント
+                var usePoint = $('#order_use_point').val();
+
+                // 利用ポイントが数値以外の時は割引金額を更新しない
+                if (isNaN(usePoint)) return;
+
+                // 割引金額を計算
+                var discountPrice = (-1) * pointConversionRate * usePoint;
+
+                // ポイント明細の金額の要素を取得
+                var $pointPrice = $('.pointPrice');
+
+                // ポイント明細の金額の要素がある場合はポイントの更新
+                if ($pointPrice.length) {
+                    $pointPrice.val(discountPrice);
+                }
+            }
+        {% endif %}
     </script>
 {% endblock javascript %}
 
@@ -175,7 +200,7 @@ file that was distributed with this source code.
         constant('Eccube\\Entity\\Master\\OrderStatus::PROCESSING'), constant('Eccube\\Entity\\Master\\OrderStatus::PENDING')] -%}
         {% set action_disabled = true %}
     {%- endif %}
-    <form name="form1" id="form1" method="post" action="?">
+    <form name="form1" id="form1" method="post" action="?"{% if BaseInfo.isOptionPoint and Order.Customer is not null %} onsubmit="updatePointItem()"{% endif %}>
         <input type="hidden" name="mode" value="">
         <input type="hidden" name="modal" value="">
         {{ form_widget(form._token) }}
@@ -707,7 +732,7 @@ file that was distributed with this source code.
                                                 <div class="col-12">
                                                     {# ポイント値引きは価格変更できない #}
                                                     {% if OrderItem.isPoint %}
-                                                        {{ form_widget(orderItemForm.price, { 'tax_display_type': OrderItem.TaxDisplayType, 'attr': { 'readonly': 'readonly' } }) }}
+                                                        {{ form_widget(orderItemForm.price, { 'tax_display_type': OrderItem.TaxDisplayType, 'attr': { 'readonly': 'readonly', 'class': 'pointPrice' } }) }}
                                                     {% else %}
                                                         {{ form_widget(orderItemForm.price, { 'tax_display_type': OrderItem.TaxDisplayType }) }}
                                                     {% endif %}

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -827,7 +827,12 @@ file that was distributed with this source code.
                                     <div class="col-auto"><span class="align-middle">{{ 'admin.order.use_point'|trans }}</span></div>
                                     <div class="col-2 text-right">
                                         <span class="h4 align-middle font-weight-normal">
-                                            {{ form_widget(form.use_point) }}
+                                            {# ポイント機能が有効かつ会員の場合のみポイントを編集可能とする #}
+                                            {% if BaseInfo.isOptionPoint and Order.Customer is not null %}
+                                                {{ form_widget(form.use_point) }}
+                                            {% else %}
+                                                {{ form_widget(form.use_point, {'attr': { 'readonly': 'readonly' } }) }}
+                                            {% endif %}
                                             {{ form_errors(form.use_point) }}
                                         </span>
                                     </div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- 管理画面の受注編集画面にて、更新ボタン押下時に明細のポイントの割引金額が更新されるように修正
- ポイント機能が有効かつ会員の場合のみポイントを編集可能なように修正

## 方針(Policy)
- POST後のサーバ側で明細の変更が難しかったので、POST前にonsubmitで明細の金額を更新するように修正。
- ポイント明細がすでにある場合は金額を更新するが、ポイント明細がない場合は明細の追加までは行っていない。
  - 影響範囲が広がるのとポイント明細を追加するユースケースが少ないことを考慮
- ポイント機能が無効な時も、過去のポイントを使った受注を確認するケースが考えられるので、利用ポイントはreadonlyとした。

## 実装に関する補足(Appendix)


## テスト（Test)
ポイントの有効無効、会員非会員で登録処理をテスト
ポイントの更新時に割引金額が更新されることを確認

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



