### PR TITLE
商品CSV登録時、未指定のカラムは更新しないように修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -259,34 +259,44 @@ class CsvImportController extends AbstractCsvImportController
                             $Product->setName(StringUtil::trimAll($row[$headerByKey['name']]));
                         }
 
-                        if (isset($row[$headerByKey['note']]) && StringUtil::isNotBlank($row[$headerByKey['note']])) {
-                            $Product->setNote(StringUtil::trimAll($row[$headerByKey['note']]));
-                        } else {
-                            $Product->setNote(null);
+                        if (isset($row[$headerByKey['note']])) {
+                            if (StringUtil::isNotBlank($row[$headerByKey['note']])) {
+                                $Product->setNote(StringUtil::trimAll($row[$headerByKey['note']]));
+                            } else {
+                                $Product->setNote(null);
+                            }
                         }
 
-                        if (isset($row[$headerByKey['description_list']]) && StringUtil::isNotBlank($row[$headerByKey['description_list']])) {
-                            $Product->setDescriptionList(StringUtil::trimAll($row[$headerByKey['description_list']]));
-                        } else {
-                            $Product->setDescriptionList(null);
+                        if (isset($row[$headerByKey['description_list']])) {
+                            if (StringUtil::isNotBlank($row[$headerByKey['description_list']])) {
+                                $Product->setDescriptionList(StringUtil::trimAll($row[$headerByKey['description_list']]));
+                            } else {
+                                $Product->setDescriptionList(null);
+                            }
                         }
 
-                        if (isset($row[$headerByKey['description_detail']]) && StringUtil::isNotBlank($row[$headerByKey['description_detail']])) {
-                            $Product->setDescriptionDetail(StringUtil::trimAll($row[$headerByKey['description_detail']]));
-                        } else {
-                            $Product->setDescriptionDetail(null);
+                        if (isset($row[$headerByKey['description_detail']])) {
+                            if (StringUtil::isNotBlank($row[$headerByKey['description_detail']])) {
+                                $Product->setDescriptionDetail(StringUtil::trimAll($row[$headerByKey['description_detail']]));
+                            } else {
+                                $Product->setDescriptionDetail(null);
+                            }
                         }
 
-                        if (isset($row[$headerByKey['search_word']]) && StringUtil::isNotBlank($row[$headerByKey['search_word']])) {
-                            $Product->setSearchWord(StringUtil::trimAll($row[$headerByKey['search_word']]));
-                        } else {
-                            $Product->setSearchWord(null);
+                        if (isset($row[$headerByKey['search_word']])) {
+                            if (StringUtil::isNotBlank($row[$headerByKey['search_word']])) {
+                                $Product->setSearchWord(StringUtil::trimAll($row[$headerByKey['search_word']]));
+                            } else {
+                                $Product->setSearchWord(null);
+                            }
                         }
 
-                        if (isset($row[$headerByKey['free_area']]) && StringUtil::isNotBlank($row[$headerByKey['free_area']])) {
-                            $Product->setFreeArea(StringUtil::trimAll($row[$headerByKey['free_area']]));
-                        } else {
-                            $Product->setFreeArea(null);
+                        if (isset($row[$headerByKey['free_area']])) {
+                            if (StringUtil::isNotBlank($row[$headerByKey['free_area']])) {
+                                $Product->setFreeArea(StringUtil::trimAll($row[$headerByKey['free_area']]));
+                            } else {
+                                $Product->setFreeArea(null);
+                            }
                         }
 
                         // 商品画像登録
@@ -751,7 +761,10 @@ class CsvImportController extends AbstractCsvImportController
      */
     protected function createProductImage($row, Product $Product, $data, $headerByKey)
     {
-        if (isset($row[$headerByKey['product_image']]) && StringUtil::isNotBlank($row[$headerByKey['product_image']])) {
+        if (!isset($row[$headerByKey['product_image']])) {
+             return;
+        }
+        if (StringUtil::isNotBlank($row[$headerByKey['product_image']])) {
             // 画像の削除
             $ProductImages = $Product->getProductImage();
             foreach ($ProductImages as $ProductImage) {
@@ -799,6 +812,9 @@ class CsvImportController extends AbstractCsvImportController
      */
     protected function createProductCategory($row, Product $Product, $data, $headerByKey)
     {
+        if (!isset($row[$headerByKey['product_category']])) {
+            return;
+        }
         // カテゴリの削除
         $ProductCategories = $Product->getProductCategories();
         foreach ($ProductCategories as $ProductCategory) {
@@ -807,7 +823,7 @@ class CsvImportController extends AbstractCsvImportController
             $this->entityManager->flush();
         }
 
-        if (isset($row[$headerByKey['product_category']]) && StringUtil::isNotBlank($row[$headerByKey['product_category']])) {
+        if (StringUtil::isNotBlank($row[$headerByKey['product_category']])) {
             // カテゴリの登録
             $categories = explode(',', $row[$headerByKey['product_category']]);
             $sortNo = 1;
@@ -863,6 +879,9 @@ class CsvImportController extends AbstractCsvImportController
      */
     protected function createProductTag($row, Product $Product, $data, $headerByKey)
     {
+        if (!isset($row[$headerByKey['product_tag']])) {
+            return;
+        }
         // タグの削除
         $ProductTags = $Product->getProductTag();
         foreach ($ProductTags as $ProductTag) {
@@ -870,7 +889,7 @@ class CsvImportController extends AbstractCsvImportController
             $this->entityManager->remove($ProductTag);
         }
 
-        if (isset($row[$headerByKey['product_tag']]) && StringUtil::isNotBlank($row[$headerByKey['product_tag']])) {
+        if (StringUtil::isNotBlank($row[$headerByKey['product_tag']])) {
             // タグの登録
             $tags = explode(',', $row[$headerByKey['product_tag']]);
             foreach ($tags as $tag_id) {

--- a/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
@@ -372,6 +372,57 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 
+    /**
+     * 省略可能なカラムが省略されている際に更新されないことを確認する
+     */
+    public function testCsvImportWithExistsProductsExceptOptionalColumns()
+    {
+        $Products = $this->productRepo->findAll();
+        $beforeProduct = $this->productRepo->findOneBy([], ['id' => 'ASC']);
+        $csv = [[
+            '商品ID',
+            '公開ステータス(ID)',
+            '商品名',
+            '販売種別(ID)',
+            '規格分類1(ID)',
+            '規格分類2(ID)',
+            '発送日目安(ID)',
+            '商品コード',
+            '在庫数',
+            '在庫数無制限フラグ',
+            '販売制限数',
+            '通常価格',
+            '販売価格',
+            '送料',
+        ]];
+        foreach ($Products as $Product) {
+            foreach ($Product->getProductClasses() as $ProductClass) {
+                $csv[] = [
+                    $Product->getId(),
+                    $Product->getStatus()->getId(),
+                    $Product->getName(),
+                    $ProductClass->getSaleType()->getId(),
+                    $ProductClass->getClassCategory1() == null ? null : $ProductClass->getClassCategory1()->getId(),
+                    $ProductClass->getClassCategory2() == null ? null : $ProductClass->getClassCategory2()->getId(),
+                    $ProductClass->getDeliveryDuration() == null ? null : $ProductClass->getDeliveryDuration()->getId(),
+                    $ProductClass->getCode(),
+                    $ProductClass->getStock(),
+                    $ProductClass->isStockUnlimited(),
+                    $ProductClass->getSaleLimit(),
+                    (int)$ProductClass->getPrice01(),
+                    (int)$ProductClass->getPrice02(),
+                    $ProductClass->getDeliveryFee()
+                ];
+            }
+        }
+        $this->filepath = $this->createCsvFromArray($csv);
+        $crawler = $this->scenario();
+        $this->assertRegexp('/CSVファイルをアップロードしました/u',
+            $crawler->filter('div.alert-success')->text());
+        $afterProduct = $this->productRepo->findOneBy([], ['id' => 'ASC']);
+        $this->assertEquals($beforeProduct->getDescriptionDetail(), $afterProduct->getDescriptionDetail());
+    }
+
     //======================================================================
     // CATEGORY Import Test
     //======================================================================


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#4250 商品CSV登録：必須項目のみのCSVを登録すると、任意項目がnullで更新される

## 方針(Policy)
以下の項目は、CSVにカラムがなければ更新されないように変更しました。

- ショップ用メモ欄	
- 商品説明(一覧)	
- 商品説明(詳細)	
- 検索ワード	
- フリーエリア	
- 商品画像
- 商品カテゴリ(ID)
- タグ(ID)

## テスト（Test)
テストコードを追加

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
