### PR TITLE
パッケージAPIのタイムアウトを5000msに設定

### DIFF
--- a/src/Eccube/Service/PluginApiService.php
+++ b/src/Eccube/Service/PluginApiService.php
@@ -306,6 +306,7 @@ class PluginApiService
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_FAILONERROR => true,
             CURLOPT_CAINFO => \Composer\CaBundle\CaBundle::getSystemCaRootBundlePath(),
+            CURLOPT_TIMEOUT_MS => 5000,
         ];
 
         // Set option value


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- パッケージAPIとの接続はできるがレスポンスが帰って来ない場合に、管理画面トップページも開かなくなるのでタイムアウトを5000msに設定。
- プラグインインストール時の通信にはこのタイムアウトは適用されない

参考
http://php.net/manual/ja/function.curl-setopt.php

## マイナーバージョン互換性保持のための制限事項チェックリスト
- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



