### PR TITLE
複数配送時に在庫数が減らない不具合を修正

### DIFF
--- a/src/Eccube/Service/PurchaseFlow/Processor/StockReduceProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/StockReduceProcessor.php
@@ -84,7 +84,7 @@ class StockReduceProcessor extends AbstractPurchaseProcessor
                 // 在庫チェックあり
                 /* @var ProductStock $productStock */
                 $productStock = $item->getProductClass()->getProductStock();
-                if($productStock->getProductClassId() === null){
+                if ($productStock->getProductClassId() === null) {
                     // 在庫に対してロックを実行
                     $this->entityManager->lock($productStock, LockMode::PESSIMISTIC_WRITE);
                     $this->entityManager->refresh($productStock);

--- a/src/Eccube/Service/PurchaseFlow/Processor/StockReduceProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/StockReduceProcessor.php
@@ -84,9 +84,12 @@ class StockReduceProcessor extends AbstractPurchaseProcessor
                 // 在庫チェックあり
                 /* @var ProductStock $productStock */
                 $productStock = $item->getProductClass()->getProductStock();
-                // 在庫に対してロックを実行
-                $this->entityManager->lock($productStock, LockMode::PESSIMISTIC_WRITE);
-                $this->entityManager->refresh($productStock);
+                if($productStock->getProductClassId() === null){
+                    // 在庫に対してロックを実行
+                    $this->entityManager->lock($productStock, LockMode::PESSIMISTIC_WRITE);
+                    $this->entityManager->refresh($productStock);
+                    $productStock->setProductClassId($item->getProductClass()->getId());
+                }
                 $ProductClass = $item->getProductClass();
                 $stock = $callback($productStock->getStock(), $item->getQuantity());
                 if ($stock < 0) {


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
#4578

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
複数配送の場合、同じProductClassのOrderItemが複数出来上がる場合があるので、2度目以降の在庫計算の際にrefreshで在庫数の計算が無かった事になってます。
lockとrefreshを一度だけ行うようにしています。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
ProductStockのEntity「private $product_class_id」は使用されてる箇所が無いかと思います。
このproduct_class_idを利用して２度目以降のProductClassが同じだった場合を判別してます。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
product_class_id使わず、チェック用の配列用意でも良かったような。
スマートな方法が知りたいです。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
