### PR TITLE
サイドカラムの CSS クラス名が間違っていたのを修正

### DIFF
--- a/src/Eccube/Resource/template/default/default_frame.twig
+++ b/src/Eccube/Resource/template/default/default_frame.twig
@@ -77,7 +77,7 @@ file that was distributed with this source code.
     <div class="ec-layoutRole__contents">
         {# Layout: SIDE_LEFT #}
         {% if Layout.SideLeft %}
-            <div class="ec-ec-layoutRole__left">
+            <div class="ec-layoutRole__left">
                 {{ include('block.twig', {'Blocks': Layout.SideLeft}) }}
             </div>
         {% endif %}
@@ -110,7 +110,7 @@ file that was distributed with this source code.
 
         {# Layout: SIDE_RIGHT #}
         {% if Layout.SideRight %}
-            <div class="ec-layoutRole__mainRight">
+            <div class="ec-layoutRole__right">
                 {{ include('block.twig', {'Blocks': Layout.SideRight}) }}
             </div>
         {% endif %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
サイドカラムの CSS クラス名が SCSS の定義と異なっていたのを修正

## 方針(Policy)
CSS クラスを SCSS の定義に合わせる

## 実装に関する補足(Appendix)
デフォルトテンプレートでは使用していないため影響なし

## テスト（Test)
- サイドナビにブロックを配置して正常に表示されるのを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



