### PR TITLE
大きなサイズのCSVを扱えるようタイムアウトを延長

### DIFF
--- a/src/Eccube/Doctrine/Common/CsvDataFixtures/CsvFixture.php
+++ b/src/Eccube/Doctrine/Common/CsvDataFixtures/CsvFixture.php
@@ -82,6 +82,12 @@ class CsvFixture implements FixtureInterface
             // batch insert
             $result = $prepare->execute();
             $this->file->next();
+            // 大きなサイズのCSVを扱えるようタイムアウトを延長する
+            $seconds
+                = is_numeric(ini_get('max_execution_time'))
+                ? intval(ini_get('max_execution_time'))
+                : intval(get_cfg_var('max_execution_time'));
+            set_time_limit($seconds);
         }
         $Connection->commit();
 


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
`src/Eccube/Resource/doctrine/import_csv` 以下に、独自の初期化用CSV ファイルを配置することで、インストール時のデータを独自にカスタマイズ可能。
また、効率的にデータインポート可能なので、 `memory_limit` を越えたサイズの CSV ファイルも扱うことができる。

しかし大きなサイズの CSV ファイルを登録すると `max_execution_time` に抵触し、システムエラーになってしまう

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

`set_time_limit()` 関数でタイムアウトを延長する。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
2系で実装されている、以下のコードを流用
https://github.com/EC-CUBE/ec-cube2/blob/4929cf1d0e4ab0b76cd4b3201998e72eeca2ccfb/data/class/util/SC_Utils.php#L1840-L1864

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

3,145,724行の mtb_country.csv を作成し、 `memory_limit=128M` の環境でインストール完了することを確認

```shell
ls -al | grep mtb_country
.rw-r--r--  128M nanasess  8 6 19:36  mtb_country.csv
wc -l mtb_country.csv
 3145725 mtb_country.csv
```

```sql
select count(*) from mtb_country;
+----------+
| count(*) |
+----------+
| 3145724  |
+----------+
```

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
