### PR TITLE
CSVで商品規格を登録時に任意の項目がない場合のエラーを修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -1202,7 +1202,7 @@ class CsvImportController extends AbstractCsvImportController
         $ProductClass->setProduct($Product);
 
         $line = $data->key() + 1;
-        if ($row[$headerByKey['sale_type']] == '') {
+        if (!isset($row[$headerByKey['sale_type']]) || $row[$headerByKey['sale_type']] == '') {
             $message = trans('admin.common.csv_invalid_required', ['%line%' => $line, '%name%' => $headerByKey['sale_type']]);
             $this->addErrors($message);
         } else {
@@ -1221,7 +1221,7 @@ class CsvImportController extends AbstractCsvImportController
         }
 
         // 規格分類1、2をそれぞれセットし作成
-        if ($row[$headerByKey['class_category1']] != '') {
+        if (isset($row[$headerByKey['class_category1']]) && $row[$headerByKey['class_category1']] != '') {
             if (preg_match('/^\d+$/', $row[$headerByKey['class_category1']])) {
                 $ClassCategory = $this->classCategoryRepository->find($row[$headerByKey['class_category1']]);
                 if (!$ClassCategory) {
@@ -1236,7 +1236,7 @@ class CsvImportController extends AbstractCsvImportController
             }
         }
 
-        if ($row[$headerByKey['class_category2']] != '') {
+        if (isset($row[$headerByKey['class_category2']]) && $row[$headerByKey['class_category2']] != '') {
             if (preg_match('/^\d+$/', $row[$headerByKey['class_category2']])) {
                 $ClassCategory = $this->classCategoryRepository->find($row[$headerByKey['class_category2']]);
                 if (!$ClassCategory) {
@@ -1251,7 +1251,7 @@ class CsvImportController extends AbstractCsvImportController
             }
         }
 
-        if ($row[$headerByKey['delivery_date']] != '') {
+        if (isset($row[$headerByKey['delivery_date']]) && $row[$headerByKey['delivery_date']] != '') {
             if (preg_match('/^\d+$/', $row[$headerByKey['delivery_date']])) {
                 $DeliveryDuration = $this->deliveryDurationRepository->find($row[$headerByKey['delivery_date']]);
                 if (!$DeliveryDuration) {
@@ -1266,7 +1266,7 @@ class CsvImportController extends AbstractCsvImportController
             }
         }
 
-        if (StringUtil::isNotBlank($row[$headerByKey['product_code']])) {
+        if (isset($row[$headerByKey['product_code']]) && StringUtil::isNotBlank($row[$headerByKey['product_code']])) {
             $ProductClass->setCode(StringUtil::trimAll($row[$headerByKey['product_code']]));
         } else {
             $ProductClass->setCode(null);
@@ -1298,7 +1298,7 @@ class CsvImportController extends AbstractCsvImportController
             $this->addErrors($message);
         }
 
-        if ($row[$headerByKey['sale_limit']] != '') {
+        if (isset($row[$headerByKey['sale_limit']]) && $row[$headerByKey['sale_limit']] != '') {
             $saleLimit = str_replace(',', '', $row[$headerByKey['sale_limit']]);
             if (preg_match('/^\d+$/', $saleLimit) && $saleLimit >= 0) {
                 $ProductClass->setSaleLimit($saleLimit);
@@ -1308,7 +1308,7 @@ class CsvImportController extends AbstractCsvImportController
             }
         }
 
-        if ($row[$headerByKey['price01']] != '') {
+        if (isset($row[$headerByKey['price01']]) && $row[$headerByKey['price01']] != '') {
             $price01 = str_replace(',', '', $row[$headerByKey['price01']]);
             $errors = $this->validator->validate($price01, new GreaterThanOrEqual(['value' => 0]));
             if ($errors->count() === 0) {
@@ -1319,7 +1319,7 @@ class CsvImportController extends AbstractCsvImportController
             }
         }
 
-        if ($row[$headerByKey['price02']] == '') {
+        if (!isset($row[$headerByKey['price02']]) || $row[$headerByKey['price02']] == '') {
             $message = trans('admin.common.csv_invalid_required', ['%line%' => $line, '%name%' => $headerByKey['price02']]);
             $this->addErrors($message);
         } else {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

CSVで商品規格を登録時に「発送日目安(ID)」などは任意の項目となっており省略可能であるはずだが、項目がないとエラーが発生する状態となっていた。

![image](https://user-images.githubusercontent.com/16895409/100574204-d4f72680-331c-11eb-9ec5-1cf7c2668533.png)

## 方針(Policy)

管理画面の「必須」の表示を正とした。
任意の項目が設定されているか確認する処理を追加した。

## 実装に関する補足(Appendix)

## テスト（Test)

エラーが発生していたCSVでエラーが発生しなくなったことを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
