### PR TITLE
管理画面からの受注登録時にもpre_order_idを発行

### DIFF
--- a/.htaccess.sample
+++ b/.htaccess.sample
@@ -25,3 +25,18 @@ DirectoryIndex index.php index.html .ht
     RewriteCond %{REQUEST_FILENAME} !^(.*)\.(gif|png|jpe?g|css|ico|js|svg)$ [NC]
     RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>
+
+# 管理画面へのBasic認証サンプル
+#
+# Satisfy Any
+#
+# AuthType Basic
+# AuthName "Please enter username and password"
+# AuthUserFile /path/to/.htpasswd
+# AuthGroupFile /dev/null
+# require valid-user
+#
+# SetEnvIf Request_URI "^/admin" admin_path  # ^/adminは, 管理画面URLに応じて変更してください
+# Order Allow,Deny
+# Allow from all
+# Deny from env=admin_path

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# EC-CUBE 3.x
+# EC-CUBE 3.0.x
 
-[![Build Status](https://travis-ci.org/EC-CUBE/ec-cube.svg?branch=master)](https://travis-ci.org/EC-CUBE/ec-cube)
-[![Build status](https://ci.appveyor.com/api/projects/status/lg3uh1539cwln2g6?svg=true)](https://ci.appveyor.com/project/ECCUBE/ec-cube)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/EC-CUBE/ec-cube/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/EC-CUBE/ec-cube/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/EC-CUBE/ec-cube/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/EC-CUBE/ec-cube/?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/EC-CUBE/ec-cube/badge.svg?branch=master)](https://coveralls.io/github/EC-CUBE/ec-cube?branch=master)
+[![Build Status](https://travis-ci.org/EC-CUBE/ec-cube.svg?branch=3.0)](https://travis-ci.org/EC-CUBE/ec-cube)
+[![Build status](https://ci.appveyor.com/api/projects/status/lg3uh1539cwln2g6/branch/3.0?svg=true)](https://ci.appveyor.com/project/ECCUBE/ec-cube/branch/3.0)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/EC-CUBE/ec-cube/badges/quality-score.png?b=3.0)](https://scrutinizer-ci.com/g/EC-CUBE/ec-cube/?branch=3.0)
+[![Code Coverage](https://scrutinizer-ci.com/g/EC-CUBE/ec-cube/badges/coverage.png?b=3.0)](https://scrutinizer-ci.com/g/EC-CUBE/ec-cube/?branch=3.0)
+[![Coverage Status](https://coveralls.io/repos/github/EC-CUBE/ec-cube/badge.svg?branch=3.0)](https://coveralls.io/github/EC-CUBE/ec-cube?branch=3.0)
   
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/EC-CUBE/ec-cube?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,14 +8,15 @@ clone_folder: c:\projects\ec-cube
 
 cache:
   - '%LOCALAPPDATA%\Composer\files'
-  
+  - vendor
+
 # Fix line endings in Windows. (runs before repo cloning)
 init:
   - git config --global core.autocrlf input
 
 environment:
   global:
-    USER: "root" 
+    USER: "root"
     DBNAME: "myapp_test"
     DBPASS: "Password12!"
     DBUSER: "root"
@@ -26,44 +27,38 @@ environment:
     provider: mysql
 
 services:
-  - iis  
   - mysql
 
 # Install scripts. (runs after repo cloning)
 install:
+  - cp phpunit.xml.dist phpunit.xml
+  # see https://github.com/phpmd/phpmd/blob/master/appveyor.yml#L10-L13
+  - cinst -y OpenSSL.Light --version 1.1.1
+  - SET PATH=C:\Program Files\OpenSSL;%PATH%
+  - sc config wuauserv start= auto
+  - net start wuauserv
   # Set MySQL.
   - cp tests/my.cnf c:\
   - SET PATH=C:\Program Files\MySql\MySQL Server 5.7\bin\;%PATH%
   #- cinst mysql
   #- SET PATH=C:\tools\mysql\current\bin\;%PATH%
   # Set PHP.
-  - cinst php --version 7.0.9 --allow-empty-checksums
-  - SET PATH=C:\tools\php\;%PATH%
-  - copy C:\tools\php\php.ini-production C:\tools\php\php.ini
-  - echo date.timezone="Asia/Tokyo" >> C:\tools\php\php.ini
-  - echo extension_dir=ext >> C:\tools\php\php.ini
-  - echo extension=php_openssl.dll >> C:\tools\php\php.ini
-  - echo extension=php_gd2.dll >> C:\tools\php\php.ini
-  - echo extension=php_mbstring.dll >> C:\tools\php\php.ini
-  - echo extension=php_pgsql.dll >> C:\tools\php\php.ini
-  - echo extension=php_pdo_mysql.dll >> C:\tools\php\php.ini
-  - echo extension=php_pdo_pgsql.dll >> C:\tools\php\php.ini
-  - echo extension=php_curl.dll >> C:\tools\php\php.ini
-  - echo extension=php_fileinfo.dll >> C:\tools\php\php.ini
-  - echo output_buffering = Off >> C:\tools\php\php.ini
-  - echo default_charset = UTF-8 >> C:\tools\php\php.ini
-  - echo mbstring.language = Japanese >> C:\tools\php\php.ini
-  - echo mbstring.encoding_translation = On >> C:\tools\php\php.ini
-  - echo mbstring.http_input = UTF-8 >> C:\tools\php\php.ini
-  - echo mbstring.http_output = pass >> C:\tools\php\php.ini
-  - echo mbstring.internal_encoding = UTF-8 >> C:\tools\php\php.ini
-  - echo memory_limit = 512M >> C:\tools\php\php.ini
+  - cinst php --version 7.1.20 --allow-empty-checksums
+  - SET PATH=C:\tools\php71\;%PATH%
+  - copy C:\tools\php71\php.ini-production C:\tools\php71\php.ini
+  - echo date.timezone="Asia/Tokyo" >> C:\tools\php71\php.ini
+  - echo extension_dir=ext >> C:\tools\php71\php.ini
+  - echo extension=php_openssl.dll >> C:\tools\php71\php.ini
+  - echo extension=php_gd2.dll >> C:\tools\php71\php.ini
+  - echo extension=php_mbstring.dll >> C:\tools\php71\php.ini
+  - echo extension=php_pgsql.dll >> C:\tools\php71\php.ini
+  - echo extension=php_pdo_mysql.dll >> C:\tools\php71\php.ini
+  - echo extension=php_pdo_pgsql.dll >> C:\tools\php71\php.ini
+  - echo extension=php_curl.dll >> C:\tools\php71\php.ini
+  - echo extension=php_fileinfo.dll >> C:\tools\php71\php.ini
+  - echo memory_limit = 512M >> C:\tools\php71\php.ini
   - php -r "readfile('http://getcomposer.org/installer');" | php
   - php composer.phar install --dev --no-interaction -o
-
-# cache:
-  # - C:\ProgramData\chocolatey\bin -> appveyor.yml
-  # - C:\ProgramData\chocolatey\lib -> appveyor.yml
 
 # Don't actually build.
 build: off
@@ -72,4 +67,4 @@ before_test:
   - php eccube_install.php mysql none
 
 test_script:
-  - vendor\bin\phpunit.bat
+  - vendor\bin\phpunit.bat -c phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "project",
     "homepage": "http://www.ec-cube.net/",
     "license": [
-       "GPL-2.0",
-       "Commercial"
+       "GPL-2.0-only",
+       "proprietary"
     ],
     "support": {
         "issues": "https://github.com/EC-CUBE/ec-cube/issues"

--- a/html/.htaccess
+++ b/html/.htaccess
@@ -21,3 +21,18 @@ allow from all
     RewriteCond %{REQUEST_FILENAME} !^(.*)\.(gif|png|jpe?g|css|ico|js|svg)$ [NC]
     RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>
+
+# 管理画面へのBasic認証サンプル
+#
+# Satisfy Any
+#
+# AuthType Basic
+# AuthName "Please enter username and password"
+# AuthUserFile /path/to/.htpasswd
+# AuthGroupFile /dev/null
+# require valid-user
+#
+# SetEnvIf Request_URI "^/admin" admin_path  # ^/adminは, 管理画面URLに応じて変更してください
+# Order Allow,Deny
+# Allow from all
+# Deny from env=admin_path

--- a/html/.htaccess
+++ b/html/.htaccess
@@ -22,7 +22,7 @@ allow from all
     RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>
 
-# 管理画面へのBasic認証サンプル
+# 管理画面へのBasic認証サンプル(※Apache2.2用)
 #
 # Satisfy Any
 #

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -613,6 +613,7 @@ class Application extends ApplicationTrait
             return new \Symfony\Component\Security\Core\Authorization\AccessDecisionManager($app['security.voters'], 'unanimous');
         });
 
+        $app = $this;
         $app['security.authentication.success_handler.admin'] = $app->share(function ($app) {
             $handler = new \Eccube\Security\Http\Authentication\EccubeAuthenticationSuccessHandler(
                 $app['security.http_utils'],

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -319,7 +319,7 @@ class Application extends ApplicationTrait
             if ($app->isAdminRequest()) {
                 // IP制限チェック
                 $allowHost = $app['config']['admin_allow_host'];
-                if (count($allowHost) > 0) {
+                if (is_array($allowHost) && count($allowHost) > 0) {
                     if (array_search($app['request']->getClientIp(), $allowHost) === false) {
                         throw new \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException();
                     }

--- a/src/Eccube/Application.php
+++ b/src/Eccube/Application.php
@@ -613,6 +613,45 @@ class Application extends ApplicationTrait
             return new \Symfony\Component\Security\Core\Authorization\AccessDecisionManager($app['security.voters'], 'unanimous');
         });
 
+        $app['security.authentication.success_handler.admin'] = $app->share(function ($app) {
+            $handler = new \Eccube\Security\Http\Authentication\EccubeAuthenticationSuccessHandler(
+                $app['security.http_utils'],
+                $app['security.firewalls']['admin']['form']
+            );
+
+            $handler->setProviderKey('admin');
+
+            return $handler;
+        });
+
+        $app['security.authentication.failure_handler.admin'] = $app->share(function ($app) {
+            return new \Eccube\Security\Http\Authentication\EccubeAuthenticationFailureHandler(
+                $app,
+                $app['security.http_utils'],
+                $app['security.firewalls']['admin']['form'],
+                $app['logger']
+            );
+        });
+
+        $app['security.authentication.success_handler.customer'] = $app->share(function ($app) {
+            $handler = new \Eccube\Security\Http\Authentication\EccubeAuthenticationSuccessHandler(
+                $app['security.http_utils'],
+                $app['security.firewalls']['customer']['form']
+            );
+
+            $handler->setProviderKey('customer');
+
+            return $handler;
+        });
+
+        $app['security.authentication.failure_handler.customer'] = $app->share(function ($app) {
+            return new \Eccube\Security\Http\Authentication\EccubeAuthenticationFailureHandler(
+                $app,
+                $app['security.http_utils'],
+                $app['security.firewalls']['customer']['form'],
+                $app['logger']
+            );
+        });
     }
 
     /**

--- a/src/Eccube/Common/Constant.php
+++ b/src/Eccube/Common/Constant.php
@@ -28,7 +28,7 @@ class Constant {
     /**
      * EC-CUBE VERSION.
      */
-    const VERSION = '3.0.16';
+    const VERSION = '3.0.17';
 
     /**
      * Enable value.

--- a/src/Eccube/Controller/Admin/AdminController.php
+++ b/src/Eccube/Controller/Admin/AdminController.php
@@ -79,6 +79,12 @@ class AdminController extends AbstractController
             }
         }
 
+        $is_danger_admin_url = false;
+        // 管理画面URLのチェック
+        if (isset($app['config']['admin_route']) && $app['config']['admin_route'] == 'admin') {
+            $is_danger_admin_url = true;
+        }
+
         // 受注マスター検索用フォーム
         $searchOrderBuilder = $app['form.factory']
             ->createBuilder('admin_search_order');
@@ -188,6 +194,7 @@ class AdminController extends AbstractController
             'salesYesterday' => $salesYesterday,
             'countNonStockProducts' => $countNonStockProducts,
             'countCustomers' => $countCustomers,
+            'is_danger_admin_url' => $is_danger_admin_url,
         ));
     }
 

--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -33,6 +33,7 @@ use Eccube\Entity\ShipmentItem;
 use Eccube\Entity\Shipping;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
+use Eccube\Util\Str;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -654,10 +655,12 @@ class EditController extends AbstractController
 
     protected function newOrder(Application $app)
     {
+        $preOrderId = sha1(Str::random(32));
         $Order = new \Eccube\Entity\Order();
         $Shipping = new \Eccube\Entity\Shipping();
         $Shipping->setDelFlg(0);
         $Order->addShipping($Shipping);
+        $Order->setPreOrderId($preOrderId);
         $Shipping->setOrder($Order);
 
         // device type

--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -655,7 +655,14 @@ class EditController extends AbstractController
 
     protected function newOrder(Application $app)
     {
-        $preOrderId = sha1(Str::random(32));
+        // ランダムなpre_order_idを作成
+        do {
+            $preOrderId = sha1(Str::random(32));
+            $Order = $app['eccube.repository.order']->findOneBy(array(
+                'pre_order_id' => $preOrderId
+            ));
+        } while ($Order);
+        
         $Order = new \Eccube\Entity\Order();
         $Shipping = new \Eccube\Entity\Shipping();
         $Shipping->setDelFlg(0);

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -129,6 +129,11 @@ class SecurityController extends AbstractController
             $form->get('force_ssl')->setData((bool)$app['config']['force_ssl']);
         }
 
+        // 管理画面URLのチェック
+        if (isset($app['config']['admin_route']) && $app['config']['admin_route'] == 'admin') {
+            $app->addWarning('admin.system.security.admin.url.warning', 'admin');
+        }
+
         return $app->render('Setting/System/security.twig', array(
             'form' => $form->createView(),
         ));

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -123,7 +123,7 @@ class SecurityController extends AbstractController
             // セキュリティ情報の取得
             $form->get('admin_route_dir')->setData($app['config']['admin_route']);
             $allowHost = $app['config']['admin_allow_host'];
-            if (count($allowHost) > 0) {
+            if (is_array($allowHost) && count($allowHost) > 0) {
                 $form->get('admin_allow_host')->setData(Str::convertLineFeed(implode("\n", $allowHost)));
             }
             $form->get('force_ssl')->setData((bool)$app['config']['force_ssl']);

--- a/src/Eccube/Form/Type/Install/Step3Type.php
+++ b/src/Eccube/Form/Type/Install/Step3Type.php
@@ -100,6 +100,7 @@ class Step3Type extends AbstractType
                         'max' => $this->app['config']['id_max_len'],
                     )),
                     new Assert\Regex(array('pattern' => '/\A\w+\z/')),
+                    new Assert\NotEqualTo(array('value' => 'admin', 'message' => 'ディレクトリ名に「admin」を使用することはできません。')),
                 ),
             ))
             ->add('admin_force_ssl', 'checkbox', array(

--- a/src/Eccube/Resource/locale/message.ja.yml
+++ b/src/Eccube/Resource/locale/message.ja.yml
@@ -177,6 +177,7 @@ admin.content.cache.save.complete: キャッシュを削除しました。
 
 admin.system.security.save.complete: セキュリティ設定を保存しました。
 admin.system.security.route.dir.complete: 管理画面のURLを変更しましたので再ログインをしてください。
+admin.system.security.admin.url.warning: 管理画面URLは、セキュリティのため推測されにくいものを設定してください。
 
 admin.system.authority.save.complete: 権限設定を保存しました。
 

--- a/src/Eccube/Resource/template/admin/error.twig
+++ b/src/Eccube/Resource/template/admin/error.twig
@@ -28,6 +28,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     <meta name="description" content="">
     <meta name="author" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex,nofollow" />
     <link rel="icon" href="{{ app.config.admin_urlpath }}/assets/img/favicon.ico">
     <link rel="stylesheet" href="{{ app.config.admin_urlpath }}/assets/css/bootstrap.min.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}">
     <link rel="stylesheet" href="{{ app.config.admin_urlpath }}/assets/css/dashboard.css?v={{ constant('Eccube\\Common\\Constant::VERSION') }}">

--- a/src/Eccube/Resource/template/admin/index.twig
+++ b/src/Eccube/Resource/template/admin/index.twig
@@ -44,7 +44,14 @@ $(function(){
 {% endblock javascript %}
 
 {% block main %}
-
+    {% if is_danger_admin_url %}
+        <div class="row">
+            <div class="alert alert-warning alert-dismissable alert-section">
+                <button type="button" class="close" data-dismiss="alert"><span class="alert-close" aria-hidden="true">×</span></button>
+                <svg class="cb cb-info-circle"> <use xlink:href="#cb-info-circle"></use></svg> 管理画面URLは、セキュリティのため推測されにくいものを設定してください。「<a href="{{ url('admin_setting_system_security') }}">セキュリティ管理</a>」から設定できます。
+            </div>
+        </div>
+    {% endif %}
         <div class="row">
             <div class="col-md-6">
                 <form id="order-state" name="form1" action="{{ url('admin_order') }}" method="post">

--- a/src/Eccube/Security/Http/Authentication/EccubeAuthenticationFailureHandler.php
+++ b/src/Eccube/Security/Http/Authentication/EccubeAuthenticationFailureHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Security\Http\Authentication;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler;
+
+class EccubeAuthenticationFailureHandler extends DefaultAuthenticationFailureHandler
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    {
+        $response = parent::onAuthenticationFailure($request, $exception);
+        $targetUrl = $response->getTargetUrl();
+
+        if (preg_match('/^https?:\\\\/i', $targetUrl)) {
+            $response->setTargetUrl($request->getUriForPath('/'));
+
+            return $response;
+        }
+
+        $host = $request->getHttpHost();
+        $targetRequest = Request::create($response->getTargetUrl());
+        $targetHost = $targetRequest->getHttpHost();
+
+        if (strpos($targetHost, $host) !== 0) {
+            $response->setTargetUrl($request->getUriForPath('/'));
+        }
+
+        return $response;
+    }
+}

--- a/src/Eccube/Security/Http/Authentication/EccubeAuthenticationSuccessHandler.php
+++ b/src/Eccube/Security/Http/Authentication/EccubeAuthenticationSuccessHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+namespace Eccube\Security\Http\Authentication;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
+
+class EccubeAuthenticationSuccessHandler extends DefaultAuthenticationSuccessHandler
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token)
+    {
+        $response = parent::onAuthenticationSuccess($request, $token);
+        $targetUrl = $response->getTargetUrl();
+
+        if (preg_match('/^https?:\\\\/i', $targetUrl)) {
+            $response->setTargetUrl($request->getUriForPath('/'));
+
+            return $response;
+        }
+
+        $host = $request->getHttpHost();
+        $targetRequest = Request::create($response->getTargetUrl());
+        $targetHost = $targetRequest->getHttpHost();
+
+        if (strpos($targetHost, $host) !== 0) {
+            $response->setTargetUrl($request->getUriForPath('/'));
+        }
+
+        return $response;
+    }
+}

--- a/tests/Eccube/Tests/Form/Type/Install/Step3TypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Install/Step3TypeTest.php
@@ -272,4 +272,12 @@ class Step3TypeTest extends AbstractTypeTestCase
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());
     }
+
+    public function testInValid_AdminDir()
+    {
+        $this->formData['admin_dir'] = 'admin';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
 }


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)



管理画面から受注登録をするとpre_order_idがNULLになる
#3972 

この状態で以下のステップを踏むとpre_order_idがNULLの受注金額で決済が行われてしまう。

クレジット決済を行う
→無意識に前の画面に戻る（完了していないのかと勘違いする）
→決済完了ボタンをクリック
→決済ができなかった旨のエラー画面が表示される
→内容をきちんと確認せずもう一度決済ボタンを押す
→pre_order_id　が NULLの受注金額で決済される。


## 実装に関する補足(Appendix)

管理画面からの受注登録でもpre_order_idを発行

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



