### PR TITLE
ログ出力最大行数をPHP_INT_MAXに変更

### DIFF
--- a/src/Eccube/Form/Type/Admin/LogType.php
+++ b/src/Eccube/Form/Type/Admin/LogType.php
@@ -76,11 +76,11 @@ class LogType extends AbstractType
             ->add('line_max', TextType::class, [
                 'data' => '50',
                 'attr' => [
-                    'maxlength' => 5,
+                    'maxlength' => strlen(PHP_INT_MAX),
                 ],
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Range(['min' => 1, 'max' => 50000]),
+                    new Assert\Range(['min' => 1, 'max' => PHP_INT_MAX]),
                 ],
             ]);
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
アクセス数の多いサイトは50000行以上のログがあり、それ以上の行数を取得出来なかったため修正した。

## テスト（Test)
管理画面で50000以上の数値を設定できることを確認した。
