### PR TITLE
新規に税率設定する場合に現在の丸め規則をデフォルト値とするよう修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductClassController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductClassController.php
@@ -367,16 +367,11 @@ class ProductClassController extends AbstractController
                     if ($TaxRule) {
                         $TaxRule->setTaxRate($rate);
                     } else {
-                        // 初期税率設定の計算方法を設定する
-                        $RoundingType = $this->taxRuleRepository->find(TaxRule::DEFAULT_TAX_RULE_ID)
-                            ->getRoundingType();
-
-                        $TaxRule = new TaxRule();
+                        // 現在の税率設定の計算方法を設定する
+                        $TaxRule = $this->taxRuleRepository->newTaxRule();
                         $TaxRule->setProduct($Product);
                         $TaxRule->setProductClass($pc);
                         $TaxRule->setTaxRate($rate);
-                        $TaxRule->setRoundingType($RoundingType);
-                        $TaxRule->setTaxAdjust(0);
                         $TaxRule->setApplyDate(new \DateTime());
                         $this->entityManager->persist($TaxRule);
                     }

--- a/src/Eccube/Repository/TaxRuleRepository.php
+++ b/src/Eccube/Repository/TaxRuleRepository.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\NoResultException;
 use Eccube\Common\EccubeConfig;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Customer;
+use Eccube\Entity\Master\RoundingType;
 use Eccube\Entity\TaxRule;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -70,14 +71,27 @@ class TaxRuleRepository extends AbstractRepository
         $this->eccubeConfig = $eccubeConfig;
     }
 
+    /**
+     * 新たな TaxRule インスタンスを生成して返す.
+     *
+     * 現在適用されている丸め規則を設定する.
+     * 現在適用されている丸め規則が取得できない場合は四捨五入を設定する.
+     *
+     * @return TaxRule
+     */
     public function newTaxRule()
     {
-        $TaxRule = new \Eccube\Entity\TaxRule();
-        $RoundingType = $this->getEntityManager()
-            ->getRepository('Eccube\Entity\Master\RoundingType')
-            ->find(1);
+        /** @var RoundingType $RoundingType */
+        $RoundingType = $this->getEntityManager()->getRepository(RoundingType::class)->find(RoundingType::ROUND);
+        try {
+            $CurrentRule = $this->getByRule();
+            $RoundingType = $CurrentRule->getRoundingType();
+        } catch (NoResultException $e) {
+            // quiet
+        }
+        $TaxRule = new TaxRule();
         $TaxRule->setRoundingType($RoundingType);
-        $TaxRule->setTaxAdjust(0);
+        $TaxRule->setTaxAdjust('0');
 
         return $TaxRule;
     }

--- a/tests/Eccube/Tests/Repository/TaxRuleRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/TaxRuleRepositoryTest.php
@@ -293,4 +293,33 @@ class TaxRuleRepositoryTest extends EccubeTestCase
         $this->actual = $TaxRule->getId();
         $this->verify();
     }
