### PR TITLE
商品一覧件数セッションキー名、受注一覧との重複を解消

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -173,7 +173,7 @@ class ProductController extends AbstractController
          * - デフォルト値
          * また, セッションに保存する際は mtb_page_maxと照合し, 一致した場合のみ保存する.
          **/
-        $page_count = $this->session->get('eccube.admin.order.search.page_count',
+        $page_count = $this->session->get('eccube.admin.product.search.page_count',
             $this->eccubeConfig->get('eccube_default_page_count'));
 
         $page_count_param = (int) $request->get('page_count');
@@ -183,7 +183,7 @@ class ProductController extends AbstractController
             foreach ($pageMaxis as $pageMax) {
                 if ($page_count_param == $pageMax->getName()) {
                     $page_count = $pageMax->getName();
-                    $this->session->set('eccube.admin.order.search.page_count', $page_count);
+                    $this->session->set('eccube.admin.product.search.page_count', $page_count);
                     break;
                 }
             }


### PR DESCRIPTION

## 概要(Overview・Refs Issue)
#4448 の修正

## 方針(Policy)
受注一覧と商品一覧の件数表示セッションキー名がどちらもeccube.admin.order.search.page_countになっているため、
商品一覧をeccube.admin.product.search.page_count に変更


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
