### PR TITLE
htmlメールを出力する際に、ディレクトリ名などに「.」が含まれていたら正常に出力されない不具合修正

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/Shop/MailController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/MailController.php
@@ -177,9 +177,9 @@ class MailController extends AbstractController
     protected function getHtmlFileName($fileName)
     {
         // HTMLテンプレートファイルの取得
-        $targetTemplate = explode('.', $fileName);
+        $targetTemplate = pathinfo($fileName);
         $suffix = '.html';
 
-        return $targetTemplate[0].$suffix.'.'.$targetTemplate[1];
+        return $targetTemplate['dirname'].DIRECTORY_SEPARATOR.$targetTemplate['filename'].$suffix.'.'.$targetTemplate['extension'];
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
メール設定からメール用htmlファイルを出力する際に、
ディレクトリ名などに「.」が含まれていたら正常に出力されない不具合修正

例)
```
/home/xxx/www.example.com/
```
配下にEC-CUBEがインストールされていると、
「.」が含まれているため正常に出力されない。


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
