### PR TITLE
受注・出荷CSVの出力時に、明細がソートされるように修正

### DIFF
--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -411,7 +411,7 @@ class OrderController extends AbstractController
                 $Csvs = $csvService->getCsvs();
 
                 $Order = $entity;
-                $OrderItems = $Order->getOrderItems();
+                $OrderItems = $Order->getItems();
 
                 foreach ($OrderItems as $OrderItem) {
                     $ExportCsvRow = new ExportCsvRow();

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
@@ -313,7 +313,7 @@ class OrderControllerTest extends AbstractAdminWebTestCase
         );
 
         // CSVの出力結果を保存
-        $csv = realpath(dirname(__FILE__)).'/test.csv';
+        $csv = tempnam(sys_get_temp_dir(), __CLASS__);
         $output = $this->getActualOutput();
         file_put_contents($csv, $output);
 

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
@@ -338,8 +338,6 @@ class OrderControllerTest extends AbstractAdminWebTestCase
 
             $this->assertSame($expected, $actual);
         }
-
-        unlink($csv);
     }
 
     /**


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
close #4509

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

- getOrderItemsからgetItemsを利用するようにし、注文明細の結果がソートされるように修正

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

- getItemsは、注文明細を明細種別でソートしてくれます。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

- ユニットテストを追加

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

- CSVの出力結果のテスト、いったん書いてみましたが、もっと良いやり方があれば

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
