### PR TITLE
インストール済プラグインをcomposer requireするコマンドを追加

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1646,16 +1646,16 @@
         },
         {
             "name": "ec-cube/plugin-installer",
-            "version": "0.0.6",
+            "version": "0.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/EC-CUBE/eccube-plugin-installer.git",
-                "reference": "3d93bd691c03d22977d971c27160f426ed27b2c8"
+                "reference": "61f7ac1cd54e8e2ec50b678c036619386589995e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/EC-CUBE/eccube-plugin-installer/zipball/3d93bd691c03d22977d971c27160f426ed27b2c8",
-                "reference": "3d93bd691c03d22977d971c27160f426ed27b2c8",
+                "url": "https://api.github.com/repos/EC-CUBE/eccube-plugin-installer/zipball/61f7ac1cd54e8e2ec50b678c036619386589995e",
+                "reference": "61f7ac1cd54e8e2ec50b678c036619386589995e",
                 "shasum": ""
             },
             "require": {
@@ -1675,7 +1675,7 @@
                 "MIT"
             ],
             "description": "EC-CUBE plugin installer.",
-            "time": "2018-09-19T09:30:27+00:00"
+            "time": "2018-11-20T11:40:27+00:00"
         },
         {
             "name": "egulias/email-validator",

--- a/src/Eccube/Command/ComposerRequireAlreadyInstalledPluginsCommand.php
+++ b/src/Eccube/Command/ComposerRequireAlreadyInstalledPluginsCommand.php
@@ -71,7 +71,7 @@ class ComposerRequireAlreadyInstalledPluginsCommand extends Command
         $unSupportedPlugins = [];
 
         $criteria = Criteria::create()
-            ->where(Criteria::expr()->neq('source', null))
+            ->where(Criteria::expr()->neq('source', 0))
             ->orderBy(['code' => 'ASC']);
         $Plugins = $this->pluginRepository->matching($criteria);
 

--- a/src/Eccube/Command/ComposerRequireAlreadyInstalledPluginsCommand.php
+++ b/src/Eccube/Command/ComposerRequireAlreadyInstalledPluginsCommand.php
@@ -13,6 +13,7 @@
 
 namespace Eccube\Command;
 
+use Doctrine\Common\Collections\Criteria;
 use Eccube\Common\Constant;
 use Eccube\Repository\PluginRepository;
 use Eccube\Service\Composer\ComposerApiService;
@@ -69,7 +70,11 @@ class ComposerRequireAlreadyInstalledPluginsCommand extends Command
         $packageNames = [];
         $unSupportedPlugins = [];
 
-        $Plugins = $this->pluginRepository->findAll();
+        $criteria = Criteria::create()
+            ->where(Criteria::expr()->neq('source', null))
+            ->orderBy(['code' => 'ASC']);
+        $Plugins = $this->pluginRepository->matching($criteria);
+
         foreach ($Plugins as $Plugin) {
             $packageNames[] = 'ec-cube/'.$Plugin->getCode().':'.$Plugin->getVersion();
             $data = $this->pluginApiService->getPlugin($Plugin->getCode());

--- a/src/Eccube/Command/ComposerRequireAlreadyInstalledPluginsCommand.php
+++ b/src/Eccube/Command/ComposerRequireAlreadyInstalledPluginsCommand.php
@@ -67,18 +67,18 @@ class ComposerRequireAlreadyInstalledPluginsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $packageNames = [];
-        $notSupportedPluigns = [];
+        $unSupportedPlugins = [];
 
         $Plugins = $this->pluginRepository->findAll();
         foreach ($Plugins as $Plugin) {
             $packageNames[] = 'ec-cube/'.$Plugin->getCode().':'.$Plugin->getVersion();
             $data = $this->pluginApiService->getPlugin($Plugin->getCode());
             if (isset($data['version_check']) && !$data['version_check']) {
-                $notSupportedPluigns[] = $Plugin;
+                $unSupportedPlugins[] = $Plugin;
             }
         }
 
-        foreach ($notSupportedPluigns as $Plugin) {
+        foreach ($unSupportedPlugins as $Plugin) {
             $message = trans('command.composer_require_already_installed.not_supported_plugin', [
                 '%name%' => $Plugin->getName(),
                 '%plugin_version%' => $Plugin->getVersion(),

--- a/src/Eccube/Command/ComposerRequireAlreadyInstalledPluginsCommand.php
+++ b/src/Eccube/Command/ComposerRequireAlreadyInstalledPluginsCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command;
+
+use Eccube\Common\Constant;
+use Eccube\Repository\PluginRepository;
+use Eccube\Service\Composer\ComposerApiService;
+use Eccube\Service\PluginApiService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+
+class ComposerRequireAlreadyInstalledPluginsCommand extends Command
+{
+    protected static $defaultName = 'eccube:composer:require-already-installed';
+
+    /**
+     * @var ComposerApiService
+     */
+    private $composerService;
+
+    /**
+     * @var PluginApiService
+     */
+    private $pluginApiService;
+
+    /**
+     * @var PluginRepository
+     */
+    private $pluginRepository;
+
+    /**
+     * @var SymfonyStyle
+     */
+    private $io;
+
+    public function __construct(
+        ComposerApiService $composerService,
+        PluginRepository $pluginRepository,
+        PluginApiService $pluginApiService
+    ) {
+        parent::__construct();
+        $this->composerService = $composerService;
+        $this->pluginApiService = $pluginApiService;
+        $this->pluginRepository = $pluginRepository;
+    }
+
+    public function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $packageNames = [];
+        $notSupportedPluigns = [];
+
+        $Plugins = $this->pluginRepository->findAll();
+        foreach ($Plugins as $Plugin) {
+            $packageNames[] = 'ec-cube/'.$Plugin->getCode().':'.$Plugin->getVersion();
+            $data = $this->pluginApiService->getPlugin($Plugin->getCode());
+            if (isset($data['version_check']) && !$data['version_check']) {
+                $notSupportedPluigns[] = $Plugin;
+            }
+        }
+
+        foreach ($notSupportedPluigns as $Plugin) {
+            $message = trans('command.composer_require_already_installed.not_supported_plugin', [
+                '%name%' => $Plugin->getName(),
+                '%plugin_version%' => $Plugin->getVersion(),
+                '%eccube_version%' => Constant::VERSION
+            ]);
+            $question = new ConfirmationQuestion($message);
+            if (!$this->io->askQuestion($question)) {
+                return;
+            }
+        }
+
+        if ($packageNames) {
+            $this->composerService->execRequire(implode(' ', $packageNames), $this->io);
+        }
+    }
+}

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -1631,3 +1631,9 @@ purchase_flow.charge_update: 手数料が更新されました。金額をご確
 purchase_flow.over_customer_point: 利用ポイントが所有ポイントを上回っています。
 purchase_flow.over_payment_total: 利用ポイントがお支払い金額を上回っています。
 purchase_flow.over_stock: 「%name%」の在庫が足りません。
+
+#------------------------------------------------------------------------------------
+# Command
+#------------------------------------------------------------------------------------
+
+command.composer_require_already_installed.not_supported_plugin: %name% %plugin_version% は EC-CUBE %eccube_version% には対応していません。続行しますか？


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

インストール済プラグインをcomposer requireするコマンドを追加

## 方針(Policy)

- 4.0.xのバージョンアップ手順は当初は3.0.xと同等のものを提供する見込み
  - http://doc.ec-cube.net/quickstart_update
- composer.json/lockファイルが、プラグインインストール時に書き換えられるため、インストール済プラグインを再度composer requireし、composer.json/lockファイルを更新する

## 実装に関する補足(Appendix)

以下で実行することができます。

```
bin/console eccube:composer:require-already-installed
```

プラグインがEC-CUBEのバージョンに対応していない場合、以下のダイアログを表示します。
```
Sample Plugin 1.0.0 は EC-CUBE 4.0.1 には対応していません。続行しますか？ (yes/no) [yes]:
```
## テスト（Test)
以下のパターンを動作確認しています。

- プラグインをインストール
- composer.json/lockを上書き
- コマンドを実行
- composer.json/lockにプラグインのrequireが追加されていることを確認

## 相談（Discussion）
- packagest等の外部ライブラリをcomposer requireしている場合は、このコマンドでは対応できません。
- 別途バージョンアップ手順に手順を追加します

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



