### PR TITLE
商品CSVアップロード時、商品詳細の文字数がDBに保存できる数を超えた場合にエラーメッセージを表示する

### DIFF
--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -287,7 +287,7 @@ class CsvImportController extends AbstractCsvImportController
 
                         if (isset($row[$headerByKey['description_detail']])) {
                             if (StringUtil::isNotBlank($row[$headerByKey['description_detail']])) {
-                                if (mb_strlen($row[$headerByKey['description_detail']]) >= 4000) {
+                                if (mb_strlen($row[$headerByKey['description_detail']]) >= $this->eccubeConfig['eccube_ltext_len']) {
                                     $message = trans('admin.common.csv_invalid_description_detail_upper_limit', [
                                         '%line%' => $line,
                                         '%name%' => $headerByKey['description_detail'],

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -287,7 +287,15 @@ class CsvImportController extends AbstractCsvImportController
 
                         if (isset($row[$headerByKey['description_detail']])) {
                             if (StringUtil::isNotBlank($row[$headerByKey['description_detail']])) {
-                                $Product->setDescriptionDetail(StringUtil::trimAll($row[$headerByKey['description_detail']]));
+                                if (mb_strlen($row[$headerByKey['description_detail']]) >= 4000) {
+                                    $message = trans('admin.common.csv_invalid_description_detail_upper_limit', ['%line%' => $line, '%name%' => $headerByKey['description_detail']]);
+                                    $this->addErrors($message);
+
+                                    return $this->renderWithError($form, $headers);
+
+                                } else {
+                                    $Product->setDescriptionDetail(StringUtil::trimAll($row[$headerByKey['description_detail']]));
+                                }
                             } else {
                                 $Product->setDescriptionDetail(null);
                             }

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -287,7 +287,7 @@ class CsvImportController extends AbstractCsvImportController
 
                         if (isset($row[$headerByKey['description_detail']])) {
                             if (StringUtil::isNotBlank($row[$headerByKey['description_detail']])) {
-                                if (mb_strlen($row[$headerByKey['description_detail']]) >= $this->eccubeConfig['eccube_ltext_len']) {
+                                if (mb_strlen($row[$headerByKey['description_detail']]) > $this->eccubeConfig['eccube_ltext_len']) {
                                     $message = trans('admin.common.csv_invalid_description_detail_upper_limit', [
                                         '%line%' => $line,
                                         '%name%' => $headerByKey['description_detail'],

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -288,7 +288,10 @@ class CsvImportController extends AbstractCsvImportController
                         if (isset($row[$headerByKey['description_detail']])) {
                             if (StringUtil::isNotBlank($row[$headerByKey['description_detail']])) {
                                 if (mb_strlen($row[$headerByKey['description_detail']]) >= 4000) {
-                                    $message = trans('admin.common.csv_invalid_description_detail_upper_limit', ['%line%' => $line, '%name%' => $headerByKey['description_detail']]);
+                                    $message = trans('admin.common.csv_invalid_description_detail_upper_limit', [
+                                        '%line%' => $line,
+                                        '%name%' => $headerByKey['description_detail'],
+                                        '%max%' => $this->eccubeConfig['eccube_ltext_len'],]);
                                     $this->addErrors($message);
 
                                     return $this->renderWithError($form, $headers);

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -462,6 +462,7 @@ admin.common.csv_invalid_not_same: 'You are not allowed to enter the same value 
 admin.common.csv_invalid_can_not: '%name% is invalid in the line %line%'
 admin.common.csv_invalid_image: 'Your are not allowed to use "/" or "../" as suffix in %name% in the %line%'
 admin.common.csv_invalid_foreign_key: 'You are unable to delete %name% in the line %line% because it has related data'
+admin.common.csv_invalid_description_detail_upper_limit: '%name% should be less than 4000 characters in the line %line%.'
 admin.common.drag_and_drop_description: You can change the order of the items by drag & drop.
 admin.common.drag_and_drop_image_description: Drag & drop the images or
 admin.common.delete_modal__title: Delete

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -462,7 +462,7 @@ admin.common.csv_invalid_not_same: 'You are not allowed to enter the same value 
 admin.common.csv_invalid_can_not: '%name% is invalid in the line %line%'
 admin.common.csv_invalid_image: 'Your are not allowed to use "/" or "../" as suffix in %name% in the %line%'
 admin.common.csv_invalid_foreign_key: 'You are unable to delete %name% in the line %line% because it has related data'
-admin.common.csv_invalid_description_detail_upper_limit: '%name% should be less than 4000 characters in the line %line%.'
+admin.common.csv_invalid_description_detail_upper_limit: '%name% should be less than %max% characters in the line %line%.'
 admin.common.drag_and_drop_description: You can change the order of the items by drag & drop.
 admin.common.drag_and_drop_image_description: Drag & drop the images or
 admin.common.delete_modal__title: Delete

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -462,7 +462,7 @@ admin.common.csv_invalid_not_same: '%line%行目の%name1%と%name2%には同じ
 admin.common.csv_invalid_can_not: '%line%行目の%name%は設定できません'
 admin.common.csv_invalid_image: '%line%行目の%name%には末尾に"/"や"../"を使用できません'
 admin.common.csv_invalid_foreign_key: '%line%行目の%name%は関連するデータがあるため削除できません'
-admin.common.csv_invalid_description_detail_upper_limit: '%line%行目の%name%は4000文字以下の文字列を指定してください。'
+admin.common.csv_invalid_description_detail_upper_limit: '%line%行目の%name%は%max%文字以下の文字列を指定してください。'
 admin.common.drag_and_drop_description: 項目の順番はドラッグ＆ドロップでも変更可能です。
 admin.common.drag_and_drop_image_description: 画像をドラッグ＆ドロップまたは
 admin.common.delete_modal__title: 削除します

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -462,6 +462,7 @@ admin.common.csv_invalid_not_same: '%line%行目の%name1%と%name2%には同じ
 admin.common.csv_invalid_can_not: '%line%行目の%name%は設定できません'
 admin.common.csv_invalid_image: '%line%行目の%name%には末尾に"/"や"../"を使用できません'
 admin.common.csv_invalid_foreign_key: '%line%行目の%name%は関連するデータがあるため削除できません'
+admin.common.csv_invalid_description_detail_upper_limit: '%line%行目の%name%は4000文字以下の文字列を指定してください。'
 admin.common.drag_and_drop_description: 項目の順番はドラッグ＆ドロップでも変更可能です。
 admin.common.drag_and_drop_image_description: 画像をドラッグ＆ドロップまたは
 admin.common.delete_modal__title: 削除します

--- a/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
@@ -857,6 +857,30 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
     }
 
     /**
+     * @dataProvider dataDescriptionDetailProvider
+     * @see https://github.com/EC-CUBE/ec-cube/pull/4218
+     */
+    public function testImportDescriptionetail($length, $selector, $pattern)
+    {
+        $csv = [];
+        $csv[] = ['公開ステータス(ID)', '商品名', '販売種別(ID)', '在庫数無制限フラグ', '販売価格', '商品説明(詳細)'];
+        $csv[] = [1, '商品詳細テスト用', 1, 1, 1, str_repeat('a', $length)];
+        $this->filepath = $this->createCsvFromArray($csv);
+
+        $crawler = $this->scenario();
+        $this->assertRegexp($pattern, $crawler->filter($selector)->text());
+    }
+
+    public function dataDescriptionDetailProvider()
+    {
+        return [
+            [2999, 'div.alert-success', '/CSVファイルをアップロードしました/u'],
+            [3000, 'div.alert-success', '/CSVファイルをアップロードしました/u'],
+            [3001, 'div.text-danger', '/2行目の商品説明\(詳細\)は3000文字以下の文字列を指定してください。/u'],
+        ];
+    }
+
+    /**
      * @see https://github.com/EC-CUBE/ec-cube/pull/4281
      *
      * @dataProvider dataTaxRuleProvider


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#4187 のバグ修正です。
商品詳細の文字数が、マルチバイトで4000文字を超えた場合にエラーメッセージを表示させるように修正しています。

## 方針(Policy)
DBのカラムに登録できる最大文字数を超える場合は、エラーメッセージを返すようにしました。

## 実装に関する補足(Appendix)
src/Eccube/Resource/locale/messages.ja.yaml 
src/Eccube/Resource/locale/messages.en.yaml 
にエラーメッセージを新たに追加しています。

## テスト（Test)
- アップロードするcsvファイルについて、商品詳細がマルチバイトで4000文字以内であれば、登録されることを確認しました。
- 4001文字以上の場合は、エラーとなることを画面で確認しました。

<img width="1649" alt="スクリーンショット 2019-07-09 14 55 30" src="https://user-images.githubusercontent.com/26207848/60862992-403ce600-a25a-11e9-9700-28d90e006ccc.png">

テストコードはありません。

## 相談（Discussion）


## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
