### PR TITLE
受注管理での税率・税額を受注時点のデータを元とし編集可能にする

### DIFF
--- a/src/Eccube/Entity/OrderItem.php
+++ b/src/Eccube/Entity/OrderItem.php
@@ -207,6 +207,13 @@ if (!class_exists('\Eccube\Entity\OrderItem')) {
         private $tax_rate = 0;
 
         /**
+         * @var string
+         *
+         * @ORM\Column(name="tax_adjust", type="decimal", precision=10, scale=0, options={"unsigned":true,"default":0})
+         */
+        private $tax_adjust = 0;
+
+        /**
          * @var int|null
          *
          * @ORM\Column(name="tax_rule_id", type="smallint", nullable=true, options={"unsigned":true})
@@ -551,6 +558,30 @@ if (!class_exists('\Eccube\Entity\OrderItem')) {
         public function getTaxRate()
         {
             return $this->tax_rate;
+        }
+
+        /**
+         * Set taxAdjust.
+         *
+         * @param string $tax_adjust
+         *
+         * @return OrderItem
+         */
+        public function setTaxAdjust($tax_adjust)
+        {
+            $this->tax_adjust = $tax_adjust;
+
+            return $this;
+        }
+
+        /**
+         * Get taxAdjust.
+         *
+         * @return string
+         */
+        public function getTaxAdjust()
+        {
+            return $this->tax_adjust;
         }
 
         /**

--- a/src/Eccube/Entity/OrderItem.php
+++ b/src/Eccube/Entity/OrderItem.php
@@ -17,7 +17,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Eccube\Entity\Master\OrderItemType;
 use Eccube\Entity\Master\RoundingType;
 use Eccube\Entity\Master\TaxDisplayType;
-use Eccube\Entity\Master\TaxType;
 
 if (!class_exists('\Eccube\Entity\OrderItem')) {
     /**
@@ -556,6 +555,7 @@ if (!class_exists('\Eccube\Entity\OrderItem')) {
 
         /**
          * Set taxRuleId.
+         * @deprecated 税率設定は受注作成時に決定するため廃止予定
          *
          * @param int|null $taxRuleId
          *
@@ -570,6 +570,7 @@ if (!class_exists('\Eccube\Entity\OrderItem')) {
 
         /**
          * Get taxRuleId.
+         * @deprecated 税率設定は受注作成時に決定するため廃止予定
          *
          * @return int|null
          */

--- a/src/Eccube/Form/Type/Admin/OrderItemType.php
+++ b/src/Eccube/Form/Type/Admin/OrderItemType.php
@@ -215,6 +215,11 @@ class OrderItemType extends AbstractType
                             $OrderItem->setClassCategoryName2($ClassCategory2->getName());
                         }
                     }
+                    if (null === $OrderItem->getRoundingType()) {
+                        $TaxRule = $this->taxRuleRepository->getByRule($Product, $ProductClass);
+                        $OrderItem->setRoundingType($TaxRule->getRoundingType())
+                            ->setTaxAdjust($TaxRule->getTaxAdjust());
+                    }
                     break;
 
                 default:

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -803,8 +803,14 @@ file that was distributed with this source code.
                                             </td>
                                             <!-- 税率 -->
                                             <td class="align-middle">
-                                                <div class="col">
-                                                    {{ OrderItem.tax_rate }}%
+                                                <div class="col-12 col-xl-8">
+                                                    {# 複数配送の場合は商品の税率を変更できない、ポイントの場合も税率を変更できない #}
+                                                    {% if (Order.isMultiple and OrderItem.isProduct) or OrderItem.isPoint %}
+                                                        {{ form_widget(orderItemForm.tax_rate, { 'attr': { 'readonly': 'readonly' } }) }}
+                                                    {% else %}
+                                                        {{ form_widget(orderItemForm.tax_rate) }}
+                                                    {% endif %}
+                                                    {{ form_errors(orderItemForm.tax_rate) }}
                                                 </div>
                                             </td>
                                             <!-- 課税区分 -->

--- a/src/Eccube/Service/PointHelper.php
+++ b/src/Eccube/Service/PointHelper.php
@@ -128,7 +128,6 @@ class PointHelper
             ->setQuantity(1)
             ->setTax(0)
             ->setTaxRate(0)
-            ->setTaxRuleId(null)
             ->setRoundingType(null)
             ->setOrderItemType($DiscountType)
             ->setTaxDisplayType($TaxInclude)

--- a/src/Eccube/Service/PurchaseFlow/Processor/TaxProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/TaxProcessor.php
@@ -86,7 +86,6 @@ class TaxProcessor implements ItemHolderPreprocessor
                 $item->setTax(0);
                 $item->setTaxRate(0);
                 $item->setRoundingType(null);
-                $item->setTaxRuleId(null);
 
                 continue;
             }

