### PR TITLE
pre_order_id に unique 制約を付与

### DIFF
--- a/src/Eccube/Entity/Cart.php
+++ b/src/Eccube/Entity/Cart.php
@@ -22,7 +22,12 @@ if (!class_exists('\Eccube\Entity\Cart')) {
     /**
      * Cart
      *
-     * @ORM\Table(name="dtb_cart", indexes={@ORM\Index(name="dtb_cart_pre_order_id_idx", columns={"pre_order_id"}), @ORM\Index(name="dtb_cart_update_date_idx", columns={"update_date"})})
+     * @ORM\Table(name="dtb_cart", indexes={
+     *     @ORM\Index(name="dtb_cart_update_date_idx", columns={"update_date"})
+     *  },
+     *  uniqueConstraints={
+     *     @ORM\UniqueConstraint(name="dtb_cart_pre_order_id_idx", columns={"pre_order_id"})
+     *  }))
      * @ORM\InheritanceType("SINGLE_TABLE")
      * @ORM\DiscriminatorColumn(name="discriminator_type", type="string", length=255)
      * @ORM\HasLifecycleCallbacks()

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -24,12 +24,14 @@ if (!class_exists('\Eccube\Entity\Order')) {
      * Order
      *
      * @ORM\Table(name="dtb_order", indexes={
-     *     @ORM\Index(name="dtb_order_pre_order_id_idx", columns={"pre_order_id"}),
      *     @ORM\Index(name="dtb_order_email_idx", columns={"email"}),
      *     @ORM\Index(name="dtb_order_order_date_idx", columns={"order_date"}),
      *     @ORM\Index(name="dtb_order_payment_date_idx", columns={"payment_date"}),
      *     @ORM\Index(name="dtb_order_update_date_idx", columns={"update_date"}),
      *     @ORM\Index(name="dtb_order_order_no_idx", columns={"order_no"})
+     *  },
+     *  uniqueConstraints={
+     *     @ORM\UniqueConstraint(name="dtb_order_pre_order_id_idx", columns={"pre_order_id"})
      *  })
      * @ORM\InheritanceType("SINGLE_TABLE")
      * @ORM\DiscriminatorColumn(name="discriminator_type", type="string", length=255)

--- a/src/Eccube/Service/OrderHelper.php
+++ b/src/Eccube/Service/OrderHelper.php
@@ -299,7 +299,6 @@ class OrderHelper
             $Order = $this->orderRepository->findOneBy(
                 [
                     'pre_order_id' => $preOrderId,
-                    'OrderStatus' => OrderStatus::PROCESSING,
                 ]
             );
         } while ($Order);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
pre_order_id の重複を防ぐために unique 制約を付与

## 方針(Policy)
- Order::pre_order_id, Cart::pre_order_id に unique 制約を付与
- OrderHelper::createPreOrderId() で、重複チェックの対象を購入処理中に限定していたの削除

## テスト（Test)
ユニットテストが通るのを確認

## 相談（Discussion）
- 3系は重複チェックの対象を購入処理中に限定しているのを削除する方針で

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



