### PR TITLE
プラグインインストール時のエラーが表示されない場合があるのを修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Store/plugin_confirm.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_confirm.twig
@@ -155,6 +155,9 @@ $(function() {
             if (res.responseJSON) {
                 log(res.responseJSON.log);
             }
+            if (res.responseText) {
+                log(res.responseText);
+            }
         }).always(function() {
             statusBar.hide();
             $('#installLogPane').show();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
プラグインインストール時のエラーが responseJson ではなく、 responseText で返ってくる場合があるのに対応。
サーバーエラーや PHP エラーが発生した場合などが該当する

## 方針(Policy)
+ responseText もログの表示に追加する

## テスト（Test)
+ ユニットテストや E2Eテストでサーバーエラーの再現が困難なため、目視確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



