### PR TITLE
プラグインの有効無効判定時にDBALの定義を作成しないように修正

### DIFF
--- a/src/Eccube/DependencyInjection/EccubeExtension.php
+++ b/src/Eccube/DependencyInjection/EccubeExtension.php
@@ -196,15 +196,9 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
             return false;
         }
 
-        $sm = $conn->getSchemaManager();
-        $tables = array_filter(
-            $sm->listTables(),
-            function ($table) {
-                return $table->getName() === 'dtb_plugin';
-            }
-        );
+        $tableNames = $conn->getSchemaManager()->listTableNames();
 
-        return empty($tables) ? false : true;
+        return in_array('dtb_plugin', $tableNames);
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

close #4461

## 方針(Policy)

動きは変えない

## 実装に関する補足(Appendix)

`\Doctrine\DBAL\Schema\AbstractSchemaManager::listTables` がエラーの原因でしたので、 `\Doctrine\DBAL\Schema\AbstractSchemaManager::listTableNames` を利用する実装に変更しました。
https://github.com/EC-CUBE/ec-cube/blob/ed5759a768fed333e593d75a3d6686cdd11193c8/src/Eccube/DependencyInjection/EccubeExtension.php#L201

## テスト（Test)

#4461 の手順でエラーが発生しないことを確認しました。

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
