### PR TITLE
DoctrineMigrationBundle を動くよう修正

### DIFF
--- a/app/DoctrineMigrations/Version20181017090225.php
+++ b/app/DoctrineMigrations/Version20181017090225.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20181017090225 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+    }
+}

--- a/app/config/eccube/bundles.php
+++ b/app/config/eccube/bundles.php
@@ -16,6 +16,7 @@ return [
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
+    Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
     Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['all' => true],
     Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle::class => ['all' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],

--- a/app/config/eccube/packages/doctrine_migrations.yaml
+++ b/app/config/eccube/packages/doctrine_migrations.yaml
@@ -1,0 +1,4 @@
+doctrine_migrations:
+    dir_name: "%kernel.project_dir%/app/DoctrineMigrations"
+    namespace: DoctrineMigrations
+    organize_migrations: false


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
DoctrineMigrationsBundle を動くようにするため、設定を追加する

## 方針(Policy)

- `bin/console make:migration` でマイグレーションファイルが生成され、 `doctrine:migrations` コマンドが使用できるようになる
- マイグレーションファイルは app/DoctrineMigrations へ格納する
   - オートローディングの対象外とするため
- namespace は `DoctrineMigrations` とする

## 実装に関する補足(Appendix)

インストーラやプラグインから利用するには、別途設定が必要

## テスト（Test)

- `bin/console make:migration` で app/DoctrineMigrations へマイグレーションファイルが生成されるのを確認
- `bin/console doctrine:migrations:migrate` でマイグレーションが実行されるのを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## See Also

https://github.com/EC-CUBE/ec-cube/issues/3925

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



