### PR TITLE
[WIP]Weeklyで網羅的にテストを実施する

### DIFF
--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-18.04 ]
-        php: [ 7.1, 7.2, 7.3, 7.4 ]
+        php: [ 7.1, 7.4 ]
         db: [ mysql55, mysql57, pgsql92, pgsql11 sqlite3 ]
         include:
           - db: mysql55
@@ -123,7 +123,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-18.04 ]
-        php: [ 7.1, 7.2, 7.3, 7.4 ]
+        php: [ 7.1, 7.4 ]
         db: [ pgsql ]
         group: [ admin01, admin02, admin03, front, installer ]
         include:
@@ -240,7 +240,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-18.04 ]
-        php: [ 7.1, 7.2, 7.3, 7.4 ]
+        php: [ 7.1, 7.4 ]
         db: [ pgsql, mysql ]
         method:
           - test_install_enable_disable_remove_store
@@ -390,7 +390,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-18.04 ]
-        php: [ 7.1, 7.2, 7.3, 7.4 ]
+        php: [ 7.1, 7.4 ]
         db: [ pgsql, mysql ]
         method:
           - test_install_update_remove_store
@@ -531,7 +531,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-18.04 ]
-        php: [ 7.1, 7.2, 7.3, 7.4 ]
+        php: [ 7.1, 7.4 ]
         db: [ pgsql, mysql ]
         method:
           - test_extend_same_table_store
@@ -672,7 +672,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-18.04 ]
-        php: [ 7.1, 7.2, 7.3, 7.4 ]
+        php: [ 7.1, 7.4 ]
         db: [ pgsql, mysql ]
         method:
           - test_dependency_each_install_plugin

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -901,10 +901,11 @@ jobs:
       - name: Translate to templates
         run: php bin/template_jp.php
 
+      - run: echo "::set-env name=PACKAGING_DATE::$(date +%Y%m%d)"
+
       - name: Packaging
         working-directory: ../
         env:
-          COMMIT_ID: ${{ github.event.head_commit.id }}
           REPOSITORY_NAME: ${{ github.event.repository.name }}
           OUTPUT_DIR: _output
         run: |
@@ -937,20 +938,20 @@ jobs:
 
           echo "complession files..."
           mkdir $OUTPUT_DIR
-          tar czfp eccube-$COMMIT_ID.tar.gz $REPOSITORY_NAME
-          zip -ry eccube-$COMMIT_ID.zip $REPOSITORY_NAME 1> /dev/null
-          md5sum eccube-$COMMIT_ID.tar.gz | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$COMMIT_ID.tar.gz.checksum.md5
-          md5sum eccube-$COMMIT_ID.zip | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$COMMIT_ID.zip.checksum.md5
-          sha1sum eccube-$COMMIT_ID.tar.gz | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$COMMIT_ID.tar.gz.checksum.sha1
-          sha1sum eccube-$COMMIT_ID.zip | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$COMMIT_ID.zip.checksum.sha1
-          sha256sum eccube-$COMMIT_ID.tar.gz | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$COMMIT_ID.tar.gz.checksum.sha256
-          sha256sum eccube-$COMMIT_ID.zip | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$COMMIT_ID.zip.checksum.sha256
-          mv eccube-$COMMIT_ID.tar.gz $OUTPUT_DIR/
-          mv eccube-$COMMIT_ID.zip $OUTPUT_DIR/
+          tar czfp eccube-$PACKAGING_DATE.tar.gz $REPOSITORY_NAME
+          zip -ry eccube-$PACKAGING_DATE.zip $REPOSITORY_NAME 1> /dev/null
+          md5sum eccube-$PACKAGING_DATE.tar.gz | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$PACKAGING_DATE.tar.gz.checksum.md5
+          md5sum eccube-$PACKAGING_DATE.zip | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$PACKAGING_DATE.zip.checksum.md5
+          sha1sum eccube-$PACKAGING_DATE.tar.gz | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$PACKAGING_DATE.tar.gz.checksum.sha1
+          sha1sum eccube-$PACKAGING_DATE.zip | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$PACKAGING_DATE.zip.checksum.sha1
+          sha256sum eccube-$PACKAGING_DATE.tar.gz | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$PACKAGING_DATE.tar.gz.checksum.sha256
+          sha256sum eccube-$PACKAGING_DATE.zip | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$PACKAGING_DATE.zip.checksum.sha256
+          mv eccube-$PACKAGING_DATE.tar.gz $OUTPUT_DIR/
+          mv eccube-$PACKAGING_DATE.zip $OUTPUT_DIR/
           ls -al $OUTPUT_DIR
 
       - name: Upload packages
         uses: actions/upload-artifact@v2
         with:
