### PR TITLE
Use MailCatcher on Docker

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@
 # Set build version format here instead of in the admin panel.
 version: 3.x-{build}
 
+image: Visual Studio 2017
+
 clone_folder: c:\projects\ec-cube
 
 cache:
@@ -21,6 +23,9 @@ environment:
     DBPASS: "Password12!"
     DBUSER: "root"
     BASE_DIR: "C:/projects/ec-cube"
+    MAIL_BACKEND: "smtp"
+    MAIL_HOST: "127.0.0.1"
+    MAIL_PORT: "1025"
 
   matrix:
   - db: mysql
@@ -31,6 +36,8 @@ services:
 
 # Install scripts. (runs after repo cloning)
 install:
+  - docker pull nanasess/mailcatcher:windowsservercore
+  - docker run -d -p 1080:1080 -p 1025:1025 --name mailcatcher nanasess/mailcatcher:windowsservercore
   - cp phpunit.xml.dist phpunit.xml
   # see https://github.com/phpmd/phpmd/blob/master/appveyor.yml#L10-L13
   - cinst -y OpenSSL.Light --version 1.1.1


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ AppVeyor で MailCatcher を使用する

## 方針(Policy)
+ VS2017 のイメージで Docker コンテナが利用できるようになったので、 MailCatcher の Docker コンテナを追加

## テスト（Test)
+ メール関係のテストがスキップされずに通ることを確認

## 相談（Discussion）
+ Windows Server Core のイメージは6GBくらいあり、 pull に時間がかかる(5分程度)
+ 本来は Nano Server を使用したいが、以下の問題があり、現在は Windows Server Core のイメージを使用している
   - Ruby 2.3.x までは SQLIte3 の gem のビルドに失敗する
   - Ruby 2.4.x 以降は Nano Server で Ruby が動かない

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



