### PR TITLE
Fix #4776 受注登録で明細削除後に追加した商品が「税込」で登録されてしまう問題の修正

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -19,6 +19,7 @@ use Eccube\Controller\AbstractController;
 use Eccube\Entity\Master\CustomerStatus;
 use Eccube\Entity\Master\OrderItemType;
 use Eccube\Entity\Master\OrderStatus;
+use Eccube\Entity\Master\TaxDisplayType;
 use Eccube\Entity\Master\TaxType;
 use Eccube\Entity\Order;
 use Eccube\Entity\Shipping;
@@ -675,11 +676,14 @@ class EditController extends AbstractController
             $NonTaxable = $this->entityManager->find(TaxType::class, TaxType::NON_TAXABLE);
             $Taxation = $this->entityManager->find(TaxType::class, TaxType::TAXATION);
 
+            $IncludedTaxDisplayType = $this->entityManager->find(TaxDisplayType::class, TaxDisplayType::INCLUDED);
+            $ExcludedTaxDisplayType = $this->entityManager->find(TaxDisplayType::class, TaxDisplayType::EXCLUDED);
+
             $OrderItemTypes = [
-                ['OrderItemType' => $Charge, 'TaxType' => $Taxation],
-                ['OrderItemType' => $DeliveryFee, 'TaxType' => $Taxation],
-                ['OrderItemType' => $Discount, 'TaxType' => $Taxation],
-                ['OrderItemType' => $Discount, 'TaxType' => $NonTaxable]
+                ['OrderItemType' => $Charge, 'TaxType' => $Taxation, 'TaxDisplayType' => $IncludedTaxDisplayType],
+                ['OrderItemType' => $DeliveryFee, 'TaxType' => $Taxation, 'TaxDisplayType' => $IncludedTaxDisplayType],
+                ['OrderItemType' => $Discount, 'TaxType' => $Taxation, 'TaxDisplayType' => $ExcludedTaxDisplayType],
+                ['OrderItemType' => $Discount, 'TaxType' => $NonTaxable, 'TaxDisplayType' => $ExcludedTaxDisplayType]
             ];
 
             return [

--- a/src/Eccube/Form/Type/Admin/OrderItemType.php
+++ b/src/Eccube/Form/Type/Admin/OrderItemType.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Common\EccubeConfig;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Master\OrderItemType as OrderItemTypeMaster;
+use Eccube\Entity\Master\TaxDisplayType;
 use Eccube\Entity\Master\TaxType;
 use Eccube\Entity\OrderItem;
 use Eccube\Entity\ProductClass;
@@ -165,6 +166,11 @@ class OrderItemType extends AbstractType
                 ->addModelTransformer(new DataTransformer\EntityToIdTransformer(
                     $this->entityManager,
                     TaxType::class
+                )))
+            ->add($builder->create('tax_display_type', HiddenType::class)
+                ->addModelTransformer(new DataTransformer\EntityToIdTransformer(
+                    $this->entityManager,
+                    TaxDisplayType::class
                 )))
             ->add($builder->create('ProductClass', HiddenType::class)
                 ->addModelTransformer(new DataTransformer\EntityToIdTransformer(

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -745,6 +745,7 @@ file that was distributed with this source code.
                                             {{ form_widget(orderItemForm.ProductClass) }}
                                             {{ form_widget(orderItemForm.order_item_type) }}
                                             {{ form_widget(orderItemForm.tax_type) }}
+                                            {{ form_widget(orderItemForm.tax_display_type) }}
                                             <!-- 商品名 -->
                                             <td class="align-middle w-25 pl-3">
                                                 <p class="mb-0 font-weight-bold">

--- a/src/Eccube/Resource/template/admin/Order/order_item_prototype.twig
+++ b/src/Eccube/Resource/template/admin/Order/order_item_prototype.twig
@@ -17,5 +17,6 @@ file that was distributed with this source code.
         {{ form_widget(orderItemForm.price) }}
         {{ form_widget(orderItemForm.quantity) }}
         {{ form_widget(orderItemForm.tax_type) }}
+        {{ form_widget(orderItemForm.tax_display_type) }}
     </td>
 </tr>

--- a/src/Eccube/Resource/template/admin/Order/order_item_type.twig
+++ b/src/Eccube/Resource/template/admin/Order/order_item_type.twig
@@ -10,7 +10,7 @@ file that was distributed with this source code.
 #}
 <script>
     // 受注明細行を追加する.
-    function fnAddOrderItem($row, product_id, type, product_name, tax_type) {
+    function fnAddOrderItem($row, product_id, type, product_name, tax_type, tax_display_type) {
         var prototype = $collectionHolder.data('prototype');
         index++;
         var newForm = prototype.replace(/__name__/g, index);
@@ -22,7 +22,7 @@ file that was distributed with this source code.
         $($lastRow).find(formIdPrefix + index + '_order_item_type').val(type);
         $($lastRow).find(formIdPrefix + index + '_product_name').val(product_name);
         $($lastRow).find(formIdPrefix + index + '_tax_type').val(tax_type);
-
+        $($lastRow).find(formIdPrefix + index + '_tax_display_type').val(tax_display_type);
         // モーダル閉じる.
         $('#addOrderItemType').modal('hide');
 
@@ -50,7 +50,7 @@ file that was distributed with this source code.
                 <td class="align-middle pl-3">{{ OrderItemType.OrderItemType.name }}</td>
                 <td class="align-middle pl-3">{{ OrderItemType.TaxType.name }}</td>
                 <td class="align-middle pr-3 text-right">
-                    <button type="button" class="btn btn-ec-actionIcon" onclick="fnAddOrderItem($(this).parent().parent(), null, {{ OrderItemType.OrderItemType.id }}, '{{ OrderItemType.OrderItemType.name }}', '{{ OrderItemType.TaxType.id }}')" name="mode" value="modal">
+                    <button type="button" class="btn btn-ec-actionIcon" onclick="fnAddOrderItem($(this).parent().parent(), null, {{ OrderItemType.OrderItemType.id }}, '{{ OrderItemType.OrderItemType.name }}', '{{ OrderItemType.TaxType.id }}', '{{ OrderItemType.TaxDisplayType.id }}')" name="mode" value="modal">
                         <i class="fa fa-plus fa-lg font-weight-bold text-secondary"></i>
                     </button>
                 </td>

--- a/src/Eccube/Resource/template/admin/Order/search_product.twig
+++ b/src/Eccube/Resource/template/admin/Order/search_product.twig
@@ -97,6 +97,7 @@ file that was distributed with this source code.
         $($lastRow).find(formIdPrefix + index + '_quantity').val(quantity);
         $($lastRow).find(formIdPrefix + index + '_order_item_type').val(type);
         $($lastRow).find(formIdPrefix + index + '_product_name').val(product_name);
+        $($lastRow).find(formIdPrefix + index + '_tax_display_type').val({{ constant('Eccube\\Entity\\Master\\TaxDisplayType::EXCLUDED') }});
 
         // モーダル閉じる.
         $('#searchProductModal').modal('hide');

--- a/src/Eccube/Resource/template/admin/Order/shipping.twig
+++ b/src/Eccube/Resource/template/admin/Order/shipping.twig
@@ -558,6 +558,7 @@ file that was distributed with this source code.
                                                     {{ form_widget(orderItemForm.ProductClass) }}
                                                     {{ form_widget(orderItemForm.order_item_type) }}
                                                     {{ form_widget(orderItemForm.tax_type) }}
+                                                    {{ form_widget(orderItemForm.tax_display_type) }}
                                                     {{ form_widget(orderItemForm.tax_rate, {'type': 'hidden'}) }}
                                                     <td class="align-middle w-25 pl-3">
                                                         <p class="mb-0 font-weight-bold">

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderItemTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderItemTypeTest.php
@@ -28,6 +28,7 @@ class OrderItemTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         'product_name' => 'name1',
         'order_item_type' => '1',
         'tax_rate' => '8',
+        'tax_display_type' => '1',
     ];
 
     public function setUp()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
Fix: #4776

### 対象画面
- 受注登録
- 出荷登録

### 不具合の内容
商品(税別)＋送料(税込)という受注の明細を１度全て削除した後、商品明細を追加すると税込価格で登録される
（追加した商品分の明細がorder[OrderItems][1]として送信され、もともと２番目の明細であった「送料」のtax_display_typeが採用されているため）

![商品明細追加時のPOST内容](https://user-images.githubusercontent.com/4304985/101985539-00d6bc80-3ccc-11eb-835e-4faea46dcc76.png)

## 方針(Policy)
tax_display_typeをhiddenのフォームとして出力しておくことで意図しないデータ上書きを防止する

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
