### PR TITLE
API: 管理画面でのOAuth2クライアント登録/削除機能の実装

### DIFF
--- a/app/config/eccube/packages/eccube_nav.yaml
+++ b/app/config/eccube/packages/eccube_nav.yaml
@@ -130,6 +130,9 @@ parameters:
                         masterdata:
                             name: admin.setting.system.master_data_management
                             url: admin_setting_system_masterdata
+                        oauth:
+                            name: admin.setting.system.oauth_management
+                            url: admin_setting_system_oauth
                         system_index:
                             name: admin.setting.system.system_info
                             url: admin_setting_system_system

--- a/src/Eccube/Controller/Admin/Setting/System/OAuth2ClientController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/OAuth2ClientController.php
@@ -1,0 +1,240 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Controller\Admin\Setting\System;
+
+use Eccube\Controller\AbstractController;
+use Eccube\Form\Type\Admin\ClientType;
+use Exception;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
+use Trikoder\Bundle\OAuth2Bundle\Manager\ClientFilter;
+use Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface;
+use Trikoder\Bundle\OAuth2Bundle\Manager\RefreshTokenManagerInterface;
+use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
+use Trikoder\Bundle\OAuth2Bundle\Model\Client;
+use Trikoder\Bundle\OAuth2Bundle\Model\Grant;
+use Trikoder\Bundle\OAuth2Bundle\Model\RedirectUri;
+use Trikoder\Bundle\OAuth2Bundle\Model\Scope;
+
+class OAuth2ClientController extends AbstractController
+{
+    /**
+     * @var ClientManagerInterface
+     */
+    private $clientManager;
+    /**
+     * @var AccessTokenManagerInterface
+     */
+    private $accessTokenManager;
+    /**
+     * @var RefreshTokenManagerInterface
+     */
+    private $refreshTokenManager;
+
+    /**
+     * OAuthController constructor.
+     *
+     * @param ClientManagerInterface $clientManager
+     * @param AccessTokenManagerInterface $accessTokenManager
+     * @param RefreshTokenManagerInterface $refreshTokenManager
+     */
+    public function __construct(
+        ClientManagerInterface $clientManager,
+        AccessTokenManagerInterface $accessTokenManager,
+        RefreshTokenManagerInterface $refreshTokenManager
+    ) {
+        $this->clientManager = $clientManager;
+        $this->accessTokenManager = $accessTokenManager;
+        $this->refreshTokenManager = $refreshTokenManager;
+    }
+
+    /**
+     * @Route("/%eccube_admin_route%/setting/system/oauth", name="admin_setting_system_oauth")
+     * @Template("@admin/Setting/System/oauth.twig")
+     *
+     * @param Request $request
+     *
+     * @return array
+     */
+    public function index(Request $request)
+    {
+        $criteria = ClientFilter::create();
+        $clients = $this->clientManager->list($criteria);
+
+        return [
+            'clients' => $clients,
+        ];
+    }
+
+    /**
+     * @Route("/%eccube_admin_route%/setting/system/oauth/create_client", name="admin_setting_oauth_create_client")
+     * @Template("@admin/Setting/System/oauth_edit.twig")
+     *
+     * @param Request $request
+     *
+     * @return array|RedirectResponse
+     *
+     * @throws Exception
+     */
+    public function create(Request $request)
+    {
+        $builder = $this->formFactory
+            ->createBuilder(ClientType::class);
+
+        $form = $builder->getForm();
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $identifier = $form->get('identifier')->getData();
+            $secret = $form->get('secret')->getData();
+
+            try {
+                $client = new Client($identifier, $secret);
+                $client = $this->updateClientFromForm($client, $form);
+
+                $this->clientManager->save($client);
+
+                $this->addSuccess('admin.common.save_complete', 'admin');
+
+                return $this->redirectToRoute('admin_setting_system_oauth');
+            } catch (Exception $e) {
+                $this->addError(trans('admin.common.save_error'), 'admin');
+                log_error('OAuth2 Client 登録エラー', [$e->getMessage()]);
+            }
+        }
+
+        return [
+            'form' => $form->createView(),
+        ];
+    }
+
+    /**
+     * @Route(
+     *     "/%eccube_admin_route%/setting/system/oauth/delete_client/{identifier}",
+     *     requirements={"identifier" = "\w+"},
+     *     name="admin_setting_oauth_delete_client",
+     *     methods={"DELETE"}
+     * )
+     *
+     * @param Request $request
+     * @param string $identifier
+     *
+     * @return RedirectResponse
+     */
+    public function delete(Request $request, string $identifier)
+    {
+        $client = $this->clientManager->find($identifier);
+        if (null === $client) {
+            $this->addError('admin.common.delete_error_already_deleted', 'admin');
+
+            return $this->redirectToRoute('admin_setting_system_oauth');
+        }
+
+        try {
+            $this->deleteAuthorizationCode($client);
+            $this->clientManager->remove($client);
+
+            $this->addSuccess('admin.common.delete_complete', 'admin');
+        } catch (Exception $e) {
+            $this->addError('admin.common.delete_error', 'admin');
+
+            log_error('OAuth2 Client 削除エラー', [$e->getMessage()]);
+        }
+
+        return $this->redirectToRoute('admin_setting_system_oauth');
+    }
+
+    /**
+     * @Route(
+     *     "/%eccube_admin_route%/setting/system/oauth/clear_expired_tokens",
+     *     name="admin_setting_oauth_clear_expired_tokens",
+     *     methods={"DELETE"}
+     * )
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    public function clearExpiredTokens(Request $request)
+    {
+        try {
+            $this->accessTokenManager->clearExpired();
+            $this->refreshTokenManager->clearExpired();
+
+            $this->addSuccess('admin.common.delete_complete', 'admin');
+        } catch (Exception $e) {
+            $this->addError(trans('admin.common.delete_error'), 'admin');
+            log_error('OAuth2 Token 削除エラー', [$e->getMessage()]);
+        }
+
+        return $this->redirectToRoute('admin_setting_system_oauth');
+    }
+
+    /**
+     * @param Client $client
+     * @param FormInterface $form
+     *
+     * @return Client
+     */
+    private function updateClientFromForm(Client $client, FormInterface $form): Client
+    {
+        $client->setActive(true);
+
+        $redirectUris = array_map(
+            function (string $redirectUri): RedirectUri {
+                return new RedirectUri($redirectUri);
+            },
+            explode(',', $form->get('redirect_uris')->getData())
+        );
+        $client->setRedirectUris(...$redirectUris);
+
+        $grants = array_map(
+            function (string $grant): Grant {
+                return new Grant($grant);
+            },
+            explode(',', $form->get('grants')->getData())
+        );
+        $client->setGrants(...$grants);
+
+        $scopes = array_map(
+            function (string $scope): Scope {
+                return new Scope($scope);
+            },
+            explode(',', $form->get('scopes')->getData())
+        );
+        $client->setScopes(...$scopes);
+
+        return $client;
+    }
+
+    /**
+     * AuthorizationCode が保存されている場合は削除
+     *
+     * @param Client $client
+     * @return int
+     */
+    private function deleteAuthorizationCode(Client $client)
+    {
+        return $this->entityManager->createQueryBuilder()
+            ->delete(AuthorizationCode::class, 'ac')
+            ->where('ac.client < :client')
+            ->setParameter('client', $client)
+            ->getQuery()
+            ->execute();
+    }
+}

