### PR TITLE
メンテナンスファイルのパスを環境変数だけで変更できるようにする

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -12,6 +12,7 @@ parameters:
     env(ECCUBE_GC_MAXLIFETIME): 1440
     env(ECCUBE_PACKAGE_API_URL): 'https://package-api.ec-cube.net'
     env(ECCUBE_OWNERS_STORE_URL): 'https://www.ec-cube.net'
+    env(ECCUBE_MAINTENANCE_FILE_PATH): '%kernel.project_dir%/.maintenance'
 
     # EC-CUBE parameter
     eccube_database_url: '%env(DATABASE_URL)%'
@@ -122,4 +123,4 @@ parameters:
     eccube_news_start_year: 2000
     eccube_result_cache_lifetime: 3600 # doctrineのresult cacheのlifetime.
     eccube_result_cache_lifetime_short: 10  # doctrineのresult cacheのlifetime. 商品一覧画面など長期間キャッシュできない箇所で使用する.
-    eccube_content_maintenance_file_path: '%kernel.project_dir%/.maintenance'
+    eccube_content_maintenance_file_path: '%env(ECCUBE_MAINTENANCE_FILE_PATH)%'

--- a/index.php
+++ b/index.php
@@ -55,7 +55,9 @@ if ($trustedHosts) {
 
 $request = Request::createFromGlobals();
 
-if (file_exists(__DIR__.'/.maintenance')) {
+$maintenanceFile = env('ECCUBE_MAINTENANCE_FILE_PATH', __DIR__.'/.maintenance');
+
+if (file_exists($maintenanceFile)) {
     $pathInfo = \rawurldecode($request->getPathInfo());
     $adminPath = env('ECCUBE_ADMIN_ROUTE', 'admin');
     $adminPath = '/'.\trim($adminPath, '/').'/';


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
`eccube_content_maintenance_file_path` を変更してもindex.phpが対応していないので、環境変数の設定だけで対応できるようにした。

## テスト（Test)
環境変数 `ECCUBE_MAINTENANCE_FILE_PATH` を設定してメンテナンスファイルが指定パスにできることと、メンテナンスモードになることを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
