### PR TITLE
Codeception を PHP7.3 で実行するように変更

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
 
 env:
   - DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
@@ -31,6 +32,7 @@ env:
 
 matrix:
   allow_failures:
+    - php: 7.4snapshot
     - env: DATABASE_URL=sqlite:///var/eccube.db DATABASE_SERVER_VERSION=3 COVERAGE=1
 
 ## see https://github.com/symfony/symfony/blob/e0bdc0c35e9afdb3bee8af172f90e9648c4012fc/.travis.yml#L92-L97
@@ -102,15 +104,20 @@ jobs:
     install:
       - *composer_install
       - *eccube_setup
+    php: 7.3
     env: GROUP=admin01 APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
     script: ./codeception.sh -g ${GROUP}
   - <<: *e2e_test
+    php: 7.3
     env: GROUP=admin02 APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
   - <<: *e2e_test
+    php: 7.3
     env: GROUP=admin03 APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
   - <<: *e2e_test
+    php: 7.3
     env: GROUP=front APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
   - <<: *e2e_test
+    php: 7.3
     env: APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025 ECCUBE_PACKAGE_API_URL=http://localhost:8080 NO_FIXTURES=1
     script:
       - *package_api_setup
@@ -138,6 +145,7 @@ jobs:
         psql eccube_db -h 127.0.0.1 -U postgres -c "update dtb_base_info set authentication_key='test';"
         ./codeception.sh EA10PluginCest:test_install_remove_store
   - <<: *e2e_test
+    php: 7.3
     env: APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025 ECCUBE_PACKAGE_API_URL=http://localhost:8080 NO_FIXTURES=1
     script:
       - *package_api_setup
@@ -165,6 +173,7 @@ jobs:
         psql eccube_db -h 127.0.0.1 -U postgres -c "update dtb_base_info set authentication_key='test';"
         ./codeception.sh EA10PluginCest:test_install_enable_update_disable_remove_local
   - <<: *e2e_test
+    php: 7.3
     env: APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025 ECCUBE_PACKAGE_API_URL=http://localhost:8080 NO_FIXTURES=1
     script:
       - *package_api_setup
@@ -192,6 +201,7 @@ jobs:
         psql eccube_db -h 127.0.0.1 -U postgres -c "update dtb_base_info set authentication_key='test';"
         ./codeception.sh EA10PluginCest:test_install_assets_store
   - <<: *e2e_test
+    php: 7.3
     env: APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025 ECCUBE_PACKAGE_API_URL=http://localhost:8080 NO_FIXTURES=1
     script:
       - *package_api_setup
@@ -219,6 +229,7 @@ jobs:
         psql eccube_db -h 127.0.0.1 -U postgres -c "update dtb_base_info set authentication_key='test';"
         ./codeception.sh EA10PluginCest:test_extend_same_table_crossed_local
   - <<: *e2e_test
+    php: 7.3
     env: APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025 ECCUBE_PACKAGE_API_URL=http://localhost:8080 NO_FIXTURES=1
     script:
       - *package_api_setup
@@ -242,6 +253,7 @@ jobs:
         psql eccube_db -h 127.0.0.1 -U postgres -c "update dtb_base_info set authentication_key='test', php_path = '$(which php)';"
         ./codeception.sh EA10PluginCest:install_enable_disable_enable_disable_remove_store
   - <<: *e2e_test
+    php: 7.3
     env: APP_ENV=codeception DATABASE_URL=mysql://root:@localhost/eccube_db DATABASE_SERVER_VERSION=5 MAILER_URL=smtp://localhost:1025 ECCUBE_PACKAGE_API_URL=http://localhost:8080 NO_FIXTURES=1
     script:
       - *package_api_setup
@@ -269,6 +281,7 @@ jobs:
         mysql -h 127.0.0.1 -u root eccube_db -e "update dtb_base_info set authentication_key='test';"
         ./codeception.sh EA10PluginCest:test_install_remove_store
   - <<: *e2e_test
+    php: 7.3
     env: APP_ENV=codeception DATABASE_URL=mysql://root:@localhost/eccube_db DATABASE_SERVER_VERSION=5 MAILER_URL=smtp://localhost:1025 ECCUBE_PACKAGE_API_URL=http://localhost:8080 NO_FIXTURES=1
     script:
       - *package_api_setup
@@ -296,6 +309,7 @@ jobs:
         mysql -h 127.0.0.1 -u root eccube_db -e "update dtb_base_info set authentication_key='test';"
         ./codeception.sh EA10PluginCest:test_install_enable_update_disable_remove_local
   - <<: *e2e_test
+    php: 7.3
     env: APP_ENV=codeception DATABASE_URL=mysql://root:@localhost/eccube_db DATABASE_SERVER_VERSION=5 MAILER_URL=smtp://localhost:1025 ECCUBE_PACKAGE_API_URL=http://localhost:8080 NO_FIXTURES=1
     script:
       - *package_api_setup
@@ -323,6 +337,7 @@ jobs:
         mysql -h 127.0.0.1 -u root eccube_db -e "update dtb_base_info set authentication_key='test';"
         ./codeception.sh EA10PluginCest:test_install_assets_store
   - <<: *e2e_test
+    php: 7.3
     env: APP_ENV=codeception DATABASE_URL=mysql://root:@localhost/eccube_db DATABASE_SERVER_VERSION=5 MAILER_URL=smtp://localhost:1025 ECCUBE_PACKAGE_API_URL=http://localhost:8080 NO_FIXTURES=1
     script:
       - *package_api_setup
@@ -350,6 +365,7 @@ jobs:
         mysql -h 127.0.0.1 -u root eccube_db -e "update dtb_base_info set authentication_key='test';"
         ./codeception.sh EA10PluginCest:test_extend_same_table_crossed_local
   - <<: *e2e_test
+    php: 7.3
     env: APP_ENV=codeception DATABASE_URL=mysql://root:@localhost/eccube_db DATABASE_SERVER_VERSION=5 MAILER_URL=smtp://localhost:1025 ECCUBE_PACKAGE_API_URL=http://localhost:8080 NO_FIXTURES=1
     script:
       - *package_api_setup
@@ -372,6 +388,7 @@ jobs:
   # インストーラのテスト
   - <<: *e2e_test
     # codeceptionのbootstrapでデータ投入を行っているので、本来は不要だけどコマンドラインからのインストールを実行させる
+    php: 7.3
     env: GROUP=installer APP_ENV=codeception DATABASE_URL=postgres://postgres:password@localhost/eccube_db DATABASE_SERVER_VERSION=9 MAILER_URL=smtp://localhost:1025
     script:
       - echo "APP_ENV=install" >> .env


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ Codeception を PHP7.3 で実行するように変更
+ PHP7.4snapshot を build matrix に追加

## 方針(Policy)
+ PHP7.4snapshot は allow_failures に設定


## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか