### PR TITLE
配送管理でお届け時間が並び替えられない不具合の修正

### DIFF
--- a/src/Eccube/Entity/Delivery.php
+++ b/src/Eccube/Entity/Delivery.php
@@ -118,6 +118,9 @@ if (!class_exists('\Eccube\Entity\Delivery')) {
          * @var \Doctrine\Common\Collections\Collection
          *
          * @ORM\OneToMany(targetEntity="Eccube\Entity\DeliveryTime", mappedBy="Delivery", cascade={"persist","remove"})
+         * @ORM\OrderBy({
+         *     "sort_no"="ASC"
+         * })
          */
         private $DeliveryTimes;
 


### PR DESCRIPTION
以下を参考にコメントを作成してください。

## 概要(Overview・Refs Issue)
[配送方法設定] お届け時間を並び替えることができない
#4228 の修正

## 方針(Policy)
現在、表示する際に$Delivery->getDeliveryTimes()を使用しているが、並び順が指定されていない。
注文画面でも$Delivery->getDeliveryTimes()を使用しているので、並び順が統一されるように、sort_noで並び順を指定。

"sort_no"="ASC"としたのは、配送方法設定で時間を追加するとsort_noが増加していくため。

既に運用している方はこの修正を取り込むと注文画面での時間の並び順が変わってしまう可能性があると思いますので、方針に問題ないかご確認いただければと思います。