### PR TITLE
商品のmin|max集計でエラーが発生するのを修正

### DIFF
--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -198,7 +198,9 @@ if (!class_exists('\Eccube\Entity\Product')) {
         {
             $this->_calc();
 
-            return max($this->stockFinds);
+            return count($this->stockFinds)
+                ? max($this->stockFinds)
+                : null;
         }
 
         /**
@@ -210,7 +212,9 @@ if (!class_exists('\Eccube\Entity\Product')) {
         {
             $this->_calc();
 
-            return min($this->stocks);
+            return count($this->stocks)
+                ? min($this->stocks)
+                : null;
         }
 
         /**
@@ -222,7 +226,9 @@ if (!class_exists('\Eccube\Entity\Product')) {
         {
             $this->_calc();
 
-            return max($this->stocks);
+            return count($this->stocks)
+                ? max($this->stocks)
+                : null;
         }
 
         /**
@@ -234,7 +240,9 @@ if (!class_exists('\Eccube\Entity\Product')) {
         {
             $this->_calc();
 
-            return min($this->stockUnlimiteds);
+            return count($this->stockUnlimiteds)
+                ? min($this->stockUnlimiteds)
+                : null;
         }
 
         /**
@@ -246,7 +254,9 @@ if (!class_exists('\Eccube\Entity\Product')) {
         {
             $this->_calc();
 
-            return max($this->stockUnlimiteds);
+            return count($this->stockUnlimiteds)
+                ? max($this->stockUnlimiteds)
+                : null;
         }
 
         /**
@@ -290,7 +300,9 @@ if (!class_exists('\Eccube\Entity\Product')) {
         {
             $this->_calc();
 
-            return min($this->price02);
+            return count($this->price02)
+                ? min($this->price02)
+                : null;
         }
 
         /**
@@ -302,7 +314,9 @@ if (!class_exists('\Eccube\Entity\Product')) {
         {
             $this->_calc();
 
-            return max($this->price02);
+            return count($this->price02)
+                ? max($this->price02)
+                : null;
         }
 
         /**
@@ -314,7 +328,9 @@ if (!class_exists('\Eccube\Entity\Product')) {
         {
             $this->_calc();
 
-            return min($this->price01IncTaxs);
+            return count($this->price01IncTaxs)
+                ? min($this->price01IncTaxs)
+                : null;
         }
 
         /**
@@ -326,7 +342,9 @@ if (!class_exists('\Eccube\Entity\Product')) {
         {
             $this->_calc();
 
-            return max($this->price01IncTaxs);
+            return count($this->price01IncTaxs)
+                ? max($this->price01IncTaxs)
+                : null;
         }
 
         /**
@@ -338,7 +356,9 @@ if (!class_exists('\Eccube\Entity\Product')) {
         {
             $this->_calc();
 
-            return min($this->price02IncTaxs);
+            return count($this->price02IncTaxs)
+                ? min($this->price02IncTaxs)
+                : null;
         }
 
         /**
@@ -350,7 +370,9 @@ if (!class_exists('\Eccube\Entity\Product')) {
         {
             $this->_calc();
 
-            return max($this->price02IncTaxs);
+            return count($this->price02IncTaxs)
+                ? max($this->price02IncTaxs)
+                : null;
         }
 
         /**

--- a/tests/Eccube/Tests/Entity/ProductTest.php
+++ b/tests/Eccube/Tests/Entity/ProductTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Entity;
+
+use Eccube\Tests\EccubeTestCase;
+
+final class ProductTest extends EccubeTestCase
+{
+    public function testAggregatesWithoutProductClass()
+    {
+        $Product = $this->createProduct(null, 0);
+        $Product->getProductClasses()->clear();
+        $this->assertNull($Product->getStockFind());
+        $this->assertNull($Product->getStockMin());
+        $this->assertNull($Product->getStockMax());
+        $this->assertNull($Product->getStockUnlimitedMin());
+        $this->assertNull($Product->getStockUnlimitedMax());
+        $this->assertNull($Product->getPrice01Min());
+        $this->assertNull($Product->getPrice01Max());
+        $this->assertNull($Product->getPrice02Min());
+        $this->assertNull($Product->getPrice02Max());
+        $this->assertNull($Product->getPrice01IncTaxMin());
+        $this->assertNull($Product->getPrice01IncTaxMax());
+        $this->assertNull($Product->getPrice02IncTaxMin());
+        $this->assertNull($Product->getPrice02IncTaxMax());
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

通常価格(price01)を登録していない商品に対して、(最高|最低)税込通常価格を取得しようとすると
> Warning: min(): Array must contain at least one element

が発生する。

## 方針(Policy)

税込通常価格以外にも、同じエラーが発生しうる箇所に同様の修正。

## テスト（Test)

修正したメンバ関数に対してテストを追加。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
