### PR TITLE
issue #213 ロード時にスライド画像が縦並びで表示されるバグ

### DIFF
--- a/src/Eccube/Resource/template/default/index.twig
+++ b/src/Eccube/Resource/template/default/index.twig
@@ -106,9 +106,9 @@ file that was distributed with this source code.
 {% block main %}
     <div class="ec-sliderRole">
         <div class="main_visual">
-            <div class="item"><img src="{{ asset('assets/img/top/img_hero_pc01.jpg') }}"></div>
-            <div class="item"><img src="{{ asset('assets/img/top/img_hero_pc02.jpg') }}"></div>
-            <div class="item"><img src="{{ asset('assets/img/top/img_hero_pc03.jpg') }}"></div>
+            <div class="item slick-slide"><img src="{{ asset('assets/img/top/img_hero_pc01.jpg') }}"></div>
+            <div class="item slick-slide"><img src="{{ asset('assets/img/top/img_hero_pc02.jpg') }}"></div>
+            <div class="item slick-slide"><img src="{{ asset('assets/img/top/img_hero_pc03.jpg') }}"></div>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
close https://github.com/EC-CUBE/Eccube-Styleguide/issues/213

## 方針(Policy)
CSSの修正では改善できなかったため、HTMLに予め `slick-slide` クラスを付与することで対応しました。
