### PR TITLE
大文字の拡張子で画像アップロードできるよう修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -326,7 +326,7 @@ class ProductController extends AbstractController
 
                     // 拡張子
                     $extension = $image->getClientOriginalExtension();
-                    if (!in_array($extension, $allowExtensions)) {
+                    if (!in_array(strtolower($extension), $allowExtensions)) {
                         throw new UnsupportedMediaTypeHttpException();
                     }
 

--- a/src/Eccube/Controller/Admin/Setting/Shop/PaymentController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/PaymentController.php
@@ -181,7 +181,7 @@ class PaymentController extends AbstractController
 
             // 拡張子
             $extension = $image->getClientOriginalExtension();
-            if (!in_array($extension, $allowExtensions)) {
+            if (!in_array(strtolower($extension), $allowExtensions)) {
                 throw new UnsupportedMediaTypeHttpException();
             }
 

--- a/src/Eccube/Controller/Admin/Store/TemplateController.php
+++ b/src/Eccube/Controller/Admin/Store/TemplateController.php
@@ -259,7 +259,7 @@ class TemplateController extends AbstractController
 
             // 一時ディレクトリへ解凍する.
             try {
-                if ($formFile->getClientOriginalExtension() === 'zip') {
+                if (strtolower($formFile->getClientOriginalExtension()) === 'zip') {
                     $zip = new \ZipArchive();
                     $zip->open($tmpDir.'/'.$archive);
                     $zip->extractTo($tmpDir);

--- a/tests/Eccube/Tests/Web/Admin/Store/TemplateControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Store/TemplateControllerTest.php
@@ -158,6 +158,16 @@ class TemplateControllerTest extends AbstractAdminWebTestCase
     }
 
     /**
+     * アップロード(大文字の拡張子)
+     */
+    public function testUploadWithUppercaseSuffix()
+    {
+        // テンプレートをアップロード
+        $this->scenarioUpload(true);
+        $this->verifyUpload();
+    }
+
+    /**
      * ダウンロード
      */
     public function testDownload()
@@ -200,10 +210,10 @@ class TemplateControllerTest extends AbstractAdminWebTestCase
         self::assertFalse(file_exists($this->container->getParameter('kernel.project_dir').'/app/template/'.$code));
     }
 
-    protected function scenarioUpload()
+    protected function scenarioUpload($uppercase = false)
     {
         $formData = $this->createFormData();
-        $fileData = $this->createFileData();
+        $fileData = $this->createFileData($uppercase);
 
         return $this->client->request(
             'POST',
@@ -231,8 +241,17 @@ class TemplateControllerTest extends AbstractAdminWebTestCase
         ];
     }
 
-    protected function createFileData()
+    protected function createFileData($uppercase = false)
     {
+        if ($uppercase) {
+            $file = $this->dir.'/template.ZIP';
+            $zip = new \ZipArchive();
+            $zip->open($file, \ZipArchive::CREATE);
+            $zip->addEmptyDir('app');
+            $zip->addEmptyDir('html');
+            $zip->close();
+            $this->file = new UploadedFile($file, 'dummy.ZIP', 'application/zip');
+        }
         return [
             'file' => $this->file,
         ];


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ #4077
+ 画像アップロード時に大文字の拡張子でアップロードできるように修正
+ ZIP 形式のテンプレートの場合も小文字の拡張子に固定されていたため、同様に修正

## 方針(Policy)
+ `strtolower()` で拡張子を小文字に変換してチェックするよう修正

## テスト（Test)
+ 大文字でファイルアップロードするテストを追加

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更


