### PR TITLE
メール設定画面でメール本文を修正しても反映されない不具合修正

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/Shop/MailController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/MailController.php
@@ -19,6 +19,7 @@ use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
 use Eccube\Form\Type\Admin\MailType;
 use Eccube\Repository\MailTemplateRepository;
+use Eccube\Util\CacheUtil;
 use Eccube\Util\StringUtil;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Filesystem\Filesystem;
@@ -51,7 +52,7 @@ class MailController extends AbstractController
      * @Route("/%eccube_admin_route%/setting/shop/mail/{id}", requirements={"id" = "\d+"}, name="admin_setting_shop_mail_edit")
      * @Template("@admin/Setting/Shop/mail.twig")
      */
-    public function index(Request $request, MailTemplate $Mail = null, Environment $twig)
+    public function index(Request $request, MailTemplate $Mail = null, Environment $twig, CacheUtil $cacheUtil)
     {
         $builder = $this->formFactory
             ->createBuilder(MailType::class, $Mail);
@@ -127,6 +128,9 @@ class MailController extends AbstractController
                 $this->eventDispatcher->dispatch(EccubeEvents::ADMIN_SETTING_SHOP_MAIL_INDEX_COMPLETE, $event);
 
                 $this->addSuccess('admin.common.save_complete', 'admin');
+
+                // キャッシュの削除
+                $cacheUtil->clearTwigCache();
 
                 return $this->redirectToRoute('admin_setting_shop_mail_edit', ['id' => $Mail->getId()]);
             }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
メール設定画面でメール本文を修正してもキャッシュが残っているため即時反映されない不具合修正


## 実装に関する補足(Appendix)
こちらのprにも変更が必要 #4440 


- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
