### PR TITLE
mod_headers が無効な環境でエラーにならないように修正

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -10,12 +10,14 @@ DirectoryIndex index.php index.html .ht
     allow from all
 </Files>
 
-# クリックジャッキング対策
-Header always set X-Frame-Options SAMEORIGIN
+<IfModule mod_headers.c>
+    # クリックジャッキング対策
+    Header always set X-Frame-Options SAMEORIGIN
 
-# XSS対策
-Header set X-XSS-Protection "1; mode=block"
-Header set X-Content-Type-Options nosniff
+    # XSS対策
+    Header set X-XSS-Protection "1; mode=block"
+    Header set X-Content-Type-Options nosniff
+</IfModule>
 
 <IfModule mod_rewrite.c>
     #403 Forbidden対応方法
@@ -24,7 +26,7 @@ Header set X-Content-Type-Options nosniff
     #Options +FollowSymLinks +SymLinksIfOwnerMatch
 
     RewriteEngine On
-    
+
     # Authorization ヘッダが取得できない環境への対応
     RewriteCond %{HTTP:Authorization} ^(.*)
     RewriteRule ^(.*) - [E=HTTP_AUTHORIZATION:%1]


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
debian 系のパッケージは mod_headers が初期設定で無効になっているため、 `IfModule mod_headers.c` で囲わないとエラーになってしまう。
原因がわかりづらいため、 エラーにならないようにする

## 方針(Policy)
`IfModule mod_headers.c`  で該当の設定を囲う

## テスト（Test)
mod_headers が無効の環境でも正常動作することを確認


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



