### PR TITLE
マイページでポイント有効時のみ保有ポイントが表示されるよう修正

### DIFF
--- a/src/Eccube/Resource/template/default/Mypage/navi.twig
+++ b/src/Eccube/Resource/template/default/Mypage/navi.twig
@@ -32,7 +32,7 @@ file that was distributed with this source code.
 
 <div class="ec-welcomeMsg">
     {{ 'front.mypage.welcome'|trans({ '%last_name%': app.user.name01, '%first_name%': app.user.name02 }) }}
-    {% if BaseInfo.option_point  %}
+    {% if BaseInfo.option_point %}
         {{ 'front.mypage.welcome__point'|trans({ '%point%': app.user.point|number_format}) }}
     {% endif %}
 </div>

--- a/src/Eccube/Resource/template/default/Mypage/navi.twig
+++ b/src/Eccube/Resource/template/default/Mypage/navi.twig
@@ -32,7 +32,7 @@ file that was distributed with this source code.
 
 <div class="ec-welcomeMsg">
     {{ 'front.mypage.welcome'|trans({ '%last_name%': app.user.name01, '%first_name%': app.user.name02 }) }}
-    {% if BaseInfo.option_favorite_product %}
+    {% if BaseInfo.option_point  %}
         {{ 'front.mypage.welcome__point'|trans({ '%point%': app.user.point|number_format}) }}
     {% endif %}
 </div>

--- a/src/Eccube/Resource/template/default/Mypage/navi.twig
+++ b/src/Eccube/Resource/template/default/Mypage/navi.twig
@@ -31,9 +31,9 @@ file that was distributed with this source code.
 </div>
 
 <div class="ec-welcomeMsg">
-    {{ 'front.mypage.welcome'|trans({ '%last_name%': app.user.name01, '%first_name%': app.user.name02 }) }}
+    <p>{{ 'front.mypage.welcome'|trans({ '%last_name%': app.user.name01, '%first_name%': app.user.name02 }) }}</p>
     {% if BaseInfo.option_point %}
-        {{ 'front.mypage.welcome__point'|trans({ '%point%': app.user.point|number_format}) }}
+        <p>{{ 'front.mypage.welcome__point'|trans({ '%point%': app.user.point|number_format}) }}</p>
     {% endif %}
 </div>
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ https://github.com/EC-CUBE/ec-cube/issues/3958

## テスト（Test)
+ ポイント機能の有効時、無効時の表示を確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



