### PR TITLE
DBの文字コードをutf8mb4に対応

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -21,6 +21,9 @@ DATABASE_URL=sqlite:///var/eccube.db
 
 # The version of your database engine
 DATABASE_SERVER_VERSION=3
+
+# The charset of your database engine
+DATABASE_CHARSET=utf8
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/mailer ###

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,12 +26,15 @@ jobs:
           - db: mysql
             database_url: mysql://root:password@127.0.0.1:3306/eccube_db
             database_server_version: 5
+            database_charset: utf8mb4
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
             database_server_version: 14
+            database_charset: utf8
           - db: sqlite3
             database_url: sqlite:///var/eccube.db
             database_server_version: 3
+            database_charset: utf8
 
     services:
       mysql:
@@ -79,6 +82,7 @@ jobs:
           APP_ENV: 'test'
           DATABASE_URL: ${{ matrix.database_url }}
           DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          DATABASE_CHARSET: ${{ matrix.database_charset }}
         run: |
           bin/console doctrine:database:create
           bin/console doctrine:schema:create
@@ -89,6 +93,7 @@ jobs:
           APP_ENV: 'test'
           DATABASE_URL: ${{ matrix.database_url }}
           DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          DATABASE_CHARSET: ${{ matrix.database_charset }}
           MAILER_URL: 'smtp://127.0.0.11025'
         run: bin/phpunit --exclude-group cache-clear,cache-clear-install,update-schema-doctrine,plugin-service
       - name: PHPUnit
@@ -96,6 +101,7 @@ jobs:
           APP_ENV: 'test'
           DATABASE_URL: ${{ matrix.database_url }}
           DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          DATABASE_CHARSET: ${{ matrix.database_charset }}
           MAILER_URL: 'smtp://127.0.0.11025'
         run: |
           bin/phpunit --group cache-clear
