### PR TITLE
商品詳細ページのmetaにデフォルトとしてデータを指定

### DIFF
--- a/src/Eccube/Resource/doctrine/import_csv/en/dtb_page.csv
+++ b/src/Eccube/Resource/doctrine/import_csv/en/dtb_page.csv
@@ -1,41 +1,49 @@
-id,page_name,url,file_name,edit_type,author,description,keyword,create_date,update_date,meta_robots,master_page_id,discriminator_type
-0,Preview,preview,,1,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-1,Home,homepage,index,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-2,All Products,product_list,Product/list,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-3,Product Details,product_detail,Product/detail,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-4,My Account,mypage,Mypage/index,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-5,My Account / Edit Customer Info (Form),mypage_change,Mypage/change,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-6,My Account / Edit Customer Info (Thank-you),mypage_change_complete,Mypage/change_complete,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-9,My Account / Favorites,mypage_favorite,Mypage/favorite,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-10,My Account / Purchase Histofy Details,mypage_history,Mypage/history,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-11,My Account / Sign In,mypage_login,Mypage/login,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-12,My Account / Membership Cancellation (Form),mypage_withdraw,Mypage/withdraw,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-14,About Us,help_about,Help/about,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-13,My Account / Membership Cancellation (Thank-you),mypage_withdraw_complete,Mypage/withdraw_complete,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-15,Items in your cart,cart,Cart/index,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-16,Inquiry (Form),contact,Contact/index,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-17,Inquiry (Thank-you),contact_complete,Contact/complete,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-18,Registration (Form),entry,Entry/index,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-20,Registration (Thank-you),entry_complete,Entry/complete,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-21,Shipping & Returns,help_tradelaw,Help/tradelaw,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-22,Regular Customer Registration (Thank-you),entry_activate,Entry/activate,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-24,Shopping / Delivery Address,shopping_shipping,Shopping/shipping,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-28,Shopping / Thank you for your order,shopping_complete,Shopping/complete,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-29,Privacy Policy,help_privacy,Help/privacy,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-30,Sign in for shopping,shopping_login,Shopping/login,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-31,Non-Customer Purchase History Record,shopping_nonmember,Shopping/nonmember,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-32,Shopping / Add a Delivery Address,shopping_shipping_edit,Shopping/shipping_edit,2,,,,2017-03-07 01:15:02,2017-03-07 01:15:02,noindex,,page
-33,Shopping / Multiple Delivery Addresses (Add Delivery Address),shopping_shipping_multiple_edit,Shopping/shipping_multiple_edit,2,,,,2017-03-07 01:15:02,2017-03-07 01:15:02,noindex,,page
-34,Shopping / Checkout Error,shopping_error,Shopping/shopping_error,2,,,,2017-03-07 01:15:02,2017-03-07 01:15:02,noindex,,page
-35,Shopping Guide,help_guide,Help/guide,2,,,,2017-03-07 01:15:02,2017-03-07 01:15:02,,,page
-36,Password Reset (Form),forgot,Forgot/index,2,,,,2017-03-07 01:15:02,2017-03-07 01:15:02,,,page
-37,Password Reset (Thank-you),forgot_complete,Forgot/complete,2,,,,2017-03-07 01:15:02,2017-03-07 01:15:02,noindex,,page
-38,Password Reset (Enter New Password),forgot_reset,Forgot/reset,2,,,,2017-03-07 01:15:02,2017-03-07 01:15:05,noindex,,page
-19,Terms & Conditions,help_agreement,Help/agreement,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page
-25,Shopping / Select multiple delivery addresses,shopping_shipping_multiple,Shopping/shipping_multiple,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-23,Shopping,shopping,Shopping/index,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-7,My Account / All Delivery Addresses,mypage_delivery,Mypage/delivery,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-8,My Account / Add a Delivery Address,mypage_delivery_new,Mypage/delivery_edit,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page
-42,Shopping / Change Delivery Address,shopping_shipping_edit_change,Shopping/index,2,,,,2017-03-07 01:15:03,2017-03-07 01:15:03,noindex,,page
-44,My Account / Edit Delivery Address,mypage_delivery_edit,Mypage/delivery_edit,2,,,,2017-03-07 01:15:05,2017-03-07 01:15:05,noindex,8,page
-45,Shopping / Review,shopping_confirm,Shopping/confirm,2,,,,2017-03-07 01:15:03,2017-03-07 01:15:03,noindex,,page
+id,page_name,url,file_name,edit_type,author,description,keyword,create_date,update_date,meta_robots,master_page_id,discriminator_type,meta_tags
+0,Preview,preview,,1,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
+1,Home,homepage,index,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
+2,All Products,product_list,Product/list,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
+3,Product Details,product_detail,Product/detail,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,"<meta property=""og:type"" content=""og:product"" />
+<meta property=""og:title"" content=""{{ Product.name }}"" />
+<meta property=""og:image"" content=""{{ url('homepage') }}{{ asset(Product.main_list_image|no_image_product, 'save_image') }}"" />
+<meta property=""og:description"" content=""{{ Product.description_list|striptags }}"" />
+<meta property=""og:url"" content=""{{ url('product_detail', {'id': Product.id}) }}"" />
+<meta property=""product:price:amount"" content=""{{ Product.getPrice02IncTaxMin }}""/>
+<meta property=""product:price:currency"" content=""{{ eccube_config.currency }}""/>
+<meta property=""product:product_link"" content=""{{ url('product_detail', {'id': Product.id}) }}""/>
+<meta property=""product:retailer_title"" content=""{{ Product.name }}""/>"
+4,My Account,mypage,Mypage/index,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+5,My Account / Edit Customer Info (Form),mypage_change,Mypage/change,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+6,My Account / Edit Customer Info (Thank-you),mypage_change_complete,Mypage/change_complete,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+9,My Account / Favorites,mypage_favorite,Mypage/favorite,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+10,My Account / Purchase Histofy Details,mypage_history,Mypage/history,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+11,My Account / Sign In,mypage_login,Mypage/login,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+12,My Account / Membership Cancellation (Form),mypage_withdraw,Mypage/withdraw,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+14,About Us,help_about,Help/about,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
+13,My Account / Membership Cancellation (Thank-you),mypage_withdraw_complete,Mypage/withdraw_complete,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+15,Items in your cart,cart,Cart/index,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+16,Inquiry (Form),contact,Contact/index,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
+17,Inquiry (Thank-you),contact_complete,Contact/complete,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
+18,Registration (Form),entry,Entry/index,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
+20,Registration (Thank-you),entry_complete,Entry/complete,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
+21,Shipping & Returns,help_tradelaw,Help/tradelaw,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
+22,Regular Customer Registration (Thank-you),entry_activate,Entry/activate,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
+24,Shopping / Delivery Address,shopping_shipping,Shopping/shipping,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+28,Shopping / Thank you for your order,shopping_complete,Shopping/complete,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+29,Privacy Policy,help_privacy,Help/privacy,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
+30,Sign in for shopping,shopping_login,Shopping/login,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
+31,Non-Customer Purchase History Record,shopping_nonmember,Shopping/nonmember,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
+32,Shopping / Add a Delivery Address,shopping_shipping_edit,Shopping/shipping_edit,2,,,,2017-03-07 01:15:02,2017-03-07 01:15:02,noindex,,page,
+33,Shopping / Multiple Delivery Addresses (Add Delivery Address),shopping_shipping_multiple_edit,Shopping/shipping_multiple_edit,2,,,,2017-03-07 01:15:02,2017-03-07 01:15:02,noindex,,page,
+34,Shopping / Checkout Error,shopping_error,Shopping/shopping_error,2,,,,2017-03-07 01:15:02,2017-03-07 01:15:02,noindex,,page,
+35,Shopping Guide,help_guide,Help/guide,2,,,,2017-03-07 01:15:02,2017-03-07 01:15:02,,,page,
+36,Password Reset (Form),forgot,Forgot/index,2,,,,2017-03-07 01:15:02,2017-03-07 01:15:02,,,page,
+37,Password Reset (Thank-you),forgot_complete,Forgot/complete,2,,,,2017-03-07 01:15:02,2017-03-07 01:15:02,noindex,,page,
+38,Password Reset (Enter New Password),forgot_reset,Forgot/reset,2,,,,2017-03-07 01:15:02,2017-03-07 01:15:05,noindex,,page,
+19,Terms & Conditions,help_agreement,Help/agreement,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
+25,Shopping / Select multiple delivery addresses,shopping_shipping_multiple,Shopping/shipping_multiple,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+23,Shopping,shopping,Shopping/index,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+7,My Account / All Delivery Addresses,mypage_delivery,Mypage/delivery,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+8,My Account / Add a Delivery Address,mypage_delivery_new,Mypage/delivery_edit,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,noindex,,page,
+42,Shopping / Change Delivery Address,shopping_shipping_edit_change,Shopping/index,2,,,,2017-03-07 01:15:03,2017-03-07 01:15:03,noindex,,page,
+44,My Account / Edit Delivery Address,mypage_delivery_edit,Mypage/delivery_edit,2,,,,2017-03-07 01:15:05,2017-03-07 01:15:05,noindex,8,page,
+45,Shopping / Review,shopping_confirm,Shopping/confirm,2,,,,2017-03-07 01:15:03,2017-03-07 01:15:03,noindex,,page,

--- a/src/Eccube/Resource/doctrine/import_csv/ja/dtb_page.csv
+++ b/src/Eccube/Resource/doctrine/import_csv/ja/dtb_page.csv
@@ -1,41 +1,49 @@
-id,page_name,url,file_name,edit_type,author,description,keyword,create_date,update_date,meta_robots,master_page_id,discriminator_type
-"0","プレビューデータ","preview",,"1",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"1","TOPページ","homepage","index","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"2","商品一覧ページ","product_list","Product/list","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"3","商品詳細ページ","product_detail","Product/detail","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"4","MYページ","mypage","Mypage/index","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"5","MYページ/会員登録内容変更(入力ページ)","mypage_change","Mypage/change","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"6","MYページ/会員登録内容変更(完了ページ)","mypage_change_complete","Mypage/change_complete","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"9","MYページ/お気に入り一覧","mypage_favorite","Mypage/favorite","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"10","MYページ/購入履歴詳細","mypage_history","Mypage/history","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"11","MYページ/ログイン","mypage_login","Mypage/login","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"12","MYページ/退会手続き(入力ページ)","mypage_withdraw","Mypage/withdraw","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"14","当サイトについて","help_about","Help/about","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"13","MYページ/退会手続き(完了ページ)","mypage_withdraw_complete","Mypage/withdraw_complete","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"15","現在のカゴの中","cart","Cart/index","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"16","お問い合わせ(入力ページ)","contact","Contact/index","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"17","お問い合わせ(完了ページ)","contact_complete","Contact/complete","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"18","会員登録(入力ページ)","entry","Entry/index","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"20","会員登録(完了ページ)","entry_complete","Entry/complete","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"21","特定商取引に関する法律に基づく表記","help_tradelaw","Help/tradelaw","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"22","本会員登録(完了ページ)","entry_activate","Entry/activate","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"24","商品購入/お届け先の指定","shopping_shipping","Shopping/shipping","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"28","商品購入/ご注文完了","shopping_complete","Shopping/complete","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"29","プライバシーポリシー","help_privacy","Help/privacy","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"30","商品購入ログイン","shopping_login","Shopping/login","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"31","非会員購入情報入力","shopping_nonmember","Shopping/nonmember","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"32","商品購入/お届け先の追加","shopping_shipping_edit","Shopping/shipping_edit","2",,,,"2017-03-07 01:15:02","2017-03-07 01:15:02","noindex",,"page"
-"33","商品購入/お届け先の複数指定(お届け先の追加)","shopping_shipping_multiple_edit","Shopping/shipping_multiple_edit","2",,,,"2017-03-07 01:15:02","2017-03-07 01:15:02","noindex",,"page"
-"34","商品購入/購入エラー","shopping_error","Shopping/shopping_error","2",,,,"2017-03-07 01:15:02","2017-03-07 01:15:02","noindex",,"page"
-"35","ご利用ガイド","help_guide","Help/guide","2",,,,"2017-03-07 01:15:02","2017-03-07 01:15:02",,,"page"
-"36","パスワード再発行(入力ページ)","forgot","Forgot/index","2",,,,"2017-03-07 01:15:02","2017-03-07 01:15:02",,,"page"
-"37","パスワード再発行(完了ページ)","forgot_complete","Forgot/complete","2",,,,"2017-03-07 01:15:02","2017-03-07 01:15:02","noindex",,"page"
-"38","パスワード再発行(再設定ページ)","forgot_reset","Forgot/reset","2",,,,"2017-03-07 01:15:02","2017-03-07 01:15:05","noindex",,"page"
-"19","ご利用規約","help_agreement","Help/agreement","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page"
-"25","商品購入/お届け先の複数指定","shopping_shipping_multiple","Shopping/shipping_multiple","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"23","商品購入","shopping","Shopping/index","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"7","MYページ/お届け先一覧","mypage_delivery","Mypage/delivery","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"8","MYページ/お届け先追加","mypage_delivery_new","Mypage/delivery_edit","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page"
-"42","商品購入/遷移","shopping_redirect_to","Shopping/index","2",,,,"2017-03-07 01:15:03","2017-03-07 01:15:03","noindex",,"page"
-"44","MYページ/お届け先編集","mypage_delivery_edit","Mypage/delivery_edit","2",,,,"2017-03-07 01:15:05","2017-03-07 01:15:05","noindex",8,"page"
-"45","商品購入/ご注文確認","shopping_confirm","Shopping/confirm","2",,,,"2017-03-07 01:15:03","2017-03-07 01:15:03","noindex",,"page"
+id,page_name,url,file_name,edit_type,author,description,keyword,create_date,update_date,meta_robots,master_page_id,discriminator_type,meta_tags
+"0","プレビューデータ","preview",,"1",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
+"1","TOPページ","homepage","index","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
+"2","商品一覧ページ","product_list","Product/list","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
+"3","商品詳細ページ","product_detail","Product/detail","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page","<meta property=""og:type"" content=""og:product"" />
+<meta property=""og:title"" content=""{{ Product.name }}"" />
+<meta property=""og:image"" content=""{{ url('homepage') }}{{ asset(Product.main_list_image|no_image_product, 'save_image') }}"" />
+<meta property=""og:description"" content=""{{ Product.description_list|striptags }}"" />
+<meta property=""og:url"" content=""{{ url('product_detail', {'id': Product.id}) }}"" />
+<meta property=""product:price:amount"" content=""{{ Product.getPrice02IncTaxMin }}""/>
+<meta property=""product:price:currency"" content=""{{ eccube_config.currency }}""/>
+<meta property=""product:product_link"" content=""{{ url('product_detail', {'id': Product.id}) }}""/>
+<meta property=""product:retailer_title"" content=""{{ Product.name }}""/>"
+"4","MYページ","mypage","Mypage/index","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"5","MYページ/会員登録内容変更(入力ページ)","mypage_change","Mypage/change","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"6","MYページ/会員登録内容変更(完了ページ)","mypage_change_complete","Mypage/change_complete","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"9","MYページ/お気に入り一覧","mypage_favorite","Mypage/favorite","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"10","MYページ/購入履歴詳細","mypage_history","Mypage/history","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"11","MYページ/ログイン","mypage_login","Mypage/login","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"12","MYページ/退会手続き(入力ページ)","mypage_withdraw","Mypage/withdraw","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"14","当サイトについて","help_about","Help/about","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
+"13","MYページ/退会手続き(完了ページ)","mypage_withdraw_complete","Mypage/withdraw_complete","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"15","現在のカゴの中","cart","Cart/index","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"16","お問い合わせ(入力ページ)","contact","Contact/index","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
+"17","お問い合わせ(完了ページ)","contact_complete","Contact/complete","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
+"18","会員登録(入力ページ)","entry","Entry/index","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
+"20","会員登録(完了ページ)","entry_complete","Entry/complete","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
+"21","特定商取引に関する法律に基づく表記","help_tradelaw","Help/tradelaw","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
+"22","本会員登録(完了ページ)","entry_activate","Entry/activate","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
+"24","商品購入/お届け先の指定","shopping_shipping","Shopping/shipping","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"28","商品購入/ご注文完了","shopping_complete","Shopping/complete","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"29","プライバシーポリシー","help_privacy","Help/privacy","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
+"30","商品購入ログイン","shopping_login","Shopping/login","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
+"31","非会員購入情報入力","shopping_nonmember","Shopping/nonmember","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
+"32","商品購入/お届け先の追加","shopping_shipping_edit","Shopping/shipping_edit","2",,,,"2017-03-07 01:15:02","2017-03-07 01:15:02","noindex",,"page",
+"33","商品購入/お届け先の複数指定(お届け先の追加)","shopping_shipping_multiple_edit","Shopping/shipping_multiple_edit","2",,,,"2017-03-07 01:15:02","2017-03-07 01:15:02","noindex",,"page",
+"34","商品購入/購入エラー","shopping_error","Shopping/shopping_error","2",,,,"2017-03-07 01:15:02","2017-03-07 01:15:02","noindex",,"page",
+"35","ご利用ガイド","help_guide","Help/guide","2",,,,"2017-03-07 01:15:02","2017-03-07 01:15:02",,,"page",
+"36","パスワード再発行(入力ページ)","forgot","Forgot/index","2",,,,"2017-03-07 01:15:02","2017-03-07 01:15:02",,,"page",
+"37","パスワード再発行(完了ページ)","forgot_complete","Forgot/complete","2",,,,"2017-03-07 01:15:02","2017-03-07 01:15:02","noindex",,"page",
+"38","パスワード再発行(再設定ページ)","forgot_reset","Forgot/reset","2",,,,"2017-03-07 01:15:02","2017-03-07 01:15:05","noindex",,"page",
+"19","ご利用規約","help_agreement","Help/agreement","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
+"25","商品購入/お届け先の複数指定","shopping_shipping_multiple","Shopping/shipping_multiple","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"23","商品購入","shopping","Shopping/index","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"7","MYページ/お届け先一覧","mypage_delivery","Mypage/delivery","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"8","MYページ/お届け先追加","mypage_delivery_new","Mypage/delivery_edit","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52","noindex",,"page",
+"42","商品購入/遷移","shopping_redirect_to","Shopping/index","2",,,,"2017-03-07 01:15:03","2017-03-07 01:15:03","noindex",,"page",
+"44","MYページ/お届け先編集","mypage_delivery_edit","Mypage/delivery_edit","2",,,,"2017-03-07 01:15:05","2017-03-07 01:15:05","noindex",8,"page",
+"45","商品購入/ご注文確認","shopping_confirm","Shopping/confirm","2",,,,"2017-03-07 01:15:03","2017-03-07 01:15:03","noindex",,"page",


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
#4108 コンテンツ管理＞ページ管理＞のmeta記載例をそのまま利用できるようにする
#4264 の代替案として、インストール時の初期データとして、商品詳細ページのmetaを設定するように変更しました。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
特になし

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
特になし

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
`bin/console eccube:install` で動作を確認しました。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
