### PR TITLE
管理画面のシステムメンバー登録における不要なバリデートの削除

### DIFF
--- a/src/Eccube/Form/Type/Admin/MemberType.php
+++ b/src/Eccube/Form/Type/Admin/MemberType.php
@@ -88,21 +88,12 @@ class MemberType extends AbstractType
                 ],
             ])
             ->add('password', RepeatedPasswordType::class, [
-                // 'type' => 'password',
                 'first_options' => [
                     'label' => 'admin.setting.system.member.password',
                 ],
                 'second_options' => [
                     'label' => 'admin.setting.system.member.password',
-                ],
-                'constraints' => [
-                    new Assert\NotBlank(),
-                    new Assert\Length([
-                        'min' => $this->eccubeConfig['eccube_id_min_len'],
-                        'max' => $this->eccubeConfig['eccube_id_max_len'],
-                    ]),
-                    new Assert\Regex(['pattern' => '/^[[:graph:][:space:]]+$/i']),
-                ],
+                ]
             ])
             ->add('Authority', EntityType::class, [
                 'class' => 'Eccube\Entity\Master\Authority',


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
管理画面のシステムメンバー登録における不要なバリデートの削除

## 方針(Policy)
MemberTypeのpasswordには、RepeatedPasswordType::classが定義されている為、
MemberTypeでは、バリデートの定義を削除する。




