### PR TITLE
お届け先の複数指定画面の「小計：」のtransが抜けていたので追加

### DIFF
--- a/src/Eccube/Resource/template/default/Shopping/shipping_multiple.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping_multiple.twig
@@ -100,7 +100,7 @@ $(function() {
                             {% if orderItem.productClass.classCategory2 %}
                                 <div class="ec-AddAddress__itemtSize">{{ orderItem.productClass.classCategory2 }}</div>
                             {% endif %}
-                            <div class="ec-AddAddress__itemtPrice">{{ 'common.subtotal__with_separator' }}{{ orderItem.totalPrice|price }}</div>
+                            <div class="ec-AddAddress__itemtPrice">{{ 'common.subtotal__with_separator'|trans }}{{ orderItem.totalPrice|price }}</div>
 
                             {% for key, value in compItemQuantities %}
                                 {% if orderItem.productClass.id == key %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
お届け先の複数指定画面の「小計：」のtransが抜けていたので追加

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)
ローカルで「小計：」が表示されることを確認

<img width="1078" alt="2018-09-12 18 00 25" src="https://user-images.githubusercontent.com/16895409/45414229-dabdae80-b6b5-11e8-9bcc-215ed27931b6.png">


## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



