### PR TITLE
注文確認メール（HTML）の見出しが本文と同じフォントサイズになっていたのを修正しました。

### DIFF
--- a/src/Eccube/Resource/template/default/Mail/order.html.twig
+++ b/src/Eccube/Resource/template/default/Mail/order.html.twig
@@ -25,7 +25,7 @@ file that was distributed with this source code.
                 <tr>
                     <td class="container-padding content" align="left" style="border-collapse:collapse;padding-left:24px;padding-right:24px;padding-top:12px;padding-bottom:12px;background-color:#ffffff;">
                         <br>
-                        <div class="title" style="font-family:Helvetica, Arial, sans-serif;font-size:14px;line-height:20px;text-align:left;color:#333333;">この度はご注文いただき誠にありがとうございます。</div>
+                        <div class="title" style="font-family:Helvetica, Arial, sans-serif;font-size:18px;font-weight:600;color:#374550;">この度はご注文いただき誠にありがとうございます。</div>
                         <br>
                         <div class="body-text" style="font-family:Helvetica, Arial, sans-serif;font-size:14px;line-height:20px;text-align:left;color:#333333;">
                             {{ Order.name01 }} {{ Order.name02 }} 様<br/>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
メールテンプレートの中で、注文確認メールだけHTMLの見出しのフォントサイズが、
本文と同じサイズになっていたのを修正しました。

## テスト（Test)
Windows/Macともに動作確認ずみです。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
