### PR TITLE
DBとPHPでソートの結果が異なりテストが失敗するのを修正

### DIFF
--- a/codeception/acceptance/EF03OrderCest.php
+++ b/codeception/acceptance/EF03OrderCest.php
@@ -388,7 +388,7 @@ class EF03OrderCest
     {
         // チェック用変数
         // 追加するお届け作の名前
-        $nameSei = '姓0302';
+        $nameSei = 'あいおい0302';
         $nameMei = '名0302';
         // カートへ入れる商品の数
         $cart_quantity = 1;
@@ -583,7 +583,7 @@ class EF03OrderCest
     {
         // チェック用変数
         // 追加するお届け作の名前
-        $nameSei = '姓0302';
+        $nameSei = 'あいおい0302';
         $nameMei = '名0302';
         // カートへ入れる商品の数
         $cart_quantity = 1;
@@ -739,7 +739,7 @@ class EF03OrderCest
     {
         // チェック用変数
         // 追加するお届け作の名前
-        $nameSei = '姓0302';
+        $nameSei = 'あいおい0302';
         $nameMei = '名0302';
         // カートへ入れる商品の数
         $cart_quantity = 1;


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
ご注文情報入力画面でのお届け先のソート順は、**姓 昇順, 名 昇順, ID 昇順** となっており、 DB でソートするが、テストケースでは PHP でソートしており、結果が異なる場合がある

### 例

```
php -r "var_dump(strnatcmp('江古田', '姓0302'));"
=> int(1)
```

PostgreSQL10.4
```
eccube_db=# SHOW LC_COLLATE;
 lc_collate
------------
 ja_JP.utf8
(1 行)

eccube_db=# select name01 from dtb_shipping where order_id = 36 order by name01 asc;
 name01
--------
 江古田
 姓0302
(2 行)
```
## 方針(Policy)
漢字のソート順に依存しないよう、ひらがなを使用する

## テスト（Test)
https://github.com/EC-CUBE/eccube-codeception/pull/153 が通るのを確認

## 相談（Discussion）
類似バグがあるかも

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



