### PR TITLE
非ログイン時のお気に入り登録挙動修正 Fix #4165

### DIFF
--- a/src/Eccube/Resource/template/default/Mypage/login.twig
+++ b/src/Eccube/Resource/template/default/Mypage/login.twig
@@ -20,6 +20,11 @@ file that was distributed with this source code.
         <div class="ec-off2Grid">
             <div class="ec-off2Grid__cell">
                 <form name="login_mypage" id="login_mypage" method="post" action="{{ url('mypage_login') }}">
+                    {% if app.session.flashBag.has('eccube.login.target.path') %}
+                        {% for targetPath in app.session.flashBag.get('eccube.login.target.path') %}
+                            <input type="hidden" name="_target_path" value="{{ targetPath }}" />
+                        {% endfor %}
+                    {% endif %}
                     <div class="ec-login">
                         <div class="ec-login__icon">
                             <div class="ec-icon"><img src="{{ asset('assets/icon/user.svg') }}" alt=""></div>


### PR DESCRIPTION

## 概要(Overview・Refs Issue)
非ログイン時にログイン画面通過後にお気に入り登録されない問題　#4165 の修正
login.twigに_target_pathを出力するコードを追加

## 方針(Policy)
+ このPullRequestを作るにあたって考慮したものや除外した内容
  - 3系の仕様を踏襲し、ログイン後はお気に入り登録して最終的に商品詳細画面へリダイレクト


## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
