### PR TITLE
プラグインバージョン警告表示を修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Store/plugin_confirm_panel.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_confirm_panel.twig
@@ -27,17 +27,16 @@ file that was distributed with this source code.
             </div>
         </div>
     </div>
-
-    <div class="row">
-        <div class="col-12">
-            <div class="alert alert-danger border border-danger">
-                {% set version_check = item.version_check  %}
-                {% if version_check == false %}
+    {% set version_check = item.version_check  %}
+    {% if version_check == false %}
+        <div class="row">
+            <div class="col-12">
+                <div class="alert alert-danger border border-danger">
                     <p class="text-danger mb-0">
                         {{ 'admin.store.plugin_owners_search.modal.note'|trans({'%version%': constant('Eccube\\Common\\Constant::VERSION')}) }}
                     </p>
-                {% endif %}
+                </div>
             </div>
         </div>
-    </div>
+    {% endif %}
 </div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
プラグインバージョンが妥当な場合でも空の警告表示がでていたのを修正

## テスト（Test)
`Constant::VERSION = '4.0.0'` で正常に表示されるのを確認

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