--- a/src/Eccube/Service/PurchaseFlow/Processor/TaxProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/TaxProcessor.php
@@ -19,6 +19,7 @@ use Eccube\Entity\Master\OrderItemType;
 use Eccube\Entity\Master\TaxDisplayType;
 use Eccube\Entity\Master\TaxType;
 use Eccube\Entity\Order;
+use Eccube\Entity\OrderItem;
 use Eccube\Repository\TaxRuleRepository;
 use Eccube\Service\PurchaseFlow\ItemHolderPreprocessor;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
@@ -90,32 +91,29 @@ class TaxProcessor implements ItemHolderPreprocessor
                 continue;
             }
 
-            if ($item->getTaxRuleId()) {
-                $TaxRule = $this->taxRuleRepository->find($item->getTaxRuleId());
-            } else {
-                $TaxRule = $this->taxRuleRepository->getByRule($item->getProduct(), $item->getProductClass());
-            }
+            // 税率が設定されていない場合は税率を明細にコピーする
+            if ($item->getRoundingType() === null) {
+                $TaxRule = $item->getOrderItemType()->getId() == OrderItemType::PRODUCT
+                    ? $this->taxRuleRepository->getByRule($item->getProduct(), $item->getProductClass())
+                    : $this->taxRuleRepository->getByRule();
 
-            // $TaxRuleを取得出来ない場合は基本税率設定を使用.
-            if (null === $TaxRule) {
-                $TaxRule = $this->taxRuleRepository->getByRule();
+                $item->setTaxRate($TaxRule->getTaxRate())
+                    ->setTaxAdjust($TaxRule->getTaxAdjust())
+                    ->setRoundingType($TaxRule->getRoundingType());
             }
 
             // 税込表示の場合は, priceが税込金額のため割り戻す.
             if ($item->getTaxDisplayType()->getId() == TaxDisplayType::INCLUDED) {
                 $tax = $this->taxRuleService->calcTaxIncluded(
-                    $item->getPrice(), $TaxRule->getTaxRate(), $TaxRule->getRoundingType()->getId(),
-                    $TaxRule->getTaxAdjust());
+                    $item->getPrice(), $item->getTaxRate(), $item->getRoundingType()->getId(),
+                    $item->getTaxAdjust());
             } else {
                 $tax = $this->taxRuleService->calcTax(
-                    $item->getPrice(), $TaxRule->getTaxRate(), $TaxRule->getRoundingType()->getId(),
-                    $TaxRule->getTaxAdjust());
+                    $item->getPrice(), $item->getTaxRate(), $item->getRoundingType()->getId(),
+                    $item->getTaxAdjust());
             }
 
             $item->setTax($tax);
-            $item->setTaxRate($TaxRule->getTaxRate());
-            $item->setRoundingType($TaxRule->getRoundingType());
-            $item->setTaxRuleId($TaxRule->getId());
         }
     }
 

--- a/src/Eccube/Service/PurchaseFlow/Processor/TaxProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/TaxProcessor.php
@@ -92,7 +92,7 @@ class TaxProcessor implements ItemHolderPreprocessor
 
             // 税率が設定されていない場合は税率を明細にコピーする
             if ($item->getRoundingType() === null) {
-                $TaxRule = $item->getOrderItemType()->getId() == OrderItemType::PRODUCT
+                $TaxRule = $item->getOrderItemType()->isProduct()
                     ? $this->taxRuleRepository->getByRule($item->getProduct(), $item->getProductClass())
                     : $this->taxRuleRepository->getByRule();
 

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderItemTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderItemTypeTest.php
@@ -27,6 +27,7 @@ class OrderItemTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         'quantity' => '10000',
         'product_name' => 'name1',
         'order_item_type' => '1',
+        'tax_rate' => '8',
     ];
 
     public function setUp()
@@ -114,38 +115,6 @@ class OrderItemTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
     {
         $this->markTestIncomplete('testInvalidQuantity_HasMinus is not implemented.');
         $this->formData['quantity'] = '-123456';
-
-        $this->form->submit($this->formData);
-        $this->assertFalse($this->form->isValid());
-    }
-
-    public function testInvalidTaxRate_Blank()
-    {
-        $this->formData['tax_rate'] = '';
-
-        $this->form->submit($this->formData);
-        $this->assertFalse($this->form->isValid());
-    }
-
-    public function testInvalidTaxRate_OverMaxLength()
-    {
-        $this->formData['tax_rate'] = '12345678910'; // Max 9
-
-        $this->form->submit($this->formData);
-        $this->assertFalse($this->form->isValid());
-    }
-
-    public function testInvalidTaxRate_NotNumeric()
-    {
-        $this->formData['tax_rate'] = 'abcde';
-
-        $this->form->submit($this->formData);
-        $this->assertFalse($this->form->isValid());
-    }
-
-    public function testInvalidTaxRate_HasMinus()
-    {
-        $this->formData['tax_rate'] = '-12345';
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());

