### PR TITLE
区分記載請求書対応

### DIFF
--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -215,6 +215,7 @@ if (!class_exists('\Eccube\Entity\Order')) {
                 } else {
                     // 新規規格の商品は新しく追加する
                     $OrderItem = new OrderItem();
+                    $OrderItem->setOrder($ProductOrderItem->getOrder());
                     $OrderItem
                     ->setProduct($ProductOrderItem->getProduct())
                     ->setProductName($ProductOrderItem->getProductName())
@@ -223,6 +224,7 @@ if (!class_exists('\Eccube\Entity\Order')) {
                     ->setClassCategoryName2($ProductOrderItem->getClassCategoryName2())
                     ->setPrice($ProductOrderItem->getPrice())
                     ->setTax($ProductOrderItem->getTax())
+                    ->setTaxRate($ProductOrderItem->getTaxRate())
                     ->setQuantity($ProductOrderItem->getQuantity());
                     $orderItemArray[$productClassId] = $OrderItem;
                 }

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -59,6 +59,10 @@ common.subtotal: Subtotal
 common.subtotal__with_separator: 'Subtotal:'
 common.total: Total
 common.total__with_separator: 'Total:'
+common.payment_total: 'Payment Total'
+common.reduced_tax_rate_symbol: '*'
+common.reduced_tax_rate_messeage: '* is subject to reduced tax rate.'
+common.tax_rate_target: '%rate% %'
 common.delivery_fee: Shipping Charge
 common.charge: Charges
 common.discount: Discount

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -59,6 +59,10 @@ common.subtotal: 小計
 common.subtotal__with_separator: 小計：
 common.total: 合計
 common.total__with_separator: 合計：
+common.payment_total: お支払い合計
+common.reduced_tax_rate_symbol: ※
+common.reduced_tax_rate_messeage: ※ は軽減税率対象商品です。
+common.tax_rate_target: '%rate% %対象'
 common.delivery_fee: 送料
 common.charge: 手数料
 common.discount: 値引き

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -879,20 +879,45 @@ file that was distributed with this source code.
                                     <div class="col-auto"><span class="align-middle">{{ 'admin.order.subtotal'|trans }}</span></div>
                                     <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.subtotal|price }}</span></div>
                                 </div>
-                                <!-- 内値引き -->
-                                <div class="row justify-content-end mb-3">
-                                    <div class="col-auto"><span class="align-middle">{{ 'admin.order.discount'|trans }}</span></div>
-                                    <div class="col-2 text-right"><span class="h4 align-middle text-danger font-weight-normal">{{ (0 - Order.discount)|price }}</span></div>
-                                </div>
-                                <!-- 内送料 -->
+                                <!-- 送料 -->
                                 <div class="row justify-content-end mb-3">
                                     <div class="col-auto"><span class="align-middle">{{ 'admin.order.delivery_fee'|trans }}</span></div>
                                     <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.delivery_fee_total|price }}</span></div>
                                 </div>
-                                <!-- 内手数料 -->
+                                <!-- 手数料 -->
                                 <div class="row justify-content-end mb-3">
                                     <div class="col-auto"><span class="align-middle">{{ 'admin.common.charge'|trans }}</span></div>
                                     <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.charge|price }}</span></div>
