### PR TITLE
受注管理画面で決済処理中の受注を検索しないよう修正

### DIFF
--- a/codeception/acceptance/EA04OrderCest.php
+++ b/codeception/acceptance/EA04OrderCest.php
@@ -43,7 +43,7 @@ class EA04OrderCest
 
         $findOrders = Fixtures::get('findOrders'); // Closure
         $TargetOrders = array_filter($findOrders(), function ($Order) {
-            return $Order->getOrderStatus()->getId() != OrderStatus::PROCESSING;
+            return !in_array($Order->getOrderStatus()->getId(), [OrderStatus::PROCESSING, OrderStatus::PENDING]);
         });
         OrderManagePage::go($I)->検索();
         $I->see('検索結果：'.count($TargetOrders).'件が該当しました', OrderManagePage::$検索結果_メッセージ);
@@ -61,7 +61,7 @@ class EA04OrderCest
 
         $findOrders = Fixtures::get('findOrders'); // Closure
         $TargetOrders = array_filter($findOrders(), function ($Order) {
-            return $Order->getOrderStatus()->getId() != OrderStatus::PROCESSING;
+            return !in_array($Order->getOrderStatus()->getId(), [OrderStatus::PROCESSING, OrderStatus::PENDING]);
         });
         $OrderListPage = OrderManagePage::go($I)->検索();
         $I->see('検索結果：'.count($TargetOrders).'件が該当しました', OrderManagePage::$検索結果_メッセージ);
@@ -79,7 +79,7 @@ class EA04OrderCest
 
         $findOrders = Fixtures::get('findOrders'); // Closure
         $TargetOrders = array_filter($findOrders(), function ($Order) {
-            return $Order->getOrderStatus()->getId() != OrderStatus::PROCESSING;
+            return !in_array($Order->getOrderStatus()->getId(), [OrderStatus::PROCESSING, OrderStatus::PENDING]);
         });
         $OrderListPage = OrderManagePage::go($I)->検索();
         $I->see('検索結果：'.count($TargetOrders).'件が該当しました', OrderManagePage::$検索結果_メッセージ);
@@ -98,7 +98,7 @@ class EA04OrderCest
 
         $findOrders = Fixtures::get('findOrders'); // Closure
         $TargetOrders = array_filter($findOrders(), function ($Order) {
-            return $Order->getOrderStatus()->getId() != OrderStatus::PROCESSING;
+            return !in_array($Order->getOrderStatus()->getId(), [OrderStatus::PROCESSING, OrderStatus::PENDING]);
         });
         $OrderListPage = OrderManagePage::go($I)->検索();
         $I->see('検索結果：'.count($TargetOrders).'件が該当しました', OrderManagePage::$検索結果_メッセージ);
@@ -116,7 +116,7 @@ class EA04OrderCest
 
         $findOrders = Fixtures::get('findOrders'); // Closure
         $TargetOrders = array_filter($findOrders(), function ($Order) {
-            return $Order->getOrderStatus()->getId() != OrderStatus::PROCESSING;
+            return !in_array($Order->getOrderStatus()->getId(), [OrderStatus::PROCESSING, OrderStatus::PENDING]);
         });
         $OrderListPage = OrderManagePage::go($I)->検索();
         $I->see('検索結果：'.count($TargetOrders).'件が該当しました', OrderManagePage::$検索結果_メッセージ);
@@ -201,7 +201,7 @@ class EA04OrderCest
 
         $findOrders = Fixtures::get('findOrders'); // Closure
         $TargetOrders = array_filter($findOrders(), function ($Order) {
-            return $Order->getOrderStatus()->getId() != OrderStatus::PROCESSING;
+            return !in_array($Order->getOrderStatus()->getId(), [OrderStatus::PROCESSING, OrderStatus::PENDING]);
         });
 
         $OrderListPage = OrderManagePage::go($I)->検索();
@@ -292,7 +292,7 @@ class EA04OrderCest
 
         $findOrders = Fixtures::get('findOrders'); // Closure
         $TargetOrders = array_filter($findOrders(), function ($Order) {
-            return $Order->getOrderStatus()->getId() != OrderStatus::PROCESSING;
+            return !in_array($Order->getOrderStatus()->getId(), [OrderStatus::PROCESSING, OrderStatus::PENDING]);
         });
         $OrderListPage = OrderManagePage::go($I)->検索();
         $I->see('検索結果：'.count($TargetOrders).'件が該当しました', OrderManagePage::$検索結果_メッセージ);
