### PR TITLE
テストケースで ID が正常に取得できなかったのを修正

### DIFF
--- a/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
@@ -395,7 +395,11 @@ class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $this->expected = 'application/pdf';
         $this->verify();
 
-        $OrderPdf = current($this->orderPdfRepository->findAll());
+        $OrderPdfs = $this->orderPdfRepository->findAll();
+        $this->assertCount(1, $OrderPdfs, '1件保存されているはず');
+
+        $OrderPdf = current($OrderPdfs);
+        $this->assertEquals($adminTest->getId(), $OrderPdf->getMemberId(), '管理ユーザーのIDと一致するはず');
 
         $this->assertNull($OrderPdf->getTitle());
         $this->assertNull($OrderPdf->getMessage1());

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
@@ -395,7 +395,7 @@ class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $this->expected = 'application/pdf';
         $this->verify();
 
-        $OrderPdf = $this->orderPdfRepository->find($adminTest->getId());
+        $OrderPdf = current($this->orderPdfRepository->findAll());
 
         $this->assertNull($OrderPdf->getTitle());
         $this->assertNull($OrderPdf->getMessage1());


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ https://github.com/EC-CUBE/ec-cube/issues/4013
+ `OrderPdfRepository::find()` メソッドの引数に管理者の ID を渡していたのを修正

## 方針(Policy)
+ Response から ID を取得できないので、全検索して先頭のオブジェクトを取得

## テスト（Test)
+ テストケースの修正

## 相談（Discussion）
+ `current()` 関数以外に良い方法があるか🤔

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更


