### PR TITLE
PHP7.3 で debug toolbar が表示されなくなったのを修正

### DIFF
--- a/src/Eccube/DataCollector/EccubeDataCollector.php
+++ b/src/Eccube/DataCollector/EccubeDataCollector.php
@@ -138,7 +138,7 @@ class EccubeDataCollector extends DataCollector
                     $Plugin->setName($code);
                     $Plugin->setEnabled(false);
                 }
-                $this->data['plugins'][$code] = $Plugin;
+                $this->data['plugins'][$code] = $Plugin->toArray();
             }
         } catch (\Exception $exception) {
         }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
- `Notice: unserialize(): Error at offset 4916 of 13889 bytes` という notice で debug toolbar が表示されなかった
- Plugin オブジェクトを serialize/unserialize しようとしていたため

## 方針(Policy)
+ 配列に変換して debug toolbar に渡すよう修正

## テスト（Test)
+ #4204 の Docker 環境で debug toolbar が表示されるのを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか