### PR TITLE
Set cookie lifetime on test

### DIFF
--- a/app/config/eccube/packages/test/framework.yaml
+++ b/app/config/eccube/packages/test/framework.yaml
@@ -2,3 +2,4 @@ framework:
     test: ~
     session:
         storage_id: session.storage.mock_file
+        cookie_lifetime: 1440


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

Cookieの持続時間は `ECCUBE_COOKIE_LIFETIME` の環境変数で指定できる。
デフォルトでは0、つまりブラウザ終了でcookieが失効して再ログインが必要な設定となっている。

https://github.com/EC-CUBE/ec-cube/blob/c26bea445bdb6b49a7b0ae01557abea6fd18c494/app/config/eccube/packages/eccube.yaml#L11

テストで利用しているSymfony BrowserKitのcookieの失効条件が見直され、 `$this->expires < time()` から `$this->expires <= time()` となった。
つまり有効期限が現在時刻のcookieは無効となった。

https://github.com/symfony/symfony/pull/38360

一般的なブラウザでアクセス時はブラウザを終了しない限りcookieは保持されるが、テストで利用しているSymfony BrowserKitは `リクエスト -> 確認 -> リクエスト -> 確認 -> ...` を繰り返し、リクエストのたびにcookieの有効性が評価されるようになっている。
cookieの有効期限が現在時刻だとセッションが保持されないためテストが通らなくなっていた。

影響があったテストケース

```
Eccube\Tests\Web\ProductControllerTest::testProductFavoriteAddThroughLogin
```

影響があるのは以下
- Symfony 3.4.46以降(まだリリースしていない)
- Symfony 4.4.15以降

## 方針(Policy)

testの環境にcookieの有効期限を設定

## 実装に関する補足(Appendix)

Symfony3.4.46はまだリリースされていないため現時点でテストは落ちていませんが、いずれ対応が必要になるためプルリクしました。

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
