### PR TITLE
永続化されたカートとセッションのカートが同一の場合はマージしない

### DIFF
--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -91,14 +91,6 @@ class CartService
 
     /**
      * CartService constructor.
-     *
-     * @param SessionInterface $session
-     * @param EntityManagerInterface $entityManager
-     * @param ProductClassRepository $productClassRepository
-     * @param CartItemComparator $cartItemComparator
-     * @param CartItemAllocator $cartItemAllocator
-     * @param TokenStorageInterface $tokenStorage
-     * @param AuthorizationCheckerInterface $authorizationChecker
      */
     public function __construct(
         SessionInterface $session,
@@ -196,15 +188,14 @@ class CartService
         $persistedCarts = $this->getPersistedCarts();
         $sessionCarts = $this->getSessionCarts();
 
+        $CartItems = [];
+
         // 永続化されたカートとセッションのカートが同一の場合はマージしない #4574
         $cartKeys = $this->session->get('cart_keys', []);
-        if (in_array($persistedCarts[0]->getCartKey(), $cartKeys)) {
-            return;
-        };
-
-        $CartItems = [];
-        foreach ($persistedCarts as $Cart) {
-            $CartItems = $this->mergeCartItems($Cart->getCartItems(), $CartItems);
+        if ((count($persistedCarts) > 0) && !in_array($persistedCarts[0]->getCartKey(), $cartKeys, true)) {
+            foreach ($persistedCarts as $Cart) {
+                $CartItems = $this->mergeCartItems($Cart->getCartItems(), $CartItems);
+            }
         }
 
         // セッションにある非会員カートとDBから取得した会員カートをマージする.
@@ -433,7 +424,7 @@ class CartService
     }
 
     /**
-     * @return null|string
+     * @return string|null
      */
     public function getPreOrderId()
     {

--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -193,13 +193,22 @@ class CartService
      */
     public function mergeFromPersistedCart()
     {
+        $persistedCarts = $this->getPersistedCarts();
+        $sessionCarts = $this->getSessionCarts();
+
+        // 永続化されたカートとセッションのカートが同一の場合はマージしない #4574
+        $cartKeys = $this->session->get('cart_keys', []);
+        if (in_array($persistedCarts[0]->getCartKey(), $cartKeys)) {
+            return;
+        };
+
         $CartItems = [];
-        foreach ($this->getPersistedCarts() as $Cart) {
+        foreach ($persistedCarts as $Cart) {
             $CartItems = $this->mergeCartItems($Cart->getCartItems(), $CartItems);
         }
 
         // セッションにある非会員カートとDBから取得した会員カートをマージする.
-        foreach ($this->getSessionCarts() as $Cart) {
+        foreach ($sessionCarts as $Cart) {
             $CartItems = $this->mergeCartItems($Cart->getCartItems(), $CartItems);
         }
 


### PR DESCRIPTION
refs #4574

## 概要(Overview・Refs Issue)

通常ログイン時、「ログアウト状態でカート(セッション)」と「以前ログインしていた時のカート(DB)」がマージされる。
自動ログイン状態では「以前ログインしていた時のカート(DB)」が復元されるため、ログイン時に「ログアウト状態でカート(セッション)」をマージする必要はない。
永続化されたカートとセッションのカートが同一の場合はマージしないように対応した。

## 方針(Policy)

## 実装に関する補足(Appendix)

CartKeyを比較して判断するようにした。

## テスト（Test)

自動テストは追加できなかった。
CartService内でセッション、DBが絡んでいてうまくテストする方法がわからなかった。

以下の言葉を使う
- ログアウト状態
- 自動ログイン状態
- ログイン状態


以下の手動テストを実施
- ログアウト状態からログイン状態でカートがマージされる（単一カート/複数カート）
- 自動ログイン状態からログイン状態でカートがマージされない（単一カート/複数カート）

## 相談（Discussion）

自動テスト方法があったら教えて欲しい。
CartServiceは不安があるので有識者のレビューが欲しい。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
