### PR TITLE
PHP7.4.8, 7.3.20 もバグでエラーになるためテストをスキップ

### DIFF
--- a/tests/Eccube/Tests/Session/Storage/Handler/SameSiteNoneCompatSessionHandlerTest.php
+++ b/tests/Eccube/Tests/Session/Storage/Handler/SameSiteNoneCompatSessionHandlerTest.php
@@ -102,14 +102,16 @@ class SameSiteNoneCompatSessionHandlerTest extends TestCase
                 continue;
             }
             if ($name == 'regenerate') {
-                // XXX PHP7.4.5-7.4.7, 7.3.17-7.3.19 のバグでエラーになるためスキップ
+                // XXX PHP7.4.5-7.4.8, 7.3.17-7.3.20 のバグでエラーになるためスキップ
                 // see https://github.com/symfony/symfony/pull/36485#issuecomment-615928699
                 if (PHP_VERSION_ID === 70405) continue;
                 if (PHP_VERSION_ID === 70406) continue;
                 if (PHP_VERSION_ID === 70407) continue;
+                if (PHP_VERSION_ID === 70408) continue;
                 if (PHP_VERSION_ID === 70317) continue;
                 if (PHP_VERSION_ID === 70318) continue;
                 if (PHP_VERSION_ID === 70319) continue;
+                if (PHP_VERSION_ID === 70320) continue;
             }
             foreach ($userAgents as $user_agent => $shouldSendSameSiteNone) {
                 yield [$name, $user_agent, $shouldSendSameSiteNone];


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

PHP7.4.8, 7.3.20 もバグでエラーになるためテストをスキップ。
はたしてこちらは修正されるのか。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
