### PR TITLE
Revert "GitHub Actions でE2Eテストがエラーになる対策"

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -196,7 +196,7 @@ jobs:
         DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
         MAILER_URL: 'smtp://localhost:1025'
         ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
-      run: php -dsession.save_path=${GITHUB_WORKSPACE}/var/sessions/${APP_ENV} -S localhost:8000 &
+      run: php -S localhost:8000 &
 
     - name: Codeception
       env:
@@ -320,7 +320,7 @@ jobs:
         DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
         MAILER_URL: 'smtp://localhost:1025'
         ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
-      run: php -dsession.save_path=${GITHUB_WORKSPACE}/var/sessions/${APP_ENV} -S localhost:8000 &
+      run: php -S localhost:8000 &
 
     ## ${PWD}/repos does not exist so service cannot be started
     - name: Run package-api
@@ -449,7 +449,7 @@ jobs:
         DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
         MAILER_URL: 'smtp://localhost:1025'
         ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
-      run: php -dsession.save_path=${GITHUB_WORKSPACE}/var/sessions/${APP_ENV} -S localhost:8000 &
+      run: php -S localhost:8000 &
 
     ## ${PWD}/repos does not exist so service cannot be started
     - name: Run package-api
@@ -578,7 +578,7 @@ jobs:
         DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
         MAILER_URL: 'smtp://localhost:1025'
         ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
-      run: php -dsession.save_path=${GITHUB_WORKSPACE}/var/sessions/${APP_ENV} -S localhost:8000 &
+      run: php -S localhost:8000 &
 
     ## ${PWD}/repos does not exist so service cannot be started
     - name: Run package-api
@@ -709,7 +709,7 @@ jobs:
         DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
         MAILER_URL: 'smtp://localhost:1025'
         ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
-      run: php -dsession.save_path=${GITHUB_WORKSPACE}/var/sessions/${APP_ENV} -S localhost:8000 &
+      run: php -S localhost:8000 &
 
     ## ${PWD}/repos does not exist so service cannot be started
     - name: Run package-api

--- a/tests/Eccube/Tests/Session/Storage/Handler/SameSiteNoneCompatSessionHandlerTest.php
+++ b/tests/Eccube/Tests/Session/Storage/Handler/SameSiteNoneCompatSessionHandlerTest.php
@@ -102,14 +102,12 @@ class SameSiteNoneCompatSessionHandlerTest extends TestCase
                 continue;
             }
             if ($name == 'regenerate') {
-                // XXX PHP7.4.5-7.4.7, 7.3.17-7.3.19 のバグでエラーになるためスキップ
+                // XXX PHP7.4.5, 7.4.6, 7.3.17, 7.3.18 のバグでエラーになるためスキップ
                 // see https://github.com/symfony/symfony/pull/36485#issuecomment-615928699
                 if (PHP_VERSION_ID === 70405) continue;
                 if (PHP_VERSION_ID === 70406) continue;
-                if (PHP_VERSION_ID === 70407) continue;
                 if (PHP_VERSION_ID === 70317) continue;
                 if (PHP_VERSION_ID === 70318) continue;
-                if (PHP_VERSION_ID === 70319) continue;
             }
             foreach ($userAgents as $user_agent => $shouldSendSameSiteNone) {
                 yield [$name, $user_agent, $shouldSendSameSiteNone];


### PR DESCRIPTION
Reverts EC-CUBE/ec-cube#4569

#4572 でセッションの挙動が修正されたのでこちらの修正は不要になったかと思います。

以下のファイルは別途修正が必要
tests/Eccube/Tests/Session/Storage/Handler/SameSiteNoneCompatSessionHandlerTest.php