### PR TITLE
.maintenance ファイルを除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ composer.phar
 .idea
 *.php~
 .env
+.maintenance
 
 ###> symfony/phpunit-bridge ###
 .phpunit

--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,6 @@
 DirectoryIndex index.php index.html .ht
 
-<FilesMatch "^composer|^COPYING|^\.env|^Procfile|^app\.json|^gulpfile\.js|^package\.json|^package-lock\.json|web\.config|\.(ini|lock|dist|git|sh|bak|swp|env|twig|yml|yaml)$">
+<FilesMatch "^composer|^COPYING|^\.env|^\.maintenance|^Procfile|^app\.json|^gulpfile\.js|^package\.json|^package-lock\.json|web\.config|\.(ini|lock|dist|git|sh|bak|swp|env|twig|yml|yaml)$">
     order allow,deny
     deny from all
 </FilesMatch>

--- a/web.config
+++ b/web.config
@@ -54,6 +54,7 @@
           <add sequence="autoload" />
           <add sequence="COPYING" />
           <add sequence=".env" />
+          <add sequence=".maintenance" />
           <add sequence=".htaccess" />
           <add sequence="Procfile" />
           <add sequence="/app.json" />


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
以下に .maintenance を追加

- `.gitignore`
- `.htaccess`
- `web.config`

## テスト（Test)
+ IIS, Apache で .maintenance にアクセスできないのを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



