### PR TITLE
商品規格画面から戻る先の制御をフラグで制御するように修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductClassController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductClassController.php
@@ -126,8 +126,8 @@ class ProductClassController extends AbstractController
 
                 $this->addSuccess('admin.common.save_complete', 'admin');
 
-                if ($request->get('return')) {
-                    return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId(), 'return' => $request->get('return')]);
+                if ($request->get('return_product_list')) {
+                    return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId(), 'return_product_list' => true]);
                 }
 
                 return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId()]);
@@ -163,8 +163,8 @@ class ProductClassController extends AbstractController
 
                         $this->addSuccess('admin.common.save_complete', 'admin');
 
-                        if ($request->get('return')) {
-                            return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId(), 'return' => $request->get('return')]);
+                        if ($request->get('return_product_list')) {
+                            return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId(), 'return_product_list' => true]);
                         }
 
                         return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId()]);
@@ -179,7 +179,7 @@ class ProductClassController extends AbstractController
             'clearForm' => $this->createForm(FormType::class)->createView(),
             'ClassName1' => $ClassName1,
             'ClassName2' => $ClassName2,
-            'return_product' => $request->get('return'),
+            'return_product_list' => $request->get('return_product_list') ? true : false,
         ];
     }
 
@@ -218,8 +218,8 @@ class ProductClassController extends AbstractController
             $this->addSuccess('admin.product.reset_complete', 'admin');
         }
 
-        if ($request->get('return')) {
-            return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId(), 'return' => $request->get('return')]);
+        if ($request->get('return_product_list')) {
+            return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId(), 'return_product_list' => true]);
         }
 
         return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId()]);

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -398,7 +398,7 @@ file that was distributed with this source code.
                                                             data-product-id="{{ Product.id }}"
                                                             data-message="{{ 'admin.product.move_to_product_class__confirm_title'|trans({'%name%': Product.name}) }}"
                                                             data-class-load="{{ url('admin_product_classes_load', { 'id' : Product.id }) }}"
-                                                            data-class-url="{{ url('admin_product_product_class', { 'id' : Product.id }) }}">
+                                                            data-class-url="{{ url('admin_product_product_class', { 'id' : Product.id, 'return_product_list' : true }) }}">
                                                         {{ 'admin.product.product_class__confirm'|trans }}
                                                     </button>
                                                 {% else %}

--- a/src/Eccube/Resource/template/admin/Product/product_class.twig
+++ b/src/Eccube/Resource/template/admin/Product/product_class.twig
@@ -151,7 +151,7 @@ file that was distributed with this source code.
                                                         {{ 'admin.common.cancel'|trans }}
                                                     </button>
                                                     <form method="post"
-                                                          action="{{ url('admin_product_product_class_clear', { id: Product.id, return: return_product }) }}">
+                                                          action="{{ url('admin_product_product_class_clear', { id: Product.id, return_product_list: return_product_list }) }}">
                                                         {{ form_widget(clearForm._token) }}
                                                         <button class="btn btn-ec-delete" type="submit">
                                                             {{ 'admin.product.product_class__reset_confirm_excecute'|trans }}
