### PR TITLE
BaseInfoのキャッシュ化対応

### DIFF
--- a/src/Eccube/Repository/BaseInfoRepository.php
+++ b/src/Eccube/Repository/BaseInfoRepository.php
@@ -24,6 +24,8 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class BaseInfoRepository extends AbstractRepository
 {
+    private $cache = [];
+
     /**
      * BaseInfoRepository constructor.
      *
@@ -36,17 +38,23 @@ class BaseInfoRepository extends AbstractRepository
 
     /**
      * @param int $id
-     *
-     * @return BaseInfo
+     * @return array|mixed
+     * @throws \Exception
      */
     public function get($id = 1)
     {
+        if (isset($this->cache[$id])) {
+            return $this->cache[$id];
+        }
+
         $BaseInfo = $this->find($id);
 
         if (null === $BaseInfo) {
             throw new \Exception('BaseInfo not found. id = '.$id);
         }
 
-        return $this->find($id);
+        $this->cache[$id] = $BaseInfo;
+
+        return $this->cache[$id];
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
同一スレッド内でBaseInfoが何度も呼び出しされていた場合、
キャッシュを見るようにしてDBアクセスをさせないようにする対応。


## 方針(Policy)
useResultCacheを利用してもいいが、
DBへアクセスされているため、頻度を減らすために変数キャッシュを利用する。


## 実装に関する補足(Appendix)
大量アクセスが無いサイトだと意味が無いものと思われる。


- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
