### PR TITLE
PHP 7.1.3を超えるバージョンを必要とするプラグインを安全にインストールできるようにする

### DIFF
--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -342,7 +342,7 @@ class ComposerApiService implements ComposerServiceInterface
                 ],
             ],
         ]);
-        $this->execConfig('platform.php', [PHP_VERSION]);
+        $this->execConfig('platform.php', [PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION]);
         $this->execConfig('repositories.eccube', [$json]);
         if (strpos($url, 'http://') === 0) {
             $this->execConfig('secure-http', ['false']);

--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -95,7 +95,6 @@ class ComposerApiService implements ComposerServiceInterface
             '--no-interaction' => true,
             '--profile' => true,
             '--prefer-dist' => true,
-            '--ignore-platform-reqs' => true,
             '--update-with-dependencies' => true,
             '--no-scripts' => true,
         ], $output);
@@ -343,6 +342,7 @@ class ComposerApiService implements ComposerServiceInterface
                 ],
             ],
         ]);
+        $this->execConfig('platform.php', [PHP_VERSION]);
         $this->execConfig('repositories.eccube', [$json]);
         if (strpos($url, 'http://') === 0) {
             $this->execConfig('secure-http', ['false']);


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
プラグインインストール時に `--ignore-platform-reqs` オプションを指定していたため、composer.jsonの `config.platform.php` で指定されている7.1.3を超えるバージョンを必要とするプラグインがインストール可能になっていた。しかし、インストールは可能であるがランタイムが7.1.3以下の場合は正常に動作しない場合がある。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

- プラグインインストール時に`--ignore-platform-reqs` オプションを外して、プラットフォームの必要条件を検証するようにする
- ランタイムが7.1.3を超えているなら正しく動作するので、composer.jsonの `config.platform.php`をランタイムのバージョンに変更するようにする


## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
- 手動でプラグインをインストールして確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
