### PR TITLE
支払金額がマイナスの場合に、ポイントのエラーが表示される問題を修正

### DIFF
--- a/app/config/eccube/packages/purchaseflow.yaml
+++ b/app/config/eccube/packages/purchaseflow.yaml
@@ -147,6 +147,8 @@ services:
             - #
                 - '@Eccube\Service\PurchaseFlow\Processor\AddPointProcessor'  # 加算ポイントの計算
                 - '@Eccube\Service\PurchaseFlow\Processor\PaymentTotalLimitValidator'
+                - '@Eccube\Service\PurchaseFlow\Processor\PaymentTotalNegativeValidator'  # 支払金額のマイナスチェック
+
 
     eccube.purchase.flow.order.purchase:
         class: Doctrine\Common\Collections\ArrayCollection

--- a/src/Eccube/Service/PurchaseFlow/Processor/PointProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PointProcessor.php
@@ -104,7 +104,7 @@ class PointProcessor implements DiscountProcessor, PurchaseProcessor
                 // 受注登録・編集実行時
             } else {
                 // 支払い金額 < 利用ポイントによる値引き額.
-                if ($itemHolder->getTotal() + $discount < 0) {
+                if ($itemHolder->getTotal() >= 0 && $itemHolder->getTotal() + $discount < 0) {
                     $result = ProcessResult::error(trans('purchase_flow.over_payment_total'), self::class);
                 }
             }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

- 支払金額のチェックを追加
- 支払金額が既にマイナスになっている場合は、ポイントのエラーを表示しないように修正

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

- 商品明細の個数をマイナスにし、ポイントを利用すると、合計金額のエラーが表示されることを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

支払金額が正の値で、ポイント値引きによりマイナスが発生した場合は、ポイントのエラーと合計金額のエラーは両方出力されます。

![image](https://user-images.githubusercontent.com/8196725/45523735-c5579a00-b805-11e8-8011-4f33dc2eacdc.png)

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



