### PR TITLE
支払い方法を検索条件に指定した場合に多重定義エラーとなる不具合の修正

### DIFF
--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -79,9 +79,9 @@ class OrderRepository extends AbstractRepository
     {
         $qb = $this->createQueryBuilder('o')
             ->select('o, s')
-            ->addSelect('oi', 'p')
+            ->addSelect('oi', 'pref')
             ->leftJoin('o.OrderItems', 'oi')
-            ->leftJoin('o.Pref', 'p')
+            ->leftJoin('o.Pref', 'pref')
             ->innerJoin('o.Shippings', 's');
 
         // order_id_start

--- a/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataAdminTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataAdminTest.php
@@ -21,6 +21,7 @@ use Eccube\Entity\Shipping;
 use Eccube\Repository\Master\OrderStatusRepository;
 use Eccube\Repository\Master\SexRepository;
 use Eccube\Repository\OrderRepository;
+use Eccube\Repository\PaymentRepository;
 use Eccube\Tests\EccubeTestCase;
 use Eccube\Util\StringUtil;
 
@@ -49,6 +50,8 @@ class OrderRepositoryGetQueryBuilderBySearchDataAdminTest extends EccubeTestCase
     protected $orderRepo;
     /** @var SexRepository */
     protected $sexRepo;
+    /** @var PaymentRepository */
+    protected $paymentRepo;
 
     public function setUp()
     {
@@ -56,6 +59,7 @@ class OrderRepositoryGetQueryBuilderBySearchDataAdminTest extends EccubeTestCase
         $this->createProduct();
 
         $this->orderStatusRepo = $this->container->get(OrderStatusRepository::class);
+        $this->paymentRepo = $this->container->get(PaymentRepository::class);
         $this->orderRepo = $this->container->get(OrderRepository::class);
         $this->sexRepo = $this->container->get(SexRepository::class);
         $this->Customer = $this->createCustomer();
@@ -486,6 +490,139 @@ class OrderRepositoryGetQueryBuilderBySearchDataAdminTest extends EccubeTestCase
         $this->expected = 2;
         $this->actual = count($this->Results);
         $this->verify();
+    }
+
+    /**
+     * @param array $searchPaymentNos
+     * @param int $expected
+     *
+     * @dataProvider dataPaymentProvider
+     */
+    public function testPayment(array $searchPaymentNos, int $expected)
+    {
+        // データの準備
+        $Payments = [];
+        for ($i = 1; $i < 4; $i++) {
+            $Payments[$i] = $this->paymentRepo->find($i);
+        }
+
+        // 支払い方法1, 2をそれぞれ設定
+        $this->Order1->setPayment($Payments[1]);
+        $this->Order2->setPayment($Payments[2]);
+
+        $this->entityManager->flush();
+
+        // Paymentの検索リストを作成
+        $Payments = array_filter($Payments, function ($Payment) use($searchPaymentNos){
+            return in_array($Payment->getId(), $searchPaymentNos);
+        });
+
+        // 検索
+        $this->searchData = [
+            'payment' => $Payments,
+        ];
+
+        $this->scenario();
+
+        $this->expected = $expected;
+        $this->actual = count($this->Results);
+        $this->verify();
+    }
+
+    /**
+     * Data for case check Payment.
+     *
+     * @return array
+     */
+    public function dataPaymentProvider()
+    {
+        return [
+            [[1], 1],
+            [[1,2], 2],
+            [[2,3], 1],
+            [[3], 0],
+        ];
+    }
+
+    public function testCompanyName()
+    {
+        $this->Order2->setCompanyName('ダミー会社名');
+        $this->entityManager->flush();
+
+        $this->searchData = [
+            'company_name' => 'ダミー会社名',
+        ];
+        $this->scenario();
+
+        $this->expected = 1;
+        $this->actual = count($this->Results);
+        $this->verify();
+    }
+
+    public function testOrderNo()
+    {
+        $this->Order2->setOrderNo('12345678abcd');
+        $this->entityManager->flush();
+
+        $this->searchData = [
+            'order_no' => '12345678abcd',
+        ];
+        $this->scenario();
+
+        $this->expected = 1;
+        $this->actual = count($this->Results);
+        $this->verify();
+    }
+
+    public function testTrackingNumber()
+    {
+        $this->Order2->getShippings()[0]->setTrackingNumber('1234abcdefgh');
+        $this->entityManager->flush();
+
+        $this->searchData = [
+            'tracking_number' => '1234abcdefgh',
+        ];
+        $this->scenario();
+
+        $this->expected = 1;
+        $this->actual = count($this->Results);
+        $this->verify();
+    }
+
+    /**
+     * @param array $checks
+     * @param int $expected
+     *
+     * @dataProvider dataShippingMailProvider
+     */
+    public function testShippingMail(array $checks, int $expected)
+    {
+        $this->Order2->getShippings()[0]->setMailSendDate(new \DateTime());
+        $this->entityManager->flush();
+
+        $this->searchData = [
+            'shipping_mail' => $checks,
+        ];
+        $this->scenario();
+
+        $this->expected = $expected;
+        $this->actual = count($this->Results);
+        $this->verify();
+    }
+
+    /**
+     * Data for case check shipping mail.
+     *
+     * @return array
+     */
+    public function dataShippingMailProvider()
+    {
+        return [
+            [[], 2],
+            [[Shipping::SHIPPING_MAIL_SENT], 1],
+            [[Shipping::SHIPPING_MAIL_UNSENT], 1],
+            [[Shipping::SHIPPING_MAIL_SENT, Shipping::SHIPPING_MAIL_UNSENT], 2],
+        ];
     }
 
     /**


### PR DESCRIPTION
issueリスト番号 534

## 概要(Overview・Refs Issue)
支払い方法を検索条件に指定した場合に多重定義エラーとなる不具合の修正
受注一覧画面の検索項目のUnitTestを追加

## 方針(Policy)
PrefとPaymentのAliasがどちらもpで被っていた

## 実装に関する補足(Appendix)
Prefはパフォーマンス対策のため、PrefのAliasを変更した。

## テスト（Test)
受注一覧から入力できる検索条件のUnitテストを追加

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