+                                </div>
+                                <!-- 値引き -->
+                                <div class="row justify-content-end mb-3">
+                                    <div class="col-auto"><span class="align-middle">{{ 'admin.order.discount'|trans }}</span></div>
+                                    <div class="col-2 text-right"><span class="h4 align-middle text-danger font-weight-normal">{{ Order.taxable_discount|price }}</span></div>
+                                </div>
+                                <hr>
+                                <!-- 合計 -->
+                                <div class="row justify-content-end mb-3">
+                                    <div class="col-auto"><span class="align-middle">{{ 'admin.order.total'|trans }}</span></div>
+                                    <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.taxable_total|price }}</span></div>
+                                </div>
+                                {% for rate, total in Order.taxable_total_by_tax_rate %}
+                                    <div class="row justify-content-end mb-3">
+                                        <div class="col-auto"><span class="align-middle">{{ 'common.tax_rate_target'|trans({ '%rate%': rate }) }}</span></div>
+                                        <div class="col-2 text-right"><span class="align-middle font-weight-normal">{{ total|price }}</span></div>
+                                    </div>
+                                {% endfor %}
+                                <hr>
+                                {% for item in Order.tax_free_discount_items %}
+                                <div class="row justify-content-end mb-3">
+                                    <div class="col-auto"><span class="align-middle">{{ item.product_name }}</span></div>
+                                    <div class="col-2 text-right"><span class="h4 align-middle text-danger font-weight-normal">{{ item.total_price|price }}</span></div>
+                                </div>
+                                {% if loop.last %}<hr>{% endif %}
+                                {% endfor %}
+                                <!-- お支払い合計 -->
+                                <div class="row justify-content-end mb-3">
+                                    <div class="col-auto"><span class="align-middle">{{ 'admin.order.payment_total'|trans }}</span></div>
+                                    <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.payment_total|price }}</span></div>
                                 </div>
                                 <!-- 加算ポイント -->
                                 <div class="row justify-content-end mb-3">
@@ -917,18 +942,6 @@ file that was distributed with this source code.
                                             {{ form_errors(form.use_point) }}
                                         </span>
                                     </div>
-                                </div>
-
-                                <hr>
-                                <!-- 小計 -->
-                                <div class="row justify-content-end mb-3">
-                                    <div class="col-auto"><span class="align-middle">{{ 'admin.order.total'|trans }}</span></div>
-                                    <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.total|price }}</span></div>
-                                </div>
-                                <!-- 合計 -->
-                                <div class="row justify-content-end mb-3">
-                                    <div class="col-auto"><span class="align-middle">{{ 'admin.order.payment_total'|trans }}</span></div>
-                                    <div class="col-2 text-right"><span class="h4 align-middle font-weight-normal">{{ Order.payment_total|price }}</span></div>
                                 </div>
                             </div>
                         </div>

--- a/src/Eccube/Resource/template/default/Mail/order.html.twig
+++ b/src/Eccube/Resource/template/default/Mail/order.html.twig
@@ -35,12 +35,13 @@ file that was distributed with this source code.
                             <hr style="border-top: 3px double #8c8b8b;">
                             　ご請求金額<br/>
                             <hr style="border-top: 3px double #8c8b8b;">
-                            ご注文日時：{{ Order.create_date|date_sec }}<br/>
+                            ご注文日時：{{ Order.order_date|date_sec }}<br/>
                             ご注文番号：{{ Order.order_no }}<br/>
                             お支払い合計：{{ Order.payment_total|price }}<br/>
                             お支払い方法：{{ Order.payment_method }}<br/>
                             {% if BaseInfo.isOptionPoint and Order.Customer is not null %}
-                            ご利用ポイント：{{ Order.usePoint }} pt<br/>
+                            ご利用ポイント：{{ Order.usePoint|number_format }} pt<br/>
+                            加算ポイント：{{ Order.addPoint|number_format }} pt<br/>
                             {% endif %}
                             お問い合わせ：{{ Order.message }}<br/>
                             <br/>
@@ -49,21 +50,28 @@ file that was distributed with this source code.
                             <hr style="border-top: 3px double #8c8b8b;">
                             {% for OrderItem in Order.MergedProductOrderItems %}
                                 商品コード：{{ OrderItem.product_code }}<br/>
-                                商品名：{{ OrderItem.product_name }}  {{ OrderItem.classcategory_name1 }}  {{ OrderItem.classcategory_name2 }}<br/>
+                                商品名：{{ OrderItem.product_name }}  {{ OrderItem.classcategory_name1 }}  {{ OrderItem.classcategory_name2 }} {{ is_reduced_tax_rate(OrderItem) ? '※' }}<br/>
                                 単価：{{ OrderItem.price_inctax|price }}<br/>
                                 数量：{{ OrderItem.quantity|number_format }}<br/>
                                 <br/>
                             {% endfor %}
