### PR TITLE
Docker Composeの各種定義を.envに移行 + DB GUIツール追加

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -15,7 +15,7 @@ APP_DEBUG=1
 # Set "serverVersion" to your server version to avoid edge-case exceptions and extra database calls
 DATABASE_URL=sqlite:///var/eccube.db
 # DATABASE_URL=mysql://root:password@mysql/cube4_dev
-# DATABASE_URL=pgsql://postgres:password@postgres/cube4_dev
+# DATABASE_URL=postgres://postgres:password@postgres/cube4_dev
 
 # The version of your database engine
 DATABASE_SERVER_VERSION=3
@@ -77,9 +77,9 @@ MAILCATCHER_HOST_SMTP_PORT=1025
 MAILCATCHER_HOST_HTTP_PORT=1080
 
 # phpMyAdmin ######################
-PHPMYADMIN_HOST_PORT=8081
+PHPMYADMIN_HOST_HTTP_PORT=8081
 
 # pgweb ######################
-PGWEB_HOST_PORT=8082
+PGWEB_HOST_HTTP_PORT=8082
 
 ###< DOCKER_COMPOSE CONFIG ###

--- a/.env.dist
+++ b/.env.dist
@@ -14,8 +14,8 @@ APP_DEBUG=1
 # For a sqlite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
 # Set "serverVersion" to your server version to avoid edge-case exceptions and extra database calls
 DATABASE_URL=sqlite:///var/eccube.db
-# DATABASE_URL=mysql://dbuser:secret@mysql/eccubedb
-# DATABASE_URL=postgresql://postgres/eccubedb?user=dbuser&password=secret
+# DATABASE_URL=mysql://root:password@mysql/cube4_dev
+# DATABASE_URL=pgsql://postgres:password@postgres/cube4_dev
 
 # The version of your database engine
 DATABASE_SERVER_VERSION=3
@@ -48,3 +48,38 @@ MAILER_URL=null://localhost
 #ECCUBE_GC_MAXLIFETIME=1440
 
 ###< APPLICATION CONFIG ###
+
+
+###> DOCKER_COMPOSE CONFIG ###
+WORKSPACE_TIMEZONE=Asia/Tokyo
+
+# ECCUBE WEB-SERVER ###########################
+APACHE_HOST_HTTP_PORT=8080
+APACHE_HOST_HTTPS_PORT=4430
+
+########################################
+
+# MySQL ############################
+MYSQL_VERSION=5.7
+MYSQL_DATABASE=cube4_dev
+MYSQL_ROOT_PASSWORD=password
+MYSQL_HOST_PORT=3306
+
+# Postgres #########################
+POSTGRES_VERSION=10
+POSTGRES_DB=cube4_dev
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+POSTGRES_HOST_PORT=5432
+
+# MailCatcher ######################
+MAILCATCHER_HOST_SMTP_PORT=1025
+MAILCATCHER_HOST_HTTP_PORT=1080
+
+# phpMyAdmin ######################
+PHPMYADMIN_HOST_PORT=8081
+
+# pgweb ######################
+PGWEB_HOST_PORT=8082
+
+###< DOCKER_COMPOSE CONFIG ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ volumes:
     driver: local
   mailcatcher-data:
     driver: local
+  phpmyadmin-sessions:
+    driver: local
   
   ### ignore folder volume #####
   var:
@@ -28,8 +30,8 @@ services:
         # ビルド時点でDBサーバの起動や接続が出来ない、という場合等にエラーとなるため。
         SKIP_INSTALL_SCRIPT_ON_DOCKER_BUILD: "true"
     ports:
-      - 8080:80
-      - 4430:443
+      - "${APACHE_HOST_HTTP_PORT}:80"
+      - "${APACHE_HOST_HTTPS_PORT}:443"
     volumes:
       - ".:/var/www/html:cached"
       ### 同期対象からコストの重いフォルダを除外 #####################
@@ -40,13 +42,13 @@ services:
   
   ### Postgres ################################
   postgres:
