### PR TITLE
インストール時に ECCUBE_COOKIE_PATH を自動設定するよう修正

### DIFF
--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -460,7 +460,7 @@ class InstallController extends AbstractController
 
     protected function removeSessionData(SessionInterface $session)
     {
-        $session->remove('eccube.session.install');
+        $session->clear();
     }
 
     protected function setSessionData(SessionInterface $session, $data = [])

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -432,6 +432,7 @@ class InstallController extends AbstractController
             'ECCUBE_ADMIN_ALLOW_HOSTS' => $this->convertAdminAllowHosts($sessionData['admin_allow_hosts']),
             'ECCUBE_FORCE_SSL' => $forceSSL,
             'ECCUBE_ADMIN_ROUTE' => isset($sessionData['admin_dir']) ? $sessionData['admin_dir'] : 'admin',
+            'ECCUBE_COOKIE_PATH' => $request->getBasePath() ? $request->getBasePath() : '/',
         ];
 
         $env = StringUtil::replaceOrAddEnv($env, $replacement);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
インストール時に ECCUBE_COOKIE_PATH を自動設定するよう修正。
サブディレクトリにインストールした場合を考慮

## 方針(Policy)
Webインストーラで ECCUBE_COOKIE_PATH を自動設定する

## 実装に関する補足(Appendix)
コマンドラインからのインストール時は ECCUBE_COOKIE_PATH を適切に設定すること

## テスト（Test)
- `/ec-cube` にインストールした場合、`ECCUBE_COOKIE_PATH=/ec-cube` となるのを確認
- `/` にインストールした場合、`ECCUBE_COOKIE_PATH=/` となるのを確認
- InstallController の Codeception は別途作成する

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