--- a/src/Eccube/Form/Type/Admin/ClientType.php
+++ b/src/Eccube/Form/Type/Admin/ClientType.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Form\Type\Admin;
+
+use Eccube\Common\EccubeConfig;
+use Exception;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class ClientType extends AbstractType
+{
+    /**
+     * @var EccubeConfig
+     */
+    protected $eccubeConfig;
+
+    /**
+     * ClientType constructor.
+     *
+     * @param EccubeConfig $eccubeConfig
+     */
+    public function __construct(
+        EccubeConfig $eccubeConfig
+    ) {
+        $this->eccubeConfig = $eccubeConfig;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws Exception
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('identifier', TextType::class, [
+                'mapped' => false,
+                'data' => hash('md5', random_bytes(16)),
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Length(['max' => 32]),
+                    new Assert\Regex(['pattern' => '/^[0-9a-zA-Z]+$/']),
+                ],
+            ])
+            ->add('secret', TextType::class, [
+                'mapped' => false,
+                'data' => hash('sha512', random_bytes(32)),
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Length(['max' => 128]),
+                    new Assert\Regex(['pattern' => '/^[0-9a-zA-Z]+$/']),
+                ],
+            ])
+            ->add('scopes', TextType::class, [
+                'mapped' => false,
+                'data' => 'read',
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                ],
+            ])
+            ->add('redirect_uris', TextType::class, [
+                'mapped' => false,
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Url(),
+                ],
+            ])
+            ->add('grants', TextType::class, [
+                'mapped' => false,
+                'data' => 'authorization_code',
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                ],
+            ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'admin_client';
+    }
+}

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -1062,6 +1062,7 @@ admin.setting.system.authority_management: Permission
 admin.setting.system.security_management: Security
 admin.setting.system.log_display: Logs
 admin.setting.system.master_data_management: Master Data
