### PR TITLE
エラーメッセージの表示位置を変更

### DIFF
--- a/src/Eccube/Resource/template/admin/Content/file.twig
+++ b/src/Eccube/Resource/template/admin/Content/file.twig
@@ -135,13 +135,12 @@ file that was distributed with this source code.
                                 </div>
                             </div>
                         </div>
+                        {% for error in errors %}
+                            <p class="text-danger errormsg">{{ error.message|trans }}</p>
+                        {% endfor %}
                     </div>
                 </div>
             </div>
-            {% for error in errors %}
-                <p class="text-danger errormsg">{{ error.message|trans }}</p>
-            {% endfor %}
-
             <div class="c-contentsArea__cols">
                 <div class="c-contentsArea__primaryCol">
                     <div class="c-primaryCol">


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)

#4260
を修正しました。

## 方針(Policy)

エラーメッセージを下図の位置に表示するように変更しました。

![スクリーンショット 2020-04-11 0 33 30](https://user-images.githubusercontent.com/26207848/79003137-e7a1cd00-7b8c-11ea-87a9-2d1692ec110a.png)


## 実装に関する補足(Appendix)

ファイルを追加項目と、フォルダを追加項目のそれぞれのフィールドのエラーごとに
エラーメッセージを表示させようとしましたが、FileControllerの変更箇所が大きくなるため
断念しました。。。

## テスト（Test)
ロジックを変更していないため、テストは追加していません。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
