### PR TITLE
プラグインのマイグレーション機能

### DIFF
--- a/app/Plugin/MigrationSample/DoctrineMigrations/Version20181101012712.php
+++ b/app/Plugin/MigrationSample/DoctrineMigrations/Version20181101012712.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Plugin\MigrationSample\DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20181101012712 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $Table = $schema->getTable('dtb_base_info');
+        if ($Table->hasColumn('migration_sample')) {
+            $this->addSql('UPDATE dtb_base_info SET migration_sample = ? WHERE id = 1', ['up']);
+            dump('up');
+        }
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $Table = $schema->getTable('dtb_base_info');
+        if ($Table->hasColumn('migration_sample')) {
+            $this->addSql('UPDATE dtb_base_info SET migration_sample = ? WHERE id = 1', ['down']);
+            dump('down');
+        }
+    }
+}

--- a/app/Plugin/MigrationSample/Entity/BaseInfo3Trait.php
+++ b/app/Plugin/MigrationSample/Entity/BaseInfo3Trait.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\MigrationSample\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Eccube\Annotation\EntityExtension;
+
+/**
+ * @EntityExtension("Eccube\Entity\BaseInfo")
+ */
+trait BaseInfo3Trait
+{
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="migration_sample", type="string", length=255, nullable=true)
+     */
+    private $migration_sample;
+}

--- a/app/Plugin/MigrationSample/PluginManager.php
+++ b/app/Plugin/MigrationSample/PluginManager.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\MigrationSample;
+
+use Eccube\Plugin\AbstractPluginManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class PluginManager.
+ */
+class PluginManager extends AbstractPluginManager
+{
+    const VERSION = '1.0.0';
+    /**
+     * Install the plugin.
+     *
+     * @param array $meta
+     * @param ContainerInterface $container
+     */
+    public function install(array $meta, ContainerInterface $container)
+    {
+        dump('install '.self::VERSION);
+    }
+
+    /**
+     * Update the plugin.
+     *
+     * @param array $meta
+     * @param ContainerInterface $container
+     */
+    public function update(array $meta, ContainerInterface $container)
+    {
+        $entityManager = $container->get('doctrine')->getManager();
+        dump('update '.self::VERSION);
+        $this->migration($entityManager->getConnection(), $meta['code']);
+    }
+
+    /**
+     * Enable the plugin.
+     *
+     * @param array $meta
+     * @param ContainerInterface $container
+     */
+    public function enable(array $meta, ContainerInterface $container)
+    {
+        dump('enable '.self::VERSION);
+    }
+
+    /**
+     * Disable the plugin.
+     *
+     * @param array $meta
+     * @param ContainerInterface $container
+     */
+    public function disable(array $meta, ContainerInterface $container)
+    {
+        $entityManager = $container->get('doctrine')->getManager();
+        dump('disable '.self::VERSION);
+        $this->migration($entityManager->getConnection(), $meta['code'], '0');
+    }
+
+    /**
+     * Uninstall the plugin.
+     *
+     * @param array $meta
+     * @param ContainerInterface $container
+     */
+    public function uninstall(array $meta, ContainerInterface $container)
+    {
+        dump('uninstall '.self::VERSION);
+    }
+}

--- a/app/Plugin/MigrationSample/composer.json
+++ b/app/Plugin/MigrationSample/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Eccube/MigrationSample",
+  "name": "ec-cube/MigrationSample",
   "version": "1.0.0",
   "description": "マイグレーションのサンプルプラグイン",
   "type": "eccube-plugin",

--- a/app/Plugin/MigrationSample/composer.json
+++ b/app/Plugin/MigrationSample/composer.json
@@ -1,0 +1,12 @@
+{
+  "name": "Eccube/MigrationSample",
+  "version": "1.0.0",
+  "description": "マイグレーションのサンプルプラグイン",
+  "type": "eccube-plugin",
+  "require": {
+    "ec-cube/plugin-installer": "~0.0.6"
+  },
+  "extra": {
+    "code": "MigrationSample"
+  }
+}

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -71,7 +71,7 @@ services:
 
     Plugin\:
         resource: '../../../app/Plugin/*'
-        exclude: '../../../app/Plugin/*/{Entity,Resource,ServiceProvider,Tests}'
+        exclude: '../../../app/Plugin/*/{Entity,Resource,ServiceProvider,Tests,DoctrineMigrations}'
 
     Customize\:
         resource: '../../../app/Customize/*'

