### PR TITLE
同名の Entity が存在した場合、Proxy ファイルを上書きしないよう修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ composer.phar
 /app/template/*
 !/app/template/admin
 !/app/template/default
+/app/proxy/entity/*
+!/app/proxy/entity/.gitkeep
 /html/plugin/*
 !/html/plugin/.gitkeep
 /html/install/temp/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ script:
   - ./bin/phpunit --group update-schema-doctrine-install --filter=testEnablePluginWithProxy
   - ./bin/phpunit --group update-schema-doctrine-install --filter=testDisablePluginWithNoProxy
   - ./bin/phpunit --group update-schema-doctrine-install --filter=testDisablePluginWithProxy
+  - ./bin/phpunit --group update-schema-doctrine-install --filter=testCreateEntityAndTrait
 
 jobs:
   fast_finish: true

--- a/codeception.sh
+++ b/codeception.sh
@@ -3,7 +3,7 @@
 if [[ $1 == '--reset' ]]; then
     rm -rf app/Plugin/* html
     git checkout app/Plugin html
-    git clean -df app/proxy/entity
+    find app/proxy/entity -name '*.php' -delete
     if [[ -f ".maintenance" ]]; then
         rm .maintenance
     fi

--- a/codeception/acceptance/EA10PluginCest.php
+++ b/codeception/acceptance/EA10PluginCest.php
@@ -790,7 +790,7 @@ class Horizon_Local extends Local_Plugin
         $this->tables[] = 'dtb_dash';
         $this->columns[] = 'dtb_cart.is_horizon';
         $this->columns[] = 'dtb_cart.dash_id';
-        $this->traits['\Plugin\Horizon\Entity\CartTrait'] = 'Cart';
+        $this->traits['\Plugin\Horizon\Entity\CartTrait'] = 'src/Eccube/Entity/Cart';
     }
 
     public static function start(AcceptanceTester $I)
@@ -807,7 +807,7 @@ class Horizon_Store extends Store_Plugin
         $this->tables[] = 'dtb_dash';
         $this->columns[] = 'dtb_cart.is_horizon';
         $this->columns[] = 'dtb_cart.dash_id';
-        $this->traits['\Plugin\Horizon\Entity\CartTrait'] = 'Cart';
+        $this->traits['\Plugin\Horizon\Entity\CartTrait'] = 'src/Eccube/Entity/Cart';
     }
 
     public static function start(AcceptanceTester $I)
@@ -852,7 +852,7 @@ class Emperor_Store extends Store_Plugin
         $this->publishPlugin('Horizon-1.0.0.tgz');
         $this->tables[] = 'dtb_foo';
         $this->columns[] = 'dtb_cart.foo_id';
-        $this->traits['\Plugin\Emperor\Entity\CartTrait'] = 'Cart';
+        $this->traits['\Plugin\Emperor\Entity\CartTrait'] = 'src/Eccube/Entity/Cart';
     }
 
     public static function start(AcceptanceTester $I, Store_Plugin $dependency = null)
@@ -864,7 +864,7 @@ class Emperor_Store extends Store_Plugin
     {
         $this->tables = ['dtb_bar'];
         $this->columns = ['dtb_cart.bar_id'];
-        $this->traits['\Plugin\Emperor\Entity\Cart2Trait'] = 'Cart';
+        $this->traits['\Plugin\Emperor\Entity\Cart2Trait'] = 'src/Eccube/Entity/Cart';
 
         return parent::アップデート();
     }
@@ -891,7 +891,7 @@ class Boomerang_Store extends Store_Plugin
         $this->tables[] = 'dtb_bar';
         $this->columns[] = 'dtb_cart.is_boomerang';
         $this->columns[] = 'dtb_cart.bar_id';
-        $this->traits['\Plugin\Boomerang\Entity\CartTrait'] = 'Cart';
+        $this->traits['\Plugin\Boomerang\Entity\CartTrait'] = 'src/Eccube/Entity/Cart';
     }
 
     public static function start(AcceptanceTester $I)
@@ -907,7 +907,7 @@ class Boomerang_Local extends Local_Plugin
         parent::__construct($I, 'Boomerang');
         $this->tables[] = 'dtb_bar';
         $this->columns[] = 'dtb_cart.is_boomerang';
-        $this->traits['\Plugin\Boomerang\Entity\CartTrait'] = 'Cart';
+        $this->traits['\Plugin\Boomerang\Entity\CartTrait'] = 'src/Eccube/Entity/Cart';
     }
 
     public static function start(AcceptanceTester $I)

--- a/src/Eccube/Command/UpdateSchemaDoctrineCommand.php
+++ b/src/Eccube/Command/UpdateSchemaDoctrineCommand.php
@@ -16,6 +16,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Command to generate the SQL needed to update the database schema to match
@@ -115,10 +117,11 @@ class UpdateSchemaDoctrineCommand extends BaseUpdateSchemaDoctrineCommand
     protected function removeOutputDir($outputDir)
     {
         if (file_exists($outputDir)) {
-            foreach (glob("${outputDir}/*") as $f) {
-                unlink($f);
-            }
-            rmdir($outputDir);
+            $files = Finder::create()
+                ->in($outputDir)
+                ->files();
+            $f = new Filesystem();
+            $f->remove($files);
         }
     }
 }

--- a/src/Eccube/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/src/Eccube/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -76,6 +76,7 @@ class AnnotationDriver extends \Doctrine\ORM\Mapping\Driver\AnnotationDriver
                     $sourceFile = str_replace('\\', '/', $sourceFile);
                     $projectDir = str_replace('\\', '/', $projectDir);
                 }
+                // Replace /path/to/ec-cube to proxies path
                 $proxyFile = str_replace($projectDir, $this->trait_proxies_directory, $path).'/'.basename($sourceFile);
                 if (file_exists($proxyFile)) {
                     require_once $proxyFile;

--- a/src/Eccube/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/src/Eccube/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -69,12 +69,14 @@ class AnnotationDriver extends \Doctrine\ORM\Mapping\Driver\AnnotationDriver
                         continue 2;
                     }
                 }
+                $projectDir = realpath(__DIR__.'/../../../../../../');
                 if ('\\' === DIRECTORY_SEPARATOR) {
                     $path = str_replace('\\', '/', $path);
                     $this->trait_proxies_directory = str_replace('\\', '/', $this->trait_proxies_directory);
                     $sourceFile = str_replace('\\', '/', $sourceFile);
+                    $projectDir = str_replace('\\', '/', $projectDir);
                 }
-                $proxyFile = str_replace($path, $this->trait_proxies_directory, $sourceFile);
+                $proxyFile = str_replace($projectDir, $this->trait_proxies_directory, $path).'/'.basename($sourceFile);
                 if (file_exists($proxyFile)) {
                     require_once $proxyFile;
 

--- a/src/Eccube/Doctrine/ORM/Mapping/Driver/ReloadSafeAnnotationDriver.php
+++ b/src/Eccube/Doctrine/ORM/Mapping/Driver/ReloadSafeAnnotationDriver.php
@@ -99,6 +99,7 @@ class ReloadSafeAnnotationDriver extends AnnotationDriver
                     $projectDir = str_replace('\\', '/', $projectDir);
                 }
 
+                // Replace /path/to/ec-cube to proxies path
                 $proxyFile = str_replace($projectDir, $this->trait_proxies_directory, $path).'/'.basename($sourceFile);
                 if (file_exists($proxyFile)) {
                     $sourceFile = $proxyFile;

--- a/src/Eccube/Doctrine/ORM/Mapping/Driver/ReloadSafeAnnotationDriver.php
+++ b/src/Eccube/Doctrine/ORM/Mapping/Driver/ReloadSafeAnnotationDriver.php
@@ -90,12 +90,16 @@ class ReloadSafeAnnotationDriver extends AnnotationDriver
                         continue 2;
                     }
                 }
+
+                $projectDir = realpath(__DIR__.'/../../../../../../');
                 if ('\\' === DIRECTORY_SEPARATOR) {
                     $path = str_replace('\\', '/', $path);
                     $this->trait_proxies_directory = str_replace('\\', '/', $this->trait_proxies_directory);
                     $sourceFile = str_replace('\\', '/', $sourceFile);
+                    $projectDir = str_replace('\\', '/', $projectDir);
                 }
-                $proxyFile = str_replace($path, $this->trait_proxies_directory, $sourceFile);
+
+                $proxyFile = str_replace($projectDir, $this->trait_proxies_directory, $path).'/'.basename($sourceFile);
                 if (file_exists($proxyFile)) {
                     $sourceFile = $proxyFile;
                 }

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -273,8 +273,12 @@ class Kernel extends BaseKernel
 
     protected function loadEntityProxies()
     {
-        foreach (glob(__DIR__.'/../../app/proxy/entity/*.php') as $file) {
-            require_once $file;
+        $files = Finder::create()
+            ->in(__DIR__.'/../../app/proxy/entity/')
+            ->name('*.php')
+            ->files();
+        foreach ($files as $file) {
+            require_once $file->getRealPath();
         }
     }
 }

--- a/src/Eccube/Service/EntityProxyService.php
+++ b/src/Eccube/Service/EntityProxyService.php
@@ -83,6 +83,7 @@ class EntityProxyService
             if (strpos($fileName, 'app/proxy/entity') === false) {
                 $this->removeClassExistsBlock($entityTokens); // remove class_exists block
             } else {
+                // Remove to duplicate path of /app/proxy/entity
                 $fileName = str_replace('/app/proxy/entity', '', $fileName);
             }
 
@@ -97,6 +98,7 @@ class EntityProxyService
             }
             $projectDir = str_replace('\\', '/', $this->container->getParameter('kernel.project_dir'));
 
+            // baseDir e.g. /src/Eccube/Entity and /app/Plugin/PluginCode/Entity
             $baseDir = str_replace($projectDir, '', str_replace($baseName, '', $fileName));
             if (!file_exists($outputDir.$baseDir)) {
                 mkdir($outputDir.$baseDir, 0777, true);

--- a/src/Eccube/Service/EntityProxyService.php
+++ b/src/Eccube/Service/EntityProxyService.php
@@ -103,8 +103,11 @@ class EntityProxyService
             $file = ltrim(str_replace($projectDir, '', $fileName), '/');
             $code = $entityTokens->generateCode();
             $generatedFiles[] = $outputFile = $outputDir.'/'.$file;
-            file_put_contents($outputFile, $code);
-            $output->writeln('gen -> '.$outputFile);
+            // Exclude output to app/proxy/entity/app/proxy/entity
+            if (strpos($outputFile, 'app/proxy/entity/app/proxy/entity') === false) {
+                file_put_contents($outputFile, $code);
+                $output->writeln('gen -> '.$outputFile);
+            }
         }
 
         return $generatedFiles;

--- a/src/Eccube/Service/EntityProxyService.php
+++ b/src/Eccube/Service/EntityProxyService.php
@@ -21,6 +21,7 @@ use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Finder\Finder;
 use Zend\Code\Reflection\ClassReflection;
 
@@ -32,13 +33,22 @@ class EntityProxyService
     protected $entityManager;
 
     /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
      * EntityProxyService constructor.
      *
      * @param EntityManagerInterface $entityManager
+     * @param ContainerInterface $container
      */