-    image: postgres:10
+    image: postgres:${POSTGRES_VERSION}
     environment:
-      - POSTGRES_DB=eccubedb
-      - POSTGRES_USER=dbuser
-      - POSTGRES_PASSWORD=secret
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     ports:
-      - 15432:5432
+      - "${POSTGRES_HOST_PORT}:5432"
     volumes:
       - pg-database:/var/lib/postgresql/data
     networks: 
@@ -54,16 +56,15 @@ services:
   
   ### MySQL ##################################
   mysql:
-    image: mysql:5.7
+    image: mysql:${MYSQL_VERSION}
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: eccubedb
-      MYSQL_USER: dbuser
-      MYSQL_PASSWORD: secret
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - TZ=${WORKSPACE_TIMEZONE}
     volumes:
       - mysql-database:/var/lib/mysql
     ports:
-      - 13306:3306
+      - ${MYSQL_HOST_PORT}:3306
     networks: 
       - backend
 
@@ -71,7 +72,36 @@ services:
   mailcatcher:
     image: schickling/mailcatcher
     ports:
-      - "1080:1080"
-      - "1025:1025"
+      - "${MAILCATCHER_HOST_HTTP_PORT}:1025"
+      - "${MAILCATCHER_HOST_SMTP_PORT}:1080"
     networks: 
       - backend
+
+
+  ### phpMyAdmin ##################################
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    environment:
+      - PMA_ARBITRARY=1
+      - PMA_HOST=mysql
+      - PMA_USER=root
+      - PMA_PASSWORD=${MYSQL_ROOT_PASSWORD}
+    ports:
+      - "${PHPMYADMIN_HOST_HTTP_PORT}:80"
+    volumes:
+      - phpmyadmin-sessions:/sessions
+    networks:
+      - backend
+    depends_on:
+      - mysql
+
+  ### pgweb ##################################
+  pgweb:
+    image: donnex/pgweb
+    command: -s --bind=0.0.0.0 --listen=8080 --url postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/${POSTGRES_DB}?sslmode=disable
+    ports:
+      - "${PGWEB_HOST_HTTP_PORT}:8080"
+    networks:
+      - backend
+    depends_on:
+      - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,8 +72,8 @@ services:
   mailcatcher:
     image: schickling/mailcatcher
     ports:
-      - "${MAILCATCHER_HOST_HTTP_PORT}:1025"
-      - "${MAILCATCHER_HOST_SMTP_PORT}:1080"
+      - "${MAILCATCHER_HOST_SMTP_PORT}:1025"
+      - "${MAILCATCHER_HOST_HTTP_PORT}:1080"
     networks: 
       - backend
 


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
#4391 
- Docker Compose構築の修正・利便性向上

先日の状態からdocker-compose周りの構造(環境変数指定の仕方やDB情報)を変更していますが、まだ日が浅い今のうちに整理しておきたいと考えた次第です。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- docker-compose.ymlに直書きしていたport類の設定等を.envに移行(できるだけGit管理外にするため)
- ついでにMySQL,Postgresのバージョン指定もできるように。
- DB GUIツールの追加(phpmyadmin, pgweb)
- DB関連情報を、従来の「Dockerを使用してインストールする」と同一のものに変更
  + DB名：eccubedb → cube4_dev　等
  + 前例に倣い、DBユーザもスーパーユーザーをそのまま使う

EC_CUBEで使用する`DATABASE_URL`等を、`MYSQL_DATABASE`等の環境変数から構築するか少し迷いましたが、複雑になるため見送りました


## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
- 構築したEC-CUBE環境の画面目視、CRUD動作が行えること
- Volumeがない状態で、.env指定の通りMySQL, Postgres共に初期化されること
  + `docker-compose down -v`でVolumeを落とし、`docker-compsoe up -d`で再初期化
-  `compose run-script compile`によるDBスキーマ作成ができること
- 各種画面がブラウザからアクセス・機能すること
  + MailCatcher : http://localhost:1080
  + phpMyAdmin : http://localhost:8081
  + pgsql : http://localhost:8082


## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
