### PR TITLE
プラグイン用データディレクトリの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ composer.phar
 /app/Plugin/*
 !/app/Plugin/.gitkeep
 !/app/Plugin/ExamplePlugin
+/app/PluginData/*
+!/app/PluginData/.gitkeep
 /app/template/*
 !/app/template/admin
 !/app/template/default

--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -56,6 +56,7 @@ parameters:
     plugin_html_realdir: '%eccube_html_dir%/plugin/'
     plugin_html_urlpath: /plugin/ # asset 使う
     plugin_realdir: '%kernel.project_dir%/app/Plugin'
+    plugin_data_realdir: '%kernel.project_dir%/app/PluginData'
     plugin_temp_realdir: /PATH/TO/WEB_ROOT/src/Eccube/Repository/Master/upload/temp_plugin/ # upload_tmp_dir に任せればよい？
     eccube_price_len: 8                                                    # 最大値で制御したい
     eccube_search_pmax: 10


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
プラグイン利用するファイルの置き場所として `app/PluginData` ディレクトリを定義。
プラグインでファイルを生成したりする場合は `app/PluginData/[プラグインコード]` ディレクトリを作成し、このディレクトリ以下にファイルを置くようにする。
各プラグイン用データディレクトリのファイルパスは`EccubeConfig`のインスタンスを利用して`$config['plugin_data_realdir']./'[プラグインコード]'`で取得できる。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