-    public function __construct(EntityManagerInterface $entityManager)
-    {
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        ContainerInterface $container
+    ) {
         $this->entityManager = $entityManager;
+        $this->container = $container;
     }
 
     /**
@@ -66,10 +76,11 @@ class EntityProxyService
         foreach ($targetEntities as $targetEntity) {
             $traits = isset($addTraits[$targetEntity]) ? $addTraits[$targetEntity] : [];
             $rc = new ClassReflection($targetEntity);
-            $fileName = $rc->getFileName();
+            $fileName = str_replace('\\', '/', $rc->getFileName());
+            $baseName = basename($fileName);
             $entityTokens = Tokens::fromCode(file_get_contents($fileName));
 
-            if (strpos(str_replace('\\', '/', $fileName), 'app/proxy/entity') === false) {
+            if (strpos($fileName, 'app/proxy/entity') === false) {
                 $this->removeClassExistsBlock($entityTokens); // remove class_exists block
             }
 
@@ -82,9 +93,14 @@ class EntityProxyService
             foreach ($traits as $trait) {
                 $this->addTrait($entityTokens, $trait);
             }
+            $projectDir = str_replace('\\', '/', $this->container->getParameter('kernel.project_dir'));
 
-            $file = basename($rc->getFileName());
+            $baseDir = str_replace($projectDir, '', str_replace($baseName, '', $fileName));
+            if (!file_exists($outputDir.$baseDir)) {
+                mkdir($outputDir.$baseDir, 0777, true);
+            }
 
+            $file = ltrim(str_replace($projectDir, '', $fileName), '/');
             $code = $entityTokens->generateCode();
             $generatedFiles[] = $outputFile = $outputDir.'/'.$file;
             file_put_contents($outputFile, $code);

--- a/src/Eccube/Service/EntityProxyService.php
+++ b/src/Eccube/Service/EntityProxyService.php
@@ -82,6 +82,8 @@ class EntityProxyService
 
             if (strpos($fileName, 'app/proxy/entity') === false) {
                 $this->removeClassExistsBlock($entityTokens); // remove class_exists block
+            } else {
+                $fileName = str_replace('/app/proxy/entity', '', $fileName);
             }
 
             if (isset($removeTrails[$targetEntity])) {
@@ -103,11 +105,9 @@ class EntityProxyService
             $file = ltrim(str_replace($projectDir, '', $fileName), '/');
             $code = $entityTokens->generateCode();
             $generatedFiles[] = $outputFile = $outputDir.'/'.$file;
-            // Exclude output to app/proxy/entity/app/proxy/entity
-            if (strpos($outputFile, 'app/proxy/entity/app/proxy/entity') === false) {
-                file_put_contents($outputFile, $code);
-                $output->writeln('gen -> '.$outputFile);
-            }
+
+            file_put_contents($outputFile, $code);
+            $output->writeln('gen -> '.$outputFile);
         }
 
         return $generatedFiles;

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -25,6 +25,7 @@ use Eccube\Service\Composer\ComposerServiceInterface;
 use Eccube\Util\CacheUtil;
 use Eccube\Util\StringUtil;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Filesystem\Filesystem;
 
 class PluginService
@@ -334,10 +335,11 @@ class PluginService
                 call_user_func($callback, $generatedFiles, $tmpProxyOutputDir);
             } finally {
                 if ($createOutputDir) {
-                    foreach (glob("${tmpProxyOutputDir}/*") as $f) {
-                        unlink($f);
-                    }
-                    rmdir($tmpProxyOutputDir);
+                    $files = Finder::create()
+                        ->in($tmpProxyOutputDir)
+                        ->files();
+                    $f = new Filesystem();
+                    $f->remove($files);
                 }
             }
         }

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -239,10 +239,7 @@ class PluginService
     {
         // dbにプラグイン登録
 
-        $isTransaction = $this->entityManager->getConnection()->isTransactionActive();
-        if (!$isTransaction) {
-            $this->entityManager->getConnection()->beginTransaction();
-        }
+        $this->entityManager->getConnection()->beginTransaction();
 
         try {
             $Plugin = $this->pluginRepository->findByCode($config['code']);
@@ -267,13 +264,10 @@ class PluginService
             $this->entityManager->persist($Plugin);
             $this->entityManager->flush();
 
-            if (!$isTransaction) {
-                $this->entityManager->getConnection()->commit();
-            }
+            $this->entityManager->flush();
+            $this->entityManager->getConnection()->commit();
         } catch (\Exception $e) {
-            if (!$isTransaction) {
-                $this->entityManager->getConnection()->rollback();
-            }
+            $this->entityManager->getConnection()->rollback();
             throw new PluginException($e->getMessage(), $e->getCode(), $e);
         }
     }
@@ -663,10 +657,7 @@ class PluginService
         try {
             $pluginDir = $this->calcPluginDir($plugin->getCode());
             $config = $this->readConfig($pluginDir);
-            $isTransaction = $em->getConnection()->isTransactionActive();
-            if (!$isTransaction) {
-                $em->getConnection()->beginTransaction();
-            }
+            $em->getConnection()->beginTransaction();
 
             $this->callPluginManagerMethod($config, $enable ? 'enable' : 'disable');
 
@@ -677,9 +668,7 @@ class PluginService
             $this->regenerateProxy($plugin, false);
 
             $em->flush();
-            if (!$isTransaction) {
-                $em->getConnection()->commit();
-            }
+            $em->getConnection()->commit();
 
             if ($enable) {
                 $this->pluginApiService->pluginEnabled($plugin);
@@ -687,9 +676,7 @@ class PluginService
                 $this->pluginApiService->pluginDisabled($plugin);
             }
         } catch (\Exception $e) {
-            if (!$isTransaction) {
-                $em->getConnection()->rollback();
-            }
+            $em->getConnection()->rollback();
             throw $e;
         }
 
@@ -753,11 +740,8 @@ class PluginService
     public function updatePlugin(Plugin $plugin, $meta)
     {
         $em = $this->entityManager;
-        $isTransaction = $this->entityManager->getConnection()->isTransactionActive();
         try {
-            if (!$isTransaction) {
-                $em->getConnection()->beginTransaction();
-            }
+            $em->getConnection()->beginTransaction();
             $plugin->setVersion($meta['version'])
                 ->setName($meta['name']);
 
@@ -768,13 +752,9 @@ class PluginService
             }
             $this->copyAssets($plugin->getCode());
             $em->flush();
-            if (!$isTransaction) {
-                $em->getConnection()->commit();
-            }
+            $em->getConnection()->commit();
         } catch (\Exception $e) {
-            if (!$isTransaction) {
-                $em->getConnection()->rollback();
-            }
+            $em->getConnection()->rollback();
             throw $e;
         }
     }

--- a/src/Eccube/Service/SchemaService.php
+++ b/src/Eccube/Service/SchemaService.php
@@ -18,6 +18,8 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
 use Eccube\Doctrine\ORM\Mapping\Driver\ReloadSafeAnnotationDriver;
 use Eccube\Util\StringUtil;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Filesystem\Filesystem;
 
 class SchemaService
 {
@@ -82,10 +84,11 @@ class SchemaService
             call_user_func($callback, $tool, $metaData);
         } finally {
             if ($createOutputDir) {
-                foreach (glob("${outputDir}/*") as $f) {
-                    unlink($f);
-                }
-                rmdir($outputDir);
+                $files = Finder::create()
+                    ->in($createOutputDir)
+                    ->files();
+                $f = new Filesystem();
+                $f->remove($files);
             }
         }
     }

--- a/src/Eccube/Service/SchemaService.php
+++ b/src/Eccube/Service/SchemaService.php
@@ -85,7 +85,7 @@ class SchemaService
         } finally {
             if ($createOutputDir) {
                 $files = Finder::create()
-                    ->in($createOutputDir)
+                    ->in($outputDir)
                     ->files();
                 $f = new Filesystem();
                 $f->remove($files);

--- a/tests/Eccube/Tests/Command/UpdateSchemaDoctrineCommandTest.php
+++ b/tests/Eccube/Tests/Command/UpdateSchemaDoctrineCommandTest.php
@@ -22,6 +22,8 @@ use Eccube\Service\SchemaService;
 use Eccube\Tests\EccubeTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -58,9 +60,12 @@ class UpdateSchemaDoctrineCommandTest extends EccubeTestCase
         if ('postgresql' !== $platform) {
             $this->markTestSkipped('does not support of '.$platform);
         }
-        foreach (glob($this->container->getParameter('kernel.project_dir').'/app/proxy/entity/*.php') as $file) {
-            unlink($file);
-        }
+        $files = Finder::create()
+            ->in($this->container->getParameter('kernel.project_dir').'/app/proxy/entity')
+            ->files();
+        $f = new Filesystem();
+        $f->remove($files);
+
         $this->pluginRepository = $this->container->get(PluginRepository::class);
         $this->pluginService = $this->container->get(PluginService::class);
         $this->schemaService = $this->container->get(SchemaService::class);

--- a/tests/Eccube/Tests/Service/EntityProxyServiceTest.php
+++ b/tests/Eccube/Tests/Service/EntityProxyServiceTest.php
@@ -18,6 +18,8 @@ use Eccube\Service\EntityProxyService;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Tokens;
 use Eccube\Tests\EccubeTestCase;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Filesystem\Filesystem;
 
 class EntityProxyServiceTest extends EccubeTestCase
 {
@@ -50,10 +52,11 @@ class EntityProxyServiceTest extends EccubeTestCase
      */
     public function tearDown()
     {
-        foreach (glob($this->tempOutputDir.'/*') as $file) {
-            unlink($file);
-        }
-        rmdir($this->tempOutputDir);
+        $files = Finder::create()
+            ->in($this->tempOutputDir)
+            ->files();
+        $f = new Filesystem();
+        $f->remove($files);
 
         parent::tearDown();
     }
