### PR TITLE
feat ogタグの例のog:imageを絶対パスに変更、ogタグの例にproduct:product_linkおよびproduct:retailer_titleを追加

### DIFF
--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -981,11 +981,13 @@ admin.content.page_meta_metatag_placeholder: |
   商品詳細ページでの記載例
     <meta property="og:type" content="og:product" />
     <meta property="og:title" content="{{ Product.name }}" />
-    <meta property="og:image" content="{{ asset(Product.main_list_image|no_image_product, 'save_image') }}" />
+    <meta property="og:image" content="{{ url('homepage') }}{{ asset(Product.main_list_image|no_image_product, 'save_image') }}" />
     <meta property="og:description" content="{{ Product.description_list|striptags }}" />
     <meta property="og:url" content="{{ url('product_detail', {'id': Product.id}) }}" />
     <meta property="product:price:amount" content="{{ Product.getPrice02IncTaxMin }}"/>
     <meta property="product:price:currency" content="{{ eccube_config.currency }}"/>
+    <meta property="product:product_link" content="{{ url('product_detail', {'id': Product.id}) }}"/>
+    <meta property="product:retailer_title" content="{{ Product.name }}"/>
 admin.content.page_file_name_exists: 同じファイル名のデータが存在しています。別のファイル名を入力してください。
 admin.content.block_name: ブロック名
 admin.content.block__card_title: ブロック設定


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
feat ogタグの例のog:imageを絶対パスに変更、ogタグの例にproduct:product_linkおよびproduct:retailer_titleを追加

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)
例通りに設定した場合でfacebookへ投稿して問題なく表示されることを確認しました。

ローカルに設定して出力されたタグ

```html
<meta property="og:type" content="og:product" />
<meta property="og:title" content="チェリーアイスサンド" />
<meta property="og:image" content="http://127.0.0.1:8000//html/upload/save_image/sand-1.png" />
<meta property="og:description" content="" />
<meta property="og:url" content="http://127.0.0.1:8000/products/detail/2" />
<meta property="product:price:amount" content="3024"/>
<meta property="product:price:currency" content="JPY"/>
<meta property="product:product_link" content="http://127.0.0.1:8000/products/detail/2"/>
<meta property="product:retailer_title" content="チェリーアイスサンド"/>
```

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



