### PR TITLE
ページ管理画面でのファイル名重複チェックを修正

### DIFF
--- a/tests/Eccube/Tests/Web/Admin/Content/PageControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/PageControllerTest.php
@@ -151,4 +151,130 @@ class PageControllerTest extends AbstractAdminWebTestCase
             unlink($templatePath.'/'.$Page->getFileName().'.twig');
         }
     }
+
+    public function testAdminContentPageDuplicateWithEditTypeDefault()
+    {
+        $client = $this->client;
+
+        $templatePath = $this->container->getParameter('eccube_theme_front_dir');
+        $Page = $this->container->get(PageRepository::class)->find(42); // Shoppin/index
+
+        $source = $this->container->get('twig')
+            ->getLoader()
+            ->getSourceContext($Page->getFileName().'.twig')
+            ->getCode();
+
+        $client->request(
+            'POST',
+            $this->generateUrl(
+                'admin_content_page_edit',
+                ['id' => $Page->getId()]
+            ),
+            [
+                'main_edit' => [
+                    'name' => 'testtest',
+                    'url' => $Page->getUrl(),
+                    'file_name' => $Page->getFileName(),
+                    'tpl_data' => $source,
+                    '_token' => 'dummy',
+                ],
+            ]
+        );
+
+        $this->assertTrue($client->getResponse()->isRedirect($this->generateUrl('admin_content_page_edit',
+            ['id' => $Page->getId()])));
+
+        $this->expected = 'testtest';
+        $this->actual = $Page->getName();
+        $this->verify('EDIT_TYPE_DEFAULT 編集時はファイル名重複していても編集可能');
+
+        if (file_exists($templatePath.'/'.$Page->getFileName().'.twig')) {
+            unlink($templatePath.'/'.$Page->getFileName().'.twig');
+        }
+    }
+
+    public function testAdminContentPageDuplicateWithEditTypeUser()
+    {
+        $client = $this->client;
+        $faker = $this->getFaker();
+
+        $templatePath = $this->container->getParameter('eccube_theme_user_data_dir');
+
+        $name = $faker->word;
+        $source = $faker->realText();
+        $client->request(
+            'POST',
+            $this->generateUrl(
+                'admin_content_page_new'
+            ),
+            [
+                'main_edit' => [
+                    'name' => $name,
+                    'url' => $name,
+                    'file_name' => $name,
+                    'tpl_data' => $source,
+                    '_token' => 'dummy',
+                ],
+            ]
+        );
+
+        $this->assertTrue($client->getResponse()->isRedirection());
+        preg_match('|content/page/([0-9]+)/edit|', $client->getResponse()->headers->get('Location'), $matches);
+        $Page = $this->container->get(PageRepository::class)->find($matches[1]);
+
+        $this->expected = $name;
+        $this->actual = $Page->getName();
+        $this->verify('ページ新規作成');
+
+        $source = $this->container->get('twig')
+            ->getLoader()
+            ->getSourceContext('@user_data/'.$Page->getFileName().'.twig')
+            ->getCode();
+
+        $client->request(
+            'POST',
+            $this->generateUrl(
+                'admin_content_page_edit',
+                ['id' => $Page->getId()]
+            ),
+            [
+                'main_edit' => [
+                    'name' => 'testtest',
+                    'url' => $Page->getUrl(),
+                    'file_name' => 'Shopping/index',
+                    'tpl_data' => $source,
+                    '_token' => 'dummy',
+                ],
+            ]
+        );
+
+        $this->assertFalse(
+            $client->getResponse()->isRedirect(
+                $this->generateUrl('admin_content_page_edit', ['id' => $Page->getId()])),
+            'ファイル名 Shopping/index は使用不可');
+
+        $name = $faker->word;
+        $source = $faker->realText();
+        $client->request(
+            'POST',
+            $this->generateUrl(
+                'admin_content_page_new'
+            ),
+            [
+                'main_edit' => [
+                    'name' => $name,
+                    'url' => $name,
+                    'file_name' => $Page->getFileName(),
+                    'tpl_data' => $source,
+                    '_token' => 'dummy',
+                ],
+            ]
+        );
+
+        $this->assertFalse($client->getResponse()->isRedirection(), 'EDIT_TYPE_USER でファイル名の重複不可');
+
+        if (file_exists($templatePath.'/'.$Page->getFileName().'.twig')) {
+            unlink($templatePath.'/'.$Page->getFileName().'.twig');
+        }
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ #3920 

- Mypage/delivery_edit
- Shopping/index
を管理画面のページ管理から該当のページを編集しようとすると、ファイル重複のエラーになる

## 方針(Policy)
編集不可のページのみ重複を許すよう、エラーチェックを修正する

- Page::EDIT_TYPE_DEFAULT を修正時、自分自身のファイル名以外は重複していたらエラー
- Page::EDIT_TYPE_USER を修正時、自分自身のファイル名と Page::EDIT_TYPE_DEFAULT で重複していたらエラー

## テスト（Test)
+ 重複チェックのユニットテストを追加

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更