@@ -62,7 +65,7 @@ class EntityProxyServiceTest extends EccubeTestCase
     {
         $this->entityProxyService->generate([__DIR__], [], $this->tempOutputDir);
 
-        $generatedFile = $this->tempOutputDir.'/Product.php';
+        $generatedFile = $this->tempOutputDir.'/src/Eccube/Entity/Product.php';
         self::assertTrue(file_exists($generatedFile));
 
         // Traitのuse句があるかどうか
@@ -85,7 +88,7 @@ class EntityProxyServiceTest extends EccubeTestCase
     {
         $this->entityProxyService->generate([__DIR__], [], $this->tempOutputDir);
 
-        $generatedFile = $this->tempOutputDir.'/Product.php';
+        $generatedFile = $this->tempOutputDir.'/src/Eccube/Entity/Product.php';
         self::assertTrue(file_exists($generatedFile));
 
         $tokens = Tokens::fromCode(file_get_contents($generatedFile));

--- a/tests/Eccube/Tests/Service/PluginServiceTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceTest.php
@@ -84,9 +84,11 @@ class PluginServiceTest extends AbstractServiceTestCase
             $this->deleteFile($dir);
         }
 
-        foreach (glob($this->container->getParameter('kernel.project_dir').'/app/proxy/entity/*.php') as $file) {
-            unlink($file);
-        }
+        $files = Finder::create()
+            ->in($this->container->getParameter('kernel.project_dir').'/app/proxy/entity')
+            ->files();
+        $f = new Filesystem();
+        $f->remove($files);
 
         $this->deleteAllRows(['dtb_plugin']);
 
@@ -540,6 +542,176 @@ EOD;
             $expected2 .= $packages.':'.$version.' ';
         }
         $this->assertEquals(trim($expected2), $actual2);
