### PR TITLE
明細のバリデーションエラー発生時にシステムエラーになる不具合を修正

### DIFF
--- a/src/Eccube/Form/Type/Admin/OrderItemType.php
+++ b/src/Eccube/Form/Type/Admin/OrderItemType.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Common\EccubeConfig;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Master\OrderItemType as OrderItemTypeMaster;
+use Eccube\Entity\Master\TaxType;
 use Eccube\Entity\OrderItem;
 use Eccube\Entity\ProductClass;
 use Eccube\Form\DataTransformer;
@@ -221,8 +222,25 @@ class OrderItemType extends AbstractType
                             ->setTaxAdjust($TaxRule->getTaxAdjust());
                     }
                     break;
-
                 default:
+            }
+            // 明細のバリデーションエラー時に、税種別がセットされないためここで補完する.
+            switch ($OrderItemType->getId()) {
+                case OrderItemTypeMaster::POINT:
+                    if (!$OrderItem->getTaxType()) {
+                        $TaxType = $this->entityManager->find(TaxType::class, TaxType::NON_TAXABLE);
+                        $OrderItem->setTaxType($TaxType);
+                    }
+                    break;
+                case OrderItemTypeMaster::PRODUCT:
+                case OrderItemTypeMaster::DISCOUNT:
+                case OrderItemTypeMaster::DELIVERY_FEE:
+                case OrderItemTypeMaster::CHARGE:
+                default:
+                    if (!$OrderItem->getTaxType()) {
+                        $TaxType = $this->entityManager->find(TaxType::class, TaxType::NON_TAXABLE);
+                        $OrderItem->setTaxType($TaxType);
+                    }
                     break;
             }
         });

--- a/src/Eccube/Form/Type/Admin/OrderItemType.php
+++ b/src/Eccube/Form/Type/Admin/OrderItemType.php
@@ -238,7 +238,7 @@ class OrderItemType extends AbstractType
                 case OrderItemTypeMaster::CHARGE:
                 default:
                     if (!$OrderItem->getTaxType()) {
-                        $TaxType = $this->entityManager->find(TaxType::class, TaxType::NON_TAXABLE);
+                        $TaxType = $this->entityManager->find(TaxType::class, TaxType::TAXATION);
                         $OrderItem->setTaxType($TaxType);
                     }
                     break;


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

受注登録・編集時に、明細のバリデーションエラー発生時にシステムエラーが発生していた問題を修正

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

明細のバリデーションエラーが発生すると、PurchaseFlowが実行されず、TaxTypeの項目がセットされない。そのため課税の合計を表示するタイミングでTaxTypeにアクセスし落ちていた。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

TaxTypeはOrderItemTypeのPostSubmitで補完するように修正

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

明細のバリデーションエラー時に、システムエラーが発生しないことを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
