### PR TITLE
Fix typo

### DIFF
--- a/src/Eccube/Controller/Admin/Content/FileController.php
+++ b/src/Eccube/Controller/Admin/Content/FileController.php
@@ -186,7 +186,7 @@ class FileController extends AbstractController
                     return $app->sendFile($file)->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT);
                 } else {
                     return $app->sendFile($file, 200, array(
-                        "Content-Type" => "aplication/octet-stream;",
+                        "Content-Type" => "application/octet-stream;",
                         "Content-Disposition" => "attachment; filename*=UTF-8\'\'".rawurlencode($this->convertStrFromServer($pathParts['basename']))
                     ));
                 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
`FileController::download` 内の MIMEタイプの誤字を修正しました。
個人開発中に気づきましたのでプルリクエストを出させていただきました。
ご確認のほどよろしくお願いいたします。
