### PR TITLE
管理画面IP制限ページのリンク先がlocalhostになる問題の修正

### DIFF
--- a/src/Eccube/Resource/template/admin/error.twig
+++ b/src/Eccube/Resource/template/admin/error.twig
@@ -35,7 +35,7 @@ file that was distributed with this source code.
                     <div class="text-center p-5 bg-white">
                         <h3><i class="fa fa-exclamation-triangle fa-lg ml-1"></i>{{ error_title }}</h3>
                         <p>{{ error_message }}</p>
-                        <a href="{{ url('admin_homepage') }}" class="btn btn-info btn-lg">{{ 'admin.error.go_to_login'|trans }}</a>
+                        <a href="{{ path('admin_homepage') }}" class="btn btn-info btn-lg">{{ 'admin.error.go_to_login'|trans }}</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
目的： #4561 の修正

## 方針(Policy)
管理画面アクセス制限画面でリンク切れ(localhostへリンク)の印象が悪いので修正したい

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
