### PR TITLE
キャッシュクリアするタイミングを変更

### DIFF
--- a/src/Eccube/Util/CacheUtil.php
+++ b/src/Eccube/Util/CacheUtil.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -54,7 +54,7 @@ class CacheUtil implements EventSubscriberInterface
         $this->clearCacheAfterResponse = $env;
     }
 
-    public function forceClearCache(PostResponseEvent $event)
+    public function forceClearCache(FinishRequestEvent $event)
     {
         if ($this->clearCacheAfterResponse === false) {
             return;
@@ -212,6 +212,6 @@ class CacheUtil implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return [KernelEvents::TERMINATE => 'forceClearCache'];
+        return [KernelEvents::FINISH_REQUEST => 'forceClearCache'];
     }
 }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

KernelEvents::TERMINATEのタイミングでキャッシュクリアする設定だと、
ブラウザでプラグインの有効化・無効化をしたときなど処理完了後にリダイレクトする場合、
$cacheUtil->clearCache()を設定していてもキャッシュクリアが実行されないのでKernelEvents::FINISH_REQUESTに変更しました。



## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
