### PR TITLE
jaとenのメッセージファイルを同期

### DIFF
--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -73,8 +73,6 @@ common.signup: Sign up
 common.forgot_login: Unable to sign in?
 common.customer_address_count_is_over: You already have max number of addresses (%eccube_deliv_addr_max% items). If you want to add a new one, please delete or overwrite the item(s) you have on the list.
 common.search_keyword: Enter keywords
-common.customer_already_exists: This email is already registered.
-common.member_already_exists: This ID is already registered.
 common.delete_confirm: Do you want to continue?
 common.pagetop: Page top
 common.name.prefix: ''
@@ -466,6 +464,7 @@ admin.common.move_to_confirm_title: Move to another page
 admin.common.move_to_confirm_message: 'Will move to %name% Setting page. Do you want to save current editing?'
 admin.common.move_to_confirm_move_only: Move
 admin.common.move_to_confirm_save_and_move: Save & Move
+admin.common.admin_url_warning: Please set the Admin Console URL that is hard to guess for security. You can set it at "<a href="%url%">Security</a>".
 
 
 # Labels related to entity
@@ -625,10 +624,6 @@ admin.product.move_to_category: Add / Edit a Category
 admin.product.move_to_tag: Add / Edit a Tag
 admin.product.move_to_product_class: Edit an Option
 admin.product.move_to_product_class__confirm_title: '%name% Options'
-admin.product.move_to_confirm_title: Leaving this page
-admin.product.move_to_confirm_message: 'You are moving to %name%. Do you want to save the product information before leaving?'
-admin.product.move_to_confirm_move_only: Do not save and leave
-admin.product.move_to_confirm_save_and_move: Save and leave
 admin.product.multi_search_label: Product Name / Product ID / SKU
 admin.product.product_class: Product Options
 admin.product.product_class__short: Options
@@ -930,6 +925,7 @@ admin.content.layout_management: Layouts
 admin.content.page_management: Pages
 admin.content.block_management: Blocks
 admin.content.cache_management: Caches
+admin.content.maintenance_management: Maintenances
 
 # Labels / Messages
 admin.content.file.add_file__card_title: Add File / Directory
@@ -988,8 +984,16 @@ admin.content.page_meta_keyword: keyword
 admin.content.page_meta_robot: robot
 admin.content.page_meta_metatag: metatag
 admin.content.page_meta_metatag_placeholder: |
- <meta property="og:title" content="Page Title" />
- <meta property="og:image" content="Image URL" />
+  商品詳細ページでの記載例
+    <meta property="og:type" content="og:product" />
+    <meta property="og:title" content="{{ Product.name }}" />
+    <meta property="og:image" content="{{ url('homepage') }}{{ asset(Product.main_list_image|no_image_product, 'save_image') }}" />
+    <meta property="og:description" content="{{ Product.description_list|striptags }}" />
+    <meta property="og:url" content="{{ url('product_detail', {'id': Product.id}) }}" />
+    <meta property="product:price:amount" content="{{ Product.getPrice02IncTaxMin }}"/>
+    <meta property="product:price:currency" content="{{ eccube_config.currency }}"/>
+    <meta property="product:product_link" content="{{ url('product_detail', {'id': Product.id}) }}"/>
+    <meta property="product:retailer_title" content="{{ Product.name }}"/>
 admin.content.page_file_name_exists: Data with the same file name already exists. Please enter a different one.
 admin.content.block_name: Block Name
 admin.content.block__card_title: Block Settings
@@ -1008,6 +1012,14 @@ admin.content.news.url: URL
 admin.content.news.body: Body
 admin.content.news.news_registration: Create News
 admin.content.news.new_window: Open in a New Window
+admin.content.maintenance__card_title: Maintenance mode
+admin.content.maintenance_message: |
+  When the maintenance mode is enabled, the shop is temporarily stopped and only the Admin Console can be accessed.
+  * When installing / enabling / disabling / deleting plugin, it automatically switches to maintenance mode.
+admin.content.maintenance_switch__on: To enable
+admin.content.maintenance_switch__off: To disable
+admin.content.maintenance_switch__on_message: Maintenance mode has been enabled.
+admin.content.maintenance_switch__off_message: Maintenance mode has been disabled.
 
 #------------------------------------------------------------------------------------
 # Settings
@@ -1096,6 +1108,7 @@ admin.setting.shop.delivery.delivery_time_setting: Delivery Time
 admin.setting.shop.delivery.delivery_fee_by_pref: Shipping Charge by Prefecture
 admin.setting.shop.delivery.apply_to_pref__title: Flat Rate (Nationwide)
 admin.setting.shop.delivery.apply_to_pref__button: Apply to All Prefectures
+admin.setting.shop.delivery.fee.invalid: Please enter with numbers.
 
 #------------------------------------------------------------------------------------
 # Settings : Store Settings : Tax Rate
@@ -1163,7 +1176,7 @@ admin.setting.system.member.work_can_not_change: You are not allowed to change t
 admin.setting.system.authority__card_title: Permission
 admin.setting.system.authority.description: |
  Please enter the URL after %url% into the [Blocked URL] field.
