### PR TITLE
Add PHP7.2 and 7.3 for EC-CUBE3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 dist: precise
 
@@ -40,6 +42,8 @@ matrix:
     - php: 7.1
       env: DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres PHP_SAPI=phpdbg
   allow_failures:
+    - php: 7.2
+    - php: 7.3
     - env: DB=sqlite
     - php: 7.1
     - php: 7.0.12 # dist: trusty を動かすためのダミー. 実際にテストは実行されない

--- a/tests/Eccube/Tests/Repository/MemberRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/MemberRepositoryTest.php
@@ -97,10 +97,7 @@ class MemberRepositoryTest extends EccubeTestCase
         }
         $this->app['orm.em']->flush();
 
-        $this->actual = 1;
-
-        $this->expected = count($this->app['eccube.repository.member']->loadUserByUsername('admin'));
-        $this->verify();
+        $this->assertInstanceOf('Eccube\Entity\Member', $this->app['eccube.repository.member']->loadUserByUsername('admin'));
     }
 
     public function testRefreshUser()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ PHP7.2, 7.3 を追加

## 方針(Policy)
+ 7.2, 7.3 は allow_failures に入れておく

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
