### PR TITLE
管理画面からの受注登録時にもpre_order_idを発行(3.1)

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -658,7 +658,14 @@ class EditController extends AbstractController
 
     protected function newOrder(Application $app)
     {
-        $preOrderId = sha1(Str::random(32));
+        // ランダムなpre_order_idを作成
+        do {
+            $preOrderId = sha1(Str::random(32));
+            $Order = $app['eccube.repository.order']->findOneBy(array(
+                'pre_order_id' => $preOrderId
+            ));
+        } while ($Order);
+        
         $Order = new \Eccube\Entity\Order();
         $Shipping = new \Eccube\Entity\Shipping();
         $Shipping->setDelFlg(0);

--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -33,6 +33,7 @@ use Eccube\Entity\ShipmentItem;
 use Eccube\Entity\Shipping;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
+use Eccube\Util\Str;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -657,10 +658,12 @@ class EditController extends AbstractController
 
     protected function newOrder(Application $app)
     {
+        $preOrderId = sha1(Str::random(32));
         $Order = new \Eccube\Entity\Order();
         $Shipping = new \Eccube\Entity\Shipping();
         $Shipping->setDelFlg(0);
         $Order->addShipping($Shipping);
+        $Order->setPreOrderId($preOrderId);
         $Shipping->setOrder($Order);
 
         // device type

--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -658,7 +658,7 @@ class EditController extends AbstractController
 
     protected function newOrder(Application $app)
     {
-        // ランダムなpre_order_idを作成
+        // ユニークでランダムなpre_order_idを作成
         do {
             $preOrderId = sha1(Str::random(32));
             $Order = $app['eccube.repository.order']->findOneBy(array(


### PR DESCRIPTION

#4025 の引き継ぎ
上記のプルリクが3.0のブランチを元に開発されていたので、3.1のブランチにチェリーピック

## 概要(Overview・Refs Issue)

管理画面から受注登録をするとpre_order_idがNULLになる
#3972 

この状態で以下のステップを踏むとpre_order_idがNULLの受注金額で決済が行われてしまう。

クレジット決済を行う
→無意識に前の画面に戻る（完了していないのかと勘違いする）
→決済完了ボタンをクリック
→決済ができなかった旨のエラー画面が表示される
→内容をきちんと確認せずもう一度決済ボタンを押す
→pre_order_id　が NULLの受注金額で決済される。


## 実装に関する補足(Appendix)

管理画面からの受注登録でもpre_order_idを発行

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