+                            ※は軽減税率対象商品です。
                             <hr style="border-top: 2px dashed #8c8b8b;">
                             小　計：{{ Order.subtotal|price }}<br/>
-                            <br/>
                             手数料：{{ Order.charge|price }}<br/>
                             送　料：{{ Order.delivery_fee_total|price }}<br/>
-                            {% if Order.discount > 0 %}
-                                値引き：{{ (0 - Order.discount)|price }}<br/>
-                            {% endif %}
+                            値引き：{{ Order.taxable_discount|price }}<br/>
                             <hr style="border-top: 1px dotted #8c8b8b;">
-                            合　計：{{ Order.payment_total|price }}<br/>
+                            合　計：{{ Order.taxable_total|price }}<br/>
+                            {% for rate, total in Order.taxable_total_by_tax_rate %}
+                                ({{ rate }} %対象：{{ total|price }})<br/>
+                            {% endfor %}
+                            {% for item in Order.tax_free_discount_items %}
+                                <hr style="border-top: 1px dotted #8c8b8b;">
+                                {{ item.product_name }}：{{ item.total_price|price }}<br/>
+                            {% endfor %}
+                            <hr style="border-top: 1px dotted #8c8b8b;">
+                            お支払い合計：{{ Order.payment_total|price }}
                             <br/>
                             <hr style="border-top: 3px double #8c8b8b;">
                             ご注文者情報<br/>

--- a/src/Eccube/Resource/template/default/Mail/order.twig
+++ b/src/Eccube/Resource/template/default/Mail/order.twig
@@ -17,12 +17,13 @@ file that was distributed with this source code.
 　ご請求金額
 ************************************************
 
-ご注文日時：{{ Order.create_date|date_sec }}
+ご注文日時：{{ Order.order_date|date_sec }}
 ご注文番号：{{ Order.order_no }}
 お支払い合計：{{ Order.payment_total|price}}
 お支払い方法：{{ Order.payment_method }}
 {% if BaseInfo.isOptionPoint and Order.Customer is not null %}
-ご利用ポイント：{{ Order.usePoint }} pt
+ご利用ポイント：{{ Order.usePoint|number_format }} pt
+加算ポイント：{{ Order.addPoint|number_format }} pt
 {% endif %}
 お問い合わせ：{{ Order.message }}
 
@@ -33,22 +34,28 @@ file that was distributed with this source code.
 
 {% for OrderItem in Order.MergedProductOrderItems %}
 商品コード：{{ OrderItem.product_code }}
-商品名：{{ OrderItem.product_name }}  {{ OrderItem.classcategory_name1 }}  {{ OrderItem.classcategory_name2 }}
+商品名：{{ OrderItem.product_name }}  {{ OrderItem.classcategory_name1 }}  {{ OrderItem.classcategory_name2 }} {{ is_reduced_tax_rate(OrderItem) ? '※' }}
 単価：{{ OrderItem.price_inctax|price }}
 数量：{{ OrderItem.quantity|number_format }}
 
 {% endfor %}
-
+※は軽減税率対象商品です。
 -------------------------------------------------
 小　計：{{ Order.subtotal|price }}
-
 手数料：{{ Order.charge|price }}
 送　料：{{ Order.delivery_fee_total|price}}
-{% if Order.discount > 0 %}
-値引き：{{ (0 - Order.discount)|price}}
-{% endif %}
+値引き：{{ Order.taxable_discount|price }}
+-------------------------------------------------
+合　計：{{ Order.taxable_total|price }}
+    {% for rate, total in Order.taxable_total_by_tax_rate %}
+    ({{ rate }} %対象：{{ total|price }})
+    {% endfor %}
+{% for item in Order.tax_free_discount_items %}
+-------------------------------------------------
+{{ item.product_name }}：{{ item.total_price|price }}
+{% endfor %}
 ============================================
