### PR TITLE
EccubeTestCase::loginTo の Client を使いまわすよう修正

### DIFF
--- a/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
@@ -299,16 +299,15 @@ class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $shippingId = $Shippings[0]->getId();
 
         /**
-         * @var Client
-         */
-        $client = $this->client;
-
-        /**
          * @var Generator
          */
         $faker = $this->getFaker();
         $adminTest = $this->createMember();
-        $this->loginTo($adminTest);
+
+        /**
+         * @var Client
+         */
+        $client = $this->loginTo($adminTest);
         $OrderPdf = new OrderPdf();
 
         $OrderPdf->setMemberId($adminTest->getId())


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ #4013 
+ OrderPdfControllerTest が落ちるのを修正する試み

## 方針(Policy)
+ `$this->loginTo()` の返り値である `HttpKernel\Client` を使いまわすよう修正



## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更


