### PR TITLE
GitHub Actions を Composer1 に固定

### DIFF
--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -227,7 +227,10 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install to Composer
-        run: composer install --dev --no-interaction -o --apcu-autoloader
+        run: |
+          sudo composer selfupdate --1
+          composer install --dev --no-interaction -o --apcu-autoloader
+
       - name: Setup to EC-CUBE
         env:
           APP_ENV: 'codeception'
@@ -368,7 +371,10 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install to Composer
-        run: composer install --dev --no-interaction -o --apcu-autoloader
+        run: |
+          sudo composer selfupdate --1
+          composer install --dev --no-interaction -o --apcu-autoloader
+
       - name: Setup to EC-CUBE
         env:
           APP_ENV: 'codeception'
@@ -512,7 +518,10 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install to Composer
-        run: composer install --dev --no-interaction -o --apcu-autoloader
+        run: |
+          sudo composer selfupdate --1
+          composer install --dev --no-interaction -o --apcu-autoloader
+
       - name: Setup to EC-CUBE
         env:
           APP_ENV: 'codeception'


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#4746 の対応の残です。
すみません、確認不足でした。

GitHub ActionsもComposer2になりましたね。

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
