### PR TITLE
規格を設定→削除を繰替えすと在庫数の更新がずれるのを修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -386,7 +386,7 @@ class ProductController extends AbstractController
                 if ($this->BaseInfo->isOptionProductTaxRule() && $ProductClass->getTaxRule()) {
                     $ProductClass->setTaxRate($ProductClass->getTaxRule()->getTaxRate());
                 }
-                $ProductStock = $ProductClasses[0]->getProductStock();
+                $ProductStock = $ProductClass->getProductStock();
             }
         }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
規格を設定→削除を繰替えすと、管理画面から在庫を更新した際に、 visible=false の ProductStock を更新してしまう。

## 方針(Policy)
ProductClasses[0] ではなく、 visible=true の ProductClass を取得するよう修正

## 実装に関する補足(Appendix)
本当は Product Entity 側でやってしまいたい

## テスト（Test)
在庫が正常に更新されることを確認


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



