### PR TITLE
拡張に備えてprivate functionをpublic、protectedに

### DIFF
--- a/src/Eccube/Controller/Admin/AdminController.php
+++ b/src/Eccube/Controller/Admin/AdminController.php
@@ -417,7 +417,7 @@ class AdminController extends AbstractController
      *
      * @return null|Request
      */
-    private function getOrderEachStatus(array $excludes)
+    protected function getOrderEachStatus(array $excludes)
     {
         $sql = 'SELECT
                     t1.order_status_id as status,
@@ -451,7 +451,7 @@ class AdminController extends AbstractController
      *
      * @throws \Doctrine\ORM\NonUniqueResultException
      */
-    private function getSalesByDay($dateTime)
+    protected function getSalesByDay($dateTime)
     {
         // concat... for pgsql
         // http://stackoverflow.com/questions/1091924/substr-does-not-work-with-datatype-timestamp-in-postgres-8-3
@@ -489,7 +489,7 @@ class AdminController extends AbstractController
      *
      * @throws \Doctrine\ORM\NonUniqueResultException
      */
-    private function getSalesByMonth($dateTime)
+    protected function getSalesByMonth($dateTime)
     {
         // concat... for pgsql
         // http://stackoverflow.com/questions/1091924/substr-does-not-work-with-datatype-timestamp-in-postgres-8-3
@@ -527,7 +527,7 @@ class AdminController extends AbstractController
      *
      * @throws \Doctrine\ORM\NonUniqueResultException
      */
-    private function countNonStockProducts()
+    protected function countNonStockProducts()
     {
         $qb = $this->productRepository->createQueryBuilder('p')
             ->select('count(DISTINCT p.id)')
@@ -545,7 +545,7 @@ class AdminController extends AbstractController
      *
      * @throws \Doctrine\ORM\NonUniqueResultException
      */
-    private function countProducts()
+    protected function countProducts()
     {
         $qb = $this->productRepository->createQueryBuilder('p')
             ->select('count(p.id)')
@@ -562,7 +562,7 @@ class AdminController extends AbstractController
      *
      * @throws \Doctrine\ORM\NonUniqueResultException
      */
-    private function countCustomers()
+    protected function countCustomers()
     {
         $qb = $this->customerRepository->createQueryBuilder('c')
             ->select('count(c.id)')
@@ -581,7 +581,7 @@ class AdminController extends AbstractController
      *
      * @return array
      */
-    private function getData(Carbon $fromDate, Carbon $toDate, $format)
+    protected function getData(Carbon $fromDate, Carbon $toDate, $format)
     {
         $qb = $this->orderRepository->createQueryBuilder('o')
             ->andWhere('o.order_date >= :fromDate')
@@ -607,7 +607,7 @@ class AdminController extends AbstractController
      *
      * @return array
      */
-    private function convert($result, Carbon $fromDate, Carbon $toDate, $format)
+    protected function convert($result, Carbon $fromDate, Carbon $toDate, $format)
     {
         $raw = [];
         for ($date = $fromDate; $date <= $toDate; $date = $date->addDay()) {

--- a/src/Eccube/Controller/Admin/Content/FileController.php
+++ b/src/Eccube/Controller/Admin/Content/FileController.php
@@ -275,7 +275,7 @@ class FileController extends AbstractController
         }
     }
 
-    private function getTreeToArray($tree)
+    protected function getTreeToArray($tree)
     {
         $arrTree = [];
         foreach ($tree as $key => $val) {
@@ -292,7 +292,7 @@ class FileController extends AbstractController
         return $arrTree;
     }
 
-    private function getPathsToArray($tree)
+    protected function getPathsToArray($tree)
     {
         $paths = [];
         foreach ($tree as $val) {
@@ -306,7 +306,7 @@ class FileController extends AbstractController
      * @param string $topDir
      * @param Request $request
      */
-    private function getTree($topDir, $request)
+    protected function getTree($topDir, $request)
     {
         $finder = Finder::create()->in($topDir)
             ->directories()
@@ -345,7 +345,7 @@ class FileController extends AbstractController
     /**
      * @param string $nowDir
      */
-    private function getFileList($nowDir)
+    protected function getFileList($nowDir)
     {
         $topDir = $this->getuserDataDir();
         $filter = function (\SplFileInfo $file) use ($topDir) {
@@ -432,7 +432,7 @@ class FileController extends AbstractController
     /**
      * @return string
      */
-    private function convertStrFromServer($target)
+    protected function convertStrFromServer($target)
     {
         if ($this->encode == self::SJIS) {
             return mb_convert_encoding($target, self::UTF, self::SJIS);
@@ -441,7 +441,7 @@ class FileController extends AbstractController
         return $target;
     }
 
-    private function convertStrToServer($target)
+    protected function convertStrToServer($target)
     {
         if ($this->encode == self::SJIS) {
             return mb_convert_encoding($target, self::SJIS, self::UTF);
@@ -450,12 +450,12 @@ class FileController extends AbstractController
         return $target;
     }
 
-    private function getUserDataDir($nowDir = null)
+    protected function getUserDataDir($nowDir = null)
     {
         return rtrim($this->getParameter('kernel.project_dir').'/html/user_data'.$nowDir, '/');
     }
 
-    private function getJailDir($path)
+    protected function getJailDir($path)
     {
         $realpath = realpath($path);
         $jailPath = str_replace(realpath($this->getUserDataDir()), '', $realpath);

--- a/src/Eccube/Controller/Admin/Order/MailController.php
+++ b/src/Eccube/Controller/Admin/Order/MailController.php
@@ -227,7 +227,7 @@ class MailController extends AbstractController
         ];
     }
 
-    private function createBody($Order, $twig = 'Mail/order.twig')
+    protected function createBody($Order, $twig = 'Mail/order.twig')
     {
         return $this->renderView($twig, [
             'Order' => $Order,

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -384,7 +384,7 @@ class OrderController extends AbstractController
      *
      * @return StreamedResponse
      */
-    private function exportCsv(Request $request, $csvTypeId, $fileName)
+    protected function exportCsv(Request $request, $csvTypeId, $fileName)
     {
         // タイムアウトを無効にする.
         set_time_limit(0);

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -1241,7 +1241,7 @@ class CsvImportController extends AbstractCsvImportController
      *
      * @return array
      */
-    private function getProductCsvHeader()
+    protected function getProductCsvHeader()
     {
         return [
             trans('admin.product.product_csv.product_id_col') => [
@@ -1365,7 +1365,7 @@ class CsvImportController extends AbstractCsvImportController
     /**
      * カテゴリCSVヘッダー定義
      */
-    private function getCategoryCsvHeader()
+    protected function getCategoryCsvHeader()
     {
         return [
             trans('admin.product.category_csv.category_id_col') => [
@@ -1400,7 +1400,7 @@ class CsvImportController extends AbstractCsvImportController
      *
      * @return ProductCategory
      */
-    private function makeProductCategory($Product, $Category, $sortNo)
+    protected function makeProductCategory($Product, $Category, $sortNo)
     {
         $ProductCategory = new ProductCategory();
         $ProductCategory->setProduct($Product);

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -1000,7 +1000,7 @@ class ProductController extends AbstractController
      *
      * @return \Eccube\Entity\ProductCategory
      */
-    private function createProductCategory($Product, $Category, $count)
+    protected function createProductCategory($Product, $Category, $count)
     {
         $ProductCategory = new ProductCategory();
         $ProductCategory->setProduct($Product);

--- a/src/Eccube/Controller/Admin/Setting/System/LogController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/LogController.php
@@ -81,7 +81,7 @@ class LogController extends AbstractController
      *
      * @return array
      */
-    private function parseLogFile($logFile, $formData)
+    protected function parseLogFile($logFile, $formData)
     {
         $log = [];
 

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -488,7 +488,7 @@ class ProductController extends AbstractController
      *
      * @return str
      */
-    private function getPageTitle($searchData)
+    public function getPageTitle($searchData)
     {
         if (isset($searchData['name']) && !empty($searchData['name'])) {
             return trans('front.product.search_result');
@@ -506,7 +506,7 @@ class ProductController extends AbstractController
      *
      * @return boolean 閲覧可能な場合はtrue
      */
-    private function checkVisibility(Product $Product)
+    public function checkVisibility(Product $Product)
     {
         $is_admin = $this->session->has('_security_admin');
 

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -710,7 +710,7 @@ class ShoppingController extends AbstractShoppingController
      *
      * @return PaymentMethodInterface
      */
-    private function createPaymentMethod(Order $Order, FormInterface $form)
+    public function createPaymentMethod(Order $Order, FormInterface $form)
     {
         $PaymentMethod = $this->container->get($Order->getPayment()->getMethodClass());
         $PaymentMethod->setOrder($Order);

--- a/src/Eccube/Form/Type/Shopping/OrderType.php
+++ b/src/Eccube/Form/Type/Shopping/OrderType.php
@@ -190,7 +190,7 @@ class OrderType extends AbstractType
         return '_shopping_order';
     }
 
-    private function addPaymentForm(FormInterface $form, array $choices, Payment $data = null)
+    protected function addPaymentForm(FormInterface $form, array $choices, Payment $data = null)
     {
         $message = trans('front.shopping.payment_method_unselected');
 
@@ -220,7 +220,7 @@ class OrderType extends AbstractType
      *
      * @return Delivery[]
      */
-    private function getDeliveries(Order $Order)
+    protected function getDeliveries(Order $Order)
     {
         $Deliveries = [];
         foreach ($Order->getShippings() as $Shipping) {
@@ -241,7 +241,7 @@ class OrderType extends AbstractType
      *
      * @return ArrayCollection
      */
-    private function getPayments($Deliveries)
+    protected function getPayments($Deliveries)
     {
         $PaymentsByDeliveries = [];
         foreach ($Deliveries as $Delivery) {
@@ -281,7 +281,7 @@ class OrderType extends AbstractType
      *
      * @return Payment[]
      */
-    private function filterPayments(ArrayCollection $Payments, $total)
+    protected function filterPayments(ArrayCollection $Payments, $total)
     {
         $PaymentArrays = $Payments->filter(function (Payment $Payment) use ($total) {
             $min = $Payment->getRuleMin();

--- a/src/Eccube/Service/OrderHelper.php
+++ b/src/Eccube/Service/OrderHelper.php
@@ -306,7 +306,7 @@ class OrderHelper
         return $preOrderId;
     }
 
-    private function setCustomer(Order $Order, Customer $Customer)
+    protected function setCustomer(Order $Order, Customer $Customer)
     {
         if ($Customer->getId()) {
             $Order->setCustomer($Customer);
@@ -328,7 +328,7 @@ class OrderHelper
      *
      * @return OrderItem[]
      */
-    private function createOrderItemsFromCartItems($CartItems)
+    protected function createOrderItemsFromCartItems($CartItems)
     {
         $ProductItemType = $this->orderItemTypeRepository->find(OrderItemType::PRODUCT);
 
@@ -369,7 +369,7 @@ class OrderHelper
      *
      * @return Shipping
      */
-    private function createShippingFromCustomer(Customer $Customer)
+    protected function createShippingFromCustomer(Customer $Customer)
     {
         $Shipping = new Shipping();
         $Shipping
@@ -390,7 +390,7 @@ class OrderHelper
     /**
      * @param Shipping $Shipping
      */
-    private function setDefaultDelivery(Shipping $Shipping)
+    protected function setDefaultDelivery(Shipping $Shipping)
     {
         // 配送商品に含まれる販売種別を抽出.
         $OrderItems = $Shipping->getOrderItems();
@@ -414,7 +414,7 @@ class OrderHelper
     /**
      * @param Order $Order
      */
-    private function setDefaultPayment(Order $Order)
+    protected function setDefaultPayment(Order $Order)
     {
         $OrderItems = $Order->getOrderItems();
 
@@ -450,7 +450,7 @@ class OrderHelper
      * @param Shipping $Shipping
      * @param array $OrderItems
      */
-    private function addOrderItems(Order $Order, Shipping $Shipping, array $OrderItems)
+    protected function addOrderItems(Order $Order, Shipping $Shipping, array $OrderItems)
     {
         foreach ($OrderItems as $OrderItem) {
             $Shipping->addOrderItem($OrderItem);

--- a/src/Eccube/Service/OrderStateMachine.php
+++ b/src/Eccube/Service/OrderStateMachine.php
@@ -223,7 +223,7 @@ class OrderStateMachine implements EventSubscriberInterface
         $Order->setOrderStatus($CompletedOrderStatus);
     }
 
-    private function newContext(Order $Order)
+    protected function newContext(Order $Order)
     {
         return new OrderStateMachineContext((string) $Order->getOrderStatus()->getId(), $Order);
     }

--- a/src/Eccube/Service/PurchaseFlow/Processor/AddPointProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/AddPointProcessor.php
@@ -63,7 +63,7 @@ class AddPointProcessor extends ItemHolderPostValidator
      *
      * @return int
      */
-    private function calculateAddPoint(ItemHolderInterface $itemHolder)
+    protected function calculateAddPoint(ItemHolderInterface $itemHolder)
     {
         $basicPointRate = $this->BaseInfo->getBasicPointRate();
 
@@ -106,7 +106,7 @@ class AddPointProcessor extends ItemHolderPostValidator
      *
      * @return bool
      */
-    private function supports(ItemHolderInterface $itemHolder)
+    protected function supports(ItemHolderInterface $itemHolder)
     {
         if (!$this->BaseInfo->isOptionPoint()) {
             return false;

--- a/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeePreprocessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeePreprocessor.php
@@ -84,7 +84,7 @@ class DeliveryFeePreprocessor implements ItemHolderPreprocessor
         $this->saveDeliveryFeeItem($itemHolder);
     }
 
-    private function removeDeliveryFeeItem(ItemHolderInterface $itemHolder)
+    protected function removeDeliveryFeeItem(ItemHolderInterface $itemHolder)
     {
         foreach ($itemHolder->getShippings() as $Shipping) {
             foreach ($Shipping->getOrderItems() as $item) {
@@ -102,7 +102,7 @@ class DeliveryFeePreprocessor implements ItemHolderPreprocessor
      *
      * @throws \Doctrine\ORM\NoResultException
      */
-    private function saveDeliveryFeeItem(ItemHolderInterface $itemHolder)
+    protected function saveDeliveryFeeItem(ItemHolderInterface $itemHolder)
     {
         $DeliveryFeeType = $this->entityManager
             ->find(OrderItemType::class, OrderItemType::DELIVERY_FEE);

--- a/src/Eccube/Service/PurchaseFlow/Processor/PaymentValidator.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PaymentValidator.php
@@ -78,7 +78,7 @@ class PaymentValidator extends ItemHolderValidator
         }
     }
 
-    private function getDeliveries(SaleType $SaleType)
+    protected function getDeliveries(SaleType $SaleType)
     {
         $Deliveries = $this->deliveryRepository->findBy(
             [
@@ -95,7 +95,7 @@ class PaymentValidator extends ItemHolderValidator
      *
      * @return ArrayCollection|Payment[]
      */
-    private function getPayments($Deliveries)
+    protected function getPayments($Deliveries)
     {
         $Payments = new ArrayCollection();
         foreach ($Deliveries as $Delivery) {

--- a/src/Eccube/Service/PurchaseFlow/Processor/PointDiffProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PointDiffProcessor.php
@@ -132,7 +132,7 @@ class PointDiffProcessor extends ItemHolderValidator implements PurchaseProcesso
      *
      * @return bool
      */
-    private function supports(ItemHolderInterface $itemHolder, PurchaseContext $context)
+    protected function supports(ItemHolderInterface $itemHolder, PurchaseContext $context)
     {
         if (!$this->pointHelper->isPointEnabled()) {
             return false;

--- a/src/Eccube/Service/PurchaseFlow/Processor/PointProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PointProcessor.php
@@ -173,7 +173,7 @@ class PointProcessor implements DiscountProcessor, PurchaseProcessor
      *
      * @return bool
      */
-    private function supports(ItemHolderInterface $itemHolder)
+    protected function supports(ItemHolderInterface $itemHolder)
     {
         if (!$this->pointHelper->isPointEnabled()) {
             return false;

--- a/src/Eccube/Service/PurchaseFlow/Processor/StockReduceProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/StockReduceProcessor.php
@@ -71,7 +71,7 @@ class StockReduceProcessor extends AbstractPurchaseProcessor
         });
     }
 
-    private function eachProductOrderItems(ItemHolderInterface $itemHolder, callable $callback)
+    protected function eachProductOrderItems(ItemHolderInterface $itemHolder, callable $callback)
     {
         // Order以外の場合は何もしない
         if (!$itemHolder instanceof Order) {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#4135 に関連して、コアのクラスを継承して拡張したいケースに備えて謎のprivate修飾子をprotected若しくはpublicに変更した。（本当は気持ちよく全部publicにしたかった）

## 方針(Policy)
各プライベートメソッドの処理を確認し、privateである必要性、そのメソッドを変更したいケースをざっくり考えて、変更する必要性が無さそう、変更しない方が良いと思うところはprivateのままに残した。

## 実装に関する補足(Appendix)
積極的にこれらのクラスを継承して子クラスを作って拡張する事はあまり想定していない。それ以外の方法で難しい、無理がでる場合に必要になると思う。（要はガッツリ改造する時）
そういった魔改造に近いケースでも改変部分をわかりやすく分離しておく事で、カスタマイズのし易さ、その後のメンテナンス性をよくしたい。

## テスト（Test)
愚問ですなw

## 相談（Discussion）
public、protectedにした箇所に関して、privateである必要性があるのであれば教えて欲しいです。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