+
+    public function testNewTaxRuleWithDefault()
+    {
+        $TaxRule = $this->taxRuleRepository->newTaxRule();
+
+        $this->expected = RoundingType::ROUND;
+        $this->actual = $TaxRule->getRoundingType()->getId();
+        $this->verify();
+    }
+
+    public function testNewTaxRuleWithCurrentRule()
+    {
+        $this->TaxRule1->setApplyDate(new \DateTime('+5 days'))
+            ->setRoundingType($this->entityManager->find(RoundingType::class, RoundingType::FLOOR));
+        $this->TaxRule2->setApplyDate(new \DateTime('-1 days'))
+            ->setRoundingType($this->entityManager->find(RoundingType::class, RoundingType::CEIL));
+        $this->TaxRule3->setApplyDate(new \DateTime('-2 days'))
+            ->setRoundingType($this->entityManager->find(RoundingType::class, RoundingType::ROUND));
+        $this->entityManager->flush();
+
+        $this->taxRuleRepository->clearCache();
+        $TaxRule = $this->taxRuleRepository->getByRule();
+
+        $TaxRule = $this->taxRuleRepository->newTaxRule();
+
+        $this->expected = RoundingType::CEIL;
+        $this->actual = $TaxRule->getRoundingType()->getId();
+        $this->verify('TaxRule2 の RoundingType が設定される');
+    }
 }

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductClassControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductClassControllerTest.php
@@ -538,13 +538,29 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
     {
         // GIVE
         $this->BaseInfo->setOptionProductTaxRule(true);
+
+        $member = $this->createMember();
+        $product = $this->createProduct();
+        // class 1
+        $className1 = $this->createClassName($member);
+        $classCate1 = $this->createClassCategory($member, $className1);
+        // class 2
+        $className2 = $this->createClassName($member);
+        $classCate2 = $this->createClassCategory($member, $className2);
+        $this->createClassCategory($member, $className2);
+        $this->createClassCategory($member, $className2);
+        $this->createClassCategory($member, $className2);
+
+        // create product class
+        $this->createProductClass($member, $product, $classCate1, $classCate2);
+
         $TaxRule = $this->taxRuleRepository->newTaxRule();
         $TaxRule->setApplyDate(new \DateTime('-1 days'))
             ->setRoundingType($this->entityManager->find(RoundingType::class, RoundingType::CEIL));
         $this->entityManager->persist($TaxRule);
         $this->entityManager->flush($TaxRule);
 
-        $id = 1;
+        $id = $product->getId();
 
         // WHEN
         // select class name
@@ -571,11 +587,11 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
         $this->assertContains('保存しました', $htmlMessage);
         // check database
         $product = $this->productRepository->find($id);
-        /* @var TaxRule $taxRule */
-        $taxRule = $this->taxRuleRepository->findOneBy(['Product' => $product]);
+        /* @var ProductTaxRule $taxRule */
+        $ProductTaxRule = $this->taxRuleRepository->findOneBy(['Product' => $product]);
 
         $this->expected = RoundingType::CEIL;
-        $this->actual = $taxRule->getRoundingType()->getId();
+        $this->actual = $ProductTaxRule->getRoundingType()->getId();
         $this->verify();
     }
 

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductClassControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductClassControllerTest.php
@@ -14,6 +14,7 @@
 namespace Eccube\Tests\Web\Admin\Product;
 
 use Eccube\Entity\BaseInfo;
+use Eccube\Entity\Master\RoundingType;
 use Eccube\Entity\TaxRule;
 use Eccube\Repository\ClassCategoryRepository;
 use Eccube\Repository\ProductRepository;
@@ -527,6 +528,55 @@ class ProductClassControllerTest extends AbstractProductCommonTestCase
         /* @var TaxRule $taxRule */
         $taxRule = $this->taxRuleRepository->findBy(['Product' => $product]);
         $this->assertCount(0, $taxRule);
