### PR TITLE
フロントでログアウトしたときに管理画面がログアウトしないようにする

### DIFF
--- a/app/config/eccube/packages/security.yaml
+++ b/app/config/eccube/packages/security.yaml
@@ -37,6 +37,7 @@ security:
             logout:
                 path: admin_logout
                 target: admin_login
+                invalidate_session: false
         customer:
             pattern: ^/
             anonymous: true
@@ -59,6 +60,7 @@ security:
             logout:
                 path: logout
                 target: homepage
+                invalidate_session: false
 
     access_decision_manager:
         strategy: unanimous

--- a/app/config/eccube/packages/security.yaml
+++ b/app/config/eccube/packages/security.yaml
@@ -61,6 +61,7 @@ security:
                 path: logout
                 target: homepage
                 invalidate_session: false
+                handlers: [eccube.security.logout_handler]
 
     access_decision_manager:
         strategy: unanimous

--- a/app/config/eccube/packages/security.yaml
+++ b/app/config/eccube/packages/security.yaml
@@ -38,6 +38,7 @@ security:
                 path: admin_logout
                 target: admin_login
                 invalidate_session: false
+                handlers: [eccube.security.admin.logout_handler]
         customer:
             pattern: ^/
             anonymous: true
@@ -61,7 +62,7 @@ security:
                 path: logout
                 target: homepage
                 invalidate_session: false
-                handlers: [eccube.security.logout_handler]
+                handlers: [eccube.security.customer.logout_handler]
 
     access_decision_manager:
         strategy: unanimous

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -96,8 +96,11 @@ services:
     eccube.security.failure_handler:
         class: Eccube\Security\Http\Authentication\EccubeAuthenticationFailureHandler
 
-    eccube.security.logout_handler:
-        class: Eccube\Security\Http\Logout\LogoutHandler
+    eccube.security.admin.logout_handler:
+        class: Eccube\Security\Http\Logout\AdminLogoutHandler
+        
+    eccube.security.customer.logout_handler:
+        class: Eccube\Security\Http\Logout\CustomerLogoutHandler
 
     # Autowiring can't guess the constructor arguments that are not type-hinted with
     # classes (e.g. container parameters) so you must define those arguments explicitly

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -96,6 +96,9 @@ services:
     eccube.security.failure_handler:
         class: Eccube\Security\Http\Authentication\EccubeAuthenticationFailureHandler
 
+    eccube.security.logout_handler:
+        class: Eccube\Security\Http\Logout\LogoutHandler
+
     # Autowiring can't guess the constructor arguments that are not type-hinted with
     # classes (e.g. container parameters) so you must define those arguments explicitly
     # Eccube\Command\ListUsersCommand:

--- a/src/Eccube/Security/Http/Logout/AdminLogoutHandler.php
+++ b/src/Eccube/Security/Http/Logout/AdminLogoutHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Eccube\Security\Http\Logout;
+
+use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class AdminLogoutHandler implements LogoutHandlerInterface {
+
+    private $session;
+
+    public function __construct(SessionInterface $session)
+    {
+        $this->session = $session;
+    }
+
+    public function logout(Request $request, Response $response, TokenInterface $token)
+    {
+        if ($this->session->has("_security_admin")) {
+            $this->session->remove("_security_admin");
+        }
+    }
+
+}

--- a/src/Eccube/Security/Http/Logout/CustomerLogoutHandler.php
+++ b/src/Eccube/Security/Http/Logout/CustomerLogoutHandler.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
-class LogoutHandler implements LogoutHandlerInterface{
+class CustomerLogoutHandler implements LogoutHandlerInterface{
 
     private $session;
     
@@ -19,8 +19,14 @@ class LogoutHandler implements LogoutHandlerInterface{
     
     public function logout(Request $request, Response $response, TokenInterface $token)
     {
-        if($this->session->has('cart_keys')) {
-            $this->session->remove('cart_keys');
+        if($sessions = $this->session->all()) {
+            unset($sessions["_security_admin"]);
+            
+            foreach ($sessions as $key => $value) {
+                if($this->session->has($key)) {
+                    $this->session->remove($key);
+                }
+            }
         }
     }
 

--- a/src/Eccube/Security/Http/Logout/LogoutHandler.php
+++ b/src/Eccube/Security/Http/Logout/LogoutHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Eccube\Security\Http\Logout;
+
+use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class LogoutHandler implements LogoutHandlerInterface{
+
+    private $session;
+    
+    public function __construct(SessionInterface $session)
+    {
+        $this->session = $session;
+    }
+    
+    public function logout(Request $request, Response $response, TokenInterface $token)
+    {
+        if($this->session->has('cart_keys')) {
+            $this->session->remove('cart_keys');
+        }
+    }
+
+}


### PR DESCRIPTION
フロントと管理画面の両方ログインしていて片方でログアウトすると両方ログアウトしてしまう問題に対応しました。

invalidate_sessionをfalseにしてログアウト時にセッションを破棄しないようにすることで、
フロントでログアウトしても管理画面はログアウトしないようになりました。

以下のファイルの99行目でSessionLogoutHandlerを無効にしてるんじゃないかと思います。
Symfony\Component\Security\Http\Firewall\LogoutListener.php

<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容 -->
<!-- 例）Symfony のXXにならって作成、2系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->
<!-- 以下の変更を行っていないことを確認してください。変更を行っていなければチェックしてください。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



