### PR TITLE
plugin_search.twigのinfoクラスのmin-heightを修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Store/plugin_search.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_search.twig
@@ -25,7 +25,7 @@ file that was distributed with this source code.
             max-height: 180px;
         }
         #plugin-list .info{
-            min-height: 65%;
+            min-height: 50%;
         }
         .plugin-ver li span{
             display: inline-block;


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#4101 の修正案になります．

## 方針(Policy)
+ 「プラグインを探す」画面において，ブラウザのウィンドウ幅が一定以下の時に，対応バージョンの表記が下にはみ出る現象を確認いたしました．
<img width="908" alt="スクリーンショット 2019-03-28 15 51 16" src="https://user-images.githubusercontent.com/22028871/55137628-d13cf500-5174-11e9-8b91-5e213af7b274.png">
<img width="900" alt="スクリーンショット 2019-03-28 15 51 54" src="https://user-images.githubusercontent.com/22028871/55137629-d1d58b80-5174-11e9-82e7-d3bbce4dd3ec.png">

+ 原因として，プラグインのタイトルと説明が記述されている.infoクラスのmin-heightが65%に指定されており，説明が短いプラグインが想定よりも長く表示されていると考えられます．
+ 実際，説明の文章が数行に渡るプラグインはバージョン表記が乱れていません．
<img width="851" alt="スクリーンショット 2019-03-28 15 55 24" src="https://user-images.githubusercontent.com/22028871/55138139-1150a780-5176-11e9-8ebc-7c44ccbda829.png">


+ そのため，infoのmin-heightを65%から50%に変更しました，自分環境で確認した限り，一定以下のウィンドウで崩れていたバージョン表記の崩れは無くなりました．

## 実装に関する補足(Appendix)
+ 特にありません