### PR TITLE
mailcatcher のバージョンを 0.6.5 に固定（3.1）

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ env:
 
 install:
   - gem install mime-types -v 2.99.1
-  - gem install mailcatcher
+  - gem install mailcatcher -v "0.6.5"
 
 before_script:
   - CODENAME=$(lsb_release -c -s)


### PR DESCRIPTION
refs https://github.com/EC-CUBE/ec-cube/pull/4103

## 概要(Overview・Refs Issue)
+ E2Eテストがエラーになるため、 mailcatcher のバージョンを 0.6.5 に固定

## 実装に関する補足(Appendix)
+ mailcatcher の最新版が 0.7.1 になり、メールの json フォーマットが変更になった

## テスト（Test)
+ Travis-CI のテストが通るのを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



