### PR TITLE
Fix error when payment limit and point use

### DIFF
--- a/src/Eccube/Form/Type/Shopping/OrderType.php
+++ b/src/Eccube/Form/Type/Shopping/OrderType.php
@@ -159,7 +159,7 @@ class OrderType extends AbstractType
             }
 
             $Payments = $this->getPayments($Deliveries);
-            $Payments = $this->filterPayments($Payments, $Order->getSubtotal());
+            $Payments = $this->filterPayments($Payments, $Order->getPaymentTotal());
 
             $form = $event->getForm();
             $this->addPaymentForm($form, $Payments);

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -612,7 +612,7 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
                 'Shippings' => [
                     0 => [
                         'Delivery' => $Delivery->getId(),
-                        'DeliveryTime' => $Delivery->getDeliveryTimes()->first()->getId(),
+                        'DeliveryTime' => null,
                     ],
                 ],
                 'Payment' => $COD2->getId(),
@@ -633,7 +633,7 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
                 'Shippings' => [
                     0 => [
                         'Delivery' => $Delivery->getId(),
-                        'DeliveryTime' => $Delivery->getDeliveryTimes()->first()->getId(),
+                        'DeliveryTime' => null,
                     ],
                 ],
                 'Payment' => $COD2->getId(),

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -579,6 +579,8 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
 
     /**
      * Check can use point when has payment limit
+     *
+     * https://github.com/EC-CUBE/ec-cube/issues/3916
      */
     public function testPaymentLimitAndPointCombination()
     {
@@ -586,8 +588,8 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
         $Customer->setPoint(99999);
         $this->entityManager->flush($Customer);
 
-        $price = 40000;
-        $pointUse = 40000;
+        $price = 27777;
+        $pointUse = 27777;
         /** @var ProductClass $ProductClass */
         $ProductClass = $this->container->get(ProductClassRepository::class)->find(1);
         $ProductClass->setPrice02($price);

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -14,13 +14,16 @@
 namespace Eccube\Tests\Web;
 
 use Eccube\Entity\Delivery;
+use Eccube\Entity\Payment;
 use Eccube\Entity\PaymentOption;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Entity\Master\SaleType;
+use Eccube\Entity\ProductClass;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\PaymentRepository;
 use Eccube\Repository\Master\OrderStatusRepository;
 use Eccube\Repository\OrderRepository;
+use Eccube\Repository\ProductClassRepository;
 use Eccube\Tests\Fixture\Generator;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -572,6 +575,79 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
         $this->expected = $Delivery->getName();
         $this->actual = $Shipping->getShippingDeliveryName();
         $this->verify();
+    }
+
+    /**
+     * Check can use point when has payment limit
+     */
+    public function testPaymentLimitAndPointCombination()
+    {
+        $Customer = $this->createCustomer();
+        $Customer->setPoint(99999);
+        $this->entityManager->flush($Customer);
+
+        $price = 40000;
+        $pointUse = 40000;
+        /** @var ProductClass $ProductClass */
+        $ProductClass = $this->container->get(ProductClassRepository::class)->find(1);
+        $ProductClass->setPrice02($price);
+        $this->entityManager->flush($ProductClass);
+
+        $Delivery = $this->container->get(Generator::class)->createDelivery();
+        $Delivery->setSaleType($ProductClass->getSaleType());
+        $this->entityManager->flush($Delivery);
+
+        $COD1 = $this->container->get(Generator::class)->createPayment($Delivery, 'COD1', 0, 0, 30000);
+        $COD2 = $this->container->get(Generator::class)->createPayment($Delivery, 'COD2', 0, 30001, 300000);
+
+        // カート画面
+        $this->scenarioCartIn($Customer, 1);
+
+        // 確認画面
+        $this->scenarioConfirm($Customer);
+
+        // without use point with payment: COD2
+        $this->scenarioRedirectTo($Customer, [
+            '_shopping_order' => [
+                'Shippings' => [
+                    0 => [
+                        'Delivery' => $Delivery->getId(),
+                        'DeliveryTime' => $Delivery->getDeliveryTimes()->first()->getId(),
+                    ],
+                ],
+                'Payment' => $COD2->getId(),
+                'use_point' => 0,
+                'message' => $this->getFaker()->realText(),
+                '_token' => 'dummy',
+            ],
+        ]);
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('shopping')));
+        $crawler = $this->client->followRedirect();
+        $html = $crawler->filter('body')->html();
+        $this->assertNotContains($COD1->getMethod(), $html);
+        $this->assertContains($COD2->getMethod(), $html);
+
+        // use point with payment: COD1
+        $this->scenarioRedirectTo($Customer, [
+            '_shopping_order' => [
+                'Shippings' => [
+                    0 => [
+                        'Delivery' => $Delivery->getId(),
+                        'DeliveryTime' => $Delivery->getDeliveryTimes()->first()->getId(),
+                    ],
+                ],
+                'Payment' => $COD2->getId(),
+                'use_point' => $pointUse,
+                'message' => $this->getFaker()->realText(),
+                '_token' => 'dummy',
+            ],
+        ]);
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('shopping')));
+        $crawler = $this->client->followRedirect();
+
+        $html = $crawler->filter('body')->html();
+        $this->assertContains($COD1->getMethod(), $html);
+        $this->assertNotContains($COD2->getMethod(), $html);
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
This PR to fix issue about payment limit (up-down) and use point

## 方針(Policy)
Uniform use paymentTotal for check and validate

## 実装に関する補足(Appendix)
Because there is inconsistency in programming(dev), when validating the price of the order is not successful.

## テスト（Test)
Env docker: 
- PHP 7.1.6
- PostgreSQL 9.4.19
- Apache/2.4.10

## 相談（Discussion）

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



