### PR TITLE
リンク型決済等のrollback実行リクエストで不正なOrder情報で処理が進まないようにpre_order_idでチェックする処理を追加

### DIFF
--- a/app/config/eccube/packages/purchaseflow.yaml
+++ b/app/config/eccube/packages/purchaseflow.yaml
@@ -101,6 +101,7 @@ services:
         class: Doctrine\Common\Collections\ArrayCollection
         arguments:
             - #
+                - '@Eccube\Service\PurchaseFlow\Processor\PreOrderIdValidator'
                 - '@Eccube\Service\PurchaseFlow\Processor\PointProcessor'
                 - '@Eccube\Service\PurchaseFlow\Processor\StockReduceProcessor'
                 - '@Eccube\Service\PurchaseFlow\Processor\CustomerPurchaseInfoProcessor'

--- a/src/Eccube/Service/PurchaseFlow/Processor/PreOrderIdValidator.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PreOrderIdValidator.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\PurchaseFlow\Processor;
+
+use Eccube\Entity\ItemHolderInterface;
+use Eccube\Entity\Order;
+use Eccube\Service\CartService;
+use Eccube\Service\PurchaseFlow\PurchaseContext;
+use Eccube\Service\PurchaseFlow\PurchaseException;
+use Eccube\Service\PurchaseFlow\PurchaseProcessor;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class PreOrderIdValidator implements PurchaseProcessor
+{
+    /**
+     * @var CartService
+     */
+    private $cartService;
+
+    /**
+     * PreOrderIdValidator constructor.
+     *
+     * @param CartService $cartService
+     */
+    public function __construct(CartService $cartService)
+    {
+        $this->cartService = $cartService;
+    }
+
+    /**
+     * 受注の仮確定処理を行います。
+     *
+     * @param ItemHolderInterface $target
+     * @param PurchaseContext $context
+     *
+     * @throws PurchaseException
+     */
+    public function prepare(ItemHolderInterface $target, PurchaseContext $context)
+    {
+        // 処理なし
+    }
+
+    /**
+     * 受注の確定処理を行います。
+     *
+     * @param ItemHolderInterface $target
+     * @param PurchaseContext $context
+     *
+     * @throws PurchaseException
+     */
+    public function commit(ItemHolderInterface $target, PurchaseContext $context)
+    {
+        // 処理なし
+    }
+
+    /**
+     * 仮確定した受注データの取り消し処理を行います。
+     *
+     * 別のorder_idが渡されてきた場合に処理が継続されないようにするため、
+     * orderのpre_order_idがsessionのpre_order_idと一致するか確認する
+     *
+     * @param ItemHolderInterface $itemHolder
+     * @param PurchaseContext $context
+     */
+    public function rollback(ItemHolderInterface $itemHolder, PurchaseContext $context)
+    {
+        // $itemHolderが受注の場合のみチェック
+        if (!$itemHolder instanceof Order) {
+            return;
+        }
+
+        $Cart = $this->cartService->getCart();
+
+        // CartがなければBad Requestエラー
+        if (!$Cart) {
+            throw new BadRequestHttpException();
+        }
+
+        $cartPreOrderId = $this->cartService->getCart()->getPreOrderId();
+        $orderPreOrderId = $itemHolder->getPreOrderId();
+
+        // orderのpre_order_idがsessionのpre_order_idが一致していなければBad Requestエラー
+        if ($cartPreOrderId != $orderPreOrderId) {
+            throw new BadRequestHttpException();
+        }
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
決済プラグインのリンク型決済等の「リンク先から戻る」処理では、そのリクエストが正しいかController等でチェックすることが望ましい。
そのチェックをすり抜けてしまった場合でも関係のない受注の情報を更新してしまわないように、PurchaseFlow内にてpre_order_idで正しい受注かをチェックする処理を追加した。

## 方針(Policy)
ShoppingのPurchaseFlowにrollback実行時にpre_order_idをチェックするPurchaseProcessorを追加した。

## 実装に関する補足(Appendix)
- 追加したProcessorは実質Validatorの役割をしているのでクラス名はPreOrderIdValidatorとした。
- shoppingFlowのみにProcessorを追加した。
- PurchaseFlowのrollback処理ではPurchaseExceptionのハンドリングをしていなかったのでBadRequestHttpExceptionをthrowする実装とした。
- エラーコードはBad Request(400)とした。

## テスト（Test)

### SamplePaymentPluginを導入して以下のテストを実施

1. リンク式決済の設定をする。
1. sessionが異なる２個のブラウザ(A,Bとする)で非会員で購入フローに進み、リンク式決済を選んでクレジットカード情報入力ページに遷移する。
1. ブラウザAの戻るボタンのリンクのパラメータを編集し、ブラウザBの受注番号を指定する。
1. ブラウザAの戻る操作を行う。（検証結果a）
1. ブラウザBでそのまま決済完了する。（検証結果b）

### 本修正前の結果

- 検証結果a：戻る処理が成功（ブラウザBのステータスを変更してしまっている）
- 検証結果b：404エラーが発生（ブラウザBのステータスが変更されてしまっているため）

### 本修正後の結果

- 検証結果a：400エラーが発生（ブラウザBのステータスを変更していない）
- 検証結果b：購入完了画面の表示（ブラウザBのステータスが変更されていないため）

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更
