### PR TITLE
商品一覧における商品個別税率のN+1問題の改善

### DIFF
--- a/src/Eccube/Service/TaxRuleService.php
+++ b/src/Eccube/Service/TaxRuleService.php
@@ -13,18 +13,26 @@
 
 namespace Eccube\Service;
 
+use Eccube\Entity\BaseInfo;
+use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\TaxRuleRepository;
 
 class TaxRuleService
 {
     /**
+     * @var BaseInfo
+     */
+    protected $BaseInfo;
+
+    /**
      * @var TaxRuleRepository
      */
     protected $taxRuleRepository;
 
-    public function __construct(TaxRuleRepository $taxRuleRepository)
+    public function __construct(TaxRuleRepository $taxRuleRepository, BaseInfoRepository $baseInfoRepository)
     {
         $this->taxRuleRepository = $taxRuleRepository;
+        $this->BaseInfo = $baseInfoRepository->get();
     }
 
     /**
@@ -40,8 +48,17 @@ class TaxRuleService
      */
     public function getTax($price, $product = null, $productClass = null, $pref = null, $country = null)
     {
+        /*
+         * 商品別税率が有効で商品別税率が設定されている場合は商品別税率
+         * 商品別税率が有効で商品別税率が設定されていない場合は基本税率
+         * 商品別税率が無効の場合は基本税率
+         */
         /* @var $TaxRule \Eccube\Entity\TaxRule */
-        $TaxRule = $this->taxRuleRepository->getByRule($product, $productClass, $pref, $country);
+        if ($this->BaseInfo->isOptionProductTaxRule() && $productClass) {
+            $TaxRule = $productClass->getTaxRule() ?: $this->taxRuleRepository->getByRule(null, null, $pref, $country);
+        } else {
+            $TaxRule = $this->taxRuleRepository->getByRule(null, null, $pref, $country);
+        }
 
         return $this->calcTax($price, $TaxRule->getTaxRate(), $TaxRule->getRoundingType()->getId(), $TaxRule->getTaxAdjust());
     }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
商品個別税率が有効の場合、商品一覧で商品規格ごとに税率設定取得のSQLが実行されているが、`ProductClass#TaxRule` はJOINして取得しているので無駄なSQLを実行しないように修正。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
フロント/管理画面ともに商品一覧では `ProductClass#TaxRule` をJOINして一度のSQLで取得している ([フロント商品一覧](https://github.com/EC-CUBE/ec-cube/blob/db6c14f3fdd33b9b9a0e4344bd103eae6130b19d/src/Eccube/Repository/ProductRepository.php#L106) / [管理画面商品一覧](https://github.com/EC-CUBE/ec-cube/blob/db6c14f3fdd33b9b9a0e4344bd103eae6130b19d/src/Eccube/Repository/ProductRepository.php#L222))


## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

このPR適用前後のフロント商品一覧で実行されるSQLの比較は以下の通り
https://gist.github.com/kiy0taka/a1c1eb0e9491a9b34e5aac142812d8b7

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
