### PR TITLE
受注登録画面の商品検索で発生することがあるエラーを修正

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -629,7 +629,7 @@ class EditController extends AbstractController
             foreach ($Products as $Product) {
                 /* @var $builder \Symfony\Component\Form\FormBuilderInterface */
                 $builder = $this->formFactory->createNamedBuilder('', AddCartType::class, null, [
-                    'product' => $this->productRepository->findWithSortedClassCategories($Product->getId()),
+                    'product' => $Product,
                 ]);
                 $addCartForm = $builder->getForm();
                 $forms[$Product->getId()] = $addCartForm->createView();

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -66,7 +66,7 @@ class ProductRepository extends AbstractRepository
     public function findWithSortedClassCategories($productId)
     {
         $qb = $this->createQueryBuilder('p');
-        $qb
+        $qb->addSelect(['pc', 'cc1', 'cc2', 'pi', 'pt'])
             ->innerJoin('p.ProductClasses', 'pc')
             ->leftJoin('pc.ClassCategory1', 'cc1')
             ->leftJoin('pc.ClassCategory2', 'cc2')

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -66,7 +66,7 @@ class ProductRepository extends AbstractRepository
     public function findWithSortedClassCategories($productId)
     {
         $qb = $this->createQueryBuilder('p');
-        $qb->addSelect(['pc', 'cc1', 'cc2', 'pi', 'pt'])
+        $qb
             ->innerJoin('p.ProductClasses', 'pc')
             ->leftJoin('pc.ClassCategory1', 'cc1')
             ->leftJoin('pc.ClassCategory2', 'cc2')

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -216,11 +216,12 @@ class ProductRepository extends AbstractRepository
     public function getQueryBuilderBySearchDataForAdmin($searchData)
     {
         $qb = $this->createQueryBuilder('p')
-            ->addSelect('pc', 'pi', 'tr', 'ps')
-            ->innerJoin('p.ProductClasses', 'pc')
+            ->addSelect('_pc', 'pi', 'tr', 'ps')
+            ->innerJoin('p.ProductClasses', '_pc')
+            ->leftJoin('p.ProductClasses', 'pc')
             ->leftJoin('p.ProductImage', 'pi')
-            ->leftJoin('pc.TaxRule', 'tr')
-            ->leftJoin('pc.ProductStock', 'ps')
+            ->leftJoin('_pc.TaxRule', 'tr')
+            ->leftJoin('_pc.ProductStock', 'ps')
             ->andWhere('pc.visible = :visible')
             ->setParameter('visible', true);
 

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -216,12 +216,11 @@ class ProductRepository extends AbstractRepository
     public function getQueryBuilderBySearchDataForAdmin($searchData)
     {
         $qb = $this->createQueryBuilder('p')
-            ->addSelect('_pc', 'pi', 'tr', 'ps')
-            ->innerJoin('p.ProductClasses', '_pc')
-            ->leftJoin('p.ProductClasses', 'pc')
+            ->addSelect('pc', 'pi', 'tr', 'ps')
+            ->innerJoin('p.ProductClasses', 'pc')
             ->leftJoin('p.ProductImage', 'pi')
-            ->leftJoin('_pc.TaxRule', 'tr')
-            ->leftJoin('_pc.ProductStock', 'ps')
+            ->leftJoin('pc.TaxRule', 'tr')
+            ->leftJoin('pc.ProductStock', 'ps')
             ->andWhere('pc.visible = :visible')
             ->setParameter('visible', true);
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#4678 

## 実装に関する補足(Appendix)

従来通り`pc`でWHEREを指定する形にしつつ、Lazy Loading対策として`_pc`というエイリアスをSELECTに追加。

## テスト（Test)

- ユニットテストなし。
- #4678 のエラーが発生しないことを確認。
- 商品管理画面でLazy Loading対策ができていることを確認。

## 相談（Discussion）

SELECTから`pc`を除いた結果、既存のカスタマイズやプラグインで下記のようなエラーが発生する懸念がある。

``` php
<?php

namespace Customize\Doctrine\Query;

use Doctrine\ORM\QueryBuilder;
use Eccube\Doctrine\Query\QueryCustomizer;
use Eccube\Repository\QueryKey;

class HogeCustomizer implements QueryCustomizer
{
    public function customize(QueryBuilder $builder, $params, $queryKey)
    {
        $qb->leftJoin('pc.SaleType', 'st')->andWhere('st.name = :hoge')->setParameter('hoge', 'HOGE');
        /*
         * ここまでなら正常に動作する。
         */

        $qb->addSelect('st');
        /*
         * Joinした対象をaddSelectすると下記の例外が発生する。
         * Doctrine\ORM\Internal\Hydration\HydrationException: The parent object of entity result with alias 'st' was not found. The parent alias is 'pc'.
         * $qb->addSelect('pc')すれば直るが、N+1問題が発生する。
         */
    }

    public function getQueryKey()
    {
        return QueryKey::PRODUCT_SEARCH_ADMIN;
    }
}
```

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
