### PR TITLE
管理画面のアクセス制限強化

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -49,3 +49,18 @@ DirectoryIndex index.php index.html .ht
     RewriteCond %{REQUEST_FILENAME} !^(.*)\.(gif|png|jpe?g|css|ico|js|svg|map)$ [NC]
     RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>
+
+# 管理画面へのBasic認証サンプル
+# 
+# Satisfy Any
+#
+# AuthType Basic
+# AuthName "Please enter username and password"
+# AuthUserFile /path/to/.htpasswd
+# AuthGroupFile /dev/null
+# require valid-user
+#
+# SetEnvIf Request_URI "^/admin" admin_path
+# Order Allow,Deny
+# Allow from all
+# Deny from env=admin_path

--- a/.htaccess
+++ b/.htaccess
@@ -58,7 +58,7 @@ DirectoryIndex index.php index.html .ht
 #     AuthGroupFile /dev/null
 #     require valid-user
 #
-#     SetEnvIf Request_URI "^/admin" admin_path
+#     SetEnvIf Request_URI "^/admin" admin_path  # ^/adminは, 管理画面URLに応じて変更してください
 # <RequireAll>
 #     Require all granted
 #     Require not env admin_path

--- a/.htaccess
+++ b/.htaccess
@@ -54,13 +54,10 @@ DirectoryIndex index.php index.html .ht
 # 
 # Satisfy Any
 #
+# <Location /admin>
 # AuthType Basic
 # AuthName "Please enter username and password"
 # AuthUserFile /path/to/.htpasswd
 # AuthGroupFile /dev/null
 # require valid-user
-#
-# SetEnvIf Request_URI "^/admin" admin_path
-# Order Allow,Deny
-# Allow from all
-# Deny from env=admin_path
+# </Location>

--- a/.htaccess
+++ b/.htaccess
@@ -52,12 +52,14 @@ DirectoryIndex index.php index.html .ht
 
 # 管理画面へのBasic認証サンプル
 # 
-# Satisfy Any
+#     AuthType Basic
+#     AuthName "Please enter username and password"
+#     AuthUserFile /path/to/.htpasswd
+#     AuthGroupFile /dev/null
+#     require valid-user
 #
-# <Location /admin>
-# AuthType Basic
-# AuthName "Please enter username and password"
-# AuthUserFile /path/to/.htpasswd
-# AuthGroupFile /dev/null
-# require valid-user
-# </Location>
+#     SetEnvIf Request_URI "^/admin" admin_path
+# <RequireAll>
+#     Require all granted
+#     Require not env admin_path
+# </RequireAll>#

