### PR TITLE
管理画面の検索機能をDateTimeTypeに対応

### DIFF
--- a/src/Eccube/Form/Type/Admin/SearchCustomerType.php
+++ b/src/Eccube/Form/Type/Admin/SearchCustomerType.php
@@ -26,6 +26,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -249,22 +250,15 @@ class SearchCustomerType extends AbstractType
         // EC-CUBE 4.0.4 以前のバージョンで互換性を保つため
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $data = $event->getData();
+            $form = $event->getForm();
 
-            // チェック対象
-            $dates = [
-                'create_date_start',
-                'update_date_start',
-                'last_buy_start',
-                'create_date_end',
-                'update_date_end',
-                'last_buy_end',
-            ];
-
-            foreach ($dates as $date) {
-                if (isset($data[$date])) {
+            /** @var $child Form */
+            foreach ($form->all() as $child) {
+                // DateTimeType でデータが送られている場合はチェック
+                if ($child->getConfig()->getType()->getInnerType() instanceof DateTimeType && isset($data[$child->getName()])) {
                     // 日時が yyyy-MM-dd で指定されて入れば末尾に 00:00 を追加
-                    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $data[$date])) {
-                        $data[$date] .= ' 00:00';
+                    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $data[$child->getName()])) {
+                        $data[$child->getName()] .= ' 00:00';
                     }
                 }
             }

--- a/src/Eccube/Form/Type/Admin/SearchCustomerType.php
+++ b/src/Eccube/Form/Type/Admin/SearchCustomerType.php
@@ -27,6 +27,8 @@ use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class SearchCustomerType extends AbstractType
@@ -243,6 +245,32 @@ class SearchCustomerType extends AbstractType
                 ],
             ])
         ;
+
+        // EC-CUBE 4.0.4 以前のバージョンで互換性を保つため
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+            $data = $event->getData();
+
+            // チェック対象
+            $dates = [
+                'create_date_start',
+                'update_date_start',
+                'last_buy_start',
+                'create_date_end',
+                'update_date_end',
+                'last_buy_end',
+            ];
+
+            foreach ($dates as $date) {
+                if (isset($data[$date])) {
+                    // 日時が yyyy-MM-dd で指定されて入れば末尾に 00:00 を追加
+                    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $data[$date])) {
+                        $data[$date] .= ' 00:00';
+                    }
+                }
+            }
+
+            $event->setData($data);
+        });
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/SearchCustomerType.php
+++ b/src/Eccube/Form/Type/Admin/SearchCustomerType.php
@@ -189,7 +189,7 @@ class SearchCustomerType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_create_datetime_start',
@@ -214,7 +214,7 @@ class SearchCustomerType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_create_datetime_end',
@@ -239,7 +239,7 @@ class SearchCustomerType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_update_datetime_start',
@@ -264,7 +264,7 @@ class SearchCustomerType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_update_datetime_end',
@@ -289,7 +289,7 @@ class SearchCustomerType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_last_buy_datetime_start',
@@ -314,7 +314,7 @@ class SearchCustomerType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_last_buy_datetime_end',

--- a/src/Eccube/Form/Type/Admin/SearchCustomerType.php
+++ b/src/Eccube/Form/Type/Admin/SearchCustomerType.php
@@ -23,13 +23,11 @@ use Eccube\Repository\Master\CustomerStatusRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\BirthdayType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class SearchCustomerType extends AbstractType
@@ -173,7 +171,20 @@ class SearchCustomerType extends AbstractType
                     new Assert\Length(['max' => $this->eccubeConfig['eccube_int_len']]),
                 ],
             ])
