### PR TITLE
Dockerリビルド時の効率改善

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,11 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # Override with custom configuration settings
 COPY dockerbuild/php.ini $PHP_INI_DIR/conf.d/
 
-RUN chown www-data:www-data /var/www
+RUN chown www-data:www-data /var/www \
+  && mkdir -p ${APACHE_DOCUMENT_ROOT}/vendor \
+  && mkdir -p ${APACHE_DOCUMENT_ROOT}/var \
+  && chown www-data:www-data ${APACHE_DOCUMENT_ROOT}/vendor \
+  && chmod g+s ${APACHE_DOCUMENT_ROOT}/vendor
 
 RUN curl -sS https://getcomposer.org/installer \
   | php \
@@ -80,10 +84,9 @@ USER root
 COPY . ${APACHE_DOCUMENT_ROOT}
 WORKDIR ${APACHE_DOCUMENT_ROOT}
 
-RUN mkdir -p ${APACHE_DOCUMENT_ROOT}/var \
-  && find ${APACHE_DOCUMENT_ROOT} \( -path ${APACHE_DOCUMENT_ROOT}/vendor -prune \) -or -print0 \
+RUN find ${APACHE_DOCUMENT_ROOT} \( -path ${APACHE_DOCUMENT_ROOT}/vendor -prune \) -or -print0 \
   | xargs -0 chown www-data:www-data \
-  && find ${APACHE_DOCUMENT_ROOT} -type d -print0 \
+  && find ${APACHE_DOCUMENT_ROOT} \( -path ${APACHE_DOCUMENT_ROOT}/vendor -prune \) -or \( -type d -print0 \) \
   | xargs -0 chmod g+s \
   ;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,31 +55,39 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # Override with custom configuration settings
 COPY dockerbuild/php.ini $PHP_INI_DIR/conf.d/
 
-COPY . ${APACHE_DOCUMENT_ROOT}
-
-WORKDIR ${APACHE_DOCUMENT_ROOT}
+RUN chown www-data:www-data /var/www
 
 RUN curl -sS https://getcomposer.org/installer \
   | php \
   && mv composer.phar /usr/bin/composer \
   && composer selfupdate --1 \
   && composer config -g repos.packagist composer https://packagist.jp \
-  && composer global require hirak/prestissimo \
-  && chown www-data:www-data /var/www \
-  && mkdir -p ${APACHE_DOCUMENT_ROOT}/var \
-  && chown -R www-data:www-data ${APACHE_DOCUMENT_ROOT} \
-  && find ${APACHE_DOCUMENT_ROOT} -type d -print0 \
-  | xargs -0 chmod g+s \
-  ;
+  && composer global require hirak/prestissimo
 
+# 全体コピー前にcomposer installを先行完了させる(docker cache利用によるリビルド速度向上)
 USER www-data
-
+COPY composer.json ${APACHE_DOCUMENT_ROOT}/composer.json
+COPY composer.lock ${APACHE_DOCUMENT_ROOT}/composer.lock
 RUN composer install \
   --no-scripts \
   --no-autoloader \
   -d ${APACHE_DOCUMENT_ROOT} \
   ;
 
+##################################################################
+# ファイル変更時、以後のステップにはキャッシュが効かなくなる
+USER root
+COPY . ${APACHE_DOCUMENT_ROOT}
+WORKDIR ${APACHE_DOCUMENT_ROOT}
+
+RUN mkdir -p ${APACHE_DOCUMENT_ROOT}/var \
+  && find ${APACHE_DOCUMENT_ROOT} \( -path ${APACHE_DOCUMENT_ROOT}/vendor -prune \) -or -print0 \
+  | xargs -0 chown www-data:www-data \
+  && find ${APACHE_DOCUMENT_ROOT} -type d -print0 \
+  | xargs -0 chmod g+s \
+  ;
+
+USER www-data
 RUN composer dumpautoload -o --apcu
 
 RUN if [ ! -f ${APACHE_DOCUMENT_ROOT}/.env ]; then \


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
現行のDockerfileを用いてDockerイメージをビルドする場合、どれかファイルを1つ変更された状態だと`composer install`が再度実行されるため、再ビルドのコストが重い。

Dockerのキャッシュを意識した処理順序にすることで、再ビルド時には`composer.json`及び`composer.lock`が変更された時以外は`composer install`をによるパッケージのダウンロード処理が行われないようにした(本PR作成者環境で80秒程度)

### ビルド速度の変化

| 条件   | 初回ビルド速度 | comoposer.* 以外変更時 |
| ------ | ------------------ | --------------- |
| 変更前 | 211 s              | 112 s           |
| 変更後 | 227 s              | 34 s            |


- ※ 作成者環境での速度
- ~~※ 初回ビルドに関しては、所有者・パーミッション設定の処理が5~10秒程のコスト増となってしまっている~~
  - 28b85c542629b0010ee54df94a529371b4917636 を適用して再分析したところ、処理の変更による影響は2秒程度。ネットワーク環境などの影響による誤差にほうがはるかに大きい

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

- composer.json及びcomposer.lock以外の更新時はビルドキャッシュを利用するようにした
- 上記タイミング調整に伴うパーミッション・所有者設定手順を調整
- 本PRによる外部仕様の変更はなし

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

### Dockerビルドのキャッシュについて

参考: https://blog.hanhans.net/2017/02/25/docker-cache-composer-install/

Dockerのビルドにおいては、主に`COPY`,`ADD`句により渡されるファイルのチェックサムが異なる場合に、以降の処理はキャッシュを使用しないという性質がある。

現行ではCOPY句でプロジェクトフォルダ全体を転送した後に`composer install`を実行していたため、以降のキャッシュが一切効かないという状況。

本PRでは、`composer install`に必要な`composer.json`とcomposer.lock`のみ先にCOPY句で転送してパッケージのダウンロードを行い、その後に変更が大きいプロジェクトフォルダ全体をCOPY句で転送するようにしたことで、パッケージダウンロードまでのキャッシュが働くようにした。

`composer dumpautoload`に関しては、ファイルが出そろったタイミングでの実行。

### 所有者の設定について
vendor以下のchmodについては、`www-data`ユーザで`composer install`を実行しているため所有者の変更必要なし。時間短縮のために除外


## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
### Dockerビルド関連のテスト
- `docker build . `が正常に完了すること

- ルート直下ファイル、`app`以下、`src`以下のファイルの変更時は`composer install`を含むステップにキャッシュが適用されること
- `composer.json`,`composer.lock`の変更時は`composer install`を含むステップにキャッシュが適用されず、再ダウンロードが発生すること

### パーミッション・所有者関連の確認
- コンテナイメージの`/var/www/html`以下のファイル・ディレクトリ(vendor含む)の所有者が`www-data`のままであること
- コンテナイメージの`/var/www/html`以下のファイル・ディレクトリ(vendor含む)のパーミッションに差分がないこと

### アプリ動作の確認
- トップページの表示確認


## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

- 初回ビルドが少し延びるのと、再ビルドが大幅に短縮されるのではどちらを取るべきか、若干迷います
  
- vendor以下に対してchmodを実行する必要があるか？(数秒の短縮は見込めると思います)
  - 実行する場合、vendor以下のディレクトリのパーミッションが`drwxr-sr-x`になる(現行)
  - 実行しない場合、vendor以下のディレクトリのパーミッションが`drwxr-xr-x`になる



## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
