### PR TITLE
PluginManager内のflush()によるdtb_pluginの更新を回避

### DIFF
--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -614,10 +614,11 @@ class PluginService
             $pluginDir = $this->calcPluginDir($plugin->getCode());
             $config = $this->readConfig($pluginDir);
             $em->getConnection()->beginTransaction();
-            $plugin->setEnabled($enable ? true : false);
-            $em->persist($plugin);
 
             $this->callPluginManagerMethod($config, $enable ? 'enable' : 'disable');
+
+            $plugin->setEnabled($enable ? true : false);
+            $em->persist($plugin);
 
             // Proxyだけ再生成してスキーマは更新しない
             $this->regenerateProxy($plugin, false);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
PluginManager内で`EntityManager#flush()`を引数なしで呼び出したときに本体側でコミットしていないデータもコミットされてしまいProxy生成等の後続処理に影響がでていたので、回避するよう修正。

## テスト（Test)
既存のテストが通る

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



