### PR TITLE
TemplateEventからTwigのコードが取れない不具合を修正

### DIFF
--- a/src/Eccube/Twig/Template.php
+++ b/src/Eccube/Twig/Template.php
@@ -32,9 +32,10 @@ abstract class Template extends \Twig\Template
         if (isset($globals['event_dispatcher']) && strpos($this->getTemplateName(), '__string_template__') !== 0) {
             /** @var EventDispatcherInterface $eventDispatcher */
             $eventDispatcher = $globals['event_dispatcher'];
-            $event = new TemplateEvent($this->getTemplateName(), $this->getSourceContext()->getCode(), $context);
+            $originCode = $this->env->getLoader()->getSourceContext($this->getTemplateName())->getCode();
+            $event = new TemplateEvent($this->getTemplateName(), $originCode, $context);
             $eventDispatcher->dispatch($this->getTemplateName(), $event);
-            if ($event->getSource() !== $this->getSourceContext()->getCode()) {
+            if ($event->getSource() !== $originCode) {
                 $newTemplate = $this->env->createTemplate($event->getSource());
                 $newTemplate->display($event->getParameters(), $blocks);
             } else {


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
`TemplateEvent#getSource()` が常に空文字になる問題に対応.
https://github.com/EC-CUBE/ec-cube/pull/4362 の修正で取得できなくなっていた。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
`APP_ENV=test` の環境では元から `TemplateEvent#getSource()` が正常に動作していたので、テストコードでは確認できず、`APP_ENV=prod` で手動確認しました。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
