### PR TITLE
CartItemAllocator のカスタマイズを適用するとシステムエラーが発生する対策

### DIFF
--- a/src/Eccube/Controller/CartController.php
+++ b/src/Eccube/Controller/CartController.php
@@ -233,7 +233,7 @@ class CartController extends AbstractController
     /**
      * カートをロック状態に設定し、購入確認画面へ遷移する.
      *
-     * @Route("/cart/buystep/{cart_key}", name="cart_buystep", requirements={"cart_key" = "[a-zA-Z0-9]+[_]\d+"})
+     * @Route("/cart/buystep/{cart_key}", name="cart_buystep", requirements={"cart_key" = "[a-zA-Z0-9]+[_][\x20-\x7E]+"})
      */
     public function buystep(Request $request, $cart_key)
     {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

以下のカスタマイズサンプルを動作するようにする修正
http://doc4.ec-cube.net/customize_service#支払方法が異なる商品を同時にカートに入れられるようにする

## 方針(Policy)
+ 印字可能な ASCII 文字を cart_key に使用可能とする

## 実装に関する補足(Appendix)
+ `\x20-\x7E` は印字可能な ASCII コードの正規表現です

## テスト（Test)
+ 上記サンプルカスタマイズが動作するのを確認

## 相談（Discussion）
+ 任意のCartItemAllocatorを設定する Webテストを書きたいが、 PHPUnit でCartItemAllocatorのインスタンスを動的に設定するのが困難

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更


