### PR TITLE
doctrineキャッシュを削除するように修正

### DIFF
--- a/codeception/acceptance/EF01TopCest.php
+++ b/codeception/acceptance/EF01TopCest.php
@@ -29,6 +29,17 @@ class EF01TopCest
     {
     }
 
+    private function clearDoctrineCache()
+    {
+        // APP_ENV=prodで実行した際は, 直接データを投入しても反映されないため,
+        // キャッシュを削除して表示できるようにする
+        $fs = new Symfony\Component\Filesystem\Filesystem();
+        $cacheDir = __DIR__.'/../../var/cache/prod/pools';
+        if ($fs->exists($cacheDir)) {
+            $fs->remove($cacheDir);
+        }
+    }
+
     public function topページ_初期表示(\AcceptanceTester $I)
     {
         $I->wantTo('EF0101-UC01-T01 TOPページ 初期表示');
@@ -52,6 +63,8 @@ class EF01TopCest
         $createNews = Fixtures::get('createNews');
         $News1 = $createNews($minus1, 'タイトル1', 'コメント1');
         $News2 = $createNews($minus2, 'タイトル2', 'コメント2');
+
+        $this->clearDoctrineCache();
 
         $I->reloadPage();
 
@@ -78,6 +91,8 @@ class EF01TopCest
 
         $createNews = Fixtures::get('createNews');
         $News = $createNews(new \DateTime(), 'タイトル1', 'コメント1', 'https://www.ec-cube.net');
+
+        $this->clearDoctrineCache();
 
         $topPage = TopPage::go($I);
 


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
- eccube-codeception( https://github.com/EC-CUBE/eccube-codeception )実行時に新着情報がキャッシュされ、テストが通らない問題を修正
- eccbe-codeceptionはAPP_ENV=prodで実行されるため、テストコード内で投入したデータは反映されません。
- そのため、データ投入後にdoctrineのキャッシュをクリアするように対応しました。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