-合　計：{{ Order.payment_total|price }}
+お支払い合計：{{ Order.payment_total|price }}
 
 ************************************************
 　ご注文者情報

--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -45,11 +45,11 @@ file that was distributed with this source code.
                     {% if BaseInfo.isOptionPoint %}
                         <div class="ec-definitions">
                             <dt>{{ 'front.mypage.use_point'|trans }}</dt>
-                            <dd>{{ Order.usePoint }} pt</dd>
+                            <dd>{{ Order.usePoint|number_format }} pt</dd>
                         </div>
                         <div class="ec-definitions">
                             <dt>{{ 'front.mypage.add_point'|trans }}</dt>
-                            <dd>{{ Order.addPoint }} pt</dd>
+                            <dd>{{ Order.addPoint|number_format }} pt</dd>
                         </div>
                     {% endif %}
 
@@ -77,7 +77,7 @@ file that was distributed with this source code.
                                                 <a href="{{ url('product_detail', {'id': orderItem.Product.id}) }}">{{ orderItem.productName }}</a>
                                             {% else %}
                                                 {{ orderItem.productName }}
-                                            {% endif %} ×{{ orderItem.quantity }}
+                                            {% endif %} ×{{ orderItem.quantity }} {{ is_reduced_tax_rate(orderItem) ? 'common.reduced_tax_rate_symbol'|trans }}
                                         </p>
                                         {% if orderItem.ProductClass is not null %}
                                             {% if orderItem.ProductClass.ClassCategory1 is not null %}
@@ -99,6 +99,7 @@ file that was distributed with this source code.
                                 </div>
                             </div>
                         {% endfor %}
+                        <p>{{ 'common.reduced_tax_rate_messeage'|trans }}</p>
                         <div class="ec-orderDelivery__address">
                             <p>{{ Shipping.name01 }}&nbsp;{{ Shipping.name02 }}&nbsp;
                                 ({{ Shipping.kana01 }}&nbsp;{{ Shipping.kana02 }})</p>
@@ -160,12 +161,26 @@ file that was distributed with this source code.
                         <dt>{{ 'common.delivery_fee'|trans }}</dt>
                         <dd>{{ Order.delivery_fee_total|price }}</dd>
                     </dl>
-                    {% if Order.discount > 0 %}
+                    <dl class="ec-totalBox__spec">
+                        <dt>{{ 'common.discount'|trans }}</dt>
+                        <dd>{{ Order.taxable_discount|price }}</dd>
+                    </dl>
+                    <div class="ec-totalBox__total">{{ 'common.total'|trans }}<span
+                                class="ec-totalBox__price">{{ Order.taxable_total|price }}</span><span
+                                class="ec-totalBox__taxLabel">{{ 'common.tax_include'|trans }}</span></div>
+                    {% for rate, total in Order.taxable_total_by_tax_rate %}
+                    <dl class="ec-totalBox__spec">
+                        <dt>{{ 'common.tax_rate_target'|trans({ '%rate%': rate }) }}</dt>
+                        <dd>{{ total|price }}</dd>
+                    </dl>
+                    {% endfor %}
+                    {% for item in Order.tax_free_discount_items %}
+                        {% if loop.first %}<div class="ec-totalBox__total"></div>{% endif %}
                         <dl class="ec-totalBox__spec">
-                            <dt>{{ 'common.discount'|trans }}</dt>
-                            <dd>{{ (0 - Order.discount)|price }}</dd>
+                            <dt>{{ item.product_name }}</dt>
+                            <dd>{{ item.total_price|price }}</dd>
                         </dl>
-                    {% endif %}
+                    {% endfor %}
                     <div class="ec-totalBox__total">{{ 'common.total'|trans }}<span
                                 class="ec-totalBox__price">{{ Order.payment_total|price }}</span><span
                                 class="ec-totalBox__taxLabel">{{ 'common.tax_include'|trans }}</span></div>