+    }
+
+    /**
+     * Test Entity and Trait
+     */
+    public function testCreateEntityAndTrait()
+    {
+
+        $this->service = $this->container->get(PluginService::class);
+        $rc = new \ReflectionClass($this->service);
+
+        $prop = $rc->getProperty('schemaService');
+        $prop->setAccessible(true);
+        $prop->setValue($this->service, $this->container->get(SchemaService::class));
+
+        $prop = $rc->getProperty('composerService');
+        $prop->setAccessible(true);
+        $prop->setValue($this->service, $this->container->get(ComposerServiceInterface::class));
+
+        $prop = $rc->getProperty('entityProxyService');
+        $prop->setAccessible(true);
+        $prop->setValue($this->service, $this->container->get(EntityProxyService::class));
+
+        $faker = $this->getFaker();
+        // インストールするプラグインを作成する
+        $tmpname = 'dummy'.$faker->word;
+        $config = [
+            'version' => $tmpname,
+            'description' => $tmpname,
+            'extra' => [
+                'code' => $tmpname,
+            ],
+        ];
+
+        $tmpdir = $this->createTempDir();
+        $tmpfile = $tmpdir.'/plugin.tar';
+
+        $tar = new \PharData($tmpfile);
+        $tar->addFromString('composer.json', json_encode($config));
+        $dummyManager = <<<'EOD'
+<?php
+namespace Plugin\@@@@ ;
+
+use Eccube\Plugin\AbstractPluginManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class PluginManager extends AbstractPluginManager
+{
+    public function install(array $meta, ContainerInterface $container)
+    {
+        echo "Installed";
+    }
+
+    public function uninstall(array $meta, ContainerInterface $container)
+    {
+        echo "Uninstalled";
+    }
+
+    public function enable(array $meta, ContainerInterface $container)
+    {
+        echo "Enabled";
+    }
+
+    public function disable(array $meta, ContainerInterface $container)
+    {
+        echo "Disabled";
+    }
+
+    public function update(array $meta, ContainerInterface $container)
+    {
+        echo "Updated";
+    }
+}
+
+EOD;
+        $dummyManager = str_replace('@@@@', $tmpname, $dummyManager); // イベントクラス名はランダムなのでヒアドキュメントの@@@@部分を置換
+        $tar->addFromString('PluginManager.php', $dummyManager);
+
+        $dummyEntity = <<<'EOD'
+<?php
+namespace Plugin\@@@@\Entity;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Blocknn
+ *
+ * @ORM\Table(name="plg_@@@@")
+ * @ORM\Entity(repositoryClass="Plugin\@@@@\Repository\BlockRepository")
+ */
+if (!class_exists('\Plugin\@@@@\Entity\Block')) {
+class Block
+{
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="id", type="integer", options={"unsigned":true})
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    private $id;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}
+}
+EOD;
+        $dummyEntity = str_replace('@@@@', $tmpname, $dummyEntity); // イベントクラス名はランダムなのでヒアドキュメントの@@@@部分を置換
+        $tar->addFromString('Entity/Block.php', $dummyEntity);
+
+        $dummyTrait = <<<'EOD'
+<?php
+namespace Plugin\@@@@\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Eccube\Annotation as Eccube;
+
+/**
+ * @Eccube\EntityExtension("Plugin\@@@@\Entity\Block")
+ */
+trait BlockTrait {
+
+    /**
+     * @ORM\Column(name="sample", type="boolean", options={"default":false})
+     */
+    public $sample;
+}
+EOD;
+        $dummyTrait = str_replace('@@@@', $tmpname, $dummyTrait); // イベントクラス名はランダムなのでヒアドキュメントの@@@@部分を置換
+        $tar->addFromString('Entity/BlockTrait.php', $dummyEntity);
+
+        // インストールできるか、インストーラが呼ばれるか
+        ob_start();
+        $this->assertTrue($this->service->install($tmpfile));
+
+        $this->assertRegexp('/Installed/', ob_get_contents());
+        ob_end_clean();
+        $this->assertFileExists(__DIR__."/../../../../app/Plugin/$tmpname/Entity/Block.php");
+        $this->assertFileExists(__DIR__."/../../../../app/Plugin/$tmpname/Entity/BlockTrait.php");
+
+        $this->assertTrue((bool) $plugin = $this->pluginRepository->findOneBy(['name' => $tmpname]));
+
+        ob_start();
+        $this->service->enable($plugin);
+        $this->assertRegexp('/Enabled/', ob_get_contents());
+        ob_end_clean();
+
+        // check to Entity and Trait
+        $clazz = '\\Plugin\\'.$tmpname.'\\Entity\\Block';
+        $Block = new $clazz();
+        $Block->sample = true;
+        $this->entityManager->persist($Block);
+        $this->entityManager->flush($Block);
+        $this->assertTrue($this->entityManager->find($clazz, 1)->sample);
+
+        ob_start();
+        $this->service->disable($plugin);
+        $this->assertRegexp('/Disabled/', ob_get_contents());
+        ob_end_clean();
+
+        // アンインストールできるか、アンインストーラが呼ばれるか
+        ob_start();
+        $this->service->disable($plugin);
+        $this->assertTrue($this->service->uninstall($plugin));
+        $this->assertRegexp('/DisabledUninstalled/', ob_get_contents());
+        ob_end_clean();
     }
 
     public function testRemoveAssets()

