### PR TITLE
プレビュー用のレイアウトがページ編集画面で選択可能となってしまっていたのを修正

### DIFF
--- a/src/Eccube/Controller/Admin/Content/LayoutController.php
+++ b/src/Eccube/Controller/Admin/Content/LayoutController.php
@@ -106,9 +106,10 @@ class LayoutController extends AbstractController
     public function index()
     {
         $qb = $this->layoutRepository->createQueryBuilder('l');
-        $Layouts = $qb->where('l.id != 0')
+        $Layouts = $qb->where('l.id != :DefaultLayoutPreviewPage')
                     ->orderBy('l.DeviceType', 'DESC')
                     ->addOrderBy('l.id', 'ASC')
+                    ->setParameter('DefaultLayoutPreviewPage', Layout::DEFAULT_LAYOUT_PREVIEW_PAGE)
                     ->getQuery()
                     ->getResult();
 

--- a/src/Eccube/Form/Type/Admin/MainEditType.php
+++ b/src/Eccube/Form/Type/Admin/MainEditType.php
@@ -162,8 +162,10 @@ class MainEditType extends AbstractType
                     $DeviceType = $this->deviceTypeRepository->find(DeviceType::DEVICE_TYPE_PC);
 
                     return $er->createQueryBuilder('l')
-                        ->where('l.DeviceType = :DeviceType')
+                        ->where('l.id != :DefaultLayoutPreviewPage')
+                        ->andWhere('l.DeviceType = :DeviceType')
                         ->setParameter('DeviceType', $DeviceType)
+                        ->setParameter('DefaultLayoutPreviewPage', Layout::DEFAULT_LAYOUT_PREVIEW_PAGE)
                         ->orderBy('l.id', 'DESC');
                 },
             ])
@@ -176,8 +178,10 @@ class MainEditType extends AbstractType
                     $DeviceType = $this->deviceTypeRepository->find(DeviceType::DEVICE_TYPE_MB);
 
                     return $er->createQueryBuilder('l')
-                        ->where('l.DeviceType = :DeviceType')
+                        ->where('l.id != :DefaultLayoutPreviewPage')
+                        ->andWhere('l.DeviceType = :DeviceType')
                         ->setParameter('DeviceType', $DeviceType)
+                        ->setParameter('DefaultLayoutPreviewPage', Layout::DEFAULT_LAYOUT_PREVIEW_PAGE)
                         ->orderBy('l.id', 'DESC');
                 },
             ])


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
プレビュー用のレイアウトがページ編集画面で選択可能となってしまっていたのを修正
ついでにマジックナンバーを定数に置き換え

## 方針(Policy)

## 実装に関する補足(Appendix)
Layoutのid=0はレビュー機能で使い回す仕様となっている。
id=0はページに紐づけてはいけない。

## テスト（Test)
ローカルでレイアウト管理とページ管理にプレビュー用のレイアウトが表示されないことを確認

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



