### PR TITLE
受注編集→商品追加での JavaScript エラー修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/search_product.twig
+++ b/src/Eccube/Resource/template/admin/Order/search_product.twig
@@ -90,7 +90,7 @@ file that was distributed with this source code.
         index++;
         var newForm = prototype.replace(/__name__/g, index);
         $collectionHolder.children('tbody').append(newForm);
-        var $lastRow = $collectionHolder.children('tbody').children('tr').last;
+        var $lastRow = $collectionHolder.children('tbody').children('tr').last();
 
         $($lastRow).find(formIdPrefix + index + '_ProductClass').val(product_class_id);
         $($lastRow).find(formIdPrefix + index + '_price').val(price);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
受注編集→商品追加での JavaScript エラーが発生していたのを修正

以下のような JavaScript エラーが出ていた
```
TypeError: this.eq is not a function. (In 'this.eq(-1)', 'this.eq' is undefined)
```

## 方針(Policy)
`.last` を関数に修正

## テスト（Test)
JavaScript エラーが出ないのを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



