### PR TITLE
InstallerControllerTest で dotenv をバックアップするよう修正

### DIFF
--- a/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
+++ b/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
@@ -40,6 +40,16 @@ class InstallControllerTest extends AbstractWebTestCase
     protected $request;
 
     /**
+     * @var string
+     */
+    protected $envFile;
+
+    /**
+     * @var string
+     */
+    protected $envFileBackup;
+
+    /**
      * @var Session
      */
     protected $session;
@@ -48,9 +58,10 @@ class InstallControllerTest extends AbstractWebTestCase
     {
         parent::setUp();
 
-        $envFile = $this->container->getParameter('kernel.project_dir').'/.env';
-        if (file_exists($envFile)) {
-            unlink($envFile);
+        $this->envFile = $this->container->getParameter('kernel.project_dir').'/.env';
+        $this->envFileBackup = $this->envFile.'.'.date('YmdHis');
+        if (file_exists($this->envFile)) {
+            rename($this->envFile, $this->envFileBackup);
         }
 
         $formFactory = $this->container->get('form.factory');
@@ -68,6 +79,14 @@ class InstallControllerTest extends AbstractWebTestCase
         $propContainer->setValue($this->controller, $this->container);
 
         $this->request = $this->createMock(Request::class);
+    }
+
+    public function tearDown()
+    {
+        if (file_exists($this->envFileBackup)) {
+            rename($this->envFileBackup, $this->envFile);
+        }
+        parent::tearDown();
     }
 
     public function testIndex()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ InstallerControllerTest で dotenv ファイルが削除されてしまうと悲しいので、バックアップするよう修正

## 方針(Policy)
+ setUp() で dotenv ファイルのバックアップを作成
+ tearDown() でバックアップから戻す

## テスト（Test)
+ テストケースの修正

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



