### PR TITLE
assetのpluginパスの誤りを修正

### DIFF
--- a/app/config/eccube/packages/framework.yaml
+++ b/app/config/eccube/packages/framework.yaml
@@ -31,7 +31,7 @@ framework:
         save_image:
           base_path: '/html/upload/save_image'
         plugin:
-          base_path: '/html/template/plugin'
+          base_path: '/html/plugin'
         install:
           base_path: '/html/template/install'
         temp_image:


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)

asset関数でプラグインのURLパスを取得した際に、誤ったパスが取得されていた不具合を修正

```
{{ asset('CategoryContent/xxx.jpg', 'plugin') }}

誤：html/template/plugin/CategoryContent/xxx.jpg
正：html/plugin/CategoryContent/xxx.jpg
```
<!-- PullRequestの目的、関連するIssue番号など -->

参考
#2608
#2644

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



