### PR TITLE
インストール時にディレクトリに加えてファイルの書き込み権限もチェックする処理を追加

### DIFF
--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -1566,7 +1566,7 @@ install.start_eccube_installation: '<p>EC-CUBEのインストールを開始し�
 install.cooperation_of_providing_information: 'EC-CUBEのシステム向上・デバッグのため、サイト情報の提供にご協力おねがいいたします。<br>目的以外で利用することはございません。<br><span class="small">（サイト情報：お店のURL、PHPバージョン、DBバージョン）</span>'
 install.accept_infomation_provision: 送信を承諾する
 install.permission_is_valid: アクセス権限は正常です
-install.permission_is_invalid: 以下のディレクトリのアクセス制限を変更してください。
+install.permission_is_invalid: 以下のファイルまたはディレクトリに書き込み権限を付与してください。
 install.system_requirement: システム要件をご確認ください
 install.required_extension_disabled: '[必須] %module%拡張モジュールが有効になっていません。'
 install.required_database_extension_disabled: '[必須] pdo_pgsql又はpdo_mysql 拡張モジュールを有効にしてください。'

--- a/src/Eccube/Resource/template/install/step2.twig
+++ b/src/Eccube/Resource/template/install/step2.twig
@@ -23,18 +23,18 @@ file that was distributed with this source code.
                     <div class="row">
                         <div class="col-md-12">
                             <textarea class="form-control disp_area" name="disp_area">
-                                {% if protectedDirs|length == 0 %}
-                                    &gt;&gt;○：{{ 'install.permission_is_valid'|trans }}
-                                {% else %}
-                                    {{ 'install.permission_is_invalid'|trans }}
-                                    {% for dir in protectedDirs %}
-                                        &gt;&gt;☓：{{ dir }}
-                                    {% endfor %}
-                                {% endif %}
+{% if noWritePermissions|length == 0 %}
+&gt;&gt;○：{{ 'install.permission_is_valid'|trans }}
+{% else %}
+{{ 'install.permission_is_invalid'|trans }}
+{% for noWritePermission in noWritePermissions %}
+&gt;&gt;☓：{{ noWritePermission }}
+{% endfor %}
+{% endif %}
                             </textarea>
                             <ul class="btn_area">
                                 <li>
-                                    {% if protectedDirs|length > 0 %}
+                                    {% if noWritePermissions|length > 0 %}
                                         <a href="{{ path('install_step2') }}" class="btn btn-primary btn-block btn-lg">{{ 'install.update'|trans }}</a>
                                     {% else %}
                                         <a href="{{ path('install_step3') }}" class="btn btn-primary btn-block btn-lg">{{ 'install.next'|trans }}</a>

--- a/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
+++ b/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
@@ -85,7 +85,7 @@ class InstallControllerTest extends AbstractWebTestCase
     public function testStep2()
     {
         $this->actual = $this->controller->step2($this->request);
-        $this->assertArrayHasKey('protectedDirs', $this->actual);
+        $this->assertArrayHasKey('noWritePermissions', $this->actual);
     }
 
     public function testStep3()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ EC-CUBE自体のアップデートを管理画面から実行するためには、全ファイル/ディレクトリへ書き込み権限が必要となる。

## 方針(Policy)
webインストール時の権限チェックについて、
+ 権限チェックの範囲をプロジェクトは以下の全フェイルに変更
+ ディレクトリに加えてファイルの書き込み権限もチェックする処理を追加

## 実装に関する補足(Appendix)
+ 文言、スペース等も調整しました。

## テスト（Test)
+ step2のUnitTestが通ることを確認
+ ローカルにてwebインストーラでインストール完了できることを確認
+ ファイル/ディレクトリそれぞれで書き込み権限がない場合に警告が出ることを確認

## 相談（Discussion）
+ UnitTestにて書き込み権限を変更する方法がありましたら教えてください。

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ Step2にてtwigに渡しているパラメータの変数名を処理内容に合わせて変更しています。
  - 基本的にカスタマイズがないインストール処理なので既存プラグインには影響がない想定です。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



