### PR TITLE
Fix #4209　商品の在庫数が足りないときに受注のステータスを「注文取消し」から「対応中」に変更しすると、システムエラーが発生する不具合を修正

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -38,6 +38,7 @@ use Eccube\Repository\OrderRepository;
 use Eccube\Repository\ProductRepository;
 use Eccube\Service\OrderHelper;
 use Eccube\Service\OrderStateMachine;
+use Eccube\Service\PurchaseFlow\InvalidItemException;
 use Eccube\Service\PurchaseFlow\Processor\OrderNoProcessor;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Eccube\Service\PurchaseFlow\PurchaseException;
@@ -279,8 +280,13 @@ class EditController extends AbstractController
                             }
                             // ステートマシンでステータスは更新されるので, 古いステータスに戻す.
                             $TargetOrder->setOrderStatus($OldStatus);
-                            // FormTypeでステータスの遷移チェックは行っているのでapplyのみ実行.
-                            $this->orderStateMachine->apply($TargetOrder, $NewStatus);
+                            try {
+                                // FormTypeでステータスの遷移チェックは行っているのでapplyのみ実行.
+                                $this->orderStateMachine->apply($TargetOrder, $NewStatus);
+                            } catch (InvalidItemException $e) {
+                                $this->addError($e->getMessage(), 'admin');
+                                break;
+                            }
                         }
 
                         $this->entityManager->persist($TargetOrder);


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
#4209 を修正しました。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

### StockReduceProcessor
- AbstractPurchaseProcessorを継承するのではなく、PurchaseProcessorを実装するように変更しました。
- ItemHolderValidatorを継承し、InvalidItemExceptionでエラーメッセージを表示するように変更しました。

### EditController
- try-catch文を追加しました。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
PHPUnitで以下のテストを実行
- EditControllerTest
- OrderStateMachineTest
- StockReduceProcessorTest

以下の手順で「＜商品名＞の在庫が足りません。」と表示されることを確認
1. 新規受注を登録する。
2. 受注管理より、`対応状況：注文取消し`、`数量：１`に設定し商品を登録する。
3. 商品管理より、受注管理で登録した商品を編集し`在庫数：０`で登録する。
4. 受注管理で登録した受注情報の編集画面に移り、受注より`対応状況：対応中`に変更し登録する。
5. 「**＜商品名＞の在庫が足りません。**」と表示される。
6. 商品一覧より、商品の`在庫数：０`のままになっていることを確認。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
EC-CUBE本体にPull Requestを出すのは今回が初めてとなります。
[公式ドキュメント](https://doc4.ec-cube.net/customize_service)や公開されている[UG勉強会の資料](https://www.slideshare.net/chihiroadachi3/201927-eccubeugpurchaseflow-130874190)などを参考に修正しました。
開発に関してはまだまだ勉強中の身ですので、改善点等ございましたらご教授いただければ幸いです。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
