### PR TITLE
Customizeディレクトリでもservices.yamlが定義できるように機能拡張

### DIFF
--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -126,6 +126,11 @@ class Kernel extends BaseKernel
         $dir = dirname(__DIR__).'/../app/Plugin/*/Resource/config';
         $loader->load($dir.'/services'.self::CONFIG_EXTS, 'glob');
         $loader->load($dir.'/services_'.$this->environment.self::CONFIG_EXTS, 'glob');
+
+        // カスタマイズディレクトリのservices.phpをロードする.
+        $dir = dirname(__DIR__).'/../app/Customize/Resource/config';
+        $loader->load($dir.'/services'.self::CONFIG_EXTS, 'glob');
+        $loader->load($dir.'/services_'.$this->environment.self::CONFIG_EXTS, 'glob');
     }
 
     protected function configureRoutes(RouteCollectionBuilder $routes)


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

プラグインのディレクトリと同様にCustomizeディレクトリでもservices.yamlが定義できるように機能拡張しました。

## 方針(Policy)

## 実装に関する補足(Appendix)

`app/Customize/Resource/config` ディレクトリ自体がないとエラーとなるので、ディレクトリの作成と `.gitkeep` を設置しています。

## テスト（Test)

services.yaml に parameters を定義して Controller 内で参照できることを確認しました。

```yaml
parameters:
  hogehoge: hogehoge
```

```php
class TopController extends AbstractController
{
    /**
     * @Route("/", name="homepage")
     * @Template("index.twig")
     */
    public function index()
    {
        dump($this->eccubeConfig['hogehoge']);
        return [];
    }
}
```

## マイナーバージョン互換性保持のための制限事項チェックリスト

機能追加となるので既存のサイトには影響はないと思います。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
