### PR TITLE
カテゴリー編集フォームのイベントに渡す変数を修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/CategoryController.php
+++ b/src/Eccube/Controller/Admin/Product/CategoryController.php
@@ -155,7 +155,7 @@ class CategoryController extends AbstractController
 
                     $event = new EventArgs(
                         [
-                            'form' => $form,
+                            'form' => $editForm,
                             'Parent' => $Parent,
                             'TargetCategory' => $editForm->getData(),
                         ],

--- a/src/Eccube/Controller/Admin/Product/CategoryController.php
+++ b/src/Eccube/Controller/Admin/Product/CategoryController.php
@@ -127,6 +127,9 @@ class CategoryController extends AbstractController
 
                 log_info('カテゴリ登録完了', [$id]);
 
+                // $formが保存されたフォーム
+                // 下の編集用フォームの場合とイベント名が共通のため
+                // このイベントのリスナーではsubmitされているフォームを判定する必要がある
                 $event = new EventArgs(
                     [
                         'form' => $form,
@@ -153,9 +156,13 @@ class CategoryController extends AbstractController
                 if ($editForm->isSubmitted() && $editForm->isValid()) {
                     $this->categoryRepository->save($editForm->getData());
 
+                    // $editFormが保存されたフォーム
+                    // 上の新規登録用フォームの場合とイベント名が共通のため
+                    // このイベントのリスナーではsubmitされているフォームを判定する必要がある
                     $event = new EventArgs(
                         [
-                            'form' => $editForm,
+                            'form' => $form,
+                            'editForm' => $editForm,
                             'Parent' => $Parent,
                             'TargetCategory' => $editForm->getData(),
                         ],


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
+ PullRequestの目的、関連するIssue番号など
#4201

カテゴリー編集フォームの登録完了時イベントにおいて、イベントに渡しているformが編集用フォームではなく、新規登録用フォームになっている問題の修正
