### PR TITLE
サイト情報の送信に失敗しても、インストールは継続できるようにする。

### DIFF
--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -907,21 +907,26 @@ class InstallController extends AbstractController
      */
     protected function sendAppData($params, EntityManager $em)
     {
-        $query = http_build_query($this->createAppData($params, $em));
-        $header = [
-            'Content-Type: application/x-www-form-urlencoded',
-            'Content-Length: '.strlen($query),
-        ];
-        $context = stream_context_create(
-            [
-                'http' => [
-                    'method' => 'POST',
-                    'header' => $header,
-                    'content' => $query,
-                ],
-            ]
-        );
-        file_get_contents('http://www.ec-cube.net/mall/use_site.php', false, $context);
+        try {
+            $query = http_build_query($this->createAppData($params, $em));
+            $header = [
+                'Content-Type: application/x-www-form-urlencoded',
+                'Content-Length: '.strlen($query),
+            ];
+            $context = stream_context_create(
+                [
+                    'http' => [
+                        'method' => 'POST',
+                        'header' => $header,
+                        'content' => $query,
+                    ],
+                ]
+            );
+            file_get_contents('http://www.ec-cube.net/mall/use_site.php', false, $context);
+        } catch (\Exception $e) {
+            // 送信に失敗してもインストールは継続できるようにする
+            log_error($e->getMessage());
+        }
 
         return $this;
     }

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -922,7 +922,7 @@ class InstallController extends AbstractController
                     ],
                 ]
             );
-            file_get_contents('http://www.ec-cube.net/mall/use_site.php', false, $context);
+            file_get_contents('https://www.ec-cube.net/mall/use_site.php', false, $context);
         } catch (\Exception $e) {
             // 送信に失敗してもインストールは継続できるようにする
             log_error($e->getMessage());


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
インストール時に「サイト情報を送信する＝ON」にした場合、インストール処理の開始時に情報送信を行っているが、この送信に失敗するとインストールが継続できない課題の修正。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->
送信に失敗したとしても、インストール継続をできるようにエラーを無視する。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
粗い実装ですが...継続できること優先で例外全キャッチです。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
1. 送信先のドメインを変更するなどして、エラーになる環境を作成。
2. エラーになってもインストール継続できることを確認。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
なし

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