-          name: eccube-${{ github.event.head_commit.id }}
+          name: eccube-$PACKAGING_DATE
           path: ${{ runner.workspace }}/_output/

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -1,0 +1,893 @@
+name: Weekly test for EC-CUBE
+on:
+  schedule:
+    # 日曜日の 00:00 (JST) に処理を実行する
+    # UTC の 15:00 は JST だと翌日の 00:00
+    - cron:  '0 15 * * 6'
+jobs:
+  phpunit:
+    name: PHPUnit
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-18.04 ]
+        php: [ 7.1, 7.2, 7.3, 7.4 ]
+        db: [ mysql55, mysql57, pgsql92, pgsql11 sqlite3 ]
+        include:
+          - db: mysql55
+            database_url: mysql://root:password@127.0.0.1:3306/eccube_db
+            database_server_version: 5
+          - db: mysql57
+            database_url: mysql://root:password@127.0.0.1:3306/eccube_db
+            database_server_version: 5
+          - db: pgsql92
+            database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
+            database_server_version: 9
+          - db: pgsql11
+            database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
+            database_server_version: 11
+          - db: sqlite3
+            database_url: sqlite:///var/eccube.db
+            database_server_version: 3
+
+    services:
+      mysql55:
+        image: mysql:5.5
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      mysql57:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      postgres92:
+        image: postgres:9.2
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd "export PGPASSWORD=password; until psql -h 127.0.0.1 -U postgres -d template1 -c '\l'; do >&2 sleep 1 ; done" --health-interval 10s --health-timeout 5s --health-retries 5
+      postgres11:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Setup PHP
+        uses: nanasess/setup-php@master
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: composer install
+        run: composer install --dev --no-interaction -o --apcu-autoloader
+
+      - name: Setup EC-CUBE
+        env:
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+        run: |
+          bin/console doctrine:database:create
+          bin/console doctrine:schema:create
+          bin/console eccube:fixtures:load
+
+      - name: PHPUnit
+        env:
+          APP_ENV: 'test'
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          MAILER_URL: 'smtp://localhost:1025'
+        run: |
+          bin/phpunit --exclude-group cache-clear,cache-clear-install,update-schema-doctrine
+          bin/phpunit --group cache-clear
+          bin/phpunit --group cache-clear-install
+          bin/phpunit --group update-schema-doctrine --exclude-group update-schema-doctrine-install
+          bin/phpunit --group update-schema-doctrine-install --filter=testInstallPluginWithNoProxy
+          bin/phpunit --group update-schema-doctrine-install --filter=testInstallPluginWithProxy
+          bin/phpunit --group update-schema-doctrine-install --filter=testEnablePluginWithNoProxy
+          bin/phpunit --group update-schema-doctrine-install --filter=testEnablePluginWithProxy
+          bin/phpunit --group update-schema-doctrine-install --filter=testDisablePluginWithNoProxy
+          bin/phpunit --group update-schema-doctrine-install --filter=testDisablePluginWithProxy
+          bin/phpunit --group update-schema-doctrine-install --filter=testCreateEntityAndTrait
+
+  codeception:
+    name: Codeception
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-18.04 ]
+        php: [ 7.1, 7.2, 7.3, 7.4 ]
+        db: [ pgsql ]
+        group: [ admin01, admin02, admin03, front, installer ]
+        include:
+          - db: pgsql
+            database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
+            database_server_version: 11
+          - group: admin01
+            app_env: 'codeception'
+          - group: admin02
+            app_env: 'codeception'
+          - group: admin03
+            app_env: 'codeception'
+          - group: front
+            app_env: 'codeception'
+          - group: installer
+            app_env: 'install'
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+      mailcatcher:
+        image: schickling/mailcatcher
+        ports:
+          - 1080:1080
+          - 1025:1025
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Setup PHP
+        uses: nanasess/setup-php@master
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: composer install
+        run: composer install --dev --no-interaction -o --apcu-autoloader
+      - name: Setup to EC-CUBE
+        env:
+          APP_ENV: ${{ matrix.app_env }}
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+        run: |
+          echo "APP_ENV=${APP_ENV}" > .env
+          bin/console doctrine:database:create --env=dev
+          bin/console doctrine:schema:create --env=dev
+          bin/console eccube:fixtures:load --env=dev
+
+      - name: setup-chromedriver
+        uses: nanasess/setup-chromedriver@master
+
+      - name: Run chromedriver
+        run: |
+          export DISPLAY=:99
+          chromedriver --url-base=/wd/hub &
+          echo ">>> Started chrome-driver"
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+          echo ">>> Started xvfb"
+
+      - name: Start PHP Development Server
+        env:
+          APP_ENV: 'codeception'
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          MAILER_URL: 'smtp://localhost:1025'
+          ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
+        run: php -S localhost:8000 &
+
+      - name: Codeception
+        env:
+          APP_ENV: ${{ matrix.app_env }}
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          MAILER_URL: 'smtp://localhost:1025'
+          ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
+          GROUP: ${{ matrix.group }}
+          SYMFONY_DEPRECATIONS_HELPER: weak
+        run: vendor/bin/codecept -vvv run acceptance --env chrome,github_action -g ${GROUP}
+      - name: Upload evidence
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: codeception-${{ matrix.group }}-evidence
+          path: codeception/_output/
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: codeception-${{ matrix.group }}-logs
+          path: var/log/
+
+  plugin-install:
+    name: Plugin install
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-18.04 ]
+        php: [ 7.1, 7.2, 7.3, 7.4 ]
+        db: [ pgsql, mysql ]
+        method:
+          - test_install_enable_disable_remove_store
+          - test_install_enable_disable_remove_local
+          - test_install_enable_disable_enable_disable_remove_store
+          - test_install_enable_disable_enable_disable_remove_local
+          - test_install_remove_local
+          - test_install_remove_store
+          - test_bundle_install_enable_disable_remove_store
+          - test_bundle_install_update_enable_disable_remove_store
+        include:
+          - db: pgsql
+            database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
+            database_server_version: 11
+          - db: mysql
+            database_url: mysql://root:password@127.0.0.1:3306/eccube_db
+            database_server_version: 5
+        exclude:
+          # bundle は PHP 7.2 以上のみ対応
+          - php: 7.1
+            method:
+              - test_bundle_install_enable_disable_remove_store
+              - test_bundle_install_update_enable_disable_remove_store
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      mailcatcher:
+        image: schickling/mailcatcher
+        ports:
+          - 1080:1080
+          - 1025:1025
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Setup PHP
+        uses: nanasess/setup-php@master
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: composer install
+        run: composer install --dev --no-interaction -o --apcu-autoloader
+
+      - name: Setup to EC-CUBE
+        env:
+          APP_ENV: 'codeception'
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+        run: |
+          echo "APP_ENV=${APP_ENV}" > .env
+          bin/console doctrine:database:create --env=dev
+          bin/console doctrine:schema:create --env=dev
+          bin/console eccube:fixtures:load --env=dev
+
+      - name: Update baseinfo with pgsql
+        if: matrix.db == 'pgsql'
+        env:
+          PGPASSWORD: 'password'
+        run: |
+          sudo apt-fast install -y postgresql-client
+          psql eccube_db -h 127.0.0.1 -U postgres -c "update dtb_base_info set authentication_key='test';"
+
+      - name: Update baseinfo with mysql
+        if: matrix.db == 'mysql'
+        run: mysql -h 127.0.0.1 -u root -ppassword eccube_db -e "update dtb_base_info set authentication_key='test';"
+
+      - name: setup-chromedriver
+        uses: nanasess/setup-chromedriver@master
+
+      - name: Run chromedriver
+        run: |
+          export DISPLAY=:99
+          chromedriver --url-base=/wd/hub &
+          echo ">>> Started chrome-driver"
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+          echo ">>> Started xvfb"
+
+      - name: Start PHP Development Server
+        env:
+          APP_ENV: 'codeception'
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          MAILER_URL: 'smtp://localhost:1025'
+          ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
+        run: php -S localhost:8000 &
+
+      ## ${PWD}/repos does not exist so service cannot be started
+      - name: Run package-api
+        run: |
+          if [[ ! -d ${PWD}/repos ]]; then mkdir -p ${PWD}/repos ; fi
+          docker run -d --rm -v ${PWD}/repos:/repos -e MOCK_REPO_DIR=/repos -p 8080:8080 eccube/mock-package-api
+
+      - name: Codeception
+        env:
+          APP_ENV: ${{ matrix.app_env }}
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          MAILER_URL: 'smtp://localhost:1025'
+          METHOD: ${{ matrix.method }}
+          ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
+          NO_FIXTURES: 1
+        run: vendor/bin/codecept -vvv run acceptance --env chrome,github_action EA10PluginCest:${METHOD}
+      - name: Upload evidence
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: plugin-install-${{ matrix.method }}-evidence
+          path: codeception/_output/
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: plugin-install-${{ matrix.method }}-logs
+          path: var/log/
+
+  plugin-update:
+    name: Plugin Update
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-18.04 ]
+        php: [ 7.1, 7.2, 7.3, 7.4 ]
+        db: [ pgsql, mysql ]
+        method:
+          - test_install_update_remove_store
+          - test_install_update_remove_local
+          - test_install_enable_disable_update_enable_disable_remove_local
+          - test_install_enable_disable_update_enable_disable_remove_store
+          - test_install_enable_update_disable_remove_store
+          - test_install_enable_update_disable_remove_local
+        include:
+          - db: pgsql
+            database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
+            database_server_version: 11
+          - db: mysql
+            database_url: mysql://root:password@127.0.0.1:3306/eccube_db
+            database_server_version: 5
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      mailcatcher:
+        image: schickling/mailcatcher
+        ports:
+          - 1080:1080
+          - 1025:1025
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Setup PHP
+        uses: nanasess/setup-php@master
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Install to Composer
+        run: composer install --dev --no-interaction -o --apcu-autoloader
+      - name: Setup to EC-CUBE
+        env:
+          APP_ENV: 'codeception'
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+        run: |
+          echo "APP_ENV=${APP_ENV}" > .env
+          bin/console doctrine:database:create --env=dev
+          bin/console doctrine:schema:create --env=dev
+          bin/console eccube:fixtures:load --env=dev
+
+      - name: Update baseinfo with pgsql
+        if: matrix.db == 'pgsql'
+        env:
+          PGPASSWORD: 'password'
+        run: |
+          sudo apt-fast install -y postgresql-client
+          psql eccube_db -h 127.0.0.1 -U postgres -c "update dtb_base_info set authentication_key='test';"
+
+      - name: Update baseinfo with mysql
+        if: matrix.db == 'mysql'
+        run: mysql -h 127.0.0.1 -u root -ppassword eccube_db -e "update dtb_base_info set authentication_key='test';"
+
+      - name: setup-chromedriver
+        uses: nanasess/setup-chromedriver@master
+
+      - name: Run chromedriver
+        run: |
+          export DISPLAY=:99
+          chromedriver --url-base=/wd/hub &
+          echo ">>> Started chrome-driver"
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+          echo ">>> Started xvfb"
+
+      - name: Start PHP Development Server
+        env:
+          APP_ENV: 'codeception'
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          MAILER_URL: 'smtp://localhost:1025'
+          ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
+        run: php -S localhost:8000 &
+
+      ## ${PWD}/repos does not exist so service cannot be started
+      - name: Run package-api
+        run: |
+          if [[ ! -d ${PWD}/repos ]]; then mkdir -p ${PWD}/repos ; fi
+          docker run -d --rm -v ${PWD}/repos:/repos -e MOCK_REPO_DIR=/repos -p 8080:8080 eccube/mock-package-api
+
+      - name: Run to Codeception
+        env:
+          APP_ENV: ${{ matrix.app_env }}
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          MAILER_URL: 'smtp://localhost:1025'
+          METHOD: ${{ matrix.method }}
+          ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
+          NO_FIXTURES: 1
+        run: vendor/bin/codecept -vvv run acceptance --env chrome,github_action EA10PluginCest:${METHOD}
+      - name: Upload evidence
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: plugin-update-${{ matrix.method }}-evidence
+          path: codeception/_output/
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: plugin-update-${{ matrix.method }}-logs
+          path: var/log/
+
+  plugin-extend:
+    name: Plugin extend
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-18.04 ]
+        php: [ 7.1, 7.2, 7.3, 7.4 ]
+        db: [ pgsql, mysql ]
+        method:
+          - test_extend_same_table_store
+          - test_extend_same_table_disabled_remove_store
+          - test_extend_same_table_local
+          - test_extend_same_table_disabled_remove_local
+          - test_extend_same_table_crossed_store
+          - test_extend_same_table_crossed_local
+        include:
+          - db: pgsql
+            database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
+            database_server_version: 11
+          - db: mysql
+            database_url: mysql://root:password@127.0.0.1:3306/eccube_db
+            database_server_version: 5
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      mailcatcher:
+        image: schickling/mailcatcher
+        ports:
+          - 1080:1080
+          - 1025:1025
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Setup PHP
+        uses: nanasess/setup-php@master
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Install to Composer
+        run: composer install --dev --no-interaction -o --apcu-autoloader
+      - name: Setup to EC-CUBE
+        env:
+          APP_ENV: 'codeception'
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+        run: |
+          echo "APP_ENV=${APP_ENV}" > .env
+          bin/console doctrine:database:create --env=dev
+          bin/console doctrine:schema:create --env=dev
+          bin/console eccube:fixtures:load --env=dev
+
+      - name: Update baseinfo with pgsql
+        if: matrix.db == 'pgsql'
+        env:
+          PGPASSWORD: 'password'
+        run: |
+          sudo apt-fast install -y postgresql-client
+          psql eccube_db -h 127.0.0.1 -U postgres -c "update dtb_base_info set authentication_key='test';"
+
+      - name: Update baseinfo with mysql
+        if: matrix.db == 'mysql'
+        run: mysql -h 127.0.0.1 -u root -ppassword eccube_db -e "update dtb_base_info set authentication_key='test';"
+
+      - name: setup-chromedriver
+        uses: nanasess/setup-chromedriver@master
+
+      - name: Run chromedriver
+        run: |
+          export DISPLAY=:99
+          chromedriver --url-base=/wd/hub &
+          echo ">>> Started chrome-driver"
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+          echo ">>> Started xvfb"
+
+      - name: Start PHP Development Server
+        env:
+          APP_ENV: 'codeception'
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          MAILER_URL: 'smtp://localhost:1025'
+          ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
+        run: php -S localhost:8000 &
+
+      ## ${PWD}/repos does not exist so service cannot be started
+      - name: Run package-api
+        run: |
+          if [[ ! -d ${PWD}/repos ]]; then mkdir -p ${PWD}/repos ; fi
+          docker run -d --rm -v ${PWD}/repos:/repos -e MOCK_REPO_DIR=/repos -p 8080:8080 eccube/mock-package-api
+
+      - name: Run to Codeception
+        env:
+          APP_ENV: ${{ matrix.app_env }}
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          MAILER_URL: 'smtp://localhost:1025'
+          METHOD: ${{ matrix.method }}
+          ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
+          NO_FIXTURES: 1
+        run: vendor/bin/codecept -vvv run acceptance --env chrome,github_action EA10PluginCest:${METHOD}
+      - name: Upload evidence
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: plugin-extend-${{ matrix.method }}-evidence
+          path: codeception/_output/
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: plugin-extend-${{ matrix.method }}-logs
+          path: var/log/
+
+  plugin-depend:
+    name: Plugin depend
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-18.04 ]
+        php: [ 7.1, 7.2, 7.3, 7.4 ]
+        db: [ pgsql, mysql ]
+        method:
+          - test_dependency_each_install_plugin
+          - test_dependency_plugin_install
+          - test_dependency_plugin_update
+          - test_install_error
+          - install_enable_disable_enable_disable_remove_store
+          - test_enhance_plugin_entity
+        include:
+          - db: pgsql
+            database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
+            database_server_version: 11
+          - db: mysql
+            database_url: mysql://root:password@127.0.0.1:3306/eccube_db
+            database_server_version: 5
+        exclude:
+          - db: mysql
+            method: test_dependency_plugin_update
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      mailcatcher:
+        image: schickling/mailcatcher
+        ports:
+          - 1080:1080
+          - 1025:1025
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Setup PHP
+        uses: nanasess/setup-php@master
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Install to Composer
+        run: composer install --dev --no-interaction -o --apcu-autoloader
+      - name: Setup to EC-CUBE
+        env:
+          APP_ENV: 'codeception'
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+        run: |
+          echo "APP_ENV=${APP_ENV}" > .env
+          bin/console doctrine:database:create --env=dev
+          bin/console doctrine:schema:create --env=dev
+          bin/console eccube:fixtures:load --env=dev
+
+      - name: Update baseinfo with pgsql
+        if: matrix.db == 'pgsql'
+        env:
+          PGPASSWORD: 'password'
+        run: |
+          sudo apt-fast install -y postgresql-client
+          psql eccube_db -h 127.0.0.1 -U postgres -c "update dtb_base_info set authentication_key='test';"
+
+      - name: Update baseinfo with mysql
+        if: matrix.db == 'mysql'
+        run: mysql -h 127.0.0.1 -u root -ppassword eccube_db -e "update dtb_base_info set authentication_key='test';"
+
+      - name: setup-chromedriver
+        uses: nanasess/setup-chromedriver@master
+
+      - name: Run chromedriver
+        run: |
+          export DISPLAY=:99
+          chromedriver --url-base=/wd/hub &
+          echo ">>> Started chrome-driver"
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+          echo ">>> Started xvfb"
+
+      - name: Start PHP Development Server
+        env:
+          APP_ENV: 'codeception'
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          MAILER_URL: 'smtp://localhost:1025'
+          ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
+        run: php -S localhost:8000 &
+
+      ## ${PWD}/repos does not exist so service cannot be started
+      - name: Run package-api
+        run: |
+          if [[ ! -d ${PWD}/repos ]]; then mkdir -p ${PWD}/repos ; fi
+          docker run -d --rm -v ${PWD}/repos:/repos -e MOCK_REPO_DIR=/repos -p 8080:8080 eccube/mock-package-api
+
+      - name: Run to Codeception
+        env:
+          APP_ENV: ${{ matrix.app_env }}
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          MAILER_URL: 'smtp://localhost:1025'
+          METHOD: ${{ matrix.method }}
+          ECCUBE_PACKAGE_API_URL: 'http://localhost:8080'
+          NO_FIXTURES: 1
+        run: vendor/bin/codecept -vvv run acceptance --env chrome,github_action EA10PluginCest:${METHOD}
+      - name: Upload evidence
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: plugin-depend-${{ matrix.method }}-evidence
+          path: codeception/_output/
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: plugin-depend-${{ matrix.method }}-logs
+          path: var/log/
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Setup PHP
+        uses: nanasess/setup-php@master
+        with:
+          php-version: '7.3'
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install to Composer
+        run: composer install --no-scripts --no-dev --no-interaction --optimize-autoloader
+
+      - name: Translate to templates
+        run: php bin/template_jp.php
+
+      - name: Packaging
+        working-directory: ../
+        env:
+          COMMIT_ID: ${{ github.event.head_commit.id }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+          OUTPUT_DIR: _output
+        run: |
+          rm -rf $GITHUB_WORKSPACE/.editorconfig
+          rm -rf $GITHUB_WORKSPACE/.gitignore
+          rm -rf $GITHUB_WORKSPACE/.buildpath
+          rm -rf $GITHUB_WORKSPACE/.gitmodules
+          rm -rf $GITHUB_WORKSPACE/.scrutinizer.yml
+          rm -rf $GITHUB_WORKSPACE/.travis.yml
+          rm -rf $GITHUB_WORKSPACE/appveyor.yml
+          rm -rf $GITHUB_WORKSPACE/.coveralls.yml
+          rm -rf $GITHUB_WORKSPACE/.php_cs.dist
+          rm -rf $GITHUB_WORKSPACE/phpunit.xml.dist
+          rm -rf $GITHUB_WORKSPACE/app.json
+          rm -rf $GITHUB_WORKSPACE/Procfile
+          rm -rf $GITHUB_WORKSPACE/LICENSE.txt
+          rm -rf $GITHUB_WORKSPACE/README.md
+          rm -rf $GITHUB_WORKSPACE/codeception.sh
+          rm -rf $GITHUB_WORKSPACE/codeception.yml
+          rm -rf $GITHUB_WORKSPACE/app/Plugin/*
+          rm -rf $GITHUB_WORKSPACE/codeception
+          rm -rf $GITHUB_WORKSPACE/tests
+          rm -rf $GITHUB_WORKSPACE/.github
+          find $GITHUB_WORKSPACE -name "dummy" -print0 | xargs -0 rm -rf
+          find $GITHUB_WORKSPACE -name ".git*" -and ! -name ".gitkeep" -print0 | xargs -0 rm -rf
+          find $GITHUB_WORKSPACE -name ".git*" -type d -print0 | xargs -0 rm -rf
+
+          echo "set permissions..."
+          chmod -R o+w $GITHUB_WORKSPACE
+
+          echo "complession files..."
+          mkdir $OUTPUT_DIR
+          tar czfp eccube-$COMMIT_ID.tar.gz $REPOSITORY_NAME
+          zip -ry eccube-$COMMIT_ID.zip $REPOSITORY_NAME 1> /dev/null
+          md5sum eccube-$COMMIT_ID.tar.gz | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$COMMIT_ID.tar.gz.checksum.md5
+          md5sum eccube-$COMMIT_ID.zip | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$COMMIT_ID.zip.checksum.md5
+          sha1sum eccube-$COMMIT_ID.tar.gz | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$COMMIT_ID.tar.gz.checksum.sha1
+          sha1sum eccube-$COMMIT_ID.zip | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$COMMIT_ID.zip.checksum.sha1
+          sha256sum eccube-$COMMIT_ID.tar.gz | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$COMMIT_ID.tar.gz.checksum.sha256
+          sha256sum eccube-$COMMIT_ID.zip | awk '{ print $1 }' > $OUTPUT_DIR/eccube-$COMMIT_ID.zip.checksum.sha256
+          mv eccube-$COMMIT_ID.tar.gz $OUTPUT_DIR/
+          mv eccube-$COMMIT_ID.zip $OUTPUT_DIR/
+          ls -al $OUTPUT_DIR
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: eccube-${{ github.event.head_commit.id }}
+          path: ${{ runner.workspace }}/_output/

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -13,18 +13,12 @@ jobs:
       matrix:
         operating-system: [ ubuntu-18.04 ]
         php: [ 7.1, 7.4 ]
-        db: [ mysql55, mysql57, pgsql92, pgsql11 sqlite3 ]
+        db: [ mysql, pgsql, sqlite3 ]
         include:
-          - db: mysql55
+          - db: mysql
             database_url: mysql://root:password@127.0.0.1:3306/eccube_db
             database_server_version: 5
-          - db: mysql57
-            database_url: mysql://root:password@127.0.0.1:3306/eccube_db
-            database_server_version: 5
-          - db: pgsql92
-            database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
-            database_server_version: 9
-          - db: pgsql11
+          - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
             database_server_version: 11
           - db: sqlite3
@@ -32,30 +26,14 @@ jobs:
             database_server_version: 3
 
     services:
-      mysql55:
-        image: mysql:5.5
-        env:
-          MYSQL_ROOT_PASSWORD: password
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-      mysql57:
+      mysql:
         image: mysql:5.7
         env:
           MYSQL_ROOT_PASSWORD: password
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-      postgres92:
-        image: postgres:9.2
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-        ports:
-          - 5432:5432
-        # needed because the postgres container does not provide a healthcheck
-        options: --health-cmd "export PGPASSWORD=password; until psql -h 127.0.0.1 -U postgres -d template1 -c '\l'; do >&2 sleep 1 ; done" --health-interval 10s --health-timeout 5s --health-retries 5
-      postgres11:
+      postgres:
         image: postgres:11
         env:
           POSTGRES_USER: postgres
@@ -65,6 +43,91 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Setup PHP
+        uses: nanasess/setup-php@master
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: composer install
+        run: composer install --dev --no-interaction -o --apcu-autoloader
+
+      - name: Setup EC-CUBE
+        env:
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+        run: |
+          bin/console doctrine:database:create
+          bin/console doctrine:schema:create
+          bin/console eccube:fixtures:load
+
+      - name: PHPUnit
+        env:
+          APP_ENV: 'test'
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          MAILER_URL: 'smtp://localhost:1025'
+        run: |
+          bin/phpunit --exclude-group cache-clear,cache-clear-install,update-schema-doctrine
+          bin/phpunit --group cache-clear
+          bin/phpunit --group cache-clear-install
+          bin/phpunit --group update-schema-doctrine --exclude-group update-schema-doctrine-install
+          bin/phpunit --group update-schema-doctrine-install --filter=testInstallPluginWithNoProxy
+          bin/phpunit --group update-schema-doctrine-install --filter=testInstallPluginWithProxy
+          bin/phpunit --group update-schema-doctrine-install --filter=testEnablePluginWithNoProxy
+          bin/phpunit --group update-schema-doctrine-install --filter=testEnablePluginWithProxy
+          bin/phpunit --group update-schema-doctrine-install --filter=testDisablePluginWithNoProxy
+          bin/phpunit --group update-schema-doctrine-install --filter=testDisablePluginWithProxy
+          bin/phpunit --group update-schema-doctrine-install --filter=testCreateEntityAndTrait
+
+  phpunit-lower:
+    name: PHPUnit
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-18.04 ]
+        php: [ 7.1, 7.4 ]
+        db: [ mysql, pgsql]
+        include:
+          - db: mysql
+            database_url: mysql://root:password@127.0.0.1:3306/eccube_db
+            database_server_version: 5
+          - db: pgsql
+            database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
+            database_server_version: 9
+
+    services:
+      mysql:
+        image: mysql:5.5
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      postgres:
+        image: postgres:9.2
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd "export PGPASSWORD=password; until psql -h 127.0.0.1 -U postgres -d template1 -c '\l'; do >&2 sleep 1 ; done" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -261,9 +261,9 @@ jobs:
         exclude:
           # bundle は PHP 7.2 以上のみ対応
           - php: 7.1
-            method:
-              - test_bundle_install_enable_disable_remove_store
-              - test_bundle_install_update_enable_disable_remove_store
+            method: test_bundle_install_enable_disable_remove_store
+          - php: 7.1
+            method: test_bundle_install_update_enable_disable_remove_store
 
     services:
       mysql:


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

マイナーバージョンのリリース前に実施している PHP/DB などのバージョンごとに網羅的なテストを毎週実施できるようにしました。

## 方針(Policy)

- 全 job が100ほどあるので、通常の自動テストの妨げにならないように毎週日曜日の0時 (JST) に実施されるようにしています。
- bundle のテストは PHP 7.1 に未対応のため対象から除外しています。
- パッケージングもして artifact にアップロードするようにしました。

## 実装に関する補足(Appendix)

## テスト（Test)

個人アカウントでのテストを実施中
https://github.com/okazy/ec-cube/actions/runs/227208918

9/6 00:00 に実行されるテストで最終確認する

## 相談（Discussion）

パッケージングのデータには日付を入れたかったのですが、簡単に実現できなかったので HEAD の commit のハッシュを入れています。
良い方法があれば教えてください。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
