### PR TITLE
会員登録時フォームのフリガナのプレースホルダーが両方メイ

### DIFF
--- a/src/Eccube/Resource/template/default/Entry/index.twig
+++ b/src/Eccube/Resource/template/default/Entry/index.twig
@@ -48,7 +48,7 @@ file that was distributed with this source code.
                             </dt>
                             <dd>
                                 <div class="ec-halfInput{{ has_errors(form.kana.kana01, form.kana.kana02) ? ' error'}}">
-                                    {{ form_widget(form.kana.kana01, { 'attr': { 'placeholder': 'common.first_name_kana' }}) }}
+                                    {{ form_widget(form.kana.kana01, { 'attr': { 'placeholder': 'common.last_name_kana' }}) }}
                                     {{ form_widget(form.kana.kana02, { 'attr': { 'placeholder': 'common.first_name_kana' }}) }}
                                     {{ form_errors(form.kana.kana01) }}
                                     {{ form_errors(form.kana.kana02) }}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
苗字が無い。両方名前になってる
<img width="1017" alt="2018-09-25 22 30 19" src="https://user-images.githubusercontent.com/485749/46017528-ac5abd00-c112-11e8-82dc-cef25266a079.png">
