### PR TITLE
動的ブロックを挿入するTwig拡張を実装

### DIFF
--- a/src/Eccube/Twig/Extension/EccubeDynamicBlockExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeDynamicBlockExtension.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Twig\Extension;
+
+use Eccube\Entity\Block;
+use Eccube\Repository\BlockRepository;
+use Symfony\Bridge\Twig\Extension\HttpKernelRuntime;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class EccubeDynamicBlockExtension extends AbstractExtension
+{
+    /** @var BlockRepository */
+    protected $blockRepository;
+
+    public function __construct(BlockRepository $blockRepository)
+    {
+        $this->blockRepository = $blockRepository;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('eccube_dynamic_block', [$this, 'eccube_dynamic_block'], [
+                'needs_environment' => true,
+                'needs_context' => true,
+                'pre_escape' => 'html',
+                'is_safe' => [
+                    'html',
+                ],
+            ]),
+        ];
+    }
+
+    public function eccube_dynamic_block(Environment $env, $context, $fileName, $parameters = [])
+    {
+        $Block = $this->blockRepository->findOneBy([
+            'file_name' => $fileName,
+        ]);
+        if (!($Block instanceof Block)) {
+            @trigger_error($fileName . ' block is not found', E_USER_WARNING);
+            return;
+        }
+        if ($Block->isUseController()) {
+            $blockPath = sprintf('block_%s', $fileName);
+            $runtime = $env->getRuntime(HttpKernelRuntime::class);
+            assert($runtime instanceof HttpKernelRuntime);
+            $path = $env->getFunction('path')->getCallable();
+            return $runtime->renderFragment(
+                $path($blockPath, $parameters)
+            );
+        } else {
+            $template = sprintf('Block/%s.twig', $fileName);
+            return ($env->getFunction('include_dispatch')->getCallable())($context, $template);
+        }
+    }
+}

--- a/tests/Eccube/Tests/Twig/Extension/EccubeDynamicBlockExtensionTest.php
+++ b/tests/Eccube/Tests/Twig/Extension/EccubeDynamicBlockExtensionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Twig\Extension;
+
+use Eccube\Application;
+use Eccube\Entity\Block;
+use Eccube\Repository\BlockRepository;
+use Eccube\Tests\EccubeTestCase;
+use Eccube\Twig\Environment;
+use Eccube\Twig\Extension\EccubeDynamicBlockExtension;
+use Eccube\Twig\Extension\TwigIncludeExtension;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Twig\Loader\ArrayLoader;
+
+class EccubeDynamicBlockExtensionTest extends EccubeTestCase
+{
+    /** @var Environment */
+    protected $twig;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->twig = $this->initializeTwig();
+
+        $BlockUsingController = new Block();
+        $BlockUsingController
+            ->setUseController(true)
+            ->setFileName('use_controller');
+        $this->entityManager->persist($BlockUsingController);
+
+        $BlockWithoutController = new Block();
+        $BlockWithoutController
+            ->setUseController(false)
+            ->setFileName('without_controller');
+        $this->entityManager->persist($BlockWithoutController);
+
+        $this->entityManager->flush();
+    }
+
+    protected function initializeTwig(): \Twig_Environment
+    {
+        $app = static::createClient()->getContainer()->get('app');
+        assert($app instanceof Application);
+
+        $loader = new ArrayLoader();
+        $loader->setTemplate('Block/use_controller.twig', '{{ value }}');
+        $loader->setTemplate('Block/without_controller.twig', 'foo');
+        $dispatcher = $app['dispatcher'];
+        assert($dispatcher instanceof EventDispatcherInterface);
+        $twig = new \Twig_Environment($loader);
+        $eccubeTwig = new Environment($twig, $dispatcher);
+        $extensions = [
+            new EccubeDynamicBlockExtension($this->container->get(BlockRepository::class)),
+            new TwigIncludeExtension($eccubeTwig),
+        ];
+        foreach ($extensions as $extension) {
+            $twig->addExtension($extension);
+        }
+
+        return $twig;
+    }
+
+    public function testEccubeDynamicBlockFunctionWithoutController()
+    {
+        $template = $this->twig->createTemplate('{{ eccube_dynamic_block("without_controller") }}');
+        $this->expected = 'foo';
+        $this->actual = $template->render([]);
+        $this->verify();
+    }
+
+    public function testEccubeDynamicBlockFunctionUsingController()
+    {
+        // TODO
+        $this->markTestSkipped();
+    }
+
+    public function testEccubeDynamicBlockFunctionUsingControllerWithParameter()
+    {
+        // TODO
+        $this->markTestSkipped();
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#4623 のプログラム側の実装。

``` twig
{{ eccube_dynamic_block('footer') }} {# コントローラなし #}
{{ eccube_dynamic_block('search_product') }} {# コントローラあり #}
{{ eccube_dynamic_block('customize', {'limit': 10}) }} {# パラメータ付きコントローラあり #}
```

## 方針(Policy)

``` twig
{% if Block.use_controller %}
    {{ render(path('block_' ~ Block.file_name)) }}
{% else %}
    {{ include_dispatch('Block/' ~ Block.file_name ~ '.twig') }}
{% endif %}
```

上記のロジックを一つの拡張にまとめただけのもの。

`render`/`path`/`include_dispatch`の処理を利用するため、下記の3クラスに依存している。

- `\Symfony\Bridge\Twig\Extension\HttpKernelRuntime`
- `\Symfony\Bridge\Twig\Extension\RoutingExtension`
- `\Eccube\Twig\Extension\TwigIncludeExtension`

## テスト（Test)

`コントローラなし`の場合のユニットテストを追加。

## 相談（Discussion）

- `コントローラあり`及び`パラメータ付きコントローラあり`はテストケース内でうまく依存関係を解決できず、スキップとしてあります。いい方法があれば/(ご教授|テストを書き換えて)/uいただけると助かります。
- `eccube_block_*`が既に存在するので、差別化のために`eccube_dynamic_block`という名前にしてあります。他に良い名前や、あるいは`eccube_block`でも良いということであればお知らせ下さい。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
