### PR TITLE
非表示や在庫切れなどでカート内に商品がなくなった場合にカート自体を削除する

### DIFF
--- a/src/Eccube/Service/PurchaseFlow/Processor/EmptyItemsValidator.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/EmptyItemsValidator.php
@@ -60,6 +60,10 @@ class EmptyItemsValidator extends ItemHolderValidator
         }
 
         if (!$itemHolder instanceof Order) {
+            // cart内に商品がなくなった場合はカート自体を削除する
+            if (count($itemHolder->getItems()) < 1) {
+                $this->entityManager->remove($itemHolder);
+            }
             return;
         }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
非表示や在庫切れなどでカート内に商品がなくなった場合にカート自体を削除する

### 問題の再現手順
1. 販売種別の違う商品をそれぞれカートに入れる
2. どちらかを非公開or在庫0にする
3. カートを再表示する

step2で操作した商品はカートから削除されているが、カート自体は削除されず残ったままとなってしまっていた。

## 方針(Policy)
数量0の商品チェックをするEmptyItemsValidatorにて、商品が0この場合にカートを削除する処理を追加

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）
~~step3の操作にて「他の商品をカートに入れる」操作をすると不要なカートが消えるのですが、「カートをリロード」しただけではカートが消えてくれません。
修正方法がわからず困っています。
助けてください 😂~~

助けていただきました！ありがとうございます！
https://github.com/okazy/ec-cube/pull/20

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



