### PR TITLE
【4系】pre_order_idが受注全体でユニークとなるように変更

### DIFF
--- a/src/Eccube/Service/OrderHelper.php
+++ b/src/Eccube/Service/OrderHelper.php
@@ -299,7 +299,6 @@ class OrderHelper
             $Order = $this->orderRepository->findOneBy(
                 [
                     'pre_order_id' => $preOrderId,
-                    'OrderStatus' => OrderStatus::PROCESSING,
                 ]
             );
         } while ($Order);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
現状の仕様では受注ステータスが「購入処理中」の受注の中でpre_order_idがユニークとなるような処理となっている。
カスタマイズによっては受注ステータスが変更されpre_order_idがユニークとならない可能性があるので、pre_order_idは受注ステータスにかかわらず受注全体でユニークとなるように処理を変更する。

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



