### PR TITLE
重複したdlの閉じタグを削除

### DIFF
--- a/src/Eccube/Resource/template/default/Forgot/reset.twig
+++ b/src/Eccube/Resource/template/default/Forgot/reset.twig
@@ -57,7 +57,6 @@ file that was distributed with this source code.
                                 </div>
                             </dd>
                         </dl>
-                        </dl>
                     </div>
                     <div class="ec-registerRole__actions">
                         <div class="ec-off4Grid">


### PR DESCRIPTION

## 概要(Overview・Refs Issue)
src/Eccube/Resource/template/default/Forgot/reset.twig の <dl>閉じが余分に多いことに気づいたので…。
