### PR TITLE
新着情報のE2Eテストが時折失敗するのを修正

### DIFF
--- a/codeception/acceptance/EF01TopCest.php
+++ b/codeception/acceptance/EF01TopCest.php
@@ -84,6 +84,7 @@ class EF01TopCest
         // 各新着情報の箇所を押下する
         // Knowhow: javascriptでclick eventハンドリングしている場合はclick('表示文字列')では探せない
         $topPage->新着情報選択(1);
+        $I->wait(1);
 
         // 押下された新着情報のセクションが広がり、詳細情報、リンクが表示される
         $I->assertContains('コメント1', $topPage->新着情報詳細(1));


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
新着情報のE2Eテストが時折失敗するのを修正してみました。
新着情報のアコーディオンが開くのを待つためにwaitを入れてあります。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->
なし

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
なし

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
既存のCIテストがテストが通ることを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
なし

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



