### PR TITLE
商品一覧画面のパフォーマンス改善

### DIFF
--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -29,6 +29,7 @@ use Eccube\Repository\ProductRepository;
 use Eccube\Service\CartService;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Eccube\Service\PurchaseFlow\PurchaseFlow;
+use Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination;
 use Knp\Component\Pager\Paginator;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -158,6 +159,7 @@ class ProductController extends AbstractController
         $this->eventDispatcher->dispatch(EccubeEvents::FRONT_PRODUCT_INDEX_SEARCH, $event);
         $searchData = $event->getArgument('searchData');
 
+        /** @var SlidingPagination $pagination */
         $pagination = $paginator->paginate(
             $qb,
             !empty($searchData['pageno']) ? $searchData['pageno'] : 1,

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -164,6 +164,12 @@ class ProductController extends AbstractController
             !empty($searchData['disp_number']) ? $searchData['disp_number']->getId() : $this->productListMaxRepository->findOneBy([], ['sort_no' => 'ASC'])->getId()
         );
 
+        $ids = [];
+        foreach ($pagination as $Product) {
+            $ids[] = $Product->getId();
+        }
+        $ProductsAndClassCategories = $this->productRepository->findProductsWithSortedClassCategories($ids, 'p.id');
+
         // addCart form
         $forms = [];
         foreach ($pagination as $Product) {
@@ -173,7 +179,7 @@ class ProductController extends AbstractController
                 AddCartType::class,
                 null,
                 [
-                    'product' => $this->productRepository->findWithSortedClassCategories($Product->getId()),
+                    'product' => $ProductsAndClassCategories[$Product->getId()],
                     'allow_extra_fields' => true,
                 ]
             );

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -92,10 +92,13 @@ class ProductRepository extends AbstractRepository
      * @param array $ids Product in ids
      * @param string $indexBy The index for the from.
      *
-     * @return ArrayCollection
+     * @return ArrayCollection|array
      */
     public function findProductsWithSortedClassCategories(array $ids, $indexBy = null)
     {
+        if (count($ids) < 1) {
+            return [];
+        }
         $qb = $this->createQueryBuilder('p', $indexBy);
         $qb->addSelect(['pc', 'cc1', 'cc2', 'pi', 'pt', 'tr', 'ps'])
             ->innerJoin('p.ProductClasses', 'pc')

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -13,6 +13,7 @@
 
 namespace Eccube\Repository;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Eccube\Common\EccubeConfig;
 use Eccube\Doctrine\Query\Queries;
 use Eccube\Entity\Product;
@@ -83,6 +84,39 @@ class ProductRepository extends AbstractRepository
             ->getSingleResult();
 
         return $product;
+    }
+
+    /**
+     * Find the Products with sorted ClassCategories.
+     *
+     * @param array $ids Product in ids
+     * @param string $indexBy The index for the from.
+     *
+     * @return ArrayCollection
+     */
+    public function findProductsWithSortedClassCategories(array $ids, $indexBy = null)
+    {
+        $qb = $this->createQueryBuilder('p', $indexBy);
+        $qb->addSelect(['pc', 'cc1', 'cc2', 'pi', 'pt', 'tr', 'ps'])
+            ->innerJoin('p.ProductClasses', 'pc')
+            // XXX Joined 'TaxRule' and 'ProductStock' to prevent lazy loading
+            ->leftJoin('pc.TaxRule', 'tr')
+            ->innerJoin('pc.ProductStock', 'ps')
+            ->leftJoin('pc.ClassCategory1', 'cc1')
+            ->leftJoin('pc.ClassCategory2', 'cc2')
+            ->leftJoin('p.ProductImage', 'pi')
+            ->leftJoin('p.ProductTag', 'pt')
+            ->where($qb->expr()->in('p.id', $ids))
+            ->andWhere('pc.visible = :visible')
+            ->setParameter('visible', true)
+            ->orderBy('cc1.sort_no', 'DESC')
+            ->addOrderBy('cc2.sort_no', 'DESC');
+
+        $products = $qb
+            ->getQuery()
+            ->getResult();
+
+        return $products;
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
規格の情報を一度に取得するよう修正

## 方針(Policy)
- 規格の情報をまとめて取得する
- Lazy Loading を防ぐために、 TaxRule 及び ProductStock も JOIN する

## テスト（Test)
SQLのコール数が削減されるのを確認
商品一覧ページ, 60件表示時
- 改修前: 320回
- 改修後: 17回

## 相談（Discussion）
本来であれば、 TaxRule 及び ProductStock を JOIN しないようにしたい

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



