### PR TITLE
カテゴリ４階層目で新規登録フォームが表示されなくなる(eccube_category_nest_level=5)

### DIFF
--- a/src/Eccube/Resource/template/admin/Product/category.twig
+++ b/src/Eccube/Resource/template/admin/Product/category.twig
@@ -187,7 +187,7 @@ file that was distributed with this source code.
                                     <form role="form" name="form1" id="form1" method="post"
                                           action="{% if TargetCategory.id %}{{ path('admin_product_category_edit', {id: TargetCategory.id}) }}{% elseif Parent %}{{ url('admin_product_category_show', {'parent_id': Parent.id}) }}{% else %}{{ url('admin_product_category') }}{% endif %}"
                                           enctype="multipart/form-data">
-                                        {% if TargetCategory.hierarchy < eccube_config.eccube_category_nest_level %}
+                                        {% if TargetCategory.hierarchy <= eccube_config.eccube_category_nest_level %}
                                             {{ form_widget(form._token) }}
                                             <div class="form-row mb-3">
                                                 <div class="col-auto">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#4630 の修正

## 方針(Policy)
カテゴリを5階層目( = eccube_category_nest_level) までは登録できるようにする

## 実装に関する補足(Appendix)

Controller側はもともと6階層目からエラーになるようなっている
https://github.com/EC-CUBE/ec-cube/blob/91580d9d1e4b31f8f28ba884c92145f66d55d032/src/Eccube/Controller/Admin/Product/CategoryController.php#L121

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
