### PR TITLE
管理画面URLの正規表現がインストーラとセキュリティ管理で異なっていたので修正

### DIFF
--- a/codeception/acceptance/EA01TopCest.php
+++ b/codeception/acceptance/EA01TopCest.php
@@ -81,7 +81,7 @@ class EA01TopCest
 
         // お知らせの記事をクリックすると設定されたURLに遷移することを確認
         $I->switchToIFrame('information');
-        $I->click(['css' => '.news_area .link_list .tableish a:nth-child(2)']);
+        $I->click(['css' => '.news_area .link_list .tableish a:nth-child(1)']);
         $I->switchToNewWindow();
         $I->assertRegExp('/^https?:\/\/www.ec-cube.net\/.*$/', $I->executeJS('return location.href'), '公式サイトが開く');
         $I->switchToWindow();

--- a/src/Eccube/Form/Type/Admin/SecurityType.php
+++ b/src/Eccube/Form/Type/Admin/SecurityType.php
@@ -68,7 +68,7 @@ class SecurityType extends AbstractType
                     new Assert\NotBlank(),
                     new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
                     new Assert\Regex([
-                        'pattern' => '/^[0-9a-zA-Z]+$/',
+                        'pattern' => '/\A\w+\z/',
                     ]),
                 ],
                 'data' => $this->eccubeConfig->get('eccube_admin_route'),

--- a/tests/Eccube/Tests/Form/Type/Admin/SecurityTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SecurityTypeTest.php
@@ -77,4 +77,30 @@ class SecurityTypeTest extends AbstractTypeTestCase
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
+
+    /**
+     * @dataProvider adminRouteDirParams
+     */
+    public function testAdminRouteDir($rootDir, $valid)
+    {
+        $this->formData['admin_route_dir'] = $rootDir;
+        $this->form->submit($this->formData);
+        $this->assertEquals($valid, $this->form->isValid());
+    }
+
+    public function adminRouteDirParams()
+    {
+        return [
+            ['admin', true],
+            ['ADMIN', true],
+            ['12345', true],
+            ['adminADMIN123', true],
+            ['admin_admin', true],
+            ['/admin', false],
+            ['admin/', false],
+            ['admin/route', false],
+            ['admin&', false],
+            ['admin?', false],
+        ];
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ インストール時の管理画面URLをチェックする正規表現は `\A\w+\z` なのに対してセキュリティ管理でのチェックは `^[0-9a-zA-Z]+$` になっており `_` が含まれているとセキュリティ管理で入力チェックに引っかかる

## 方針(Policy)
+ セキュリティ管理でも `\A\w+\z` でチェックする

## テスト（Test)
+ `SecurityTypeTest` にテストケースを追加

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



