### PR TITLE
マスタデータ管理でOrderStatusを追加できない不具合を修正

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/System/MasterdataController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/MasterdataController.php
@@ -132,7 +132,6 @@ class MasterdataController extends AbstractController
                 $data = $form2->getData();
 
                 $entityName = str_replace('-', '\\', $data['masterdata_name']);
-                $entity = new $entityName();
                 $sortNo = 0;
                 $ids = array_filter(array_map(
                     function ($v) {
@@ -141,12 +140,18 @@ class MasterdataController extends AbstractController
                     $data['data']
                 ));
 
+                $repository = $this->entityManager->getRepository($entityName);
+
                 foreach ($data['data'] as $key => $value) {
                     if ($value['id'] !== null && $value['name'] !== null) {
+                        $entity = $repository->find($value['id']);
+                        if ($entity === null) {
+                            $entity = new $entityName();
+                        }
                         $entity->setId($value['id']);
                         $entity->setName($value['name']);
                         $entity->setSortNo($sortNo++);
-                        $this->entityManager->merge($entity);
+                        $this->entityManager->persist($entity);
                     } elseif (!in_array($key, $ids)) {
                         // remove
                         $delKey = $this->entityManager->getRepository($entityName)->find($key);

--- a/src/Eccube/Entity/Master/OrderStatus.php
+++ b/src/Eccube/Entity/Master/OrderStatus.php
@@ -51,7 +51,7 @@ class OrderStatus extends \Eccube\Entity\Master\AbstractMasterEntity
      *
      * @ORM\Column(name="display_order_count", type="boolean", options={"default":false})
      */
-    private $display_order_count;
+    private $display_order_count = false;
 
     /**
      * @return bool

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/MasterdataControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/MasterdataControllerTest.php
@@ -370,7 +370,7 @@ class MasterdataControllerTest extends AbstractAdminWebTestCase
     }
 
     /**
-     * Add new name test
+     * 受注ステータスが追加できない不具合の修正
      *
      * @see https://github.com/EC-CUBE/ec-cube/issues/4035
      */

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/MasterdataControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/MasterdataControllerTest.php
@@ -13,6 +13,7 @@
 
 namespace Eccube\Tests\Web\Admin\Setting\System;
 
+use Eccube\Entity\Master\OrderStatus;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 use Symfony\Component\HttpFoundation\Session\Session;
 
@@ -366,6 +367,39 @@ class MasterdataControllerTest extends AbstractAdminWebTestCase
         $this->actual = array_shift($outPut);
         $this->expected = 'admin.common.save_complete';
         $this->verify();
+    }
+
+    /**
+     * Add new name test
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/4035
+     */
+    public function testNewOrderStatus()
+    {
+        $entityName = 'Eccube-Entity-Master-OrderStatus';
+        $formData = $this->createFormData($entityName);
+        $editForm = $this->createFormDataEdit($entityName);
+        $id = 999;
+        $status = '新ステータス';
+        $editForm['data'][$id]['id'] = $id;
+        $editForm['data'][$id]['name'] = $status;
+
+        $crawler = $this->client->request(
+            'POST',
+            $this->generateUrl('admin_setting_system_masterdata_edit'),
+            [
+                'admin_system_masterdata' => $formData,
+                'admin_system_masterdata_edit' => $editForm,
+            ]
+        );
+        $html = $crawler->html();
+        $this->assertContains('保存しました。', $html);
+
+        /** @var OrderStatus $actual */
+        $actual = $this->entityManager->getRepository(OrderStatus::class)->find($id);
+        $this->assertNotNull($actual);
+        $this->assertSame($status, $actual->getName());
+        $this->assertFalse($actual->isDisplayOrderCount());
     }
 
     /**

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/MasterdataControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/MasterdataControllerTest.php
@@ -392,8 +392,11 @@ class MasterdataControllerTest extends AbstractAdminWebTestCase
                 'admin_system_masterdata_edit' => $editForm,
             ]
         );
-        $html = $crawler->html();
-        $this->assertContains('保存しました。', $html);
+        // message check
+        $outPut = $this->session->getFlashBag()->get('eccube.admin.success');
+        $this->actual = array_shift($outPut);
+        $this->expected = 'admin.common.save_complete';
+        $this->verify();
 
         /** @var OrderStatus $actual */
         $actual = $this->entityManager->getRepository(OrderStatus::class)->find($id);


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#4035 の修正

## 方針(Policy)

- 独自のカラムがあり更新に失敗していたため、一度データを取得してから更新を行うように修正
- デフォルト値がnullになる問題を修正

以下のコメントの通り修正しています。
https://github.com/EC-CUBE/ec-cube/issues/4035#issuecomment-471368819

## テスト（Test)
+ 受注ステータスを追加するユニットテストを追加
+ MasterDataControllerのテストで登録・更新の正常系のテストケースがあるため、上記テストのみ追加しています。

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