--- a/src/Eccube/Controller/Admin/AdminController.php
+++ b/src/Eccube/Controller/Admin/AdminController.php
@@ -169,6 +169,10 @@ class AdminController extends AbstractController
      */
     public function index(Request $request)
     {
+        $adminRoute = $this->eccubeConfig['eccube_admin_route'];
+        if ($adminRoute === 'admin') {
+            $this->addWarning('adminは危険です', 'admin');
+        }
         /**
          * 受注状況.
          */

--- a/src/Eccube/Controller/Admin/AdminController.php
+++ b/src/Eccube/Controller/Admin/AdminController.php
@@ -170,8 +170,9 @@ class AdminController extends AbstractController
     public function index(Request $request)
     {
         $adminRoute = $this->eccubeConfig['eccube_admin_route'];
+        $is_danger_admin_url = false;
         if ($adminRoute === 'admin') {
-            $this->addWarning('adminは危険です', 'admin');
+            $is_danger_admin_url = true;
         }
         /**
          * 受注状況.
@@ -265,6 +266,7 @@ class AdminController extends AbstractController
             'countProducts' => $countProducts,
             'countCustomers' => $countCustomers,
             'recommendedPlugins' => $recommendedPlugins,
+            'is_danger_admin_url' => $is_danger_admin_url,
         ];
     }
 

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -98,7 +98,7 @@ class SecurityController extends AbstractController
         // 管理画面URLがadminの場合アラートを表示する。
         $adminRoute = $this->eccubeConfig['eccube_admin_route'];
         if ($adminRoute === 'admin') {
-            $this->addWarning('admin.setting.system.security.admin.url.warning', 'admin');
+            $this->addWarning('admin.setting.system.security.admin_url_warning', 'admin');
         }
 
         return [

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -96,6 +96,7 @@ class SecurityController extends AbstractController
 
             return $this->redirectToRoute('admin_setting_system_security');
         }
+
         if ($adminRoute === 'admin') {
             $this->addWarning('管理画面URLは、セキュリティのため推測されにくいものを設定してください。', 'admin');
         }

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -46,9 +46,6 @@ class SecurityController extends AbstractController
     public function index(Request $request, CacheUtil $cacheUtil)
     {
         $adminRoute = $this->eccubeConfig['eccube_admin_route'];
-        if ($adminRoute === 'admin') {
-            $this->addWarning('adminは危険です', 'admin');
-        }
 
         $builder = $this->formFactory->createBuilder(SecurityType::class);
         $form = $builder->getForm();
@@ -98,6 +95,9 @@ class SecurityController extends AbstractController
             $cacheUtil->clearCache();
 
             return $this->redirectToRoute('admin_setting_system_security');
+        }
+        if ($adminRoute === 'admin') {
+            $this->addWarning('管理画面URLは、セキュリティのため推測されにくいものを設定してください。', 'admin');
         }
 
         return [

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -45,6 +45,11 @@ class SecurityController extends AbstractController
      */
     public function index(Request $request, CacheUtil $cacheUtil)
     {
+        $adminRoute = $this->eccubeConfig['eccube_admin_route'];
+        if ($adminRoute === 'admin') {
+            $this->addWarning('adminは危険です', 'admin');
+        }
+
         $builder = $this->formFactory->createBuilder(SecurityType::class);
         $form = $builder->getForm();
         $form->handleRequest($request);

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -98,7 +98,7 @@ class SecurityController extends AbstractController
         // 管理画面URLがadminの場合アラートを表示する。
         $adminRoute = $this->eccubeConfig['eccube_admin_route'];
         if ($adminRoute === 'admin') {
-            $this->addWarning('管理画面URLは、セキュリティのため推測されにくいものを設定してください。', 'admin');
+            $this->addWarning('admin.setting.system.security.admin.url.warning', 'admin');
         }
 
         return [

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -45,8 +45,6 @@ class SecurityController extends AbstractController
      */
     public function index(Request $request, CacheUtil $cacheUtil)
     {
-        $adminRoute = $this->eccubeConfig['eccube_admin_route'];
-
         $builder = $this->formFactory->createBuilder(SecurityType::class);
         $form = $builder->getForm();
         $form->handleRequest($request);
@@ -97,6 +95,8 @@ class SecurityController extends AbstractController
             return $this->redirectToRoute('admin_setting_system_security');
         }
 
+        // 管理画面URLがadminの場合アラートを表示する。
+        $adminRoute = $this->eccubeConfig['eccube_admin_route'];
         if ($adminRoute === 'admin') {
             $this->addWarning('管理画面URLは、セキュリティのため推測されにくいものを設定してください。', 'admin');
         }

--- a/src/Eccube/Form/Type/Install/Step3Type.php
+++ b/src/Eccube/Form/Type/Install/Step3Type.php
@@ -113,6 +113,7 @@ class Step3Type extends AbstractType
                         'max' => $this->eccubeConfig['eccube_id_max_len'],
                     ]),
                     new Assert\Regex(['pattern' => '/\A\w+\z/']),
+                    new Assert\NotEqualTo(['value' => 'admin', 'message' => 'form_error.admin_is_not_available']),
                 ],
             ])
             ->add('admin_force_ssl', CheckboxType::class, [

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -463,7 +463,7 @@ admin.common.move_to_confirm_title: ページを移動します
 admin.common.move_to_confirm_message: '%name%に移動します。編集内容を保存してから移動しますか？'
 admin.common.move_to_confirm_move_only: 保存せずに移動
 admin.common.move_to_confirm_save_and_move: 保存して移動
-admin.common.admin.url.warning: 管理画面URLは、セキュリティのため推測されにくいものを設定してください。「<a href="%url%">セキュリティ管理</a>」から設定できます。
+admin.common.admin_url_warning: 管理画面URLは、セキュリティのため推測されにくいものを設定してください。「<a href="%url%">セキュリティ管理</a>」から設定できます。
 
 
 # エンティティに関連するラベル
@@ -1192,7 +1192,7 @@ admin.setting.system.security.force_ssl: SSLを強制
 admin.setting.system.security.force_ssl_description: httpsからの接続でなければSSL制限を設定できません。
 admin.setting.system.security.ip_limit_invalid_ipv4: '%ip%はIPv4アドレスではありません。'
 admin.setting.system.security.ip_limit_invalid_https: 'httpの場合には設定できません。'
-admin.setting.system.security.admin.url.warning: 管理画面URLは、セキュリティのため推測されにくいものを設定してください。
+admin.setting.system.security.admin_url_warning: 管理画面URLは、セキュリティのため推測されにくいものを設定してください。
 
 #------------------------------------------------------------------------------------
 # 設定：システム設定：ログ表示

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -463,6 +463,7 @@ admin.common.move_to_confirm_title: ページを移動します
 admin.common.move_to_confirm_message: '%name%に移動します。編集内容を保存してから移動しますか？'
 admin.common.move_to_confirm_move_only: 保存せずに移動
 admin.common.move_to_confirm_save_and_move: 保存して移動
+admin.common.admin.url.warning: 管理画面URLは、セキュリティのため推測されにくいものを設定してください。「<a href="%url%">セキュリティ管理</a>」から設定できます。
 
 
 # エンティティに関連するラベル
@@ -1191,6 +1192,7 @@ admin.setting.system.security.force_ssl: SSLを強制
 admin.setting.system.security.force_ssl_description: httpsからの接続でなければSSL制限を設定できません。
 admin.setting.system.security.ip_limit_invalid_ipv4: '%ip%はIPv4アドレスではありません。'
 admin.setting.system.security.ip_limit_invalid_https: 'httpの場合には設定できません。'
+admin.setting.system.security.admin.url.warning: 管理画面URLは、セキュリティのため推測されにくいものを設定してください。
 
 #------------------------------------------------------------------------------------
 # 設定：システム設定：ログ表示

--- a/src/Eccube/Resource/locale/validators.ja.yaml
+++ b/src/Eccube/Resource/locale/validators.ja.yaml
@@ -39,6 +39,7 @@ form_error.select_is_future_or_now_date: 生年月日が不正な日付です。
 form_error.float_only: 数字と小数点のみ入力できます。
 form_error.same_password: 同じパスワードを入力してください。
 form_error.same_email: 同じメールアドレスを入力してください。
+form_error.admin_is_not_available: 「admin」は利用できません。
 
 #------------------------------------------------------------------------------------
 # Deplicated

--- a/src/Eccube/Resource/locale/validators.ja.yaml
+++ b/src/Eccube/Resource/locale/validators.ja.yaml
@@ -39,7 +39,7 @@ form_error.select_is_future_or_now_date: 生年月日が不正な日付です。
 form_error.float_only: 数字と小数点のみ入力できます。
 form_error.same_password: 同じパスワードを入力してください。
 form_error.same_email: 同じメールアドレスを入力してください。
-form_error.admin_is_not_available: 「admin」は利用できません。
+form_error.admin_is_not_available: ディレクトリ名に「admin」を使用することはできません。
 
 #------------------------------------------------------------------------------------
 # Deplicated

--- a/src/Eccube/Resource/template/admin/index.twig
+++ b/src/Eccube/Resource/template/admin/index.twig
@@ -109,6 +109,15 @@ file that was distributed with this source code.
 {% endblock javascript %}
 
 {% block main %}
+    {% if is_danger_admin_url %}
+    <div class="alert alert-warning alert-dismissible fade show m-3" role="alert">
+        <i class="fa fa-warning fa-lg mr-2"></i>
+        <span class="font-weight-bold">管理画面URLは、セキュリティのため推測されにくいものを設定してください。「<a href="/admin/setting/system/security">セキュリティ管理</a>」から設定できます。</span>
+        <button class="close" type="button" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">×</span>
+        </button>
+    </div>
+    {% endif %}
     <div class="c-contentsArea__cols">
         <div class="c-contentsArea__primaryCol">
             <div class="c-primaryCol">

--- a/src/Eccube/Resource/template/admin/index.twig
+++ b/src/Eccube/Resource/template/admin/index.twig
@@ -112,7 +112,7 @@ file that was distributed with this source code.
     {% if is_danger_admin_url %}
     <div class="alert alert-warning alert-dismissible fade show m-3" role="alert">
         <i class="fa fa-warning fa-lg mr-2"></i>
-        <span class="font-weight-bold">管理画面URLは、セキュリティのため推測されにくいものを設定してください。「<a href="{{ url('admin_setting_system_security') }}">セキュリティ管理</a>」から設定できます。</span>
+        <span class="font-weight-bold">{{ 'admin.common.admin.url.warning'|trans({ '%url%': url('admin_setting_system_security') })|raw }}</span>
         <button class="close" type="button" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">×</span>
         </button>

--- a/src/Eccube/Resource/template/admin/index.twig
+++ b/src/Eccube/Resource/template/admin/index.twig
@@ -112,7 +112,7 @@ file that was distributed with this source code.
     {% if is_danger_admin_url %}
     <div class="alert alert-warning alert-dismissible fade show m-3" role="alert">
         <i class="fa fa-warning fa-lg mr-2"></i>
-        <span class="font-weight-bold">管理画面URLは、セキュリティのため推測されにくいものを設定してください。「<a href="/admin/setting/system/security">セキュリティ管理</a>」から設定できます。</span>
+        <span class="font-weight-bold">管理画面URLは、セキュリティのため推測されにくいものを設定してください。「<a href="{{ url('admin_setting_system_security') }}">セキュリティ管理</a>」から設定できます。</span>
         <button class="close" type="button" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">×</span>
         </button>

--- a/src/Eccube/Resource/template/admin/index.twig
+++ b/src/Eccube/Resource/template/admin/index.twig
@@ -112,7 +112,7 @@ file that was distributed with this source code.
     {% if is_danger_admin_url %}
     <div class="alert alert-warning alert-dismissible fade show m-3" role="alert">
         <i class="fa fa-warning fa-lg mr-2"></i>
-        <span class="font-weight-bold">{{ 'admin.common.admin.url.warning'|trans({ '%url%': url('admin_setting_system_security') })|raw }}</span>
+        <span class="font-weight-bold">{{ 'admin.common.admin_url_warning'|trans({ '%url%': url('admin_setting_system_security') })|raw }}</span>
         <button class="close" type="button" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">×</span>
         </button>

--- a/tests/Eccube/Tests/Form/Type/Install/Step3TypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Install/Step3TypeTest.php
@@ -256,4 +256,11 @@ class Step3TypeTest extends AbstractTypeTestCase
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
+
+    public function testInValid_AdminDir()
+    {
+        $this->formData['admin_dir'] = 'admin';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 管理画面への不正アクセスを防ぐ対策を行う
+ #3988

## 方針(Policy)
+ webインストーラーでは、管理画面URLに"admin"を指定できないように変更する
+ 4.0.0からのアップデートを考慮し、すでに"admin"に設定されている場合はアラートを表示する

## テスト（Test)
+ 対象画面のアラート表示確認
+ Basic認証のフロント、管理画面の表示確認

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

