### PR TITLE
[Suggestion] 商品画像削除時のバリデーションを改善

### DIFF
--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -168,11 +168,14 @@ class ProductType extends AbstractType
             ->add('delete_images', CollectionType::class, [
                 'entry_type' => HiddenType::class,
                 'entry_options' => [
-                    'constraints' => new Assert\Regex([
-                        'pattern' => '#(?:\A|/)\.{1,2}(?:\z|/)#u',
-                        'match' => false,
-                        'message' => 'admin.product.image__invalid_path',
-                    ]),
+                    'constraints' => [
+                        new Assert\Regex([
+                            'pattern' => '#(?:\A|/)\.{1,2}(?:\z|/)#u',
+                            'match' => false,
+                            'message' => 'admin.product.image__invalid_path',
+                        ]),
+                        new Assert\NotBlank(),
+                    ],
                 ],
                 'prototype' => true,
                 'mapped' => false,

--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -27,10 +27,6 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormError;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -171,6 +167,13 @@ class ProductType extends AbstractType
             ])
             ->add('delete_images', CollectionType::class, [
                 'entry_type' => HiddenType::class,
+                'entry_options' => [
+                    'constraints' => new Assert\Regex([
+                        'pattern' => '#(?:\A|/)\.{1,2}(?:\z|/)#u',
+                        'match' => false,
+                        'message' => 'admin.product.image__invalid_path',
+                    ]),
+                ],
                 'prototype' => true,
                 'mapped' => false,
                 'allow_add' => true,
@@ -180,35 +183,6 @@ class ProductType extends AbstractType
                 'mapped' => false,
             ])
         ;
-
-        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
-            /** @var FormInterface $form */
-            $form = $event->getForm();
-            $saveImgDir = $this->eccubeConfig['eccube_save_image_dir'];
-            $tempImgDir = $this->eccubeConfig['eccube_temp_image_dir'];
-            $this->validateFilePath($form->get('delete_images'), [$saveImgDir, $tempImgDir]);
-            $this->validateFilePath($form->get('add_images'), [$tempImgDir]);
-        });
-    }
-
-    /**
-     * 指定された複数ディレクトリのうち、いずれかのディレクトリ以下にファイルが存在するかを確認。
-     *
-     * @param $form FormInterface
-     * @param $dirs array
-     */
-    private function validateFilePath($form, $dirs)
-    {
-        foreach ($form->getData() as $fileName) {
-            $fileInDir = array_filter($dirs, function ($dir) use ($fileName) {
-                $filePath = realpath($dir.'/'.$fileName);
-                $topDirPath = realpath($dir);
-                return strpos($filePath, $topDirPath) === 0 && $filePath !== $topDirPath;
-            });
-            if (!$fileInDir) {
-                $form->getRoot()['product_image']->addError(new FormError(trans('admin.product.image__invalid_path')));
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)

#4752 のバリデーションの見直し案。

## 方針(Policy)

- 商品画像削除時の、ファイル存在バリデーションは廃止。
- `delete_images`対して`.`及び`..`に関するバリデーションを追加。 (正規表現は差分を参照)

## 相談（Discussion）

- Windowsでの動作がどうなるか未検証。
- 商品登録画面にて`delete_images`のエラーがうまく表示できない。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
