### PR TITLE
[fix]refs #4316 CLIインストール時、管理画面URLがadminに固定されてしまう状況の解消

### DIFF
--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -98,6 +98,39 @@ class InstallerCommand extends Command
         }
         $authMagic = $this->io->ask('Auth Magic', $authMagic);
 
+        // 以下環境変数に規定済の設定値があれば利用する
+        // APP_ENV
+        $appEnv = getenv('APP_ENV');
+        // .envが存在しない状態では規定値'install'となっているため、
+        // devに変更する。
+        if (empty($appEnv) || $appEnv === 'install') {
+            $appEnv = 'dev';
+        }
+
+        // APP_DEBUG
+        $appDebug = getenv('APP_DEBUG');
+        if (empty($appDebug)) {
+            $appDebug = '1';
+        }
+
+        // ECCUBE_ADMIN_ROUTE
+        $adminRoute = $this->container->getParameter('eccube_admin_route');
+        if (empty($adminRoute)) {
+            $adminRoute = 'admin';
+        }
+
+        // ECCUBE_TEMPLATE_CODE
+        $templateCode = $this->container->getParameter('eccube_theme_code');
+        if (empty($templateCode)) {
+            $templateCode = 'default';
+        }
+
+        // ECCUBE_LOCALE
+        $locale = $this->container->getParameter('locale');
+        if (empty($locale)) {
+            $locale = 'ja';
+        }
+
         $this->io->caution('Execute the installation process. All data is initialized.');
         $question = new ConfirmationQuestion('Is it OK?');
         if (!$this->io->askQuestion($question)) {
@@ -110,15 +143,15 @@ class InstallerCommand extends Command
         }
 
         $envParameters = [
-            'APP_ENV' => 'dev',
-            'APP_DEBUG' => '1',
+            'APP_ENV' => $appEnv,
+            'APP_DEBUG' => $appDebug,
             'DATABASE_URL' => $databaseUrl,
             'DATABASE_SERVER_VERSION' => $serverVersion,
             'MAILER_URL' => $mailerUrl,
             'ECCUBE_AUTH_MAGIC' => $authMagic,
-            'ECCUBE_ADMIN_ROUTE' => 'admin',
-            'ECCUBE_TEMPLATE_CODE' => 'default',
-            'ECCUBE_LOCALE' => 'ja',
+            'ECCUBE_ADMIN_ROUTE' => $adminRoute,
+            'ECCUBE_TEMPLATE_CODE' => $templateCode,
+            'ECCUBE_LOCALE' => $locale,
         ];
 
         $envDir = $this->container->getParameter('kernel.project_dir');

--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -100,18 +100,14 @@ class InstallerCommand extends Command
 
         // 以下環境変数に規定済の設定値があれば利用する
         // APP_ENV
-        $appEnv = getenv('APP_ENV');
+        $appEnv = env('APP_ENV', 'dev');
         // .envが存在しない状態では規定値'install'となっているため、
