### PR TITLE
3.1.xブランチはunstable版であるということをREADMEに明記した

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EC-CUBE 3.1.x
+# EC-CUBE 3.1.x (unstable)
 
 [![Build Status](https://travis-ci.com/EC-CUBE/ec-cube.svg?branch=3.1)](https://travis-ci.com/EC-CUBE/ec-cube)
 [![Build status](https://ci.appveyor.com/api/projects/status/lg3uh1539cwln2g6/branch/3.1?svg=true)](https://ci.appveyor.com/project/ECCUBE/ec-cube)
@@ -11,6 +11,13 @@
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
+
+EC-CUBE 3.1.xは、まだリリースされていないunstable版です。  
+EC-CUBE 3.0系をベースにして、後方互換性の無い内容も含めた変更が取り込まれています。
+
+安定版のEC-CUBE 3.0系は、[3.0ブランチ](https://github.com/EC-CUBE/ec-cube/tree/3.0)を参照してください。
+
+---
 
 + 本ドキュメントはEC-CUBEの開発者を主要な対象者としております。  
 + パッケージ版をご利用の方は[EC-CUBEオフィシャルサイト](http://www.ec-cube.net)をご確認ください。  


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
3.1.xブランチはunstable版であるということをREADMEに明記しました。
後方互換性のない変更も含めて取り込まれている旨も記載しています。

## 方針(Policy)
わかりやすく

## 実装に関する補足(Appendix)
なし

## テスト（Test)
なし

## 相談（Discussion）
なし

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
