### PR TITLE
新着情報の登録「年」を2000年以降から選択できるように変更

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -118,3 +118,4 @@ parameters:
     # {random_alnum,桁数} : ランダムな半角英数大文字を桁数分作成
     eccube_order_no_format: ''
     eccube_order_pdf_message_len: 30
+    eccube_news_start_year: 2000

--- a/src/Eccube/Form/Type/Admin/NewsType.php
+++ b/src/Eccube/Form/Type/Admin/NewsType.php
@@ -47,7 +47,7 @@ class NewsType extends AbstractType
                 'date_widget' => 'choice',
                 'input' => 'datetime',
                 'format' => 'yyyy-MM-dd hh:mm',
-                'years' => range(date('Y'), date('Y') + 3),
+                'years' => range($this->eccubeConfig['eccube_news_start_year'], date('Y') + 3),
                 'constraints' => [
                     new Assert\NotBlank(),
                 ],


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
新着情報の日付で過去の「年」が選択できなかった。
過去の新着情報を編集するときなどに困るので、2000年以降で選択できるようにする。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->
- デフォルトの新着情報の選択範囲は、2000年～現在＋3年。
- eccube.ymlの `eccube_news_start_year` で変更可能。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
なし

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
eccube.ymlの `eccube_news_start_year` に連動して、「年」の選択肢が変化することを確認。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
なし

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



