### PR TITLE
#4296 の差し戻し

### DIFF
--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -45,7 +45,6 @@ if (!class_exists('\Eccube\Entity\Order')) {
 
         /**
          * 課税対象の明細を返す.
-         * 税率が0より大きい明細を返す.
          *
          * @return array
          */
@@ -54,7 +53,7 @@ if (!class_exists('\Eccube\Entity\Order')) {
             $Items = [];
 
             foreach ($this->OrderItems as $Item) {
-                if ($Item->getTaxRate() > 0) {
+                if ($Item->getTaxType()->getId() == TaxType::TAXATION) {
                     $Items[] = $Item;
                 }
             }
@@ -126,15 +125,12 @@ if (!class_exists('\Eccube\Entity\Order')) {
         /**
          * 非課税・不課税の値引き明細を返す.
          *
-         * - ポイント明細
-         * - 値引き明細のうち、税率が0で設定されているもの
-         *
          * @return array
          */
         public function getTaxFreeDiscountItems()
         {
             return array_filter($this->OrderItems->toArray(), function(OrderItem $Item) {
-                return $Item->isPoint() || ($Item->isDiscount() && $Item->getTaxRate() == 0);
+                return $Item->isPoint() || ($Item->isDiscount() && $Item->getTaxType()->getId() != TaxType::TAXATION);
             });
         }
 

--- a/tests/Eccube/Tests/Entity/OrderTest.php
+++ b/tests/Eccube/Tests/Entity/OrderTest.php
@@ -201,7 +201,7 @@ class OrderTest extends EccubeTestCase
     public function testGetTaxableDiscountItems()
     {
         $Order = $this->createTestOrder();
-        self::assertCount(6, $Order->getTaxableItems());
+        self::assertCount(2, $Order->getTaxableDiscountItems());
     }
 
     public function testGetTaxableDiscount()

--- a/tests/Eccube/Tests/Entity/OrderTest.php
+++ b/tests/Eccube/Tests/Entity/OrderTest.php
@@ -182,7 +182,7 @@ class OrderTest extends EccubeTestCase
         self::assertCount(6, $Order->getTaxableItems());
         /** @var OrderItem $Item */
         foreach ($Order->getTaxableItems() as $Item) {
-            self::assertGreaterThan(0, $Item->getTaxRate());
+            self::assertSame(TaxType::TAXATION, $Item->getTaxType()->getId());
         }
     }
 
@@ -201,7 +201,7 @@ class OrderTest extends EccubeTestCase
     public function testGetTaxableDiscountItems()
     {
         $Order = $this->createTestOrder();
-        self::assertCount(2, $Order->getTaxableDiscountItems());
+        self::assertCount(6, $Order->getTaxableItems());
     }
 
     public function testGetTaxableDiscount()
@@ -213,10 +213,10 @@ class OrderTest extends EccubeTestCase
     public function testGetTaxFreeDiscountItems()
     {
         $Order = $this->createTestOrder();
-        self::assertCount(3, $Order->getTaxFreeDiscountItems());
+        self::assertCount(2, $Order->getTaxFreeDiscountItems());
         /** @var OrderItem $Item */
         foreach ($Order->getTaxFreeDiscountItems() as $Item) {
-            self::assertSame(0, $Item->getTaxRate());
+            self::assertNotSame(TaxType::TAXATION, $Item->getTaxType()->getId());
         }
     }
 
@@ -229,7 +229,7 @@ class OrderTest extends EccubeTestCase
         $ProductItem = $this->entityManager->find(OrderItemType::class, OrderItemType::PRODUCT);
         $DiscountItem = $this->entityManager->find(OrderItemType::class, OrderItemType::DISCOUNT);
 
-        // 非課税・不課税をのぞいて、税率ごとに金額を集計する
+        // 非課税・不課税を覗いて、税率ごとに金額を集計する
         $data = [
             [$Taxation, 10, 100, 10, 1, $ProductItem],    // 商品明細
             [$Taxation, 10, 200, 20, 1, $ProductItem],    // 商品明細
@@ -237,7 +237,6 @@ class OrderTest extends EccubeTestCase
             [$Taxation, 8, 200, 16, 1, $ProductItem],     // 商品明細
             [$Taxation, 10, -100, -10, 1, $DiscountItem],  // 課税値引き
             [$Taxation, 8, -100, -8, 1, $DiscountItem],    // 課税値引き
-            [$Taxation, 0, -100, 0, 1, $DiscountItem],    // 課税であっても、税率が0%の値引きは非課税・不課税と同様に扱う
             [$NonTaxable, 0, -10, 0, 1, $DiscountItem],    // 不課税明細、 集計対象外
             [$TaxExempt, 0, -10, 0, 1, $DiscountItem],     // 非課税明細、集計対象外
         ];


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

- #4296 で、税率が0%の値引き明細をクーポン・ポイントと同様の扱いにしていたが、これを差し戻し

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

- #4296 では、強制的にクーポン・ポイントと同様の扱いにしていたが、税に関する概念が異なるため、ユーザーが選択できるようにする必要がある
- 以下のように扱います
  - 「値引き」の対象：値引き明細のうち、税種別が`課税`である明細の集計値
  - 合計(課税合計)から差し引く対象：ポイント明細、または値引き明細のうち、税種別が`非課税・不課税`の明細

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

- テストコードに誤りがあったので、https://github.com/EC-CUBE/ec-cube/pull/4298/commits/af0778b6c8a0bdce575266c7e37d9af3de86d304 で修正しています

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
