### PR TITLE
有効化したプラグインが無効と判定されてしまうのを修正

### DIFF
--- a/src/Eccube/DependencyInjection/EccubeExtension.php
+++ b/src/Eccube/DependencyInjection/EccubeExtension.php
@@ -107,6 +107,9 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
         // prependのタイミングではコンテナのインスタンスは利用できない.
         // 直接dbalのconnectionを生成し, dbアクセスを行う.
         $params = $config['dbal']['connections'][$config['dbal']['default_connection']];
+        // ContainerInterface::resolveEnvPlaceholders() で取得した DATABASE_URL は
+        // % がエスケープされているため、環境変数から取得し直す
+        $params['url'] = env('DATABASE_URL');
         $conn = DriverManager::getConnection($params);
 
         if (!$this->isConnected($conn)) {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
https://github.com/EC-CUBE/ec-cube/issues/4043 の対策

PrependExtension では、Symfony Container のパラメータはまだ有効になっていないため、 `ContainerInterface::resolveEnvPlaceholders()` を使用して Doctrine のパラメータを取得している。
DATABASE_URL に `%` が含まれていると、エスケープされてしまい、後続の DB 接続に失敗してしまう


## 方針(Policy)
+ DATABASE_URL を環境変数から取得し直すよう修正

## テスト（Test)
+ URLエンコードされたパスワードを使用して、プラグイン設定画面のアイコンが表示されることを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更


