### PR TITLE
metatag記載例の追加機能

### DIFF
--- a/codeception/_support/Page/Admin/PageEditPage.php
+++ b/codeception/_support/Page/Admin/PageEditPage.php
@@ -55,6 +55,12 @@ class PageEditPage extends AbstractAdminPageStyleGuide
         return $this;
     }
 
+    public function 入力_metatag()
+    {
+        $this->tester->scrollTo(['xpath' => '//*[@id="pageMeta"]/div/div[5]/div[1]/div[2]/i'],  '0', '0');
+        $this->tester->click(['xpath' => '//*[@id="pageMeta"]/div/div[5]/div[1]/div[2]/i']);
+    }
+
     public function 入力_内容($value)
     {
         $value = preg_replace("/([^\\\])'/", "$1\\'", $value);

--- a/codeception/acceptance/EA06ContentsManagementCest.php
+++ b/codeception/acceptance/EA06ContentsManagementCest.php
@@ -170,6 +170,14 @@ class EA06ContentsManagementCest
 
         /* 編集 */
         PageManagePage::go($I)->ページ編集($page);
+
+        /* metaを入力 */
+        PageEditPage::at($I)->入力_metatag();
+
+        /* popup確認 */
+        $I->seeInPopup('metatagに「商品詳細ページでの記載例」を追記しました。');
+        $I->acceptPopup();
+
         PageEditPage::at($I)
             ->入力_内容("{% extends 'default_frame.twig' %}")
             ->登録();

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -987,8 +987,9 @@ admin.content.page_meta_description: description
 admin.content.page_meta_keyword: keyword
 admin.content.page_meta_robot: robot
 admin.content.page_meta_metatag: metatag
+admin.content.page_meta_metatag_placeholder_annotation: |
+ Description example on the product details page.
 admin.content.page_meta_metatag_placeholder: |
-  商品詳細ページでの記載例
     <meta property="og:type" content="og:product" />
     <meta property="og:title" content="{{ Product.name }}" />
     <meta property="og:image" content="{{ url('homepage') }}{{ asset(Product.main_list_image|no_image_product, 'save_image') }}" />
@@ -1531,6 +1532,8 @@ tooltip.content.page_source_code: Editing the template file. Coding has to be wi
 tooltip.content.page_layout: Selecting the layouts to be applied to this page.
 tooltip.content.page_meta: You can enter the META tag contents of the page.
 tooltip.content.page_meta_tags: You can add META tag freely. You can also use variables used within twig.
+tooltip.content.page_meta_tag_insert: Enter the settings for the product detail page.
+tooltip.content.page_meta_tag_insert_complate: Entered a settings for the product detail page.
 tooltip.content.js_source_code: Editing the JavaScript file. Coding has to be with JavaScript.
 tooltip.content.css_source_code: Editing the CSS file. Coding has to be with CSS.
 tooltip.content.block_name: This is a name of a block for management use.

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -987,8 +987,9 @@ admin.content.page_meta_description: description
 admin.content.page_meta_keyword: keyword
 admin.content.page_meta_robot: robot
 admin.content.page_meta_metatag: metatag
-admin.content.page_meta_metatag_placeholder: |
+admin.content.page_meta_metatag_placeholder_annotation: |
   商品詳細ページでの記載例
+admin.content.page_meta_metatag_placeholder: |
     <meta property="og:type" content="og:product" />
     <meta property="og:title" content="{{ Product.name }}" />
     <meta property="og:image" content="{{ url('homepage') }}{{ asset(Product.main_list_image|no_image_product, 'save_image') }}" />
@@ -1531,6 +1532,8 @@ tooltip.content.page_source_code: テンプレートファイルを編集しま�
 tooltip.content.page_layout: このページに適用するレイアウトを選択します。
 tooltip.content.page_meta: ページのMETAタグの内容を指定できます。
 tooltip.content.page_meta_tags: 自由にMETAタグを追加できます。twig内で利用されている変数も利用できます。
+tooltip.content.page_meta_tag_insert: 「商品詳細ページでの記載例」をmetatagに追記します。
+tooltip.content.page_meta_tag_insert_complate: metatagに「商品詳細ページでの記載例」を追記しました。
 tooltip.content.css_source_code: カスタマイズ用CSSファイルを編集します。CSSで記述します。
 tooltip.content.js_source_code: カスタマイズ用JavaScriptファイルを編集します。JavaScriptで記述します。
 tooltip.content.block_name: ブロックの管理用名称です。

--- a/src/Eccube/Resource/template/admin/Content/page_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/page_edit.twig
@@ -60,6 +60,15 @@ file that was distributed with this source code.
         $('#content_page_form').on('submit', function(elem) {
             $('#main_edit_tpl_data').val(editor.getValue());
         });
+
+        $('.meta-insert').on('click',function(){
+            metaTags = $('#main_edit_meta_tags').val();
+            $('#main_edit_meta_tags').val(metaTags + $('.meta-insert').data('meta'));
+
+            alert('{{ 'tooltip.content.page_meta_tag_insert_complate'|trans }}');
+        });
+
+
     </script>
 {% endblock %}
 
@@ -272,9 +281,12 @@ file that was distributed with this source code.
                                             <span>{{ 'admin.content.page_meta_metatag'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ml-1"></i>
                                         </div>
+                                        <div class="btn btn-ec-actionIcon d-inline-block meta-insert" data-tooltip="true" data-placement="top" title="{{ 'tooltip.content.page_meta_tag_insert'|trans }}" data-meta="{{ 'admin.content.page_meta_metatag_placeholder'|trans }}">
+                                            <i class="fa fa-copy fa-lg text-secondary"></i>
+                                        </div>
                                     </div>
                                     <div class="col-10">
-                                        {{ form_widget(form.meta_tags, { attr : { placeholder : 'admin.content.page_meta_metatag_placeholder'|trans, rows : '10' }}) }}
+                                        {{ form_widget(form.meta_tags, { attr : { placeholder : 'admin.content.page_meta_metatag_placeholder_annotation'|trans~'admin.content.page_meta_metatag_placeholder'|trans, rows : '10' }}) }}
                                         {{ form_errors(form.meta_tags) }}
                                     </div>
                                 </div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#4108 コンテンツ管理＞ページ管理＞のmeta記載例をそのまま利用できるようにする

## 方針(Policy)
metatagの上書きではなく追記するように対応しました。

## 実装に関する補足(Appendix)
とくにありません

## テスト（Test)
Codeceptionでのテストを修正しました。

## 相談（Discussion）
特にありません

## マイナーバージョン互換性保持のための制限事項チェックリスト
+ マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
