### PR TITLE
postgresqlのDBのバージョンが10.xの場合に、Webインストーラーで発生する不具合修正

### DIFF
--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -13,6 +13,7 @@
 
 namespace Eccube\Command;
 
+use Doctrine\DBAL\DriverManager;
 use Dotenv\Dotenv;
 use Eccube\Util\StringUtil;
 use Symfony\Component\Console\Command\Command;
@@ -81,11 +82,7 @@ class InstallerCommand extends Command
         $databaseUrl = $this->io->ask('Database Url', $databaseUrl);
 
         // DATABASE_SERVER_VERSION
-        $databaseName = $this->getDatabaseName($databaseUrl);
-        $serverVersion = $this->io->ask('Database Server version', 'auto');
-        if ('auto' === $serverVersion) {
-            $serverVersion = $this->getDatabaseServerVersion($databaseName);
-        }
+        $serverVersion = $this->getDatabaseServerVersion($databaseUrl);
 
         // MAILER_URL
         $mailerUrl = $this->container->getParameter('eccube_mailer_url');
@@ -200,18 +197,35 @@ class InstallerCommand extends Command
         throw new \LogicException(sprintf('Database Url %s is invalid.', $databaseUrl));
     }
 
-    protected function getDatabaseServerVersion($databaseName)
+    protected function getDatabaseServerVersion($databaseUrl)
     {
-        $versions = [
-            'sqlite' => 3,
-            'postgres' => 9,
-            'mysql' => 5,
-        ];
+        try {
+            $conn = DriverManager::getConnection([
+                'url' => $databaseUrl,
+            ]);
+        } catch (\Exception $e) {
+            throw new \LogicException(sprintf('Database Url %s is invalid.', $databaseUrl));
+        }
+        $platform = $conn->getDatabasePlatform()->getName();
+        switch ($platform) {
+            case 'sqlite':
+                $sql = 'SELECT sqlite_version() AS server_version';
+                break;
+            case 'mysql':
+                $sql = 'SELECT version() AS server_version';
+                break;
+            case 'postgresql':
+            default:
+                $sql = 'SHOW server_version';
+        }
+        $stmt = $conn->executeQuery($sql);
+        $version = $stmt->fetchColumn();
 
-        if (!isset($versions[$databaseName])) {
-            throw new \LogicException(sprintf('Database Name %s is invalid.', $databaseName));
+        if ($platform === 'postgresql') {
+            preg_match('/\A([\d+\.]+)/', $version, $matches);
+            $version = $matches[1];
         }
 
-        return $versions[$databaseName];
+        return $version;
     }
 }

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -1025,6 +1025,12 @@ class InstallController extends AbstractController
         $version = $em->createNativeQuery($sql, $rsm)
             ->getSingleScalarResult();
 
+        // postgresのバージョンが10の場合、末尾に不要な文字列が入るため削除
+        if ($platform === 'postgresql') {
+            preg_match('/\A([\d+\.]+)/', $version, $matches);
+            $version = $matches[1];
+        }
+
         return $version;
     }
 

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -1017,7 +1017,7 @@ class InstallController extends AbstractController
                 $sql = 'SELECT version() AS server_version';
                 break;
 
-            case 'pgsql':
+            case 'postgresql':
             default:
                 $sql = 'SHOW server_version';
         }

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -1025,7 +1025,7 @@ class InstallController extends AbstractController
         $version = $em->createNativeQuery($sql, $rsm)
             ->getSingleScalarResult();
 
-        // postgresのバージョンが10の場合、末尾に不要な文字列が入るため削除
+        // postgresqlのバージョンが10.x以降の場合に、getSingleScalarResult()で取得される不要な文字列を除く処理
         if ($platform === 'postgresql') {
             preg_match('/\A([\d+\.]+)/', $version, $matches);
             $version = $matches[1];

--- a/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
+++ b/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
@@ -407,7 +407,7 @@ class InstallControllerTest extends AbstractWebTestCase
     public function testDatabaseVersion()
     {
         $version = $this->controller->getDatabaseVersion($this->entityManager);
-        $this->assertRegExp('/\A[\d\.]+/', $version);
+        $this->assertRegExp('/\A([\d+\.]+)/', $version);
     }
 
     public function testCreateAppData()

--- a/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
+++ b/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
@@ -407,7 +407,7 @@ class InstallControllerTest extends AbstractWebTestCase
     public function testDatabaseVersion()
     {
         $version = $this->controller->getDatabaseVersion($this->entityManager);
-        $this->assertRegExp('/\A[0-9\.]+/', $version);
+        $this->assertRegExp('/\A[\d\.]+/', $version);
     }
 
     public function testCreateAppData()

--- a/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
+++ b/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
@@ -407,7 +407,7 @@ class InstallControllerTest extends AbstractWebTestCase
     public function testDatabaseVersion()
     {
         $version = $this->controller->getDatabaseVersion($this->entityManager);
-        $this->assertRegExp('/[0-9.]+/', $version);
+        $this->assertRegExp('/\A[0-9\.]+/', $version);
     }
 
     public function testCreateAppData()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ PullRequestの目的、関連するIssue番号など
#3976 
PostgreSQL10 では SHOW server_versionを返してしまい。インストール完了後に.envに不要な文字列が書き込まれてしまう。

## 方針(Policy)
+ Webインストーラーでpostgresqlを利用した場合は、DBのバージョン情報取得時に、実数のみの値を返す正規表現の処理を行う

## 実装に関する補足(Appendix)
+ テストコードの正規表現のチェック時、小数点のドットの文字「.」の前にエスケープ文字を追加した

## テスト（Test)
+ テストコードでのチェック時の正規表現を、インストール時の正規表現と統一した

## 相談（Discussion）
+ 今回の変更において、他に影響範囲があるかどうか

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
