### PR TITLE
独自プラグインの有効/無効ボタンの重なりを修正 (Fixed Original Plugin On/Off button position.)

### DIFF
--- a/src/Eccube/Resource/template/admin/Store/plugin_table.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_table.twig
@@ -69,41 +69,43 @@ $(function() {
                             {% endif %}
                         </td>
                         <td class="align-middle">
-                            <div class="col-12 col-xs-11 col-md-10 col-lg-8 pull-right text-center">
+                            <div class="col-12 col-xs-11 col-md-12 col-lg-12 pull-right text-center">
                                 <div class="row">
-                                    <div class="col-4 px-0">
                                         {% if Plugin.enabled == false %}
+                                        <div class="col-6 px-0">
                                             <a href="#" class="btn btn-ec-actionIcon"
                                                data-toggle="modal"
                                                data-target="#localPluginDeleteModal"
                                                data-delete-url="{{ url('admin_store_plugin_uninstall', { id : Plugin.id }) }}">
                                                 <i class="fa fa-close fa-lg text-secondary" data-tooltip="true" data-placement="top" title="削除"></i>
                                             </a>
+                                        </div>
                                         {% endif %}
-                                    </div>
-                                    <div class="col-4 px-0">
                                         {% if Plugin.enabled %}
+                                        <div class="col-6 px-0">
                                             <a href="{{ url('admin_store_plugin_disable', { id : Plugin.id }) }}" {{ csrf_token_for_anchor() }}
                                                class="btn btn-ec-actionIcon"
                                                data-method="post" data-confirm="false">
                                                 <i class="fa fa-pause fa-lg text-secondary" data-tooltip="true" data-placement="top" title="{{ 'admin.store.plugin_table.903'|trans }}"></i>
                                             </a>
+                                        </div>
                                         {% else %}
+                                        <div class="col-6 px-0">
                                             <a href="{{ url('admin_store_plugin_enable', { id : Plugin.id }) }}" {{ csrf_token_for_anchor() }}
                                                class="btn btn-ec-actionIcon"
                                                data-method="post" data-confirm="false">
                                                 <i class="fa fa-play fa-lg text-secondary" data-tooltip="true" data-placement="top" title="{{ 'admin.store.plugin_table.902'|trans }}"></i>
                                             </a>
+                                        </div>
                                         {% endif %}
-                                    </div>
-                                    <div class="col-4 pl-0">
                                         {% if configPages[Plugin.code] is defined %}
+                                        <div class="col-6 pl-0">
                                             <a href='{{ configPages[Plugin.code] }}'
                                                class="btn btn-ec-actionIcon">
                                                 <i class="fa fa-cog fa-lg text-secondary" data-tooltip="true"
                                                    data-placement="top" title="{{ 'admin.store.plugin_table.891'|trans }}"></i></a>
+                                        </div>
                                         {% endif %}
-                                    </div>
                                 </div>
                             </div>
                         </td>

--- a/src/Eccube/Resource/template/admin/Store/plugin_table.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_table.twig
@@ -99,7 +99,7 @@ $(function() {
                                         </div>
                                         {% endif %}
                                         {% if configPages[Plugin.code] is defined %}
-                                        <div class="col-6 pl-0">
+                                        <div class="col-6 px-0">
                                             <a href='{{ configPages[Plugin.code] }}'
                                                class="btn btn-ec-actionIcon">
                                                 <i class="fa fa-cog fa-lg text-secondary" data-tooltip="true"


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ PullRequestの目的、関連するIssue番号など
関連Issue : #4078 
EC-CUBE 4.0.1 のプラグイン有効化、無効化、削除をする際に表示されるアイコンが低解像度のブラウザーで表示すると押したアイコンの隣のアイコンを押したと条件判定されるため、有効化を試みた際に削除が開始される恐れがある。

## 方針(Policy)
+ 独自プラグインのインストール時のみ修正されており、オーナーズストアからのインストール時はオーナーズストア側の仕様のため修正されていません。

## 実装に関する補足(Appendix)
+ 

## テスト（Test)
+ 

## 相談（Discussion）
+ 

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更