@@ -190,7 +190,7 @@ file that was distributed with this source code.
                         </div>
                     {% else %}
                         {# 規格なし商品 #}
-                        <form method="post" action="{{ url('admin_product_product_class', { id: Product.id, return: return_product }) }}">
+                        <form method="post" action="{{ url('admin_product_product_class', { id: Product.id, return_product_list: return_product_list }) }}">
                             <input type="hidden" name="_token" value="{{ csrf_token('_token') }}">
                             <div class="card-header">
                                 <div class="row">
@@ -220,7 +220,7 @@ file that was distributed with this source code.
                 </div>
 
                 {% if form.product_classes|length > 0 %}
-                    <form method="post" action="{{ url('admin_product_product_class', {'id': Product.id, return: return_product }) }}">
+                    <form method="post" action="{{ url('admin_product_product_class', {'id': Product.id, return_product_list: return_product_list }) }}">
                         <input type="hidden" name="_token" value="{{ csrf_token('_token') }}">
                         <input type="hidden" name="{{ form.class_name1.vars.full_name }}"
                                value="{{ form.class_name1.vars.value }}">
@@ -365,15 +365,15 @@ file that was distributed with this source code.
                                 <div class="row justify-content-between align-items-center">
                                     <div class="col-6">
                                         <div class="c-conversionArea__leftBlockItem">
-                                            {% if return_product %}
-                                                <a class="c-beseLink" href="{{ url(return_product, {'id': Product.id}) }}">
-                                                    <i class="fa fa-backward" aria-hidden="true"></i>
-                                                    <span>{{ 'admin.product.product_registration'|trans }}</span>
-                                                </a>
-                                            {% else %}
+                                            {% if return_product_list %}
                                                 <a class="c-beseLink" href="{{ url('admin_product', {'resume': 1}) }}">
                                                     <i class="fa fa-backward" aria-hidden="true"></i>
                                                     <span>{{ 'admin.product.product_list'|trans }}</span>
+                                                </a>
+                                            {% else %}
+                                                <a class="c-beseLink" href="{{ url('admin_product_product_edit', {'id': Product.id}) }}">
+                                                    <i class="fa fa-backward" aria-hidden="true"></i>
+                                                    <span>{{ 'admin.product.product_registration'|trans }}</span>
                                                 </a>
                                             {% endif %}
                                         </div>
@@ -398,15 +398,15 @@ file that was distributed with this source code.
                             <div class="row justify-content-between align-items-center">
                                 <div class="col-6">
                                     <div class="c-conversionArea__leftBlockItem">
-                                        {% if return_product %}
-                                            <a class="c-beseLink" href="{{ url(return_product, {'id': Product.id}) }}">
-                                                <i class="fa fa-backward" aria-hidden="true"></i>
-                                                <span>{{ 'admin.product.product_registration'|trans }}</span>
-                                            </a>
-                                        {% else %}
+                                        {% if return_product_list %}
                                             <a class="c-beseLink" href="{{ url('admin_product', {'resume': 1}) }}">
                                                 <i class="fa fa-backward" aria-hidden="true"></i>
                                                 <span>{{ 'admin.product.product_list'|trans }}</span>
+                                            </a>
+                                        {% else %}
+                                            <a class="c-beseLink" href="{{ url('admin_product_product_edit', {'id': Product.id}) }}">
+                                                <i class="fa fa-backward" aria-hidden="true"></i>
+                                                <span>{{ 'admin.product.product_registration'|trans }}</span>
                                             </a>
                                         {% endif %}
                                     </div>


### PR DESCRIPTION
以下の課題への対応
https://github.com/EC-CUBE/ec-cube/issues/3538

既存機能の実装は以下のプルリクエスト
https://github.com/EC-CUBE/ec-cube/pull/3318

## 概要(Overview・Refs Issue)

### 目的
商品規格設定画面へは商品一覧画面と商品編集画面の両方から遷移できる。
商品規格設定画面の戻るボタンの遷移先を制御したい。

### 既存の実装の課題
- ルーティングをそのままパラメータとして渡していたので、ルーティングにないパラメータを指定してしまうとシステムエラーとなっていた。
- ルーティング登録のある遷移先のみにしか遷移できないようにはなっているが、オープンリダイレクトとして利用されるリスクを排除したい。
- 不具合があり、うまく機能していない。

## 方針(Policy)
パラメータにルーティングを渡すのではなく、単に一覧画面に戻るかどうかのフラグを渡すように変更。

## 実装に関する補足(Appendix)
商品編集画面から商品規格画面への遷移は「保存して遷移する」機能と競合するためパラメータの設定が難しかったので、商品一覧画面からの遷移にのみフラグを持たせた。

## テスト（Test)
ローカルで一覧、編集それぞれから遷移して正しく戻れることを確認

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト
**twigファイルに渡しているパラメータの変数名を適切なものに変更しています。**
そもそもバグがありうまく動いていない点と、そもそも拡張で利用される可能性が低いパラメータとの判断で変数名を変更しています。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



