### PR TITLE
「※ は軽減税率対象商品です。」表示判断を追加

### DIFF
--- a/src/Eccube/Resource/template/default/Mail/order.html.twig
+++ b/src/Eccube/Resource/template/default/Mail/order.html.twig
@@ -48,14 +48,15 @@ file that was distributed with this source code.
                             <hr style="border-top: 3px double #8c8b8b;">
                             　ご注文商品明細<br/>
                             <hr style="border-top: 3px double #8c8b8b;">
+                            {% set isShowReducedTaxMess = false %}
                             {% for OrderItem in Order.MergedProductOrderItems %}
                                 商品コード：{{ OrderItem.product_code }}<br/>
-                                商品名：{{ OrderItem.product_name }}  {{ OrderItem.classcategory_name1 }}  {{ OrderItem.classcategory_name2 }} {{ is_reduced_tax_rate(OrderItem) ? '※' }}<br/>
+                                商品名：{{ OrderItem.product_name }}  {{ OrderItem.classcategory_name1 }}  {{ OrderItem.classcategory_name2 }}{% if is_reduced_tax_rate(OrderItem) %}※{% set isShowReducedTaxMess = true %}{% endif %}<br/>
                                 単価：{{ OrderItem.price_inctax|price }}<br/>
                                 数量：{{ OrderItem.quantity|number_format }}<br/>
                                 <br/>
                             {% endfor %}
-                            ※は軽減税率対象商品です。
+                            {% if isShowReducedTaxMess %}※は軽減税率対象商品です。{% endif %}
                             <hr style="border-top: 2px dashed #8c8b8b;">
                             小　計：{{ Order.subtotal|price }}<br/>
                             手数料：{{ Order.charge|price }}<br/>

--- a/src/Eccube/Resource/template/default/Mail/order.twig
+++ b/src/Eccube/Resource/template/default/Mail/order.twig
@@ -32,14 +32,17 @@ file that was distributed with this source code.
 　ご注文商品明細
 ************************************************
 
+{% set isShowReducedTaxMess = false %}
 {% for OrderItem in Order.MergedProductOrderItems %}
 商品コード：{{ OrderItem.product_code }}
-商品名：{{ OrderItem.product_name }}  {{ OrderItem.classcategory_name1 }}  {{ OrderItem.classcategory_name2 }} {{ is_reduced_tax_rate(OrderItem) ? '※' }}
+商品名：{{ OrderItem.product_name }}  {{ OrderItem.classcategory_name1 }}  {{ OrderItem.classcategory_name2 }} {{ OrderItem.classcategory_name2 }}{% if is_reduced_tax_rate(OrderItem) %}※
+{% set isShowReducedTaxMess = true %}{% endif %}
 単価：{{ OrderItem.price_inctax|price }}
 数量：{{ OrderItem.quantity|number_format }}
 
 {% endfor %}
-※は軽減税率対象商品です。
+{% if isShowReducedTaxMess %}※は軽減税率対象商品です。
+{% endif %}
 -------------------------------------------------
 小　計：{{ Order.subtotal|price }}
 手数料：{{ Order.charge|price }}

--- a/src/Eccube/Resource/template/default/Mail/order.twig
+++ b/src/Eccube/Resource/template/default/Mail/order.twig
@@ -35,8 +35,8 @@ file that was distributed with this source code.
 {% set isShowReducedTaxMess = false %}
 {% for OrderItem in Order.MergedProductOrderItems %}
 商品コード：{{ OrderItem.product_code }}
-商品名：{{ OrderItem.product_name }}  {{ OrderItem.classcategory_name1 }}  {{ OrderItem.classcategory_name2 }} {{ OrderItem.classcategory_name2 }}{% if is_reduced_tax_rate(OrderItem) %}※
-{% set isShowReducedTaxMess = true %}{% endif %}
+商品名：{{ OrderItem.product_name }}  {{ OrderItem.classcategory_name1 }}  {{ OrderItem.classcategory_name2 }} {{ OrderItem.classcategory_name2 }}{% if is_reduced_tax_rate(OrderItem) %}※{% set isShowReducedTaxMess = true %}{% endif %}
+
 単価：{{ OrderItem.price_inctax|price }}
 数量：{{ OrderItem.quantity|number_format }}
 

