### PR TITLE
受注ステータス一括変更のテストが落ちるのを修正する試み

### DIFF
--- a/codeception/acceptance/EA04OrderCest.php
+++ b/codeception/acceptance/EA04OrderCest.php
@@ -348,42 +348,47 @@ class EA04OrderCest
         // 新規受付ステータスをキャンセルに変更する
         $entityManager = Fixtures::get('entityManager');
         $findOrders = Fixtures::get('findOrders');
-        $NewOrders = array_filter($findOrders(), function ($Order) {
+        $ExistsNewOrders = array_filter($findOrders(), function ($Order) {
             return $Order->getOrderStatus()->getId() == OrderStatus::NEW;
         });
         $CancelStatus = $entityManager->getRepository('Eccube\Entity\Master\OrderStatus')->find(OrderStatus::CANCEL);
-        foreach ($NewOrders as $newOrder) {
-            $newOrder->setOrderStatus($CancelStatus);
+        foreach ($ExistsNewOrders as $ExistsNewOrder) {
+            $ExistsNewOrder->setOrderStatus($CancelStatus);
         }
         $entityManager->flush();
 
         // 新規受付ステータスの受注を作る
         $createCustomer = Fixtures::get('createCustomer');
         $createOrders = Fixtures::get('createOrders');
-        $newOrders = $createOrders($createCustomer(), 2, []);
+        $NewOrders = $createOrders($createCustomer(), 2, []);
         $Status = $entityManager->getRepository('Eccube\Entity\Master\OrderStatus')->find(OrderStatus::NEW);
-        foreach ($newOrders as $newOrder) {
-            $newOrder->setOrderStatus($Status);
+        foreach ($NewOrders as $NewOrder) {
+            $NewOrder->setOrderStatus($Status);
         }
         $entityManager->flush();
 
+        // 検索し直す
         $NewOrders = array_filter($findOrders(), function ($Order) {
             return $Order->getOrderStatus()->getId() == OrderStatus::NEW;
         });
         OrderManagePage::go($I)->受注ステータス検索(OrderStatus::NEW);
+        $I->comment('新規受付の受注を検索します。想定値: '.count($NewOrders).'件');
         $I->see('検索結果：'.count($NewOrders).'件が該当しました', OrderManagePage::$検索結果_メッセージ);
 
         $DeliveredOrders = array_filter($findOrders(), function ($Order) {
             return $Order->getOrderStatus()->getId() == OrderStatus::DELIVERED;
         });
         OrderManagePage::go($I)->受注ステータス検索(OrderStatus::DELIVERED);
+        $I->comment('発送済みの受注を検索します。想定値: '.count($DeliveredOrders).'件');
         $I->see('検索結果：'.count($DeliveredOrders).'件が該当しました', OrderManagePage::$検索結果_メッセージ);
 
+        $I->comment('受注ステータスを新規受付から発送済みに変更します');
         OrderManagePage::go($I)->受注ステータス検索(OrderStatus::NEW)
             ->一覧_全選択()
             ->受注ステータス変更('発送済み');
 
         OrderManagePage::go($I)->受注ステータス検索(OrderStatus::DELIVERED);
+        $I->comment('発送済みに変更した件数を確認します。新規受付: '.count($NewOrders).'件 +  発送済み: '.count($DeliveredOrders).'件');
         $I->see('検索結果：'.(count($DeliveredOrders) + count($NewOrders)).'件が該当しました', OrderManagePage::$検索結果_メッセージ);
     }
 
@@ -396,22 +401,22 @@ class EA04OrderCest
         // 新規受付ステータスをキャンセルに変更する
         $entityManager = Fixtures::get('entityManager');
         $findOrders = Fixtures::get('findOrders');
-        $NewOrders = array_filter($findOrders(), function ($Order) {
+        $ExistsNewOrders = array_filter($findOrders(), function ($Order) {
             return $Order->getOrderStatus()->getId() == OrderStatus::NEW;
         });
         $CancelStatus = $entityManager->getRepository('Eccube\Entity\Master\OrderStatus')->find(OrderStatus::CANCEL);
-        foreach ($NewOrders as $newOrder) {
-            $newOrder->setOrderStatus($CancelStatus);
+        foreach ($ExistsNewOrders as $ExistsNewOrder) {
+            $ExistsNewOrder->setOrderStatus($CancelStatus);
         }
         $entityManager->flush();
 
         // 新規受付ステータスの受注を作る
         $createCustomer = Fixtures::get('createCustomer');
         $createOrders = Fixtures::get('createOrders');
-        $newOrders = $createOrders($createCustomer(), 2, []);
+        $NewOrders = $createOrders($createCustomer(), 2, []);
         $Status = $entityManager->getRepository('Eccube\Entity\Master\OrderStatus')->find(OrderStatus::NEW);
-        foreach ($newOrders as $newOrder) {
-            $newOrder->setOrderStatus($Status);
+        foreach ($NewOrders as $NewOrder) {
+            $NewOrder->setOrderStatus($Status);
         }
         $entityManager->flush();
 
@@ -419,14 +424,17 @@ class EA04OrderCest
             return $Order->getOrderStatus()->getId() == OrderStatus::DELIVERED;
         });
         OrderManagePage::go($I)->受注ステータス検索(OrderStatus::DELIVERED);
+        $I->comment('発送済みの受注を検索します。想定値: '.count($DeliveredOrders).'件');
         $I->see('検索結果：'.count($DeliveredOrders).'件が該当しました', OrderManagePage::$検索結果_メッセージ);
 
         $NewOrders = array_filter($findOrders(), function ($Order) {
             return $Order->getOrderStatus()->getId() == OrderStatus::NEW;
         });
         OrderManagePage::go($I)->受注ステータス検索(OrderStatus::NEW);
+        $I->comment('新規受付の受注を検索します。想定値: '.count($NewOrders).'件');
         $I->see('検索結果：'.count($NewOrders).'件が該当しました', OrderManagePage::$検索結果_メッセージ);
 
+        $I->comment('出荷済みに変更します');
         OrderManagePage::go($I)->受注ステータス検索(OrderStatus::NEW)
             ->出荷済にする(1);
 

--- a/codeception/acceptance/EA04OrderCest.php
+++ b/codeception/acceptance/EA04OrderCest.php
@@ -438,6 +438,7 @@ class EA04OrderCest
         OrderManagePage::go($I)->受注ステータス検索(OrderStatus::NEW)
             ->出荷済にする(1);
 
+        $I->wait(5);
         $I->seeEmailCount(2);
         $I->seeInLastEmailSubjectTo('admin@example.com', '[EC-CUBE SHOP] 商品出荷のお知らせ');
 


### PR DESCRIPTION

以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ #4013 
- 変数の大文字小文字を統一
- 変数名が重複していたのを修正
- コメント追加
- メール送信数チェックの前に wait 追加

## 実装に関する補足(Appendix)
+ まずはテストが落ちたときの詳細がわかるように

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更


