### PR TITLE
【3系】pre_order_idが受注全体でユニークとなるように変更

### DIFF
--- a/src/Eccube/Service/ShoppingService.php
+++ b/src/Eccube/Service/ShoppingService.php
@@ -154,7 +154,6 @@ class ShoppingService
             $preOrderId = sha1(Str::random(32));
             $Order = $this->app['eccube.repository.order']->findOneBy(array(
                 'pre_order_id' => $preOrderId,
-                'OrderStatus' => $this->app['config']['order_processing'],
             ));
         } while ($Order);
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
現状の仕様では受注ステータスが「購入処理中」の受注の中でpre_order_idがユニークとなるような処理となっている。
カスタマイズによっては受注ステータスが変更されpre_order_idがユニークとならない可能性があるので、pre_order_idは受注ステータスにかかわらず受注全体でユニークとなるように処理を変更する。

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



