### PR TITLE
DATABASE_URLのデフォルト値の修正

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -13,7 +13,7 @@ APP_DEBUG=1
 # Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # For a sqlite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
 # Set "serverVersion" to your server version to avoid edge-case exceptions and extra database calls
-DATABASE_URL=sqlite:///%kernel.project_dir%/var/eccube.db
+DATABASE_URL=sqlite:///var/eccube.db
 # The version of your database engine
 DATABASE_SERVER_VERSION=3
 ###< doctrine/doctrine-bundle ###


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
git clone 後に
```
composer install
```
を実行して
```
php bin/console eccube:install
```
でインストールコマンドを実行すると.env.distの内容がデフォルト表示されるが、
```
Database Url [sqlite:///%kernel.project_dir%/var/eccube.db]:
```
だとdatabase作成時にエラーが発生するため、
```
Database Url [sqlite:///var/eccube.db]:
```
とデフォルトで設定するように修正

ref #3929 