### PR TITLE
Fix command of doctrine errors #4284

### DIFF
--- a/src/Eccube/Entity/BaseInfo.php
+++ b/src/Eccube/Entity/BaseInfo.php
@@ -228,6 +228,7 @@ if (!class_exists('\Eccube\Entity\BaseInfo')) {
 
         /**
          * @var string|null
+         * @deprecated 使用していないため、削除予定
          *
          * @ORM\Column(name="php_path", type="string", length=255, nullable=true)
          */
@@ -1056,6 +1057,7 @@ if (!class_exists('\Eccube\Entity\BaseInfo')) {
 
         /**
          * @return null|string
+         * @deprecated 使用していないため、削除予定
          */
         public function getPhpPath()
         {
@@ -1064,6 +1066,7 @@ if (!class_exists('\Eccube\Entity\BaseInfo')) {
 
         /**
          * @param null|string $php_path
+         * @deprecated 使用していないため、削除予定
          *
          * @return $this
          */

--- a/src/Eccube/Repository/BaseInfoRepository.php
+++ b/src/Eccube/Repository/BaseInfoRepository.php
@@ -41,12 +41,17 @@ class BaseInfoRepository extends AbstractRepository
      */
     public function get($id = 1)
     {
-        $BaseInfo = $this->find($id);
-
-        if (null === $BaseInfo) {
-            throw new \Exception('BaseInfo not found. id = '.$id);
+        $BaseInfo = null;
+        try {
+            $BaseInfo = $this->find($id);
+        } catch (\Exception $exception) {
         }
 
-        return $this->find($id);
+        if (!$BaseInfo) {
+            // create temp object
+            $BaseInfo = new BaseInfo();
+        }
+
+        return $BaseInfo;
     }
 }

--- a/src/Eccube/Repository/BaseInfoRepository.php
+++ b/src/Eccube/Repository/BaseInfoRepository.php
@@ -41,17 +41,12 @@ class BaseInfoRepository extends AbstractRepository
      */
     public function get($id = 1)
     {
-        $BaseInfo = null;
-        try {
-            $BaseInfo = $this->find($id);
-        } catch (\Exception $exception) {
+        $BaseInfo = $this->find($id);
+
+        if (null === $BaseInfo) {
+            throw new \Exception('BaseInfo not found. id = '.$id);
         }
 
-        if (!$BaseInfo) {
-            // create temp object
-            $BaseInfo = new BaseInfo();
-        }
-
-        return $BaseInfo;
+        return $this->find($id);
     }
 }

--- a/src/Eccube/Service/Composer/ComposerServiceFactory.php
+++ b/src/Eccube/Service/Composer/ComposerServiceFactory.php
@@ -21,12 +21,6 @@ class ComposerServiceFactory
 {
     public static function createService(ContainerInterface $container)
     {
-        /** @var BaseInfo $BaseInfo */
-        $BaseInfo = $container->get(BaseInfoRepository::class)->get();
-        if (!empty($BaseInfo->getPhpPath())) {
-            return $container->get(ComposerProcessService::class);
-        }
-
         return $container->get(ComposerApiService::class);
     }
 }

--- a/src/Eccube/Service/PluginApiService.php
+++ b/src/Eccube/Service/PluginApiService.php
@@ -15,7 +15,6 @@ namespace Eccube\Service;
 
 use Eccube\Common\Constant;
 use Eccube\Common\EccubeConfig;
-use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Plugin;
 use Eccube\Exception\PluginApiException;
 use Eccube\Repository\BaseInfoRepository;
@@ -42,9 +41,9 @@ class PluginApiService
     private $requestStack;
 
     /**
-     * @var BaseInfo
+     * @var BaseInfoRepository
      */
-    private $BaseInfo;
+    private $baseInfoRepository;
 
     /**
      * @var PluginRepository
@@ -66,7 +65,7 @@ class PluginApiService
     {
         $this->eccubeConfig = $eccubeConfig;
         $this->requestStack = $requestStack;
-        $this->BaseInfo = $baseInfoRepository->get();
+        $this->baseInfoRepository = $baseInfoRepository;
         $this->pluginRepository = $pluginRepository;
     }
 
@@ -286,7 +285,7 @@ class PluginApiService
             }
         }
 
-        $key = $this->BaseInfo->getAuthenticationKey();
+        $key = $this->baseInfoRepository->get()->getAuthenticationKey();
 
         $baseUrl = null;
         if ($this->requestStack->getCurrentRequest()) {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
This PR to fix #4284 

## 方針(Policy)
`ComposerServiceFactory` uses the `base_info` data without exception handling. So I will handle the exception for `BaseInfoRepository` before returning, if there is an error an empty object will be returned.

## テスト（Test)
![fixed](https://user-images.githubusercontent.com/36109121/63502227-4d0a5600-c4f7-11e9-8e81-08829836af27.PNG)

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