--- a/src/Eccube/Resource/template/default/Shopping/confirm.twig
+++ b/src/Eccube/Resource/template/default/Shopping/confirm.twig
@@ -91,7 +91,7 @@ file that was distributed with this source code.
                                 <div class="ec-imageGrid">
                                     <div class="ec-imageGrid__img"><img src="{{ asset((orderItem.product is null ? null : orderItem.product.MainListImage)|no_image_product, 'save_image') }}" alt="{{ orderItem.productName }}"></div>
                                     <div class="ec-imageGrid__content">
-                                        <p>{{ orderItem.productName }}</p>
+                                        <p>{{ orderItem.productName }}{% if is_reduced_tax_rate(orderItem) %}{{ 'common.reduced_tax_rate_symbol'|trans }}{% endif %}</p>
                                         {% if orderItem.productClass is not null and orderItem.productClass.classCategory1 %}
                                             <p>{{ orderItem.productClass.classCategory1.className.name }}：{{ orderItem.productClass.classCategory1 }}</p>
                                         {% endif %}
@@ -104,6 +104,7 @@ file that was distributed with this source code.
                             </li>
                             {% endfor %}
                         </ul>
+                        <p>{{ 'common.reduced_tax_rate_messeage'|trans }}</p>
                     </div>
                     <div class="ec-orderDelivery__address">
                         <p>{{ 'common.name.prefix'|trans }}{{ shipping.name01 }} {{ shipping.name02 }} ({{ shipping.kana01 }} {{ shipping.kana02 }}){{ 'common.name.suffix'|trans }}</p>
@@ -179,9 +180,23 @@ file that was distributed with this source code.
                 </dl>
                 <dl class="ec-totalBox__spec">
                     <dt>{{ 'common.discount'|trans }}</dt>
-                    <dd>{{ (0 - Order.discount)|price}}</dd>
+                    <dd>{{ Order.taxable_discount|price }}</dd>
                 </dl>
-                <div class="ec-totalBox__total">{{ 'common.total'|trans }}<span class="ec-totalBox__price">{{ Order.total|price }}</span><span class="ec-totalBox__taxLabel">{{ 'common.tax_include'|trans }}</span></div>
+                <div class="ec-totalBox__total">{{ 'common.total'|trans }}<span class="ec-totalBox__price">{{ Order.taxable_total|price }}</span><span class="ec-totalBox__taxLabel">{{ 'common.tax_include'|trans }}</span></div>
+                {% for rate, total in Order.taxable_total_by_tax_rate %}
+                    <dl class="ec-totalBox__spec">
+                        <dt>{{ 'common.tax_rate_target'|trans({ '%rate%': rate }) }}</dt>
+                        <dd>{{ total|price }}</dd>
+                    </dl>
+                {% endfor %}
+                {% for item in Order.tax_free_discount_items %}
+                    {% if loop.first %}<div class="ec-totalBox__total"></div>{% endif %}
+                    <dl class="ec-totalBox__spec">
+                        <dt>{{ item.product_name }}</dt>
+                        <dd>{{ item.total_price|price }}</dd>
+                    </dl>
+                {% endfor %}
+                <div class="ec-totalBox__total">{{ 'common.payment_total'|trans }}<span class="ec-totalBox__price">{{ Order.payment_total|price }}</span><span class="ec-totalBox__taxLabel">{{ 'common.tax_include'|trans }}</span></div>
                 {% if BaseInfo.isOptionPoint and Order.Customer is not null %}
                     <dl class="ec-totalBox__spec">
                         <dt>{{ 'front.shopping.use_point'|trans }}</dt>

--- a/src/Eccube/Resource/template/default/Shopping/index.twig
+++ b/src/Eccube/Resource/template/default/Shopping/index.twig
@@ -299,7 +299,7 @@ file that was distributed with this source code.
                                         <div class="ec-imageGrid">
                                             <div class="ec-imageGrid__img"><img src="{{ asset((orderItem.product is null ? null : orderItem.product.MainListImage)|no_image_product, 'save_image') }}" alt="{{ orderItem.productName }}"></div>
                                             <div class="ec-imageGrid__content">
