### PR TITLE
インストール時にプロダクションモードをデフォルトに変更

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -3,8 +3,10 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
 ###> symfony/framework-bundle ###
-APP_ENV=dev
-APP_DEBUG=1
+# For production servers, use: "APP_ENV=prod" and "APP_DEBUG=0"
+# For local development, use: "APP_ENV=dev" and "APP_DEBUG=1"
+APP_ENV=prod
+APP_DEBUG=0
 #TRUSTED_PROXIES=127.0.0.1,127.0.0.2
 #TRUSTED_HOSTS=localhost,example.com
 ###< symfony/framework-bundle ###

--- a/.env.install
+++ b/.env.install
@@ -1,4 +1,4 @@
 ###> symfony/framework-bundle ###
 APP_ENV=install
-APP_DEBUG=1
+APP_DEBUG=0
 ###< symfony/framework-bundle ###

--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -113,8 +113,8 @@ class InstallerCommand extends Command
         $this->io->text([
             'If you prefer to not use this interactive wizard, define the environment valiables as follows:',
             '',
-            ' $ export APP_ENV=dev',
-            ' $ export APP_DEBUG=1',
+            ' $ export APP_ENV=prod',
+            ' $ export APP_DEBUG=0',
             ' $ export DATABASE_URL=database_url',
             ' $ export DATABASE_SERVER_VERSION=server_version',
             ' $ export MAILER_URL=mailer_url',
@@ -150,15 +150,15 @@ class InstallerCommand extends Command
 
         // 以下環境変数に規定済の設定値があれば利用する
         // APP_ENV
-        $appEnv = env('APP_ENV', 'dev');
-        // .envが存在しない状態では規定値'install'となっているため、devに更新する
+        $appEnv = env('APP_ENV', 'prod');
+        // .envが存在しない状態では規定値'install'となっているため、prodに更新する
         if ($appEnv === 'install') {
-            $appEnv = 'dev';
+            $appEnv = 'prod';
         }
         $this->envFileUpdater->appEnv = $appEnv;
 
         // APP_DEBUG
-        $this->envFileUpdater->appDebug = env('APP_DEBUG', '1');
+        $this->envFileUpdater->appDebug = env('APP_DEBUG', '0');
 
         // ECCUBE_ADMIN_ROUTE
         $adminRoute = $this->container->getParameter('eccube_admin_route');


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

インストール時のデフォルトのAPP_ENVの値について、Webインストーラでインストールをするとプロダクションモードとなりますが、コマンドラインからインストールをすると開発モードとなっていました。
間違って開発モードのままサイトが公開されてしまうことを極力減らすため、コマンドラインからのインストール時もプロダクションモードをデフォルトに変更しました。

## 方針(Policy)

環境変数で明示的に指定した場合を除き、以下をデフォルトとする。

```env
APP_ENV=prod
APP_DEBUG=0
```

## 実装に関する補足(Appendix)

インストール時の設定( `.env.install` )も `APP_DEBUG=1` となっていましたが、不要だと思うので `APP_DEBUG=0` に変更しました。

## テスト（Test)

以下のインストール方法でprodでインストールされることを確認しました。

- Webインストーラ
- コマンド `bin/console e:i --no-interaction`
- コマンド `bin/console e:i`

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
