### PR TITLE
OrderNoをTimeZoneの変更に対応

### DIFF
--- a/src/Eccube/Service/PurchaseFlow/Processor/OrderNoProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/OrderNoProcessor.php
@@ -69,15 +69,16 @@ class OrderNoProcessor implements ItemHolderPreprocessor
                 do {
                     $orderNo = preg_replace_callback('/\{(.*)}/U', function ($matches) use ($Order) {
                         if (count($matches) === 2) {
+                            $dateTime = new \DateTime('now', new \DateTimeZone($this->eccubeConfig->get('timezone')));
                             switch ($matches[1]) {
                                 case 'yyyy':
-                                    return (new \DateTime())->format('Y');
+                                    return $dateTime->format('Y');
                                 case 'yy':
-                                    return (new \DateTime())->format('y');
+                                    return $dateTime->format('y');
                                 case 'mm':
-                                    return (new \DateTime())->format('m');
+                                    return $dateTime->format('m');
                                 case 'dd':
-                                    return (new \DateTime())->format('d');
+                                    return $dateTime->format('d');
                                 default:
                                     $res = explode(',', str_replace(' ', '', $matches[1]));
                                     if (count($res) === 2 && is_numeric($res[1])) {

--- a/src/Eccube/Service/PurchaseFlow/Processor/OrderNoProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/OrderNoProcessor.php
@@ -71,13 +71,13 @@ class OrderNoProcessor implements ItemHolderPreprocessor
                         if (count($matches) === 2) {
                             switch ($matches[1]) {
                                 case 'yyyy':
-                                    return date('Y');
+                                    return (new \DateTime())->format('Y');
                                 case 'yy':
-                                    return date('y');
+                                    return (new \DateTime())->format('y');
                                 case 'mm':
-                                    return date('m');
+                                    return (new \DateTime())->format('m');
                                 case 'dd':
-                                    return date('d');
+                                    return (new \DateTime())->format('d');
                                 default:
                                     $res = explode(',', str_replace(' ', '', $matches[1]));
                                     if (count($res) === 2 && is_numeric($res[1])) {

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/OrderNoProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/OrderNoProcessorTest.php
@@ -42,6 +42,7 @@ class OrderNoProcessorTest extends EccubeTestCase
 
         $config = $this->createMock(EccubeConfig::class);
         $config->method('offsetGet')->willReturn($orderNoFormat);
+        $config->method('get')->willReturn('Asia/Tokyo');
         $processor = new OrderNoProcessor($config, $this->container->get(OrderRepository::class));
 
         $processor->process($Order, new PurchaseContext());
@@ -53,10 +54,10 @@ class OrderNoProcessorTest extends EccubeTestCase
     {
         return [
             ['', '/^123$/'],
-            ['{yyyy}', '/^'.(new \DateTime())->format('Y').'$/'],
-            ['{yy}', '/^'.(new \DateTime())->format('y').'$/'],
-            ['{mm}', '/^'.(new \DateTime())->format('m').'$/'],
-            ['{dd}', '/^'.(new \DateTime())->format('d').'$/'],
+            ['{yyyy}', '/^'.(new \DateTime('now', new \DateTimeZone('Asia/Tokyo')))->format('Y').'$/'],
+            ['{yy}', '/^'.(new \DateTime('now', new \DateTimeZone('Asia/Tokyo')))->format('y').'$/'],
+            ['{mm}', '/^'.(new \DateTime('now', new \DateTimeZone('Asia/Tokyo')))->format('m').'$/'],
+            ['{dd}', '/^'.(new \DateTime('now', new \DateTimeZone('Asia/Tokyo')))->format('d').'$/'],
             ['{id}', '/^123$/'],
             ['{id,0}', '/^123$/'],
             ['{id,1}', '/^123$/'],
@@ -74,9 +75,9 @@ class OrderNoProcessorTest extends EccubeTestCase
             ['ORDER_{yy}_{mm}_{dd}_{id,5}_{random,5}_{random_alnum,10}',
                 '/^'.
                 'ORDER_'.
-                (new \DateTime())->format('y').'_'.
-                (new \DateTime())->format('m').'_'.
-                (new \DateTime())->format('d').'_'.
+                (new \DateTime('now', new \DateTimeZone('Asia/Tokyo')))->format('y').'_'.
+                (new \DateTime('now', new \DateTimeZone('Asia/Tokyo')))->format('m').'_'.
+                (new \DateTime('now', new \DateTimeZone('Asia/Tokyo')))->format('d').'_'.
                 '00123_'.
                 '\d{5}_'.
                 '[[:alnum:]]{10}'.


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

デフォルトでは協定世界時になっているため、日本時間で9時までに購入された受注では日付がずれる可能性がありました。
OrderNoをEC-CUBEのTimeZoneの設定に合わせました。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

早朝にテストが走ると必ず落ちる問題も解決するかと思います。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

環境変数 `ECCUBE_TIMEZONE` を変更してOrderNoが変更されることを確認しました。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
