### PR TITLE
RepeatedEmailTypeのバリデーションに文字列長を追加

### DIFF
--- a/src/Eccube/Form/Type/RepeatedEmailType.php
+++ b/src/Eccube/Form/Type/RepeatedEmailType.php
@@ -52,6 +52,9 @@ class RepeatedEmailType extends AbstractType
                 'constraints' => [
                     new Assert\NotBlank(),
                     new Email(['strict' => $this->eccubeConfig['eccube_rfc_email_check']]),
+                    new Assert\Length([
+                        'max' => $this->eccubeConfig['eccube_stext_len'],
+                    ]),
                 ],
             ],
             'first_options' => [

--- a/tests/Eccube/Tests/Form/Type/RepeatedEmailTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/RepeatedEmailTypeTest.php
@@ -93,4 +93,14 @@ class RepeatedEmailTypeTest extends AbstractTypeTestCase
 
         $this->assertTrue($this->form->isValid());
     }
+
+    public function testInvalidEmail_MaxLength()
+    {
+        $mail = str_repeat("a", $this->eccubeConfig['eccube_stext_len'] - strlen('@example.com') + 1) . '@example.com';
+        $this->formData['email']['first'] = $mail;
+        $this->formData['email']['second'] = $mail;
+        $this->form->submit($this->formData);
+
+        $this->assertFalse($this->form->isValid());
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#4340 の修正PR

## 方針(Policy)

- 他の文字列長のバリデーションに習って実装

## 実装に関する補足(Appendix)

## テスト（Test)

- RepeatedEmailTypeのテストコードが既に合ったので、そこに文字列長のテストを他のTypeのテストと同じように実装。

## 相談（Discussion）

- 文字列長の制限として `eccube_stext_len` を利用するのはEC-CUBEの意図として合っているか

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
