### PR TITLE
注文完了メールで規格名を表示できるように修正

### DIFF
--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -215,24 +215,7 @@ if (!class_exists('\Eccube\Entity\Order')) {
                 } else {
                     // 新規規格の商品は新しく追加する
                     $OrderItem = new OrderItem();
-                    $OrderItem->setOrder($ProductOrderItem->getOrder());
-                    $OrderItem
-                    ->setProduct($ProductOrderItem->getProduct())
-                    ->setProductName($ProductOrderItem->getProductName())
-                    ->setProductCode($ProductOrderItem->getProductCode())
-                    ->setClassName1($ProductOrderItem->getClassName1())
-                    ->setClassName2($ProductOrderItem->getClassName2())
-                    ->setClassCategoryName1($ProductOrderItem->getClassCategoryName1())
-                    ->setClassCategoryName2($ProductOrderItem->getClassCategoryName2())
-                    ->setPrice($ProductOrderItem->getPrice())
-                    ->setTax($ProductOrderItem->getTax())
-                    ->setTaxRate($ProductOrderItem->getTaxRate())
-                    ->setQuantity($ProductOrderItem->getQuantity())
-                    ->setProductClass($ProductOrderItem->getProductClass())
-                    ->setRoundingType($ProductOrderItem->getRoundingType())
-                    ->setTaxType($ProductOrderItem->getTaxType())
-                    ->setTaxDisplayType($ProductOrderItem->getTaxDisplayType())
-                    ->setOrderItemType($ProductOrderItem->getOrderItemType());
+                    $OrderItem->copyProperties($ProductOrderItem, ['id']);
                     $orderItemArray[$productClassId] = $OrderItem;
                 }
             }

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -220,12 +220,19 @@ if (!class_exists('\Eccube\Entity\Order')) {
                     ->setProduct($ProductOrderItem->getProduct())
                     ->setProductName($ProductOrderItem->getProductName())
                     ->setProductCode($ProductOrderItem->getProductCode())
+                    ->setClassName1($ProductOrderItem->getClassName1())
+                    ->setClassName2($ProductOrderItem->getClassName2())
                     ->setClassCategoryName1($ProductOrderItem->getClassCategoryName1())
                     ->setClassCategoryName2($ProductOrderItem->getClassCategoryName2())
                     ->setPrice($ProductOrderItem->getPrice())
                     ->setTax($ProductOrderItem->getTax())
                     ->setTaxRate($ProductOrderItem->getTaxRate())
-                    ->setQuantity($ProductOrderItem->getQuantity());
+                    ->setQuantity($ProductOrderItem->getQuantity())
+                    ->setProductClass($ProductOrderItem->getProductClass())
+                    ->setRoundingType($ProductOrderItem->getRoundingType())
+                    ->setTaxType($ProductOrderItem->getTaxType())
+                    ->setTaxDisplayType($ProductOrderItem->getTaxDisplayType())
+                    ->setOrderItemType($ProductOrderItem->getOrderItemType());
                     $orderItemArray[$productClassId] = $OrderItem;
                 }
             }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Close #4385

`Order::getMergedProductOrderItems()` 関数で商品リストを作成時に必要事項をセットするように設定

## 方針(Policy)

規格名に加え、表示する可能性がある項目を設定

## 実装に関する補足(Appendix)


## テスト（Test)

受注完了メールで規格名が表示されることを確認

https://github.com/EC-CUBE/ec-cube/blob/4.0/src/Eccube/Resource/template/default/Mail/order.twig
https://github.com/EC-CUBE/ec-cube/blob/4.0/src/Eccube/Resource/template/default/Mail/order.html.twig

注文完了メールのテンプレートに以下を追加

```php
表示される
{{ OrderItem.classcategory_name1 }}
{{ OrderItem.classcategory_name2 }}

表示されない
{{ OrderItem.class_name1 }}
{{ OrderItem.class_name2 }}
```

## 相談（Discussion）

なし

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