--- a/src/Eccube/Resource/template/default/Mypage/history.twig
+++ b/src/Eccube/Resource/template/default/Mypage/history.twig
@@ -59,6 +59,7 @@ file that was distributed with this source code.
                         <h2>{{ 'front.mypage.delivery_info'|trans }}</h2>
                     </div>
                     {% for Shipping in Order.Shippings %}
+                        {% set isShowReducedTaxMess = false %}
                         <div class="ec-orderDelivery__title">{{ 'front.mypage.delivery'|trans }}{% if Order.multiple %}({{ loop.index }}){% endif %}</div>
                         {% for orderItem in Shipping.productOrderItems %}
                             <div class="ec-orderDelivery__item">
@@ -77,7 +78,7 @@ file that was distributed with this source code.
                                                 <a href="{{ url('product_detail', {'id': orderItem.Product.id}) }}">{{ orderItem.productName }}</a>
                                             {% else %}
                                                 {{ orderItem.productName }}
-                                            {% endif %} ×{{ orderItem.quantity }} {{ is_reduced_tax_rate(orderItem) ? 'common.reduced_tax_rate_symbol'|trans }}
+                                            {% endif %} ×{{ orderItem.quantity }} {% if is_reduced_tax_rate(orderItem) %}{{ 'common.reduced_tax_rate_symbol'|trans }}{% set isShowReducedTaxMess = true %}{% endif %}
                                         </p>
                                         {% if orderItem.ProductClass is not null %}
                                             {% if orderItem.ProductClass.ClassCategory1 is not null %}
@@ -99,7 +100,7 @@ file that was distributed with this source code.
                                 </div>
                             </div>
                         {% endfor %}
-                        <p>{{ 'common.reduced_tax_rate_messeage'|trans }}</p>
+                        <p>{{ isShowReducedTaxMess ? 'common.reduced_tax_rate_messeage'|trans }}</p>
                         <div class="ec-orderDelivery__address">
                             <p>{{ Shipping.name01 }}&nbsp;{{ Shipping.name02 }}&nbsp;
                                 ({{ Shipping.kana01 }}&nbsp;{{ Shipping.kana02 }})</p>

--- a/src/Eccube/Resource/template/default/Shopping/confirm.twig
+++ b/src/Eccube/Resource/template/default/Shopping/confirm.twig
@@ -84,6 +84,7 @@ file that was distributed with this source code.
                 </div>
                 {% for shipping in Order.shippings %}
                     {% set idx = loop.index0 %}
+                    {% set isShowReducedTaxMess = false %}
                     <div class="ec-orderDelivery__item">
                         <ul class="ec-borderedList">
                             {% for orderItem in shipping.productOrderItems %}
@@ -91,7 +92,7 @@ file that was distributed with this source code.
                                 <div class="ec-imageGrid">
                                     <div class="ec-imageGrid__img"><img src="{{ asset((orderItem.product is null ? null : orderItem.product.MainListImage)|no_image_product, 'save_image') }}" alt="{{ orderItem.productName }}"></div>
                                     <div class="ec-imageGrid__content">
-                                        <p>{{ orderItem.productName }}{% if is_reduced_tax_rate(orderItem) %}{{ 'common.reduced_tax_rate_symbol'|trans }}{% endif %}</p>
+                                        <p>{{ orderItem.productName }}{% if is_reduced_tax_rate(orderItem) %}{{ 'common.reduced_tax_rate_symbol'|trans }}{% set isShowReducedTaxMess = true %}{% endif %}</p>
                                         {% if orderItem.productClass is not null and orderItem.productClass.classCategory1 %}
                                             <p>{{ orderItem.productClass.classCategory1.className.name }}：{{ orderItem.productClass.classCategory1 }}</p>
                                         {% endif %}
@@ -104,7 +105,7 @@ file that was distributed with this source code.
                             </li>
                             {% endfor %}
                         </ul>
-                        <p>{{ 'common.reduced_tax_rate_messeage'|trans }}</p>
+                        <p>{{ isShowReducedTaxMess ? 'common.reduced_tax_rate_messeage'|trans }}</p>
                     </div>
                     <div class="ec-orderDelivery__address">
                         <p>{{ 'common.name.prefix'|trans }}{{ shipping.name01 }} {{ shipping.name02 }} ({{ shipping.kana01 }} {{ shipping.kana02 }}){{ 'common.name.suffix'|trans }}</p>

