### PR TITLE
商品一覧のパフォーマンスチューニング

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -119,3 +119,5 @@ parameters:
     eccube_order_no_format: ''
     eccube_order_pdf_message_len: 30
     eccube_news_start_year: 2000
+    eccube_result_cache_lifetime: 3600 # doctrineのresult cacheのlifetime.
+    eccube_result_cache_lifetime_short: 10  # doctrineのresult cacheのlifetime. 商品一覧画面など長期間キャッシュできない箇所で使用する.

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -138,7 +138,7 @@ class CsvImportController extends AbstractCsvImportController
      * @Route("/%eccube_admin_route%/product/product_csv_upload", name="admin_product_csv_import")
      * @Template("@admin/Product/csv_product.twig")
      */
-    public function csvProduct(Request $request)
+    public function csvProduct(Request $request, CacheUtil $cacheUtil)
     {
         $form = $this->formFactory->createBuilder(CsvImportType::class)->getForm();
         $headers = $this->getProductCsvHeader();
@@ -526,6 +526,8 @@ class CsvImportController extends AbstractCsvImportController
                     log_info('商品CSV登録完了');
                     $message = 'admin.common.csv_upload_complete';
                     $this->session->getFlashBag()->add('eccube.admin.success', $message);
+
+                    $cacheUtil->clearDoctrineCache();
                 }
             }
         }

--- a/src/Eccube/Controller/Admin/Product/ProductClassController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductClassController.php
@@ -26,6 +26,7 @@ use Eccube\Repository\ClassCategoryRepository;
 use Eccube\Repository\ProductClassRepository;
 use Eccube\Repository\ProductRepository;
 use Eccube\Repository\TaxRuleRepository;
+use Eccube\Util\CacheUtil;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\HttpFoundation\Request;
@@ -85,7 +86,7 @@ class ProductClassController extends AbstractController
      * @Route("/%eccube_admin_route%/product/product/class/{id}", requirements={"id" = "\d+"}, name="admin_product_product_class")
      * @Template("@admin/Product/product_class.twig")
      */
-    public function index(Request $request, $id)
+    public function index(Request $request, $id, CacheUtil $cacheUtil)
     {
         $Product = $this->findProduct($id);
         if (!$Product) {
@@ -126,6 +127,8 @@ class ProductClassController extends AbstractController
 
                 $this->addSuccess('admin.common.save_complete', 'admin');
 
+                $cacheUtil->clearDoctrineCache();
+
                 if ($request->get('return_product_list')) {
                     return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId(), 'return_product_list' => true]);
                 }
@@ -163,6 +166,8 @@ class ProductClassController extends AbstractController
 
                         $this->addSuccess('admin.common.save_complete', 'admin');
 
+                        $cacheUtil->clearDoctrineCache();
+
                         if ($request->get('return_product_list')) {
                             return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId(), 'return_product_list' => true]);
                         }
@@ -188,7 +193,7 @@ class ProductClassController extends AbstractController
      *
      * @Route("/%eccube_admin_route%/product/product/class/{id}/clear", requirements={"id" = "\d+"}, name="admin_product_product_class_clear")
      */
-    public function clearProductClasses(Request $request, Product $Product)
+    public function clearProductClasses(Request $request, Product $Product, CacheUtil $cacheUtil)
     {
         if (!$Product->hasProductClass()) {
             return $this->redirectToRoute('admin_product_product_class', ['id' => $Product->getId()]);
@@ -216,6 +221,8 @@ class ProductClassController extends AbstractController
             $this->entityManager->flush();
 
             $this->addSuccess('admin.product.reset_complete', 'admin');
+
+            $cacheUtil->clearDoctrineCache();
         }
 
         if ($request->get('return_product_list')) {

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -40,6 +40,7 @@ use Eccube\Repository\ProductRepository;
 use Eccube\Repository\TagRepository;
 use Eccube\Repository\TaxRuleRepository;
 use Eccube\Service\CsvExportService;
+use Eccube\Util\CacheUtil;
 use Eccube\Util\FormUtil;
 use Knp\Component\Pager\Paginator;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
@@ -354,7 +355,7 @@ class ProductController extends AbstractController
      * @Route("/%eccube_admin_route%/product/product/{id}/edit", requirements={"id" = "\d+"}, name="admin_product_product_edit")
      * @Template("@admin/Product/product.twig")
      */
-    public function edit(Request $request, $id = null, RouterInterface $router)
+    public function edit(Request $request, $id = null, RouterInterface $router, CacheUtil $cacheUtil)
     {
         $has_class = false;
         if (is_null($id)) {
@@ -620,6 +621,8 @@ class ProductController extends AbstractController
                     }
                 }
 
+                $cacheUtil->clearDoctrineCache();
+
                 return $this->redirectToRoute('admin_product_product_edit', ['id' => $Product->getId()]);
             }
         }