@@ -315,7 +315,7 @@ class EA04OrderCest
 
         $findOrders = Fixtures::get('findOrders'); // Closure
         $TargetOrders = array_filter($findOrders(), function ($Order) {
-            return $Order->getOrderStatus()->getId() != OrderStatus::PROCESSING;
+            return !in_array($Order->getOrderStatus()->getId(), [OrderStatus::PROCESSING, OrderStatus::PENDING]);
         });
         $OrderListPage = OrderManagePage::go($I)->検索();
         $I->see('検索結果：'.count($TargetOrders).'件が該当しました', OrderManagePage::$検索結果_メッセージ);

--- a/codeception/acceptance/EA09ShippingCest.php
+++ b/codeception/acceptance/EA09ShippingCest.php
@@ -252,8 +252,8 @@ class EA09ShippingCest
         $Customer = (Fixtures::get('createCustomer'))();
         /* @var Order[] $Orders */
         $Orders = (Fixtures::get('createOrders'))($Customer, 3);
-        // 決済処理中に更新しておく
-        $Status = $entityManager->getRepository('Eccube\Entity\Master\OrderStatus')->find(OrderStatus::PENDING);
+        // キャンセルに更新しておく
+        $Status = $entityManager->getRepository('Eccube\Entity\Master\OrderStatus')->find(OrderStatus::CANCEL);
         foreach ($Orders as $newOrder) {
             $newOrder->setOrderStatus($Status);
         }

--- a/codeception/acceptance/EA09ShippingCest.php
+++ b/codeception/acceptance/EA09ShippingCest.php
@@ -297,11 +297,11 @@ class EA09ShippingCest
                 ->入力_CSVファイル('shipping.csv')
                 ->CSVアップロード();
 
-            $I->see(sprintf('%s: %s から %s にはステータス変更できません', $Orders[0]->getShippings()[0]->getId(), '決済処理中', '発送済み'),
+            $I->see(sprintf('%s: %s から %s にはステータス変更できません', $Orders[0]->getShippings()[0]->getId(), '注文取消し', '発送済み'),
                     '#upload-form > div:nth-child(4)');
-            $I->see(sprintf('%s: %s から %s にはステータス変更できません', $Orders[1]->getShippings()[0]->getId(), '決済処理中', '発送済み'),
+            $I->see(sprintf('%s: %s から %s にはステータス変更できません', $Orders[1]->getShippings()[0]->getId(), '注文取消し', '発送済み'),
                     '#upload-form > div:nth-child(5)');
-            $I->see(sprintf('%s: %s から %s にはステータス変更できません', $Orders[2]->getShippings()[0]->getId(), '決済処理中', '発送済み'),
+            $I->see(sprintf('%s: %s から %s にはステータス変更できません', $Orders[2]->getShippings()[0]->getId(), '注文取消し', '発送済み'),
                     '#upload-form > div:nth-child(6)');
         } finally {
             if (file_exists($csvFileName)) {

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -132,12 +132,9 @@ class OrderRepository extends AbstractRepository
         }
 
         if (!$filterStatus) {
-            // 購入処理中は検索対象から除外
-            $OrderStatuses = $this->getEntityManager()
-                ->getRepository('Eccube\Entity\Master\OrderStatus')
-                ->findNotContainsBy(['id' => OrderStatus::PROCESSING]);
-            $qb->andWhere($qb->expr()->in('o.OrderStatus', ':status'))
-                ->setParameter('status', $OrderStatuses);
+            // 購入処理中, 決済処理中は検索対象から除外
+            $qb->andWhere($qb->expr()->notIn('o.OrderStatus', ':status'))
+                ->setParameter('status', [OrderStatus::PROCESSING, OrderStatus::PENDING]);
         }
 
         // company_name

--- a/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataAdminTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataAdminTest.php
@@ -160,6 +160,22 @@ class OrderRepositoryGetQueryBuilderBySearchDataAdminTest extends EccubeTestCase
         $this->verify();
     }
 
+    public function testOrderIdEnd2()
+    {
+        $this->Order->setOrderStatus($this->orderStatusRepo->find(OrderStatus::PENDING));
+        $this->entityManager->flush();
+
+        $this->searchData = [
+            'order_id_end' => $this->Order->getId(),
+        ];
+        $this->scenario();
+
+        // $this->Order は決済処理中なので 0 件になる
+        $this->expected = 0;
+        $this->actual = count($this->Results);
+        $this->verify();
+    }
+
     public function testStatus()
     {
         $NewStatus = $this->orderStatusRepo->find(OrderStatus::NEW);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
受注管理画面の初期表示で決済処理中の受注を検索しないよう修正

## テスト（Test)
- 決済処理中を除外するテストケースを追加
- 既存のテストケースが通るのを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



