### PR TITLE
商品編集画面で価格を編集時にも商品の更新日時が更新されるように修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductClassController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductClassController.php
@@ -218,6 +218,7 @@ class ProductClassController extends AbstractController
                 }
             }
 
+            $Product->setUpdateDate(new \DateTime());
             $this->entityManager->flush();
 
             $this->addSuccess('admin.product.reset_complete', 'admin');
@@ -397,6 +398,7 @@ class ProductClassController extends AbstractController
         ]);
         $DefaultProductClass->setVisible(false);
 
+        $Product->setUpdateDate(new \DateTime());
         $this->entityManager->flush();
     }
 

--- a/src/Eccube/Controller/Admin/Product/ProductClassController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductClassController.php
@@ -218,7 +218,6 @@ class ProductClassController extends AbstractController
                 }
             }
 
-            $Product->setUpdateDate(new \DateTime());
             $this->entityManager->flush();
 
             $this->addSuccess('admin.product.reset_complete', 'admin');
@@ -398,7 +397,6 @@ class ProductClassController extends AbstractController
         ]);
         $DefaultProductClass->setVisible(false);
 
-        $Product->setUpdateDate(new \DateTime());
         $this->entityManager->flush();
     }
 

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -587,6 +587,7 @@ class ProductController extends AbstractController
                     $this->entityManager->persist($ProductTag);
                 }
 
+                $Product->setUpdateDate(new \DateTime());
                 $this->entityManager->flush();
 
                 log_info('商品登録完了', [$id]);

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
@@ -339,6 +339,15 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $rUrl = $this->generateUrl('admin_product_product_edit', ['id' => $Product->getId()]);
         $this->assertTrue($this->client->getResponse()->isRedirect($rUrl));
 
+        // 編集前の更新日時を取得
+        /** @var Product $PreProduct */
+        $PreProduct = $this->productRepository->findOneBy(['id' => $Product->getId()]);
+        $PreUpdateDate = $PreProduct->getUpdateDate();
+        $preTimestamp = $PreUpdateDate->getTimestamp();
+
+        // タイムスタンプが変わっていることを確認するために3秒待って更新
+        sleep(3);
+
         $formData['return_link'] = $this->generateUrl('admin_product_category');
         $this->client->request(
             'POST',
@@ -351,6 +360,13 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $this->expected = $formData['name'];
         $this->actual = $EditedProduct->getName();
         $this->verify();
+
+        // 商品の更新日時が更新されているか確認
+        /** @var \DateTime $EditedUpdateDate */
+        $EditedUpdateDate = $EditedProduct->getUpdateDate();
+        $editedTimestamp = $EditedUpdateDate->getTimestamp();
+
+        $this->assertNotSame($preTimestamp, $editedTimestamp);
     }
 
     public function testDisplayProduct()


### PR DESCRIPTION
close #4098

## 概要(Overview・Refs Issue)
+ 価格は商品規格のテーブルにデータが保存されているため、商品の価格が更新されても商品の更新日時が更新されない状況となっていた。

## 方針(Policy)
+ 管理画面商品詳細画面での商品情報更新時には必ずの更新日時も更新されるように修正をした。
+ ただし、何も情報を変更しなくても更新日時が更新される仕様となる。

## 実装に関する補足(Appendix)
+ 

## テスト（Test)
+ 更新日時が更新されることを確認するテストコードを追加

## 相談（Discussion）
+ 

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ **商品の更新日時が更新される条件の仕様変更あり**

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



