### PR TITLE
バリデーションエラー発生時に、ブロックの変更内容が保持されない問題に対応 

### DIFF
--- a/codeception/_support/Page/Admin/LayoutEditPage.php
+++ b/codeception/_support/Page/Admin/LayoutEditPage.php
@@ -124,4 +124,11 @@ class LayoutEditPage extends AbstractAdminPageStyleGuide
 
         return $this;
     }
+
+    public function レイアウト名($value)
+    {
+        $this->tester->fillField(['css' => '#admin_layout_name'], $value);
+
+        return $this;
+    }
 }

--- a/codeception/_support/Page/Admin/LayoutManagePage.php
+++ b/codeception/_support/Page/Admin/LayoutManagePage.php
@@ -39,4 +39,9 @@ class LayoutManagePage extends AbstractAdminPageStyleGuide
         $this->tester->click(['xpath' => "//div[@id='sortable_list_box__list']//div[@class='item_pattern td'][translate(text(), ' \r\n', '')='${layoutName}']/parent::node()/div[@class='icon_edit td']/div/span"]);
         $this->tester->click(['xpath' => "//div[@id='sortable_list_box__list']//div[@class='item_pattern td'][translate(text(), ' \r\n', '')='${layoutName}']/parent::node()/div[@class='icon_edit td']/div/ul/li[2]/span"]);
     }
+
+    public function 新規登録()
+    {
+        $this->tester->click(['xpath' => "//*[@id=\"page_admin_content_layout\"]/div[1]/div[3]/div[2]/div/div/div[1]/a"]);
+    }
 }

--- a/codeception/acceptance/EA06ContentsManagementCest.php
+++ b/codeception/acceptance/EA06ContentsManagementCest.php
@@ -225,6 +225,25 @@ class EA06ContentsManagementCest
         $I->see('削除しました', PageEditPage::$登録完了メッセージ);
     }
 
+    public function contentsmanagement_レイアウト管理(\AcceptanceTester $I)
+    {
+        // レイアウト名を未入力で登録
+        LayoutManagePage::go($I)->新規登録();
+        LayoutEditPage::at($I)
+            ->登録();
+
+        // html5のバリデーションエラーで画面遷移しないはず
+        $I->seeInCurrentUrl('/admin/content/layout/new');
+        $I->cantSee('入力されていません。');
+
+        // レイアウト名を入力して登録
+        LayoutEditPage::at($I)
+            ->レイアウト名('あたらしいレイアウト')
+            ->登録();
+
+        $I->see('保存しました');
+    }
+
     public function contentsmanagement_検索未使用ブロック(\AcceptanceTester $I)
     {
         $I->wantTo('EA0603-UC01-T06 検索未使用ブロック');

--- a/src/Eccube/Form/Type/Admin/LayoutType.php
+++ b/src/Eccube/Form/Type/Admin/LayoutType.php
@@ -43,7 +43,6 @@ class LayoutType extends AbstractType
                     'constraints' => [
                         new Assert\NotBlank(),
                     ],
-                    'required' => false,
                 ]
             )->add(
                 'DeviceType',


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- バリデーションエラー発生時に、ブロックの変更内容が保持されない問題に対応 
- #3364

## 方針(Policy)
- 事象が発生する操作としては、新規登録時にレイアウト名を未入力のまま登録、というケースが大半と思われるため、html5でのバリデーションで制御し、画面遷移を発生させないように修正

## テスト（Test)
+ e2eテストを追加

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



