### PR TITLE
税率が0%の値引き明細はクーポン・ポイントと同様に扱うように変更

### DIFF
--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -45,6 +45,7 @@ if (!class_exists('\Eccube\Entity\Order')) {
 
         /**
          * 課税対象の明細を返す.
+         * 税率が0より大きい明細を返す.
          *
          * @return array
          */
@@ -53,7 +54,7 @@ if (!class_exists('\Eccube\Entity\Order')) {
             $Items = [];
 
             foreach ($this->OrderItems as $Item) {
-                if ($Item->getTaxType()->getId() == TaxType::TAXATION) {
+                if ($Item->getTaxRate() > 0) {
                     $Items[] = $Item;
                 }
             }
@@ -125,12 +126,15 @@ if (!class_exists('\Eccube\Entity\Order')) {
         /**
          * 非課税・不課税の値引き明細を返す.
          *
+         * - ポイント明細
+         * - 値引き明細のうち、税率が0で設定されているもの
+         *
          * @return array
          */
         public function getTaxFreeDiscountItems()
         {
             return array_filter($this->OrderItems->toArray(), function(OrderItem $Item) {
-                return $Item->isPoint() || ($Item->isDiscount() && $Item->getTaxType()->getId() != TaxType::TAXATION);
+                return $Item->isPoint() || ($Item->isDiscount() && $Item->getTaxRate() == 0);
             });
         }
 

--- a/src/Eccube/Form/Type/Admin/OrderItemType.php
+++ b/src/Eccube/Form/Type/Admin/OrderItemType.php
@@ -223,6 +223,12 @@ class OrderItemType extends AbstractType
                     }
                     break;
                 default:
+                    if (null === $OrderItem->getRoundingType()) {
+                        $TaxRule = $this->taxRuleRepository->getByRule();
+                        $OrderItem->setRoundingType($TaxRule->getRoundingType())
+                            ->setTaxAdjust($TaxRule->getTaxAdjust());
+                    }
+
             }
             // 明細のバリデーションエラー時に、税種別がセットされないためここで補完する.
             switch ($OrderItemType->getId()) {

--- a/tests/Eccube/Tests/Entity/OrderTest.php
+++ b/tests/Eccube/Tests/Entity/OrderTest.php
@@ -182,7 +182,7 @@ class OrderTest extends EccubeTestCase
         self::assertCount(6, $Order->getTaxableItems());
         /** @var OrderItem $Item */
         foreach ($Order->getTaxableItems() as $Item) {
-            self::assertSame(TaxType::TAXATION, $Item->getTaxType()->getId());
+            self::assertGreaterThan(0, $Item->getTaxRate());
         }
     }
 
@@ -201,7 +201,7 @@ class OrderTest extends EccubeTestCase
     public function testGetTaxableDiscountItems()
     {
         $Order = $this->createTestOrder();
-        self::assertCount(6, $Order->getTaxableItems());
+        self::assertCount(2, $Order->getTaxableDiscountItems());
     }
 
     public function testGetTaxableDiscount()
@@ -213,10 +213,10 @@ class OrderTest extends EccubeTestCase
     public function testGetTaxFreeDiscountItems()
     {
         $Order = $this->createTestOrder();
-        self::assertCount(2, $Order->getTaxFreeDiscountItems());
+        self::assertCount(3, $Order->getTaxFreeDiscountItems());
         /** @var OrderItem $Item */
         foreach ($Order->getTaxFreeDiscountItems() as $Item) {
-            self::assertNotSame(TaxType::TAXATION, $Item->getTaxType()->getId());
+            self::assertSame(0, $Item->getTaxRate());
         }
     }
 
@@ -229,7 +229,7 @@ class OrderTest extends EccubeTestCase
         $ProductItem = $this->entityManager->find(OrderItemType::class, OrderItemType::PRODUCT);
         $DiscountItem = $this->entityManager->find(OrderItemType::class, OrderItemType::DISCOUNT);
 
-        // 非課税・不課税を覗いて、税率ごとに金額を集計する
+        // 非課税・不課税をのぞいて、税率ごとに金額を集計する
         $data = [
             [$Taxation, 10, 100, 10, 1, $ProductItem],    // 商品明細
             [$Taxation, 10, 200, 20, 1, $ProductItem],    // 商品明細
@@ -237,6 +237,7 @@ class OrderTest extends EccubeTestCase
             [$Taxation, 8, 200, 16, 1, $ProductItem],     // 商品明細
             [$Taxation, 10, -100, -10, 1, $DiscountItem],  // 課税値引き
             [$Taxation, 8, -100, -8, 1, $DiscountItem],    // 課税値引き
+            [$Taxation, 0, -100, 0, 1, $DiscountItem],    // 課税であっても、税率が0%の値引きは非課税・不課税と同様に扱う
             [$NonTaxable, 0, -10, 0, 1, $DiscountItem],    // 不課税明細、 集計対象外
             [$TaxExempt, 0, -10, 0, 1, $DiscountItem],     // 非課税明細、集計対象外
         ];


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

税率が0%の値引き明細はクーポン・ポイントと同様に扱うように変更しています。
従来の「値引き」項目ではなく、合計の下部に表示されるようになります。

あわせて、明細追加時に税率がただしく設定されない不具合を修正しています。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

- 税率が0%の値引き明細はクーポン・ポイントと同様に扱うように変更

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

- OrderTestを修正・追加

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
