### PR TITLE
Eccube\Form\Type\Admin\OrderType::validateOrderStatus内のtransの引数の修正

### DIFF
--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -426,7 +426,10 @@ class OrderType extends AbstractType
         if ($oldStatus->getId() != $newStatus->getId()) {
             if (!$this->orderStateMachine->can($Order, $newStatus)) {
                 $form['OrderStatus']->addError(
-                    new FormError(trans('admin.order.failed_to_change_status__short', $oldStatus->getName(), $newStatus->getName())));
+                    new FormError(trans('admin.order.failed_to_change_status__short', [
+                        '%from%' => $oldStatus->getName(),
+                        '%to%' => $newStatus->getName(),
+                    ])));
             }
         }
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
Eccube\Form\Type\Admin\OrderType::validateOrderStatus内のtransの引数に誤りがあった

## 方針(Policy)
IDEの構文チェックでエラーが出るため修正したい

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
