### PR TITLE
数字入力の最大文字数設定

### DIFF
--- a/src/Eccube/Form/Type/TelType.php
+++ b/src/Eccube/Form/Type/TelType.php
@@ -113,18 +113,21 @@ class TelType extends AbstractType
         $resolver->setDefaults(array(
             'options' => array('constraints' => array()),
             'tel01_options' => array(
+                'attr' => array('maxlength' => $this->config['tel_len']),
                 'constraints' => array(
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')), //todo  messageは汎用的に出来ないものか?
                     new Assert\Length(array('max' => $this->config['tel_len'], 'min' => $this->config['tel_len_min'])),
                 ),
             ),
             'tel02_options' => array(
+                'attr' => array('maxlength' => $this->config['tel_len']),
                 'constraints' => array(
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')),
                     new Assert\Length(array('max' => $this->config['tel_len'], 'min' => $this->config['tel_len_min'])),
                 ),
             ),
             'tel03_options' => array(
+                'attr' => array('maxlength' => $this->config['tel_len']),
                 'constraints' => array(
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')),
                     new Assert\Length(array('max' => $this->config['tel_len'], 'min' => $this->config['tel_len_min'])),

--- a/src/Eccube/Form/Type/ZipType.php
+++ b/src/Eccube/Form/Type/ZipType.php
@@ -93,12 +93,14 @@ class ZipType extends AbstractType
         $resolver->setDefaults(array(
             'options' => array('constraints' => array(), 'attr' => array('class' => 'p-postal-code')),
             'zip01_options' => array(
+                'attr' => array('maxlength' => $this->config['zip01_len']),
                 'constraints' => array(
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')),
                     new Assert\Length(array('min' => $this->config['zip01_len'], 'max' => $this->config['zip01_len'])),
                 ),
             ),
             'zip02_options' => array(
+                'attr' => array('maxlength' => $this->config['zip02_len']),
                 'constraints' => array(
                     new Assert\Type(array('type' => 'numeric', 'message' => 'form.type.numeric.invalid')),
                     new Assert\Length(array('min' => $this->config['zip02_len'], 'max' => $this->config['zip02_len'])),


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
郵便番号や電話番号の入力文字数に制限を掛けて頂いたいとお客様より多数要望を頂いております。
過去に一度設定を外しているようなのですが、
https://github.com/EC-CUBE/ec-cube/commit/7f84ddc6e31737662eeda88cc403742c9d1cb54b#diff-d32abddc37fc04e56e8ed3d015c1050f
max_lengthの設定をデフォルトにしたいと思っております。

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)
- [x] ユーザー側、各ページの郵便番号が3桁、4桁以上入力出来ない事
- [x] ユーザー側、各ページの電話番号が各欄5桁以上入力出来ない事
- [x] ユーザー側、各ページでFAX番号が各欄5桁以上入力出来ない事
- [x] 管理画面側、各ページの郵便番号が3桁、4桁以上入力出来ない事
- [x] 管理画面側、各ページの電話番号が各欄5桁以上入力出来ない事
- [x] 管理画面側、各ページでFAX番号が各欄5桁以上入力出来ない事

## 相談（Discussion）
こちらの対応が問題ないようでしたら、4.0にも対応したいと思っております。