--- a/tests/Eccube/Tests/Repository/ShippingRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/ShippingRepositoryTest.php
@@ -13,6 +13,7 @@
 
 namespace Eccube\Tests\Repository;
 
+use Eccube\Entity\Master\OrderItemType;
 use Eccube\Entity\Master\TaxDisplayType;
 use Eccube\Entity\Master\TaxType;
 use Eccube\Entity\OrderItem;
@@ -105,6 +106,7 @@ class ShippingRepositoryTest extends EccubeTestCase
 
         $TaxDisplayType = $this->entityManager->find(TaxDisplayType::class, TaxDisplayType::EXCLUDED);
         $TaxType = $this->entityManager->find(TaxType::class, TaxType::TAXATION);
+        $ProductOrderItemType = $this->entityManager->find(OrderItemType::class, OrderItemType::PRODUCT);
 
         // 1個ずつ別のお届け先に届ける
         for ($i = 0; $i < $quantity; $i++) {
@@ -129,6 +131,7 @@ class ShippingRepositoryTest extends EccubeTestCase
                 ->setQuantity(1)
                 ->setTaxDisplayType($TaxDisplayType)
                 ->setTaxType($TaxType)
+                ->setOrderItemType($ProductOrderItemType)
             ;
             $this->Order->addOrderItem($OrderItem);
             $Shipping->addOrderItem($OrderItem);

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/TaxProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/TaxProcessorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\PurchaseFlow\Processor;
+
+use Eccube\Entity\Master\RoundingType;
+use Eccube\Entity\OrderItem;
+use Eccube\Entity\Product;
+use Eccube\Entity\ProductClass;
+use Eccube\Entity\TaxRule;
+use Eccube\Service\PurchaseFlow\PurchaseContext;
+use Eccube\Tests\EccubeTestCase;
+
+class TaxProcessorTest extends EccubeTestCase
+{
+    /** @var TaxProcessor */
+    private $processor;
+
+    /** @var  */
+    private $Order;
+
+    /** @var Product */
+    private $Product;
+
+    /** @var ProductClass */
+    private $ProductClass;
+
+    private $TaxRule;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->processor = $this->container->get(TaxProcessor::class);
+
+        /** @var RoundingType $RoundingType */
+        $RoundingType = $this->entityManager->find(RoundingType::class, RoundingType::ROUND);
+        $this->TaxRule = new TaxRule();
+        $this->TaxRule->setTaxRate(8)
+            ->setApplyDate(new \DateTime('yesterday'))
+            ->setRoundingType($RoundingType);
+        $this->entityManager->persist($this->TaxRule);
+
+        $Customer = $this->createCustomer();
+        $this->Product = $this->createProduct('test', 1);
+
+        $this->ProductClass = $this->Product->getProductClasses()[0];
+        $this->ProductClass->setPrice02(1000);
+        $this->entityManager->persist($this->ProductClass);
+
+        $this->Order = $this->createOrderWithProductClasses($Customer, $this->Product->getProductClasses()->toArray());
+        $this->Order->getProductOrderItems()[0]->setQuantity(1);
+
+        $this->entityManager->flush();
+    }
+
+    public function testCalcTax()
+    {
+        $this->processor->process($this->Order, new PurchaseContext());
+
+        /** @var OrderItem[] $ProductOrderItems */
+        $ProductOrderItems = $this->Order->getProductOrderItems();
+
+        self::assertEquals(1, count($ProductOrderItems));
+        self::assertEquals(1080, $ProductOrderItems[0]->getTotalPrice());
+    }
+
+    /**
+     * @see https://github.com/EC-CUBE/ec-cube/issues/4269
+     */
+    public function testTaxRateChanged()
+    {
+        // 受注作成後に税率を変更
+        $this->TaxRule->setTaxRate(10);
+
+        $this->processor->process($this->Order, new PurchaseContext());
+
+        /** @var OrderItem[] $ProductOrderItems */
+        $ProductOrderItems = $this->Order->getProductOrderItems();
+
+        self::assertEquals(1, count($ProductOrderItems));
+        self::assertEquals(1080, $ProductOrderItems[0]->getTotalPrice());
+    }
+}


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
- #4269 の実装

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

- `Order`作成時の税率設定を`OrderItem`に持たせ、`Order`編集時には作成時の税率設定を使用して計算する

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
- `OrderItem.TaxRule`は非推奨にして使用しない
- `OrderItem`に`tax_adjust`を追加
- `Order`作成時に、`OrderItem`の`tax_rate`,`tax_adust`,`RoundingType`を `TaxRule`からコピーする

## TODO
- [x] Entityの変更
- [x] 購入時/受注登録時の税率設定で固定されるように修正
- [x] 購入後/受注登録後に税率設定を変更しても受注データの税率は変更されないテストの追加
- [x] 管理画面で明細の税率設定を変更できるように修正
- [x] マイグレーション処理の追加

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