@@ -668,7 +671,7 @@ class ProductController extends AbstractController
     /**
      * @Route("/%eccube_admin_route%/product/product/{id}/delete", requirements={"id" = "\d+"}, name="admin_product_product_delete", methods={"DELETE"})
      */
-    public function delete(Request $request, $id = null)
+    public function delete(Request $request, $id = null, CacheUtil $cacheUtil)
     {
         $this->isTokenValid();
         $session = $request->getSession();
@@ -728,6 +731,9 @@ class ProductController extends AbstractController
 
                     $success = true;
                     $message = trans('admin.common.delete_complete');
+
+                    $cacheUtil->clearDoctrineCache();
+
                 } catch (ForeignKeyConstraintViolationException $e) {
                     log_info('商品削除エラー', [$id]);
                     $message = trans('admin.common.delete_error_foreign_key', ['%name%' => $Product->getName()]);
@@ -1015,7 +1021,7 @@ class ProductController extends AbstractController
      *
      * @return RedirectResponse
      */
-    public function bulkProductStatus(Request $request, ProductStatus $ProductStatus)
+    public function bulkProductStatus(Request $request, ProductStatus $ProductStatus, CacheUtil $cacheUtil)
     {
         $this->isTokenValid();
 
@@ -1039,6 +1045,7 @@ class ProductController extends AbstractController
                     '%status%' => $ProductStatus->getName(),
                 ]);
                 $this->addSuccess($msg, 'admin');
+                $cacheUtil->clearDoctrineCache();
             }
         } catch (\Exception $e) {
             $this->addError($e->getMessage(), 'admin');

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -159,9 +159,12 @@ class ProductController extends AbstractController
         $this->eventDispatcher->dispatch(EccubeEvents::FRONT_PRODUCT_INDEX_SEARCH, $event);
         $searchData = $event->getArgument('searchData');
 
+        $query = $qb->getQuery()
+            ->useResultCache(true, $this->eccubeConfig['eccube_result_cache_lifetime_short']);
+
         /** @var SlidingPagination $pagination */
         $pagination = $paginator->paginate(
-            $qb,
+            $query,
             !empty($searchData['pageno']) ? $searchData['pageno'] : 1,
             !empty($searchData['disp_number']) ? $searchData['disp_number']->getId() : $this->productListMaxRepository->findOneBy([], ['sort_no' => 'ASC'])->getId()
         );

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -29,6 +29,7 @@ use Eccube\Repository\ProductRepository;
 use Eccube\Service\CartService;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Eccube\Service\PurchaseFlow\PurchaseFlow;
+use Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination;
 use Knp\Component\Pager\Paginator;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -158,6 +159,7 @@ class ProductController extends AbstractController
         $this->eventDispatcher->dispatch(EccubeEvents::FRONT_PRODUCT_INDEX_SEARCH, $event);
         $searchData = $event->getArgument('searchData');
 
+        /** @var SlidingPagination $pagination */
         $pagination = $paginator->paginate(
             $qb,
             !empty($searchData['pageno']) ? $searchData['pageno'] : 1,

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -164,6 +164,12 @@ class ProductController extends AbstractController
             !empty($searchData['disp_number']) ? $searchData['disp_number']->getId() : $this->productListMaxRepository->findOneBy([], ['sort_no' => 'ASC'])->getId()
         );
 
+        $ids = [];
+        foreach ($pagination as $Product) {
+            $ids[] = $Product->getId();
+        }
+        $ProductsAndClassCategories = $this->productRepository->findProductsWithSortedClassCategories($ids, 'p.id');
+
         // addCart form
         $forms = [];
         foreach ($pagination as $Product) {
@@ -173,7 +179,7 @@ class ProductController extends AbstractController
                 AddCartType::class,
                 null,
                 [
-                    'product' => $this->productRepository->findWithSortedClassCategories($Product->getId()),
+                    'product' => $ProductsAndClassCategories[$Product->getId()],
                     'allow_extra_fields' => true,
                 ]
             );

--- a/src/Eccube/Repository/AbstractRepository.php
+++ b/src/Eccube/Repository/AbstractRepository.php
@@ -46,6 +46,6 @@ abstract class AbstractRepository extends ServiceEntityRepository
 
     protected function getCacheLifetime()
     {
-        return 3600; // TODO 設定に切り出すほどでもないので一旦固定で.
+        return $this->eccubeConfig['eccube_result_cache_lifetime'];
     }
 }

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -117,6 +117,7 @@ class ProductRepository extends AbstractRepository
 
         $products = $qb
             ->getQuery()
