### PR TITLE
AppVeyor が落ちるのを修正

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,6 @@ cache:
   - '%LOCALAPPDATA%\Composer\files'
   - vendor
   - bin\.phpunit
-  - C:\ProgramData\chocolatey\bin -> appveyor.yml
-  - C:\ProgramData\chocolatey\lib -> appveyor.yml
 
 # Fix line endings in Windows. (runs before repo cloning)
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
   #- cinst mysql
   #- SET PATH=C:\tools\mysql\current\bin\;%PATH%
   # Set PHP.
-  - cinst php --version 7.2.9 --allow-empty-checksums
+  - cinst php --version 7.2.10 --allow-empty-checksums
   - SET PATH=C:\tools\php72\;%PATH%
   - copy C:\tools\php72\php.ini-production C:\tools\php72\php.ini
   - echo date.timezone="Asia/Tokyo" >> C:\tools\php72\php.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ services:
 # Install scripts. (runs after repo cloning)
 install:
   # see https://github.com/phpmd/phpmd/blob/master/appveyor.yml#L10-L13
-  - cinst -y OpenSSL.Light
+  - cinst -y OpenSSL.Light --version 1.1.1
   - SET PATH=C:\Program Files\OpenSSL;%PATH%
   - sc config wuauserv start= auto
   - net start wuauserv


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
- [OpenSSL.Light 1.1.1.20181020](https://chocolatey.org/packages/OpenSSL.Light) が依存関係でエラーになるため、 1.1.1 にバージョンを固定
- PHP7.2.10 へバージョンアップ
- Chocolatly のキャッシュ設定が警告を出すため削除

## 実装に関する補足(Appendix)
OpenSSL.Light 1.1.1 から 1.1.1.20181020 の変更点は、 [Microsoft Visual C++ Redistributable for Visual Studio 2017](https://chocolatey.org/packages/vcredist140) の依存関係が追加されているのみである。
このパッケージは AppVeyor の環境では不要と思われるため、 OpenSSL.Light 1.1.1 の固定で問題ない

## テスト（Test)
AppVeyor のテストが通るのを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



