### PR TITLE
環境変数に`APP_ENV`を定義していてもWebインストーラが起動する問題を修正

### DIFF
--- a/index.php
+++ b/index.php
@@ -18,7 +18,7 @@ if (!file_exists($autoload) && !is_readable($autoload)) {
 require $autoload;
 
 // The check is to ensure we don't use .env in production
-if (!isset($_SERVER['APP_ENV'])) {
+if (!isset($_ENV['APP_ENV'])) {
     if (!class_exists(Dotenv::class)) {
         throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
     }
@@ -34,8 +34,8 @@ if (!isset($_SERVER['APP_ENV'])) {
     }
 }
 
-$env = isset($_SERVER['APP_ENV']) ? $_SERVER['APP_ENV'] : 'dev';
-$debug = isset($_SERVER['APP_DEBUG']) ? $_SERVER['APP_DEBUG'] : ('prod' !== $env);
+$env = isset($_ENV['APP_ENV']) ? $_ENV['APP_ENV'] : 'dev';
+$debug = isset($_ENV['APP_DEBUG']) ? $_ENV['APP_DEBUG'] : ('prod' !== $env);
 
 if ($debug) {
     umask(0000);
@@ -43,12 +43,12 @@ if ($debug) {
     Debug::enable();
 }
 
-$trustedProxies = isset($_SERVER['TRUSTED_PROXIES']) ? $_SERVER['TRUSTED_PROXIES'] : false;
+$trustedProxies = isset($_ENV['TRUSTED_PROXIES']) ? $_ENV['TRUSTED_PROXIES'] : false;
 if ($trustedProxies) {
     Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
 }
 
-$trustedHosts = isset($_SERVER['TRUSTED_HOSTS']) ? $_SERVER['TRUSTED_HOSTS'] : false;
+$trustedHosts = isset($_ENV['TRUSTED_HOSTS']) ? $_ENV['TRUSTED_HOSTS'] : false;
 if ($trustedHosts) {
     Request::setTrustedHosts(explode(',', $trustedHosts));
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ index.phpで`APP_ENV`などの値を`$_SERVER`から取得していたため、`.env`ファイルがない場合に環境変数を設定していても使われていなかった。
+ `$_ENV`を参照するように修正。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



