### PR TITLE
メンテナンス管理からはモードに関わらずメンテナンスを解除する

### DIFF
--- a/src/Eccube/Controller/Admin/Content/MaintenanceController.php
+++ b/src/Eccube/Controller/Admin/Content/MaintenanceController.php
@@ -48,7 +48,7 @@ class MaintenanceController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
 
-            $this->systemService->switchMaintenance(($request->request->get('maintenance') == "on"), null);
+            $this->systemService->switchMaintenance(($request->request->get('maintenance') == "on"), null, true);
 
             $isMaintenance = $this->systemService->isMaintenanceMode();
 

--- a/src/Eccube/Controller/Admin/Content/MaintenanceController.php
+++ b/src/Eccube/Controller/Admin/Content/MaintenanceController.php
@@ -40,7 +40,7 @@ class MaintenanceController extends AbstractController
      */
     public function index(Request $request)
     {
-        $isMaintenace = $this->systemService->isMaintenanceMode();
+        $isMaintenance = $this->systemService->isMaintenanceMode();
 
         $builder = $this->formFactory->createBuilder(FormType::class);
         $form = $builder->getForm();
@@ -50,16 +50,16 @@ class MaintenanceController extends AbstractController
 
             $this->systemService->switchMaintenance(($request->request->get('maintenance') == "on"), null);
 
-            $isMaintenace = $this->systemService->isMaintenanceMode();
+            $isMaintenance = $this->systemService->isMaintenanceMode();
 
-            $this->addSuccess(($isMaintenace) ? 'admin.content.maintenance_switch__on_message' : 'admin.content.maintenance_switch__off_message', 'admin');
+            $this->addSuccess(($isMaintenance) ? 'admin.content.maintenance_switch__on_message' : 'admin.content.maintenance_switch__off_message', 'admin');
 
             return $this->redirectToRoute('admin_content_maintenance');
         }
 
         return [
             'form' => $form->createView(),
-            'isMaintenance' => $isMaintenace,
+            'isMaintenance' => $isMaintenance,
         ];
     }
 

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -120,11 +120,13 @@ class SystemService
      *
      * - $isEnable = true の場合, $mode の文字列が記載された .maintenance ファイルを生成する
      * - $isEnable = false の場合, $mode の文字列が記載された .maintenance ファイルを削除する
+     * - $isEnable = false かつ $force = true の場合は $mode に関わらず .maintenance ファイルを削除する
      *
      * @param bool $isEnable
      * @param string $mode
+     * @param bool $force
      */
-    public function switchMaintenance($isEnable = false, $mode = self::AUTO_MAINTENANCE)
+    public function switchMaintenance($isEnable = false, $mode = self::AUTO_MAINTENANCE, $force = false)
     {
         $isMaintenanceMode = $this->isMaintenanceMode();
         $path = $this->container->getParameter('eccube_content_maintenance_file_path');
@@ -133,7 +135,7 @@ class SystemService
             file_put_contents($path, $mode);
         } elseif ($isEnable === false && $isMaintenanceMode) {
             $contents = file_get_contents($path);
-            if ($contents == $mode) {
+            if ($contents == $mode || $force == true) {
                 unlink($path);
             }
         }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
メンテナンス管理からはモードに関わらずメンテナンスを解除できるように修正しました。

## 方針(Policy)
+ プラグインのインストール等の処理開始時にはauto_maintenanceモードとなり、処理終了時にはauto_maintenanceモードを解除する仕様となっている。
+ もし処理の途中で問題が発生した場合には管理画面のメンテナンス管理から手動でメンテナンス状態を解除できる必要がある。

## 実装に関する補足(Appendix)
+ タイポがあったので合わせて修正しています。

## テスト（Test)
手元の環境で以下の操作を確認
+ メンテナンス管理画面からの操作で
  - メンテナンス開始できることを確認
  - 通常モードとauto_maintenanceモード共にメンテナンス解除できることを確認
+ プラグインのインストール、有効、無効、削除でauto_maintenanceが開始、終了することを確認

## 相談（Discussion）
+ 

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ Serviceクラスの公開関数に引数を追加しています。

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



