### PR TITLE
在庫数の操作をする時に整合性を保つように修正

### DIFF
--- a/src/Eccube/Service/PurchaseFlow/Processor/StockReduceProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/StockReduceProcessor.php
@@ -85,7 +85,7 @@ class StockReduceProcessor extends AbstractPurchaseProcessor
                 /* @var ProductStock $productStock */
                 $productStock = $item->getProductClass()->getProductStock();
                 // 在庫に対してロックを実行
-                $this->entityManager->lock($productStock, LockMode::PESSIMISTIC_WRITE);
+                $this->entityManager->lock($productStock, LockMode::PESSIMISTIC_READ);
                 $this->entityManager->refresh($productStock);
                 $ProductClass = $item->getProductClass();
                 $stock = $callback($productStock->getStock(), $item->getQuantity());


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 現状の実装だと在庫数の不整合が発生してしまうのでそれを修正したい

## 方針(Policy)
+ 特になし

## 実装に関する補足(Appendix)
+ 在庫数を参照してからsetStockしているので、ロックをPESSIMISTIC_WRITEからPESSIMISTIC_READに変更し、参照時点でロックを掛けるように変更。(現状だと参照時にロックされずにsetStockのタイミングでロックが掛かるため不整合が起きる)

## テスト（Test)
+ unitテストを追加しようとしましたが既存のテストの実行方法が分からず追加しておりません(codeception.shを実行したらエラー担ってしまいました)

## 相談（Discussion）
なし

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
