### PR TITLE
プラグイン一覧画面にインストールリンクを設置

### DIFF
--- a/src/Eccube/Resource/template/admin/Store/plugin_table_official.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_table_official.twig
@@ -99,6 +99,8 @@ $(function() {
                             {% else %}
                                 <p class="mb-0">{{ 'admin.store.plugin_table_official.920'|trans }}。</p>
                             {% endif %}
+                        {% else %}
+                            <a href="{{ url('admin_store_plugin_install_confirm', {'id': Plugin.source}) }}" class="btn btn-ec-regular">{{ 'admin.store.plugin.install'|trans }}</a>
                         {% endif %}
                     </td>
                     <td class="align-middle">

--- a/src/Eccube/Resource/template/admin/Store/plugin_table_official.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_table_official.twig
@@ -80,7 +80,8 @@ $(function() {
                         {% endif %}
                     </td>
                     <td class="align-middle">
-                        {% if Plugin.id and pluginDetail %}
+                        {% if pluginDetail %}
+                            {% if Plugin.id %}
                             {% if pluginDetail.update_status == 3 %}
                                 <a href="{{ url('admin_store_plugin_update_confirm', {'id': Plugin.id}) }}"
                                    class="btn btn-ec-regular">{{ 'admin.store.plugin_table_official.916'|trans }}</a>
@@ -99,8 +100,9 @@ $(function() {
                             {% else %}
                                 <p class="mb-0">{{ 'admin.store.plugin_table_official.920'|trans }}。</p>
                             {% endif %}
-                        {% else %}
-                            <a href="{{ url('admin_store_plugin_install_confirm', {'id': Plugin.source}) }}" class="btn btn-ec-regular">{{ 'admin.store.plugin.install'|trans }}</a>
+                            {% else %}
+                                <a href="{{ url('admin_store_plugin_install_confirm', {'id': Plugin.source}) }}" class="btn btn-ec-regular">{{ 'admin.store.plugin.install'|trans }}</a>
+                            {% endif %}
                         {% endif %}
                     </td>
                     <td class="align-middle">

--- a/src/Eccube/Resource/template/admin/Store/plugin_table_official.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_table_official.twig
@@ -82,24 +82,24 @@ $(function() {
                     <td class="align-middle">
                         {% if pluginDetail %}
                             {% if Plugin.id %}
-                            {% if pluginDetail.update_status == 3 %}
-                                <a href="{{ url('admin_store_plugin_update_confirm', {'id': Plugin.id}) }}"
-                                   class="btn btn-ec-regular">{{ 'admin.store.plugin_table_official.916'|trans }}</a>
-                                <ul class="plugin-meta dl-horizontal">
-                                    <li class="plugin-version">{{ 'admin.store.plugin_table_official.917'|trans({'%version%' : pluginDetail.version}) }}</li>
-                                    <li class="plugin-version">
-                                        {% set versions = '' %}
-                                        {% for version in pluginDetail.supported_versions %}
-                                            {% set versions = versions ~ version %}
-                                            {%- if loop.last == false%}{% set versions = versions ~ ',' %}{% endif -%}
-                                        {% endfor %}
-                                        {{ 'admin.store.plugin_table_official.918'|trans({'%versions%' : versions}) }}
-                                    </li>
-                                    <li class="plugin-update">{{ 'admin.store.plugin_table_official.919'|trans({'%update_date%' : pluginDetail.update_date|time_ago}) }}</li>
-                                </ul>
-                            {% else %}
-                                <p class="mb-0">{{ 'admin.store.plugin_table_official.920'|trans }}。</p>
-                            {% endif %}
+                                {% if pluginDetail.update_status == 3 %}
+                                    <a href="{{ url('admin_store_plugin_update_confirm', {'id': Plugin.id}) }}"
+                                       class="btn btn-ec-regular">{{ 'admin.store.plugin_table_official.916'|trans }}</a>
+                                    <ul class="plugin-meta dl-horizontal">
+                                        <li class="plugin-version">{{ 'admin.store.plugin_table_official.917'|trans({'%version%' : pluginDetail.version}) }}</li>
+                                        <li class="plugin-version">
+                                            {% set versions = '' %}
+                                            {% for version in pluginDetail.supported_versions %}
+                                                {% set versions = versions ~ version %}
+                                                {%- if loop.last == false%}{% set versions = versions ~ ',' %}{% endif -%}
+                                            {% endfor %}
+                                            {{ 'admin.store.plugin_table_official.918'|trans({'%versions%' : versions}) }}
+                                        </li>
+                                        <li class="plugin-update">{{ 'admin.store.plugin_table_official.919'|trans({'%update_date%' : pluginDetail.update_date|time_ago}) }}</li>
+                                    </ul>
+                                {% else %}
+                                    <p class="mb-0">{{ 'admin.store.plugin_table_official.920'|trans }}。</p>
+                                {% endif %}
                             {% else %}
                                 <a href="{{ url('admin_store_plugin_install_confirm', {'id': Plugin.source}) }}" class="btn btn-ec-regular">{{ 'admin.store.plugin.install'|trans }}</a>
                             {% endif %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
オーナーズストア経由でプラグインを購入した際の動線を改善するため、プラグイン一覧画面に未インストールのプラグインがあればインストールに遷移できるようにリンクを追加しました。
#4230 

## 実装に関する補足(Appendix)
とくになし

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
