### PR TITLE
商品規格画面のエンターボタン押した時の項目がコピーされてしまう問題の修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Product/product_class.twig
+++ b/src/Eccube/Resource/template/admin/Product/product_class.twig
@@ -238,7 +238,7 @@ file that was distributed with this source code.
                                         {{ form_errors(form.product_classes) }}
                                     </div>
                                     <div class="col-4 text-right">
-                                        <button id="copy" class="btn btn-ec-regular"><i
+                                        <button type="button" id="copy" class="btn btn-ec-regular"><i
                                                     class="fa fa-files-o mr-1"></i><span>{{ 'admin.product.copy_first_line'|trans }}</span></button>
                                     </div>
                                 </div>

--- a/src/Eccube/Resource/template/admin/Product/product_class.twig
+++ b/src/Eccube/Resource/template/admin/Product/product_class.twig
@@ -226,7 +226,6 @@ file that was distributed with this source code.
                                value="{{ form.class_name1.vars.value }}">
                         <input type="hidden" name="{{ form.class_name2.vars.full_name }}"
                                value="{{ form.class_name2.vars.value }}">
-
                         <div class="card rounded border-0 mb-4">
                             <div class="card-header">
                                 <div class="row justify-content-between">
@@ -238,8 +237,10 @@ file that was distributed with this source code.
                                         {{ form_errors(form.product_classes) }}
                                     </div>
                                     <div class="col-4 text-right">
-                                        <button type="button" id="copy" class="btn btn-ec-regular"><i
-                                                    class="fa fa-files-o mr-1"></i><span>{{ 'admin.product.copy_first_line'|trans }}</span></button>
+                                        <button type="button" id="copy" class="btn btn-ec-regular">
+                                            <i class="fa fa-files-o mr-1"></i>
+                                            <span>{{ 'admin.product.copy_first_line'|trans }}</span>
+                                        </button>
                                     </div>
                                 </div>
                             </div>
@@ -365,13 +366,15 @@ file that was distributed with this source code.
                                     <div class="col-6">
                                         <div class="c-conversionArea__leftBlockItem">
                                             {% if return_product %}
-                                                <a class="c-beseLink" href="{{ url(return_product, {'id': Product.id}) }}"><i
-                                                            class="fa fa-backward"
-                                                            aria-hidden="true"></i><span>{{ 'admin.product.product_registration'|trans }}</span></a>
+                                                <a class="c-beseLink" href="{{ url(return_product, {'id': Product.id}) }}">
+                                                    <i class="fa fa-backward" aria-hidden="true"></i>
+                                                    <span>{{ 'admin.product.product_registration'|trans }}</span>
+                                                </a>
                                             {% else %}
-                                                <a class="c-beseLink" href="{{ url('admin_product', {'resume': 1}) }}"><i
-                                                            class="fa fa-backward"
-                                                            aria-hidden="true"></i><span>{{ 'admin.product.product_list'|trans }}</span></a>
+                                                <a class="c-beseLink" href="{{ url('admin_product', {'resume': 1}) }}">
+                                                    <i class="fa fa-backward" aria-hidden="true"></i>
+                                                    <span>{{ 'admin.product.product_list'|trans }}</span>
+                                                </a>
                                             {% endif %}
                                         </div>
                                     </div>
@@ -396,13 +399,15 @@ file that was distributed with this source code.
                                 <div class="col-6">
                                     <div class="c-conversionArea__leftBlockItem">
                                         {% if return_product %}
-                                            <a class="c-beseLink" href="{{ url(return_product, {'id': Product.id}) }}"><i
-                                                        class="fa fa-backward"
-                                                        aria-hidden="true"></i><span>{{ 'admin.product.product_registration'|trans }}</span></a>
+                                            <a class="c-beseLink" href="{{ url(return_product, {'id': Product.id}) }}">
+                                                <i class="fa fa-backward" aria-hidden="true"></i>
+                                                <span>{{ 'admin.product.product_registration'|trans }}</span>
+                                            </a>
                                         {% else %}
-                                            <a class="c-beseLink" href="{{ url('admin_product', {'resume': 1}) }}"><i
-                                                        class="fa fa-backward"
-                                                        aria-hidden="true"></i><span>{{ 'admin.product.product_list'|trans }}</span></a>
+                                            <a class="c-beseLink" href="{{ url('admin_product', {'resume': 1}) }}">
+                                                <i class="fa fa-backward" aria-hidden="true"></i>
+                                                <span>{{ 'admin.product.product_list'|trans }}</span>
+                                            </a>
                                         {% endif %}
                                     </div>
                                 </div>


### PR DESCRIPTION
issue番号 383

## 概要(Overview・Refs Issue)
buttonタグに `type="button"` 要素が抜けていたため追加

## 方針(Policy)

## 実装に関する補足(Appendix)
コードのフォーマットの調整も行なっています。
２個のコミット別々にご確認いただければと思います。

### buttonの問題の修正

https://github.com/EC-CUBE/ec-cube/pull/3819/commits/18e07585f52f877f8827e4387b97252fad83beae

### フォーマットの調整

https://github.com/EC-CUBE/ec-cube/pull/3819/commits/c728bc3a1bd9aa00b9c7b2a2c3ca499a165dafbd

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