--- a/tests/Eccube/Tests/Service/PluginServiceTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceTest.php
@@ -546,9 +546,16 @@ EOD;
 
     /**
      * Test Entity and Trait
+     * @group update-schema-doctrine
+     * @group update-schema-doctrine-install
      */
     public function testCreateEntityAndTrait()
     {
+        $conn = $this->entityManager->getConnection();
+        $platform = $conn->getDatabasePlatform()->getName();
+        if ('postgresql' !== $platform) {
+            $this->markTestSkipped('does not support of '.$platform);
+        }
 
         $this->service = $this->container->get(PluginService::class);
         $rc = new \ReflectionClass($this->service);

--- a/tests/Eccube/Tests/Service/PluginServiceWithEntityExtensionTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceWithEntityExtensionTest.php
@@ -78,9 +78,12 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
             $this->deleteFile($dir);
         }
 
-        foreach (glob($this->container->getParameter('kernel.project_dir').'/app/proxy/entity/*.php') as $file) {
-            unlink($file);
-        }
+        $files = Finder::create()
+            ->in($this->container->getParameter('kernel.project_dir').'/app/proxy/entity')
+            ->files();
+        $f = new Filesystem();
+        $f->remove($files);
+
         parent::tearDown();
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ https://github.com/EC-CUBE/ec-cube/issues/4097
+ プラグインをアンインストールしたらテーブルが削除されてしまう場合があるのを修正

## 方針(Policy)
+ proxy ファイルを生成する際、 namespace を考慮できていないため、namespace ごとにディレクトリを分けるよう修正

## 実装に関する補足(Appendix)
+ プラグインアンインストールでテーブルが削除されるのは防げるようになった模様

## テスト（Test)
+ Entity と Trait を追加するテストケースを追加

## 相談（Discussion）
+ **バージョンアップ時に、 proxy ファイルを生成し直す必要がある**

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更


