### PR TITLE
セキュリティ設定画面での.envファイルのチェックするように変更

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -50,6 +50,12 @@ class SecurityController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            //.envファイルが存在しないときに設定は失敗する
+            if( file_exists('.env') == false) {
+                $this->addError('admin.common.save_error', 'admin');
+                return $this->redirectToRoute('admin_setting_system_security');
+            }
+
             $data = $form->getData();
             $envFile = $this->getParameter('kernel.project_dir').'/.env';
             $env = file_get_contents($envFile);
@@ -99,6 +105,11 @@ class SecurityController extends AbstractController
         $adminRoute = $this->eccubeConfig['eccube_admin_route'];
         if ($adminRoute === 'admin') {
             $this->addWarning('admin.setting.system.security.admin_url_warning', 'admin');
+        }
+
+        // .envファイルが存在しない場合警告を出す。
+        if (file_exists('.env') == false) {
+            $this->addDanger('admin.setting.system.security.not_found_env_file', 'admin');
         }
 
         return [

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -17,9 +17,9 @@ use Eccube\Controller\AbstractController;
 use Eccube\Form\Type\Admin\SecurityType;
 use Eccube\Util\CacheUtil;
 use Eccube\Util\StringUtil;
-use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class SecurityController extends AbstractController
@@ -53,6 +53,7 @@ class SecurityController extends AbstractController
             //.envファイルが存在しないときに設定は失敗する
             if (file_exists($this->getParameter('kernel.project_dir').'/.env') === false) {
                 $this->addError('admin.common.save_error', 'admin');
+
                 return $this->redirectToRoute('admin_setting_system_security');
             }
 

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -51,7 +51,7 @@ class SecurityController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             //.envファイルが存在しないときに設定は失敗する
-            if( file_exists('.env') === false) {
+            if (file_exists($this->getParameter('kernel.project_dir').'/.env') === false) {
                 $this->addError('admin.common.save_error', 'admin');
                 return $this->redirectToRoute('admin_setting_system_security');
             }
@@ -108,8 +108,8 @@ class SecurityController extends AbstractController
         }
 
         // .envファイルが存在しない場合警告を出す。
-        if (file_exists('.env') === false) {
-            $this->addDanger('admin.setting.system.security.not_found_env_file', 'admin');
+        if (file_exists($this->getParameter('kernel.project_dir').'/.env') === false) {
+            $this->addWarning('admin.setting.system.security.not_found_env_file', 'admin');
         }
 
         return [

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -51,7 +51,7 @@ class SecurityController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             //.envファイルが存在しないときに設定は失敗する
-            if( file_exists('.env') == false) {
+            if( file_exists('.env') === false) {
                 $this->addError('admin.common.save_error', 'admin');
                 return $this->redirectToRoute('admin_setting_system_security');
             }
@@ -108,7 +108,7 @@ class SecurityController extends AbstractController
         }
 
         // .envファイルが存在しない場合警告を出す。
-        if (file_exists('.env') == false) {
+        if (file_exists('.env') === false) {
             $this->addDanger('admin.setting.system.security.not_found_env_file', 'admin');
         }
 

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -1205,6 +1205,8 @@ admin.setting.system.security.force_ssl_description: Only https access is allowe
 admin.setting.system.security.ip_limit_invalid_ipv4: '%ip% is not an IPv4 address.'
 admin.setting.system.security.ip_limit_invalid_https: 'http is not allowed to do this setting.'
 admin.setting.system.security.admin_url_warning: Please set the Admin Console URL that is hard to guess for security.
+admin.setting.system.security.not_found_env_file: .env file not found. If you do not use the .env file you can not change security config in Admin Console.
+
 
 #------------------------------------------------------------------------------------
 # Settings : System : Logs

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -1207,7 +1207,6 @@ admin.setting.system.security.ip_limit_invalid_https: 'http is not allowed to do
 admin.setting.system.security.admin_url_warning: Please set the Admin Console URL that is hard to guess for security.
 admin.setting.system.security.not_found_env_file: .env file not found. If you do not use the .env file you can not change security config in Admin Console.
 
-
 #------------------------------------------------------------------------------------
 # Settings : System : Logs
 #------------------------------------------------------------------------------------

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -1205,6 +1205,7 @@ admin.setting.system.security.force_ssl_description: httpsからの接続でな�
 admin.setting.system.security.ip_limit_invalid_ipv4: '%ip%はIPv4アドレスではありません。'
 admin.setting.system.security.ip_limit_invalid_https: 'httpの場合には設定できません。'
 admin.setting.system.security.admin_url_warning: 管理画面URLは、セキュリティのため推測されにくいものを設定してください。
+admin.setting.system.security.not_found_env_file: .envファイルが見つかりません。.envを利用していない場合はセキュリティ設定を管理画面から変更できません。
 
 #------------------------------------------------------------------------------------
 # 設定：システム設定：ログ表示


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ #4061 の対策

## 方針(Policy)
+ .envファイルが存在しないときに、警告メッセージを画面に表示するように変更
+ .envファイルが存在しないときに、設定が失敗するように変更

## 実装に関する補足(Appendix)
+ 特になし

## テスト（Test)
+ .envの有無でのブラウザでの動作確認

## 相談（Discussion）
+ メッセージとして、.envファイル無しで画面を開いたときはaddDanger、登録に失敗したときは、addErrorとしたが使い方として妥当か。

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