- The URL will be blocked, if it matches the URL entered there (left-hand match).'
+ The URL will be blocked, if it matches the URL entered there (left-hand match).
 admin.setting.system.authority.example: 'e.g. /setting <span class="text-danger">: / (slash) is required.</span>'
 admin.setting.system.authority.authority: Role
 admin.setting.system.authority.deny_url: Blocked URL
@@ -1191,6 +1204,7 @@ admin.setting.system.security.force_ssl: SSL is mandatory
 admin.setting.system.security.force_ssl_description: Only https access is allowed to set SSL restrictions.
 admin.setting.system.security.ip_limit_invalid_ipv4: '%ip% is not an IPv4 address.'
 admin.setting.system.security.ip_limit_invalid_https: 'http is not allowed to do this setting.'
+admin.setting.system.security.admin_url_warning: Please set the Admin Console URL that is hard to guess for security.
 
 #------------------------------------------------------------------------------------
 # Settings : System : Logs
@@ -1255,9 +1269,14 @@ admin.store.plugin.search.not_auth: Please set the authentication key.
 admin.store.plugin.installed: Installed
 admin.store.plugin.update: Update
 admin.store.plugin.install.complete: A plugin has been installed.
-admin.store.plugin.enable.complete: %plugin_name%　is enabled.
+admin.store.plugin.install.failed: Failed to install plugin.
+admin.store.plugin.enable.complete: %plugin_name% is enabled.
+admin.store.plugin.already.enabled: %plugin_name% has already been enabled.
 admin.store.plugin.disable.complete: %plugin_name% is disabled.
+admin.store.plugin.already.disabled: %plugin_name% has already been disabled.
 admin.store.plugin.uninstall.complete: The plugin has been deleted.
+admin.store.plugin.update.complete: %plugin_name% has been updated.
+admin.store.plugin.update.failed: Failed to update %plugin_name% .
 admin.store.plugin.mkdir.error: Failed to creat a directory '%dir_name%'.
 admin.store.setting: Settings
 admin.store.setting.api_key_setting: Set API authentication Key
@@ -1274,7 +1293,6 @@ admin.store.package.api.500.error: Failed to communicate with Owners' Store. Ple
 admin.plugin.uninstall.error.not_disable: Please disable the plugin.
 admin.plugin.uninstall.depend: 'Unable to delete %depend_name% because it depends on %name%.'
 admin.plugin.disable.depend: 'Please disable %depend_name% before disabling %name%.'
-
 
 
 # TODO: Verify Message
@@ -1505,13 +1523,14 @@ tooltip.content.page_file_name: This is the name of a twig template file which h
 tooltip.content.page_source_code: Editing the template file. Coding has to be with twig.
 tooltip.content.page_layout: Selecting the layouts to be applied to this page.
 tooltip.content.page_meta: You can enter the META tag contents of the page.
+tooltip.content.page_meta_tags: You can add META tag freely. You can also use variables used within twig.
 tooltip.content.block_name: This is a name of a block for management use.
 tooltip.content.block_file_name: This is the name of the twig template file which has this block contents. You can not change it later in the Admin Console.
 tooltip.content.block_source_code: Editing the template file. Coding has to be with twig.
 tooltip.setting.shop.shop.email_from: This will be the From address when you send emails from your store to your customers.
 tooltip.setting.shop.shop.email_for_inquiries: This is the email address by which you will receive the notice when someone submits an inquiry from the inquiry form.
 tooltip.setting.shop.shop.email_reply_to: This is the email address by which you will receive reply emails.
-tooltip.setting.shop.shop.email_return_path: This is the email address by which you will receive a notice when a transmission error occurs in sending emails from your store. 
+tooltip.setting.shop.shop.email_return_path: This is the email address by which you will receive a notice when a transmission error occurs in sending emails from your store.
 tooltip.setting.shop.shop.good_traded: Brief descriptions of your products.
 tooltip.setting.shop.shop.message: This will be displayed on storefront. The placement varies according to the design templates.
 tooltip.setting.shop.shop.option_delivery_fee_free_amount: Shipping charge will be waived if a customer purchases more than this amount.
@@ -1624,3 +1643,9 @@ purchase_flow.charge_update: Charge has been updated. Please confirm the total a
 purchase_flow.over_customer_point: You are not able to use points more than your current points.
 purchase_flow.over_payment_total: The points are more than the total amount.
 purchase_flow.over_stock: '%name% does not have enough stock.'
+
+#------------------------------------------------------------------------------------
+# Command
+#------------------------------------------------------------------------------------
+
+command.composer_require_already_installed.not_supported_plugin: %name% %plugin_version% does not support EC-CUBE %eccube_version% . Do you want to continue?

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -547,7 +547,6 @@ admin.change_password.current_password: 現在のパスワード
 admin.change_password.new_password: 新しいパスワード
 admin.change_password.new_password_confirm: 新しいパスワード(確認)
 admin.change_password.password_changed: パスワードを更新しました
