### PR TITLE
キャッシュ削除後、デバッグツールバーでエラーが発生する問題を修正

### DIFF
--- a/src/Eccube/Twig/Template.php
+++ b/src/Eccube/Twig/Template.php
@@ -13,16 +13,14 @@
 
 namespace Eccube\Twig;
 
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Eccube\Event\TemplateEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-abstract class Template extends \Twig\Template
+class Template extends \Twig\Template
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
-     * @param array $context
-     * @param array $blocks
      * @throws \Twig\Error\LoaderError
      * @throws \Twig\Error\SyntaxError
      */
@@ -44,5 +42,23 @@ abstract class Template extends \Twig\Template
         } else {
             parent::display($context, $blocks);
         }
+    }
+
+    public function getTemplateName()
+    {
+        // Templateのキャッシュ作成時に動的に作成されるメソッド
+        // デバッグツールバーでエラーが発生するためから文字を返しておく。
+        // @see https://github.com/EC-CUBE/ec-cube/issues/4529
+        return '';
+    }
+
+    public function getDebugInfo()
+    {
+        // Templateのキャッシュ作成時に動的に作成されるメソッド
+    }
+
+    protected function doDisplay(array $context, array $blocks = [])
+    {
+        // Templateのキャッシュ作成時に動的に作成されるメソッド
     }
 }

--- a/src/Eccube/Twig/Template.php
+++ b/src/Eccube/Twig/Template.php
@@ -47,7 +47,7 @@ class Template extends \Twig\Template
     public function getTemplateName()
     {
         // Templateのキャッシュ作成時に動的に作成されるメソッド
-        // デバッグツールバーでエラーが発生するためから文字を返しておく。
+        // デバッグツールバーでエラーが発生するため空文字を返しておく。
         // @see https://github.com/EC-CUBE/ec-cube/issues/4529
         return '';
     }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

close #4529
close #4520

`Template` クラスから `abstract` をとって必要なメソッドを足した。

#4362 のPRで `base_template_class` オプションを設定しているが、非推奨となっている。
`base_template_class` がデバッグがサポートされていないことが根本的な問題かと思われるが、私の能力ではそこまで読み解けなかった。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容

エラー解消を優先。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

`Template` クラスはTwigから作成されるキャッシュの基底クラスとなる。
`getTemplateName`, `getDebugInfo`, `doDisplay` メソッドは `\Twig\Template` を `abstract` なしで継承しているためやむを得なく追加した。
これらのメソッドはキャッシュ作成時に動的に生成されるため、本来ここで実装する必要はない。
また実装しても通常実行時には影響を受けないはずである。

利用している `base_template_class` オプションが非推奨のためか、デバッグモードで `Template` クラスをインスタンス化している。
コードを追ったが、該当箇所は見つけられず。

この時 `getTemplateName` 内で何らかの文字列を返さないとエラーとなったので、空文字を返すようにした。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

なし（プロダクトモードでは発生しない）

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

今回の修正で、デバッグモードのエラーの解消のためにプロダクトに本来不要なコードが入ることになることが悩ましい。
上記に問題がある場合は #4362 の取り込み自体を見直しも必要か。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