-        // devに変更する。
-        if (empty($appEnv) || $appEnv === 'install') {
+        if ($appEnv === 'install') {
             $appEnv = 'dev';
         }
 
         // APP_DEBUG
-        $appDebug = getenv('APP_DEBUG');
-        if (empty($appDebug)) {
-            $appDebug = '1';
-        }
+        $appDebug = env('APP_DEBUG','1');
 
         // ECCUBE_ADMIN_ROUTE
         $adminRoute = $this->container->getParameter('eccube_admin_route');

--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -101,7 +101,7 @@ class InstallerCommand extends Command
         // 以下環境変数に規定済の設定値があれば利用する
         // APP_ENV
         $appEnv = env('APP_ENV', 'dev');
-        // .envが存在しない状態では規定値'install'となっているため、
+        // .envが存在しない状態では規定値'install'となっているため、devに更新する
         if ($appEnv === 'install') {
             $appEnv = 'dev';
         }

--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -44,11 +44,61 @@ class InstallerCommand extends Command
      */
     protected $databaseUrl;
 
+    private $envFileUpdater;
+
     public function __construct(ContainerInterface $container)
     {
         parent::__construct();
 
         $this->container = $container;
+
+        /* env更新処理無名クラス */
+        $this->envFileUpdater = new class() {
+            public $appEnv;
+            public $appDebug;
+            public $databaseUrl;
+            public $serverVersion;
+            public $mailerUrl;
+            public $authMagic;
+            public $adminRoute;
+            public $templateCode;
+            public $locale;
+
+            public $envDir;
+
+            private function getEnvParameters()
+            {
+                return  [
+                            'APP_ENV' => $this->appEnv,
+                            'APP_DEBUG' => $this->appDebug,
+                            'DATABASE_URL' => $this->databaseUrl,
+                            'DATABASE_SERVER_VERSION' => $this->serverVersion,
+                            'MAILER_URL' => $this->mailerUrl,
+                            'ECCUBE_AUTH_MAGIC' => $this->authMagic,
+                            'ECCUBE_ADMIN_ROUTE' => $this->adminRoute,
+                            'ECCUBE_TEMPLATE_CODE' => $this->templateCode,
+                            'ECCUBE_LOCALE' => $this->locale,
+                        ];
+            }
+
+            /**
+             * envファイル更新処理
+             */
+            public function updateEnvFile()
+            {
+                // $envDir = $this->container->getParameter('kernel.project_dir');
+                $envFile = $this->envDir.'/.env';
+                $envDistFile = $this->envDir.'/.env.dist';
+
+                $env = file_exists($envFile)
+                            ? file_get_contents($envFile)
+                            : file_get_contents($envDistFile);
+
+                $env = StringUtil::replaceOrAddEnv($env, $this->getEnvParameters());
+
+                file_put_contents($envFile, $env);
+            }
+        };
     }
 
     protected function configure()
@@ -79,24 +129,24 @@ class InstallerCommand extends Command
         if (empty($databaseUrl)) {
             $databaseUrl = 'sqlite:///var/eccube.db';
         }
-        $databaseUrl = $this->io->ask('Database Url', $databaseUrl);
+        $this->envFileUpdater->databaseUrl = $this->io->ask('Database Url', $databaseUrl);
 
         // DATABASE_SERVER_VERSION
-        $serverVersion = $this->getDatabaseServerVersion($databaseUrl);
+        $this->envFileUpdater->serverVersion = $this->getDatabaseServerVersion($databaseUrl);
 
         // MAILER_URL
         $mailerUrl = $this->container->getParameter('eccube_mailer_url');
         if (empty($mailerUrl)) {
             $mailerUrl = 'null://localhost';
         }
-        $mailerUrl = $this->io->ask('Mailer Url', $mailerUrl);
+        $this->envFileUpdater->mailerUrl = $this->io->ask('Mailer Url', $mailerUrl);
 
         // ECCUBE_AUTH_MAGIC
         $authMagic = $this->container->getParameter('eccube_auth_magic');
         if (empty($authMagic) || $authMagic === '<change.me>') {
             $authMagic = StringUtil::random();
         }
-        $authMagic = $this->io->ask('Auth Magic', $authMagic);
+        $this->envFileUpdater->authMagic = $this->io->ask('Auth Magic', $authMagic);
 
         // 以下環境変数に規定済の設定値があれば利用する
         // APP_ENV
@@ -105,27 +155,31 @@ class InstallerCommand extends Command
         if ($appEnv === 'install') {
             $appEnv = 'dev';
         }
+        $this->envFileUpdater->appEnv = $appEnv;
 
         // APP_DEBUG
-        $appDebug = env('APP_DEBUG','1');
+        $this->envFileUpdater->appDebug = env('APP_DEBUG', '1');
 
         // ECCUBE_ADMIN_ROUTE
         $adminRoute = $this->container->getParameter('eccube_admin_route');
         if (empty($adminRoute)) {
             $adminRoute = 'admin';
         }
+        $this->envFileUpdater->adminRoute = $adminRoute;
 
         // ECCUBE_TEMPLATE_CODE
         $templateCode = $this->container->getParameter('eccube_theme_code');
         if (empty($templateCode)) {
             $templateCode = 'default';
         }
+        $this->envFileUpdater->templateCode = $templateCode;
 
         // ECCUBE_LOCALE
         $locale = $this->container->getParameter('locale');
         if (empty($locale)) {
             $locale = 'ja';
         }
+        $this->envFileUpdater->locale = $locale;
 
         $this->io->caution('Execute the installation process. All data is initialized.');
         $question = new ConfirmationQuestion('Is it OK?');
@@ -138,29 +192,9 @@ class InstallerCommand extends Command
             return;
         }
 
-        $envParameters = [
-            'APP_ENV' => $appEnv,
-            'APP_DEBUG' => $appDebug,
-            'DATABASE_URL' => $databaseUrl,
-            'DATABASE_SERVER_VERSION' => $serverVersion,
-            'MAILER_URL' => $mailerUrl,
-            'ECCUBE_AUTH_MAGIC' => $authMagic,
-            'ECCUBE_ADMIN_ROUTE' => $adminRoute,
-            'ECCUBE_TEMPLATE_CODE' => $templateCode,
-            'ECCUBE_LOCALE' => $locale,
-        ];
-
-        $envDir = $this->container->getParameter('kernel.project_dir');
-        $envFile = $envDir.'/.env';
-        $envDistFile = $envDir.'/.env.dist';
-
-        $env = file_exists($envFile)
-            ? file_get_contents($envFile)
-            : file_get_contents($envDistFile);
-
-        $env = StringUtil::replaceOrAddEnv($env, $envParameters);
-
-        file_put_contents($envFile, $env);
+        // envファイルへの更新反映処理
+        $this->envFileUpdater->envDir = $this->container->getParameter('kernel.project_dir');
+        $this->envFileUpdater->updateEnvFile();
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
refs #4316 
CLIインストーラを使用した際に、管理画面URLがadminに固定されてしまう状況の解消  
CLIインストーラの実行結果がやや変わるという点では仕様変更

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
.envの記述有無にかかわらず、以下の通り無視して強制的に固定値を設定している項目があったため、.envにて設定値がある場合は維持するようにした。
- APP_ENV : dev
- APP_DEBUG : 1
- ECCUBE_ADMIN_ROUTE : admin
- ECCUBE_TEMPLATE_CODE : default
- ECCUBE_LOCALE : ja


## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
以下のコマンドを用いて.envの有無・記述パターンでインストールを実行
```
bin/console eccube:install
```
- .envが存在しない時、方針で示した項目がデフォルト値でインストールされること
- .envが存在する時、かつ方針で示した項目が指定されていない時
  - 各項目についてデフォルト値が設定されること
- .envが存在する時、かつ方針で示した項目が指定されている時
  - 各項目について.env指定値が維持されること 

### 確認方法
- .envへの書き込み確認
- 画面及びキャッシュ生成にてdev/prodモード動作確認
- 画面にて管理画面へのアクセスURL変更確認
- 画面にて言語表示確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