+            ->useResultCache(true, $this->eccubeConfig['eccube_result_cache_lifetime_short'])
             ->getResult();
 
         return $products;

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -92,10 +92,13 @@ class ProductRepository extends AbstractRepository
      * @param array $ids Product in ids
      * @param string $indexBy The index for the from.
      *
-     * @return ArrayCollection
+     * @return ArrayCollection|array
      */
     public function findProductsWithSortedClassCategories(array $ids, $indexBy = null)
     {
+        if (count($ids) < 1) {
+            return [];
+        }
         $qb = $this->createQueryBuilder('p', $indexBy);
         $qb->addSelect(['pc', 'cc1', 'cc2', 'pi', 'pt', 'tr', 'ps'])
             ->innerJoin('p.ProductClasses', 'pc')

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -13,6 +13,7 @@
 
 namespace Eccube\Repository;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Eccube\Common\EccubeConfig;
 use Eccube\Doctrine\Query\Queries;
 use Eccube\Entity\Product;
@@ -83,6 +84,39 @@ class ProductRepository extends AbstractRepository
             ->getSingleResult();
 
         return $product;
+    }
+
+    /**
+     * Find the Products with sorted ClassCategories.
+     *
+     * @param array $ids Product in ids
+     * @param string $indexBy The index for the from.
+     *
+     * @return ArrayCollection
+     */
+    public function findProductsWithSortedClassCategories(array $ids, $indexBy = null)
+    {
+        $qb = $this->createQueryBuilder('p', $indexBy);
+        $qb->addSelect(['pc', 'cc1', 'cc2', 'pi', 'pt', 'tr', 'ps'])
+            ->innerJoin('p.ProductClasses', 'pc')
+            // XXX Joined 'TaxRule' and 'ProductStock' to prevent lazy loading
+            ->leftJoin('pc.TaxRule', 'tr')
+            ->innerJoin('pc.ProductStock', 'ps')
+            ->leftJoin('pc.ClassCategory1', 'cc1')
+            ->leftJoin('pc.ClassCategory2', 'cc2')
+            ->leftJoin('p.ProductImage', 'pi')
+            ->leftJoin('p.ProductTag', 'pt')
+            ->where($qb->expr()->in('p.id', $ids))
+            ->andWhere('pc.visible = :visible')
+            ->setParameter('visible', true)
+            ->orderBy('cc1.sort_no', 'DESC')
+            ->addOrderBy('cc2.sort_no', 'DESC');
+
+        $products = $qb
+            ->getQuery()
+            ->getResult();
+
+        return $products;
     }
 
     /**


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

- 商品一覧画面で、短時間のみ結果をキャッシュするように修正

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

APP_ENV=prod時、商品一覧画面で、結果キャッシュが有効になります。

キャッシュの有効期間は、デフォルトで10秒に設定しています。
app/config/eccube/packages/eccube.yaml
```
    eccube_result_cache_lifetime: 3600 # doctrineのresult cacheのlifetime.
    eccube_result_cache_lifetime_short: 10  # doctrineのresult cacheのlifetime. 商品一覧画面など長期間キャッシュできない箇所で使用する.
```

管理画面で商品情報の変更や削除等が行われた場合はキャッシュはクリアされます。
フロントで商品が購入された場合、一覧画面では、在庫情報等は有効期限内は反映されません。
※一覧画面では閲覧できるが、詳細画面/カート画面では在庫切れとなります。

## 相談（Discussion）

#3862 の続きでPRしています

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



