### PR TITLE
ProductおよびProductClassのisEnable()関数を非推奨に変更

### DIFF
--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -123,6 +123,8 @@ if (!class_exists('\Eccube\Entity\Product')) {
          * Is Enable
          *
          * @return bool
+         *
+         * @deprecated
          */
         public function isEnable()
         {

--- a/src/Eccube/Entity/ProductClass.php
+++ b/src/Eccube/Entity/ProductClass.php
@@ -53,6 +53,8 @@ if (!class_exists('\Eccube\Entity\ProductClass')) {
          * Is Enable
          *
          * @return bool
+         *
+         * @deprecated
          */
         public function isEnable()
         {

--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -73,7 +73,7 @@ file that was distributed with this source code.
                                     </div>
                                     <div class="ec-imageGrid__content">
                                         <p>
-                                            {% if orderItem.Product is not null and orderItem.Product.enable %}
+                                            {% if orderItem.Product is not null and orderItem.Product.Status.id == constant('Eccube\\Entity\\Master\\ProductStatus::DISPLAY_SHOW') %}
                                                 <a href="{{ url('product_detail', {'id': orderItem.Product.id}) }}">{{ orderItem.productName }}</a>
                                             {% else %}
                                                 {{ orderItem.productName }}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ delete ProductおよびProductClassのisEnable()関数は論理削除されているか判定するためのもので、現在はProductStatusを確認することで対応できるので関数を非推奨に変更

関連
https://github.com/EC-CUBE/ec-cube/pull/3615

## 方針(Policy)
+ 次のメジャーバージョンアップで削除

## 実装に関する補足(Appendix)
+ 本体では利用されていない状態にした

## テスト（Test)
+ 自動テストが通っていることを確認

## 相談（Discussion）
+ 

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



