### PR TITLE
ログのダウンロード機能を追加

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/System/LogController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/LogController.php
@@ -20,6 +20,7 @@ use Eccube\Form\Type\Admin\LogType;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class LogController extends AbstractController
 {
@@ -27,7 +28,7 @@ class LogController extends AbstractController
      * @Route("/%eccube_admin_route%/setting/system/log", name="admin_setting_system_log")
      * @Template("@admin/Setting/System/log.twig")
      *
-     * @return array
+     * @return array|Symfony\Component\HttpFoundation\StreamedResponse
      */
     public function index(Request $request)
     {
@@ -67,10 +68,27 @@ class LogController extends AbstractController
         $logDir = $this->getParameter('kernel.logs_dir').DIRECTORY_SEPARATOR.$this->getParameter('kernel.environment');
         $logFile = $logDir.'/'.$formData['files'];
 
-        return [
-            'form' => $form->createView(),
-            'log' => $this->parseLogFile($logFile, $formData),
-        ];
+        if ($form->getClickedButton() && $form->getClickedButton()->getName() === 'download') {
+            $bufferSize = 1024 * 50;
+            $response = new StreamedResponse();
+            $response->headers->set('Content-Length',filesize($logFile));
+            $response->headers->set('Content-Disposition','attachment; filename=' . basename($logFile));
+            $response->headers->set('Content-Type','application/octet-stream');
+            $response->setCallback(function() use($logFile,$bufferSize) {
+                if ($fh = fopen($logFile,'r')) {
+                    while (!feof($fh)) {
+                        echo fread($fh,$bufferSize);
+                    }
+                }
+            });
+            $response->send();
+            return $response;
+        } else {
+            return [
+                'form' => $form->createView(),
+                'log' => $this->parseLogFile($logFile, $formData),
+            ];
+        }
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/LogType.php
+++ b/src/Eccube/Form/Type/Admin/LogType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -82,6 +83,9 @@ class LogType extends AbstractType
                     new Assert\NotBlank(),
                     new Assert\Range(['min' => 1, 'max' => 50000]),
                 ],
+            ])
+            ->add('download', SubmitType::class, [
+                'label' => 'admin.common.download'
             ]);
     }
 

--- a/src/Eccube/Resource/template/admin/Setting/System/log.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/log.twig
@@ -40,6 +40,9 @@ file that was distributed with this source code.
                                 <button type="submit"
                                         class="btn btn-ec-conversion">{{ 'admin.setting.system.log.read'|trans }}</button>
                             </div>
+                            <div class="form-group pr-3">
+                                {{ form_widget(form.download) }}
+                            </div>
                             {{ form_errors(form.line_max) }}
                         </div>
                     </form>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
ログのデータ量が多い場合、全て読み込むことが出来ないため、ダウンロード出来る機能を追加した。

関連PR：#4650

## テスト（Test)
2Gbyte超のログファイルをダウンロードしても、メモリーはほぼ使用されず、ひっ迫した状態にならないことを確認した。