### PR TITLE
DBのパスワードに記号を利用できない不具合の修正 #3928

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ php:
 env:
   - DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
   - DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
-  - DATABASE_URL=sqlite:///%kernel.project_dir%/var/eccube.db DATABASE_SERVER_VERSION=3 COVERAGE=1
+  - DATABASE_URL=sqlite:///var/eccube.db DATABASE_SERVER_VERSION=3 COVERAGE=1
 
 matrix:
   allow_failures:
-    - env: DATABASE_URL=sqlite:///%kernel.project_dir%/var/eccube.db DATABASE_SERVER_VERSION=3 COVERAGE=1
+    - env: DATABASE_URL=sqlite:///var/eccube.db DATABASE_SERVER_VERSION=3 COVERAGE=1
 
 ## see https://github.com/symfony/symfony/blob/e0bdc0c35e9afdb3bee8af172f90e9648c4012fc/.travis.yml#L92-L97
 before_install: &php_setup |

--- a/app/config/eccube/packages/doctrine.yaml
+++ b/app/config/eccube/packages/doctrine.yaml
@@ -16,7 +16,7 @@ doctrine:
           collate: 'utf8_general_ci'
 
         # With Symfony 3.3, remove the `resolve:` prefix
-        url: '%env(resolve:DATABASE_URL)%'
+        url: '%env(DATABASE_URL)%'
 
         # types
         types:

--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -76,7 +76,7 @@ class InstallerCommand extends Command
         // DATABASE_URL
         $databaseUrl = $this->container->getParameter('eccube_database_url');
         if (empty($databaseUrl)) {
-            $databaseUrl = 'sqlite:///%kernel.project_dir%/var/eccube.db';
+            $databaseUrl = 'sqlite:///var/eccube.db';
         }
         $databaseUrl = $this->io->ask('Database Url', $databaseUrl);
 

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -575,7 +575,7 @@ class InstallController extends AbstractController
                 if (isset($params['database_user'])) {
                     $url .= $params['database_user'];
                     if (isset($params['database_password'])) {
-                        $url .= ':'.$params['database_password'];
+                        $url .= ':'.urlencode($params['database_password']);
                     }
                     $url .= '@';
                 }

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -301,7 +301,7 @@ class InstallController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             if ($data['database'] === 'pdo_sqlite') {
-                $data['database_name'] = '/%kernel.project_dir%/var/eccube.db';
+                $data['database_name'] = '/var/eccube.db';
             }
 
             $this->setSessionData($this->session, $data);
@@ -344,8 +344,6 @@ class InstallController extends AbstractController
             $noUpdate = $form['no_update']->getData();
 
             $url = $this->createDatabaseUrl($sessionData);
-            // for sqlite, resolve %kernel.project_dir% paramter.
-            $url = $this->container->getParameterBag()->resolveValue($url);
 
             try {
                 $conn = $this->createConnection(['url' => $url]);
@@ -575,7 +573,7 @@ class InstallController extends AbstractController
                 if (isset($params['database_user'])) {
                     $url .= $params['database_user'];
                     if (isset($params['database_password'])) {
-                        $url .= ':'.urlencode($params['database_password']);
+                        $url .= ':'.\rawurlencode($params['database_password']);
                     }
                     $url .= '@';
                 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- ref #3928 
- DBのパスワードで記号を利用できるように対応しました

## 方針(Policy)

- Webインストーラでは記号ありのパスワード文字列をそのまま入力できます。
- コンソールコマンドでインストールする場合は、パスワード部分を事前にrawurlencodeしてください。

## 4.0.0との仕様変更点について

- https://github.com/EC-CUBE/ec-cube/pull/3929#issuecomment-437760483 のため、DATABASE_URLには`%kernel.project_dir%`等のSymfonyパラメータは利用できなくなります。
- SQLiteの場合、DATABASE_URLは`sqlite:///var/eccube.db`と生成されます(データベースファイルは`[EC-CUBEのディレクトリ]/var/eccube.db`に生成されます)。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
以下の修正を行っています。

- database URIを作る際、パスワードの文字列に対しURLエンコードを行う
- symfonyのパラメータとして解釈されないよう、resolveしないように変更
- 上記に伴い、SQLiteで`%kernel.project_dir%`が使用できなくなるため、パスを修正

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
~ごめんなさい！~
- Webインストーラで、`jejW7!1Vo#ApE0D.dyR`をパスワードとして登録できることを確認
- インストール後、DB接続エラーが起きないことを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



