### PR TITLE
Search text no matter if is in lower or upper case

### DIFF
--- a/html/template/admin/assets/js/function.js
+++ b/html/template/admin/assets/js/function.js
@@ -183,3 +183,28 @@ $(window).on('load', function() {
         icon.addClass('fa-angle-up');
     }
 });
+
+var searchWord = function (searchText, el) {
+    var targetText;
+
+    // 検索ボックスに値が入っていない場合
+    if (searchText == '') {
+        // 全て表示する
+        el.show();
+        return;
+    }
+
+    // 検索ボックスに値が入ってる場合
+    // 表示を全て空にする
+    el.hide();
+
+    // 検索ワードが（子を含めて）含まれる要素のみ表示
+    el.each(function () {
+        targetText = $(this).text();
+        // 検索対象となるリストに入力された文字列が存在するかどうかを判断
+        if (targetText.toLowerCase().indexOf(searchText.toLowerCase()) != -1) {
+            // 存在する場合はそのリストのテキストを用意した配列に格納
+            $(this).show();
+        }
+    });
+};

--- a/src/Eccube/Resource/template/admin/Content/block.twig
+++ b/src/Eccube/Resource/template/admin/Content/block.twig
@@ -25,35 +25,10 @@ file that was distributed with this source code.
 
 {% block javascript %}
     <script>
-        var searchWord = function () {
-            var searchText = $(this).val(), // 検索ボックスに入力された値
-                targetText;
-
-            // 検索ボックスに値が入っていない場合
-            if (searchText == '') {
-                // 全て表示する
-                $('.list-group li').show();
-                return;
-            }
-
-            // 検索ボックスに値が入ってる場合
-            // 表示を全て空にする
-            $('.list-group li').hide();
-
-            // 検索ワードが（子を含めて）含まれる要素のみ表示
-            $('.list-group li').each(function () {
-                targetText = $(this).find('> div.row > div > a').text();
-
-                // 検索対象となるリストに入力された文字列が存在するかどうかを判断
-                if (targetText.indexOf(searchText) != -1) {
-                    // 存在する場合はそのリストのテキストを用意した配列に格納
-                    $(this).show();
-                }
-            });
-        };
-
         // searchWordの実行
-        $('#search-block').on('input', searchWord);
+        $('#search-block').on('input', function () {
+            searchWord($(this).val(), $(".list-group li"));
+        });
     </script>
 {% endblock javascript %}
 

--- a/src/Eccube/Resource/template/admin/Content/layout.twig
+++ b/src/Eccube/Resource/template/admin/Content/layout.twig
@@ -153,33 +153,6 @@ file that was distributed with this source code.
         });
     </script>
     <script>
-        var searchWord = function(){
-            var searchText = $(this).val(), // 検索ボックスに入力された値
-                targetText;
-
-            // 検索ボックスに値が入っていない場合
-            if (searchText == '') {
-                // 全て表示する
-                $('#unused-block .sort').show();
-                return;
-            }
-
-            // 検索ボックスに値が入ってる場合
-            // 表示を全て空にする
-            $('#unused-block .sort').hide();
-
-            // 検索ワードが（子を含めて）含まれる要素のみ表示
-            $('#unused-block .sort').each(function() {
-                targetText = $(this).find('.col span').text();
-
-                // 検索対象となるリストに入力された文字列が存在するかどうかを判断
-                if (targetText.indexOf(searchText) != -1) {
-                    // 存在する場合はそのリストのテキストを用意した配列に格納
-                    $(this).show();
-                }
-            });
-        };
-
         // プレビューボタンクリック時
         {% if Layout.id -%}
         $('#preview-button').on('click', function(){
@@ -202,7 +175,9 @@ file that was distributed with this source code.
         {% endif %}
 
         // searchWordの実行
-        $('#search-block').on('input', searchWord);
+        $('#search-block').on('input', function () {
+            searchWord($(this).val(), $('#unused-block .sort'));
+        });
     </script>
 {% endblock javascript %}
 

--- a/src/Eccube/Resource/template/admin/Content/page.twig
+++ b/src/Eccube/Resource/template/admin/Content/page.twig
@@ -17,35 +17,10 @@ file that was distributed with this source code.
 
 {% block javascript %}
 <script>
-    var searchWord = function(){
-        var searchText = $(this).val(), // 検索ボックスに入力された値
-            targetText;
-
-        // 検索ボックスに値が入っていない場合
-        if (searchText == '') {
-            // 全て表示する
-            $('table.table tbody tr').show();
-            return;
-        }
-
-        // 検索ボックスに値が入ってる場合
-        // 表示を全て空にする
-        $('table.table tbody tr').hide();
-
-        // 検索ワードが（子を含めて）含まれる要素のみ表示
-        $('table.table tbody tr').each(function() {
-            targetText = $(this).find('td a').text();
-
-            // 検索対象となるリストに入力された文字列が存在するかどうかを判断
-            if (targetText.indexOf(searchText) != -1) {
-                // 存在する場合はそのリストのテキストを用意した配列に格納
-                $(this).show();
-            }
-        });
-    };
-
     // searchWordの実行
-    $('#search-page').on('input', searchWord);
+    $('#search-page').on('input', function () {
+        searchWord($(this).val(), $('table.table tbody tr'));
+    });
 </script>
 {% endblock javascript %}
 

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -220,37 +220,10 @@ file that was distributed with this source code.
             confirmFormChange($('#form1'), $('a[data-action="confirm"]'), $('#confirmFormChangeModal'))
         });
 
-    </script>
-    <script>
-        var searchWord = function() {
-            var searchText = $(this).val(), // 検索ボックスに入力された値
-                targetText
-
-            // 検索ボックスに値が入っていない場合
-            if (searchText == '') {
-                // 全て表示する
-                $('.category-li').show();
-                return;
-            }
-
-            // 検索ボックスに値が入ってる場合
-            // 表示を全て空にする
-            $('.category-li').hide();
-
-            // 検索ワードが（子を含めて）含まれる要素のみ表示
-            $('.category-li').each(function() {
-                targetText = $(this).text();
-
-                // 検索対象となるリストに入力された文字列が存在するかどうかを判断
-                if (targetText.indexOf(searchText) != -1) {
-                    // 存在する場合はそのリストのテキストを用意した配列に格納
-                    $(this).show();
-                }
-            });
-        };
-
         // searchWordの実行
-        $('#search-category').on('input', searchWord);
+        $('#search-category').on('input', function () {
+            searchWord($(this).val(), $('.category-li'));
+        });
     </script>
 {% endblock javascript %}
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
In English, you can not search for uppercase letters when you type lowercase letters and vice versa.

## 方針(Policy)
convert all character to lowercase letters when search

## 実装に関する補足(Appendix)
1. Move `searchWord` function to `function.js`
2. Change search at some pages:
- block
- page
- layout
- product

## テスト（Test)
on chrome, firefox, edge

## 相談（Discussion）
