### PR TITLE
管理画面へのアクセス制御(3.0)

### DIFF
--- a/.htaccess.sample
+++ b/.htaccess.sample
@@ -25,3 +25,18 @@ DirectoryIndex index.php index.html .ht
     RewriteCond %{REQUEST_FILENAME} !^(.*)\.(gif|png|jpe?g|css|ico|js|svg)$ [NC]
     RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>
+
+# 管理画面へのBasic認証サンプル
+#
+# Satisfy Any
+#
+# AuthType Basic
+# AuthName "Please enter username and password"
+# AuthUserFile /path/to/.htpasswd
+# AuthGroupFile /dev/null
+# require valid-user
+#
+# SetEnvIf Request_URI "^/admin" admin_path  # ^/adminは, 管理画面URLに応じて変更してください
+# Order Allow,Deny
+# Allow from all
+# Deny from env=admin_path

--- a/html/.htaccess
+++ b/html/.htaccess
@@ -21,3 +21,18 @@ allow from all
     RewriteCond %{REQUEST_FILENAME} !^(.*)\.(gif|png|jpe?g|css|ico|js|svg)$ [NC]
     RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>
+
+# 管理画面へのBasic認証サンプル
+#
+# Satisfy Any
+#
+# AuthType Basic
+# AuthName "Please enter username and password"
+# AuthUserFile /path/to/.htpasswd
+# AuthGroupFile /dev/null
+# require valid-user
+#
+# SetEnvIf Request_URI "^/admin" admin_path  # ^/adminは, 管理画面URLに応じて変更してください
+# Order Allow,Deny
+# Allow from all
+# Deny from env=admin_path

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -319,7 +319,7 @@ class Application extends ApplicationTrait
             if ($app->isAdminRequest()) {
                 // IP制限チェック
                 $allowHost = $app['config']['admin_allow_host'];
-                if (count($allowHost) > 0) {
+                if (is_array($allowHost) && count($allowHost) > 0) {
                     if (array_search($app['request']->getClientIp(), $allowHost) === false) {
                         throw new \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException();
                     }

--- a/src/Eccube/Controller/Admin/AdminController.php
+++ b/src/Eccube/Controller/Admin/AdminController.php
@@ -79,6 +79,12 @@ class AdminController extends AbstractController
             }
         }
 
+        $is_danger_admin_url = false;
+        // 管理画面URLのチェック
+        if (isset($app['config']['admin_route']) && $app['config']['admin_route'] == 'admin') {
+            $is_danger_admin_url = true;
+        }
+
         // 受注マスター検索用フォーム
         $searchOrderBuilder = $app['form.factory']
             ->createBuilder('admin_search_order');
@@ -188,6 +194,7 @@ class AdminController extends AbstractController
             'salesYesterday' => $salesYesterday,
             'countNonStockProducts' => $countNonStockProducts,
             'countCustomers' => $countCustomers,
+            'is_danger_admin_url' => $is_danger_admin_url,
         ));
     }
 

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -129,6 +129,11 @@ class SecurityController extends AbstractController
             $form->get('force_ssl')->setData((bool)$app['config']['force_ssl']);
         }
 
+        // 管理画面URLのチェック
+        if (isset($app['config']['admin_route']) && $app['config']['admin_route'] == 'admin') {
+            $app->addWarning('admin.system.security.admin.url.warning', 'admin');
+        }
+
         return $app->render('Setting/System/security.twig', array(
             'form' => $form->createView(),
         ));

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -123,7 +123,7 @@ class SecurityController extends AbstractController
             // セキュリティ情報の取得
             $form->get('admin_route_dir')->setData($app['config']['admin_route']);
             $allowHost = $app['config']['admin_allow_host'];
