### PR TITLE
管理画面の受注管理からお届け時間の指定を「指定なし」に変更できない不具合の修正

### DIFF
--- a/src/Eccube/Form/Type/Admin/ShippingType.php
+++ b/src/Eccube/Form/Type/Admin/ShippingType.php
@@ -297,6 +297,9 @@ class ShippingType extends AbstractType
                 if ($DeliveryTime) {
                     $Shipping->setShippingDeliveryTime($DeliveryTime->getDeliveryTime());
                     $Shipping->setTimeId($DeliveryTime->getId());
+                } else {
+                    $Shipping->setShippingDeliveryTime(null);
+                    $Shipping->setTimeId(null);
                 }
             })
             ->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {

--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -482,7 +482,7 @@ class EditControllerTest extends AbstractEditControllerTestCase
         $this->entityManager->flush($Order);
 
         $formData = $this->createFormData($this->Customer, $this->Product);
-        // まずお届け時間に何か指定する(便宜上、最初に取得できたのものを利用)
+        // まずお届け時間に何か指定する(便宜上、最初に取得できたものを利用)
         $Delivery = $this->container->get(DeliveryRepository::class)->find($formData['Shipping']['Delivery']);
         $DeliveryTime = $Delivery->getDeliveryTimes()[0];
         $delivery_time_id = $DeliveryTime->getId();


### PR DESCRIPTION
受注管理にて、お届け時間の指定を「指定なし」に変更できなかったのを修正。
#4143


