### PR TITLE
sqlite3 extension が存在しないとハマるのでインストーラに遷移するよう修正

### DIFF
--- a/index.php
+++ b/index.php
@@ -25,6 +25,10 @@ if (!isset($_SERVER['APP_ENV'])) {
 
     if (file_exists(__DIR__.'/.env')) {
         (new Dotenv(__DIR__))->overload();
+
+        if (strpos(getenv('DATABASE_URL'), 'sqlite') !== false && !extension_loaded('pdo_sqlite')) {
+            (new Dotenv(__DIR__, '.env.install'))->overload();
+        }
     } else {
         (new Dotenv(__DIR__, '.env.install'))->overload();
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
composer install を実行すると、 .env が自動生成されるが、 この時に SQLite3 Extension が存在しないとエラー画面に遷移してしまう。
レンタルサーバー等の環境では、どうしたらよいか、わからなくなってしまう。

## 方針(Policy)
環境変数 DATABASE_URL が sqlite で設定されており、かつ pdo_sqlite extension が存在しない場合はインストーラへ遷移するよう修正

## テスト（Test)
sqlite3 extension の無い環境で composer install を実行し、正常にインストーラ画面に遷移するのを確認


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



