### PR TITLE
メンテナンス管理の不具合修正

### DIFF
--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -31,8 +31,6 @@ use Eccube\Util\FormUtil;
 use Knp\Component\Pager\Paginator;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -262,7 +260,7 @@ class OwnerStoreController extends AbstractController
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
-    public function apiInstall(Request $request, EventDispatcherInterface $dispatcher)
+    public function apiInstall(Request $request)
     {
         $this->isTokenValid();
 
@@ -270,10 +268,7 @@ class OwnerStoreController extends AbstractController
         $this->systemService->switchMaintenance(true);
 
         // TERMINATE時のイベントを設定
-        $dispatcher->addListener(KernelEvents::TERMINATE, function () {
-            // .maintenanceファイルを削除
-            $this->systemService->switchMaintenance();
-        });
+        $this->systemService->disableMaintenance(SystemService::AUTO_MAINTENANCE);
 
         $this->cacheUtil->clearCache();
 
@@ -301,7 +296,7 @@ class OwnerStoreController extends AbstractController
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
-    public function apiUninstall(Plugin $Plugin, EventDispatcherInterface $dispatcher)
+    public function apiUninstall(Plugin $Plugin)
     {
         $this->isTokenValid();
 
@@ -309,10 +304,7 @@ class OwnerStoreController extends AbstractController
         $this->systemService->switchMaintenance(true);
 
         // TERMINATE時のイベントを設定
-        $dispatcher->addListener(KernelEvents::TERMINATE, function () {
-            // .maintenanceファイルを削除
-            $this->systemService->switchMaintenance();
-        });
+        $this->systemService->disableMaintenance(SystemService::AUTO_MAINTENANCE);
 
         $this->cacheUtil->clearCache();
 
@@ -438,15 +430,12 @@ class OwnerStoreController extends AbstractController
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
-    public function apiUpdate(Request $request, EventDispatcherInterface $dispatcher)
+    public function apiUpdate(Request $request)
     {
         $this->isTokenValid();
 
         // TERMINATE時のイベントを設定
-        $dispatcher->addListener(KernelEvents::TERMINATE, function () {
-            // .maintenanceファイルを削除
-            $this->systemService->switchMaintenance(false, SystemService::AUTO_MAINTENANCE_UPDATE);
-        });
+        $this->systemService->disableMaintenance(SystemService::AUTO_MAINTENANCE_UPDATE);
 
         $this->cacheUtil->clearCache();
 

--- a/src/Eccube/Service/SystemService.php
+++ b/src/Eccube/Service/SystemService.php
@@ -25,7 +25,16 @@ class SystemService implements EventSubscriberInterface
     const AUTO_MAINTENANCE = 'auto_maintenance';
     const AUTO_MAINTENANCE_UPDATE = 'auto_maintenance_update';
 
+    /**
+     * メンテナンスモードを無効にする場合はtrue
+     * @var bool
+     */
     private $disableMaintenanceAfterResponse = false;
+
+    /**
+     * メンテナンスモードの識別子
+     * @var string
+     */
     private $maintenanceMode = null;
 
     /**
@@ -145,6 +154,11 @@ class SystemService implements EventSubscriberInterface
         }
     }
 
+    /**
+     * KernelEvents::TERMINATE で設定されるEvent
+     *
+     * @param PostResponseEvent $event
+     */
     public function disableMaintenanceEvent(PostResponseEvent $event)
     {
         if ($this->disableMaintenanceAfterResponse) {
@@ -152,6 +166,12 @@ class SystemService implements EventSubscriberInterface
         }
     }
 
+    /**
+     * メンテナンスモードを解除する
+     *
+     * KernelEvents::TERMINATE で解除のEventを設定し、メンテナンスモードを解除する
+     * @param string $mode
+     */
     public function disableMaintenance($mode = self::AUTO_MAINTENANCE)
     {
         $this->disableMaintenanceAfterResponse = true;


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ メンテナンス有効化時に .maintenance が削除されなかった不具合を修正

## テスト（Test)
+ メンテナンス管理と、プラグインの有効/無効/インストール/削除時にメンテナンスモードが機能していることを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