+    }
+
+    /**
+     * 個別税率設定をした場合に現在適用されている丸め規則が設定される
+     * @see https://github.com/EC-CUBE/ec-cube/issues/2114
+     */
+    public function testProductClassEditWhenProductTaxRuleEnableAndCurrentRoundingType()
+    {
+        // GIVE
+        $this->BaseInfo->setOptionProductTaxRule(true);
+        $TaxRule = $this->taxRuleRepository->newTaxRule();
+        $TaxRule->setApplyDate(new \DateTime('-1 days'))
+            ->setRoundingType($this->entityManager->find(RoundingType::class, RoundingType::CEIL));
+        $this->entityManager->persist($TaxRule);
+        $this->entityManager->flush($TaxRule);
+
+        $id = 1;
+
+        // WHEN
+        // select class name
+        /* @var Crawler $crawler */
+        $crawler = $this->client->request(
+            'GET',
+            $this->generateUrl('admin_product_product_class', ['id' => $id])
+        );
+
+        // edit class category with tax
+        /* @var Form $form */
+        $form = $crawler->selectButton('登録')->form();
+        $form['product_class_matrix[product_classes][2][checked]']->tick();
+        $form['product_class_matrix[product_classes][2][stock]'] = 1;
+        $form['product_class_matrix[product_classes][2][price02]'] = 1;
+        $form['product_class_matrix[product_classes][2][tax_rate]'] = $this->faker->randomNumber(2);
+        $this->client->submit($form);
+
+        // THEN
+        // check submit
+
+        $crawler = $this->client->followRedirect();
+        $htmlMessage = $crawler->filter('body .c-contentsArea')->html();
+        $this->assertContains('保存しました', $htmlMessage);
+        // check database
+        $product = $this->productRepository->find($id);
+        /* @var TaxRule $taxRule */
+        $taxRule = $this->taxRuleRepository->findOneBy(['Product' => $product]);
+
+        $this->expected = RoundingType::CEIL;
+        $this->actual = $taxRule->getRoundingType()->getId();
+        $this->verify();
     }
 
     protected function enableProductTaxRule()

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
@@ -15,6 +15,7 @@ namespace Eccube\Tests\Web\Admin\Product;
 
 use Eccube\Common\Constant;
 use Eccube\Entity\Master\ProductStatus;
+use Eccube\Entity\Master\RoundingType;
 use Eccube\Entity\ProductClass;
 use Eccube\Entity\TaxRule;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
@@ -667,9 +668,9 @@ class ProductControllerTest extends AbstractAdminWebTestCase
      *
      * @see https://github.com/EC-CUBE/ec-cube/issues/1547
      *
-     * @param $before 更新前の税率
-     * @param $after POST値
-     * @param $expected 期待値
+     * @param string|null $before 更新前の税率
+     * @param string|null $after POST値
+     * @param string|null $expected 期待値
      *
      * @dataProvider dataEditProductProvider
      */
@@ -682,17 +683,16 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $ProductClass = $ProductClasses[0];
         $formData = $this->createFormData();
 
