### PR TITLE
fix save and close btn in admin/shipping, /admin/product/product/new,…

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -156,6 +156,7 @@ file that was distributed with this source code.
                 });
                 saveBtn.on('click', function() {
                     returnLink.val($(this).data('return-link'));
+                    $(this).addClass('disabled');
                     $('#form1').append('<input type="hidden" name="mode" value="register">');
                     form.submit();
                 });

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -207,6 +207,7 @@ file that was distributed with this source code.
                 });
                 saveBtn.on('click', function() {
                     returnLink.val($(this).data('return-link'));
+                    $(this).addClass('disabled');
                     form.submit();
                 });
                 target.on('click', function() {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
#4315
管理画面の
- 商品登録・編集画面内の左下の「商品一覧」リンク
- 受注登録画面内の「出荷情報の追加」ボタン

を押下した際に出現するモーダルの「保存して移動」ボタンが連打できてしまう問題を対応しました。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
「保存して移動」ボタンの押下と同時に、当該ボタンに対して"disabled"クラスを付与するようにしました。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
