### PR TITLE
受注登録画面の利用ポイントフォームのバリデーションをrequire=trueに修正

### DIFF
--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -191,7 +191,7 @@ class OrderType extends AbstractType
                 'required' => false,
             ])
             ->add('use_point', NumberType::class, [
-                'required' => false,
+                'required' => true,
                 'constraints' => [
                     new Assert\Regex([
                         'pattern' => "/^\d+$/u",


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
受注登録画面の利用ポイントフォームがnullでpostされると、not null制約エラーになるため、require=false→ require=trueに変更

## 方針(Policy)
dtb_order.use_pointカラムはnot null制約のため、必須バリデーションが必要と判断し、修正

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
nullで登録したとき、バリデーションが発生することを確認


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
