### PR TITLE
会員削除時メッセージの修正

### DIFF
--- a/src/Eccube/Controller/Admin/Customer/CustomerController.php
+++ b/src/Eccube/Controller/Admin/Customer/CustomerController.php
@@ -243,7 +243,7 @@ class CustomerController extends AbstractController
         try {
             $this->entityManager->remove($Customer);
             $this->entityManager->flush($Customer);
-            $this->addSuccess('admin.customer.delete.complete', 'admin');
+            $this->addSuccess('admin.common.delete_complete', 'admin');
         } catch (ForeignKeyConstraintViolationException $e) {
             log_error('会員削除失敗', [$e], 'admin');
 


### PR DESCRIPTION

## 概要(Overview・Refs Issue)
会員削除時のメッセージが「admin.customer.delete.complete」と表示されることの修正
→　翻訳済みのadmin.common.delete_completeに修正

![スクリーンショット 0031-07-15 18 35 44](https://user-images.githubusercontent.com/4304985/61207398-f9566100-a72f-11e9-9103-c0b0e8957328.png)
