### PR TITLE
AbstractRepository::save() のタイプヒント（アノテーション）の誤りを修正

### DIFF
--- a/src/Eccube/Repository/AbstractRepository.php
+++ b/src/Eccube/Repository/AbstractRepository.php
@@ -37,7 +37,7 @@ abstract class AbstractRepository extends ServiceEntityRepository
     /**
      * エンティティの登録/保存します。
      *
-     * @param $entity|AbstractEntity エンティティ
+     * @param AbstractEntity $entity
      */
     public function save($entity)
     {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

AbstractRepository::save() の `$entity` パラメータのタイプヒントの誤りを修正しました。
（オーバーライドした際にIntelliSenseが型情報を正しく認識できない場合がありました。）

## 方針(Policy)

`delete()` の方は問題なかったのでそちらと全く同じ指定にしてあります。

## テスト（Test)

AbstractRepositoryを継承したクラスでsave()をオーバーライドした際に
下記の環境でオーバーライド先で`$entity`の補完が効くことを確認しました。

* vim + vim-lsp + intelephense-server
* VSCode + vscode-intelephense

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
