### PR TITLE
docker buildでエラーが出るので対処

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,10 +71,10 @@ USER www-data
 RUN composer install \
   --no-scripts \
   --no-autoloader \
-  --no-dev -d ${APACHE_DOCUMENT_ROOT} \
+  -d ${APACHE_DOCUMENT_ROOT} \
   ;
 
-RUN composer dumpautoload -o --apcu --no-dev
+RUN composer dumpautoload -o --apcu
 
 RUN if [ ! -f ${APACHE_DOCUMENT_ROOT}/.env ]; then \
         cp -p .env.dist .env \


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

docker buildでエラーが出るので Dockerfile内の --no-dev オプションを削除する
#4606 

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)

修正後、docker build でエラーが出ないこと、そのままインストールを続けてブラウザからアクセスし、TOP画面が表示されるところまで確認しました。

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
