### PR TITLE
apt-get install libicu-devでエラーが発生する問題を解消。（aptのリモートリポジトリとの相性が悪い）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,6 @@ FROM php:7.3-apache-stretch
 
 ENV APACHE_DOCUMENT_ROOT /var/www/html
 
-RUN /bin/rm /etc/apt/sources.list \
-  && { \
-    echo 'deb http://cdn.debian.net/debian/ stretch main contrib non-free'; \
-    echo 'deb http://cdn.debian.net/debian/ stretch-updates main contrib'; \
-  } > /etc/apt/sources.list.d/mirror.jp.list
-
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
     apt-transport-https \


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

`docker-compose build --no-cache` を実行すると、Dockerイメージのビルドでエラーが発生する。

以下のページのコメントから発覚。

* https://ryo-endo.github.io/doc4.ec-cube.net/quickstart_install#comment-4862621717

*一部抜粋*

```bash
The following packages have unmet dependencies:
libicu-dev : Depends: libicu57 (= 57.1-6+deb9u3) but 57.1-6+deb9u4 is to be installed
E: Unable to correct problems, you have held broken packages.
ERROR: Service 'ec-cube' failed to build: The command '/bin/sh -c apt-get update && apt-get install --no-install-recommends -y apt-transport-https apt-utils build-essential curl debconf-utils gcc git gnupg2 libfreetype6-dev libicu-dev libjpeg62-turbo-dev libpng-dev libpq-dev libzip-dev locales ssl-cert unzip zlib1g-dev && apt-get clean && rm -rf /var/lib/apt/lists/* && echo "en_US.UTF-8 UTF-8" >/etc/locale.gen && locale-gen ;' returned a non-zero code: 100
```

`libicu-dev` パッケージのインストールで外パッケージの依存関係と競合している模様。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

Dockerイメージのビルドが正常に動作するようにする。

`Dockerfile` 内の処理で *apt* のリモートリポジトリをデフォルトではないものを使用するように切り替えているが、これを削除することで問題が解消。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

本体サービスは触っていない。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

* Dockerイメージのビルドが正常終了
* EC-CUBEアプリケーションの起動

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
