### PR TITLE
バリデーションメッセージをvalidators.ja.yamlに移動

### DIFF
--- a/src/Eccube/Entity/Customer.php
+++ b/src/Eccube/Entity/Customer.php
@@ -330,7 +330,7 @@ if (!class_exists('\Eccube\Entity\Customer')) {
         {
             $metadata->addConstraint(new UniqueEntity([
             'fields' => 'email',
-            'message' => 'common.customer_already_exists',
+            'message' => trans('common.customer_already_exists'),
             'repositoryMethod' => 'getNonWithdrawingCustomers',
         ]));
         }

--- a/src/Eccube/Entity/Customer.php
+++ b/src/Eccube/Entity/Customer.php
@@ -330,7 +330,7 @@ if (!class_exists('\Eccube\Entity\Customer')) {
         {
             $metadata->addConstraint(new UniqueEntity([
             'fields' => 'email',
-            'message' => trans('common.customer_already_exists'),
+            'message' => 'form.type.customer_already_exists',
             'repositoryMethod' => 'getNonWithdrawingCustomers',
         ]));
         }

--- a/src/Eccube/Entity/Customer.php
+++ b/src/Eccube/Entity/Customer.php
@@ -329,10 +329,10 @@ if (!class_exists('\Eccube\Entity\Customer')) {
         public static function loadValidatorMetadata(ClassMetadata $metadata)
         {
             $metadata->addConstraint(new UniqueEntity([
-            'fields' => 'email',
-            'message' => 'form.type.customer_already_exists',
-            'repositoryMethod' => 'getNonWithdrawingCustomers',
-        ]));
+                'fields' => 'email',
+                'message' => 'form_error.customer_already_exists',
+                'repositoryMethod' => 'getNonWithdrawingCustomers',
+            ]));
         }
 
         /**

--- a/src/Eccube/Entity/Member.php
+++ b/src/Eccube/Entity/Member.php
@@ -33,9 +33,9 @@ if (!class_exists('\Eccube\Entity\Member')) {
         public static function loadValidatorMetadata(ClassMetadata $metadata)
         {
             $metadata->addConstraint(new UniqueEntity([
-            'fields' => 'login_id',
-            'message' => 'common.member_already_exists',
-        ]));
+                'fields' => 'login_id',
+                'message' => 'form_error.member_already_exists',
+            ]));
         }
 
         /**

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -72,7 +72,6 @@ common.signup: 新規会員登録
 common.forgot_login: ログイン情報をお忘れですか？
 common.customer_address_count_is_over: お届け先登録の上限の%eccube_deliv_addr_max%件に達しています。お届け先を入力したい場合は、削除か変更を行ってください。
 common.search_keyword: キーワードを入力
-common.member_already_exists: 既に利用されているログインIDです
 common.delete_confirm: 削除してもよろしいですか?
 common.pagetop: ページトップへ
 

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -72,7 +72,6 @@ common.signup: 新規会員登録
 common.forgot_login: ログイン情報をお忘れですか？
 common.customer_address_count_is_over: お届け先登録の上限の%eccube_deliv_addr_max%件に達しています。お届け先を入力したい場合は、削除か変更を行ってください。
 common.search_keyword: キーワードを入力
-common.customer_already_exists: このメールアドレスは利用できません
 common.member_already_exists: 既に利用されているログインIDです
 common.delete_confirm: 削除してもよろしいですか?
 common.pagetop: ページトップへ

--- a/src/Eccube/Resource/locale/validators.ja.yaml
+++ b/src/Eccube/Resource/locale/validators.ja.yaml
@@ -57,6 +57,7 @@ errors.graph_and_hyphen: 半角英数字かハイフンのみを入力してく�
 form.type.graph.invalid: 半角英数字で入力してください。
 form.type.name.firstname.nothasspace: お名前(名)にスペース、タブ、改行は含めないで下さい。
 form.type.name.lastname.nothasspace: お名前(性)にスペース、タブ、改行は含めないで下さい。
+form.type.customer_already_exists: このメールアドレスは利用できません
 form.type.customer.password.too_short: パスワードが短すぎます。{{ limit }}文字以上でなければなりません。
 form.type.customer.password.too_long: パスワードが長すぎます。{{ limit }}文字以内でなければなりません。
 form.type.customer.company.nothasspace: 会社名にスペース、タブ、改行は含めないで下さい。

--- a/src/Eccube/Resource/locale/validators.ja.yaml
+++ b/src/Eccube/Resource/locale/validators.ja.yaml
@@ -40,6 +40,8 @@ form_error.float_only: 数字と小数点のみ入力できます。
 form_error.same_password: 同じパスワードを入力してください。
 form_error.same_email: 同じメールアドレスを入力してください。
 form_error.admin_is_not_available: ディレクトリ名に「admin」を使用することはできません。
+form_error.member_already_exists: 既に利用されているログインIDです
+form_error.customer_already_exists:  このメールアドレスは利用できません
 
 #------------------------------------------------------------------------------------
 # Deplicated
@@ -57,7 +59,6 @@ errors.graph_and_hyphen: 半角英数字かハイフンのみを入力してく�
 form.type.graph.invalid: 半角英数字で入力してください。
 form.type.name.firstname.nothasspace: お名前(名)にスペース、タブ、改行は含めないで下さい。
 form.type.name.lastname.nothasspace: お名前(性)にスペース、タブ、改行は含めないで下さい。
-form.type.customer_already_exists: このメールアドレスは利用できません
 form.type.customer.password.too_short: パスワードが短すぎます。{{ limit }}文字以上でなければなりません。
 form.type.customer.password.too_long: パスワードが長すぎます。{{ limit }}文字以内でなければなりません。
 form.type.customer.company.nothasspace: 会社名にスペース、タブ、改行は含めないで下さい。


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

バリデーションメッセージがmessages.ja.yamlに定義されており翻訳に失敗していたので、validators.ja.yamlに移動

以下の引き継ぎ
https://github.com/EC-CUBE/ec-cube/pull/3850

## 方針(Policy)


## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



