### PR TITLE
タグが紐付いている商品を、商品一覧より削除できるように変更

### DIFF
--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -513,7 +513,7 @@ if (!class_exists('\Eccube\Entity\Product')) {
         /**
          * @var \Doctrine\Common\Collections\Collection
          *
-         * @ORM\OneToMany(targetEntity="Eccube\Entity\ProductTag", mappedBy="Product")
+         * @ORM\OneToMany(targetEntity="Eccube\Entity\ProductTag", mappedBy="Product", cascade={"remove"})
          */
         private $ProductTag;
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#4227 に対する修正


## 方針(Policy)
商品が削除されると商品に関連するタグも同時に削除するように変更。

## 実装に関する補足(Appendix)


## テスト（Test)
商品削除時に、タグが削除されているかをチェックするテストを追加しています。

## 相談（Discussion）
+ 相談したいことや意見を求めたいこと

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
