### PR TITLE
Fix shopping overlay in firefox + other

### DIFF
--- a/app/DoctrineMigrations/Version20181109101907.php
+++ b/app/DoctrineMigrations/Version20181109101907.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20181109101907 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $this->addSql("UPDATE dtb_page SET page_name = '商品購入/遷移', url = 'shopping_redirect_to' WHERE id = 42");
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->addSql("UPDATE dtb_page SET page_name = '商品購入/お届け先変更', url = 'shopping_shipping_edit_change' WHERE id = 42");
+    }
+}

--- a/src/Eccube/Resource/doctrine/import_csv/dtb_page.csv
+++ b/src/Eccube/Resource/doctrine/import_csv/dtb_page.csv
@@ -36,6 +36,6 @@ id,page_name,url,file_name,edit_type,author,description,keyword,create_date,upda
 "23","商品購入","shopping","Shopping/index","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
 "7","MYページ/お届け先一覧","mypage_delivery","Mypage/delivery","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
 "8","MYページ/お届け先追加","mypage_delivery_new","Mypage/delivery_edit","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"42","商品購入/お届け先変更","shopping_shipping_edit_change","Shopping/index","2",,,,"2017-03-07 01:15:03","2017-03-07 01:15:03","noindex",,"page"
+"42","商品購入/遷移","shopping_redirect_to","Shopping/index","2",,,,"2017-03-07 01:15:03","2017-03-07 01:15:03","noindex",,"page"
 "44","MYページ/お届け先編集","mypage_delivery_edit","Mypage/delivery_edit","2",,,,"2017-03-07 01:15:05","2017-03-07 01:15:05","noindex",8,"page"
 "45","商品購入/ご注文確認","shopping_confirm","Shopping/confirm","2",,,,"2017-03-07 01:15:03","2017-03-07 01:15:03","noindex",,"page"

--- a/src/Eccube/Resource/template/default/Shopping/index.twig
+++ b/src/Eccube/Resource/template/default/Shopping/index.twig
@@ -19,6 +19,9 @@ file that was distributed with this source code.
                 loadingOverlay();
                 $('#shopping_order_redirect_to').val($(this).attr('data-path'));
                 $('#shopping-form').attr('action', '{{ url("shopping_redirect_to") }}').submit();
+                setTimeout(function () {
+                    loadingOverlay("hide");
+                }, 2000);
             };
             $('[data-trigger]').each(function() {
                 $(this).on($(this).attr('data-trigger'), $redirectCallback);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
This pr to fix:
1. Overlay will not remove when there is an error (**firefox only**) at the shopping page.
2. `shopping_redirect_to` route without header/footer.
3. #3939

## 方針(Policy)
- Issue 1: Set timeout for overlay if the page don't reload.
- Issue 2 & 3: change `商品購入/お届け先変更` => `商品購入/遷移` and `shopping_shipping_edit_change` => `shopping_redirect_to` 

## 実装に関する補足(Appendix)
1. reproduce (firefox only):
- step 1: go to the shopping page (with a product).
- step 2: click on `変更` button of `お届け先`.
- step 3: The shopping page will be overlay and html validation fail at the payment section => we cannot do anything
![capture](https://user-images.githubusercontent.com/36109121/47203532-a7102b80-d3bb-11e8-9ea4-71442e2752de.PNG)

2. 
![capture2](https://user-images.githubusercontent.com/36109121/47203539-af686680-d3bb-11e8-8767-8c7959d6a4c2.PNG)


## テスト（Test)
firefox, chrome, edge

## 相談（Discussion）


- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更