### PR TITLE
CustomerTypeTestのテストの判定が間違っていたので修正

### DIFF
--- a/tests/Eccube/Tests/Form/Type/Admin/CustomerTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/CustomerTypeTest.php
@@ -209,7 +209,10 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInvalidPassword_MinLength()
     {
-        $this->formData['password']['first'] = str_repeat('a', $this->eccubeConfig['eccube_password_min_len'] - 1);
+        $password = str_repeat('a', $this->eccubeConfig['eccube_password_min_len'] - 1);
+
+        $this->formData['password']['first'] = $password;
+        $this->formData['password']['second'] = $password;
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
@@ -226,7 +229,10 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInvalidPassword_MaxLength()
     {
-        $this->formData['password']['first'] = str_repeat('a', $this->eccubeConfig['eccube_password_max_len'] + 1);
+        $password = str_repeat('a', $this->eccubeConfig['eccube_password_max_len'] + 1);
+
+        $this->formData['password']['first'] = $password;
+        $this->formData['password']['second'] = $password;
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

パスワードの文字数をテストしたいテストケースで文字数以外のエラーが発生してテストの判定がうまくできていなかった問題を修正

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

本来なら `$this->form->isValid()` ではなく `$this->form->getErrors(true)[0]->getMessage()` で判定すべきですが、修正箇所が多かったため一旦そのままにしています。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
