### PR TITLE
商品別税率設定の修正

### DIFF
--- a/src/Eccube/Entity/TaxRule.php
+++ b/src/Eccube/Entity/TaxRule.php
@@ -456,8 +456,9 @@ if (!class_exists('\Eccube\Entity\TaxRule')) {
          * 自分の方が大きければ正の整数
          * 小さければ負の整数を返す.
          *
-         * 1. apply_date
-         * 2. sort_no
+         * 1. 商品別税率が有効
+         * 2. apply_date
+         * 3. sort_no
          *
          * このメソッドは usort() 関数などで使用する.
          *
@@ -467,22 +468,38 @@ if (!class_exists('\Eccube\Entity\TaxRule')) {
          */
         public function compareTo(TaxRule $Target)
         {
-            if ($this->getApplyDate()->format('YmdHis') == $Target->getApplyDate()->format('YmdHis')) {
-                if ($this->getSortNo() == $Target->getSortNo()) {
-                    return 0;
-                }
-                if ($this->getSortNo() > $Target->getSortNo()) {
-                    return -1;
-                } else {
-                    return 1;
-                }
+            if ($this->isProductTaxRule() && !$Target->isProductTaxRule()) {
+                return -1;
+            } elseif (!$this->isProductTaxRule() && $Target->isProductTaxRule()) {
+                return 1;
             } else {
-                if ($this->getApplyDate()->format('YmdHis') > $Target->getApplyDate()->format('YmdHis')) {
-                    return -1;
+                if ($this->getApplyDate()->format('YmdHis') == $Target->getApplyDate()->format('YmdHis')) {
+                    if ($this->getSortNo() == $Target->getSortNo()) {
+                        return 0;
+                    }
+                    if ($this->getSortNo() > $Target->getSortNo()) {
+                        return -1;
+                    } else {
+                        return 1;
+                    }
                 } else {
-                    return 1;
+                    if ($this->getApplyDate()->format('YmdHis') > $Target->getApplyDate()->format('YmdHis')) {
+                        return -1;
+                    } else {
+                        return 1;
+                    }
                 }
             }
+        }
+
+        /**
+         * 商品別税率設定が適用されているかどうか.
+         *
+         * @return bool 商品別税率が適用されている場合 true
+         */
+        public function isProductTaxRule()
+        {
+            return ($this->getProductClass() !== null || $this->getProduct() !== null);
         }
     }
 }

--- a/src/Eccube/Service/PurchaseFlow/Processor/TaxProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/TaxProcessor.php
@@ -93,8 +93,7 @@ class TaxProcessor implements ItemHolderPreprocessor
             // 税率が設定されていない場合は税率を明細にコピーする
             if ($item->getRoundingType() === null) {
                 $TaxRule = $item->getOrderItemType()->isProduct()
-                    && $item->getProductClass()->getTaxRule()
-                    ? $item->getProductClass()->getTaxRule()
+                    ? $this->taxRuleRepository->getByRule($item->getProduct(), $item->getProductClass())
                     : $this->taxRuleRepository->getByRule();
 
                 $item->setTaxRate($TaxRule->getTaxRate())

--- a/src/Eccube/Service/PurchaseFlow/Processor/TaxProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/TaxProcessor.php
@@ -93,7 +93,8 @@ class TaxProcessor implements ItemHolderPreprocessor
             // 税率が設定されていない場合は税率を明細にコピーする
             if ($item->getRoundingType() === null) {
                 $TaxRule = $item->getOrderItemType()->isProduct()
-                    ? $this->taxRuleRepository->getByRule($item->getProduct(), $item->getProductClass())
+                    && $item->getProductClass()->getTaxRule()
+                    ? $item->getProductClass()->getTaxRule()
                     : $this->taxRuleRepository->getByRule();
 
                 $item->setTaxRate($TaxRule->getTaxRate())

--- a/tests/Eccube/Tests/Entity/TaxRuleTest.php
+++ b/tests/Eccube/Tests/Entity/TaxRuleTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Entity;
+
+use Eccube\Entity\Product;
+use Eccube\Entity\ProductClass;
+use Eccube\Entity\TaxRule;
+use Eccube\Tests\EccubeTestCase;
+
+/**
+ * TaxRule test cases.
+ *
+ * @author Kentaro Ohkouchi
+ */
+class TaxRuleTest extends EccubeTestCase
+{
+    public function testCompareTo()
+    {
+        $TaxRules = [
+            $this->createTaxRule('1', 3, new \DateTime()),
+            $this->createTaxRule('2', 2, new \DateTime()),
+            $this->createTaxRule('3', 1, new \DateTime())
+        ];
+        $this->expected = $TaxRules;
+
+        shuffle($TaxRules);
+        usort($TaxRules, function ($a, $b) {
+            return $a->compareTo($b);
+        });
+        $this->actual = $TaxRules;
+
+        $this->verify();
+    }
+
+    public function testCompareToWithApplydate()
+    {
+        $TaxRules = [
+            $this->createTaxRule('1', 0, new \DateTime('+2 days')),
+            $this->createTaxRule('2', 2, new \DateTime('+1 days')),
+            $this->createTaxRule('3', 1, new \DateTime('+1 days')),
+            $this->createTaxRule('4', 3, new \DateTime()),
+            $this->createTaxRule('5', 4, new \DateTime('-1 days'))
+        ];
+        $this->expected = $TaxRules;
+
+        shuffle($TaxRules);
+        usort($TaxRules, function ($a, $b) {
+            return $a->compareTo($b);
+        });
+        $this->actual = $TaxRules;
+
+        $this->verify();
+    }
+
+    public function testCompareToWithProductClass()
+    {
+        $TaxRules = [
+            $this->createTaxRule('1', 1, new \DateTime('-1 days'), new ProductClass()),
+            $this->createTaxRule('2', 1, new \DateTime('+2 days')),
+            $this->createTaxRule('3', 2, new \DateTime()),
+            $this->createTaxRule('4', 3, new \DateTime('-1 days'))
+        ];
+        $this->expected = $TaxRules;
+
+        shuffle($TaxRules);
+        usort($TaxRules, function ($a, $b) {
+            return $a->compareTo($b);
+        });
+        $this->actual = $TaxRules;
+
+        $this->verify();
+    }
+
+    public function testCompareToWithProducts()
+    {
+        $TaxRules = [
+            $this->createTaxRule('1', 1, new \DateTime('-1 days'), null, new Product()),
+            $this->createTaxRule('2', 1, new \DateTime('+2 days')),
+            $this->createTaxRule('3', 2, new \DateTime()),
+            $this->createTaxRule('4', 3, new \DateTime('-1 days'))
+        ];
+        $this->expected = $TaxRules;
+
+        shuffle($TaxRules);
+        usort($TaxRules, function ($a, $b) {
+            return $a->compareTo($b);
+        });
+        $this->actual = $TaxRules;
+
+        $this->verify();
+    }
+
+    public function testCompareToWithProductTaxRule()
+    {
+        $TaxRules = [
+            $this->createTaxRule('1', 1, new \DateTime('-1 days'), new ProductClass(), new Product()),
+            $this->createTaxRule('2', 1, new \DateTime('+2 days')),
+            $this->createTaxRule('3', 2, new \DateTime()),
+            $this->createTaxRule('4', 3, new \DateTime('-1 days'))
+        ];
+        $this->expected = $TaxRules;
+
+        shuffle($TaxRules);
+        usort($TaxRules, function ($a, $b) {
+            return $a->compareTo($b);
+        });
+        $this->actual = $TaxRules;
+
+        $this->verify();
+    }
+
+    /**
+     * @param string $taxRate
+     * @param int $sortNo
+     * @param \DateTime|null $applyDate
+     * @param ProductClass|null $ProductClass
+     * @param Product|null $Product;
+     * @return TaxRule
+     */
+    private function createTaxRule($taxRate, $sortNo = 0, \DateTime $applyDate = null, ProductClass $ProductClass = null, Product $Product = null)
+    {
+        if ($applyDate === null) {
+            $applyDate = new \DateTime();
+        }
+        $TaxRule = new TaxRule();
+        $TaxRule
+            ->setTaxRate($taxRate)
+            ->setApplyDate($applyDate)
+            ->setProductClass($ProductClass)
+            ->setProduct($Product)
+            ->setSortNo($sortNo);
+        return $TaxRule;
+    }
+}

--- a/tests/Eccube/Tests/Repository/TaxRuleRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/TaxRuleRepositoryTest.php
@@ -288,8 +288,8 @@ class TaxRuleRepositoryTest extends EccubeTestCase
         $this->taxRuleRepository->clearCache();
         $TaxRule = $this->taxRuleRepository->getByRule($this->Product, null, null, $Country);
 
-        // 国別設定の方が優先される
-        $this->expected = $this->TaxRule2->getId();
+        // 商品別設定の方が優先される
+        $this->expected = $this->TaxRule3->getId();
         $this->actual = $TaxRule->getId();
         $this->verify();
     }

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/TaxProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/TaxProcessorTest.php
@@ -11,15 +11,18 @@
  * file that was distributed with this source code.
  */
 
-namespace Eccube\Service\PurchaseFlow\Processor;
+namespace Eccube\Tests\Service\PurchaseFlow\Processor;
 
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Master\RoundingType;
+use Eccube\Entity\Order;
 use Eccube\Entity\OrderItem;
 use Eccube\Entity\Product;
 use Eccube\Entity\ProductClass;
 use Eccube\Entity\TaxRule;
+use Eccube\Repository\TaxRuleRepository;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
+use Eccube\Service\PurchaseFlow\Processor\TaxProcessor;
 use Eccube\Tests\EccubeTestCase;
 
 class TaxProcessorTest extends EccubeTestCase
@@ -27,7 +30,7 @@ class TaxProcessorTest extends EccubeTestCase
     /** @var TaxProcessor */
     private $processor;
 
-    /** @var  */
+    /** @var Order  */
     private $Order;
 
     /** @var Product */
@@ -36,13 +39,18 @@ class TaxProcessorTest extends EccubeTestCase
     /** @var ProductClass */
     private $ProductClass;
 
+    /** @var TaxRule */
     private $TaxRule;
+
+    /** @var TaxRuleRepository */
+    private $taxRuleRepository;
 
     public function setUp()
     {
         parent::setUp();
 
         $this->processor = $this->container->get(TaxProcessor::class);
+        $this->taxRuleRepository = $this->container->get(TaxRuleRepository::class);
 
         /** @var RoundingType $RoundingType */
         $RoundingType = $this->entityManager->find(RoundingType::class, RoundingType::ROUND);
@@ -116,6 +124,12 @@ class TaxProcessorTest extends EccubeTestCase
         $this->entityManager->persist($TaxRule);
         $this->entityManager->flush();
         $this->entityManager->refresh($this->TaxRule);
+        $this->entityManager->refresh($TaxRule);
+
+        $this->taxRuleRepository->clearCache();
+        $actual = $this->taxRuleRepository->getByRule($this->Product, $this->ProductClass);
+        self::assertEquals($TaxRule, $actual);
+
 
         $Customer = $this->createCustomer();
         $Order = $this->createOrderWithProductClasses($Customer, $this->Product->getProductClasses()->toArray());


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#4330 の修正

## 方針(Policy)

- 商品別税率が設定されている場合は、常に最優先するよう修正

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
- Pref や Country が設定されている場合でも、商品別税率を優先する
- 商品別税率設定は同じ商品、商品規格で重複して登録されてないことを前提とする
- **TaxRule の proxy クラスが生成されている場合は、再生成が必要**

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
- テストケースを追加

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
- この修正を適用すると、商品別税率設定では適用日を考慮しなくなるため、事前に設定している場合は注意が必要
- `eccube_tax_rule_priority` が意味を無さなくなる

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか