### PR TITLE
アクセス修飾子をprivateからprotectedに変更した

### DIFF
--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -75,7 +75,7 @@ class ProductController extends AbstractController
      */
     protected $productListMaxRepository;
 
-    private $title = '';
+    protected $title = '';
 
     /**
      * ProductController constructor.
@@ -488,7 +488,7 @@ class ProductController extends AbstractController
      *
      * @return str
      */
-    private function getPageTitle($searchData)
+    protected function getPageTitle($searchData)
     {
         if (isset($searchData['name']) && !empty($searchData['name'])) {
             return trans('front.product.search_result');
@@ -506,7 +506,7 @@ class ProductController extends AbstractController
      *
      * @return boolean 閲覧可能な場合はtrue
      */
-    private function checkVisibility(Product $Product)
+    protected function checkVisibility(Product $Product)
     {
         $is_admin = $this->session->has('_security_admin');
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
public メソッドから 同クラス内の private メソッドをコールしているコードがあるため、
このクラスで定義している public メソッドは子クラスからエラーが発生し、使用できません。

## 実装に関する補足(Appendix)
各クラス内のメソッド、プロパティは継承されることを前提に、privateではなく、protectedで実装して欲しいです。
このような実装は他のクラスにも散見されますが、レビューが大変になりますので、このクラスのみ修正します。

## テスト（Test)
子クラスを作成し、エラーが発生しないことを確認しました。