@@ -118,6 +124,7 @@ jobs:
           APP_ENV: 'test'
           DATABASE_URL: ${{ matrix.database_url }}
           DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          DATABASE_CHARSET: ${{ matrix.database_charset }}
           MAILER_URL: 'smtp://127.0.0.11025'
         run: |
           rm -r app/Plugin/*

--- a/app/config/eccube/packages/doctrine.yaml
+++ b/app/config/eccube/packages/doctrine.yaml
@@ -9,7 +9,7 @@ doctrine:
     dbal:
         driver: 'pdo_sqlite'
         server_version: "%env(DATABASE_SERVER_VERSION)%"
-        charset: utf8mb4
+        charset: 'utf8'
 
         # for mysql only
         default_table_options:

--- a/app/config/eccube/packages/doctrine.yaml
+++ b/app/config/eccube/packages/doctrine.yaml
@@ -9,11 +9,11 @@ doctrine:
     dbal:
         driver: 'pdo_sqlite'
         server_version: "%env(DATABASE_SERVER_VERSION)%"
-        charset: utf8
+        charset: utf8mb4
 
         # for mysql only
         default_table_options:
-          collate: 'utf8_general_ci'
+          collate: 'utf8mb4_general_ci'
 
         # With Symfony 3.3, remove the `resolve:` prefix
         url: '%env(DATABASE_URL)%'

--- a/app/config/eccube/packages/doctrine.yaml
+++ b/app/config/eccube/packages/doctrine.yaml
@@ -5,11 +5,13 @@ parameters:
     # You should not need to change this value.
     env(DATABASE_URL): ''
     env(DATABASE_SERVER_VERSION): ~
+    env(DATABASE_CHARSET): 'utf8'
+
 doctrine:
     dbal:
         driver: 'pdo_sqlite'
         server_version: "%env(DATABASE_SERVER_VERSION)%"
-        charset: 'utf8'
+        charset: '%env(DATABASE_CHARSET)%'
 
         # for mysql only
         default_table_options:

--- a/app/config/eccube/packages/doctrine.yaml
+++ b/app/config/eccube/packages/doctrine.yaml
@@ -13,7 +13,8 @@ doctrine:
 
         # for mysql only
         default_table_options:
-          collate: 'utf8mb4_general_ci'
+            charset: 'utf8mb4'
+            collation: 'utf8mb4_bin'
 
         # With Symfony 3.3, remove the `resolve:` prefix
         url: '%env(DATABASE_URL)%'

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -11,6 +11,7 @@ services:
     environment:
       DATABASE_URL: "mysql://dbuser:secret@mysql/eccubedb"
       DATABASE_SERVER_VERSION: 5.7
+      DATABASE_CHARSET: 'utf8mb4'
 
   mysql:
     image: mysql:5.7

--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -11,6 +11,7 @@ services:
     environment:
       DATABASE_URL: "postgres://dbuser:secret@postgres/eccubedb"
       DATABASE_SERVER_VERSION: 14
+      DATABASE_CHARSET: 'utf8'
 
   postgres:
     image: postgres:14

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       APP_DEBUG: 1
       DATABASE_URL: "sqlite:///var/eccube.db"
       DATABASE_SERVER_VERSION: 3
+      DATABASE_CHARSET: 'utf8'
       MAILER_DSN: "smtp://mailcatcher:1025"
       ECCUBE_AUTH_MAGIC: "<change.me>"
       # TRUSTED_HOSTS: '^127.0.0.1$$,^localhost$$'

--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -58,6 +58,7 @@ class InstallerCommand extends Command
             public $appDebug;
             public $databaseUrl;
             public $serverVersion;
+            public $databaseCharset;
             public $mailerDsn;
             public $authMagic;
             public $adminRoute;
@@ -74,6 +75,7 @@ class InstallerCommand extends Command
                             'APP_DEBUG' => $this->appDebug,
                             'DATABASE_URL' => $this->databaseUrl,
                             'DATABASE_SERVER_VERSION' => $this->serverVersion,
+                            'DATABASE_CHARSET' => $this->databaseCharset,
                             'MAILER_DSN' => $this->mailerDsn,
                             'ECCUBE_AUTH_MAGIC' => $this->authMagic,
                             'ECCUBE_ADMIN_ROUTE' => $this->adminRoute,
@@ -140,6 +142,9 @@ class InstallerCommand extends Command
 
         // DATABASE_SERVER_VERSION
         $this->envFileUpdater->serverVersion = $this->getDatabaseServerVersion($databaseUrl);
+
+        // DATABASE_CHARSET
+        $this->envFileUpdater->databaseCharset = \str_starts_with($databaseUrl, 'mysql') ? 'utf8mb4' : 'utf8';
 
         // MAILER_DSN
         $mailerDsn = $this->container->getParameter('eccube_mailer_dsn');

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -563,9 +563,9 @@ class InstallController extends AbstractController
     protected function createConnection(array $params)
     {
         if (strpos($params['url'], 'mysql') !== false) {
-            $params['charset'] = 'utf8';
+            $params['charset'] = 'utf8mb4';
             $params['defaultTableOptions'] = [
-                'collate' => 'utf8_general_ci',
+                'collate' => 'utf8mb4_general_ci',
             ];
         }
 

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -481,6 +481,7 @@ class InstallController extends AbstractController
             'ECCUBE_TEMPLATE_CODE' => 'default',
             'ECCUBE_LOCALE' => 'ja',
             'TRUSTED_HOSTS' => '^'.str_replace('.', '\\.', $request->getHost()).'$',
+            'DATABASE_CHARSET' => \str_starts_with($databaseUrl, 'mysql') ? 'utf8mb4' : 'utf8',
         ];
 
         $env = StringUtil::replaceOrAddEnv($env, $replacement);

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -565,7 +565,8 @@ class InstallController extends AbstractController
         if (strpos($params['url'], 'mysql') !== false) {
             $params['charset'] = 'utf8mb4';
             $params['defaultTableOptions'] = [
-                'collate' => 'utf8mb4_general_ci',
+                'charset' => 'utf8mb4',
+                'collation' => 'utf8mb4_bin',
             ];
         }
 

--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -462,28 +462,28 @@ if (!class_exists('\Eccube\Entity\Product')) {
         /**
          * @var string|null
          *
-         * @ORM\Column(name="note", type="string", length=4000, nullable=true)
+         * @ORM\Column(name="note", type="text", nullable=true)
          */
         private $note;
 
         /**
          * @var string|null
          *
-         * @ORM\Column(name="description_list", type="string", length=4000, nullable=true)
+         * @ORM\Column(name="description_list", type="text", nullable=true)
          */
         private $description_list;
 
         /**
          * @var string|null
          *
-         * @ORM\Column(name="description_detail", type="string", length=4000, nullable=true)
+         * @ORM\Column(name="description_detail", type="text", nullable=true)
          */
         private $description_detail;
 
         /**
          * @var string|null
          *
-         * @ORM\Column(name="search_word", type="string", length=4000, nullable=true)
+         * @ORM\Column(name="search_word", type="text", nullable=true)
          */
         private $search_word;
 

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
@@ -1133,4 +1133,23 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $this->assertTrue(file_exists($dir.$DuplicatedImage->getFileName()));
         $this->assertFalse(file_exists($dir.$NotDuplicatedImage->getFileName()));
     }
+
+    public function test絵文字()
+    {
+        $name = '🍣🍺';
+        $crawler = $this->client->request('GET', $this->generateUrl('product_list', ['name' => $name]));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $message = $crawler->filter('.ec-searchnavRole__counter > span')->text();
+        $this->assertSame('お探しの商品は見つかりませんでした', $message);
+
+        // 絵文字の商品を登録
+        $this->createProduct($name);
+
+        $crawler = $this->client->request('GET', $this->generateUrl('product_list', ['name' => $name]));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $message = $crawler->filter('.ec-searchnavRole__counter > span')->text();
+        $this->assertSame('1件', $message);
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
レンタルサーバでもutf8mb4を扱えるDBが増えてきたため、
MySQLの標準文字コードをutf8mb4でインストールするように対応
#4525 

## 実装に関する補足(Appendix)
2系や3系からutf8の文字コードを利用しているDBを移行してきても特に影響はなさそう。

## 相談（Discussion）
初期インストールであれば問題ないが、
バージョンアップ時に、
dtb_productの
note
description_list
description_detail
search_word
の型変更は必要かどうか。


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
