### PR TITLE
[Symfony4.4] Doctrineのキャッシュをクリアできるように修正

### DIFF
--- a/src/Eccube/Util/CacheUtil.php
+++ b/src/Eccube/Util/CacheUtil.php
@@ -30,9 +30,6 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class CacheUtil implements EventSubscriberInterface
 {
-
-    const DOCTRINE_APP_CACHE_KEY = 'doctrine.app_cache_pool';
-
     private $clearCacheAfterResponse = false;
 
     /**
@@ -111,23 +108,18 @@ class CacheUtil implements EventSubscriberInterface
     /**
      * Doctrineのキャッシュを削除します.
      *
-     * @param null $env
-     *
      * @return string
      *
      * @throws \Exception
      */
     public function clearDoctrineCache()
     {
-        if (!$this->container->has(self::DOCTRINE_APP_CACHE_KEY)) {
-            return;
-        }
         $console = new Application($this->kernel);
         $console->setAutoExit(false);
 
         $command = [
             'command' => 'cache:pool:clear',
-            'pools' => [self::DOCTRINE_APP_CACHE_KEY],
+            'pools' => ['cache.app_clearer'],
             '--no-ansi' => true,
         ];
 

--- a/src/Eccube/Util/CacheUtil.php
+++ b/src/Eccube/Util/CacheUtil.php
@@ -32,7 +32,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 class CacheUtil implements EventSubscriberInterface
 {
 
-    const DOCTRINE_APP_CACHE_KEY = 'cache.doctrine.orm.default.metadata';
+    const DOCTRINE_APP_CACHE_KEY = 'doctrine.app_cache_pool';
 
     private $clearCacheAfterResponse = false;
 

--- a/src/Eccube/Util/CacheUtil.php
+++ b/src/Eccube/Util/CacheUtil.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer;
 use Symfony\Component\HttpKernel\Event\PostResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -30,6 +31,9 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class CacheUtil implements EventSubscriberInterface
 {
+
+    const DOCTRINE_APP_CACHE_KEY = 'cache.doctrine.orm.default.metadata';
+
     private $clearCacheAfterResponse = false;
 
     /**
@@ -114,12 +118,18 @@ class CacheUtil implements EventSubscriberInterface
      */
     public function clearDoctrineCache()
     {
+        /** @var Psr6CacheClearer $poolClearer */
+        $poolClearer = $this->container->get('cache.global_clearer');
+        if (!$poolClearer->hasPool(self::DOCTRINE_APP_CACHE_KEY)) {
+            return;
+        }
+
         $console = new Application($this->kernel);
         $console->setAutoExit(false);
 
         $command = [
             'command' => 'cache:pool:clear',
-            'pools' => ['cache.app_clearer'],
+            'pools' => [self::DOCTRINE_APP_CACHE_KEY],
             '--no-ansi' => true,
         ];
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)


EC-CUBE4.0では prod (およびテスト) では Doctrine のキャッシュを有効にしているが、 dev では有効にしていない。
そのためキャッシュ削除時に pool の有無を確認してからキャッシュを削除する実装となっている。

Symfony service がデフォルトで private になったため、 `$container->has()` で pool の有無の確認ができないようになった。
キャッシュ pool がないとの判定になり、キャッシュがクリアできない状態となっていた。

もともと落ちていたテストケースは以下

Codeception (ubuntu-18.04, 7.3, pgsql, admin01)

```
There were 2 failures:

---------
1) EA03ProductCest: Ea0305-uc01-t01(& uc01-t02/uc02-t01/uc04-t01) カテゴリ登録/編集/削除
 Test  codeception/acceptance/EA03ProductCest.php:product_カテゴリ登録
 Step  Click "body > div > div.c-contentsArea > div.c-contentsArea__cols > div.c-contentsArea__primaryCol > div > div > div > div > ul > li:nth-child(3) > div > div.col-auto.text-right > div > a"
 Fail  Link or Button or CSS or XPath element with 'body > div > div.c-contentsArea > div.c-contentsArea__cols > div.c-contentsArea__primaryCol > div > div > div > div > ul > li:nth-child(3) > div > div.col-auto.text-right > div > a' was not found.

Scenario Steps:

 26. $I->click("body > div > div.c-contentsArea > div.c...") at codeception/_support/Page/Admin/CategoryManagePage.php:83
 25. $I->see("保存しました","body > div > div.c-contentsArea ...") at codeception/acceptance/EA03ProductCest.php:615
 24. $I->click("#form1 > div:nth-child(2) > div:nth-chi...") at codeception/_support/Page/Admin/CategoryManagePage.php:48
 23. $I->fillField({"id":"admin_cat...},"test category11-1") at codeception/_support/Page/Admin/CategoryManagePage.php:41
 22. $I->see("test category11","body > div > div.c-cont...") at codeception/acceptance/EA03ProductCest.php:610
 21. $I->click("body > div.c-container > div.c-contents...") at codeception/_support/Page/Admin/CategoryManagePage.php:55

---------
2) EA03ProductCest: Ea0307-uc01-t01(& uc01-t02) カテゴリcsv登録
 Test  codeception/acceptance/EA03ProductCest.php:product_カテゴリCSV登録
 Step  See element {"xpath":"//*[@id="page_admin_product_category"]/div[1]/div[3]/div[3]/div[1]/div/div/div/div/ul/li/div/div[3]/a[contains(text(), "アップロードカテゴリ1")]"}
 Fail  Failed asserting that an array is not empty.

Scenario Steps:

 14. $I->seeElement({"xpath":"//*[@id="page_admin_produ...}) at codeception/acceptance/EA03ProductCest.php:700
 13. $I->see("カテゴリ管理商品管理",".c-pageTitle") at codeception/_support/Page/Admin/AbstractAdminPageStyleGuide.php:27
 12. $I->amOnPage("/admin/product/category") at codeception/_support/Page/Admin/AbstractAdminPage.php:32
 11. $I->see("CSVファイルをアップロードしました",".c-container div.c-c...") at codeception/acceptance/EA03ProductCest.php:696
 10. $I->click({"id":"upload-button"}) at codeception/_support/Page/Admin/CategoryCsvUploadPage.php:44
 9. $I->attachFile({"id":"admin_csv_impo...},"category.csv") at codeception/_support/Page/Admin/CategoryCsvUploadPage.php:37
```

Codeception (ubuntu-18.04, 7.3, pgsql, admin02)

```
There was 1 failure:

---------
1) EA06ContentsManagementCest: Ea0603-uc01-t01(& uc01-t02/uc01-t03/uc01-t04/uc01-t05) ページ管理
 Test  codeception/acceptance/EA06ContentsManagementCest.php:contentsmanagement_ページ管理
 Step  See "新着情報",".ec-newsRole"
 Fail  Element located either by name, CSS or XPath element with '.ec-newsRole' was not found.

Scenario Steps:

 42. $I->see("新着情報",".ec-newsRole") at codeception/acceptance/EA06ContentsManagementCest.php:190
 41. $I->amOnPage("/user_data/page_aliquid") at codeception/acceptance/EA06ContentsManagementCest.php:189
 40. $I->see("保存しました",{"xpath":"//div[@class='alert ale...}) at codeception/acceptance/EA06ContentsManagementCest.php:188
 39. $I->click("#form1 > div > div.c-conversionArea > d...") at codeception/_support/Page/Admin/LayoutEditPage.php:39
 38. $I->waitForElementVisible("#form1 > div > div.c-co...") at codeception/_support/Page/Admin/LayoutEditPage.php:38
 37. $I->dragAndDrop({"xpath":"//div[cont...},"#position_4") at codeception/_support/Page/Admin/LayoutEditPage.php:47
```

他のケースでもキャッシュの削除がうまくできていなかったが、偶然通っていただけ・・・

## 方針(Policy)

該当のpoolを削除

## 実装に関する補足(Appendix)

キャッシュ削除機構はコマンド実行に任せる

## テスト（Test)

prod/dev の両方でエラーなくキャッシュが削除されることを確認。

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
