### PR TITLE
Fix html5 validate conflict with ladda spinner

### DIFF
--- a/html/template/admin/assets/js/function.js
+++ b/html/template/admin/assets/js/function.js
@@ -117,7 +117,7 @@ var toggleBtnBulk = function(checkboxSelector, btnSelector) {
 /////////// 2重submit制御.
 
 if (typeof Ladda !== 'undefined') {
-    Ladda.bind('button[type=submit]');
+    Ladda.bind('button[type=submit]', {timeout: 2000});
 }
 
 // anchorをクリックした時にformを裏で作って指定のメソッドでリクエストを飛ばす


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
When the html5 validation fails, the ladda button can not be clicked again. (it's always disable)
![image](https://user-images.githubusercontent.com/36109121/47140036-4370fa00-d2f8-11e8-8ee2-a19122cdfec6.png)


## 方針(Policy)
Set timeout for that ladda button

## 実装に関する補足(Appendix)
Particular: 
- tax page - new button

## テスト（Test)
chrome, firefox, edge


## 相談（Discussion）