+admin.setting.system.oauth_management: OAuth
 admin.setting.system.system_info: System Info
 
 #------------------------------------------------------------------------------------
@@ -1244,6 +1245,20 @@ admin.setting.system.master_data.description: |
 admin.setting.system.master_data.id: ID
 admin.setting.system.master_data.name: Name
 admin.setting.system.master_data.duplicate_id: You are not allowed to register duplicated IDs.
+
+#------------------------------------------------------------------------------------
+# Settings : System : OAuth
+#------------------------------------------------------------------------------------
+
+admin.setting.system.oauth.identifier: Client ID
+admin.setting.system.oauth.secret: Client Secret
+admin.setting.system.oauth.scope: Scope
+admin.setting.system.oauth.redirect_uri: Redirect URI
+admin.setting.system.oauth.grant_type: Grant Type
+admin.setting.system.oauth.client_registration: Client Registration
+admin.setting.system.oauth.delete__confirm_title: Delete a Client
+admin.setting.system.oauth.delete__confirm_message: Are you sure to delete this Client?
+admin.setting.system.oauth.clear_expired_tokens: Clears all expired access and/or refresh tokens
 
 #------------------------------------------------------------------------------------
 # Settings : System : System Info

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -1062,6 +1062,7 @@ admin.setting.system.authority_management: 権限管理
 admin.setting.system.security_management: セキュリティ管理
 admin.setting.system.log_display: ログ表示
 admin.setting.system.master_data_management: マスタデータ管理
+admin.setting.system.oauth_management: OAuth管理
 admin.setting.system.system_info: システム情報
 
 #------------------------------------------------------------------------------------
@@ -1244,6 +1245,20 @@ admin.setting.system.master_data.description: |
 admin.setting.system.master_data.id: ID
 admin.setting.system.master_data.name: Name
 admin.setting.system.master_data.duplicate_id: 重複したIDを登録することはできません。