-            if (count($allowHost) > 0) {
+            if (is_array($allowHost) && count($allowHost) > 0) {
                 $form->get('admin_allow_host')->setData(Str::convertLineFeed(implode("\n", $allowHost)));
             }
             $form->get('force_ssl')->setData((bool)$app['config']['force_ssl']);

--- a/src/Eccube/Form/Type/Install/Step3Type.php
+++ b/src/Eccube/Form/Type/Install/Step3Type.php
@@ -100,6 +100,7 @@ class Step3Type extends AbstractType
                         'max' => $this->app['config']['id_max_len'],
                     )),
                     new Assert\Regex(array('pattern' => '/\A\w+\z/')),
+                    new Assert\NotEqualTo(array('value' => 'admin', 'message' => 'ディレクトリ名に「admin」を使用することはできません。')),
                 ),
             ))
             ->add('admin_force_ssl', 'checkbox', array(

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -177,6 +177,7 @@ admin.content.cache.save.complete: キャッシュを削除しました。
 
 admin.system.security.save.complete: セキュリティ設定を保存しました。
 admin.system.security.route.dir.complete: 管理画面のURLを変更しましたので再ログインをしてください。
+admin.system.security.admin.url.warning: 管理画面URLは、セキュリティのため推測されにくいものを設定してください。
 
 admin.system.authority.save.complete: 権限設定を保存しました。
 

--- a/src/Eccube/Resource/template/admin/error.twig
+++ b/src/Eccube/Resource/template/admin/error.twig
@@ -28,6 +28,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     <meta name="description" content="">
     <meta name="author" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex,nofollow" />
     <link rel="icon" href="{{ app.config.admin_urlpath }}/assets/img/favicon.ico">
     <link rel="stylesheet" href="{{ app.config.admin_urlpath }}/assets/css/bootstrap.min.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}">
     <link rel="stylesheet" href="{{ app.config.admin_urlpath }}/assets/css/dashboard.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}">

--- a/src/Eccube/Resource/template/admin/index.twig
+++ b/src/Eccube/Resource/template/admin/index.twig
@@ -44,7 +44,14 @@ $(function(){
 {% endblock javascript %}
 
 {% block main %}
-
+    {% if is_danger_admin_url %}
+        <div class="row">
+            <div class="alert alert-warning alert-dismissable alert-section">
+                <button type="button" class="close" data-dismiss="alert"><span class="alert-close" aria-hidden="true">×</span></button>
+                <svg class="cb cb-info-circle"> <use xlink:href="#cb-info-circle"></use></svg> 管理画面URLは、セキュリティのため推測されにくいものを設定してください。「<a href="{{ url('admin_setting_system_security') }}">セキュリティ管理</a>」から設定できます。
+            </div>
+        </div>
+    {% endif %}
         <div class="row">
             <div class="col-md-6">
                 <form id="order-state" name="form1" action="{{ url('admin_order') }}" method="post">

--- a/tests/Eccube/Tests/Form/Type/Install/Step3TypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Install/Step3TypeTest.php
@@ -272,4 +272,12 @@ class Step3TypeTest extends AbstractTypeTestCase
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());
     }
+
+    public function testInValid_AdminDir()
+    {
+        $this->formData['admin_dir'] = 'admin';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

+ #3987 の対応

## 方針(Policy)
+ 管理画面URLの警告表示について、以下のように実装しています。
  - Webインストーラで管理画面URLに`admin`はバリデーションエラーとする
  - 管理画面のセキュリティ管理では、後方互換のため`admin`の入力は可能
  - `admin`利用時、管理画面ダッシュボード/セキュリティ管理で警告が表示される
  

## 実装に関する補足(Appendix)
+ ダッシュボードの警告表示は、htmlがエスケープされるため、Admin/index.twigに実装しています。

## テスト（Test)
+ インストール時にadminがバリデーションエラーになることを確認
- 管理画面ダッシュボード/セキュリティ管理で警告が表示されることを確認
- Basic認証が動作することを確認
- 管理画面のエラーページでnoindexが出力されていることを確認

## 相談（Discussion）
+ 相談したいことや意見を求めたいこと

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



