### PR TITLE
メンテナンスモード有効時でも管理者でログインしていればフロント画面を表示できるように対応

### DIFF
--- a/index.php
+++ b/index.php
@@ -53,24 +53,8 @@ if ($trustedHosts) {
     Request::setTrustedHosts(explode(',', $trustedHosts));
 }
 
-$request = Request::createFromGlobals();
-
-if (file_exists(__DIR__.'/.maintenance')) {
-    $pathInfo = \rawurldecode($request->getPathInfo());
-    $adminPath = env('ECCUBE_ADMIN_ROUTE', 'admin');
-    $adminPath = '/'.\trim($adminPath, '/').'/';
-    if (\strpos($pathInfo, $adminPath) !== 0) {
-        $locale = env('ECCUBE_LOCALE');
-        $templateCode = env('ECCUBE_TEMPLATE_CODE');
-        $baseUrl = \htmlspecialchars(\rawurldecode($request->getBaseUrl()), ENT_QUOTES);
-
-        header('HTTP/1.1 503 Service Temporarily Unavailable');
-        require __DIR__.'/maintenance.php';
-        return;
-    }
-}
-
 $kernel = new Kernel($env, $debug);
+$request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);

--- a/src/Eccube/EventListener/MaintenanceListener.php
+++ b/src/Eccube/EventListener/MaintenanceListener.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
+ *
+ * http://www.lockon.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\EventListener;
+
+use Eccube\Service\SystemService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * メンテナンス管理制御のためのListener
+ */
+class MaintenanceListener implements EventSubscriberInterface
+{
+
+    /**
+     * @var Session
+     */
+    protected $session;
+
+    /**
+     * @var SystemService
+     */
+    protected $systemService;
+
+    /**
+     * MaintenanceListener constructor.
+     *
+     * @param SessionInterface $session
+     * @param SystemService $systemService
+     */
+    public function __construct(SessionInterface $session, SystemService $systemService)
+    {
+        $this->session = $session;
+        $this->systemService = $systemService;
+    }
+
+
+    /**
+     * Kernel request listener callback.
+     *
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $isMaintenance = $this->systemService->isMaintenanceMode();
+
+        if ($isMaintenance) {
+
+            // メンテナンス中であればメンテナンス画面を表示させるが、管理者としてログインされていればフロント画面を表示させる
+            $is_admin = $this->session->has('_security_admin');
+            if (!$is_admin) {
+                $request = $event->getRequest();
+
+                $pathInfo = \rawurldecode($request->getPathInfo());
+                $adminPath = env('ECCUBE_ADMIN_ROUTE', 'admin');
+                $adminPath = '/'.\trim($adminPath, '/').'/';
+                if (\strpos($pathInfo, $adminPath) !== 0) {
+                    $locale = env('ECCUBE_LOCALE');
+                    $templateCode = env('ECCUBE_TEMPLATE_CODE');
+                    $baseUrl = \htmlspecialchars(\rawurldecode($request->getBaseUrl()), ENT_QUOTES);
+
+                    header('HTTP/1.1 503 Service Temporarily Unavailable');
+                    require __DIR__.'/../../../maintenance.php';
+                    exit;
+                }
+
+            }
+        }
+
+    }
+
+    /**
+     * Return the events to subscribe to.
+     *
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => 'onKernelRequest',
+        ];
+    }
+}

--- a/src/Eccube/Resource/template/default/maintenance.twig
+++ b/src/Eccube/Resource/template/default/maintenance.twig
@@ -1,5 +1,5 @@
 <!doctype html>
-<?php /*
+{#
 This file is part of EC-CUBE
 
 Copyright(c) LOCKON CO.,LTD. All Rights Reserved.
@@ -8,14 +8,14 @@ http://www.lockon.co.jp/
 
 For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
-*/ ?>
-<html lang="<?php echo $locale; ?>">
+#}
+<html lang="{{ eccube_config.locale }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>ただいまメンテナンス中です。</title>
-    <link rel="icon" href="<?php echo $baseUrl; ?>/html/template/<?php echo $templateCode; ?>/assets/img/common/favicon.ico">
-    <link rel="stylesheet" href="<?php echo $baseUrl; ?>/html/template/<?php echo $templateCode; ?>/assets/css/style.css">
+    <link rel="icon" href="{{ asset('assets/img/common/favicon.ico') }}">
+    <link rel="stylesheet" href="{{ asset('assets/css/style.css') }}">
 </head>
 <body>
 <div class="ec-layoutRole">
@@ -24,7 +24,7 @@ file that was distributed with this source code.
             <div class="ec-off4Grid__cell">
                 <div style="font-size:100px;text-align:center;">
                     <div class="ec-404Role__icon ec-icon">
-                        <img src="<?php echo $baseUrl; ?>/html/template/<?php echo $templateCode; ?>/assets/icon/exclamation-pale.svg" alt="">
+                        <img src="{{ asset('assets/icon/exclamation-pale.svg') }}" alt="">
                     </div>
                 </div>
                 <p class="ec-404Role__title ec-reportHeading">ただいまメンテナンス中です。</p>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
メンテナンスモード有効時だとフロント画面が参照できないため、
管理者でログインしていた場合、フロント画面が参照できるように対応

## 実装に関する補足(Appendix)
maintenance.phpからmaintenance.twigへと変更しています。

## テスト（Test)
テストコードは断念しました。

## 相談（Discussion）
管理者でログインしていなくても特定のIPアドレスが設定されていればフロント画面を表示できるようにした方が良いのか。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更
