### PR TITLE
レイアウト削除失敗時のメッセージを適切に変更

### DIFF
--- a/src/Eccube/Controller/Admin/Content/LayoutController.php
+++ b/src/Eccube/Controller/Admin/Content/LayoutController.php
@@ -131,7 +131,7 @@ class LayoutController extends AbstractController
 
         /** @var Layout $Layout */
         if (!$Layout->isDeletable()) {
-            $this->deleteMessage();
+            $this->addError(trans('admin.common.delete_error_foreign_key', ['%name%' => $Layout->getName()]), 'admin');
 
             return $this->redirectToRoute('admin_content_layout');
         }

--- a/src/Eccube/Controller/Admin/Content/LayoutController.php
+++ b/src/Eccube/Controller/Admin/Content/LayoutController.php
@@ -131,7 +131,7 @@ class LayoutController extends AbstractController
 
         /** @var Layout $Layout */
         if (!$Layout->isDeletable()) {
-            $this->addError(trans('admin.common.delete_error_foreign_key', ['%name%' => $Layout->getName()]), 'admin');
+            $this->addWarning(trans('admin.common.delete_error_foreign_key', ['%name%' => $Layout->getName()]), 'admin');
 
             return $this->redirectToRoute('admin_content_layout');
         }

--- a/tests/Eccube/Tests/Web/Admin/Content/LayoutControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/LayoutControllerTest.php
@@ -207,6 +207,6 @@ class LayoutControllerTest extends AbstractAdminWebTestCase
             $this->generateUrl('admin_content_layout_delete', ['id' => $Layout->getId()])
         );
         $crawler = $this->client->followRedirect();
-        $this->assertRegExp('/既に削除されています/u', $crawler->filter('div.alert-warning')->text());
+        $this->assertRegExp('/削除できませんでした/u', $crawler->filter('div.alert-warning')->text());
     }
 }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

`関連するデータがあるため「{{ レイアウト名 }}」を削除できませんでした` のメッセージに変更しました。

close #4558

![image](https://user-images.githubusercontent.com/16895409/85844050-166b2f00-b7dd-11ea-99e8-8d207e5647c1.png)

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

ローカルで #4558 の手順で確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
