### PR TITLE
discount が大きくなりすぎて, total がマイナスになる対策

### DIFF
--- a/codeception/acceptance/_bootstrap.php
+++ b/codeception/acceptance/_bootstrap.php
@@ -108,7 +108,7 @@ if ($allOrderCount < $config['fixture_order_num']) {
         $Delivery = $Deliveries[$faker->numberBetween(0, count($Deliveries) - 1)];
         $Product = $Products[$faker->numberBetween(0, count($Products) - 1)];
         $charge = $faker->randomNumber(4);
-        $discount = $faker->randomNumber(4);
+        $discount = $faker->numberBetween(0, $charge);
 
         $orderCountPerCustomer = $entityManager->getRepository('Eccube\Entity\Order')
             ->createQueryBuilder('o')


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
Codeception にて discount が大きくなりすぎて, total がマイナスになってしまう

## 方針(Policy)
charge > discount にする

## テスト（Test)
Codeception が通るのを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



