### PR TITLE
サイズが大きなデザプレが反映できるようにアップロード最大ファイルサイズを10Mに変更

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -21,7 +21,7 @@ DirectoryIndex index.php index.html .ht
 
 # デフォルトテンプレートの状態で 2M 以上となるため
 <IfModule mod_php7.c>
-    php_value upload_max_filesize 5M
+    php_value upload_max_filesize 10M
 </IfModule>
 
 <IfModule mod_rewrite.c>

--- a/.htaccess
+++ b/.htaccess
@@ -19,7 +19,7 @@ DirectoryIndex index.php index.html .ht
     Header set X-Content-Type-Options nosniff
 </IfModule>
 
-# デフォルトテンプレートの状態で 2M 以上となるため
+# デザインテンプレートが適用できるようにするため 
 <IfModule mod_php7.c>
     php_value upload_max_filesize 10M
 </IfModule>

--- a/.htaccess
+++ b/.htaccess
@@ -19,7 +19,7 @@ DirectoryIndex index.php index.html .ht
     Header set X-Content-Type-Options nosniff
 </IfModule>
 
-# デザインテンプレートが適用できるようにするため 
+# デザインテンプレートを適用するため10Mで設定 
 <IfModule mod_php7.c>
     php_value upload_max_filesize 10M
 </IfModule>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ デザインテンプレートのサイズが10M以上となることがあるため、アップロード最大ファイルサイズを10Mに変更。

## 実装に関する補足(Appendix)
+ https://github.com/EC-CUBE/ec-cube/pull/3851 を参考に、最大ファイルサイズを変更

## テスト（Test)
+ apacheでupload_max_filesizeが書き換わることを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
