### PR TITLE
コマンドラインからのプラグインインストールに、with-composer option を追加

### DIFF
--- a/src/Eccube/Command/PluginInstallCommand.php
+++ b/src/Eccube/Command/PluginInstallCommand.php
@@ -30,6 +30,7 @@ class PluginInstallCommand extends Command
         $this
             ->addOption('path', null, InputOption::VALUE_OPTIONAL, 'path of tar or zip')
             ->addOption('code', null, InputOption::VALUE_OPTIONAL, 'plugin code')
+            ->addOption('with-composer')
             ->setDescription('Install plugin from local.');
     }
 
@@ -39,10 +40,14 @@ class PluginInstallCommand extends Command
 
         $path = $input->getOption('path');
         $code = $input->getOption('code');
+        $composer = $input->getOption('with-composer');
 
         // アーカイブからインストール
         if ($path) {
             if ($this->pluginService->install($path)) {
+                if ($composer) {
+                    $this->pluginService->installComposer($code);
+                }
                 $io->success('Installed.');
 
                 return 0;
@@ -52,11 +57,15 @@ class PluginInstallCommand extends Command
         // 設置済ファイルからインストール
         if ($code) {
             $this->pluginService->installWithCode($code);
+            if ($composer) {
+                $this->pluginService->installComposer($code);
+            }
             $this->clearCache($io);
             $io->success('Installed.');
 
             return 0;
         }
+
 
         $io->error('path or code is required.');
     }

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -936,4 +936,19 @@ class PluginService
 
         return false;
     }
+
+    public function installComposer($code) {
+
+        $pluginDir = $this->calcPluginDir($code);
+        $this->checkPluginArchiveContent($pluginDir);
+        $config = $this->readConfig($pluginDir);
+
+        // Check dependent plugin
+        // Don't install ec-cube library
+        $dependents = $this->getDependentByCode($config['code'], self::OTHER_LIBRARY);
+        if (!empty($dependents)) {
+            $package = $this->parseToComposerCommand($dependents);
+            $this->composerService->execRequire($package);
+        }
+    }
 }


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ composerを使用するプラグインをコマンドラインからインストール出来るオプションを追加する

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外した内容
  - 既存コードを再利用

## 実装に関する補足(Appendix)
+ コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと

## テスト（Test)
+ テストを行っている範囲など、レビューアが安心できるような情報

## 相談（Discussion）
+ 相談したいことや意見を求めたいこと

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



