### PR TITLE
[Suggestion] 商品画像削除時の挙動を変更

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -546,9 +546,14 @@ class ProductController extends AbstractController
                     }
                     $this->entityManager->persist($Product);
 
+                    $basename = basename($delete_image);
+                    if (in_array($basename, ['', '.', '..'], true)) {
+                        continue;
+                    }
+
                     // 削除
                     $fs = new Filesystem();
-                    $fs->remove($this->eccubeConfig['eccube_save_image_dir'].'/'.$delete_image);
+                    $fs->remove($this->eccubeConfig['eccube_save_image_dir'] . '/' . $basename);
                 }
                 $this->entityManager->persist($Product);
                 $this->entityManager->flush();

--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -27,10 +27,6 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormError;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -180,35 +176,6 @@ class ProductType extends AbstractType
                 'mapped' => false,
             ])
         ;
-
-        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
-            /** @var FormInterface $form */
-            $form = $event->getForm();
-            $saveImgDir = $this->eccubeConfig['eccube_save_image_dir'];
-            $tempImgDir = $this->eccubeConfig['eccube_temp_image_dir'];
-            $this->validateFilePath($form->get('delete_images'), [$saveImgDir, $tempImgDir]);
-            $this->validateFilePath($form->get('add_images'), [$tempImgDir]);
-        });
-    }
-
-    /**
-     * 指定された複数ディレクトリのうち、いずれかのディレクトリ以下にファイルが存在するかを確認。
-     *
-     * @param $form FormInterface
-     * @param $dirs array
-     */
-    private function validateFilePath($form, $dirs)
-    {
-        foreach ($form->getData() as $fileName) {
-            $fileInDir = array_filter($dirs, function ($dir) use ($fileName) {
-                $filePath = realpath($dir.'/'.$fileName);
-                $topDirPath = realpath($dir);
-                return strpos($filePath, $topDirPath) === 0 && $filePath !== $topDirPath;
-            });
-            if (!$fileInDir) {
-                $form->getRoot()['product_image']->addError(new FormError(trans('admin.product.image__invalid_path')));
-            }
-        }
     }
 
     /**

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -608,7 +608,6 @@ admin.product.name: Product Name
 admin.product.image: Product Images
 admin.product.image__short: Images
 admin.product.image_size: 'More than 600px x 600px is recommended'
-admin.product.image__invalid_path: Invalid image path.
 admin.product.sale_type: Sales Type
 admin.product.description_detail: Product Descriptions
 admin.product.description_list: Product Descriptions (All)

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -608,7 +608,6 @@ admin.product.name: 商品名
 admin.product.image: 商品画像
 admin.product.image__short: 画像
 admin.product.image_size: '推奨サイズ : 600px x 600px以上'
-admin.product.image__invalid_path: 画像のパスが不正です。
 admin.product.sale_type: 販売種別
 admin.product.description_detail: 商品説明
 admin.product.description_list: 商品説明(一覧)


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)

#4752 のバリデーションの見直し案。

## 方針(Policy)

- 商品画像削除時の、ファイル存在バリデーションは廃止。
- ファイル削除時に用いるファイル名を`basename`でサニタイズ。
- `basename`の結果が`''`か`'.'`か`'..'`の場合はファイルを削除しない。
(`...`は有効なファイル名)

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
