### PR TITLE
ファイル管理：画像の場合はサムネイル表示を行うように対応

### DIFF
--- a/src/Eccube/Resource/template/admin/Content/file.twig
+++ b/src/Eccube/Resource/template/admin/Content/file.twig
@@ -172,7 +172,17 @@ file that was distributed with this source code.
                                                     {% if file.is_dir %}
                                                         <i class="fa fa-folder-o fa-2x"></i>
                                                     {% else %}
-                                                        <div class="d-inline-block p-3 bg-light">{{ file.extension|file_ext_icon({class: "fa-2x"}) }} </div>
+                                                        {% if file.extension|file_ext_icon({}, true) == 'fa-file-image-o' %}
+                                                            <div class="d-inline-block p-3 bg-light"
+                                                                 style="background: no-repeat center center;
+                                                                    background-image: url('{{ asset('', 'user_data') }}{{ file.file_path|slice(1) }}');
+                                                                    background-size: contain; width: 49px; height: 57px;">
+                                                            </div>
+                                                        {% else %}
+                                                            <div class="d-inline-block p-3 bg-light">
+                                                                {{ file.extension|file_ext_icon({class: "fa-2x"}) }}
+                                                            </div>
+                                                        {% endif %}
                                                     {% endif %}
                                                 </td>
                                                 <td class="align-middle">

--- a/src/Eccube/Twig/Extension/EccubeExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeExtension.php
@@ -294,10 +294,11 @@ class EccubeExtension extends AbstractExtension
      *
      * @param $ext
      * @param $attr
+     * @param $iconOnly アイコンのクラス名のみ返す場合はtrue
      *
      * @return string
      */
-    public function getExtensionIcon($ext, $attr = [])
+    public function getExtensionIcon($ext, $attr = [], $iconOnly = false)
     {
         $classes = [
             'txt' => 'fa-file-text-o',
@@ -328,7 +329,14 @@ class EccubeExtension extends AbstractExtension
             'mov' => 'fa-file-video-o',
             'mkv' => 'fa-file-video-o',
         ];
+        $ext = strtolower($ext);
+
         $class = isset($classes[$ext]) ? $classes[$ext] : 'fa-file-o';
+
+        if ($iconOnly) {
+            return $class;
+        }
+
         $attr['class'] = isset($attr['class'])
             ? $attr['class']." fa {$class}"
             : "fa {$class}";

--- a/tests/Eccube/Tests/Twig/Extension/EccubeExtensionTest.php
+++ b/tests/Eccube/Tests/Twig/Extension/EccubeExtensionTest.php
@@ -76,4 +76,24 @@ class EccubeExtensionTest extends EccubeTestCase
             }
         }
     }
+
+    /**
+     * @dataProvider extensionProvider
+     */
+    public function testGetExtensionIcon($ext, $iconOnly, $expected)
+    {
+        $actual = $this->Extension->getExtensionIcon($ext, [], $iconOnly);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function extensionProvider()
+    {
+        return [
+            ['jpg', false, '<i class="fa fa-file-image-o" ></i>'],
+            ['JPG', false, '<i class="fa fa-file-image-o" ></i>'],
+            ['jpg', true, 'fa-file-image-o'],
+            ['JPG', true, 'fa-file-image-o'],
+        ];
+    }
 }
+


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ #4109 画像の場合はサムネイル表示するように対応 

## 方針(Policy)
+ 画像のみサムネイル表示。その他は現状のアイコンを表示する
+ EccubeExtension::getExtensionIconでfontawsomeのクラス名を取得できるように修正

## テスト（Test)
+ EccubeExtension::getExtensionIconのテストと追加

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