-
 admin.error.go_to_login: ログイン画面へ
 
 #------------------------------------------------------------------------------------
@@ -634,7 +633,8 @@ admin.product.product_class__confirm_of_product: この商品の規格を確認
 admin.product.product_class__card_title: 商品規格情報
 admin.product.product_class__reset: 商品規格の初期化
 admin.product.product_class__reset_confirm_title: この商品の規格を初期化します
-admin.product.product_class__reset_confirm_message: この商品に登録された規格を初期化します。
+admin.product.product_class__reset_confirm_message: |
+  この商品に登録された規格を初期化します。
   これまでの販売データには影響はありませんが、この操作は取り消すことができません。
   初期化しますか？
 admin.product.product_class__reset_confirm_excecute: 規格を初期化
@@ -657,7 +657,8 @@ admin.product.class_category2: 規格分類2
 admin.product.class_category2__short: 規格2
 admin.product.category: カテゴリ
 admin.product.category__product_card_title: カテゴリ
-admin.product.category_id: カテゴリID
+admin.product.category_id: |
+  カテゴリID
   既存カテゴリの更新はカテゴリIDを設定
 admin.product.category_name: カテゴリ名
 admin.product.parent_category_id: 親カテゴリID
@@ -1107,7 +1108,7 @@ admin.setting.shop.delivery.delivery_time_setting: お届け時間設定
 admin.setting.shop.delivery.delivery_fee_by_pref: 都道府県別送料設定
 admin.setting.shop.delivery.apply_to_pref__title: 全国一律に設定
 admin.setting.shop.delivery.apply_to_pref__button: 各都道府県に適用
-admin.setting.shop.delivery.fee.invalid: 有効な値ではありません。
+admin.setting.shop.delivery.fee.invalid: 数字で入力してください。
 
 #------------------------------------------------------------------------------------
 # 設定：店舗設定：税率設定
@@ -1173,8 +1174,9 @@ admin.setting.system.member.work_can_not_change: 非稼働に変更すること�
 #------------------------------------------------------------------------------------
 
 admin.setting.system.authority__card_title: 権限設定
-admin.setting.system.authority.description: '%url%以降からのURLを拒否URLに入力してください。
-  拒否URL以降がアクセス拒否されます。(URLは前方一致)'
+admin.setting.system.authority.description: |
+  %url%以降からのURLを拒否URLに入力してください。
+  拒否URL以降がアクセス拒否されます。(URLは前方一致)
 admin.setting.system.authority.example: '例) /setting <span class="text-danger">「/」を必ず記入してください</span>'
 admin.setting.system.authority.authority: 権限
 admin.setting.system.authority.deny_url: 拒否URL
@@ -1456,7 +1458,6 @@ admin.store.unregistered_plugin_table.948: 詳細を表示
 admin.store.unregistered_plugin_table.949: 不明
 admin.store.unregistered_plugin_table.950: 設定
 admin.store.install.label: 'プラグイン (zip、tar、tar.gz形式)'
-
 
 
 #------------------------------------------------------------------------------------

--- a/src/Eccube/Resource/locale/validators.en.yaml
+++ b/src/Eccube/Resource/locale/validators.en.yaml
@@ -39,6 +39,9 @@ form_error.select_is_future_or_now_date: Invalid Date of Birth.
 form_error.float_only: Entry must be numbers and decimal points.
 form_error.same_password: Please enter the same password.
 form_error.same_email: Please enter the same email address.
+form_error.admin_is_not_available: Do not use "admin" as the directory name.
+form_error.member_already_exists: This ID is already registered.
+form_error.customer_already_exists:  This email address can not be used.
 
 #------------------------------------------------------------------------------------
 # Deplicated

--- a/src/Eccube/Resource/locale/validators.ja.yaml
+++ b/src/Eccube/Resource/locale/validators.ja.yaml
@@ -40,8 +40,8 @@ form_error.float_only: 数字と小数点のみ入力できます。
 form_error.same_password: 同じパスワードを入力してください。
 form_error.same_email: 同じメールアドレスを入力してください。
 form_error.admin_is_not_available: ディレクトリ名に「admin」を使用することはできません。
-form_error.member_already_exists: 既に利用されているログインIDです
-form_error.customer_already_exists:  このメールアドレスは利用できません
+form_error.member_already_exists: 既に利用されているログインIDです。
+form_error.customer_already_exists:  このメールアドレスは利用できません。
 
 #------------------------------------------------------------------------------------
 # Deplicated


### PR DESCRIPTION
closes https://github.com/EC-CUBE/ec-cube/issues/4036

## 概要(Overview・Refs Issue)
+ enが少し古いままとなっていたのでjaに追随する形でjaとenのメッセージを同期

## 方針(Policy)
+ jaとenで全ての行を揃えた
+ 他のページで使われている単語はできるだけ合わせた

## 実装に関する補足(Appendix)
+ Gと最大限の英語力で頑張った

## テスト（Test)
+ ８割くらい画面で確認したが、全メッセージは画面では確認できていない

## 相談（Discussion）
+ 新幹線で作業をすると酔います。

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ なし

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更