-                                                <p>{{ orderItem.productName }}</p>
+                                                <p>{{ orderItem.productName }}{{ is_reduced_tax_rate(orderItem) ? 'common.reduced_tax_rate_symbol'|trans }}</p>
                                                 {% if orderItem.productClass is not null and orderItem.productClass.classCategory1 %}
                                                     <p>{{ orderItem.productClass.classCategory1.className.name }}：{{ orderItem.productClass.classCategory1 }}</p>
                                                 {% endif %}
@@ -312,6 +312,7 @@ file that was distributed with this source code.
                                     </li>
                                 {% endfor %}
                             </ul>
+                            <p>{{ 'common.reduced_tax_rate_messeage'|trans }}</p>
                         </div>
                         <div class="ec-orderDelivery__address">
                             <p>{{ 'common.name.prefix'|trans }}{{ shipping.name01 }} {{ shipping.name02 }} ({{ shipping.kana01 }} {{ shipping.kana02 }}){{ 'common.name.suffix'|trans }}</p>
@@ -397,9 +398,23 @@ file that was distributed with this source code.
                     </dl>
                     <dl class="ec-totalBox__spec">
                         <dt>{{ 'common.discount'|trans }}</dt>
-                        <dd>{{ (0 - Order.discount)|price }}</dd>
+                        <dd>{{ Order.taxable_discount|price }}</dd>
                     </dl>
-                    <div class="ec-totalBox__total">{{ 'common.total'|trans }}<span class="ec-totalBox__price">{{ Order.total|price }}</span><span class="ec-totalBox__taxLabel">{{ 'common.tax_include'|trans }}</span></div>
+                    <div class="ec-totalBox__total">{{ 'common.total'|trans }}<span class="ec-totalBox__price">{{ Order.taxable_total|price }}</span><span class="ec-totalBox__taxLabel">{{ 'common.tax_include'|trans }}</span></div>
+                    {% for rate, total in Order.taxable_total_by_tax_rate %}
+                    <dl class="ec-totalBox__spec">
+                        <dt>{{ 'common.tax_rate_target'|trans({ '%rate%': rate }) }}</dt>
+                        <dd>{{ total|price }}</dd>
+                    </dl>
+                    {% endfor %}
+                    {% for item in Order.tax_free_discount_items %}
+                        {% if loop.first %}<div class="ec-totalBox__total"></div>{% endif %}
+                        <dl class="ec-totalBox__spec">
+                            <dt>{{ item.product_name }}</dt>
+                            <dd>{{ item.total_price|price }}</dd>
+                        </dl>
+                    {% endfor %}
+                    <div class="ec-totalBox__total">{{ 'common.payment_total'|trans }}<span class="ec-totalBox__price">{{ Order.payment_total|price }}</span><span class="ec-totalBox__taxLabel">{{ 'common.tax_include'|trans }}</span></div>
                     {% if BaseInfo.isOptionPoint and Order.Customer is not null %}
                         <dl class="ec-totalBox__spec">
                             <dt>{{ 'front.shopping.use_point'|trans }}</dt>

