### PR TITLE
フロントの注文履歴画面で、お問い合わせ欄の改行がエスケープされないように修正

### DIFF
--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -129,7 +129,7 @@ file that was distributed with this source code.
                     <div class="ec-rectHeading">
                         <h2>{{ 'front.mypage.message'|trans }}</h2>
                     </div>
-                    <p>{{ Order.message|nl2br|default('front.mypage.message_not_found'|trans) }}</p>
+                    <p>{{ Order.message|default('front.mypage.message_not_found'|trans)|nl2br }}</p>
                 </div>
                 <div class="ec-orderMails">
                     <div class="ec-rectHeading">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#4030 に対する修正。
マイページ/ご注文履歴詳細にて、お問い合わせ欄の改行が改行タグ「&lt;br /&gt;」の表示のままで表示されるのを修正。

## 方針(Policy)
エスケープされないようにnl2brフィルター指定を最後に移動。

## 実装に関する補足(Appendix)
Gmail でのメールの方に関しては、こちらでは再現しませんでした。