-            ->add('create_date_start', DateTimeType::class, [
+            ->add('create_date_start', DateType::class, [
+                'label' => 'admin.common.create_date__start',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_create_date_start',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('create_datetime_start', DateTimeType::class, [
                 'label' => 'admin.common.create_date__start',
                 'required' => false,
                 'input' => 'datetime',
@@ -181,11 +192,24 @@ class SearchCustomerType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_create_date_start',
+                    'data-target' => '#'.$this->getBlockPrefix().'_create_datetime_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('create_date_end', DateTimeType::class, [
+            ->add('create_date_end', DateType::class, [
+                'label' => 'admin.common.create_date__end',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_create_date_end',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('create_datetime_end', DateTimeType::class, [
                 'label' => 'admin.common.create_date__end',
                 'required' => false,
                 'input' => 'datetime',
@@ -193,11 +217,24 @@ class SearchCustomerType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_create_date_end',
+                    'data-target' => '#'.$this->getBlockPrefix().'_create_datetime_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('update_date_start', DateTimeType::class, [
+            ->add('update_date_start', DateType::class, [
+                'label' => 'admin.common.update_date__start',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_update_date_start',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('update_datetime_start', DateTimeType::class, [
                 'label' => 'admin.common.update_date__start',
                 'required' => false,
                 'input' => 'datetime',
@@ -205,11 +242,24 @@ class SearchCustomerType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_update_date_start',
+                    'data-target' => '#'.$this->getBlockPrefix().'_update_datetime_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('update_date_end', DateTimeType::class, [
+            ->add('update_date_end', DateType::class, [
+                'label' => 'admin.common.update_date__end',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_update_date_end',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('update_datetime_end', DateTimeType::class, [
                 'label' => 'admin.common.update_date__end',
                 'required' => false,
                 'input' => 'datetime',
@@ -217,11 +267,24 @@ class SearchCustomerType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_update_date_end',
+                    'data-target' => '#'.$this->getBlockPrefix().'_update_datetime_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('last_buy_start', DateTimeType::class, [
+            ->add('last_buy_start', DateType::class, [
+                'label' => 'admin.order.last_buy_date__start',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_last_buy_start',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('last_buy_datetime_start', DateTimeType::class, [
                 'label' => 'admin.order.last_buy_date__start',
                 'required' => false,
                 'input' => 'datetime',
@@ -229,11 +292,24 @@ class SearchCustomerType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_last_buy_start',
+                    'data-target' => '#'.$this->getBlockPrefix().'_last_buy_datetime_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('last_buy_end', DateTimeType::class, [
+            ->add('last_buy_end', DateType::class, [
+                'label' => 'admin.order.last_buy_date__end',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_last_buy_end',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('last_buy_datetime_end', DateTimeType::class, [
                 'label' => 'admin.order.last_buy_date__end',
                 'required' => false,
                 'input' => 'datetime',
@@ -241,30 +317,11 @@ class SearchCustomerType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_last_buy_end',
+                    'data-target' => '#'.$this->getBlockPrefix().'_last_buy_datetime_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
         ;
-
-        // EC-CUBE 4.0.4 以前のバージョンで互換性を保つため
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
-            $data = $event->getData();
-            $form = $event->getForm();
-
-            /** @var $child Form */
-            foreach ($form->all() as $child) {
-                // DateTimeType でデータが送られている場合はチェック
-                if ($child->getConfig()->getType()->getInnerType() instanceof DateTimeType && isset($data[$child->getName()])) {
-                    // 日時が yyyy-MM-dd で指定されて入れば末尾に 00:00 を追加
-                    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $data[$child->getName()])) {
-                        $data[$child->getName()] .= ' 00:00';
-                    }
-                }
-            }
-
-            $event->setData($data);
-        });
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/SearchCustomerType.php
+++ b/src/Eccube/Form/Type/Admin/SearchCustomerType.php
@@ -23,7 +23,7 @@ use Eccube\Repository\Master\CustomerStatusRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\BirthdayType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -170,78 +170,72 @@ class SearchCustomerType extends AbstractType
                     new Assert\Length(['max' => $this->eccubeConfig['eccube_int_len']]),
                 ],
             ])
-            ->add('create_date_start', DateType::class, [
+            ->add('create_date_start', DateTimeType::class, [
                 'label' => 'admin.common.create_date__start',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_create_date_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('create_date_end', DateType::class, [
+            ->add('create_date_end', DateTimeType::class, [
                 'label' => 'admin.common.create_date__end',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_create_date_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('update_date_start', DateType::class, [
+            ->add('update_date_start', DateTimeType::class, [
                 'label' => 'admin.common.update_date__start',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_update_date_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('update_date_end', DateType::class, [
+            ->add('update_date_end', DateTimeType::class, [
                 'label' => 'admin.common.update_date__end',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_update_date_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('last_buy_start', DateType::class, [
+            ->add('last_buy_start', DateTimeType::class, [
                 'label' => 'admin.order.last_buy_date__start',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_last_buy_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('last_buy_end', DateType::class, [
+            ->add('last_buy_end', DateTimeType::class, [
                 'label' => 'admin.order.last_buy_date__end',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_last_buy_end',

--- a/src/Eccube/Form/Type/Admin/SearchOrderType.php
+++ b/src/Eccube/Form/Type/Admin/SearchOrderType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -230,24 +231,15 @@ class SearchOrderType extends AbstractType
         // EC-CUBE 4.0.4 以前のバージョンで互換性を保つため
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $data = $event->getData();
+            $form = $event->getForm();
 
-            // チェック対象
-            $dates = [
-                'order_date_start',
-                'payment_date_start',
-                'update_date_start',
-                'shipping_delivery_date_start',
-                'order_date_end',
-                'payment_date_end',
-                'update_date_end',
-                'shipping_delivery_date_end',
-            ];
-
-            foreach ($dates as $date) {
-                if (isset($data[$date])) {
+            /** @var $child Form */
+            foreach ($form->all() as $child) {
+                // DateTimeType でデータが送られている場合はチェック
+                if ($child->getConfig()->getType()->getInnerType() instanceof DateTimeType && isset($data[$child->getName()])) {
                     // 日時が yyyy-MM-dd で指定されて入れば末尾に 00:00 を追加
-                    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $data[$date])) {
-                        $data[$date] .= ' 00:00';
+                    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $data[$child->getName()])) {
+                        $data[$child->getName()] .= ' 00:00';
                     }
                 }
             }

--- a/src/Eccube/Form/Type/Admin/SearchOrderType.php
+++ b/src/Eccube/Form/Type/Admin/SearchOrderType.php
@@ -16,7 +16,7 @@ namespace Eccube\Form\Type\Admin;
 use Eccube\Entity\Shipping;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -115,104 +115,96 @@ class SearchOrderType extends AbstractType
                 'expanded' => true,
                 'multiple' => true,
             ])
-            ->add('order_date_start', DateType::class, [
+            ->add('order_date_start', DateTimeType::class, [
                 'label' => 'admin.order.order_date__start',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_order_date_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('order_date_end', DateType::class, [
+            ->add('order_date_end', DateTimeType::class, [
                 'label' => 'admin.order.order_date__end',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_order_date_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('payment_date_start', DateType::class, [
+            ->add('payment_date_start', DateTimeType::class, [
                 'label' => 'admin.order.payment_date__start',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_payment_date_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('payment_date_end', DateType::class, [
+            ->add('payment_date_end', DateTimeType::class, [
                 'label' => 'admin.order.payment_date__end',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_payment_date_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('update_date_start', DateType::class, [
+            ->add('update_date_start', DateTimeType::class, [
                 'label' => 'admin.common.update_date__start',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_update_date_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('update_date_end', DateType::class, [
+            ->add('update_date_end', DateTimeType::class, [
                 'label' => 'admin.common.update_date__end',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_update_date_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('shipping_delivery_date_start', DateType::class, [
+            ->add('shipping_delivery_date_start', DateTimeType::class, [
                 'label' => 'admin.order.delivery_date__start',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_shipping_delivery_date_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('shipping_delivery_date_end', DateType::class, [
+            ->add('shipping_delivery_date_end', DateTimeType::class, [
                 'label' => 'admin.order.delivery_date__end',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_shipping_delivery_date_end',

--- a/src/Eccube/Form/Type/Admin/SearchOrderType.php
+++ b/src/Eccube/Form/Type/Admin/SearchOrderType.php
@@ -16,12 +16,10 @@ namespace Eccube\Form\Type\Admin;
 use Eccube\Entity\Shipping;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Validator\Constraints as Assert;
 use Eccube\Common\EccubeConfig;
 use Eccube\Form\Type\PriceType;
@@ -118,7 +116,20 @@ class SearchOrderType extends AbstractType
                 'expanded' => true,
                 'multiple' => true,
             ])
-            ->add('order_date_start', DateTimeType::class, [
+            ->add('order_date_start', DateType::class, [
+                'label' => 'admin.order.order_date__start',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_order_date_start',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('order_datetime_start', DateTimeType::class, [
                 'label' => 'admin.order.order_date__start',
                 'required' => false,
                 'input' => 'datetime',
@@ -126,11 +137,24 @@ class SearchOrderType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_order_date_start',
+                    'data-target' => '#'.$this->getBlockPrefix().'_order_datetime_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('order_date_end', DateTimeType::class, [
+            ->add('order_date_end', DateType::class, [
+                'label' => 'admin.order.order_date__end',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_order_date_end',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('order_datetime_end', DateTimeType::class, [
                 'label' => 'admin.order.order_date__end',
                 'required' => false,
                 'input' => 'datetime',
@@ -138,11 +162,24 @@ class SearchOrderType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_order_date_end',
+                    'data-target' => '#'.$this->getBlockPrefix().'_order_datetime_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('payment_date_start', DateTimeType::class, [
+            ->add('payment_date_start', DateType::class, [
+                'label' => 'admin.order.payment_date__start',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_payment_date_start',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('payment_datetime_start', DateTimeType::class, [
                 'label' => 'admin.order.payment_date__start',
                 'required' => false,
                 'input' => 'datetime',
@@ -150,11 +187,24 @@ class SearchOrderType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_payment_date_start',
+                    'data-target' => '#'.$this->getBlockPrefix().'_payment_datetime_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('payment_date_end', DateTimeType::class, [
+            ->add('payment_date_end', DateType::class, [
+                'label' => 'admin.order.payment_date__end',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_payment_date_end',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('payment_datetime_end', DateTimeType::class, [
                 'label' => 'admin.order.payment_date__end',
                 'required' => false,
                 'input' => 'datetime',
@@ -162,11 +212,24 @@ class SearchOrderType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_payment_date_end',
+                    'data-target' => '#'.$this->getBlockPrefix().'_payment_datetime_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('update_date_start', DateTimeType::class, [
+            ->add('update_date_start', DateType::class, [
+                'label' => 'admin.common.update_date__start',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_update_date_start',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('update_datetime_start', DateTimeType::class, [
                 'label' => 'admin.common.update_date__start',
                 'required' => false,
                 'input' => 'datetime',
@@ -174,11 +237,24 @@ class SearchOrderType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_update_date_start',
+                    'data-target' => '#'.$this->getBlockPrefix().'_update_datetime_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('update_date_end', DateTimeType::class, [
+            ->add('update_date_end', DateType::class, [
+                'label' => 'admin.common.update_date__end',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_update_date_end',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('update_datetime_end', DateTimeType::class, [
                 'label' => 'admin.common.update_date__end',
                 'required' => false,
                 'input' => 'datetime',
@@ -186,11 +262,24 @@ class SearchOrderType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_update_date_end',
+                    'data-target' => '#'.$this->getBlockPrefix().'_update_datetime_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('shipping_delivery_date_start', DateTimeType::class, [
+            ->add('shipping_delivery_date_start', DateType::class, [
+                'label' => 'admin.order.delivery_date__start',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_shipping_delivery_date_start',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('shipping_delivery_datetime_start', DateTimeType::class, [
                 'label' => 'admin.order.delivery_date__start',
                 'required' => false,
                 'input' => 'datetime',
@@ -198,11 +287,24 @@ class SearchOrderType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_shipping_delivery_date_start',
+                    'data-target' => '#'.$this->getBlockPrefix().'_shipping_delivery_datetime_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('shipping_delivery_date_end', DateTimeType::class, [
+            ->add('shipping_delivery_date_end', DateType::class, [
+                'label' => 'admin.order.delivery_date__end',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_shipping_delivery_date_end',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('shipping_delivery_datetime_end', DateTimeType::class, [
                 'label' => 'admin.order.delivery_date__end',
                 'required' => false,
                 'input' => 'datetime',
@@ -210,7 +312,7 @@ class SearchOrderType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_shipping_delivery_date_end',
+                    'data-target' => '#'.$this->getBlockPrefix().'_shipping_delivery_datetime_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
@@ -227,25 +329,6 @@ class SearchOrderType extends AbstractType
                 'required' => false,
             ])
         ;
-
-        // EC-CUBE 4.0.4 以前のバージョンで互換性を保つため
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
-            $data = $event->getData();
-            $form = $event->getForm();
-
-            /** @var $child Form */
-            foreach ($form->all() as $child) {
-                // DateTimeType でデータが送られている場合はチェック
-                if ($child->getConfig()->getType()->getInnerType() instanceof DateTimeType && isset($data[$child->getName()])) {
-                    // 日時が yyyy-MM-dd で指定されて入れば末尾に 00:00 を追加
-                    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $data[$child->getName()])) {
-                        $data[$child->getName()] .= ' 00:00';
-                    }
-                }
-            }
-
-            $event->setData($data);
-        });
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/SearchOrderType.php
+++ b/src/Eccube/Form/Type/Admin/SearchOrderType.php
@@ -134,7 +134,7 @@ class SearchOrderType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_order_datetime_start',
@@ -159,7 +159,7 @@ class SearchOrderType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_order_datetime_end',
@@ -184,7 +184,7 @@ class SearchOrderType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_payment_datetime_start',
@@ -209,7 +209,7 @@ class SearchOrderType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_payment_datetime_end',
@@ -234,7 +234,7 @@ class SearchOrderType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_update_datetime_start',
@@ -259,7 +259,7 @@ class SearchOrderType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_update_datetime_end',
@@ -284,7 +284,7 @@ class SearchOrderType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_shipping_delivery_datetime_start',
@@ -309,7 +309,7 @@ class SearchOrderType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_shipping_delivery_datetime_end',

--- a/src/Eccube/Form/Type/Admin/SearchProductType.php
+++ b/src/Eccube/Form/Type/Admin/SearchProductType.php
@@ -25,6 +25,8 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 
 class SearchProductType extends AbstractType
 {
@@ -140,6 +142,30 @@ class SearchProductType extends AbstractType
                 ],
             ])
         ;
+
+        // EC-CUBE 4.0.4 以前のバージョンで互換性を保つため
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+            $data = $event->getData();
+
+            // チェック対象
+            $dates = [
+                'create_date_start',
+                'update_date_start',
+                'create_date_end',
+                'update_date_end',
+            ];
+
+            foreach ($dates as $date) {
+                if (isset($data[$date])) {
+                    // 日時が yyyy-MM-dd で指定されて入れば末尾に 00:00 を追加
+                    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $data[$date])) {
+                        $data[$date] .= ' 00:00';
+                    }
+                }
+            }
+
+            $event->setData($data);
+        });
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/SearchProductType.php
+++ b/src/Eccube/Form/Type/Admin/SearchProductType.php
@@ -110,7 +110,7 @@ class SearchProductType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_create_datetime_start',
@@ -135,7 +135,7 @@ class SearchProductType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_create_datetime_end',
@@ -160,7 +160,7 @@ class SearchProductType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_update_datetime_start',
@@ -185,7 +185,7 @@ class SearchProductType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd HH:mm',
+                'format' => 'yyyy-MM-dd HH:mm:ss',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_update_datetime_end',

--- a/src/Eccube/Form/Type/Admin/SearchProductType.php
+++ b/src/Eccube/Form/Type/Admin/SearchProductType.php
@@ -22,7 +22,7 @@ use Eccube\Repository\CategoryRepository;
 use Eccube\Repository\Master\ProductStatusRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -91,52 +91,48 @@ class SearchProductType extends AbstractType
                 'expanded' => true,
                 'multiple' => true,
             ])
-            ->add('create_date_start', DateType::class, [
+            ->add('create_date_start', DateTimeType::class, [
                 'label' => 'admin.common.create_date__start',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_create_date_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('create_date_end', DateType::class, [
+            ->add('create_date_end', DateTimeType::class, [
                 'label' => 'admin.common.create_date__end',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_create_date_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('update_date_start', DateType::class, [
+            ->add('update_date_start', DateTimeType::class, [
                 'label' => 'admin.common.update_date__start',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_update_date_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('update_date_end', DateType::class, [
+            ->add('update_date_end', DateTimeType::class, [
                 'label' => 'admin.common.update_date__end',
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
-                'format' => 'yyyy-MM-dd',
-                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
                     'data-target' => '#'.$this->getBlockPrefix().'_update_date_end',

--- a/src/Eccube/Form/Type/Admin/SearchProductType.php
+++ b/src/Eccube/Form/Type/Admin/SearchProductType.php
@@ -24,6 +24,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -146,20 +147,15 @@ class SearchProductType extends AbstractType
         // EC-CUBE 4.0.4 以前のバージョンで互換性を保つため
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $data = $event->getData();
+            $form = $event->getForm();
 
-            // チェック対象
-            $dates = [
-                'create_date_start',
-                'update_date_start',
-                'create_date_end',
-                'update_date_end',
-            ];
-
-            foreach ($dates as $date) {
-                if (isset($data[$date])) {
+            /** @var $child Form */
+            foreach ($form->all() as $child) {
+                // DateTimeType でデータが送られている場合はチェック
+                if ($child->getConfig()->getType()->getInnerType() instanceof DateTimeType && isset($data[$child->getName()])) {
                     // 日時が yyyy-MM-dd で指定されて入れば末尾に 00:00 を追加
-                    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $data[$date])) {
-                        $data[$date] .= ' 00:00';
+                    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $data[$child->getName()])) {
+                        $data[$child->getName()] .= ' 00:00';
                     }
                 }
             }

--- a/src/Eccube/Form/Type/Admin/SearchProductType.php
+++ b/src/Eccube/Form/Type/Admin/SearchProductType.php
@@ -22,12 +22,10 @@ use Eccube\Repository\CategoryRepository;
 use Eccube\Repository\Master\ProductStatusRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
 
 class SearchProductType extends AbstractType
 {
@@ -94,7 +92,20 @@ class SearchProductType extends AbstractType
                 'expanded' => true,
                 'multiple' => true,
             ])
-            ->add('create_date_start', DateTimeType::class, [
+            ->add('create_date_start', DateType::class, [
+                'label' => 'admin.common.create_date__start',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_create_date_start',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('create_datetime_start', DateTimeType::class, [
                 'label' => 'admin.common.create_date__start',
                 'required' => false,
                 'input' => 'datetime',
@@ -102,11 +113,24 @@ class SearchProductType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_create_date_start',
+                    'data-target' => '#'.$this->getBlockPrefix().'_create_datetime_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('create_date_end', DateTimeType::class, [
+            ->add('create_date_end', DateType::class, [
+                'label' => 'admin.common.create_date__end',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_create_date_end',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('create_datetime_end', DateTimeType::class, [
                 'label' => 'admin.common.create_date__end',
                 'required' => false,
                 'input' => 'datetime',
@@ -114,11 +138,24 @@ class SearchProductType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_create_date_end',
+                    'data-target' => '#'.$this->getBlockPrefix().'_create_datetime_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('update_date_start', DateTimeType::class, [
+            ->add('update_date_start', DateType::class, [
+                'label' => 'admin.common.update_date__start',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_update_date_start',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('update_datetime_start', DateTimeType::class, [
                 'label' => 'admin.common.update_date__start',
                 'required' => false,
                 'input' => 'datetime',
@@ -126,11 +163,24 @@ class SearchProductType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_update_date_start',
+                    'data-target' => '#'.$this->getBlockPrefix().'_update_datetime_start',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
-            ->add('update_date_end', DateTimeType::class, [
+            ->add('update_date_end', DateType::class, [
+                'label' => 'admin.common.update_date__end',
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'format' => 'yyyy-MM-dd',
+                'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
+                'attr' => [
+                    'class' => 'datetimepicker-input',
+                    'data-target' => '#'.$this->getBlockPrefix().'_update_date_end',
+                    'data-toggle' => 'datetimepicker',
+                ],
+            ])
+            ->add('update_datetime_end', DateTimeType::class, [
                 'label' => 'admin.common.update_date__end',
                 'required' => false,
                 'input' => 'datetime',
@@ -138,30 +188,11 @@ class SearchProductType extends AbstractType
                 'format' => 'yyyy-MM-dd HH:mm',
                 'attr' => [
                     'class' => 'datetimepicker-input',
-                    'data-target' => '#'.$this->getBlockPrefix().'_update_date_end',
+                    'data-target' => '#'.$this->getBlockPrefix().'_update_datetime_end',
                     'data-toggle' => 'datetimepicker',
                 ],
             ])
         ;
-
-        // EC-CUBE 4.0.4 以前のバージョンで互換性を保つため
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
-            $data = $event->getData();
-            $form = $event->getForm();
-
-            /** @var $child Form */
-            foreach ($form->all() as $child) {
-                // DateTimeType でデータが送られている場合はチェック
-                if ($child->getConfig()->getType()->getInnerType() instanceof DateTimeType && isset($data[$child->getName()])) {
-                    // 日時が yyyy-MM-dd で指定されて入れば末尾に 00:00 を追加
-                    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $data[$child->getName()])) {
-                        $data[$child->getName()] .= ' 00:00';
-                    }
-                }
-            }
-
-            $event->setData($data);
-        });
     }
 
     /**

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -183,12 +183,23 @@ class CustomerRepository extends AbstractRepository
         }
 
         // create_date
-        if (!empty($searchData['create_date_start']) && $searchData['create_date_start']) {
+        if (!empty($searchData['create_datetime_start']) && $searchData['create_datetime_start']) {
+            $date = $searchData['create_datetime_start'];
+            $qb
+                ->andWhere('c.create_date >= :create_date_start')
+                ->setParameter('create_date_start', $date);
+        } elseif (!empty($searchData['create_date_start']) && $searchData['create_date_start']) {
             $qb
                 ->andWhere('c.create_date >= :create_date_start')
                 ->setParameter('create_date_start', $searchData['create_date_start']);
         }
-        if (!empty($searchData['create_date_end']) && $searchData['create_date_end']) {
+
+        if (!empty($searchData['create_datetime_end']) && $searchData['create_datetime_end']) {
+            $date = $searchData['create_datetime_end'];
+            $qb
+                ->andWhere('c.create_date < :create_date_end')
+                ->setParameter('create_date_end', $date);
+        } elseif (!empty($searchData['create_date_end']) && $searchData['create_date_end']) {
             $date = clone $searchData['create_date_end'];
             $date->modify('+1 days');
             $qb
@@ -197,12 +208,23 @@ class CustomerRepository extends AbstractRepository
         }
 
         // update_date
-        if (!empty($searchData['update_date_start']) && $searchData['update_date_start']) {
+        if (!empty($searchData['update_datetime_start']) && $searchData['update_datetime_start']) {
+            $date = $searchData['update_datetime_start'];
+            $qb
+                ->andWhere('c.update_date >= :update_date_start')
+                ->setParameter('update_date_start', $date);
+        } elseif (!empty($searchData['update_date_start']) && $searchData['update_date_start']) {
             $qb
                 ->andWhere('c.update_date >= :update_date_start')
                 ->setParameter('update_date_start', $searchData['update_date_start']);
         }
-        if (!empty($searchData['update_date_end']) && $searchData['update_date_end']) {
+
+        if (!empty($searchData['update_datetime_end']) && $searchData['update_datetime_end']) {
+            $date = $searchData['update_datetime_end'];
+            $qb
+                ->andWhere('c.update_date < :update_date_end')
+                ->setParameter('update_date_end', $date);
+        } elseif (!empty($searchData['update_date_end']) && $searchData['update_date_end']) {
             $date = clone $searchData['update_date_end'];
             $date->modify('+1 days');
             $qb
@@ -211,12 +233,23 @@ class CustomerRepository extends AbstractRepository
         }
 
         // last_buy
-        if (!empty($searchData['last_buy_start']) && $searchData['last_buy_start']) {
+        if (!empty($searchData['last_buy_datetime_start']) && $searchData['last_buy_datetime_start']) {
+            $date = $searchData['last_buy_datetime_start'];
+            $qb
+                ->andWhere('c.last_buy_date >= :last_buy_start')
+                ->setParameter('last_buy_start', $date);
+        } elseif (!empty($searchData['last_buy_start']) && $searchData['last_buy_start']) {
             $qb
                 ->andWhere('c.last_buy_date >= :last_buy_start')
                 ->setParameter('last_buy_start', $searchData['last_buy_start']);
         }
-        if (!empty($searchData['last_buy_end']) && $searchData['last_buy_end']) {
+
+        if (!empty($searchData['last_buy_datetime_end']) && $searchData['last_buy_datetime_end']) {
+            $date = $searchData['last_buy_datetime_end'];
+            $qb
+                ->andWhere('c.last_buy_date < :last_buy_end')
+                ->setParameter('last_buy_end', $date);
+        } elseif (!empty($searchData['last_buy_end']) && $searchData['last_buy_end']) {
             $date = clone $searchData['last_buy_end'];
             $date->modify('+1 days');
             $qb

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -193,13 +193,24 @@ class OrderRepository extends AbstractRepository
         }
 
         // oreder_date
-        if (!empty($searchData['order_date_start']) && $searchData['order_date_start']) {
+        if (!empty($searchData['order_datetime_start']) && $searchData['order_datetime_start']) {
+            $date = $searchData['order_datetime_start'];
+            $qb
+                ->andWhere('o.order_date >= :order_date_start')
+                ->setParameter('order_date_start', $date);
+        } elseif (!empty($searchData['order_date_start']) && $searchData['order_date_start']) {
             $date = $searchData['order_date_start'];
             $qb
                 ->andWhere('o.order_date >= :order_date_start')
                 ->setParameter('order_date_start', $date);
         }
-        if (!empty($searchData['order_date_end']) && $searchData['order_date_end']) {
+
+        if (!empty($searchData['order_datetime_end']) && $searchData['order_datetime_end']) {
+            $date = $searchData['order_datetime_end'];
+            $qb
+                ->andWhere('o.order_date < :order_date_end')
+                ->setParameter('order_date_end', $date);
+        } elseif (!empty($searchData['order_date_end']) && $searchData['order_date_end']) {
             $date = clone $searchData['order_date_end'];
             $date = $date
                 ->modify('+1 days');
@@ -209,13 +220,24 @@ class OrderRepository extends AbstractRepository
         }
 
         // payment_date
-        if (!empty($searchData['payment_date_start']) && $searchData['payment_date_start']) {
+        if (!empty($searchData['payment_datetime_start']) && $searchData['payment_datetime_start']) {
+            $date = $searchData['payment_datetime_start'];
+            $qb
+                ->andWhere('o.payment_date >= :payment_date_start')
+                ->setParameter('payment_date_start', $date);
+        } elseif (!empty($searchData['payment_date_start']) && $searchData['payment_date_start']) {
             $date = $searchData['payment_date_start'];
             $qb
                 ->andWhere('o.payment_date >= :payment_date_start')
                 ->setParameter('payment_date_start', $date);
         }
-        if (!empty($searchData['payment_date_end']) && $searchData['payment_date_end']) {
+
+        if (!empty($searchData['payment_datetime_end']) && $searchData['payment_datetime_end']) {
+            $date = $searchData['payment_datetime_end'];
+            $qb
+                ->andWhere('o.payment_date < :payment_date_end')
+                ->setParameter('payment_date_end', $date);
+        } elseif (!empty($searchData['payment_date_end']) && $searchData['payment_date_end']) {
             $date = clone $searchData['payment_date_end'];
             $date = $date
                 ->modify('+1 days');
@@ -225,13 +247,24 @@ class OrderRepository extends AbstractRepository
         }
 
         // update_date
-        if (!empty($searchData['update_date_start']) && $searchData['update_date_start']) {
+        if (!empty($searchData['update_datetime_start']) && $searchData['update_datetime_start']) {
+            $date = $searchData['update_datetime_start'];
+            $qb
+                ->andWhere('o.update_date >= :update_date_start')
+                ->setParameter('update_date_start', $date);
+        } elseif (!empty($searchData['update_date_start']) && $searchData['update_date_start']) {
             $date = $searchData['update_date_start'];
             $qb
                 ->andWhere('o.update_date >= :update_date_start')
                 ->setParameter('update_date_start', $date);
         }
-        if (!empty($searchData['update_date_end']) && $searchData['update_date_end']) {
+
+        if (!empty($searchData['update_datetime_end']) && $searchData['update_datetime_end']) {
+            $date = $searchData['update_datetime_end'];
+            $qb
+                ->andWhere('o.update_date < :update_date_end')
+                ->setParameter('update_date_end', $date);
+        } elseif (!empty($searchData['update_date_end']) && $searchData['update_date_end']) {
             $date = clone $searchData['update_date_end'];
             $date = $date
                 ->modify('+1 days');
@@ -284,13 +317,24 @@ class OrderRepository extends AbstractRepository
         }
 
         // お届け予定日(Shipping.delivery_date)
-        if (!empty($searchData['shipping_delivery_date_start']) && $searchData['shipping_delivery_date_start']) {
+        if (!empty($searchData['shipping_delivery_datetime_start']) && $searchData['shipping_delivery_datetime_start']) {
+            $date = $searchData['shipping_delivery_datetime_start'];
+            $qb
+                ->andWhere('s.shipping_delivery_date >= :shipping_delivery_date_start')
+                ->setParameter('shipping_delivery_date_start', $date);
+        } elseif (!empty($searchData['shipping_delivery_date_start']) && $searchData['shipping_delivery_date_start']) {
             $date = $searchData['shipping_delivery_date_start'];
             $qb
                 ->andWhere('s.shipping_delivery_date >= :shipping_delivery_date_start')
                 ->setParameter('shipping_delivery_date_start', $date);
         }
-        if (!empty($searchData['shipping_delivery_date_end']) && $searchData['shipping_delivery_date_end']) {
+
+        if (!empty($searchData['shipping_delivery_datetime_end']) && $searchData['shipping_delivery_datetime_end']) {
+            $date = $searchData['shipping_delivery_datetime_end'];
+            $qb
+                ->andWhere('s.shipping_delivery_date < :shipping_delivery_date_end')
+                ->setParameter('shipping_delivery_date_end', $date);
+        } elseif (!empty($searchData['shipping_delivery_date_end']) && $searchData['shipping_delivery_date_end']) {
             $date = clone $searchData['shipping_delivery_date_end'];
             $date = $date
                 ->modify('+1 days');

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -301,14 +301,24 @@ class ProductRepository extends AbstractRepository
         }
 
         // crate_date
-        if (!empty($searchData['create_date_start']) && $searchData['create_date_start']) {
+        if (!empty($searchData['create_datetime_start']) && $searchData['create_datetime_start']) {
+            $date = $searchData['create_datetime_start'];
+            $qb
+                ->andWhere('p.create_date >= :create_date_start')
+                ->setParameter('create_date_start', $date);
+        } elseif (!empty($searchData['create_date_start']) && $searchData['create_date_start']) {
             $date = $searchData['create_date_start'];
             $qb
                 ->andWhere('p.create_date >= :create_date_start')
                 ->setParameter('create_date_start', $date);
         }
 
-        if (!empty($searchData['create_date_end']) && $searchData['create_date_end']) {
+        if (!empty($searchData['create_datetime_end']) && $searchData['create_datetime_end']) {
+            $date = $searchData['create_datetime_end'];
+            $qb
+                ->andWhere('p.create_date < :create_date_end')
+                ->setParameter('create_date_end', $date);
+        } elseif (!empty($searchData['create_date_end']) && $searchData['create_date_end']) {
             $date = clone $searchData['create_date_end'];
             $date = $date
                 ->modify('+1 days');
@@ -318,13 +328,24 @@ class ProductRepository extends AbstractRepository
         }
 
         // update_date
-        if (!empty($searchData['update_date_start']) && $searchData['update_date_start']) {
+        if (!empty($searchData['update_datetime_start']) && $searchData['update_datetime_start']) {
+            $date = $searchData['update_datetime_start'];
+            $qb
+                ->andWhere('p.update_date >= :update_date_start')
+                ->setParameter('update_date_start', $date);
+        } elseif (!empty($searchData['update_date_start']) && $searchData['update_date_start']) {
             $date = $searchData['update_date_start'];
             $qb
                 ->andWhere('p.update_date >= :update_date_start')
                 ->setParameter('update_date_start', $date);
         }
-        if (!empty($searchData['update_date_end']) && $searchData['update_date_end']) {
+
+        if (!empty($searchData['update_datetime_end']) && $searchData['update_datetime_end']) {
+            $date = $searchData['update_datetime_end'];
+            $qb
+                ->andWhere('p.update_date < :update_date_end')
+                ->setParameter('update_date_end', $date);
+        } elseif (!empty($searchData['update_date_end']) && $searchData['update_date_end']) {
             $date = clone $searchData['update_date_end'];
             $date = $date
                 ->modify('+1 days');

--- a/src/Eccube/Repository/ShippingRepository.php
+++ b/src/Eccube/Repository/ShippingRepository.php
@@ -37,6 +37,8 @@ class ShippingRepository extends AbstractRepository
      * @param  array $searchData
      *
      * @return QueryBuilder
+     *
+     * @deprecated 使用していないので削除予定
      */
     public function getQueryBuilderBySearchDataForAdmin($searchData)
     {

--- a/src/Eccube/Resource/template/admin/Customer/index.twig
+++ b/src/Eccube/Resource/template/admin/Customer/index.twig
@@ -44,7 +44,7 @@ file that was distributed with this source code.
                 ).done(function() {
                     $('input[id$=_date_start]').datetimepicker({
                         locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD',
+                        format: 'YYYY-MM-DD HH:mm',
                         useCurrent: false,
                         buttons: {
                             showToday: true,
@@ -54,7 +54,7 @@ file that was distributed with this source code.
 
                     $('input[id$=_date_end]').datetimepicker({
                         locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD',
+                        format: 'YYYY-MM-DD HH:mm',
                         useCurrent: false,
                         buttons: {
                             showToday: true,

--- a/src/Eccube/Resource/template/admin/Customer/index.twig
+++ b/src/Eccube/Resource/template/admin/Customer/index.twig
@@ -35,75 +35,55 @@ file that was distributed with this source code.
 {% block javascript %}
     <script>
         $(function() {
-            if ($('[type="date"]').prop('type') != 'date') {
-                // input type属性でdateが利用できるかどうか(カレンダー表示できないブラウザ対応)
-                $.when(
-                    $.getScript("{{ asset('assets/js/vendor/moment.min.js', 'admin') }}"),
-                    $.getScript("{{ asset('assets/js/vendor/moment-with-locales.min.js', 'admin') }}"),
-                    $.getScript("{{ asset('assets/js/vendor/tempusdominus-bootstrap-4.min.js', 'admin') }}")
-                ).done(function() {
-                    $('input[id$=_date_start]').datetimepicker({
-                        locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD HH:mm',
-                        useCurrent: false,
-                        buttons: {
-                            showToday: true,
-                            showClose: true
-                        }
-                    });
 
-                    $('input[id$=_date_end]').datetimepicker({
-                        locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD HH:mm',
-                        useCurrent: false,
-                        buttons: {
-                            showToday: true,
-                            showClose: true
-                        }
-                    });
+            // datetimepicker と競合するため HTML5 のカレンダ入力を無効に
+            $('input[type="date"]').attr('type','text');
 
-                    $('#admin_search_customer_birth_start').datetimepicker({
-                        locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD',
-                        useCurrent: false,
-                        buttons: {
-                            showToday: true,
-                            showClose: true
-                        }
-                    });
-
-                    $('#admin_search_customer_birth_end').datetimepicker({
-                        locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD',
-                        useCurrent: false,
-                        buttons: {
-                            showToday: true,
-                            showClose: true
-                        }
-                    });
-
-                    $('#admin_search_customer_last_buy_start').datetimepicker({
-                        locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD',
-                        useCurrent: false,
-                        buttons: {
-                            showToday: true,
-                            showClose: true
-                        }
-                    });
-
-                    $('#admin_search_customer_last_buy_end').datetimepicker({
-                        locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD',
-                        useCurrent: false,
-                        buttons: {
-                            showToday: true,
-                            showClose: true
-                        }
-                    });
+            $.when(
+                $.getScript("{{ asset('assets/js/vendor/moment.min.js', 'admin') }}"),
+                $.getScript("{{ asset('assets/js/vendor/moment-with-locales.min.js', 'admin') }}"),
+                $.getScript("{{ asset('assets/js/vendor/tempusdominus-bootstrap-4.min.js', 'admin') }}")
+            ).done(function() {
+                // datetimepicker で value が消えてしまうので data-value に保持しておく
+                $('input.datetimepicker-input').each(function() {
+                    $(this).data('value', $(this).val());
                 });
-            }
 
+                $('input.datetimepicker-input').not('#admin_search_customer_birth_start').not('#admin_search_customer_birth_end').datetimepicker({
+                    locale: '{{ eccube_config.locale }}',
+                    format: 'YYYY-MM-DD HH:mm',
+                    useCurrent: false,
+                    buttons: {
+                        showToday: true,
+                        showClose: true
+                    },
+                });
+
+                $('#admin_search_customer_birth_start').datetimepicker({
+                    locale: '{{ eccube_config.locale }}',
+                    format: 'YYYY-MM-DD',
+                    useCurrent: false,
+                    buttons: {
+                        showToday: true,
+                        showClose: true
+                    }
+                });
+
+                $('#admin_search_customer_birth_end').datetimepicker({
+                    locale: '{{ eccube_config.locale }}',
+                    format: 'YYYY-MM-DD',
+                    useCurrent: false,
+                    buttons: {
+                        showToday: true,
+                        showClose: true
+                    }
+                });
+
+                // datetimepicker で value が消えてしまうので更新
+                $('input.datetimepicker-input').each(function() {
+                    $(this).val($(this).data('value'));
+                });
+            });
         });
 
     </script>

--- a/src/Eccube/Resource/template/admin/Customer/index.twig
+++ b/src/Eccube/Resource/template/admin/Customer/index.twig
@@ -51,7 +51,7 @@ file that was distributed with this source code.
 
                 $('input.datetimepicker-input').not('#admin_search_customer_birth_start').not('#admin_search_customer_birth_end').datetimepicker({
                     locale: '{{ eccube_config.locale }}',
-                    format: 'YYYY-MM-DD HH:mm',
+                    format: 'YYYY-MM-DD HH:mm:ss',
                     useCurrent: false,
                     buttons: {
                         showToday: true,

--- a/src/Eccube/Resource/template/admin/Customer/index.twig
+++ b/src/Eccube/Resource/template/admin/Customer/index.twig
@@ -203,13 +203,13 @@ file that was distributed with this source code.
                             <label>{{ 'admin.common.create_date'|trans }}</label>
                             <div class="form-row align-items-center">
                                 <div class="col">
-                                    {{ form_widget(searchForm.create_date_start) }}
-                                    {{ form_errors(searchForm.create_date_start) }}
+                                    {{ form_widget(searchForm.create_datetime_start) }}
+                                    {{ form_errors(searchForm.create_datetime_start) }}
                                 </div>
                                 <div class="col-auto text-center"><span>{{ 'admin.common.separator__range'|trans }}</span></div>
                                 <div class="col">
-                                    {{ form_widget(searchForm.create_date_end) }}
-                                    {{ form_errors(searchForm.create_date_end) }}
+                                    {{ form_widget(searchForm.create_datetime_end) }}
+                                    {{ form_errors(searchForm.create_datetime_end) }}
                                 </div>
                             </div>
                         </div>
@@ -233,13 +233,13 @@ file that was distributed with this source code.
                             <label>{{ 'admin.common.update_date'|trans }}</label>
                             <div class="form-row align-items-center">
                                 <div class="col">
-                                    {{ form_widget(searchForm.update_date_start) }}
-                                    {{ form_errors(searchForm.update_date_start) }}
+                                    {{ form_widget(searchForm.update_datetime_start) }}
+                                    {{ form_errors(searchForm.update_datetime_start) }}
                                 </div>
                                 <div class="col-auto text-center"><span>{{ 'admin.common.separator__range'|trans }}</span></div>
                                 <div class="col">
-                                    {{ form_widget(searchForm.update_date_end) }}
-                                    {{ form_errors(searchForm.update_date_end) }}
+                                    {{ form_widget(searchForm.update_datetime_end) }}
+                                    {{ form_errors(searchForm.update_datetime_end) }}
                                 </div>
                             </div>
                         </div>

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -34,34 +34,31 @@ file that was distributed with this source code.
 {% block javascript %}
     <script>
         $(function() {
-            if ($('[type="date"]').prop('type') != 'date') {
-                // input type属性でdateが利用できるかどうか(カレンダー表示できないブラウザ対応)
-                $.when(
-                    $.getScript("{{ asset('assets/js/vendor/moment.min.js', 'admin') }}"),
-                    $.getScript("{{ asset('assets/js/vendor/moment-with-locales.min.js', 'admin') }}"),
-                    $.getScript("{{ asset('assets/js/vendor/tempusdominus-bootstrap-4.min.js', 'admin') }}")
-                ).done(function() {
-                    $('input[id$=_date_start]').datetimepicker({
-                        locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD HH:mm',
-                        useCurrent: false,
-                        buttons: {
-                            showToday: true,
-                            showClose: true
-                        }
-                    });
-
-                    $('input[id$=_date_end]').datetimepicker({
-                        locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD HH:mm',
-                        useCurrent: false,
-                        buttons: {
-                            showToday: true,
-                            showClose: true
-                        }
-                    });
+            $.when(
+                $.getScript("{{ asset('assets/js/vendor/moment.min.js', 'admin') }}"),
+                $.getScript("{{ asset('assets/js/vendor/moment-with-locales.min.js', 'admin') }}"),
+                $.getScript("{{ asset('assets/js/vendor/tempusdominus-bootstrap-4.min.js', 'admin') }}")
+            ).done(function() {
+                // datetimepicker で value が消えてしまうので data-value に保持しておく
+                $('input.datetimepicker-input').each(function() {
+                    $(this).data('value', $(this).val());
                 });
-            }
+
+                $('input.datetimepicker-input').datetimepicker({
+                    locale: '{{ eccube_config.locale }}',
+                    format: 'YYYY-MM-DD HH:mm',
+                    useCurrent: false,
+                    buttons: {
+                        showToday: true,
+                        showClose: true
+                    },
+                });
+
+                // datetimepicker で value が消えてしまうので更新
+                $('input.datetimepicker-input').each(function() {
+                    $(this).val($(this).data('value'));
+                });
+            });
 
             toggleBtnBulk('input[id^="check_"]', '.btn-bulk-wrapper');
             $('input[id^="check_"]').on('change', function() {

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -46,7 +46,7 @@ file that was distributed with this source code.
 
                 $('input.datetimepicker-input').datetimepicker({
                     locale: '{{ eccube_config.locale }}',
-                    format: 'YYYY-MM-DD HH:mm',
+                    format: 'YYYY-MM-DD HH:mm:ss',
                     useCurrent: false,
                     buttons: {
                         showToday: true,

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -255,13 +255,13 @@ file that was distributed with this source code.
                         <label class="col-form-label">{{ 'admin.order.order_date'|trans }}</label>
                         <div class="form-row align-items-center">
                             <div class="col">
-                                {{ form_widget(searchForm.order_date_start) }}
-                                {{ form_errors(searchForm.order_date_start) }}
+                                {{ form_widget(searchForm.order_datetime_start) }}
+                                {{ form_errors(searchForm.order_datetime_start) }}
                             </div>
                             <div class="col-auto text-center">{{ 'admin.common.separator__range'|trans }}</div>
                             <div class="col">
-                                {{ form_widget(searchForm.order_date_end) }}
-                                {{ form_errors(searchForm.order_date_end) }}
+                                {{ form_widget(searchForm.order_datetime_end) }}
+                                {{ form_errors(searchForm.order_datetime_end) }}
                             </div>
                         </div>
                     </div>
@@ -276,13 +276,13 @@ file that was distributed with this source code.
                         <label class="col-form-label">{{ 'admin.order.payment_date'|trans }}</label>
                         <div class="form-row align-items-center">
                             <div class="col">
-                                {{ form_widget(searchForm.payment_date_start) }}
-                                {{ form_errors(searchForm.payment_date_start) }}
+                                {{ form_widget(searchForm.payment_datetime_start) }}
+                                {{ form_errors(searchForm.payment_datetime_start) }}
                             </div>
                             <div class="col-auto text-center">{{ 'admin.common.separator__range'|trans }}</div>
                             <div class="col">
-                                {{ form_widget(searchForm.payment_date_end) }}
-                                {{ form_errors(searchForm.payment_date_end) }}
+                                {{ form_widget(searchForm.payment_datetime_end) }}
+                                {{ form_errors(searchForm.payment_datetime_end) }}
                             </div>
                         </div>
                     </div>
@@ -297,13 +297,13 @@ file that was distributed with this source code.
                         <label class="col-form-label">{{ 'admin.common.update_date'|trans }}</label>
                         <div class="form-row align-items-center">
                             <div class="col">
-                                {{ form_widget(searchForm.update_date_start) }}
-                                {{ form_errors(searchForm.update_date_start) }}
+                                {{ form_widget(searchForm.update_datetime_start) }}
+                                {{ form_errors(searchForm.update_datetime_start) }}
                             </div>
                             <div class="col-auto text-center">{{ 'admin.common.separator__range'|trans }}</div>
                             <div class="col">
-                                {{ form_widget(searchForm.update_date_end) }}
-                                {{ form_errors(searchForm.update_date_end) }}
+                                {{ form_widget(searchForm.update_datetime_end) }}
+                                {{ form_errors(searchForm.update_datetime_end) }}
                             </div>
                         </div>
                     </div>
@@ -319,15 +319,15 @@ file that was distributed with this source code.
                         <div class="form-row align-items-center">
                             <div class="col">
                                 <div class="input-group">
-                                    {{ form_widget(searchForm.shipping_delivery_date_start) }}
-                                    {{ form_errors(searchForm.shipping_delivery_date_start) }}
+                                    {{ form_widget(searchForm.shipping_delivery_datetime_start) }}
+                                    {{ form_errors(searchForm.shipping_delivery_datetime_start) }}
                                 </div>
                             </div>
                             <div class="col-auto text-center">{{ 'admin.common.separator__range'|trans }}</div>
                             <div class="col">
                                 <div class="input-group">
-                                    {{ form_widget(searchForm.shipping_delivery_date_end) }}
-                                    {{ form_errors(searchForm.shipping_delivery_date_end) }}
+                                    {{ form_widget(searchForm.shipping_delivery_datetime_end) }}
+                                    {{ form_errors(searchForm.shipping_delivery_datetime_end) }}
                                 </div>
                             </div>
                         </div>

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -43,7 +43,7 @@ file that was distributed with this source code.
                 ).done(function() {
                     $('input[id$=_date_start]').datetimepicker({
                         locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD',
+                        format: 'YYYY-MM-DD HH:mm',
                         useCurrent: false,
                         buttons: {
                             showToday: true,
@@ -53,7 +53,7 @@ file that was distributed with this source code.
 
                     $('input[id$=_date_end]').datetimepicker({
                         locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD',
+                        format: 'YYYY-MM-DD HH:mm',
                         useCurrent: false,
                         buttons: {
                             showToday: true,

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -45,7 +45,7 @@ file that was distributed with this source code.
                 ).done(function() {
                     $('input[id$=_date_start]').datetimepicker({
                         locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD',
+                        format: 'YYYY-MM-DD HH:mm',
                         useCurrent: false,
                         buttons: {
                             showToday: true,
@@ -55,7 +55,7 @@ file that was distributed with this source code.
 
                     $('input[id$=_date_end]').datetimepicker({
                         locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD',
+                        format: 'YYYY-MM-DD HH:mm',
                         useCurrent: false,
                         buttons: {
                             showToday: true,

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -47,7 +47,7 @@ file that was distributed with this source code.
 
                 $('input.datetimepicker-input').datetimepicker({
                     locale: '{{ eccube_config.locale }}',
-                    format: 'YYYY-MM-DD HH:mm',
+                    format: 'YYYY-MM-DD HH:mm:ss',
                     useCurrent: false,
                     buttons: {
                         showToday: true,

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -238,14 +238,14 @@ file that was distributed with this source code.
                             <div class="form-row align-items-center">
                                 <div class="col">
                                     {# TODO: カレンダー表示の調整 #}
-                                    {{ form_widget(searchForm.create_date_start) }}
-                                    {{ form_errors(searchForm.create_date_start) }}
+                                    {{ form_widget(searchForm.create_datetime_start) }}
+                                    {{ form_errors(searchForm.create_datetime_start) }}
                                 </div>
                                 <div class="col-auto text-center"><span>{{ 'admin.common.separator__range'|trans }}</span>
                                 </div>
                                 <div class="col">
-                                    {{ form_widget(searchForm.create_date_end) }}
-                                    {{ form_errors(searchForm.create_date_end) }}
+                                    {{ form_widget(searchForm.create_datetime_end) }}
+                                    {{ form_errors(searchForm.create_datetime_end) }}
                                 </div>
                             </div>
                         </div>
@@ -254,13 +254,13 @@ file that was distributed with this source code.
                             <div class="form-row align-items-center">
                                 <div class="col">
                                     {# TODO: カレンダー表示の調整 #}
-                                    {{ form_widget(searchForm.update_date_start) }}
-                                    {{ form_errors(searchForm.update_date_start) }}
+                                    {{ form_widget(searchForm.update_datetime_start) }}
+                                    {{ form_errors(searchForm.update_datetime_start) }}
                                 </div>
                                 <div class="col-auto"><span>{{ 'admin.common.separator__range'|trans }}</span></div>
                                 <div class="col">
-                                    {{ form_widget(searchForm.update_date_end) }}
-                                    {{ form_errors(searchForm.update_date_end) }}
+                                    {{ form_widget(searchForm.update_datetime_end) }}
+                                    {{ form_errors(searchForm.update_datetime_end) }}
                                 </div>
                             </div>
                         </div>

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -35,35 +35,31 @@ file that was distributed with this source code.
 {% block javascript %}
     <script>
         $(function() {
-
-            if ($('[type="date"]').prop('type') != 'date') {
-                // input type属性でdateが利用できるかどうか(カレンダー表示できないブラウザ対応)
-                $.when(
-                    $.getScript("{{ asset('assets/js/vendor/moment.min.js', 'admin') }}"),
-                    $.getScript("{{ asset('assets/js/vendor/moment-with-locales.min.js', 'admin') }}"),
-                    $.getScript("{{ asset('assets/js/vendor/tempusdominus-bootstrap-4.min.js', 'admin') }}")
-                ).done(function() {
-                    $('input[id$=_date_start]').datetimepicker({
-                        locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD HH:mm',
-                        useCurrent: false,
-                        buttons: {
-                            showToday: true,
-                            showClose: true
-                        }
-                    });
-
-                    $('input[id$=_date_end]').datetimepicker({
-                        locale: '{{ eccube_config.locale }}',
-                        format: 'YYYY-MM-DD HH:mm',
-                        useCurrent: false,
-                        buttons: {
-                            showToday: true,
-                            showClose: true
-                        }
-                    });
+            $.when(
+                $.getScript("{{ asset('assets/js/vendor/moment.min.js', 'admin') }}"),
+                $.getScript("{{ asset('assets/js/vendor/moment-with-locales.min.js', 'admin') }}"),
+                $.getScript("{{ asset('assets/js/vendor/tempusdominus-bootstrap-4.min.js', 'admin') }}")
+            ).done(function() {
+                // datetimepicker で value が消えてしまうので data-value に保持しておく
+                $('input.datetimepicker-input').each(function() {
+                    $(this).data('value', $(this).val());
                 });
-            }
+
+                $('input.datetimepicker-input').datetimepicker({
+                    locale: '{{ eccube_config.locale }}',
+                    format: 'YYYY-MM-DD HH:mm',
+                    useCurrent: false,
+                    buttons: {
+                        showToday: true,
+                        showClose: true
+                    },
+                });
+
+                // datetimepicker で value が消えてしまうので更新
+                $('input.datetimepicker-input').each(function() {
+                    $(this).val($(this).data('value'));
+                });
+            });
 
             $('#bulkDelete').on('click', function() {
 

--- a/src/Eccube/Resource/template/admin/search_items.twig
+++ b/src/Eccube/Resource/template/admin/search_items.twig
@@ -22,7 +22,7 @@ file that was distributed with this source code.
                     {{ not loop.last ? ',&nbsp;' }}
                 {%- endfor -%}
             {%- elseif php_is_a(child.vars.data, '\DateTime') -%}
-                {{ child.vars.data|date_day }}
+                {{ child.vars.data|date_min }}
             {%- else -%}
                 {# ChoiceType -> multiple:false #}
                 {%- if child.vars.choices is defined and child.vars.choices is not empty -%}

--- a/src/Eccube/Resource/template/admin/search_items.twig
+++ b/src/Eccube/Resource/template/admin/search_items.twig
@@ -24,7 +24,7 @@ file that was distributed with this source code.
             {%- elseif php_is_a(child.vars.data, '\DateTime') -%}
                 {# DateTimeType の時は分まで表示 #}
                 {% if 'datetime' in child.vars.id %}
-                    {{ child.vars.data|date_min }}
+                    {{ child.vars.data|date_sec }}
                 {% else %}
                     {{ child.vars.data|date_day }}
                 {% endif %}

--- a/src/Eccube/Resource/template/admin/search_items.twig
+++ b/src/Eccube/Resource/template/admin/search_items.twig
@@ -22,7 +22,12 @@ file that was distributed with this source code.
                     {{ not loop.last ? ',&nbsp;' }}
                 {%- endfor -%}
             {%- elseif php_is_a(child.vars.data, '\DateTime') -%}
-                {{ child.vars.data|date_min }}
+                {# DateTimeType の時は分まで表示 #}
+                {% if 'datetime' in child.vars.id %}
+                    {{ child.vars.data|date_min }}
+                {% else %}
+                    {{ child.vars.data|date_day }}
+                {% endif %}
             {%- else -%}
                 {# ChoiceType -> multiple:false #}
                 {%- if child.vars.choices is defined and child.vars.choices is not empty -%}

--- a/tests/Eccube/Tests/Form/Type/Admin/SearchCustomerTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchCustomerTypeTest.php
@@ -92,7 +92,7 @@ class SearchCustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCas
     }
 
     /**
-     * EC-CUBE 4.0.5 以降で yyyy-MM-dd HH:mm のフォーマットでの検索機能を追加
+     * EC-CUBE 4.0.5 以降で yyyy-MM-dd HH:mm:ss のフォーマットでの検索機能を追加
      *
      * @dataProvider dataFormDateTimeProvider
      *

--- a/tests/Eccube/Tests/Form/Type/Admin/SearchCustomerTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchCustomerTypeTest.php
@@ -72,17 +72,15 @@ class SearchCustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCas
      * @dataProvider dataFormDateProvider
      *
      * @param string $formName
-     * @param string $formValue
-     * @param bool $result
      */
-    public function testDateSearch(string $formName, string $formValue, bool $result)
+    public function testDateSearch(string $formName)
     {
         $formData = [
-            $formName => $formValue,
+            $formName => '2020-07-09',
         ];
 
         $this->form->submit($formData);
-        $this->assertEquals($result, $this->form->isValid());
+        $this->assertTrue($this->form->isValid());
     }
 
     /**
@@ -93,27 +91,47 @@ class SearchCustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCas
     public function dataFormDateProvider()
     {
         return [
-            ['create_date_start', '2020-07-09', true],
-            ['create_date_start', '2020-07-09 09:00', true],
-            ['create_date_start', '2020-07-09 aa', false],
-            ['update_date_start', '2020-07-09', true],
-            ['update_date_start', '2020-07-09 09:00', true],
-            ['update_date_start', '2020-07-09 aa', false],
-            ['last_buy_start', '2020-07-09', true],
-            ['last_buy_start', '2020-07-09 09:00', true],
-            ['last_buy_start', '2020-07-09 aa', false],
-            ['create_date_end', '2020-07-09', true],
-            ['create_date_end', '2020-07-09 09:00', true],
-            ['create_date_end', '2020-07-09 aa', false],
-            ['update_date_end', '2020-07-09', true],
-            ['update_date_end', '2020-07-09 09:00', true],
-            ['update_date_end', '2020-07-09 aa', false],
-            ['last_buy_end', '2020-07-09', true],
-            ['last_buy_end', '2020-07-09 09:00', true],
-            ['last_buy_end', '2020-07-09 aa', false],
-            ['birth_start', '2020-07-09', true],
-            ['birth_end', '2020-07-09', true],
-            ['phone_number', '2020-07-09', true],
+            ['create_date_start'],
+            ['update_date_start'],
+            ['last_buy_start'],
+            ['create_date_end'],
+            ['update_date_end'],
+            ['last_buy_end'],
+            ['birth_start'],
+        ];
+    }
+
+    /**
+     * EC-CUBE 4.0.5 以降で yyyy-MM-dd HH:mm のフォーマットでの検索機能を追加
+     *
+     * @dataProvider dataFormDateTimeProvider
+     *
+     * @param string $formName
+     */
+    public function testDateTimeSearch(string $formName)
+    {
+        $formData = [
+            $formName => '2020-07-09 09:00',
+        ];
+
+        $this->form->submit($formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    /**
+     * Data provider datetime form test.
+     *
+     * @return array
+     */
+    public function dataFormDateTimeProvider()
+    {
+        return [
+            ['create_datetime_start'],
+            ['update_datetime_start'],
+            ['last_buy_datetime_start'],
+            ['create_datetime_end'],
+            ['update_datetime_end'],
+            ['last_buy_datetime_end'],
         ];
     }
 }

--- a/tests/Eccube/Tests/Form/Type/Admin/SearchCustomerTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchCustomerTypeTest.php
@@ -111,7 +111,7 @@ class SearchCustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCas
     public function testDateTimeSearch(string $formName)
     {
         $formData = [
-            $formName => '2020-07-09 09:00',
+            $formName => '2020-07-09 09:00:00',
         ];
 
         $this->form->submit($formData);

--- a/tests/Eccube/Tests/Form/Type/Admin/SearchCustomerTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchCustomerTypeTest.php
@@ -111,6 +111,9 @@ class SearchCustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCas
             ['last_buy_end', '2020-07-09', true],
             ['last_buy_end', '2020-07-09 09:00', true],
             ['last_buy_end', '2020-07-09 aa', false],
+            ['birth_start', '2020-07-09', true],
+            ['birth_end', '2020-07-09', true],
+            ['phone_number', '2020-07-09', true],
         ];
     }
 }

--- a/tests/Eccube/Tests/Form/Type/Admin/SearchOrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchOrderTypeTest.php
@@ -64,7 +64,7 @@ class SearchOrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
     }
 
     /**
-     * EC-CUBE 4.0.5 以降で yyyy-MM-dd HH:mm のフォーマットでの検索機能を追加
+     * EC-CUBE 4.0.5 以降で yyyy-MM-dd HH:mm:ss のフォーマットでの検索機能を追加
      *
      * @dataProvider dataFormDateTimeProvider
      *

--- a/tests/Eccube/Tests/Form/Type/Admin/SearchOrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchOrderTypeTest.php
@@ -1,0 +1,83 @@
+<?php
+
+
+namespace Eccube\Tests\Form\Type\Admin;
+
+
+use Eccube\Form\Type\Admin\SearchOrderType;
+use Symfony\Component\Form\FormInterface;
+
+class SearchOrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
+{
+    /**
+     * @var FormInterface
+     */
+    protected $form;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        // CSRF tokenを無効にしてFormを作成
+        $this->form = $this->formFactory
+            ->createBuilder(SearchOrderType::class, null, ['csrf_protection' => false])
+            ->getForm();
+    }
+
+    /**
+     * EC-CUBE 4.0.4 以前のバージョンで互換性を保つため yyyy-MM-dd のフォーマットもチェック
+     *
+     * @dataProvider dataFormDateProvider
+     *
+     * @param string $formName
+     * @param string $formValue
+     * @param bool $result
+     */
+    public function testDateSearch(string $formName, string $formValue, bool $result)
+    {
+        $formData = [
+            $formName => $formValue,
+        ];
+
+        $this->form->submit($formData);
+        $this->assertEquals($result, $this->form->isValid());
+    }
+
+    /**
+     * Data provider date form test.
+     *
+     * @return array
+     */
+    public function dataFormDateProvider()
+    {
+        return [
+            ['order_date_start', '2020-07-09', true],
+            ['order_date_start', '2020-07-09 09:00', true],
+            ['order_date_start', '2020-07-09 aa', false],
+            ['payment_date_start', '2020-07-09', true],
+            ['payment_date_start', '2020-07-09 09:00', true],
+            ['payment_date_start', '2020-07-09 aa', false],
+            ['update_date_start', '2020-07-09', true],
+            ['update_date_start', '2020-07-09 09:00', true],
+            ['update_date_start', '2020-07-09 aa', false],
+            ['shipping_delivery_date_start', '2020-07-09', true],
+            ['shipping_delivery_date_start', '2020-07-09 09:00', true],
+            ['shipping_delivery_date_start', '2020-07-09 aa', false],
+            ['order_date_end', '2020-07-09', true],
+            ['order_date_end', '2020-07-09 09:00', true],
+            ['order_date_end', '2020-07-09 aa', false],
+            ['payment_date_end', '2020-07-09', true],
+            ['payment_date_end', '2020-07-09 09:00', true],
+            ['payment_date_end', '2020-07-09 aa', false],
+            ['update_date_end', '2020-07-09', true],
+            ['update_date_end', '2020-07-09 09:00', true],
+            ['update_date_end', '2020-07-09 aa', false],
+            ['shipping_delivery_date_end', '2020-07-09', true],
+            ['shipping_delivery_date_end', '2020-07-09 09:00', true],
+            ['shipping_delivery_date_end', '2020-07-09 aa', false],
+        ];
+    }
+}

--- a/tests/Eccube/Tests/Form/Type/Admin/SearchOrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchOrderTypeTest.php
@@ -73,7 +73,7 @@ class SearchOrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
     public function testDateTimeSearch(string $formName)
     {
         $formData = [
-            $formName => '2020-07-09 09:00',
+            $formName => '2020-07-09 09:00:00',
         ];
 
         $this->form->submit($formData);

--- a/tests/Eccube/Tests/Form/Type/Admin/SearchOrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchOrderTypeTest.php
@@ -78,6 +78,7 @@ class SearchOrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
             ['shipping_delivery_date_end', '2020-07-09', true],
             ['shipping_delivery_date_end', '2020-07-09 09:00', true],
             ['shipping_delivery_date_end', '2020-07-09 aa', false],
+            ['phone_number', '2020-07-09', true],
         ];
     }
 }

--- a/tests/Eccube/Tests/Form/Type/Admin/SearchOrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchOrderTypeTest.php
@@ -33,17 +33,15 @@ class SearchOrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
      * @dataProvider dataFormDateProvider
      *
      * @param string $formName
-     * @param string $formValue
-     * @param bool $result
      */
-    public function testDateSearch(string $formName, string $formValue, bool $result)
+    public function testDateSearch(string $formName)
     {
         $formData = [
-            $formName => $formValue,
+            $formName => '2020-07-09',
         ];
 
         $this->form->submit($formData);
-        $this->assertEquals($result, $this->form->isValid());
+        $this->assertTrue($this->form->isValid());
     }
 
     /**
@@ -54,31 +52,50 @@ class SearchOrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
     public function dataFormDateProvider()
     {
         return [
-            ['order_date_start', '2020-07-09', true],
-            ['order_date_start', '2020-07-09 09:00', true],
-            ['order_date_start', '2020-07-09 aa', false],
-            ['payment_date_start', '2020-07-09', true],
-            ['payment_date_start', '2020-07-09 09:00', true],
-            ['payment_date_start', '2020-07-09 aa', false],
-            ['update_date_start', '2020-07-09', true],
-            ['update_date_start', '2020-07-09 09:00', true],
-            ['update_date_start', '2020-07-09 aa', false],
-            ['shipping_delivery_date_start', '2020-07-09', true],
-            ['shipping_delivery_date_start', '2020-07-09 09:00', true],
-            ['shipping_delivery_date_start', '2020-07-09 aa', false],
-            ['order_date_end', '2020-07-09', true],
-            ['order_date_end', '2020-07-09 09:00', true],
-            ['order_date_end', '2020-07-09 aa', false],
-            ['payment_date_end', '2020-07-09', true],
-            ['payment_date_end', '2020-07-09 09:00', true],
-            ['payment_date_end', '2020-07-09 aa', false],
-            ['update_date_end', '2020-07-09', true],
-            ['update_date_end', '2020-07-09 09:00', true],
-            ['update_date_end', '2020-07-09 aa', false],
-            ['shipping_delivery_date_end', '2020-07-09', true],
-            ['shipping_delivery_date_end', '2020-07-09 09:00', true],
-            ['shipping_delivery_date_end', '2020-07-09 aa', false],
-            ['phone_number', '2020-07-09', true],
+            ['order_date_start'],
+            ['payment_date_start'],
+            ['update_date_start'],
+            ['shipping_delivery_date_start'],
+            ['order_date_end'],
+            ['payment_date_end'],
+            ['update_date_end'],
+            ['shipping_delivery_date_end'],
+        ];
+    }
+
+    /**
+     * EC-CUBE 4.0.5 以降で yyyy-MM-dd HH:mm のフォーマットでの検索機能を追加
+     *
+     * @dataProvider dataFormDateTimeProvider
+     *
+     * @param string $formName
+     */
+    public function testDateTimeSearch(string $formName)
+    {
+        $formData = [
+            $formName => '2020-07-09 09:00',
+        ];
+
+        $this->form->submit($formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    /**
+     * Data provider datetime form test.
+     *
+     * @return array
+     */
+    public function dataFormDateTimeProvider()
+    {
+        return [
+            ['order_datetime_start'],
+            ['payment_datetime_start'],
+            ['update_datetime_start'],
+            ['shipping_delivery_datetime_start'],
+            ['order_datetime_end'],
+            ['payment_datetime_end'],
+            ['update_datetime_end'],
+            ['shipping_delivery_datetime_end'],
         ];
     }
 }

--- a/tests/Eccube/Tests/Form/Type/Admin/SearchProductTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchProductTypeTest.php
@@ -69,7 +69,7 @@ class SearchProductTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
     public function testDateTimeSearch(string $formName)
     {
         $formData = [
-            $formName => '2020-07-09 09:00',
+            $formName => '2020-07-09 09:00:00',
         ];
 
         $this->form->submit($formData);

--- a/tests/Eccube/Tests/Form/Type/Admin/SearchProductTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchProductTypeTest.php
@@ -66,6 +66,8 @@ class SearchProductTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
             ['update_date_end', '2020-07-09', true],
             ['update_date_end', '2020-07-09 09:00', true],
             ['update_date_end', '2020-07-09 aa', false],
+            ['id', '2020-07-09', true],
+            ['category_id', '1', true],
         ];
     }
 }

--- a/tests/Eccube/Tests/Form/Type/Admin/SearchProductTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchProductTypeTest.php
@@ -33,17 +33,15 @@ class SearchProductTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
      * @dataProvider dataFormDateProvider
      *
      * @param string $formName
-     * @param string $formValue
-     * @param bool $result
      */
-    public function testDateSearch(string $formName, string $formValue, bool $result)
+    public function testDateSearch(string $formName)
     {
         $formData = [
-            $formName => $formValue,
+            $formName => '2020-07-09',
         ];
 
         $this->form->submit($formData);
-        $this->assertEquals($result, $this->form->isValid());
+        $this->assertTrue($this->form->isValid());
     }
 
     /**
@@ -54,20 +52,42 @@ class SearchProductTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
     public function dataFormDateProvider()
     {
         return [
-            ['create_date_start', '2020-07-09', true],
-            ['create_date_start', '2020-07-09 09:00', true],
-            ['create_date_start', '2020-07-09 aa', false],
-            ['update_date_start', '2020-07-09', true],
-            ['update_date_start', '2020-07-09 09:00', true],
-            ['update_date_start', '2020-07-09 aa', false],
-            ['create_date_end', '2020-07-09', true],
-            ['create_date_end', '2020-07-09 09:00', true],
-            ['create_date_end', '2020-07-09 aa', false],
-            ['update_date_end', '2020-07-09', true],
-            ['update_date_end', '2020-07-09 09:00', true],
-            ['update_date_end', '2020-07-09 aa', false],
-            ['id', '2020-07-09', true],
-            ['category_id', '1', true],
+            ['create_date_start'],
+            ['update_date_start'],
+            ['create_date_end'],
+            ['update_date_end'],
+        ];
+    }
+
+    /**
+     * EC-CUBE 4.0.5 以降で yyyy-MM-dd HH:mm のフォーマットでの検索機能を追加
+     *
+     * @dataProvider dataFormDateTimeProvider
+     *
+     * @param string $formName
+     */
+    public function testDateTimeSearch(string $formName)
+    {
+        $formData = [
+            $formName => '2020-07-09 09:00',
+        ];
+
+        $this->form->submit($formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    /**
+     * Data provider datetime form test.
+     *
+     * @return array
+     */
+    public function dataFormDateTimeProvider()
+    {
+        return [
+            ['create_datetime_start'],
+            ['update_datetime_start'],
+            ['create_datetime_end'],
+            ['update_datetime_end'],
         ];
     }
 }

--- a/tests/Eccube/Tests/Form/Type/Admin/SearchProductTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchProductTypeTest.php
@@ -60,7 +60,7 @@ class SearchProductTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
     }
 
     /**
-     * EC-CUBE 4.0.5 以降で yyyy-MM-dd HH:mm のフォーマットでの検索機能を追加
+     * EC-CUBE 4.0.5 以降で yyyy-MM-dd HH:mm:ss のフォーマットでの検索機能を追加
      *
      * @dataProvider dataFormDateTimeProvider
      *

--- a/tests/Eccube/Tests/Form/Type/Admin/SearchProductTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchProductTypeTest.php
@@ -1,22 +1,13 @@
 <?php
 
-/*
- * This file is part of EC-CUBE
- *
- * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
- *
- * http://www.ec-cube.co.jp/
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 
 namespace Eccube\Tests\Form\Type\Admin;
 
-use Eccube\Form\Type\Admin\SearchCustomerType;
+
+use Eccube\Form\Type\Admin\SearchProductType;
 use Symfony\Component\Form\FormInterface;
 
-class SearchCustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
+class SearchProductTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 {
     /**
      * @var FormInterface
@@ -32,38 +23,8 @@ class SearchCustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCas
 
         // CSRF tokenを無効にしてFormを作成
         $this->form = $this->formFactory
-            ->createBuilder(SearchCustomerType::class, null, ['csrf_protection' => false])
+            ->createBuilder(SearchProductType::class, null, ['csrf_protection' => false])
             ->getForm();
-    }
-
-    public function testPhoneNumber_NotValidData()
-    {
-        $formData = [
-            'phone_number' => str_repeat('A', 55),
-        ];
-
-        $this->form->submit($formData);
-        $this->assertFalse($this->form->isValid());
-    }
-
-    public function testBuyProductName_NotValiedData()
-    {
-        $formData = [
-            'buy_product_name' => str_repeat('A', $this->eccubeConfig['eccube_stext_len'] + 1),
-        ];
-
-        $this->form->submit($formData);
-        $this->assertFalse($this->form->isValid());
-    }
-
-    public function testBuyProductCode_NotValiedData()
-    {
-        $formData = [
-            'buy_product_code' => str_repeat('A', $this->eccubeConfig['eccube_stext_len'] + 1),
-        ];
-
-        $this->form->submit($formData);
-        $this->assertFalse($this->form->isValid());
     }
 
     /**
@@ -99,18 +60,12 @@ class SearchCustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCas
             ['update_date_start', '2020-07-09', true],
             ['update_date_start', '2020-07-09 09:00', true],
             ['update_date_start', '2020-07-09 aa', false],
-            ['last_buy_start', '2020-07-09', true],
-            ['last_buy_start', '2020-07-09 09:00', true],
-            ['last_buy_start', '2020-07-09 aa', false],
             ['create_date_end', '2020-07-09', true],
             ['create_date_end', '2020-07-09 09:00', true],
             ['create_date_end', '2020-07-09 aa', false],
             ['update_date_end', '2020-07-09', true],
             ['update_date_end', '2020-07-09 09:00', true],
             ['update_date_end', '2020-07-09 aa', false],
-            ['last_buy_end', '2020-07-09', true],
-            ['last_buy_end', '2020-07-09 09:00', true],
-            ['last_buy_end', '2020-07-09 aa', false],
         ];
     }
 }

--- a/tests/Eccube/Tests/Repository/CustomerRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/CustomerRepositoryGetQueryBuilderBySearchDataTest.php
@@ -578,84 +578,101 @@ class CustomerRepositoryGetQueryBuilderBySearchDataTest extends EccubeTestCase
         $this->verify();
     }
 
-    public function testCreateDateStart()
-    {
-        $this->searchData = [
-            'create_date_start' => new \DateTime('- 1 days'),
-        ];
-
-        $this->scenario();
-
-        $this->expected = 4;
-        $this->actual = count($this->Results);
-        $this->verify();
-    }
-
-    public function testCreateDateEnd()
-    {
-        $this->searchData = [
-            'create_date_end' => new \DateTime('+ 1 days'),
-        ];
-
-        $this->scenario();
-        $this->expected = 4;
-        $this->actual = count($this->Results);
-        $this->verify();
-    }
-
-    public function testUpdateDateStart()
-    {
-        $this->searchData = [
-            'update_date_start' => new \DateTime('- 1 days'),
-        ];
-
-        $this->scenario();
-
-        $this->expected = 4;
-        $this->actual = count($this->Results);
-        $this->verify();
-    }
-
-    public function testUpdateDateEnd()
-    {
-        $this->searchData = [
-            'update_date_end' => new \DateTime('+ 1 days'),
-        ];
-
-        $this->scenario();
-        $this->expected = 4;
-        $this->actual = count($this->Results);
-        $this->verify();
-    }
-
-    public function testLastBuyStart()
+    /**
+     * @dataProvider dataFormDateProvider
+     *
+     * @param string $formName
+     * @param string $time
+     * @param int $expected
+     */
+    public function testDate(string $formName, string $time, int $expected)
     {
         $this->Customer->setLastBuyDate(new \DateTime());
         $this->entityManager->flush();
 
         $this->searchData = [
-            'last_buy_start' => new \DateTime('- 1 days'),
+            $formName => new \DateTime($time),
         ];
 
         $this->scenario();
-        $this->expected = 1;
+
+        $this->expected = $expected;
         $this->actual = count($this->Results);
         $this->verify();
     }
 
-    public function testLastBuyEnd()
+    /**
+     * Data provider date form test.
+     *
+     * time:
+     * - today: 今日の00:00:00
+     * - tomorrow: 明日の00:00:00
+     * - yesterday: 昨日の00:00:00
+     *
+     * @return array
+     */
+    public function dataFormDateProvider()
+    {
+        return [
+            ['create_date_start', 'today', 4],
+            ['create_date_start', 'tomorrow', 0],
+            ['update_date_start', 'today', 4],
+            ['update_date_start', 'tomorrow', 0],
+            ['last_buy_start', 'today', 1],
+            ['last_buy_start', 'tomorrow', 0],
+            ['create_date_end', 'today', 4],
+            ['create_date_end', 'yesterday', 0],
+            ['update_date_end', 'today', 4],
+            ['update_date_end', 'yesterday', 0],
+            ['last_buy_end', 'today', 1],
+            ['last_buy_end', 'yesterday', 0],
+        ];
+    }
+
+    /**
+     * @dataProvider dataFormDateTimeProvider
+     *
+     * @param string $formName
+     * @param string $time
+     * @param int $expected
+     */
+    public function testDateTime(string $formName, string $time, int $expected)
     {
         $this->Customer->setLastBuyDate(new \DateTime());
         $this->entityManager->flush();
 
         $this->searchData = [
-            'last_buy_end' => new \DateTime('+ 1 days'),
+            $formName => new \DateTime($time),
         ];
 
         $this->scenario();
-        $this->expected = 1;
+
+        $this->expected = $expected;
         $this->actual = count($this->Results);
         $this->verify();
+    }
+
+    /**
+     * Data provider datetime form test.
+     *
+     * @return array
+     */
+    public function dataFormDateTimeProvider()
+    {
+        return [
+            ['create_datetime_start', '- 1 hour', 4],
+            ['create_datetime_start', '+ 1 hour', 0],
+            ['update_datetime_start', '- 1 hour', 4],
+            ['update_datetime_start', '+ 1 hour', 0],
+            ['last_buy_datetime_start', '- 1 hour', 1],
+            ['last_buy_datetime_start', '+ 1 hour', 0],
+            ['create_datetime_end', '+ 1 hour', 4],
+            ['create_datetime_end', '- 1 hour', 0],
+            ['update_datetime_end', '+ 1 hour', 4],
+            ['update_datetime_end', '- 1 hour', 0],
+            ['last_buy_datetime_end', '+ 1 hour', 1],
+            ['last_buy_datetime_end', '- 1 hour', 0],
+        ];
     }
 
     public function testStatus()

--- a/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataAdminTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryGetQueryBuilderBySearchDataAdminTest.php
@@ -364,120 +364,107 @@ class OrderRepositoryGetQueryBuilderBySearchDataAdminTest extends EccubeTestCase
         $this->verify();
     }
 
-    public function testOrderDateStart()
+    /**
+     * @dataProvider dataFormDateProvider
+     *
+     * @param string $formName
+     * @param string $time
+     * @param int $expected
+     * @param int $OrderStatusId
+     */
+    public function testDate(string $formName, string $time, int $expected, int $OrderStatusId = null)
     {
+        if (!is_null($OrderStatusId)) {
+            $Status = $this->orderStatusRepo->find($OrderStatusId);
+            $this->orderRepo->changeStatus($this->Order2->getId(), $Status);
+        }
+
         $this->searchData = [
-            'order_date_start' => new \DateTime('- 1 days'),
+            $formName => new \DateTime($time),
         ];
 
         $this->scenario();
 
-        $this->expected = 2;
+        $this->expected = $expected;
         $this->actual = count($this->Results);
         $this->verify();
     }
 
-    public function testOrderDateEnd()
+    /**
+     * Data provider date form test.
+     *
+     * time:
+     * - today: 今日の00:00:00
+     * - tomorrow: 明日の00:00:00
+     * - yesterday: 昨日の00:00:00
+     *
+     * @return array
+     */
+    public function dataFormDateProvider()
     {
+        return [
+            ['order_date_start', 'today', 2],
+            ['order_date_start', 'tomorrow', 0],
+            ['payment_date_start', 'today', 1, OrderStatus::PAID],
+            ['payment_date_start', 'tomorrow', 0, OrderStatus::PAID],
+            ['update_date_start', 'today', 2],
+            ['update_date_start', 'tomorrow', 0],
+            ['order_date_end', 'today', 2],
+            ['order_date_end', 'yesterday', 0],
+            ['payment_date_end', 'today', 1, OrderStatus::PAID],
+            ['payment_date_end', 'yesterday', 0, OrderStatus::PAID],
+            ['update_date_end', 'today', 2],
+            ['update_date_end', 'yesterday', 0],
+        ];
+    }
+
+    /**
+     * @dataProvider dataFormDateTimeProvider
+     *
+     * @param string $formName
+     * @param string $time
+     * @param int $expected
+     * @param int|null $OrderStatusId
+     */
+    public function testDateTime(string $formName, string $time, int $expected, int $OrderStatusId = null)
+    {
+        if (!is_null($OrderStatusId)) {
+            $Status = $this->orderStatusRepo->find($OrderStatusId);
+            $this->orderRepo->changeStatus($this->Order2->getId(), $Status);
+        }
+
         $this->searchData = [
-            'order_date_end' => new \DateTime('+ 1 days'),
+            $formName => new \DateTime($time),
         ];
 
         $this->scenario();
 
-        $this->expected = 2;
+        $this->expected = $expected;
         $this->actual = count($this->Results);
         $this->verify();
     }
 
-    public function testUpdateDateStart()
+    /**
+     * Data provider datetime form test.
+     *
+     * @return array
+     */
+    public function dataFormDateTimeProvider()
     {
-        $this->searchData = [
-            'update_date_start' => new \DateTime('- 1 days'),
+        return [
+            ['order_datetime_start', '- 1 hour', 2],
+            ['order_datetime_start', '+ 1 hour', 0],
+            ['payment_datetime_start', '- 1 hour', 1, OrderStatus::PAID],
+            ['payment_datetime_start', '+ 1 hour', 0, OrderStatus::PAID],
+            ['update_datetime_start', '- 1 hour', 2],
+            ['update_datetime_start', '+ 1 hour', 0],
+            ['order_datetime_end', '+ 1 hour', 2],
+            ['order_datetime_end', '- 1 hour', 0],
+            ['payment_datetime_end', '+ 1 hour', 1, OrderStatus::PAID],
+            ['payment_datetime_end', '- 1 hour', 0, OrderStatus::PAID],
+            ['update_datetime_end', '+ 1 hour', 2],
+            ['update_datetime_end', '- 1 hour', 0],
         ];
-
-        $this->scenario();
-
-        $this->expected = 2;
-        $this->actual = count($this->Results);
-        $this->verify();
-    }
-
-    public function testUpdateDateEnd()
-    {
-        $this->searchData = [
-            'update_date_end' => new \DateTime('+ 1 days'),
-        ];
-
-        $this->scenario();
-
-        $this->expected = 2;
-        $this->actual = count($this->Results);
-        $this->verify();
-    }
-
-    public function testPaymentDateStart()
-    {
-        $Status = $this->orderStatusRepo->find(OrderStatus::PAID);
-        $this->orderRepo->changeStatus($this->Order2->getId(), $Status);
-
-        $this->searchData = [
-            'payment_date_start' => new \DateTime('- 1 days'),
-        ];
-
-        $this->scenario();
-
-        $this->expected = 1;
-        $this->actual = count($this->Results);
-        $this->verify();
-    }
-
-    public function testPaymentDateEnd()
-    {
-        $Status = $this->orderStatusRepo->find(OrderStatus::PAID);
-        $this->orderRepo->changeStatus($this->Order2->getId(), $Status);
-        $this->searchData = [
-            'payment_date_end' => new \DateTime('+ 1 days'),
-        ];
-
-        $this->scenario();
-
-        $this->expected = 1;
-        $this->actual = count($this->Results);
-        $this->verify();
-    }
-
-    public function testCommitDateStart()
-    {
-        $this->markTestSkipped('order.shipping_dateは不要と思われる.');
-        $Status = $this->orderStatusRepo->find(OrderStatus::DELIVERED);
-        $this->orderRepo->changeStatus($this->Order2->getId(), $Status);
-
-        $this->searchData = [
-            'shipping_date_start' => new \DateTime('- 1 days'),
-        ];
-
-        $this->scenario();
-
-        $this->expected = 1;
-        $this->actual = count($this->Results);
-        $this->verify();
-    }
-
-    public function testCommitDateEnd()
-    {
-        $this->markTestSkipped('order.shipping_dateは不要と思われる.');
-        $Status = $this->orderStatusRepo->find(OrderStatus::DELIVERED);
-        $this->orderRepo->changeStatus($this->Order2->getId(), $Status);
-        $this->searchData = [
-            'shipping_date_end' => new \DateTime('+ 1 days'),
-        ];
-
-        $this->scenario();
-
-        $this->expected = 1;
-        $this->actual = count($this->Results);
-        $this->verify();
     }
 
     public function testPaymentTotalStart()

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataAdminTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataAdminTest.php
@@ -228,56 +228,87 @@ class ProductRepositoryGetQueryBuilderBySearchDataAdminTest extends AbstractProd
         $this->verify();
     }
 
-    public function testCreateDateStart()
+    /**
+     * @dataProvider dataFormDateProvider
+     *
+     * @param string $formName
+     * @param string $time
+     * @param int $expected
+     */
+    public function testDate(string $formName, string $time, int $expected)
     {
         $this->searchData = [
-            'create_date_start' => new \DateTime('- 1 days'),
+            $formName => new \DateTime($time),
         ];
 
         $this->scenario();
 
-        $this->expected = 3;
+        $this->expected = $expected;
         $this->actual = count($this->Results);
         $this->verify();
     }
 
-    public function testCreateDateEnd()
+    /**
+     * Data provider date form test.
+     *
+     * time:
+     * - today: 今日の00:00:00
+     * - tomorrow: 明日の00:00:00
+     * - yesterday: 昨日の00:00:00
+     *
+     * @return array
+     */
+    public function dataFormDateProvider()
+    {
+        return [
+            ['create_date_start', 'today', 3],
+            ['create_date_start', 'tomorrow', 0],
+            ['update_date_start', 'today', 3],
+            ['update_date_start', 'tomorrow', 0],
+            ['create_date_end', 'today', 3],
+            ['create_date_end', 'yesterday', 0],
+            ['update_date_end', 'today', 3],
+            ['update_date_end', 'yesterday', 0],
+        ];
+    }
+
+    /**
+     * @dataProvider dataFormDateTimeProvider
+     *
+     * @param string $formName
+     * @param string $time
+     * @param int $expected
+     */
+    public function testDateTime(string $formName, string $time, int $expected)
     {
         $this->searchData = [
-            'create_date_end' => new \DateTime('+ 1 days'),
+            $formName => new \DateTime($time),
         ];
 
         $this->scenario();
 
-        $this->expected = 3;
+        $this->expected = $expected;
         $this->actual = count($this->Results);
         $this->verify();
     }
 
-    public function testUpdateDateStart()
+    /**
+     * Data provider datetime form test.
+     *
+     * @return array
+     */
+    public function dataFormDateTimeProvider()
     {
-        $this->searchData = [
-            'update_date_start' => new \DateTime('- 1 days'),
+        return [
+            ['create_datetime_start', '- 1 hour', 3],
+            ['create_datetime_start', '+ 1 hour', 0],
+            ['update_datetime_start', '- 1 hour', 3],
+            ['update_datetime_start', '+ 1 hour', 0],
+            ['create_datetime_end', '+ 1 hour', 3],
+            ['create_datetime_end', '- 1 hour', 0],
+            ['update_datetime_end', '+ 1 hour', 3],
+            ['update_datetime_end', '- 1 hour', 0],
         ];
-
-        $this->scenario();
-
-        $this->expected = 3;
-        $this->actual = count($this->Results);
-        $this->verify();
-    }
-
-    public function testUpdateDateEnd()
-    {
-        $this->searchData = [
-            'update_date_end' => new \DateTime('+ 1 days'),
-        ];
-
-        $this->scenario();
-
-        $this->expected = 3;
-        $this->actual = count($this->Results);
-        $this->verify();
     }
 
     public function testCategory()


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

管理画面の検索機能をDateTimeTypeに対応

互換性を確保するため `yyyy-MM-dd` と `yyyy-MM-dd HH:mm:ss` のどちらのフォーマットでも検索可能なようにしました。

close #4618 

### Chrome

![image](https://user-images.githubusercontent.com/16895409/87366748-648d7a00-c5b4-11ea-99b4-9bd3b787a124.png)

### Safari

![image](https://user-images.githubusercontent.com/16895409/87367826-fdbd9000-c5b6-11ea-9bca-5cc4f557d5a8.png)

### FireFox

![image](https://user-images.githubusercontent.com/16895409/87367702-b0412300-c5b6-11ea-9c32-1d0ddb029190.png)

## 方針(Policy)

- カスタマイズさてていることを考慮して既存の DateType は残しつつ DateTimeType を新たに追加
- ブラウザ間の差異をなくすためにUIは `datetimepicker` に統一
- 実装はできるだけ今のものを利用できるように配慮

## 実装に関する補足(Appendix)

- カレンダーのUIはブラウザごとにHTML5と `datetimepicker` が混在していたのを統一した
  - シンプルで使いやすいHTML5にしたかったが対応ブラウザが限られてしまうので諦めた
- `datetimepicker` で検索条件が消えてしまう課題にも対応
- `ShippingRepository::getQueryBuilderBySearchDataForAdmin()` は利用されていなかったので `@ deprecated ` とした
- DateType と DateTimeType のどちらも指定されていた場合には DateTimeType を優先する

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

UnitTestを追加

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
