### PR TITLE
SSL強制でないときは、http,httpsどちらでも受け入れるように修正。

### DIFF
--- a/app/config/eccube/packages/security.yaml
+++ b/app/config/eccube/packages/security.yaml
@@ -56,16 +56,6 @@ security:
                 path: logout
                 target: homepage
 
-    access_control:
-        # this is a catch-all for the admin area
-        # additional security lives in the controllers
-        - { path: '^/%eccube_admin_route%/login', roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: "@=container.getParameter('eccube_force_ssl') ? 'https' : 'http'" }
-        - { path: '^/%eccube_admin_route%/', roles: ROLE_ADMIN, requires_channel: "@=container.getParameter('eccube_force_ssl') ? 'https' : 'http'"  }
-        - { path: ^/mypage/login, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: "@=container.getParameter('eccube_force_ssl') ? 'https' : 'http'" }
-        - { path: ^/mypage/withdraw_complete, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: "@=container.getParameter('eccube_force_ssl') ? 'https' : 'http'" }
-        - { path: ^/mypage/change, roles: IS_AUTHENTICATED_FULLY, requires_channel: "@=container.getParameter('eccube_force_ssl') ? 'https' : 'http'" }
-        - { path: ^/mypage/, roles: ROLE_USER, requires_channel: "@=container.getParameter('eccube_force_ssl') ? 'https' : 'http'" }
-
     access_decision_manager:
         strategy: unanimous
         allow_if_all_abstain: false

--- a/src/Eccube/DependencyInjection/EccubeExtension.php
+++ b/src/Eccube/DependencyInjection/EccubeExtension.php
@@ -61,6 +61,26 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
                 'cookie_secure' => $forceSSL,
             ],
         ]);
+
+        // SSL強制時は, httpsのみにアクセス制限する
+        $accessControl = [
+          [ 'path' => '^/%eccube_admin_route%/login', 'roles' => 'IS_AUTHENTICATED_ANONYMOUSLY' ],
+          [ 'path' => '^/%eccube_admin_route%/', 'roles' => 'ROLE_ADMIN' ],
+          [ 'path' => '^/mypage/login', 'roles' => 'IS_AUTHENTICATED_ANONYMOUSLY' ],
+          [ 'path' => '^/mypage/withdraw_complete', 'roles' => 'IS_AUTHENTICATED_ANONYMOUSLY' ],
+          [ 'path' => '^/mypage/change', 'roles' => 'IS_AUTHENTICATED_FULLY' ],
+          [ 'path' => '^/mypage/', 'roles' => 'ROLE_USER' ],
+        ];
+        if ($forceSSL) {
+            foreach ($accessControl as &$control) {
+                $control['requires_channel'] = 'https';
+            }
+        }
+
+        // security.ymlでは制御できないため, ここで定義する.
+        $container->prependExtensionConfig('security', [
+          'access_control' => $accessControl,
+        ]);
     }
 
     protected function configurePlugins(ContainerBuilder $container)

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -132,8 +132,11 @@ class Kernel extends BaseKernel
     {
         $container = $this->getContainer();
 
+        $scheme = ['https', 'http'];
         $forceSSL = $container->getParameter('eccube_force_ssl');
-        $scheme = $forceSSL ? 'https' : 'http';
+        if ($forceSSL) {
+            $scheme = 'https';
+        }
         $routes->setSchemes($scheme);
 
         $confDir = $this->getProjectDir().'/app/config/eccube';


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
SSL強制を指定していないときは、スキーマがhttpに固定されていましたが、http/httpsのどちらでも受け入れるように変更しました。
これにより、httpsでアクセスしてもhttpにリダイレクトされてしまう挙動が直り、http/httpsのどちらでもアクセスできるようになります。

SLL強制=true のときは、今までどおり https 固定です。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
3系は以下のコードでした。
https://github.com/EC-CUBE/ec-cube/blob/master/src/Eccube/Application.php#L575

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
- さくらレンタルサーバー
- ローカルDocker環境
- Cloud9 (ただしサーバー構成特殊なのでSSL強制した場合にはTRUSTED_PROXIESの設定が必要)
にて、
httpsアクセスでインストーラ起動して、SSL強制できることを確認
管理画面からSSL強制をON/OFFできることを確認

また、
IS_AUTHENTICATED_FULLY などの権限管理が動作していることを確認しました。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
cookieのセキュア属性は、はSSL強制のオプションに連動するままです。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



