### PR TITLE
html配下のプラグインディレクトリを削除するように修正

### DIFF
--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -925,7 +925,7 @@ class PluginService
      */
     public function removeAssets($pluginCode)
     {
-        $assetsDir = $this->eccubeConfig['plugin_html_realdir'].$pluginCode.'/assets';
+        $assetsDir = $this->eccubeConfig['plugin_html_realdir'].$pluginCode;
 
         // コピーされているリソースファイルがあれば削除
         if (file_exists($assetsDir)) {

--- a/tests/Eccube/Tests/Service/PluginServiceTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceTest.php
@@ -542,6 +542,19 @@ EOD;
         $this->assertEquals(trim($expected2), $actual2);
     }
 
+    public function testRemoveAssets()
+    {
+        $code = 'remove_assets_dir';
+        $dir = $this->eccubeConfig['plugin_html_realdir'].$code;
+        mkdir($dir, 0777, true);
+
+        $this->assertFileExists($dir);
+
+        $this->service->removeAssets($code);
+
+        $this->assertFileNotExists($dir);
+    }
+
     /**
      * @param $config
      *


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

- #3796 の対応

## 方針(Policy)

- プラグインのアンインストール時にはプラグインディレクトリごと削除する
- コマンドからのアンインストールの場合は, --uninstall-forceオプション指定時に削除される

## テスト（Test)
+ ユニットテストを追加

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



