### PR TITLE
editorconfig設定 `*.md` ファイルは行末空白の自動削除は行わない

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,9 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
+[*.md]
+trim_trailing_whitespace = false
+
 [codeception/**.{yml,yaml}]
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

.editorconfig の設定により `*.md` ファイルに意図しない変更（行末文字の強制削除）が行われてしまうのを防ぐ。

## 方針(Policy)

一部Markdownパーサは、段落中に改行を挿入する際は行末に2つ以上のホワイトスペースを挿入することを求めている。  
参考 : [CommonMark Spec - 6.9Hard line breaks](https://spec.commonmark.org/0.29/#hard-line-break)

現在の README.md はこの仕様を考慮し行末に適宜スペースを挿入した状態となっているが、  
.editorconfig の下記の設定により、保存時にこのスペースが強制的に削除されてしまう。

> [*]
> trim_trailing_whitespace = true

行末文字が削除されてもgithub上の表示は問題ない（ホワイトスペースがなくとも改行を認識する）が、
意図しないcommit差分の発生抑止やgithub以外での表示を考慮し
`*.md` ファイルに限り行末空白の自動削除を抑制するのが望ましいと思われます。
検討よろしくおねがいします。

## 実装に関する補足(Appendix)

製品の動作には一切影響ありません。

## テスト（Test)

* 意図せぬ動作 修正 **前** 状態でREADME.mdに変更を加えた際、改行のための行末空白が自動的に削除 **される** こと。
* 望ましい動作 修正 **後** 状態でREADME.mdに変更を加えた際、改行のための行末空白が自動的に削除 **されない** こと。

以上を目視で確認しました。