### PR TITLE
EntityUtil::isEmpty() に @deprecated を追加

### DIFF
--- a/src/Eccube/Util/EntityUtil.php
+++ b/src/Eccube/Util/EntityUtil.php
@@ -33,9 +33,12 @@ class EntityUtil
      * @return bool エンティティが削除済みの場合 true
      *
      * @see https://github.com/EC-CUBE/ec-cube/pull/602#issuecomment-125431246
+     *
+     * @deprecated
      */
     public static function isEmpty($entity)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated.', E_USER_DEPRECATED);
         if ($entity instanceof Proxy) {
             try {
                 $entity->__load();
@@ -59,9 +62,12 @@ class EntityUtil
      * @return bool
      *
      * @see EntityUtil::isEmpty()
+     *
+     * @deprecated
      */
     public static function isNotEmpty($entity)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated.', E_USER_DEPRECATED);
         return !self::isEmpty($entity);
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
soft delete filter を廃止したため、 `EntityUtil::isEmpty()` は非推奨にする

## 相談（Discussion）
他にも 4.0で削除予定の `@deprecated` なメソッドが残存している

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



