### PR TITLE
商品画像削除時、他の商品画像が参照するファイルは削除しないよう変更

### DIFF
--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -31,6 +31,7 @@ use Eccube\Repository\ClassCategoryRepository;
 use Eccube\Repository\DeliveryDurationRepository;
 use Eccube\Repository\Master\ProductStatusRepository;
 use Eccube\Repository\Master\SaleTypeRepository;
+use Eccube\Repository\ProductImageRepository;
 use Eccube\Repository\ProductRepository;
 use Eccube\Repository\TagRepository;
 use Eccube\Repository\TaxRuleRepository;
@@ -75,6 +76,11 @@ class CsvImportController extends AbstractCsvImportController
     protected $classCategoryRepository;
 
     /**
+     * @var ProductImageRepository
+     */
+    protected $productImageRepository;
+
+    /**
      * @var ProductStatusRepository
      */
     protected $productStatusRepository;
@@ -109,6 +115,7 @@ class CsvImportController extends AbstractCsvImportController
      * @param TagRepository $tagRepository
      * @param CategoryRepository $categoryRepository
      * @param ClassCategoryRepository $classCategoryRepository
+     * @param ProductImageRepository $productImageRepository
      * @param ProductStatusRepository $productStatusRepository
      * @param ProductRepository $productRepository
      * @param TaxRuleRepository $taxRuleRepository
@@ -122,6 +129,7 @@ class CsvImportController extends AbstractCsvImportController
         TagRepository $tagRepository,
         CategoryRepository $categoryRepository,
         ClassCategoryRepository $classCategoryRepository,
+        ProductImageRepository $productImageRepository,
         ProductStatusRepository $productStatusRepository,
         ProductRepository $productRepository,
         TaxRuleRepository $taxRuleRepository,
@@ -133,6 +141,7 @@ class CsvImportController extends AbstractCsvImportController
         $this->tagRepository = $tagRepository;
         $this->categoryRepository = $categoryRepository;
         $this->classCategoryRepository = $classCategoryRepository;
+        $this->productImageRepository = $productImageRepository;
         $this->productStatusRepository = $productStatusRepository;
         $this->productRepository = $productRepository;
         $this->taxRuleRepository = $taxRuleRepository;
@@ -629,7 +638,11 @@ class CsvImportController extends AbstractCsvImportController
 
                     // 画像ファイルの削除(commit後に削除させる)
                     foreach ($deleteImages as $images) {
+                        /** @var ProductImage $image */
                         foreach ($images as $image) {
+                            if ($this->productImageRepository->findOneBy(['file_name' => $image->getFileName()])) {
+                                continue;
+                            }
                             try {
                                 $fs = new Filesystem();
                                 $fs->remove($this->eccubeConfig['eccube_save_image_dir'].'/'.$image);

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -545,10 +545,13 @@ class ProductController extends AbstractController
                         $this->entityManager->remove($ProductImage);
                     }
                     $this->entityManager->persist($Product);
+                    $this->entityManager->flush();
 
-                    // 削除
-                    $fs = new Filesystem();
-                    $fs->remove($this->eccubeConfig['eccube_save_image_dir'].'/'.$delete_image);
+                    if (!$this->productImageRepository->findOneBy(['file_name' => $delete_image])) {
+                        // 削除
+                        $fs = new Filesystem();
+                        $fs->remove($this->eccubeConfig['eccube_save_image_dir'] . '/' . $delete_image);
+                    }
                 }
                 $this->entityManager->persist($Product);
                 $this->entityManager->flush();

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -722,7 +722,11 @@ class ProductController extends AbstractController
                     $deleteImages = $event->getArgument('deleteImages');
 
                     // 画像ファイルの削除(commit後に削除させる)
+                    /** @var ProductImage $deleteImage */
                     foreach ($deleteImages as $deleteImage) {
+                        if ($this->productImageRepository->findOneBy(['file_name' => $deleteImage->getFileName()])) {
+                            continue;
+                        }
                         try {
                             $fs = new Filesystem();
                             $fs->remove($this->eccubeConfig['eccube_save_image_dir'].'/'.$deleteImage);

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
@@ -17,9 +17,11 @@ use Eccube\Common\Constant;
 use Eccube\Entity\Master\ProductStatus;
 use Eccube\Entity\Master\RoundingType;
 use Eccube\Entity\ProductClass;
+use Eccube\Entity\ProductImage;
 use Eccube\Entity\ProductTag;
 use Eccube\Entity\Tag;
 use Eccube\Entity\TaxRule;
+use Eccube\Tests\Fixture\Generator;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 use Eccube\Util\StringUtil;
 use Symfony\Component\DomCrawler\Crawler;
@@ -1048,5 +1050,47 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         ];
 
         return $post;
+    }
+
+    /**
+     * 商品画像を削除する際に、他の商品画像が参照しているファイルは削除せず、それ以外は削除することをテスト
+     */
+    public function testDeleteImage()
+    {
+        /** @var Generator $generator */
+        $generator = $this->container->get(Generator::class);
+        $Product1 = $generator->createProduct(null, 0, 'abstract');
+        $Product2 = $generator->createProduct(null, 0, 'abstract');
+
+        $DuplicatedImage = $Product1->getProductImage()->first();
+        assert($DuplicatedImage instanceof ProductImage);
+
+        $NotDuplicatedImage = $Product1->getProductImage()->last();
+        assert($NotDuplicatedImage instanceof ProductImage);
+
+        $NewProduct2Image = new ProductImage();
+        $NewProduct2Image
+            ->setProduct($Product2)
+            ->setFileName($DuplicatedImage->getFileName())
+            ->setSortNo(999)
+        ;
+        $Product2->addProductImage($NewProduct2Image);
+        $this->entityManager->persist($NewProduct2Image);
+        $this->entityManager->flush();
+
+        $data = $this->createFormData();
+        $data['delete_images'] = $Product1->getProductImage()->map(static function (ProductImage $ProductImage) {
+            return $ProductImage->getFileName();
+        })->toArray();
+        $this->client->request(
+            'POST',
+            $this->generateUrl('admin_product_product_edit', ['id' => $Product1->getId()]),
+            ['admin_product' => $data]
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect());
+
+        $dir = __DIR__.'/../../../../../../html/upload/save_image/';
+        $this->assertTrue(file_exists($dir . $DuplicatedImage->getFileName()));
+        $this->assertFalse(file_exists($dir . $NotDuplicatedImage->getFileName()));
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#4752 の内、ファイル削除に関する処理の見直し。

## 方針(Policy)

`ProductImage`エンティティを削除後、同ファイル名の`ProductImage`が存在しない場合のみファイルを削除。

## テスト（Test)

ユニットテストを追加。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
