### PR TITLE
GitHub Actions でE2Eテストがエラーになる対策

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -196,7 +196,7 @@ jobs:
         DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
         MAILER_URL: 'smtp://localhost:1025'
         ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
-      run: php -S localhost:8000 &
+      run: php -dsession.save_path=${GITHUB_WORKSPACE}/var/sessions/${APP_ENV} -S localhost:8000 &
 
     - name: Codeception
       env:
@@ -320,7 +320,7 @@ jobs:
         DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
         MAILER_URL: 'smtp://localhost:1025'
         ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
-      run: php -S localhost:8000 &
+      run: php -dsession.save_path=${GITHUB_WORKSPACE}/var/sessions/${APP_ENV} -S localhost:8000 &
 
     ## ${PWD}/repos does not exist so service cannot be started
     - name: Run package-api
@@ -449,7 +449,7 @@ jobs:
         DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
         MAILER_URL: 'smtp://localhost:1025'
         ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
-      run: php -S localhost:8000 &
+      run: php -dsession.save_path=${GITHUB_WORKSPACE}/var/sessions/${APP_ENV} -S localhost:8000 &
 
     ## ${PWD}/repos does not exist so service cannot be started
     - name: Run package-api
@@ -578,7 +578,7 @@ jobs:
         DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
         MAILER_URL: 'smtp://localhost:1025'
         ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
-      run: php -S localhost:8000 &
+      run: php -dsession.save_path=${GITHUB_WORKSPACE}/var/sessions/${APP_ENV} -S localhost:8000 &
 
     ## ${PWD}/repos does not exist so service cannot be started
     - name: Run package-api
@@ -709,7 +709,7 @@ jobs:
         DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
         MAILER_URL: 'smtp://localhost:1025'
         ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
-      run: php -S localhost:8000 &
+      run: php -dsession.save_path=${GITHUB_WORKSPACE}/var/sessions/${APP_ENV} -S localhost:8000 &
 
     ## ${PWD}/repos does not exist so service cannot be started
     - name: Run package-api

--- a/tests/Eccube/Tests/Session/Storage/Handler/SameSiteNoneCompatSessionHandlerTest.php
+++ b/tests/Eccube/Tests/Session/Storage/Handler/SameSiteNoneCompatSessionHandlerTest.php
@@ -102,12 +102,14 @@ class SameSiteNoneCompatSessionHandlerTest extends TestCase
                 continue;
             }
             if ($name == 'regenerate') {
-                // XXX PHP7.4.5, 7.4.6, 7.3.17, 7.3.18 のバグでエラーになるためスキップ
+                // XXX PHP7.4.5-7.4.7, 7.3.17-7.3.19 のバグでエラーになるためスキップ
                 // see https://github.com/symfony/symfony/pull/36485#issuecomment-615928699
                 if (PHP_VERSION_ID === 70405) continue;
                 if (PHP_VERSION_ID === 70406) continue;
+                if (PHP_VERSION_ID === 70407) continue;
                 if (PHP_VERSION_ID === 70317) continue;
                 if (PHP_VERSION_ID === 70318) continue;
+                if (PHP_VERSION_ID === 70319) continue;
             }
             foreach ($userAgents as $user_agent => $shouldSendSameSiteNone) {
                 yield [$name, $user_agent, $shouldSendSameSiteNone];


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
- #4541 
- E2Eテスト実行時、エラーになる問題の対策

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- ローカルWebサーバー起動時に session.save_path を明示的に指定

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
- Symfony によって session.save_path が設定される前に GC が実行される模様


## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
Github Actions でエラーにならないのを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
