### PR TITLE
エンティティ拡張の自動出力でCSSクラス名を指定できるよう修正

### DIFF
--- a/src/Eccube/Annotation/FormAppend.php
+++ b/src/Eccube/Annotation/FormAppend.php
@@ -41,4 +41,9 @@ final class FormAppend implements Annotation
      * @var array
      */
     public $options;
+
+    /**
+     * @var string
+     */
+    public $style_class;
 }

--- a/src/Eccube/Form/Extension/DoctrineOrmExtension.php
+++ b/src/Eccube/Form/Extension/DoctrineOrmExtension.php
@@ -103,6 +103,10 @@ class DoctrineOrmExtension extends AbstractTypeExtension
             $options['form_theme'] = null;
         }
 
+        if (!array_key_exists('style_class', $options)) {
+            $options['style_class'] = 'ec-select';
+        }
+
         $view->vars['eccube_form_options'] = $options;
     }
 
@@ -113,6 +117,7 @@ class DoctrineOrmExtension extends AbstractTypeExtension
             [
                 'auto_render' => false,
                 'form_theme' => null,
+                'style_class' => 'ec-select',
             ]
         );
     }

--- a/src/Eccube/Form/Extension/DoctrineOrmExtension.php
+++ b/src/Eccube/Form/Extension/DoctrineOrmExtension.php
@@ -80,6 +80,7 @@ class DoctrineOrmExtension extends AbstractTypeExtension
                         $options['eccube_form_options'] = [
                             'auto_render' => (true === $anno->auto_render),
                             'form_theme' => $anno->form_theme,
+                            'style_class' => $anno->style_class ? $anno->style_class : 'ec-select'
                         ];
                         if (!isset($form[$prop->getName()])) {
                             $form->add($prop->getName(), $anno->type, $options);

--- a/src/Eccube/Resource/template/default/Contact/confirm.twig
+++ b/src/Eccube/Resource/template/default/Contact/confirm.twig
@@ -97,7 +97,7 @@ file that was distributed with this source code.
                                         {{ form_label(f) }}
                                     </dt>
                                     <dd>
-                                        <div class="ec-select{{ has_errors(f) ? ' error' }}">
+                                        <div class="{{ f.vars.eccube_form_options.style_class }}{{ has_errors(f) ? ' error' }}">
                                             {{ f.vars.data }}
                                             {{ form_widget(f, { type: 'hidden'}) }}
                                         </div>

--- a/src/Eccube/Resource/template/default/Contact/index.twig
+++ b/src/Eccube/Resource/template/default/Contact/index.twig
@@ -132,7 +132,7 @@ file that was distributed with this source code.
                                         {{ form_label(f) }}
                                     </dt>
                                     <dd>
-                                        <div class="ec-select{{ has_errors(f) ? ' error' }}">
+                                        <div class="{{ f.vars.eccube_form_options.style_class }}{{ has_errors(f) ? ' error' }}">
                                             {{ form_widget(f) }}
                                             {{ form_errors(f) }}
                                         </div>

--- a/src/Eccube/Resource/template/default/Entry/confirm.twig
+++ b/src/Eccube/Resource/template/default/Entry/confirm.twig
@@ -141,7 +141,7 @@ file that was distributed with this source code.
                                         {{ form_label(f) }}
                                     </dt>
                                     <dd>
-                                        <div class="ec-select{{ has_errors(f) ? ' error' }}">
+                                        <div class="{{ f.vars.eccube_form_options.style_class }}{{ has_errors(f) ? ' error' }}">
                                             {{ f.vars.data }}
                                             {{ form_widget(f, { type: 'hidden'}) }}
                                         </div>

--- a/src/Eccube/Resource/template/default/Entry/index.twig
+++ b/src/Eccube/Resource/template/default/Entry/index.twig
@@ -190,7 +190,7 @@ file that was distributed with this source code.
                                         {{ form_label(f) }}
                                     </dt>
                                     <dd>
-                                        <div class="ec-select{{ has_errors(f) ? ' error' }}">
+                                        <div class="{{ f.vars.eccube_form_options.style_class }}{{ has_errors(f) ? ' error' }}">
                                             {{ form_widget(f) }}
                                             {{ form_errors(f) }}
                                         </div>

--- a/src/Eccube/Resource/template/default/Mypage/change.twig
+++ b/src/Eccube/Resource/template/default/Mypage/change.twig
@@ -197,7 +197,7 @@ file that was distributed with this source code.
                                                 {{ form_label(f) }}
                                             </dt>
                                             <dd>
-                                                <div class="ec-select{{ has_errors(f) ? ' error' }}">
+                                                <div class="{{ f.vars.eccube_form_options.style_class }}{{ has_errors(f) ? ' error' }}">
                                                     {{ form_widget(f) }}
                                                     {{ form_errors(f) }}
                                                 </div>

--- a/src/Eccube/Resource/template/default/Mypage/delivery_edit.twig
+++ b/src/Eccube/Resource/template/default/Mypage/delivery_edit.twig
@@ -127,7 +127,7 @@ file that was distributed with this source code.
                                                 {{ form_label(f) }}
                                             </dt>
                                             <dd>
-                                                <div class="ec-select{{ has_errors(f) ? ' error' }}">
+                                                <div class="{{ f.vars.eccube_form_options.style_class }}{{ has_errors(f) ? ' error' }}">
                                                     {{ form_widget(f) }}
                                                     {{ form_errors(f) }}
                                                 </div>

--- a/src/Eccube/Resource/template/default/Shopping/shipping_edit.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping_edit.twig
@@ -132,7 +132,7 @@ file that was distributed with this source code.
                                             {{ form_label(f) }}
                                         </dt>
                                         <dd>
-                                            <div class="ec-select{{ has_errors(f) ? ' error' }}">
+                                            <div class="{{ f.vars.eccube_form_options.style_class }}{{ has_errors(f) ? ' error' }}">
                                                 {{ form_widget(f) }}
                                                 {{ form_errors(f) }}
                                             </div>

--- a/src/Eccube/Resource/template/default/Shopping/shipping_multiple_edit.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping_multiple_edit.twig
@@ -114,7 +114,7 @@ file that was distributed with this source code.
                                         {{ form_label(f) }}
                                     </dt>
                                     <dd>
-                                        <div class="ec-select{{ has_errors(f) ? ' error' }}">
+                                        <div class="{{ f.vars.eccube_form_options.style_class }}{{ has_errors(f) ? ' error' }}">
                                             {{ form_widget(f) }}
                                             {{ form_errors(f) }}
                                         </div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
フロント画面のエンティティ拡張の自動出力でCSSクラス名を指定できるよう修正。
`ec-select` が決め打ちになっていたため、 checkbox や radio が使用できなかった

https://github.com/EC-CUBE/ec-cube/issues/3768

## 方針(Policy)
`FormAppend` で **style_class** を設定すると、 CSSクラスが出力されます。
デフォルトは `ec-select` です

## 実装に関する補足(Appendix)

以下のように `FormAppend` を定義すると、ラジオボタン出力されます

```
     /*
     * @FormAppend(
     *     auto_render=true,
     *     type="\Symfony\Component\Form\Extension\Core\Type\ChoiceType",
     *     style_class="ec-radio",
     *     options={
     *         "choices": {"a"=true,"b"=true},
     *         "multiple": false,
     *         "expanded": true
     *     }
     * )
     */
```
## テスト（Test)
任意の CSS クラス名が出力されることを確認

## 相談（Discussion）
`style_class` という命名は古すぎるか...

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



