### PR TITLE
メンテナンス機能を追加

### DIFF
--- a/index.php
+++ b/index.php
@@ -57,8 +57,6 @@ $request = Request::createFromGlobals();
 
 if (file_exists(__DIR__.'/.maintenance')) {
     $pathInfo = \rawurldecode($request->getPathInfo());
-    // TODO
-    // コマンドインストール時に、.envにECCUBE_ADMIN_ROUTEは書き出されないため、コマンド側の修正必要
     $adminPath = env('ECCUBE_ADMIN_ROUTE');
     $adminPath = '/'.\trim($adminPath, '/').'/';
     if (\strpos($pathInfo, $adminPath) !== 0) {

--- a/index.php
+++ b/index.php
@@ -53,8 +53,25 @@ if ($trustedHosts) {
     Request::setTrustedHosts(explode(',', $trustedHosts));
 }
 
-$kernel = new Kernel($env, $debug);
 $request = Request::createFromGlobals();
+
+if (file_exists(__DIR__.'/.maintenance')) {
+    $pathInfo = \rawurldecode($request->getPathInfo());
+    // TODO
+    // コマンドインストール時に、.envにECCUBE_ADMIN_ROUTEは書き出されないため、コマンド側の修正必要
+    $adminPath = env('ECCUBE_ADMIN_ROUTE');
+    $adminPath = '/'.\trim($adminPath, '/').'/';
+    if (\strpos($pathInfo, $adminPath) !== 0) {
+        // TODO
+        // 503でレスポンスを返す
+        // テンプレートパス, URLのベースパスをmaintenance.phpに渡す必要がある
+        // 多言語化は対応しない
+        require __DIR__.'/maintenance.php';
+        return;
+    }
+}
+
+$kernel = new Kernel($env, $debug);
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);

--- a/index.php
+++ b/index.php
@@ -60,6 +60,7 @@ if (file_exists(__DIR__.'/.maintenance')) {
     $adminPath = env('ECCUBE_ADMIN_ROUTE');
     $adminPath = '/'.\trim($adminPath, '/').'/';
     if (\strpos($pathInfo, $adminPath) !== 0) {
+        $locale = env('ECCUBE_LOCALE');
         $templateCode = env('ECCUBE_TEMPLATE_CODE');
         $baseUrl = \rawurldecode($request->getBaseUrl());
 

--- a/index.php
+++ b/index.php
@@ -62,9 +62,9 @@ if (file_exists(__DIR__.'/.maintenance')) {
     $adminPath = env('ECCUBE_ADMIN_ROUTE');
     $adminPath = '/'.\trim($adminPath, '/').'/';
     if (\strpos($pathInfo, $adminPath) !== 0) {
-        // TODO
-        // テンプレートパス, URLのベースパスをmaintenance.phpに渡す必要がある
-        // 多言語化は対応しない
+        $templateCode = env('ECCUBE_TEMPLATE_CODE');
+        $baseUrl = \rawurldecode($request->getBaseUrl());
+
         header('HTTP/1.1 503 Service Temporarily Unavailable');
         require __DIR__.'/maintenance.php';
         return;

--- a/index.php
+++ b/index.php
@@ -63,9 +63,9 @@ if (file_exists(__DIR__.'/.maintenance')) {
     $adminPath = '/'.\trim($adminPath, '/').'/';
     if (\strpos($pathInfo, $adminPath) !== 0) {
         // TODO
-        // 503でレスポンスを返す
         // テンプレートパス, URLのベースパスをmaintenance.phpに渡す必要がある
         // 多言語化は対応しない
+        header('HTTP/1.1 503 Service Temporarily Unavailable');
         require __DIR__.'/maintenance.php';
         return;
     }

--- a/index.php
+++ b/index.php
@@ -62,7 +62,7 @@ if (file_exists(__DIR__.'/.maintenance')) {
     if (\strpos($pathInfo, $adminPath) !== 0) {
         $locale = env('ECCUBE_LOCALE');
         $templateCode = env('ECCUBE_TEMPLATE_CODE');
-        $baseUrl = \rawurldecode($request->getBaseUrl());
+        $baseUrl = \htmlspecialchars(\rawurldecode($request->getBaseUrl()));
 
         header('HTTP/1.1 503 Service Temporarily Unavailable');
         require __DIR__.'/maintenance.php';

--- a/index.php
+++ b/index.php
@@ -62,7 +62,7 @@ if (file_exists(__DIR__.'/.maintenance')) {
     if (\strpos($pathInfo, $adminPath) !== 0) {
         $locale = env('ECCUBE_LOCALE');
         $templateCode = env('ECCUBE_TEMPLATE_CODE');
-        $baseUrl = \htmlspecialchars(\rawurldecode($request->getBaseUrl()));
+        $baseUrl = \htmlspecialchars(\rawurldecode($request->getBaseUrl()), ENT_QUOTES);
 
         header('HTTP/1.1 503 Service Temporarily Unavailable');
         require __DIR__.'/maintenance.php';

--- a/maintenance.php
+++ b/maintenance.php
@@ -1,5 +1,5 @@
 <!doctype html>
-<!--
+<?php /*
 This file is part of EC-CUBE
 
 Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
@@ -8,14 +8,14 @@ http://www.lockon.co.jp/
 
 For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
--->
+*/ ?>
 <html lang="ja">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>ただいまメンテナンス中です。</title>
-    <link rel="icon" href="/html/template/default/assets/img/common/favicon.ico">
-    <link rel="stylesheet" href="/html/template/default/assets/css/style.css">
+    <link rel="icon" href="<?php echo $baseUrl; ?>/html/template/<?php echo $templateCode; ?>/assets/img/common/favicon.ico">
+    <link rel="stylesheet" href="<?php echo $baseUrl; ?>/html/template/<?php echo $templateCode; ?>/assets/css/style.css">
 </head>
 <body>
 <div class="ec-layoutRole">
@@ -24,7 +24,7 @@ file that was distributed with this source code.
             <div class="ec-off4Grid__cell">
                 <div style="font-size:100px;text-align:center;">
                     <div class="ec-404Role__icon ec-icon">
-                        <img src="/html/template/default/assets/icon/exclamation-pale.svg" alt="">
+                        <img src="<?php echo $baseUrl; ?>/html/template/<?php echo $templateCode; ?>/assets/icon/exclamation-pale.svg" alt="">
                     </div>
                 </div>
                 <p class="ec-404Role__title ec-reportHeading">ただいまメンテナンス中です。</p>

--- a/maintenance.php
+++ b/maintenance.php
@@ -9,7 +9,7 @@ http://www.lockon.co.jp/
 For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 */ ?>
-<html lang="ja">
+<html lang="<?php echo $locale; ?>">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/maintenance.php
+++ b/maintenance.php
@@ -1,0 +1,37 @@
+<!doctype html>
+<!--
+This file is part of EC-CUBE
+
+Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+-->
+<html lang="ja">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>ただいまメンテナンス中です。</title>
+    <link rel="icon" href="/html/template/default/assets/img/common/favicon.ico">
+    <link rel="stylesheet" href="/html/template/default/assets/css/style.css">
+</head>
+<body>
+<div class="ec-layoutRole">
+    <div class="ec-404Role">
+        <div class="ec-off4Grid">
+            <div class="ec-off4Grid__cell">
+                <div style="font-size:100px;text-align:center;">
+                    <div class="ec-404Role__icon ec-icon">
+                        <img src="/html/template/default/assets/icon/exclamation-pale.svg" alt="">
+                    </div>
+                </div>
+                <p class="ec-404Role__title ec-reportHeading">ただいまメンテナンス中です。</p>
+                <p class="ec-404Role__description ec-reportDescription">大変お手数ですが、しばらくしてから再度アクセスをお願いします。</p>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -119,6 +119,8 @@ class InstallerCommand extends Command
             'DATABASE_SERVER_VERSION' => $serverVersion,
             'MAILER_URL' => $mailerUrl,
             'ECCUBE_AUTH_MAGIC' => $authMagic,
+            'ECCUBE_ADMIN_ROUTE' => 'admin',
+            'ECCUBE_TEMPLATE_CODE' => 'default',
         ];
 
         $envDir = $this->container->getParameter('kernel.project_dir');

--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -121,6 +121,7 @@ class InstallerCommand extends Command
             'ECCUBE_AUTH_MAGIC' => $authMagic,
             'ECCUBE_ADMIN_ROUTE' => 'admin',
             'ECCUBE_TEMPLATE_CODE' => 'default',
+            'ECCUBE_LOCALE' => 'ja',
         ];
 
         $envDir = $this->container->getParameter('kernel.project_dir');

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -440,6 +440,7 @@ class InstallController extends AbstractController
             'ECCUBE_ADMIN_ROUTE' => isset($sessionData['admin_dir']) ? $sessionData['admin_dir'] : 'admin',
             'ECCUBE_COOKIE_PATH' => $request->getBasePath() ? $request->getBasePath() : '/',
             'ECCUBE_TEMPLATE_CODE' => 'default',
+            'ECCUBE_LOCALE' => 'ja',
         ];
 
         $env = StringUtil::replaceOrAddEnv($env, $replacement);

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -439,6 +439,7 @@ class InstallController extends AbstractController
             'ECCUBE_FORCE_SSL' => $forceSSL,
             'ECCUBE_ADMIN_ROUTE' => isset($sessionData['admin_dir']) ? $sessionData['admin_dir'] : 'admin',
             'ECCUBE_COOKIE_PATH' => $request->getBasePath() ? $request->getBasePath() : '/',
+            'ECCUBE_TEMPLATE_CODE' => 'default',
         ];
 
         $env = StringUtil::replaceOrAddEnv($env, $replacement);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ プラグインのインストール/有効処理や本体のアップデート処理でアクセスがあるとキャッシュが中途半端に生成されてしまいシステムエラーとなる可能性がある
+ プロジェクトのルートディレクトリに.maintenanceファイルを設置するとメンテナンス画面に切り替わる機能を追加

## 方針(Policy)
+ 最低限のメンテナンス機能のみ実装
+ wordpressのメンテナンス機能を参考に.maintenanceファイルの有無で状態を切り替えるようにした
+ 管理画面はプラグインの操作等のため接続可能とした
+ メンテナンス画面では503のステータスを返す

## 使い方

+ メンテナンスモード開始
  + EC-CUBEのルートディレクトリに `.maintenance` ファイルを作成
    + 例
```shell
touch {ec-cubeのルートディレクトリ}/.maintenance
```
+ メンテナンスモード解除
  + EC-CUBEのルートディレクトリの `.maintenance` ファイルを削除
    + 例
```shell
rm -f {ec-cubeのルートディレクトリ}/.maintenance
```
+ メンテナンスページのデザイン変更
  + EC-CUBEのルートディレクトリの `maintenance.php` ファイルを編集

## 実装に関する補足(Appendix)
+ フロント画面はsymfonyのキャッシュが生成されないよう、index.phpファイルにメンテナンス画面へ切り替える処理を記載した
+ フロント画面のテンプレート切り替えに対応
+ 管理画面のURL変更に対応
+ 必要な環境変数をインストール時に.envへ追加する処理を追加

## テスト（Test)
+ サブディレクトリあり/なしでテスト
+ テンプレートを切り替えてテスト
+ Webインストーラでテスト
+ commandでのインストールでテスト

## 相談（Discussion）
+ メンテナンス中はデバッグツールバーが使えないが対応は必要か

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ **環境変数に 'ECCUBE_ADMIN_ROUTE', 'ECCUBE_TEMPLATE_CODE' を定義する必要があります**

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