-        if (!is_null($after)) {
+        if ($after !== null) {
             $formData['class']['tax_rate'] = $after;
         }
-        if (!is_null($before)) {
-            $DefaultTaxRule = $this->taxRuleRepository->find(\Eccube\Entity\TaxRule::DEFAULT_TAX_RULE_ID);
-
+        if ($before !== null) {
+            $RoundingType = $this->entityManager->find(RoundingType::class, RoundingType::ROUND);
             $TaxRule = new TaxRule();
             $TaxRule->setProductClass($ProductClass)
                 ->setCreator($Product->getCreator())
                 ->setProduct($Product)
-                ->setRoundingType($DefaultTaxRule->getRoundingType())
+                ->setRoundingType($RoundingType)
                 ->setTaxRate($before)
                 ->setTaxAdjust(0)
                 ->setApplyDate(new \DateTime());
@@ -716,11 +716,77 @@ class ProductControllerTest extends AbstractAdminWebTestCase
 
         if (is_null($TaxRule)) {
             $this->actual = null;
+            $this->assertNull($TaxRule);
         } else {
             $this->actual = $TaxRule->getTaxRate();
         }
 
-        $this->assertTrue($this->actual === $this->expected);
+        $this->assertSame($this->expected, $this->actual);
+    }
+
+    /**
+     * 個別税率設定をした場合の RoundingType のテストケース
+     *
+     * @param string|null $tax_rate 個別税率
+     * @param string|null $currentRoundingTypeId 現在の RoundingType ID
+     * @param string|null $expected RoundingType ID の期待値
+     * @param bool $isNew 商品を新規作成の場合 true
+     * @see https://github.com/EC-CUBE/ec-cube/issues/2114
+     *
+     * @dataProvider dataEditRoundingTypeProvider
+     */
+    public function testEditWithCurrnetRoundingType($tax_rate, $currentRoundingTypeId, $expected, $isNew)
+    {
+        // Give
+        $this->baseInfo->setOptionProductTaxRule(true);
+        $Product = $this->createProduct(null, 0);
+        $ProductClasses = $Product->getProductClasses();
+        $ProductClass = $ProductClasses[0];
+        $formData = $this->createFormData();
+
+        if ($tax_rate !== null) {
+            $formData['class']['tax_rate'] = $tax_rate;
+        }
+        if ($currentRoundingTypeId !== null) {
+            $RoundingType = $this->entityManager->find(RoundingType::class, $currentRoundingTypeId);
+            $TaxRule = new TaxRule();
+            $TaxRule->setProductClass(null)
+                ->setCreator($Product->getCreator())
+                ->setProduct(null)
+                ->setRoundingType($RoundingType)
+                ->setTaxRate($tax_rate)
+                ->setTaxAdjust(0)
+                ->setApplyDate(new \DateTime('-1 days'));
+            $this->entityManager->persist($TaxRule);
+            $this->entityManager->flush();
+        }
+        $url = $isNew ? $this->generateUrl('admin_product_product_new') :
+            $this->generateUrl('admin_product_product_edit', ['id' => $Product->getId()]);
+        // When
+        $this->client->request(
+            'POST',
+            $url,
+            ['admin_product' => $formData]
+        );
+
+        // Then
+        $this->assertTrue($this->client->getResponse()->isRedirection());
+
+        $arrTmp = explode('/', $this->client->getResponse()->getTargetUrl());
+        $productId = $arrTmp[count($arrTmp) - 2];
+        $EditProduct = $this->productRepository->find($productId);
+
+        $TaxRule = $this->taxRuleRepository->getByRule($EditProduct);
+        if ($tax_rate !== null) {
+            $this->assertInstanceOf(TaxRule::class, $TaxRule);
+            $this->expected = $expected;
+            $this->actual = $TaxRule->getRoundingType()->getId();
+            $this->verify('tax_rate が設定されている場合は税率設定と RoundingType が取得できる');
+        } else {
+            $this->expected = $expected;
+            $this->actual = RoundingType::ROUND;
+            $this->verify('tax_rate が設定されていない場合は初期設定の RoundingType');
+        }
     }
 
     /**
@@ -921,6 +987,22 @@ class ProductControllerTest extends AbstractAdminWebTestCase
             [null, '0', '0'],
             [null, '1', '1'],
             [null, null, null],
+        ];
+    }
+
+    /**
+     * 個別税率編集時のテストデータ
+     * 個別税率 / 現在の RoundingType / RoundingType 期待値 / 新規商品 の配列を返す
+     *
+     * @return array
+     */
+    public function dataEditRoundingTypeProvider()
+    {
+        return [
+            [null, null, RoundingType::ROUND, false],
+            ['10', null, RoundingType::ROUND, false],
+            ['10', RoundingType::CEIL, RoundingType::CEIL, false],
+            ['10', RoundingType::CEIL, RoundingType::CEIL, true],
         ];
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 新規に税率設定する場合、現在の丸め規則が取得できる場合はデフォルト値とする
+ 個別税率設定をする場合、常に四捨五入となっていたのを修正
+ https://github.com/EC-CUBE/ec-cube/issues/2114
+ https://github.com/EC-CUBE/ec-cube/pull/2117

## 方針(Policy)
+ 新規税率設定で、常に四捨五入となっているより、現在運用中の丸め規則を初期値とした方が利便性が良いと思われる
+ 個別税率設定の場合は #2114 の方針に従う

## 実装に関する補足(Appendix)
+ 税率の日付設定には連動していないため、税率設定を新たに追加した場合でも既存の商品別税率の丸め規則は更新されない
+ [開発コミュニティのスレッドも参照ください](https://xoops.ec-cube.net/modules/newbb/viewtopic.php?viewmode=flat&order=ASC&topic_id=22232&forum=11)

## テスト（Test)
+ ユニットテストを追加

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか