### PR TITLE
PHP7.4 で notice が発生して再インストールできないのを修正

### DIFF
--- a/src/Eccube/DependencyInjection/EccubeExtension.php
+++ b/src/Eccube/DependencyInjection/EccubeExtension.php
@@ -121,7 +121,7 @@ class EccubeExtension extends Extension implements PrependExtensionInterface
 
         $enabled = [];
         foreach ($plugins as $plugin) {
-            if ($plugin['enabled']) {
+            if (array_key_exists('enabled', $plugin) && $plugin['enabled']) {
                 $enabled[] = $plugin['code'];
             }
         }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
PHP7.4 で `bin/console doctrine:schema:drop` を実行した際に `E_NOTICE` が発生する。
`APP_ENV=dev` の場合は実行が停止してしまい、再インストールできない

```
$ bin/console doctrine:schema:drop --force

In EccubeExtension.php line 124:

  Notice: Undefined index: enabled

```

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

- `E_NOTICE` の出ないよう修正する

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

- `APP_ENV=dev` にて、`bin/console doctrine:schema:drop` が完了するのを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
