### PR TITLE
購入時の在庫数修正処理を改善

### DIFF
--- a/src/Eccube/EventListener/TransactionListener.php
+++ b/src/Eccube/EventListener/TransactionListener.php
@@ -14,6 +14,7 @@
 namespace Eccube\EventListener;
 
 use Doctrine\Dbal\Connection;
+use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -80,6 +81,7 @@ class TransactionListener implements EventSubscriberInterface
             $Connection->connect();
         }
         $Connection->setAutoCommit(false);
+        $Connection->setTransactionIsolation(TransactionIsolationLevel::READ_COMMITTED);
         $this->em->beginTransaction();
         log_debug('Begin Transaction.');
     }

--- a/src/Eccube/Service/PurchaseFlow/Processor/StockReduceProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/StockReduceProcessor.php
@@ -85,6 +85,7 @@ class StockReduceProcessor extends AbstractPurchaseProcessor
                 $productStock = $item->getProductClass()->getProductStock();
                 // 在庫に対してロックを実行
                 $this->entityManager->lock($productStock, LockMode::PESSIMISTIC_WRITE);
+                $this->entityManager->refresh($productStock);
                 $stock = $callback($productStock->getStock(), $item->getQuantity());
                 $productStock->setStock($stock);
                 $item->getProductClass()->setStock($stock);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
購入処理時に在庫数をロックしていたが、ロック前の数を使用していたのでロック後に再読込するよう修正

