### PR TITLE
Feature/#4716 管理者ページ-受注一覧における検索条件の修正

### DIFF
--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -106,16 +106,18 @@ class OrderRepository extends AbstractRepository
         }
         // multi
         if (isset($searchData['multi']) && StringUtil::isNotBlank($searchData['multi'])) {
-            $multi = preg_match('/^\d{0,10}$/', $searchData['multi']) ? $searchData['multi'] : null;
-            if ($multi && $multi > '2147483647' && $this->isPostgreSQL()) {
-                $multi = null;
+            //スペース除去
+            $clean_key_multi = preg_replace('/\s+|[　]+/u', '', $searchData['multi']);
+            $id = preg_match('/^\d{0,10}$/', $clean_key_multi) ? $clean_key_multi : null;
+            if ($id && $id > '2147483647' && $this->isPostgreSQL()) {
+                $id = null;
             }
             $qb
-                ->andWhere('o.id = :multi OR o.name01 LIKE :likemulti OR o.name02 LIKE :likemulti OR '.
-                            'o.kana01 LIKE :likemulti OR o.kana02 LIKE :likemulti OR o.company_name LIKE :likemulti OR '.
+                ->andWhere('o.id = :order_id OR CONCAT(o.name01, o.name02) LIKE :likemulti OR '.
+                            'CONCAT(o.kana01, o.kana02) LIKE :likemulti OR o.company_name LIKE :likemulti OR '.
                             'o.order_no LIKE :likemulti OR o.email LIKE :likemulti OR o.phone_number LIKE :likemulti')
-                ->setParameter('multi', $multi)
-                ->setParameter('likemulti', '%'.$searchData['multi'].'%');
+                ->setParameter('order_id', $id)
+                ->setParameter('likemulti', '%'.$clean_key_multi.'%');
         }
 
         // order_id_end

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -108,15 +108,15 @@ class OrderRepository extends AbstractRepository
         if (isset($searchData['multi']) && StringUtil::isNotBlank($searchData['multi'])) {
             //スペース除去
             $clean_key_multi = preg_replace('/\s+|[　]+/u', '', $searchData['multi']);
-            $id = preg_match('/^\d{0,10}$/', $clean_key_multi) ? $clean_key_multi : null;
-            if ($id && $id > '2147483647' && $this->isPostgreSQL()) {
-                $id = null;
+            $multi = preg_match('/^\d{0,10}$/', $clean_key_multi) ? $clean_key_multi : null;
+            if ($multi && $multi > '2147483647' && $this->isPostgreSQL()) {
+                $multi = null;
             }
             $qb
-                ->andWhere('o.id = :order_id OR CONCAT(o.name01, o.name02) LIKE :likemulti OR '.
+                ->andWhere('o.id = :multi OR CONCAT(o.name01, o.name02) LIKE :likemulti OR '.
                             'CONCAT(o.kana01, o.kana02) LIKE :likemulti OR o.company_name LIKE :likemulti OR '.
                             'o.order_no LIKE :likemulti OR o.email LIKE :likemulti OR o.phone_number LIKE :likemulti')
-                ->setParameter('order_id', $id)
+                ->setParameter('multi', $multi)
                 ->setParameter('likemulti', '%'.$clean_key_multi.'%');
         }
 

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -151,16 +151,18 @@ class OrderRepository extends AbstractRepository
 
         // name
         if (isset($searchData['name']) && StringUtil::isNotBlank($searchData['name'])) {
+            $clean_name = preg_replace('/\s+|[　]+/u', '', $searchData['name']);
             $qb
                 ->andWhere('CONCAT(o.name01, o.name02) LIKE :name')
-                ->setParameter('name', '%'.$searchData['name'].'%');
+                ->setParameter('name', '%'.$clean_name.'%');
         }
 
         // kana
         if (isset($searchData['kana']) && StringUtil::isNotBlank($searchData['kana'])) {
+            $clean_kana = preg_replace('/\s+|[　]+/u', '', $searchData['kana']);
             $qb
                 ->andWhere('CONCAT(o.kana01, o.kana02) LIKE :kana')
-                ->setParameter('kana', '%'.$searchData['kana'].'%');
+                ->setParameter('kana', '%'.$clean_kana.'%');
         }
 
         // email

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -114,10 +114,11 @@ class OrderRepository extends AbstractRepository
             }
             $qb
                 ->andWhere('o.id = :multi OR CONCAT(o.name01, o.name02) LIKE :likemulti OR '.
-                            'CONCAT(o.kana01, o.kana02) LIKE :likemulti OR o.company_name LIKE :likemulti OR '.
+                            'CONCAT(o.kana01, o.kana02) LIKE :likemulti OR o.company_name LIKE :company_name OR '.
                             'o.order_no LIKE :likemulti OR o.email LIKE :likemulti OR o.phone_number LIKE :likemulti')
                 ->setParameter('multi', $multi)
-                ->setParameter('likemulti', '%'.$clean_key_multi.'%');
+                ->setParameter('likemulti', '%'.$clean_key_multi.'%')
+                ->setParameter('company_name', '%'.$searchData['multi'].'%'); // 会社名はスペースを除去せず検索
         }
 
         // order_id_end

--- a/tests/Eccube/Tests/Repository/OrderRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryTest.php
@@ -14,8 +14,8 @@
 namespace Eccube\Tests\Repository;
 
 use Eccube\Entity\Customer;
-use Eccube\Entity\Order;
 use Eccube\Entity\Master\OrderStatus;
+use Eccube\Entity\Order;
 use Eccube\Repository\OrderRepository;
 use Eccube\Tests\EccubeTestCase;
 
@@ -125,12 +125,81 @@ class OrderRepositoryTest extends EccubeTestCase
         $Order = $this->createOrder($this->createCustomer('2147483648@example.com'));
         $Order->setOrderStatus($this->entityManager->find(OrderStatus::class, OrderStatus::NEW));
         $this->orderRepository->save($Order);
-        $this->entityManager->flush();;
+        $this->entityManager->flush();
 
         $actual = $this->orderRepository->getQueryBuilderBySearchDataForAdmin(['multi' => '2147483648'])
             ->getQuery()
             ->getResult();
 
         self::assertEquals($Order, $actual[0]);
+    }
+
+    /**
+     * @dataProvider dataGetQueryBuilderBySearchDataForAdmin_nameProvider
+     */
+    public function testGetQueryBuilderBySearchDataForAdmin_name(string $formName, string $searchWord, int $expected)
+    {
+        $this->Order
+            ->setOrderStatus($this->entityManager->find(OrderStatus::class, OrderStatus::NEW))
+            ->setName01('姓')
+            ->setName02('名')
+            ->setKana01('セイ')
+            ->setKana02('メイ')
+            ->setCompanyName('株式会社　会社名'); // 全角スペース
+        $this->orderRepository->save($this->Order);
+        $this->entityManager->flush();
+
+        $actual = $this->orderRepository->getQueryBuilderBySearchDataForAdmin([$formName => $searchWord])
+            ->getQuery()
+            ->getResult();
+
+        self::assertCount($expected, $actual);
+    }
+
+    public function dataGetQueryBuilderBySearchDataForAdmin_nameProvider()
+    {
+        return [
+            ['multi', '姓', 1],
+            ['multi', '名', 1],
+            ['multi', '姓名', 1],
+            ['multi', '姓 名', 1],
+            ['multi', '姓　名', 1],
+            ['multi', 'セイ', 1],
+            ['multi', 'メイ', 1],
+            ['multi', 'セイメイ', 1],
+            ['multi', 'セイ メイ', 1],
+            ['multi', 'セイ　メイ', 1],
+            ['multi', '株式会社', 1],
+            ['multi', '会社名', 1],
+            ['multi', '株式会社会社名', 0],
+            ['multi', '株式会社 会社名', 0], // 半角スペース
+            ['multi', '株式会社　会社名', 1], // 全角スペース
+            ['multi', '石', 0],
+            ['multi', 'キューブ', 0],
+            ['multi', '姓 球部', 0],
+            ['multi', 'セイ 名', 0],
+            ['multi', '姓　メイ', 0],
+            ['name', '姓', 1],
+            ['name', '名', 1],
+            ['name', '姓名', 1],
+            ['name', '姓 名', 1],
+            ['name', '姓　名', 1],
+            ['name', 'セイ', 0],
+            ['name', '株式会社　会社名', 0],
+            ['kana', 'セイ', 1],
+            ['kana', 'メイ', 1],
+            ['kana', 'セイメイ', 1],
+            ['kana', 'セイ メイ', 1],
+            ['kana', 'セイ　メイ', 1],
+            ['kana', '姓', 0],
+            ['kana', '株式会社　会社名', 0],
+            ['company_name', '株式会社', 1],
+            ['company_name', '会社名', 1],
+            ['company_name', '株式会社会社名', 0],
+            ['company_name', '株式会社 会社名', 0], // 半角スペース
+            ['company_name', '株式会社　会社名', 1], // 全角スペース
+            ['company_name', '姓', 0],
+            ['company_name', 'セイ', 0],
+        ];
     }
 }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
#4716 
## 方針(Policy)
注文者名（カナ）については記載がありませんでしたが、利便性を考えると「カナ」の場合もフルネームで検索できる方がいいと思いますので、こちらも対応しております。


## 実装に関する補足(Appendix)

特にありません。

## テスト（Test)
https://github.com/EC-CUBE/ec-cube/issues/4716#issuecomment-704020918
・上記不可の項目が検索可能となること
・カナ入力においてもフルネームで検索可能であること
・既存機能の注文番号・お名前・会社名・メールアドレス・電話番号で検索可能なこと（デグレを起こしていないこと）

## 相談（Discussion）
受注一覧-詳細検索-注文者名（カナ）においてスペースを入れて検索しようとすると、
ec-cube/src/Eccube/Form/Type/Admin/SearchOrderTypeでスペースを含めていないため、不正入力扱いになります。
仕様的にOKでしょうか。（スペースも入力可能とする必要はないでしょうか）
ちなみに（注文番号・お名前・会社名・メールアドレス・電話番号）の方で検索すると「ヤマダ　タロウ」のようにスペースを含めたカナ検索は可能となっています。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