--- a/src/Eccube/Twig/Extension/TaxExtension.php
+++ b/src/Eccube/Twig/Extension/TaxExtension.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Twig\Extension;
+
+use Eccube\Common\EccubeConfig;
+use Eccube\Entity\Master\ProductStatus;
+use Eccube\Entity\Product;
+use Eccube\Entity\ProductClass;
+use Eccube\Entity\TaxRule;
+use Eccube\Repository\ProductRepository;
+use Eccube\Repository\TaxRuleRepository;
+use Eccube\Util\StringUtil;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Intl\Intl;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+class TaxExtension extends AbstractExtension
+{
+    /**
+     * @var TaxRuleRepository
+     */
+    private $taxRuleRepository;
+
+    /**
+     * TaxExtension constructor.
+     * @param TaxRuleRepository $taxRuleRepository
+     */
+    public function __construct(TaxRuleRepository $taxRuleRepository)
+    {
+        $this->taxRuleRepository = $taxRuleRepository;
+    }
+
+    /**
+     * Returns a list of functions to add to the existing list.
+     *
+     * @return TwigFunction[] An array of functions
+     */
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('is_reduced_tax_rate', [$this, 'isReducedTaxRate']),
+        ];
+    }
+
+    /**
+     * 明細が軽減税率対象かどうかを返す.
+     *
+     * 受注作成時点での標準税率と比較し, 異なれば軽減税率として判定する.
+     *
+     * @param null $OrderItem
+     * @return bool
+     */
+    public function isReducedTaxRate($OrderItem = null)
+    {
+        if (null === $OrderItem) {
+            return false;
+        }
+
+        $Order = $OrderItem->getOrder();
+
+        $qb = $this->taxRuleRepository->createQueryBuilder('t');
+        try {
+            $TaxRule = $qb
+                ->where('t.Product IS NULL AND t.ProductClass IS NULL AND t.apply_date < :apply_date')
+                ->orderBy('t.apply_date', 'DESC')
+                ->setParameter('apply_date', $Order->getCreateDate())
+                ->setMaxResults(1)
+                ->getQuery()
+                ->getOneOrNullResult();
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return $TaxRule && $TaxRule->getTaxRate() != $OrderItem->getTaxRate();
+    }
+}

--- a/tests/Eccube/Tests/Entity/OrderTest.php
+++ b/tests/Eccube/Tests/Entity/OrderTest.php
@@ -16,6 +16,7 @@ namespace Eccube\Tests\Entity;
 use Eccube\Entity\Customer;
 use Eccube\Entity\Master\OrderItemType;
 use Eccube\Entity\Master\OrderStatus;
+use Eccube\Entity\Master\TaxType;
 use Eccube\Entity\Order;
 use Eccube\Entity\OrderItem;
 use Eccube\Entity\Product;
@@ -173,5 +174,85 @@ class OrderTest extends EccubeTestCase
         $this->expected = $quantity * $times;
         $this->actual = $OrderItem->getQuantity();
         $this->verify();
