### PR TITLE
納品書の送料が２つ表示される問題を修正

### DIFF
--- a/src/Eccube/Service/OrderPdfService.php
+++ b/src/Eccube/Service/OrderPdfService.php
@@ -461,8 +461,12 @@ class OrderPdfService extends TcpdfFpdi
         // =========================================
         $i = 0;
         $isShowReducedTaxMess = false;
+        $Order = $Shipping->getOrder();
         /* @var OrderItem $OrderItem */
         foreach ($Shipping->getOrderItems() as $OrderItem) {
+            if (!$Order->isMultiple() && is_null($OrderItem->getProduct())) {
+                continue;
+            }
             // class categoryの生成
             $classCategory = '';
             /** @var OrderItem $OrderItem */
@@ -497,8 +501,6 @@ class OrderPdfService extends TcpdfFpdi
 
             ++$i;
         }
-
-        $Order = $Shipping->getOrder();
 
         if (!$Order->isMultiple()) {
             // =========================================

--- a/src/Eccube/Service/OrderPdfService.php
+++ b/src/Eccube/Service/OrderPdfService.php
@@ -464,7 +464,7 @@ class OrderPdfService extends TcpdfFpdi
         $Order = $Shipping->getOrder();
         /* @var OrderItem $OrderItem */
         foreach ($Shipping->getOrderItems() as $OrderItem) {
-            if (!$Order->isMultiple() && is_null($OrderItem->getProduct())) {
+            if (!$Order->isMultiple() && !$OrderItem->isProduct()) {
                 continue;
             }
             // class categoryの生成


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
納品書出力した際に「送料」が２つ表示される。

![スクリーンショット_2020-10-06_1_21_11](https://user-images.githubusercontent.com/34618717/95105685-7b3a0c00-0772-11eb-9cf4-58822c8e9d9e.png)

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- 受注管理に影響が無いよう、OrderPdfServiceのrenderOrderDetailDataで対応。
- 複数配送の納品書では送料が必要なので、複数配送ではない場合に限定。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
単価1,000円、税込1,000円という表記もおかしい気がするので、詳細の方から除きました。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
手動で動作確認。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
