### PR TITLE
SearchCustomerType に buy_product_code のフォームは無いのでテストから削除

### DIFF
--- a/tests/Eccube/Tests/Form/Type/Admin/SearchCustomerTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SearchCustomerTypeTest.php
@@ -55,14 +55,4 @@ class SearchCustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCas
         $this->form->submit($formData);
         $this->assertFalse($this->form->isValid());
     }
-
-    public function testBuyProductCode_NotValiedData()
-    {
-        $formData = [
-            'buy_product_code' => str_repeat('A', $this->eccubeConfig['eccube_stext_len'] + 1),
-        ];
-
-        $this->form->submit($formData);
-        $this->assertFalse($this->form->isValid());
-    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

SearchCustomerType に buy_product_code のフォームは無いのでテストから削除

## 方針(Policy)

ProductCodeで検索できるようにする選択肢もあったがいったんプロダクトコードを正とした

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