--- a/src/Eccube/Plugin/AbstractPluginManager.php
+++ b/src/Eccube/Plugin/AbstractPluginManager.php
@@ -39,7 +39,7 @@ abstract class AbstractPluginManager
      */
     public function migration(Connection $connection, $pluginCode, $version = null, $migrationFilePath = null)
     {
-        if (!$migrationFilePath) {
+        if (null === $migrationFilePath) {
             $migrationFilePath = __DIR__.'/../../../app/Plugin/'.$pluginCode.'/DoctrineMigrations';
         }
         $config = new Configuration($connection);

--- a/src/Eccube/Plugin/AbstractPluginManager.php
+++ b/src/Eccube/Plugin/AbstractPluginManager.php
@@ -13,11 +13,43 @@
 
 namespace Eccube\Plugin;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Migrations\Migration;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 abstract class AbstractPluginManager
 {
     const MIGRATION_TABLE_PREFIX = 'migration_';
+
+    /**
+     * プラグインのマイグレーションを実行する.
+     *
+     * PluginManager 実行時に、 Doctrine SchemaUpdate が自動的に行なわれるため、
+     * このメソッドは主にデータの更新に使用する.
+     *
+     * 引数 $version で指定したバージョンまでマイグレーションする.
+     * null 又は 'last' を渡すと最新バージョンまでマイグレートする.
+     * 0 又は 'first' を渡すと最初に戻る。
+     *
+     * @param Connection $connection Doctrine Connection
+     * @param string $pluginCode プラグインコード
+     * @param string $version マイグレーション先のバージョン
+     * @param string $migrationFilePath マイグレーションファイルを格納したファイルパス. 指定しない場合は app/Plugin/<pluginCode>/DoctrineMigrations を使用する
+     */
+    public function migration(Connection $connection, $pluginCode, $version = null, $migrationFilePath = null)
+    {
+        if (!$migrationFilePath) {
+            $migrationFilePath = __DIR__.'/../../../app/Plugin/'.$pluginCode.'/DoctrineMigrations';
+        }
+        $config = new Configuration($connection);
+        $config->setMigrationsNamespace('\Plugin\\'.$pluginCode.'\DoctrineMigrations');
+        $config->setMigrationsDirectory($migrationFilePath);
+        $config->registerMigrationsFromDirectory($migrationFilePath);
+        $config->setMigrationsTableName(self::MIGRATION_TABLE_PREFIX.$pluginCode);
+        $migration = new Migration($config);
+        $migration->migrate($version, false);
+    }
 
     /**
      * Install the plugin.

--- a/src/Eccube/Plugin/AbstractPluginManager.php
+++ b/src/Eccube/Plugin/AbstractPluginManager.php
@@ -29,8 +29,8 @@ abstract class AbstractPluginManager
      * このメソッドは主にデータの更新に使用する.
      *
      * 引数 $version で指定したバージョンまでマイグレーションする.
-     * null 又は 'last' を渡すと最新バージョンまでマイグレートする.
-     * 0 又は 'first' を渡すと最初に戻る。
+     * null を渡すと最新バージョンまでマイグレートする.
+     * 0 を渡すと最初に戻る。
      *
      * @param Connection $connection Doctrine Connection
      * @param string $pluginCode プラグインコード


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
プラグインごとのマイグレーション機能の実装

PluginManager 実行時に、 Doctrine SchemaUpdate が自動的に行なわれるため、この機能は主にデータの更新に使用する.

## 方針(Policy)

- 基本的に3系と同様の実装
   - 4.0 の実態に合わせて引数を変更
- namespace は `\Plugin\<PluginCode>\DoctrineMigrations` とする

## 実装に関する補足(Appendix)
 - マイグレーションファイルの namespace は、クラスのオートローディングから除外することが推奨されているが、 `\Plugin` 以下がすべて PSR-4 Autoload の対象となっているため、除外することが難しい
    - Symfony DI の Autowire からは除外している

## テスト（Test)

マイグレーションのサンプルプラグインが正常に動作することを確認
https://github.com/EC-CUBE/ec-cube/pull/3960/commits/85cc66039da0f70f8a4bae84ed9deddb994d8e37

## See Also

https://github.com/EC-CUBE/ec-cube/issues/3948

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



