### PR TITLE
管理画面からの受注登録時にもpre_order_idを発行(4.0)

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -35,6 +35,7 @@ use Eccube\Repository\Master\OrderItemTypeRepository;
 use Eccube\Repository\Master\OrderStatusRepository;
 use Eccube\Repository\OrderRepository;
 use Eccube\Repository\ProductRepository;
+use Eccube\Service\OrderHelper;
 use Eccube\Service\OrderStateMachine;
 use Eccube\Service\PurchaseFlow\Processor\OrderNoProcessor;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
@@ -118,6 +119,11 @@ class EditController extends AbstractController
     protected $orderStatusRepository;
 
     /**
+     * @var OrderHelper
+     */
+    private $orderHelper;
+
+    /**
      * EditController constructor.
      *
      * @param TaxRuleService $taxRuleService
@@ -130,6 +136,10 @@ class EditController extends AbstractController
      * @param PurchaseFlow $orderPurchaseFlow
      * @param OrderRepository $orderRepository
      * @param OrderNoProcessor $orderNoProcessor
+     * @param OrderItemTypeRepository $orderItemTypeRepository
+     * @param OrderStatusRepository $orderStatusRepository
+     * @param OrderStateMachine $orderStateMachine
+     * @param OrderHelper $orderHelper
      */
     public function __construct(
         TaxRuleService $taxRuleService,
@@ -144,7 +154,8 @@ class EditController extends AbstractController
         OrderNoProcessor $orderNoProcessor,
         OrderItemTypeRepository $orderItemTypeRepository,
         OrderStatusRepository $orderStatusRepository,
-        OrderStateMachine $orderStateMachine
+        OrderStateMachine $orderStateMachine,
+        OrderHelper $orderHelper
     ) {
         $this->taxRuleService = $taxRuleService;
         $this->deviceTypeRepository = $deviceTypeRepository;
@@ -159,6 +170,7 @@ class EditController extends AbstractController
         $this->orderItemTypeRepository = $orderItemTypeRepository;
         $this->orderStatusRepository = $orderStatusRepository;
         $this->orderStateMachine = $orderStateMachine;
+        $this->orderHelper = $orderHelper;
     }
 
     /**
@@ -177,6 +189,9 @@ class EditController extends AbstractController
             // 空のエンティティを作成.
             $TargetOrder = new Order();
             $TargetOrder->addShipping((new Shipping())->setOrder($TargetOrder));
+
+            $preOrderId = $this->orderHelper->createPreOrderId();
+            $TargetOrder->setPreOrderId($preOrderId);
         } else {
             $TargetOrder = $this->orderRepository->find($id);
             if (null === $TargetOrder) {

--- a/src/Eccube/Service/OrderHelper.php
+++ b/src/Eccube/Service/OrderHelper.php
@@ -290,7 +290,7 @@ class OrderHelper
         }
     }
 
-    private function createPreOrderId()
+    public function createPreOrderId()
     {
         // ランダムなpre_order_idを作成
         do {

--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -16,6 +16,7 @@ namespace Eccube\Tests\Web\Admin\Order;
 use Eccube\Common\Constant;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Master\OrderStatus;
+use Eccube\Entity\Order;
 use Eccube\Repository\CustomerRepository;
 use Eccube\Repository\OrderRepository;
 use Eccube\Service\CartService;
@@ -27,6 +28,10 @@ class EditControllerTest extends AbstractEditControllerTestCase
     protected $Order;
     protected $Product;
     protected $cartService;
+
+    /**
+     * @var OrderRepository
+     */
     protected $orderRepository;
 
     public function setUp()
@@ -62,6 +67,11 @@ class EditControllerTest extends AbstractEditControllerTestCase
 
         $url = $crawler->filter('a')->text();
         $this->assertTrue($this->client->getResponse()->isRedirect($url));
+
+        // pre_order_id がセットされているか確認
+        /** @var Order[] $Orders */
+        $Orders = $this->orderRepository->findBy([], ['create_date' => 'DESC']);
+        $this->assertNotNull($Orders[0]->getPreOrderId());
     }
 
     public function testRoutingAdminOrderEdit()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

管理画面から受注登録をするとpre_order_idがNULLになる
#3972 

## 実装に関する補足(Appendix)

管理画面からの受注登録でもpre_order_idを発行

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ OrderHelper:: createPreOrderId()をprivateからpublicに変更しています。

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

