### PR TITLE
eccube:composer:require-already-installedコマンドで404エラーが発生するのを修正

### DIFF
--- a/src/Eccube/Command/ComposerRequireAlreadyInstalledPluginsCommand.php
+++ b/src/Eccube/Command/ComposerRequireAlreadyInstalledPluginsCommand.php
@@ -70,7 +70,7 @@ class ComposerRequireAlreadyInstalledPluginsCommand extends Command
         $unSupportedPlugins = [];
 
         $criteria = Criteria::create()
-            ->where(Criteria::expr()->neq('source', 0))
+            ->where(Criteria::expr()->notIn('source', ['', '0']))
             ->orderBy(['code' => 'ASC']);
         $Plugins = $this->pluginRepository->matching($criteria);
 

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -460,7 +460,7 @@ class PluginService
             'code' => $json['extra']['code'],
             'name' => isset($json['description']) ? $json['description'] : $json['extra']['code'],
             'version' => $json['version'],
-            'source' => isset($json['extra']['id']) ? $json['extra']['id'] : false,
+            'source' => isset($json['extra']['id']) ? $json['extra']['id'] : 0,
         ];
     }
 

--- a/tests/Eccube/Tests/Service/PluginServiceTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceTest.php
@@ -734,6 +734,23 @@ EOD;
         $this->assertFileNotExists($dir);
     }
 
+    public function testReadConfig_normalizeSourceToZero()
+    {
+        $pluginDir = $this->createTempDir();
+        $composerFile = json_encode([
+            'name' => 'ReadConfig',
+            'version' => '1.0.0',
+            'extra' => [
+                'code' => 'ReadConfig',
+            ],
+        ]);
+        file_put_contents($pluginDir.'/composer.json', $composerFile);
+
+        $config = $this->service->readConfig($pluginDir);
+
+        self::assertEquals('0', $config['source']);
+    }
+
     /**
      * @param $config
      *


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
`eccube:plugin:uninstall` コマンドでインストールした独自プラグインがあるとき、`eccube:composer:require-already-installed` コマンドを実行するとエラーになる.

- `eccube:plugin:uninstall` コマンドでインストールしたプラグインは `dtb_plugin.source` の値が空文字になる.
- `eccube:composer:require-already-installed` コマンドは `dtb_plugin.source` が `0` 以外のものをPackage APIに問い合わせるため、空文字のプラグインでは以下のように404エラーが発生する.

```
$ bin/console eccube:composer:require-already-installed
ERROR     [console] Error thrown while running command "eccube:composer:require-already-installed". Message: "404 : The requested URL returned error: 404 " ...

In PluginApiService.php line 322:

  404 : The requested URL returned error: 404
```

## 方針(Policy)
- `dtb_plugin.source` が空文字のプラグインはPackage APIに問い合わせない.
- `eccube:plugin:uninstall` コマンドでインストールしたときには `dtb_plugin.source` が `0` になるようにする.

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
404エラーのテストは以下の手順で発生しないことを確認。

1. 独自プラグインをコマンドからインストール

        $ bin/console e:p:i --code=AnnotatedRouting

1. 認証キーを設定する.
1. コマンドを叩いて404が発生しないこと確認

        $ bin/console eccube:composer:require-already-installed

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