--- a/src/Eccube/Resource/template/default/Shopping/index.twig
+++ b/src/Eccube/Resource/template/default/Shopping/index.twig
@@ -283,6 +283,7 @@ file that was distributed with this source code.
                     </div>
                     {% for shipping in Order.shippings %}
                         {% set idx = loop.index0 %}
+                        {% set isShowReducedTaxMess = false %}
                         <div class="ec-orderDelivery__title">{{ 'front.shopping.delivery_to'|trans }}{% if Order.multiple %}({{ loop.index }}){% endif %}
                             <div class="ec-orderDelivery__change">
                                 {% if is_granted('ROLE_USER') %}
@@ -299,7 +300,7 @@ file that was distributed with this source code.
                                         <div class="ec-imageGrid">
                                             <div class="ec-imageGrid__img"><img src="{{ asset((orderItem.product is null ? null : orderItem.product.MainListImage)|no_image_product, 'save_image') }}" alt="{{ orderItem.productName }}"></div>
                                             <div class="ec-imageGrid__content">
-                                                <p>{{ orderItem.productName }}{{ is_reduced_tax_rate(orderItem) ? 'common.reduced_tax_rate_symbol'|trans }}</p>
+                                                <p>{{ orderItem.productName }}{% if is_reduced_tax_rate(orderItem) %}{{ 'common.reduced_tax_rate_symbol'|trans }}{% set isShowReducedTaxMess = true %}{% endif %}</p>
                                                 {% if orderItem.productClass is not null and orderItem.productClass.classCategory1 %}
                                                     <p>{{ orderItem.productClass.classCategory1.className.name }}：{{ orderItem.productClass.classCategory1 }}</p>
                                                 {% endif %}
@@ -312,7 +313,7 @@ file that was distributed with this source code.
                                     </li>
                                 {% endfor %}
                             </ul>
-                            <p>{{ 'common.reduced_tax_rate_messeage'|trans }}</p>
+                            <p>{{ isShowReducedTaxMess ? 'common.reduced_tax_rate_messeage'|trans }}</p>
                         </div>
                         <div class="ec-orderDelivery__address">
                             <p>{{ 'common.name.prefix'|trans }}{{ shipping.name01 }} {{ shipping.name02 }} ({{ shipping.kana01 }} {{ shipping.kana02 }}){{ 'common.name.suffix'|trans }}</p>

--- a/src/Eccube/Service/OrderPdfService.php
+++ b/src/Eccube/Service/OrderPdfService.php
@@ -460,6 +460,7 @@ class OrderPdfService extends TcpdfFpdi
         // 受注詳細情報
         // =========================================
         $i = 0;
+        $isShowReducedTaxMess = false;
         /* @var OrderItem $OrderItem */
         foreach ($Shipping->getOrderItems() as $OrderItem) {
             // class categoryの生成
@@ -484,6 +485,7 @@ class OrderPdfService extends TcpdfFpdi
             }
             if ($this->taxExtension->isReducedTaxRate($OrderItem)) {
                 $productName .= ' ※';
+                $isShowReducedTaxMess = true;
             }
             $arrOrder[$i][0] = $productName;
             // 購入数量
@@ -571,11 +573,13 @@ class OrderPdfService extends TcpdfFpdi
             $arrOrder[$i][2] = '請求金額';
             $arrOrder[$i][3] = $this->eccubeExtension->getPriceFilter($Order->getPaymentTotal());
 
-            ++$i;
-            $arrOrder[$i][0] = '※は軽減税率対象商品です。';
-            $arrOrder[$i][1] = '';
-            $arrOrder[$i][2] = '';
-            $arrOrder[$i][3] = '';
+            if ($isShowReducedTaxMess) {
+                ++$i;
+                $arrOrder[$i][0] = '※は軽減税率対象商品です。';
+                $arrOrder[$i][1] = '';
+                $arrOrder[$i][2] = '';
+                $arrOrder[$i][3] = '';
+            }
         }
 
         // PDFに設定する


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

https://github.com/EC-CUBE/ec-cube/issues/4304

軽減税率商品存在しない場合は「※ は軽減税率対象商品です。」が非表示にする

##対象範囲

- ご注文手続き画面
- ご注文内容のご確認画面
- マイページの注文履歴画面
- 購入完了時のメール
- 納品書を出力