### PR TITLE
docker / docker-compose のコンテナでnodejsを利用できるようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,11 @@ RUN docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
 
 RUN pecl install apcu && echo "extension=apcu.so" > /usr/local/etc/php/conf.d/apc.ini
 
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+  && apt-get install -y nodejs \
+  && apt-get clean \
+  ;
+
 RUN mkdir -p ${APACHE_DOCUMENT_ROOT} \
   && sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
   && sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ volumes:
     driver: local
   vendor:
     driver: local
+  node_modules:
+    driver: local
 
 services:
   ### ECCube4 ##################################
@@ -35,6 +37,7 @@ services:
       ### 同期対象からコストの重いフォルダを除外 #####################
       - "var:/var/www/html/var"
       - "vendor:/var/www/html/vendor"
+      - "node_modules:/var/www/html/node_modules"
     networks:
       - backend
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

docker / docker-compose を用いた開発環境でnodejsを利用できるようにする。
コンテナ内で次のことが出来るようになる。

* nodeコマンドの実行
* npmコマンドの実行
* gulp等によるフロントエンドのビルド

## 方針(Policy)

nodejs実行用の新たなコンテナを用意するのではなく既存のec-cubeコンテナにnodejsを追加でインストールする。
（composer script も専用環境は特に存在せず ec-cube コンテナ内で実行する設定なので node/npm もそれにあわせる）

## 実装に関する補足(Appendix)

* nodejs はディストリビューター（debian / ec-cubeコンテナベースイメージ）のデフォルトの配布物ではなく nodejs 側がdebian向けに配布しているものを利用しています。
  * debian配布のバージョンは既にサポートが切れているため。

* node_modulesフォルダ配下はホストとコンテナとで同期しないようにしています。
  * vendor/ を外しているのと同じ理由。IOコストが高いとnpmスクリプト等の実行に多大な時間がかかるため。
  * node-sass が環境依存のバイナリ（ホストとコンテナとの間で互換性が無いプログラム）をインストールするため、同期してしまうと該当箇所が上手く動かなくなる。（sassのビルドに失敗する）

## テスト（Test)

`docker-compose build` でコンテナをビルドし直した後、以下の項目を目視で確認しました。

* docker-compose の ec-cube コンテナ内で npm install が行えること。
* 前項の後 ec-cube コンテナ内に作成された `node_modules/*` フォルダはホスト側には存在しないこと。
* インストールマニュアル [3.Dockerを使用してインストールする](https://doc4.ec-cube.net/quickstart_install#3docker%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E3%81%99%E3%82%8B) の方法でEC CUBEが起動すること。

---

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

製品の動作には一切の影響はありません。

開発環境への影響としては、docker-composeで開発を行っていた場合、コンテナ内からホスト側のnode_modulesが見えなくなります。ただ上に書いたとおり、見えなくても良い（別プラットフォームのバイナリを含むため実行も失敗する）ファイルなので特段の支障は無いのではと思います。

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
