### PR TITLE
メンテナンス管理からはモードに関わらずメンテナンスを解除する

### DIFF
--- a/src/Eccube/Controller/Admin/Content/MaintenanceController.php
+++ b/src/Eccube/Controller/Admin/Content/MaintenanceController.php
@@ -40,7 +40,7 @@ class MaintenanceController extends AbstractController
      */
     public function index(Request $request)
     {
-        $isMaintenace = $this->systemService->isMaintenanceMode();
+        $isMaintenance = $this->systemService->isMaintenanceMode();
 
         $builder = $this->formFactory->createBuilder(FormType::class);
         $form = $builder->getForm();
@@ -50,16 +50,16 @@ class MaintenanceController extends AbstractController
 
             $this->systemService->switchMaintenance(($request->request->get('maintenance') == "on"), null);
 
-            $isMaintenace = $this->systemService->isMaintenanceMode();
+            $isMaintenance = $this->systemService->isMaintenanceMode();
 
-            $this->addSuccess(($isMaintenace) ? 'admin.content.maintenance_switch__on_message' : 'admin.content.maintenance_switch__off_message', 'admin');
+            $this->addSuccess(($isMaintenance) ? 'admin.content.maintenance_switch__on_message' : 'admin.content.maintenance_switch__off_message', 'admin');
 
             return $this->redirectToRoute('admin_content_maintenance');
         }
 
         return [
             'form' => $form->createView(),
-            'isMaintenance' => $isMaintenace,
+            'isMaintenance' => $isMaintenance,
         ];
     }
 

--- a/src/Eccube/Controller/Admin/Content/MaintenanceController.php
+++ b/src/Eccube/Controller/Admin/Content/MaintenanceController.php
@@ -47,12 +47,22 @@ class MaintenanceController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $changeTo = $request->request->get('maintenance');
+            $path = $this->container->getParameter('eccube_content_maintenance_file_path');
 
-            $this->systemService->switchMaintenance(($request->request->get('maintenance') == "on"), null);
+            if ($isMaintenance === false && $changeTo == 'on') {
+                // 現在メンテナンスモードではない　かつ　メンテナンスモードを有効　にした場合
+                // メンテナンスモードを有効にする
+                file_put_contents($path, null);
 
-            $isMaintenance = $this->systemService->isMaintenanceMode();
+                $this->addSuccess('admin.content.maintenance_switch__on_message', 'admin');
+            } elseif ($isMaintenance && $changeTo == 'off') {
+                // 現在メンテナンスモード　かつ　メンテナンスモードを無効　にした場合
+                // メンテナンスモードを無効にする
+                unlink($path);
 
-            $this->addSuccess(($isMaintenance) ? 'admin.content.maintenance_switch__on_message' : 'admin.content.maintenance_switch__off_message', 'admin');
+                $this->addSuccess('admin.content.maintenance_switch__off_message', 'admin');
+            }
 
             return $this->redirectToRoute('admin_content_maintenance');
         }
@@ -62,5 +72,4 @@ class MaintenanceController extends AbstractController
             'isMaintenance' => $isMaintenance,
         ];
     }
-
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
メンテナンス管理からはモードに関わらずメンテナンスを解除できるように修正しました。

以下の引き継ぎです。
https://github.com/EC-CUBE/ec-cube/pull/4021
実装方針が変わったので別のプルリクにしました。


## 方針(Policy)
+ プラグインのインストール等の処理開始時にはauto_maintenanceモードとなり、処理終了時にはauto_maintenanceモードを解除する仕様となっている。
+ もし処理の途中で問題が発生した場合には管理画面のメンテナンス管理から手動でメンテナンス状態を解除できる必要がある。
+ メンテナンス管理画面の動作はプラグイン等に依存しないので、Controller内でメンテナンス変更処理をした。

## 実装に関する補足(Appendix)
+ ロジックを見直しています。
+ タイポがあったので合わせて修正しています。

## テスト（Test)
手元の環境で以下の操作を確認
+ メンテナンス管理画面からの操作で
  - メンテナンス開始できることを確認
  - 通常モードとauto_maintenanceモード共にメンテナンス解除できることを確認

## 相談（Discussion）
+ 

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ メンテナンス管理でのメンテナンス状態解除条件を変更

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更
