### PR TITLE
Change build environment to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 # for travis-ci
 # see also. https://travis-ci.org
+dist: xenial
 git:
   submodules: false
 
-sudo: required
-
 language: php
+services:
+  - docker
+  - mysql
+  - postgresql
+  - xvfb
 
 addons:
   apt:
@@ -91,12 +95,8 @@ jobs:
     stage: E2E Test
     before_install:
       - *php_setup
-      - export DISPLAY=:99.0
-      - sh -e /etc/init.d/xvfb start
       - wget -c -nc --retry-connrefused --tries=0 http://chromedriver.storage.googleapis.com/2.43/chromedriver_linux64.zip
       - unzip -o -q chromedriver_linux64.zip
-      - sudo mv -f ./chromedriver /usr/local/bin/
-      - sudo chmod +x /usr/local/bin/chromedriver
       - docker pull schickling/mailcatcher
       - docker run -d -p 1080:1080 -p 1025:1025 --name mailcatcher schickling/mailcatcher
     install:

--- a/codeception.sh
+++ b/codeception.sh
@@ -16,7 +16,7 @@ if [[ $1 == '--reset' ]]; then
     exit
 fi
 
-chromedriver --url-base=/wd/hub &
+./chromedriver --url-base=/wd/hub &
 CDPID="$!"
 trap "kill ${CDPID}" exit
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ Travis CI で xenial のビルドイメージを使用するよう変更

## 実装に関する補足(Appendix)
+ Travis CI のアカウントによっては自動的にアップデートされるため xenial に固定する
    + https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476

## テスト（Test)
+ Travis CI のテストが通ることを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか