### PR TITLE
ルート以下ディレクトリにインストールした場合お気に入りに登録できない問題の対応

### DIFF
--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -36,6 +36,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class ProductController extends AbstractController
@@ -344,7 +345,7 @@ class ProductController extends AbstractController
         } else {
             // 非会員の場合、ログイン画面を表示
             //  ログイン後の画面遷移先を設定
-            $this->setLoginTargetPath($this->generateUrl('product_add_favorite', ['id' => $Product->getId()]));
+            $this->setLoginTargetPath($this->generateUrl('product_add_favorite', ['id' => $Product->getId()], UrlGeneratorInterface::ABSOLUTE_URL));
             $this->session->getFlashBag()->set('eccube.add.favorite', true);
 
             $event = new EventArgs(


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
#4369  の修正

## 方針(Policy)

`<input type="hidden" name="_target_path" value="{{ targetPath }}" />`

ルート以下ディレクトリにインストールした場合
targetPathで指定した値がSymfony\Component\Security\Http\HttpUtils::generateUriに渡されるため、targetPathがルートパスだとさらに$request->getBaseUrl()が付与されてしまう

>  return new RedirectResponse($this->generateUri($request, $path), $status);
※$pathがそのまま_target_pathの値


targetPathがスラッシュから始まるパスの場合
　→$request->getBaseUrl()が付与されるのでまずい

targetPathがルーティング名の場合
　→URL化されるが商品IDも渡さないといけないので不採用

targetPathが絶対URLの場合
　→そのままのURLにリダイレクトされるので採用



## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
