### PR TITLE
PDFのロゴ画像をファイル管理から変更できる機能を追加

### DIFF
--- a/src/Eccube/Command/LoadDataFixturesEccubeCommand.php
+++ b/src/Eccube/Command/LoadDataFixturesEccubeCommand.php
@@ -125,6 +125,15 @@ EOF
             );
         }
 
+        $logoPath = '/assets/pdf/logo.png';
+        if (!file_exists($this->container->getParameter('eccube_html_dir').'/user_data'.$logoPath)) {
+            $file = new Filesystem();
+            $file->copy(
+                $this->container->getParameter('eccube_html_admin_dir').$logoPath,
+                $this->container->getParameter('eccube_html_dir').'/user_data'.$logoPath
+            );
+        }
+
         $output->writeln(sprintf('  <comment>></comment> <info>%s</info>', 'Finished Successful!'));
     }
 }

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -230,6 +230,15 @@ class InstallController extends AbstractController
             );
         }
 
+        $logoPath = '/assets/pdf/logo.png';
+        if (!file_exists($this->getParameter('eccube_html_dir').'/user_data'.$logoPath)) {
+            $file = new Filesystem();
+            $file->copy(
+                $this->getParameter('eccube_html_admin_dir').$logoPath,
+                $this->getParameter('eccube_html_dir').'/user_data'.$logoPath
+            );
+        }
+
         return [
             'noWritePermissions' => $noWritePermissions,
         ];

--- a/src/Eccube/Service/OrderPdfService.php
+++ b/src/Eccube/Service/OrderPdfService.php
@@ -306,8 +306,13 @@ class OrderPdfService extends TcpdfFpdi
             $this->lfText(125, 75, $text, 8); // Email
         }
 
-        // ロゴ画像(app配下のロゴ画像を優先して読み込む)
-        $logoFile = $this->eccubeConfig->get('eccube_html_admin_dir').'/assets/pdf/logo.png';
+        // user_dataにlogo.pngが配置されている場合は優先的に読み込む
+        $logoFile = $this->eccubeConfig->get('eccube_html_dir').'/'.$this->eccubeConfig->get('eccube_user_data_route').'/assets/pdf/logo.png';
+
+        if (!file_exists($logoFile)) {
+            $logoFile = $this->eccubeConfig->get('eccube_html_admin_dir').'/assets/pdf/logo.png';
+        }
+
         $this->Image($logoFile, 124, 46, 40);
     }
 

--- a/src/Eccube/Service/OrderPdfService.php
+++ b/src/Eccube/Service/OrderPdfService.php
@@ -307,7 +307,7 @@ class OrderPdfService extends TcpdfFpdi
         }
 
         // user_dataにlogo.pngが配置されている場合は優先的に読み込む
-        $logoFile = $this->eccubeConfig->get('eccube_html_dir').'/'.$this->eccubeConfig->get('eccube_user_data_route').'/assets/pdf/logo.png';
+        $logoFile = $this->eccubeConfig->get('eccube_html_dir').'/user_data/assets/pdf/logo.png';
 
         if (!file_exists($logoFile)) {
             $logoFile = $this->eccubeConfig->get('eccube_html_admin_dir').'/assets/pdf/logo.png';

--- a/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
+++ b/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
@@ -112,6 +112,7 @@ class InstallControllerTest extends AbstractWebTestCase
         $this->assertArrayHasKey('noWritePermissions', $this->actual);
 
         $this->assertFileExists($this->container->getParameter('eccube_html_dir').'/user_data/assets/img/common/favicon.ico');
+        $this->assertFileExists($this->container->getParameter('eccube_html_dir').'/user_data/assets/pdf/logo.png');
     }
 
     public function testStep3()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#4105 納品書に表示されているロゴの変更をファイル管理から出来るようにする

## 方針(Policy)
コンテンツ管理/ファイル管理 から、以下のパスにロゴ画像を設置することで納品書のロゴを変更できるように機能追加しました。
```
user_data/assets/pdf/logo.png
```

## 実装に関する補足(Appendix)
「user_data/assets/pdf/logo.png」にファイルが存在しない場合は、「html/template/admin/assets/pdf/logo.png」を使用するように実装しています。
また、Command、Webからインストールする際に「html/template/admin/assets/pdf/logo.png」を「user_data/assets/pdf/logo.png」にコピーする処理を追加しています。

## テスト（Test)
- Webインストール時のテストを追加
- CIでのテストを予定

## 相談（Discussion）
特にありません

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
