### PR TITLE
管理画面>ファイル管理のファイル削除時にそのままカレントディレクトリに止まるように修正

### DIFF
--- a/src/Eccube/Controller/Admin/Content/FileController.php
+++ b/src/Eccube/Controller/Admin/Content/FileController.php
@@ -198,7 +198,8 @@ class FileController extends AbstractController
             }
         }
 
-        return $this->redirectToRoute('admin_content_file');
+        // 削除実行時のカレントディレクトリを表示させる
+        return $this->redirectToRoute('admin_content_file', array('tree_select_file' => dirname($selectFile)));
     }
 
     /**

--- a/tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php
@@ -68,7 +68,7 @@ class FileControllerTest extends AbstractAdminWebTestCase
             'DELETE',
             $this->generateUrl('admin_content_file_delete').'?select_file='.$this->getJailDir($filepath)
         );
-        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('admin_content_file')));
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('admin_content_file', array('tree_select_file' => dirname($this->getJailDir($filepath))))));
         $this->assertFalse(file_exists($filepath));
     }
 


### PR DESCRIPTION
#3728
コンテンツ管理>ファイル管理での削除完了後にTOPディレクトリーに戻らさせずに、そのままカレントディレクトリを表示するよう改良。
遷移先URLにtree_select_fileパラメーターを指定しディレクトリー情報を渡すようにして対応。