+
+#------------------------------------------------------------------------------------
+# 設定：システム設定：OAuth管理
+#------------------------------------------------------------------------------------
+
+admin.setting.system.oauth.identifier: クライアントID
+admin.setting.system.oauth.secret: クライアントシークレット
+admin.setting.system.oauth.scope: スコープ
+admin.setting.system.oauth.redirect_uri: リダイレクトURI
+admin.setting.system.oauth.grant_type: グラントタイプ
+admin.setting.system.oauth.client_registration: OAuthクライアント登録
+admin.setting.system.oauth.delete__confirm_title: OAuthクライアントを削除します。
+admin.setting.system.oauth.delete__confirm_message: OAuthクライアントを削除してよろしいですか？
+admin.setting.system.oauth.clear_expired_tokens: 期限切れのアクセストークンとリフレッシュトークンを削除する
 
 #------------------------------------------------------------------------------------
 # 設定：システム設定：システム情報

--- a/src/Eccube/Resource/template/admin/Setting/System/oauth.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/oauth.twig
@@ -1,0 +1,127 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+
+http://www.ec-cube.co.jp/
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+#}
+{% extends '@admin/default_frame.twig' %}
+
+{% set menus = ['setting', 'system', 'oauth'] %}
+
+{% block title %}{{ 'admin.setting.system.oauth_management'|trans }}{% endblock %}
+{% block sub_title %}{{ 'admin.setting.system'|trans }}{% endblock %}
+
+{% block main %}
+    <div class="c-contentsArea__cols">
+        <div class="c-contentsArea__primaryCol">
+            <div class="c-primaryCol">
+                <div id="create-client" class="d-block mb-3">
+                    <a class="btn btn-ec-regular" href="{{ url('admin_setting_oauth_create_client') }}">{{ 'admin.common.registration__new'|trans }}</a>
+                </div>
+                <div class="card rounded border-0 mb-4">
+                    <div class="card-body p-0">
+                        <table class="table table-sm" style="table-layout:fixed;">
+                            <thead>
+                                <tr>
+                                    <th class="border-top-0 pt-2 pb-2 text-center" style="width:300px;">
+                                        {{ 'admin.setting.system.oauth.identifier'|trans }}
+                                    </th>
+                                    <th class="border-top-0 pt-2 pb-2 text-center" style="width:400px;">
+                                        {{ 'admin.setting.system.oauth.secret'|trans }}
+                                    </th>
+                                    <th class="border-top-0 pt-2 pb-2 text-center">
+                                        {{ 'admin.setting.system.oauth.scope'|trans }}
+                                    </th>
+                                    <th class="border-top-0 pt-2 pb-2 text-center">
+                                        {{ 'admin.setting.system.oauth.redirect_uri'|trans }}
+                                    </th>
+                                    <th class="border-top-0 pt-2 pb-2 text-center">
+                                        {{ 'admin.setting.system.oauth.grant_type'|trans }}
+                                    </th>
+                                    <th class="border-top-0 pt-2 pb-2 text-center"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for client in clients %}
+                                    <tr id="client-{{ client.identifier }}">
+                                        <td class="align-middle text-center pl-3">
+                                            {{ client.identifier }}
+                                        </td>
+                                        <td class="align-middle text-center">
+                                            {{ client.Secret }}
+                                        </td>
+                                        <td class="align-middle text-center pl-3">
+                                            {% for Scope in client.scopes %}
+                                                {{ Scope }}<br>
+                                            {% endfor %}
+                                        </td>
+                                        <td class="align-middle text-center">
+                                            {% for RedirectUri in client.redirectUris %}
+                                                {{ RedirectUri }}<br>
+                                            {% endfor %}
+                                        </td>
+                                        <td class="align-middle text-center pl-3">
+                                            {% for Grant in client.grants %}
+                                                {{ Grant }}<br>
+                                            {% endfor %}
+                                        </td>
+                                        <td class="align-middle pr-3">
+                                            <div class="text-right">
+                                                <div class="px-1 d-inline-block">
+                                                    <div class="d-inline-block mr-2" data-tooltip="true"
+                                                         data-placement="top" title="{{ 'admin.common.delete'|trans }}">
+                                                        <a class="btn btn-ec-actionIcon action-delete" data-toggle="modal"
+                                                           data-target="#oauth_delete_{{ client.identifier }}">
+                                                            <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
+                                                        </a>
+                                                    </div>
+                                                    <div class="modal fade" id="oauth_delete_{{ client.identifier }}" tabindex="-1"
+                                                         role="dialog" aria-labelledby="oauth_delete_{{ client.identifier }}" aria-hidden="true">
+                                                        <div class="modal-dialog" role="document">
+                                                            <div class="modal-content">
+                                                                <div class="modal-header">
+                                                                    <h5 class="modal-title font-weight-bold">
+                                                                        {{ 'admin.setting.system.oauth.delete__confirm_title'|trans }}
+                                                                    </h5>
+                                                                    <button class="close" type="button" data-dismiss="modal" aria-label="Close">
+                                                                        <span aria-hidden="true">×</span>
+                                                                    </button>
+                                                                </div>
+                                                                <div class="modal-body text-left">
+                                                                    <p class="text-left">{{ 'admin.setting.system.oauth.delete__confirm_message'|trans }}</p>
+                                                                </div>
+                                                                <div class="modal-footer">
+                                                                    <button class="btn btn-ec-sub" type="button" data-dismiss="modal">
+                                                                        {{ 'admin.common.cancel'|trans }}
+                                                                    </button>
+                                                                    <a class="btn btn-ec-delete" href="{{ url('admin_setting_oauth_delete_client', {identifier: client.identifier}) }}"
+                                                                            {{ csrf_token_for_anchor() }} data-method="delete" data-confirm="false">
+                                                                        {{ 'admin.common.delete'|trans }}
+                                                                    </a>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="card rounded border-0 mb-4">
+                    <a class="btn btn-ec-conversion ladda-button" href="{{ url('admin_setting_oauth_clear_expired_tokens') }}"
+                            {{ csrf_token_for_anchor() }} data-method="delete" data-confirm="false">
+                        {{ 'admin.setting.system.oauth.clear_expired_tokens'|trans }}
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Eccube/Resource/template/admin/Setting/System/oauth_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/oauth_edit.twig
@@ -1,0 +1,147 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+
+http://www.ec-cube.co.jp/
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+#}
+{% extends '@admin/default_frame.twig' %}
+
+{% set menus = ['setting', 'system', 'oauth'] %}
+
+{% block title %}{{ 'admin.setting.system.oauth.client_registration'|trans }}{% endblock %}
+{% block sub_title %}{{ 'admin.setting.system'|trans }}{% endblock %}
+
+{% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
+
+{% block main %}
+    <form name="client_form" role="form" id="client_form" method="post" action="" novalidate>
+        {{ form_widget(form._token) }}
+        <div class="c-contentsArea__cols">
+            <div class="c-contentsArea__primaryCol">
+                <div class="c-primaryCol">
+                    <div class="card rounded border-0 mb-4">
+                        <div class="card-header">
+                            <div class="row">
+                                <div class="col-8">
+                                    <span class="card-title">{{ 'admin.setting.system.oauth.client_registration'|trans }}</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="collapse show ec-cardCollapse" id="clientInfo">
+                            <div class="card-body">
+
+                                {# identifier #}
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <span>{{ 'admin.setting.system.oauth.identifier'|trans }}</span>
+                                        <span class="badge badge-primary ml-1">{{ 'admin.common.required'|trans }}</span>
+                                    </div>
+                                    <div class="col">
+                                        <div class="row">
+                                            <div class="col">
+                                                {{ form_widget(form.identifier) }}
+                                            </div>
+                                            {{ form_errors(form.identifier) }}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                {# secret #}
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <span>{{ 'admin.setting.system.oauth.secret'|trans }}</span>
+                                        <span class="badge badge-primary ml-1">{{ 'admin.common.required'|trans }}</span>
+                                    </div>
+                                    <div class="col">
+                                        <div class="row">
+                                            <div class="col">
+                                                {{ form_widget(form.secret) }}
+                                            </div>
+                                            {{ form_errors(form.secret) }}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                {# scope #}
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <span>{{ 'admin.setting.system.oauth.scope'|trans }}</span>
+                                        <span class="badge badge-primary ml-1">{{ 'admin.common.required'|trans }}</span>
+                                    </div>
+                                    <div class="col">
+                                        <div class="row">
+                                            <div class="col">
+                                                {{ form_widget(form.scopes, {'attr': { 'readonly': 'readonly' } }) }}
+                                            </div>
+                                            {{ form_errors(form.scopes) }}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                {# redirect_uri #}
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <span>{{ 'admin.setting.system.oauth.redirect_uri'|trans }}</span>
+                                        <span class="badge badge-primary ml-1">{{ 'admin.common.required'|trans }}</span>
+                                    </div>
+                                    <div class="col">
+                                        <div class="row">
+                                            <div class="col">
+                                                {{ form_widget(form.redirect_uris) }}
+                                            </div>
+                                            {{ form_errors(form.redirect_uris) }}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                {# grant_type #}
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <span>{{ 'admin.setting.system.oauth.grant_type'|trans }}</span>
+                                        <span class="badge badge-primary ml-1">{{ 'admin.common.required'|trans }}</span>
+                                    </div>
+                                    <div class="col">
+                                        <div class="row">
+                                            <div class="col">
+                                                {{ form_widget(form.grants, {'attr': { 'readonly': 'readonly' } }) }}
+                                            </div>
+                                            {{ form_errors(form.grants) }}
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="c-conversionArea">
+            <div class="c-conversionArea__container">
+                <div class="row justify-content-between align-items-center">
+                    <div class="col-6">
+                        <div class="c-conversionArea__leftBlockItem">
+                            <a class="c-baseLink"
+                               href="{{ url('admin_setting_system_oauth') }}">
+                                <i class="fa fa-backward" aria-hidden="true"></i>
+                                <span>{{ 'admin.setting.system.oauth_management'|trans }}</span>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="col-6">
+                        <div id="ex-conversion-action" class="row align-items-center justify-content-end">
+                            <div class="col-auto">
+                                <button class="btn btn-ec-conversion px-5" type="submit">
+                                    {{ 'admin.common.registration'|trans }}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+{% endblock %}

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/OAuth2ClientControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/OAuth2ClientControllerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Web\Admin\Setting\System;
+
+use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\ClientManager;
+use Trikoder\Bundle\OAuth2Bundle\Model\Client;
+
+class OAuth2ClientControllerTest extends AbstractAdminWebTestCase
+{
+    /**
+     * @var ClientManager
+     */
+    protected $clientManager;
+
+    /**
+     * @{@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->clientManager = $this->container->get(ClientManager::class);
+    }
+
+    public function testRoutingAdminSettingSystemOAuth2Client()
+    {
+        $this->client->request('GET', $this->generateUrl('admin_setting_system_oauth'));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+    }
+
+    public function testRoutingAdminSettingSystemOAuth2ClientCreate()
+    {
+        $this->client->request('GET', $this->generateUrl('admin_setting_oauth_create_client'));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+    }
+
+    public function testRoutingAdminSettingSystemOAuth2ClientDelete()
+    {
+        // before
+        $identifier = hash('md5', random_bytes(16));
+        $secret = hash('sha512', random_bytes(32));
+        $client = new Client($identifier, $secret);
+        $this->clientManager->save($client);
+
+        // main
+        $redirectUrl = $this->generateUrl('admin_setting_system_oauth');
+        $this->client->request('DELETE',
+            $this->generateUrl('admin_setting_oauth_delete_client', ['identifier' => $identifier])
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($redirectUrl));
+        $this->assertNull($this->clientManager->find($identifier));
+
+        $crawler = $this->client->followRedirect();
+        $this->assertRegExp('/削除しました/u', $crawler->filter('div.alert-success')->text());
+    }
+
+    public function testOAuth2ClientCreateSubmit()
+    {
+        // before
+        $formData = $this->createFormData();
+
+        // main
+        $this->client->request('POST',
+            $this->generateUrl('admin_setting_oauth_create_client'),
+            [
+                'admin_client' => $formData,
+            ]
+        );
+
+        $client = $this->clientManager->find($formData['identifier']);
+
+        $redirectUrl = $this->generateUrl('admin_setting_system_oauth');
+        $this->assertTrue($this->client->getResponse()->isRedirect($redirectUrl));
+
+        $this->actual = $client->getIdentifier();
+        $this->expected = $formData['identifier'];
+        $this->verify();
+
+        $crawler = $this->client->followRedirect();
+        $this->assertRegExp('/保存しました/u', $crawler->filter('div.alert-success')->text());
+    }
+
+    public function testOAuth2ClientCreateSubmitFail()
+    {
+        // before
+        $formData = $this->createFormData();
+        $formData['identifier'] = '';
+
+        // main
+        $crawler = $this->client->request('POST',
+            $this->generateUrl('admin_setting_oauth_create_client'),
+            [
+                'admin_client' => $formData,
+            ]
+        );
+
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $this->assertRegExp('/入力されていません。/u', $crawler->filter('span.form-error-message')->text());
+    }
+
+    public function testOAuth2ClientDeleteIdentifierNotFound()
+    {
+        // before
+        $identifier = hash('md5', random_bytes(16));
+
+        // main
+        $redirectUrl = $this->generateUrl('admin_setting_system_oauth');
+        $this->client->request('DELETE',
+            $this->generateUrl('admin_setting_oauth_delete_client', ['identifier' => $identifier])
+        );
+
+        $this->assertTrue($this->client->getResponse()->isRedirect($redirectUrl));
+
+        $crawler = $this->client->followRedirect();
+        $this->assertRegExp('/既に削除されています/u', $crawler->filter('div.alert-danger')->text());
+    }
+
+    protected function createFormData()
+    {
+        return [
+            '_token' => 'dummy',
+            'identifier' => hash('md5', random_bytes(16)),
+            'secret' => hash('sha512', random_bytes(32)),
+            'scopes' => 'read',
+            'redirect_uris' => 'http://127.0.0.1:8000/',
+            'grants' => 'authorization_code',
+        ];
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

refs https://github.com/EC-CUBE/eccube-api4/issues/2

管理画面で以下の機能を実装しました。
- [x] 登録済みのOAuth2クライアント一覧
- [x] OAuth2クライアント登録
- [x] OAuth2クライアント削除
- [x] 期限切れトークの削除機能

![image](https://user-images.githubusercontent.com/16895409/86545863-91b2aa80-bf6c-11ea-86e3-da6aca815406.png)

![image](https://user-images.githubusercontent.com/16895409/86546897-d55be300-bf71-11ea-80f1-634afcca1879.png)

## 方針(Policy)

refs https://github.com/EC-CUBE/eccube-api4/issues/2

まずは最低限の機能としてクライアントの追加と削除を実装する

クライアントの登録に関して
- クライアントID: 32桁のランダムな文字列を初期値とした
- クライアントシークレット: 128桁のランダムな文字列を初期値とした
- スコープ: 実質 `read` しかないので初期値として入力し、readonly属性を付与した
- リダイレクトURI: 連携サービスによるため初期値なし
- グラントタイプ: 実質 `authorization_code` しかないので初期値として入力し、readonly属性を付与した

## 実装に関する補足(Appendix)



## テスト（Test)

コントローラの簡単なUnitテストを追加

## 相談（Discussion）

クライアントテーブルにシーケンシャルなIDが存在しないためエラー発生時にクライアントIDをログに出しているところがあるが問題ないか。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
