### PR TITLE
Entity Proxy をプログラム内で動的に変更した場合にエラーにならないように修正

### DIFF
--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -190,7 +190,6 @@ class Kernel extends BaseKernel
                 $builder->setSchemes($scheme);
             }
             if (file_exists($pluginDir.'/'.$plugin.'/Resource/config')) {
-
                 $builder = $routes->import($pluginDir.'/'.$plugin.'/Resource/config/routes'.self::CONFIG_EXTS, '/', 'glob');
                 $builder->setSchemes($scheme);
             }
@@ -213,7 +212,6 @@ class Kernel extends BaseKernel
 
         // DocumentRootをルーティディレクトリに設定する.
         $container->addCompilerPass(new WebServerDocumentRootPass('%kernel.project_dir%/'));
-
 
         // twigのurl,path関数を差し替え
         $container->addCompilerPass(new TwigExtensionPass());
@@ -303,6 +301,12 @@ class Kernel extends BaseKernel
 
     protected function loadEntityProxies()
     {
+        // see https://github.com/EC-CUBE/ec-cube/issues/4727
+        // キャッシュクリアなど、コード内でコマンドを利用している場合に2回実行されてしまう
+        if (true === $this->booted) {
+            return;
+        }
+
         $files = Finder::create()
             ->in(__DIR__.'/../../app/proxy/entity/')
             ->name('*.php')


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

close #4727

プラグインの有効/無効/アップデートなどの場合のキャッシュクリアの処理でエラーが発生していた。
プラグインの自動テストが不安定でしたが、こちらの変更で安定して通るようになりました。
プラグイン有効化時に設定ボタンが表示されない問題も解決できると思います。

関連

#4173
#3412
#3957

## 方針(Policy)

Kernelをboot済みの場合はproxyファイルを読み込まないようにしました。

## 実装に関する補足(Appendix)


## テスト（Test)

自分のリポジトリで数回テストを走らせて安定してテストが通ることを確認しました。

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
