### PR TITLE
READMEからwikiのコピーライトポリシーにリンクするように修正(3系)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ Issuesの利用方法については、[こちら](https://github.com/EC-CUBE/ec
 ### コピーライトポリシーへの同意
 
 コードの提供・追加、修正・変更その他「EC-CUBE」への開発の御協力（Issue投稿、PullRequest投稿など、GitHub上での活動）を行っていただく場合には、
-[EC-CUBEのコピーライトポリシー](https://github.com/EC-CUBE/ec-cube/blob/3.0/LICENSE.txt)をご理解いただき、ご了承いただく必要がございます。
+[EC-CUBEのコピーライトポリシー](https://github.com/EC-CUBE/ec-cube/wiki/EC-CUBE%E3%81%AE%E3%82%B3%E3%83%94%E3%83%BC%E3%83%A9%E3%82%A4%E3%83%88%E3%83%9D%E3%83%AA%E3%82%B7%E3%83%BC)をご理解いただき、ご了承いただく必要がございます。
 Issueの投稿やPullRequestを送信する際は、EC-CUBEのコピーライトポリシーに同意したものとみなします。
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ Issuesの利用方法については、[こちら](https://github.com/EC-CUBE/ec
 ### コピーライトポリシーへの同意
 
 コードの提供・追加、修正・変更その他「EC-CUBE」への開発の御協力（Issue投稿、PullRequest投稿など、GitHub上での活動）を行っていただく場合には、
-[EC-CUBEのコピーライトポリシー](https://github.com/EC-CUBE/ec-cube/blob/50de4ac511ab5a5577c046b61754d98be96aa328/LICENSE.txt)をご理解いただき、ご了承いただく必要がございます。
+[EC-CUBEのコピーライトポリシー](https://github.com/EC-CUBE/ec-cube/blob/3.0/LICENSE.txt)をご理解いただき、ご了承いただく必要がございます。
 Issueの投稿やPullRequestを送信する際は、EC-CUBEのコピーライトポリシーに同意したものとみなします。
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
READMEからLICENSE.txtにリンクをしているところを、wikiのコピーライトポリシーにリンクするように修正しました。

## 方針(Policy)
最新のコピーライトポリシーにリンクが貼られているべき。

## 実装に関する補足(Appendix)
なし

## テスト（Test)
不要

## 相談（Discussion）
なし

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
