### PR TITLE
MakerBundleのmakeコマンドで生成されるファイルの出力先を変更

### DIFF
--- a/app/config/eccube/packages/maker.yml
+++ b/app/config/eccube/packages/maker.yml
@@ -1,0 +1,2 @@
+maker:
+    root_namespace: 'Customize'


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
カスタマイズ時の工数を減らすため、MakerBundleのmakeコマンドで生成されるファイルの出力先をCustomizeディレクトリに変更してほしいです。


## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、2系で同様の仕様があったため など

## 実装に関する補足(Appendix)
+ コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと

## テスト（Test)
+ テストを行っている範囲など、レビューアが安心できるような情報

## 相談（Discussion）
Controllerを生成するとテンプレートも出力されるのですが、
そのテンプレートの出力先が/templatesになっている点が気になっています。

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



