### PR TITLE
数字入力の最大文字数設定EC-CUBE4.0版

### DIFF
--- a/src/Eccube/Form/Type/PhoneNumberType.php
+++ b/src/Eccube/Form/Type/PhoneNumberType.php
@@ -81,6 +81,7 @@ class PhoneNumberType extends AbstractType
             'constraints' => $constraints,
             'attr' => [
                 'placeholder' => 'common.phone_number_sample',
+                'maxlength' => $eccubeConfig['eccube_tel_len_max'],
             ],
             'trim' => true,
         ]);

--- a/src/Eccube/Form/Type/PostalType.php
+++ b/src/Eccube/Form/Type/PostalType.php
@@ -81,6 +81,7 @@ class PostalType extends AbstractType
             'attr' => [
                 'class' => 'p-postal-code',
                 'placeholder' => 'common.postal_code_sample',
+                'maxlength' => $eccubeConfig['eccube_postal_code'],
             ],
             'trim' => true,
         ]);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
こちらのVersion4.0.0版になります。
https://github.com/EC-CUBE/ec-cube/pull/3816

## テスト（Test)
- [x] ユーザー側、各ページの郵便番号が9桁以上入力出来ない事
- [x] ユーザー側、各ページで電話番号が15桁以上入力出来ない事
- [x] 管理画面側、各ページの郵便番号が9桁以上入力出来ない事
- [x] 管理画面側、各ページで電話番号が15桁以上入力出来ない事

不備等ございましたら、ご連絡を頂けますと幸いです。