+    }
+
+    public function testGetTaxableItems()
+    {
+        $Order = $this->createTestOrder();
+        self::assertCount(6, $Order->getTaxableItems());
+        /** @var OrderItem $Item */
+        foreach ($Order->getTaxableItems() as $Item) {
+            self::assertSame(TaxType::TAXATION, $Item->getTaxType()->getId());
+        }
+    }
+
+    public function testGetTaxableTotal()
+    {
+        $Order = $this->createTestOrder();
+        self::assertSame(436, $Order->getTaxableTotal());
+    }
+
+    public function testGetTaxableTotalByTaxRate()
+    {
+        $Order = $this->createTestOrder();
+        self::assertArraySubset([10 => 220, 8 => 216,], $Order->getTaxableTotalByTaxRate());
+    }
+
+    public function testGetTaxableDiscountItems()
+    {
+        $Order = $this->createTestOrder();
+        self::assertCount(6, $Order->getTaxableItems());
+    }
+
+    public function testGetTaxableDiscount()
+    {
+        $Order = $this->createTestOrder();
+        self::assertSame(-218, $Order->getTaxableDiscount());
+    }
+
+    public function testGetTaxFreeDiscountItems()
+    {
+        $Order = $this->createTestOrder();
+        self::assertCount(2, $Order->getTaxFreeDiscountItems());
+        /** @var OrderItem $Item */
+        foreach ($Order->getTaxFreeDiscountItems() as $Item) {
+            self::assertNotSame(TaxType::TAXATION, $Item->getTaxType()->getId());
+        }
+    }
+
+    protected function createTestOrder()
+    {
+        $Taxation = $this->entityManager->find(TaxType::class, TaxType::TAXATION);
+        $NonTaxable = $this->entityManager->find(TaxType::class, TaxType::NON_TAXABLE);
+        $TaxExempt = $this->entityManager->find(TaxType::class, TaxType::TAX_EXEMPT);
+
+        $ProductItem = $this->entityManager->find(OrderItemType::class, OrderItemType::PRODUCT);
+        $DiscountItem = $this->entityManager->find(OrderItemType::class, OrderItemType::DISCOUNT);
+
+        // 非課税・不課税を覗いて、税率ごとに金額を集計する
+        $data = [
+            [$Taxation, 10, 100, 10, 1, $ProductItem],    // 商品明細
+            [$Taxation, 10, 200, 20, 1, $ProductItem],    // 商品明細
+            [$Taxation, 8, 100, 8, 1, $ProductItem],      // 商品明細
+            [$Taxation, 8, 200, 16, 1, $ProductItem],     // 商品明細
+            [$Taxation, 10, -100, -10, 1, $DiscountItem],  // 課税値引き
+            [$Taxation, 8, -100, -8, 1, $DiscountItem],    // 課税値引き
+            [$NonTaxable, 0, -10, 0, 1, $DiscountItem],    // 不課税明細、 集計対象外
+            [$TaxExempt, 0, -10, 0, 1, $DiscountItem],     // 非課税明細、集計対象外
+        ];
+
+        $Order = new Order();
+        foreach ($data as $row) {
+            $OrderItem = new OrderItem();
+            $OrderItem->setTaxType($row[0]);
+            $OrderItem->setTaxRate($row[1]);
+            $OrderItem->setPrice($row[2]);
+            $OrderItem->setTax($row[3]);
+            $OrderItem->setQuantity($row[4]);
+            $OrderItem->setOrderItemType($row[5]);
+            $Order->addOrderItem($OrderItem);
+        }
+
+        return $Order;
     }
 }

--- a/tests/Eccube/Tests/Twig/Extension/TaxExtensionTest.php
+++ b/tests/Eccube/Tests/Twig/Extension/TaxExtensionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Twig\Extension;
+
+use Eccube\Repository\TaxRuleRepository;
+use Eccube\Tests\EccubeTestCase;
+use Eccube\Twig\Extension\TaxExtension;
+
+class TaxExtensionTest extends EccubeTestCase
+{
+    /**
+     * @var TaxExtension
+     */
+    protected $taxExtension;
+
+    /**
+     * @var TaxRuleRepository
+     */
+    protected $taxRuleRepository;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->taxExtension = $this->container->get(TaxExtension::class);
+        $this->taxRuleRepository = $this->container->get(TaxRuleRepository::class);
+    }
+
+    public function testIsReducedTaxRate()
+    {
+        self::assertFalse($this->taxExtension->isReducedTaxRate(null));
+
+        $Customer = $this->createCustomer();
+        $Order = $this->createOrder($Customer);
+
+        $OrderItem = $Order->getProductOrderItems()[0];
+        self::assertFalse($this->taxExtension->isReducedTaxRate($OrderItem));
+
+        $OrderItem->setTaxRate(99);
+        self::assertTrue($this->taxExtension->isReducedTaxRate($OrderItem));
+    }
+}


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

#4182, #4274, #4267

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- 区分記載請求のフォーマットに対応
  - 複数配送の納品書は現状どおりです
- 合計の扱いについて
  - 従来の合計は、顧客が支払う最終的な支払い金額が表示されていましたが、以下の二つに変更されます
  - 合計（taxable total）
    - 課税対象の合計。商品小計+送料+手数料-課税値引きで算出します
  - 支払い合計（payment total）
    - 顧客が支払う金額。課税合計-非課税、不課税値引きで算出します
- 値引きの扱いについて
  - 非課税、不課税の値引きは、支払い合計から差し引く
  - 課税値引きは、合計（課税合計）に含まれる

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
