### PR TITLE
マイページ／お気に入り画面の表示件数の調整

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -59,7 +59,7 @@ parameters:
     plugin_data_realdir: '%kernel.project_dir%/app/PluginData'
     plugin_temp_realdir: /PATH/TO/WEB_ROOT/src/Eccube/Repository/Master/upload/temp_plugin/ # upload_tmp_dir に任せればよい？
     eccube_price_len: 8                                                    # 最大値で制御したい
-    eccube_search_pmax: 10
+    eccube_search_pmax: 12
     eccube_stext_len: 255
     eccube_sltext_len: 500
     eccube_smtext_len: 100


### PR DESCRIPTION
##  概要(Overview・Refs Issue)
#4206 への修正。
4列表示のため表示件数を4の倍数になるように調整。

## 方針(Policy)
ここの表示件数はeccube_search_pmaxで定義されていて、この設定値を使っているのは、マイページのお気に入り一覧とご注文履歴。
別途お気に入り画面用の表示件数とかを追加も考えましたが、ご注文履歴は１カラム表示なので気にしなくてもというご意見頂いたので既存の設定値を調整しました。

## テスト（Test)
実際の画面で表示を確認。

![Screenshot-2019-7-3 EC-CUBE SHOP MYページ お気に入り一覧](https://user-images.githubusercontent.com/52161801/60555626-bcc25700-9d78-11e9-941b-57bb0e9ff890.png)

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
