### PR TITLE
受注管理 マルチ検索の対象項目修正

### DIFF
--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -110,7 +110,7 @@ class OrderRepository extends AbstractRepository
             $qb
                 ->andWhere('o.id = :multi OR o.name01 LIKE :likemulti OR o.name02 LIKE :likemulti OR '.
                             'o.kana01 LIKE :likemulti OR o.kana02 LIKE :likemulti OR o.company_name LIKE :likemulti OR '.
-                            'o.order_no LIKE :likemulti')
+                            'o.order_no LIKE :likemulti OR o.email LIKE :likemulti OR o.phone_number LIKE :likemulti')
                 ->setParameter('multi', $multi)
                 ->setParameter('likemulti', '%'.$searchData['multi'].'%');
         }

--- a/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataAdminTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataAdminTest.php
@@ -147,6 +147,46 @@ class OrderRepositoryGetQueryBuilderBySearchDataAdminTest extends EccubeTestCase
         $this->verify();
     }
 
+    public function testMultiWithEmail()
+    {
+        $this->entityManager->flush();
+
+        $this->searchData = [
+            'multi' => 'test@example.com',
+        ];
+        $this->scenario();
+
+        $this->expected = 1;
+        $this->actual = count($this->Results);
+        $this->verify();
+    }
+
+
+    public function testMultiWithPhoneNumber()
+    {
+        /** @var Order[] $Orders */
+        $Orders = $this->orderRepo->findAll();
+        // 全受注の Phone Number を変更しておく
+        foreach ($Orders as $Order) {
+            $Order->setPhoneNumber('9876543210');
+        }
+
+        // 1受注のみ検索対象とする
+        $this->Order1->setPhoneNumber('0123456789');
+        $this->entityManager->flush();
+
+        $this->searchData = [
+            'multi' => '0123456789',
+        ];
+        $this->scenario();
+
+        $this->expected = 1;
+        $this->actual = count($this->Results);
+        $this->verify();
+    }
+
+
+
     public function testOrderIdEnd()
     {
         $this->searchData = [

--- a/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataAdminTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataAdminTest.php
@@ -135,30 +135,22 @@ class OrderRepositoryGetQueryBuilderBySearchDataAdminTest extends EccubeTestCase
 
     public function testMultiWithNo()
     {
-        $this->entityManager->flush();
-
         $this->searchData = [
             'multi' => $this->Order2->getOrderNo(),
         ];
         $this->scenario();
 
-        $this->expected = 1;
-        $this->actual = count($this->Results);
-        $this->verify();
+        $this->assertCount(1, $this->Results);
     }
 
     public function testMultiWithEmail()
     {
-        $this->entityManager->flush();
-
         $this->searchData = [
             'multi' => 'test@example.com',
         ];
         $this->scenario();
 
-        $this->expected = 1;
-        $this->actual = count($this->Results);
-        $this->verify();
+        $this->assertCount(1, $this->Results);
     }
 
 
@@ -180,9 +172,7 @@ class OrderRepositoryGetQueryBuilderBySearchDataAdminTest extends EccubeTestCase
         ];
         $this->scenario();
 
-        $this->expected = 1;
-        $this->actual = count($this->Results);
-        $this->verify();
+        $this->assertCount(1, $this->Results);
     }
 
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
受注管理のマルチ検索ラベルにメールアドレス・電話番号と記載があるが検索対象になっていないため、検索対象に含めるよう修正

![スクリーンショット 0031-07-15 14 23 04](https://user-images.githubusercontent.com/4304985/61196805-1842fc00-a70c-11e9-881b-37802da27470.png)
