### PR TITLE
商品CSVの分割アップロード

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -42,6 +42,7 @@ parameters:
     eccube_temp_image_dir: '%kernel.project_dir%/html/upload/temp_image'
     eccube_csv_size: 5                 # post_max_size, upload_max_filesize に任せればよい？
     eccube_csv_temp_realdir: '%kernel.cache_dir%/%kernel.environment%/eccube' # upload_tmp_dir に任せればよい？
+    eccube_csv_split_lines: 100
     eccube_default_password: '**********'
     eccube_deliv_addr_max: 20
     eccube_deliv_date_end_max: 21

--- a/codeception/_support/Page/Admin/ProductCsvUploadPage.php
+++ b/codeception/_support/Page/Admin/ProductCsvUploadPage.php
@@ -15,7 +15,7 @@ namespace Page\Admin;
 
 class ProductCsvUploadPage extends AbstractAdminPageStyleGuide
 {
-    public static $完了メッセージ = 'div.c-container > div.c-contentsArea > div.alert-success';
+    public static $完了メッセージ = '#importCsvModal > div > div > div.modal-body.text-left > p';
 
     /**
      * ProductCsvUploadPage constructor.
@@ -32,6 +32,13 @@ class ProductCsvUploadPage extends AbstractAdminPageStyleGuide
         return $page->goPage('/product/product_csv_upload', '商品CSV登録商品管理');
     }
 
+    public static function at($I)
+    {
+        $page = new self($I);
+
+        return $page->atPage('商品CSV登録商品管理');
+    }
+
     public function 入力_CSVファイル($fileName)
     {
         $this->tester->attachFile(['id' => 'admin_csv_import_import_file'], $fileName);
@@ -42,6 +49,44 @@ class ProductCsvUploadPage extends AbstractAdminPageStyleGuide
     public function CSVアップロード()
     {
         $this->tester->click(['id' => 'upload-button']);
+
+        return $this;
+    }
+
+    public function アップロードボタン有効化()
+    {
+        // $this->tester->attachFileでイベントが効かずボタンが有効化されないので、テストコードで有効化する.
+        $this->tester->waitForJS('return $("#upload-button").prop("disabled", false);', 1);
+
+        return $this;
+    }
+
+    public function モーダルを表示()
+    {
+        $this->tester->click(['id' => 'upload-button']);
+
+        return $this;
+    }
+
+    public function CSVアップロード実行()
+    {
+        $this->tester->wait(1);
+        $this->tester->click(['id' => 'importCsv']);
+
+        return $this;
+    }
+
+    public function CSVアップロード確認()
+    {
+        $this->tester->wait(1);
+        $this->tester->see('CSVファイルをアップロードしました', ProductCsvUploadPage::$完了メッセージ);
+
+        return $this;
+    }
+
+    public function モーダルを閉じる()
+    {
+        $this->tester->click(['id' => 'importCsvDone']);
 
         return $this;
     }

--- a/codeception/acceptance/EA03ProductCest.php
+++ b/codeception/acceptance/EA03ProductCest.php
@@ -662,8 +662,14 @@ class EA03ProductCest
 
         ProductCsvUploadPage::go($I)
             ->入力_CSVファイル('product.csv')
-            ->CSVアップロード();
-        $I->see('CSVファイルをアップロードしました', ProductCsvUploadPage::$完了メッセージ);
+            ->アップロードボタン有効化()
+            ->モーダルを表示()
+            ->CSVアップロード実行()
+            ->CSVアップロード確認()
+            ->モーダルを閉じる()
+        ;
+
+        ProductCsvUploadPage::at($I);
 
         ProductManagePage::go($I)->検索('アップロード商品');
         $I->see('検索結果：3件が該当しました', ProductManagePage::$検索結果_メッセージ);

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -1627,15 +1627,16 @@ class CsvImportController extends AbstractCsvImportController
             $src->next();
             $dist->fputcsv($header);
 
+            $i = 0;
             while ($row = $src->current()) {
                 $dist->fputcsv($row);
-                if (($src->key() + $fileNo) % $this->eccubeConfig['eccube_csv_split_lines'] === 0) {
-                    \error_log($dir.'/'.$fileName.$fileNo.'.csv');
+                $src->next();
+
+                if (!$src->eof() && ++$i % $this->eccubeConfig['eccube_csv_split_lines'] === 0) {
                     $fileNo++;
                     $dist = new \SplFileObject($dir.'/'.$fileName.$fileNo.'.csv', 'w');
                     $dist->fputcsv($header);
                 }
-                $src->next();
             }
 
             return $this->json(['success' => true, 'file_name' => $fileName, 'max_file_no' => $fileNo]);
@@ -1694,7 +1695,7 @@ class CsvImportController extends AbstractCsvImportController
 
     protected function convertLineNo($currentLineNo) {
         if ($this->isXmlHttpRequest) {
-            return ($this->eccubeConfig['eccube_csv_split_lines'] - 1) * ($this->csvFileNo - 1) + $currentLineNo;
+            return ($this->eccubeConfig['eccube_csv_split_lines']) * ($this->csvFileNo - 1) + $currentLineNo;
         }
 
         return $currentLineNo;

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -893,8 +893,7 @@ class CsvImportController extends AbstractCsvImportController
                     '%to%' => $this->currentLineNo]),
                 'errors' => $this->errors,
                 'error_message' => trans('admin.common.csv_upload_line_error',[
-                    '%from%' => $this->convertLineNo(2),
-                    '%to%' => $this->currentLineNo])
+                    '%from%' => $this->convertLineNo(2)])
             ]);
         }
 

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -111,7 +111,7 @@ class CsvImportController extends AbstractCsvImportController
 
     private $errors = [];
 
-    protected $isXmlHttpRequest = false;
+    protected $isSplitCsv = false;
 
     protected $csvFileNo = 1;
 
@@ -177,7 +177,7 @@ class CsvImportController extends AbstractCsvImportController
         if ('POST' === $request->getMethod()) {
             $form->handleRequest($request);
             if ($form->isValid()) {
-                $this->isXmlHttpRequest = $form['is_xml_http_request']->getData();
+                $this->isSplitCsv = $form['is_split_csv']->getData();
                 $this->csvFileNo = $form['csv_file_no']->getData();
 
                 $formFile = $form['import_file']->getData();
@@ -667,7 +667,7 @@ class CsvImportController extends AbstractCsvImportController
                     }
 
                     log_info('商品CSV登録完了');
-                    if (!$this->isXmlHttpRequest) {
+                    if (!$this->isSplitCsv) {
                         $message = 'admin.common.csv_upload_complete';
                         $this->session->getFlashBag()->add('eccube.admin.success', $message);
                     }
@@ -885,7 +885,7 @@ class CsvImportController extends AbstractCsvImportController
 
         $this->removeUploadedFile();
 
-        if ($this->isXmlHttpRequest) {
+        if ($this->isSplitCsv) {
             return $this->json([
                 'success' => !$this->hasErrors(),
                 'success_message' => trans('admin.common.csv_upload_line_success', [
@@ -1685,7 +1685,7 @@ class CsvImportController extends AbstractCsvImportController
         $request->setMethod('POST');
         $request->request->set('admin_csv_import', [
             Constant::TOKEN_NAME => $tokenManager->getToken('admin_csv_import')->getValue(),
-            'is_xml_http_request' => true,
+            'is_split_csv' => true,
             'csv_file_no' => $request->get('file_no'),
         ]);
 
@@ -1693,7 +1693,7 @@ class CsvImportController extends AbstractCsvImportController
     }
 
     protected function convertLineNo($currentLineNo) {
-        if ($this->isXmlHttpRequest) {
+        if ($this->isSplitCsv) {
             return ($this->eccubeConfig['eccube_csv_split_lines']) * ($this->csvFileNo - 1) + $currentLineNo;
         }
 

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -40,11 +40,15 @@ use Eccube\Util\CacheUtil;
 use Eccube\Util\StringUtil;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -107,6 +111,12 @@ class CsvImportController extends AbstractCsvImportController
 
     private $errors = [];
 
+    protected $isXmlHttpRequest = false;
+
+    protected $csvFileNo = 1;
+
+    protected $currentLineNo = 1;
+
     /**
      * CsvImportController constructor.
      *
@@ -167,6 +177,9 @@ class CsvImportController extends AbstractCsvImportController
         if ('POST' === $request->getMethod()) {
             $form->handleRequest($request);
             if ($form->isValid()) {
+                $this->isXmlHttpRequest = $form['is_xml_http_request']->getData();
+                $this->csvFileNo = $form['csv_file_no']->getData();
+
                 $formFile = $form['import_file']->getData();
                 if (!empty($formFile)) {
                     log_info('商品CSV登録開始');
@@ -207,7 +220,8 @@ class CsvImportController extends AbstractCsvImportController
                     $this->entityManager->getConnection()->beginTransaction();
                     // CSVファイルの登録処理
                     foreach ($data as $row) {
-                        $line = $data->key() + 1;
+                        $line = $this->convertLineNo($data->key() + 1);
+                        $this->currentLineNo = $line;
                         if ($headerSize != count($row)) {
                             $message = trans('admin.common.csv_invalid_format_line', ['%line%' => $line]);
                             $this->addErrors($message);
@@ -653,8 +667,10 @@ class CsvImportController extends AbstractCsvImportController
                     }
 
                     log_info('商品CSV登録完了');
-                    $message = 'admin.common.csv_upload_complete';
-                    $this->session->getFlashBag()->add('eccube.admin.success', $message);
+                    if (!$this->isXmlHttpRequest) {
+                        $message = 'admin.common.csv_upload_complete';
+                        $this->session->getFlashBag()->add('eccube.admin.success', $message);
+                    }
 
                     $cacheUtil->clearDoctrineCache();
                 }
@@ -868,6 +884,19 @@ class CsvImportController extends AbstractCsvImportController
         }
 
         $this->removeUploadedFile();
+
+        if ($this->isXmlHttpRequest) {
+            return $this->json([
+                'success' => !$this->hasErrors(),
+                'success_message' => trans('admin.common.csv_upload_line_success', [
+                    '%from%' => $this->convertLineNo(2),
+                    '%to%' => $this->currentLineNo]),
+                'errors' => $this->errors,
+                'error_message' => trans('admin.common.csv_upload_line_error',[
+                    '%from%' => $this->convertLineNo(2),
+                    '%to%' => $this->currentLineNo])
+            ]);
+        }
 
         return [
             'form' => $form->createView(),
@@ -1560,5 +1589,114 @@ class CsvImportController extends AbstractCsvImportController
         $ProductCategory->setCategoryId($Category->getId());
 
         return $ProductCategory;
+    }
+
+    /**
+     * @Route("/%eccube_admin_route%/product/csv_split", name="admin_product_csv_split")
+     * @param Request $request
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     */
+    public function splitCsv(Request $request)
+    {
+        $this->isTokenValid();
+
+        if (!$request->isXmlHttpRequest()) {
+            throw new BadRequestHttpException();
+        }
+
+        $form = $this->formFactory->createBuilder(CsvImportType::class)->getForm();
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+
+            $dir = $this->eccubeConfig['eccube_csv_temp_realdir'];
+            if (!file_exists($dir)) {
+                $fs = new Filesystem();
+                $fs->mkdir($dir);
+            }
+
+            $data = $form['import_file']->getData();
+            $src = new \SplFileObject($data->getRealPath());
+            $src->setFlags(\SplFileObject::READ_CSV | \SplFileObject::READ_AHEAD | \SplFileObject::SKIP_EMPTY | \SplFileObject::DROP_NEW_LINE);
+
+            $fileNo = 1;
+            $fileName = StringUtil::random(8);
+
+            $dist = new \SplFileObject($dir.'/'.$fileName.$fileNo.'.csv', 'w');
+            $header = $src->current();
+            $src->next();
+            $dist->fputcsv($header);
+
+            while ($row = $src->current()) {
+                $dist->fputcsv($row);
+                if (($src->key() + $fileNo) % $this->eccubeConfig['eccube_csv_split_lines'] === 0) {
+                    \error_log($dir.'/'.$fileName.$fileNo.'.csv');
+                    $fileNo++;
+                    $dist = new \SplFileObject($dir.'/'.$fileName.$fileNo.'.csv', 'w');
+                    $dist->fputcsv($header);
+                }
+                $src->next();
+            }
+
+            return $this->json(['success' => true, 'file_name' => $fileName, 'max_file_no' => $fileNo]);
+        }
+
+        return $this->json(['success' => false, 'message' => $form->getErrors(true ,true)]);
+    }
+
+    /**
+     * @Route("/%eccube_admin_route%/product/csv_split_import", name="admin_product_csv_split_import")
+     * @param Request $request
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     */
+    public function importCsv(Request $request, CsrfTokenManagerInterface $tokenManager)
+    {
+        $this->isTokenValid();
+
+        if (!$request->isXmlHttpRequest()) {
+            throw new BadRequestHttpException();
+        }
+
+        $files = Finder::create()
+            ->in($this->eccubeConfig['eccube_csv_temp_realdir'])
+            ->name('*.csv')
+            ->files();
+
+        $choices = [];
+        foreach ($files as $file) {
+            $choices[$file->getBaseName()] = true;
+        }
+
+        $filename = $request->get('file_name');
+        if (!isset($choices[$filename])) {
+            throw new BadRequestHttpException();
+        }
+
+        $path = $this->eccubeConfig['eccube_csv_temp_realdir'].'/'.$filename;
+        $request->files->set('admin_csv_import', ['import_file' => new UploadedFile(
+            $path,
+            'import.csv',
+            'text/csv',
+            filesize($path),
+            null,
+            true
+        )]);
+
+        $request->setMethod('POST');
+        $request->request->set('admin_csv_import', [
+            Constant::TOKEN_NAME => $tokenManager->getToken('admin_csv_import')->getValue(),
+            'is_xml_http_request' => true,
+            'csv_file_no' => $request->get('file_no'),
+        ]);
+
+        return $this->forwardToRoute('admin_product_csv_import');
+    }
+
+    protected function convertLineNo($currentLineNo) {
+        if ($this->isXmlHttpRequest) {
+            return ($this->eccubeConfig['eccube_csv_split_lines'] - 1) * ($this->csvFileNo - 1) + $currentLineNo;
+        }
+
+        return $currentLineNo;
     }
 }

--- a/src/Eccube/Form/Type/Admin/CsvImportType.php
+++ b/src/Eccube/Form/Type/Admin/CsvImportType.php
@@ -15,7 +15,9 @@ namespace Eccube\Form\Type\Admin;
 
 use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -52,6 +54,16 @@ class CsvImportType extends AbstractType
                         'maxSize' => $this->csvMaxSize.'M',
                     ]),
                 ],
+            ])
+            ->add('is_xml_http_request', CheckboxType::class, [
+                'label' => false,
+                'mapped' => false,
+                'required' => false,
+            ])
+            ->add('csv_file_no', IntegerType::class, [
+                'label' => false,
+                'mapped' => false,
+                'required' => false,
             ]);
     }
 

--- a/src/Eccube/Form/Type/Admin/CsvImportType.php
+++ b/src/Eccube/Form/Type/Admin/CsvImportType.php
@@ -55,7 +55,7 @@ class CsvImportType extends AbstractType
                     ]),
                 ],
             ])
-            ->add('is_xml_http_request', CheckboxType::class, [
+            ->add('is_split_csv', CheckboxType::class, [
                 'label' => false,
                 'mapped' => false,
                 'required' => false,

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -428,6 +428,8 @@ admin.common.next: Next
 admin.common.first: Go to First
 admin.common.last: Go to Last
 admin.common.back: Go back
+admin.common.open_detail: 'Show details'
+admin.common.close_detail: 'Close details'
 
 # Generic Labels, Messages
 admin.common.show: Display
@@ -469,6 +471,9 @@ admin.common.csv_invalid_can_not: '%name% is invalid in the line %line%'
 admin.common.csv_invalid_image: 'Your are not allowed to use "/" or "../" as suffix in %name% in the %line%'
 admin.common.csv_invalid_foreign_key: 'You are unable to delete %name% in the line %line% because it has related data'
 admin.common.csv_invalid_description_detail_upper_limit: '%name% should be less than %max% characters in the line %line%.'
+admin.common.csv_upload_in_progress: 'Uploading CSV file ...'
+admin.common.csv_upload_line_success: 'The %from% to %to% lines have been registered.'
+admin.common.csv_upload_line_error: 'An error occurred on lines %from% to %to%.'
 admin.common.drag_and_drop_description: You can change the order of the items by drag & drop.
 admin.common.drag_and_drop_image_description: Drag & drop the images or
 admin.common.delete_modal__title: Delete
@@ -743,6 +748,10 @@ admin.product.category_csv.parent_category_id_col: Parent Category ID
 admin.product.category_csv.parent_category_id_description: ''
 admin.product.category_csv.delete_flag_col: Category Deletion Flag
 admin.product.category_csv.delete_flag_description: 'Specify 0: Upload or 1: Delete. If unspecified, it is set to 0.'
+
+# Product CSV
+admin.product.product_csv_upload__title: 'Upload product CSV'
+admin.product.product_csv_upload__message: 'Upload the product CSV file. Is it OK?'
 
 #------------------------------------------------------------------------------------
 # Orders

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -473,7 +473,7 @@ admin.common.csv_invalid_foreign_key: 'You are unable to delete %name% in the li
 admin.common.csv_invalid_description_detail_upper_limit: '%name% should be less than %max% characters in the line %line%.'
 admin.common.csv_upload_in_progress: 'Uploading CSV file ...'
 admin.common.csv_upload_line_success: 'The %from% to %to% lines have been registered.'
-admin.common.csv_upload_line_error: 'An error occurred on lines %from% to %to%.'
+admin.common.csv_upload_line_error: 'An error has occurred. The registration process after the %from% line has been cancelled.'
 admin.common.drag_and_drop_description: You can change the order of the items by drag & drop.
 admin.common.drag_and_drop_image_description: Drag & drop the images or
 admin.common.delete_modal__title: Delete

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -472,8 +472,8 @@ admin.common.csv_invalid_image: '%line%行目の%name%には末尾に"/"や"../"
 admin.common.csv_invalid_foreign_key: '%line%行目の%name%は関連するデータがあるため削除できません'
 admin.common.csv_invalid_description_detail_upper_limit: '%line%行目の%name%は%max%文字以下の文字列を指定してください。'
 admin.common.csv_upload_in_progress: 'CSVファイルのアップロード中...'
-admin.common.csv_upload_line_success: '%from%行目〜%to%行目を登録しました。'
-admin.common.csv_upload_line_error: '%from%行目〜%to%行目でエラーが発生しました。'
+admin.common.csv_upload_line_success: '%from%行目〜%to%行目を登録しました'
+admin.common.csv_upload_line_error: 'エラーが発生しました。%from%行目以降の登録処理はキャンセルされました'
 admin.common.drag_and_drop_description: 項目の順番はドラッグ＆ドロップでも変更可能です。
 admin.common.drag_and_drop_image_description: 画像をドラッグ＆ドロップまたは
 admin.common.delete_modal__title: 削除します

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -428,6 +428,8 @@ admin.common.next: 次へ
 admin.common.first: 最初へ
 admin.common.last: 最後へ
 admin.common.back: 戻る
+admin.common.open_detail: '詳細を表示'
+admin.common.close_detail: '詳細を閉じる'
 
 # 汎用ラベル, メッセージ
 admin.common.show: 表示
@@ -469,6 +471,9 @@ admin.common.csv_invalid_can_not: '%line%行目の%name%は設定できません
 admin.common.csv_invalid_image: '%line%行目の%name%には末尾に"/"や"../"を使用できません'
 admin.common.csv_invalid_foreign_key: '%line%行目の%name%は関連するデータがあるため削除できません'
 admin.common.csv_invalid_description_detail_upper_limit: '%line%行目の%name%は%max%文字以下の文字列を指定してください。'
+admin.common.csv_upload_in_progress: 'CSVファイルのアップロード中...'
+admin.common.csv_upload_line_success: '%from%行目〜%to%行目を登録しました。'
+admin.common.csv_upload_line_error: '%from%行目〜%to%行目でエラーが発生しました。'
 admin.common.drag_and_drop_description: 項目の順番はドラッグ＆ドロップでも変更可能です。
 admin.common.drag_and_drop_image_description: 画像をドラッグ＆ドロップまたは
 admin.common.delete_modal__title: 削除します
@@ -743,6 +748,10 @@ admin.product.category_csv.parent_category_id_col: 親カテゴリID
 admin.product.category_csv.parent_category_id_description: ''
 admin.product.category_csv.delete_flag_col: カテゴリ削除フラグ
 admin.product.category_csv.delete_flag_description: 0:登録 1:削除を指定します。未指定の場合、0として扱います。
+
+# 商品CSV
+admin.product.product_csv_upload__title: '商品CSVをアップロードします'
+admin.product.product_csv_upload__message: '商品CSVファイルをアップロードします。よろしいですか？'
 
 #------------------------------------------------------------------------------------
 # 受注

--- a/src/Eccube/Resource/template/admin/Product/csv_product.twig
+++ b/src/Eccube/Resource/template/admin/Product/csv_product.twig
@@ -153,12 +153,12 @@ file that was distributed with this source code.
                 var display = $('#bulkMessages li:last').css('display')
                 if (display == 'none') {
                     $('#bulkMessages li').show();
-                    $('#toggleMessages span').text("{{ 'admin.common.open_detail'|trans }}")
+                    $('#toggleMessages span').text("{{ 'admin.common.close_detail'|trans }}")
                     $('#toggleMessages i').removeClass('fa-plus-square-o')
                     $('#toggleMessages i').addClass('fa-minus-square-o')
                 } else {
                     $('#bulkMessages li:nth-child(n+2)').hide()
-                    $('#toggleMessages span').text("{{ 'admin.common.close_detail'|trans }}")
+                    $('#toggleMessages span').text("{{ 'admin.common.open_detail'|trans }}")
                     $('#toggleMessages i').removeClass('fa-minus-square-o')
                     $('#toggleMessages i').addClass('fa-plus-square-o')
                 }

--- a/src/Eccube/Resource/template/admin/Product/csv_product.twig
+++ b/src/Eccube/Resource/template/admin/Product/csv_product.twig
@@ -88,7 +88,9 @@ file that was distributed with this source code.
                                 $('.progress-bar', modal).css('width', (current / total * 100) + '%');
                                 d.resolve(data)
                             } else {
-                                addError(data.error_message)
+                                $('.modal-body p', modal)
+                                    .text(data.error_message)
+
                                 data.errors.forEach(function (error) {
                                     addError(error)
                                 });
@@ -116,10 +118,11 @@ file that was distributed with this source code.
                 setupModal(modal)
                     // CSV分割
                     .then(split(formData))
-                    .catch(function(data) {
+                    .catch(function() {
+                        $('.modal-body p', modal).text("{{ 'admin.common.csv_upload_error'|trans }}")
                         $('.progress-bar', modal).css('width', '100%')
-                        $('.progress-bar', modal).addClass('bg-danger');
-                        return $.Deferred().reject()
+                        $('.progress-bar', modal).addClass('bg-danger')
+                        return $.Deferred().reject();
                     })
                     // 分割したCSVを登録
                     .then(function(data) {
@@ -131,17 +134,12 @@ file that was distributed with this source code.
                         return d.promise()
                     })
                     // 完了メッセージ
-                    .then(
-                        function() {
-                            $('.modal-body p', modal).text("{{ 'admin.common.csv_upload_complete'|trans }}")
-                            $('.progress-bar', modal).addClass('bg-success');
-                        },
-                        function() {
-                            $('.modal-body p', modal).text("{{ 'admin.common.csv_upload_error'|trans }}")
-                        }
-                    )
-                    // モーダルのロック解除
                     .then(function() {
+                        $('.modal-body p', modal).text("{{ 'admin.common.csv_upload_complete'|trans }}")
+                        $('.progress-bar', modal).addClass('bg-success');
+                    })
+                    // モーダルのロック解除
+                    .always(function() {
                         $('.progress-bar', modal).removeClass('progress-bar-animated')
                         // メッセージ行が複数ある場合に詳細表示
                         if ($('#bulkMessages li').length > 1) {

--- a/src/Eccube/Resource/template/admin/Product/csv_product.twig
+++ b/src/Eccube/Resource/template/admin/Product/csv_product.twig
@@ -78,7 +78,7 @@ file that was distributed with this source code.
                             url: '{{ url('admin_product_csv_split_import') }}',
                             type: 'POST',
                             data: {
-                                file_name: file_name,
+                                file_name: file_name + current + '.csv',
                                 file_no: current
                             },
                         })
@@ -102,6 +102,15 @@ file that was distributed with this source code.
                                     .appendTo('.progress', modal)
 
                                 $('.progress-bar', modal).addClass('bg-success')
+
+                                // エラー発生以降の分割ファイルをクリア
+                                var files = []
+                                for (var i = current + 1; i <= total; i++) {
+                                    files.push(file_name + i + '.csv')
+                                }
+                                if (files.length > 0) {
+                                    $.post('{{ url('admin_product_csv_split_cleanup') }}', { files: files })
+                                }
 
                                 d.reject(data);
                             }
@@ -128,8 +137,7 @@ file that was distributed with this source code.
                     .then(function(data) {
                         var d = $.Deferred().resolve();
                         for (var i = 1; i <= data.max_file_no; i++) {
-                            var file_name = data.file_name + i + '.csv'
-                            d = d.then(upload(file_name, i, data.max_file_no))
+                            d = d.then(upload(data.file_name, i, data.max_file_no))
                         }
                         return d.promise()
                     })

--- a/src/Eccube/Resource/template/admin/Product/csv_product.twig
+++ b/src/Eccube/Resource/template/admin/Product/csv_product.twig
@@ -18,34 +18,156 @@ file that was distributed with this source code.
 {% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
 
 {% block javascript %}
-    <script src="{{ asset('assets/js/vendor/spin.min.js', 'admin') }}"></script>
     <script>
         $(function() {
-            var opts = {
-                lines: 13,
-                length: 30,
-                width: 2,
-                radius: 12,
-                corners: 1,
-                rotate: 0,
-                direction: 1,
-                color: '#BBB',
-                speed: 1,
-                trail: 67,
-                shadow: true,
-                hwaccel: false,
-                className: 'spinner',
-                zIndex: 2e9,
-                top: top
-            };
+            $('#importCsv').on('click', function() {
 
-            ImageSpinner = new Spinner(opts).spin(document.getElementById('spinner'));
-            ImageSpinner.stop();
+                var setupModal = function (modal) {
+                    modal.find('button').attr('disabled', 'disabled');
+                    $('.modal-body p', modal).text("{{ 'admin.common.csv_upload_in_progress'|trans }}");
+                    $('.progress', modal).show();
+                    return (new $.Deferred).resolve().promise();
+                }
 
-            $('#upload-form').submit(function() {
-                $('#upload-button').attr('disabled', 'disabled');
-                $('#download-button').attr('disabled', 'disabled');
-                ImageSpinner.spin(document.getElementById('spinner'));
+                var addError = function(message) {
+                    $('<li><span class="badge badge-danger">ERROR</span> </li>')
+                        .append($('<span></span>').text(message))
+                        .prependTo('#bulkMessages');
+                    $('#bulkMessages li:nth-child(n+2)').hide()
+                };
+
+                var addSuccess = function(message) {
+                    $('<li><span class="badge badge-success">SUCCESS</span> </li>')
+                        .append($('<span></span>').text(message))
+                        .prependTo('#bulkMessages');
+                    $('#bulkMessages li:nth-child(n+2)').hide()
+                };
+
+                var split = function(formData) {
+                    return function() {
+                        var d = new $.Deferred();
+                        $.ajax({
+                            url: '{{ url('admin_product_csv_split') }}',
+                            type: 'POST',
+                            data: formData,
+                            processData: false,
+                            contentType: false,
+                            cache: false,
+                        })
+                        .then(function(data) {
+                            if (data.success) {
+                                d.resolve(data)
+                            } else {
+                                data.message.forEach(function(error) {
+                                    addError(error.message)
+                                })
+                                d.reject(data)
+                            }
+                        })
+                        .catch(function() {
+                            d.reject()
+                        })
+                        return d.promise();
+                    }
+                }
+
+                var upload = function(file_name, current, total) {
+                    return function() {
+                        var d = new $.Deferred();
+                        $.ajax({
+                            url: '{{ url('admin_product_csv_split_import') }}',
+                            type: 'POST',
+                            data: {
+                                file_name: file_name,
+                                file_no: current
+                            },
+                        })
+                        .then(function(data) {
+                            if (data.success) {
+                                addSuccess(data.success_message)
+                                $('.progress-bar', modal).css('width', (current / total * 100) + '%');
+                                d.resolve(data)
+                            } else {
+                                addError(data.error_message)
+                                data.errors.forEach(function (error) {
+                                    addError(error)
+                                });
+
+                                $('.progress-bar', modal)
+                                    .clone()
+                                    .addClass('bg-danger')
+                                    .css('width', 100 - ((current - 1) / total * 100) + '%')
+                                    .appendTo('.progress', modal)
+
+                                $('.progress-bar', modal).addClass('bg-success')
+
+                                d.reject(data);
+                            }
+                        }, function(data) {
+                            d.reject(data)
+                        })
+                        return d.promise()
+                    }
+                }
+
+                var modal = $('#importCsvModal')
+                var formData = new FormData($('#upload-form').get(0))
+
+                setupModal(modal)
+                    // CSV分割
+                    .then(split(formData))
+                    .catch(function(data) {
+                        $('.progress-bar', modal).css('width', '100%')
+                        $('.progress-bar', modal).addClass('bg-danger');
+                        return $.Deferred().reject()
+                    })
+                    // 分割したCSVを登録
+                    .then(function(data) {
+                        var d = $.Deferred().resolve();
+                        for (var i = 1; i <= data.max_file_no; i++) {
+                            var file_name = data.file_name + i + '.csv'
+                            d = d.then(upload(file_name, i, data.max_file_no))
+                        }
+                        return d.promise()
+                    })
+                    // 完了メッセージ
+                    .then(
+                        function() {
+                            $('.modal-body p', modal).text("{{ 'admin.common.csv_upload_complete'|trans }}")
+                            $('.progress-bar', modal).addClass('bg-success');
+                        },
+                        function() {
+                            $('.modal-body p', modal).text("{{ 'admin.common.csv_upload_error'|trans }}")
+                        }
+                    )
+                    // モーダルのロック解除
+                    .then(function() {
+                        $('.progress-bar', modal).removeClass('progress-bar-animated')
+                        // メッセージ行が複数ある場合に詳細表示
+                        if ($('#bulkMessages li').length > 1) {
+                            $('#toggleMessages').show()
+                        }
+                        modal.find('button').removeAttr('disabled').toggle()
+                    })
+            })
+
+            $('#toggleMessages').on('click', function() {
+                var display = $('#bulkMessages li:last').css('display')
+                if (display == 'none') {
+                    $('#bulkMessages li').show();
+                    $('#toggleMessages span').text("{{ 'admin.common.open_detail'|trans }}")
+                    $('#toggleMessages i').removeClass('fa-plus-square-o')
+                    $('#toggleMessages i').addClass('fa-minus-square-o')
+                } else {
+                    $('#bulkMessages li:nth-child(n+2)').hide()
+                    $('#toggleMessages span').text("{{ 'admin.common.close_detail'|trans }}")
+                    $('#toggleMessages i').removeClass('fa-minus-square-o')
+                    $('#toggleMessages i').addClass('fa-plus-square-o')
+                }
+            })
+
+            $('#importCsvDone').on('click', function() {
+                location.reload(true);
             });
 
             $('#file-select').click(function() {
@@ -54,6 +176,7 @@ file that was distributed with this source code.
                     var files = $(this).prop('files');
                     if (files.length) {
                         $('#admin_csv_import_import_file_name').text(files[0].name);
+                        $('#upload-button').prop('disabled', false);
                     }
                 });
             });
@@ -73,7 +196,7 @@ file that was distributed with this source code.
                         <div class="row">
                             <div class="col-2"><span>{{ 'admin.common.csv_select'|trans }}</span></div>
                             <div class="col">
-                                <form id="upload-form" method="post" action="{{ url('admin_product_csv_import') }}" enctype="multipart/form-data">
+                                <form id="upload-form" method="post" action="{{ url('admin_product_csv_split') }}" enctype="multipart/form-data">
                                     {{ form_widget(form._token) }}
                                     <div class="mb-2">
                                         <span id="file-select" class="btn btn-ec-regular mr-2">{{ 'admin.common.file_select'|trans }}</span>
@@ -81,10 +204,7 @@ file that was distributed with this source code.
                                         {{ form_widget(form.import_file, {'attr': {'accept': 'text/csv,text/tsv', 'class': 'd-none'}}) }}
                                         {{ form_errors(form.import_file) }}
                                     </div>
-                                    <button class="btn btn-ec-conversion" id="upload-button" type="submit">{{ 'admin.common.bulk_registration'|trans }}</button>
-                                    {% for error in errors %}
-                                        <div class="text-danger">{{ error }}</div>
-                                    {% endfor %}
+                                    <button class="btn btn-ec-conversion" id="upload-button" type="button" data-toggle="modal" data-target="#importCsvModal" disabled>{{ 'admin.common.bulk_registration'|trans }}</button>
                                 </form>
                             </div>
                         </div>
@@ -121,6 +241,32 @@ file that was distributed with this source code.
                             </tbody>
                         </table>
                     </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="modal fade" id="importCsvModal" tabindex="-1" role="dialog" aria-labelledby="importCsvModal" aria-hidden="true" data-keyboard="false" data-backdrop="static">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title font-weight-bold">{{ 'admin.product.product_csv_upload__title'|trans }}</h5>
+                    <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                </div>
+                <div class="modal-body text-left">
+                    <span class="badge"></span>
+                    <p class="text-left">{{ 'admin.product.product_csv_upload__message'|trans }}</p>
+                    <div class="progress mb-1" style="display: none">
+                        <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+                    </div>
+                    <ul id="bulkMessages"></ul>
+                    <div id="toggleMessages" style="display: none;">
+                        <i class="fa font-weight-bold mr-1 fa-plus-square-o"></i><span>{{ 'admin.common.open_detail'|trans }}</span>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-ec-sub" type="button" data-dismiss="modal">{{ 'admin.common.cancel'|trans }}</button>
+                    <button class="btn btn-ec-conversion" type="button" id="importCsv">{{ 'admin.common.bulk_registration' | trans }}</button>
+                    <button class="btn btn-ec-regular" id="importCsvDone" style="display: none" type="button" data-dismiss="modal">{{ 'admin.common.close'|trans }}</button>
                 </div>
             </div>
         </div>

--- a/src/Eccube/Resource/template/admin/Product/csv_product.twig
+++ b/src/Eccube/Resource/template/admin/Product/csv_product.twig
@@ -205,6 +205,9 @@ file that was distributed with this source code.
                                         {{ form_errors(form.import_file) }}
                                     </div>
                                     <button class="btn btn-ec-conversion" id="upload-button" type="button" data-toggle="modal" data-target="#importCsvModal" disabled>{{ 'admin.common.bulk_registration'|trans }}</button>
+                                    {% for error in errors %}
+                                        <div class="text-danger">{{ error }}</div>
+                                    {% endfor %}
                                 </form>
                             </div>
                         </div>

--- a/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
@@ -48,6 +48,7 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         copy(__DIR__.'/../../../../../Fixtures/products.csv', $this->filepath); // 削除されてしまうのでコピーしておく
 
         $fs = new Filesystem();
+        $fs->mkdir($this->eccubeConfig['eccube_csv_temp_realdir']);
         $fs->remove($this->getCsvTempFiles());
     }
 
@@ -1066,6 +1067,29 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         $json = \json_decode($response->getContent(), true);
         $this->assertTrue($json['success']);
         $this->assertEquals('2行目〜2行目を登録しました', $json['success_message']);
+    }
+
+    public function testCleanupCsv()
+    {
+        $fileName = 'product.csv';
+        touch($this->eccubeConfig['eccube_csv_temp_realdir'].'/'.$fileName);
+
+        $this->client->request(
+            'POST',
+            $this->generateUrl('admin_product_csv_split_cleanup'),
+            [
+                'files' => [$fileName],
+            ],
+            [],
+            ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertTrue($response->isSuccessful());
+
+        $json = \json_decode($response->getContent(), true);
+        $this->assertTrue($json['success']);
+        $this->assertFalse(file_exists($this->eccubeConfig['eccube_csv_temp_realdir'].'/'.$fileName));
     }
 
     private function getCsvTempFiles()

--- a/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
@@ -21,6 +21,8 @@ use Eccube\Repository\CategoryRepository;
 use Eccube\Repository\ProductRepository;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 use Faker\Generator;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class CsvImportControllerTest extends AbstractAdminWebTestCase
@@ -44,6 +46,9 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         $this->categoryRepo = $this->container->get(CategoryRepository::class);
         $this->filepath = __DIR__.'/products.csv';
         copy(__DIR__.'/../../../../../Fixtures/products.csv', $this->filepath); // 削除されてしまうのでコピーしておく
+
+        $fs = new Filesystem();
+        $fs->remove($this->getCsvTempFiles());
     }
 
     public function tearDown()
@@ -51,6 +56,10 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         if (file_exists($this->filepath)) {
             unlink($this->filepath);
         }
+
+        $fs = new Filesystem();
+        $fs->remove($this->getCsvTempFiles());
+
         parent::tearDown();
     }
 
@@ -798,7 +807,7 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
      *
      * @return \Symfony\Component\DomCrawler\Crawler
      */
-    protected function scenario($bind = 'admin_product_csv_import', $original_name = 'products.csv')
+    protected function scenario($bind = 'admin_product_csv_import', $original_name = 'products.csv', $isXmlHttpRequest = false)
     {
         $file = new UploadedFile(
             $this->filepath,    // file path
@@ -818,7 +827,8 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
                     'import_file' => $file,
                 ],
             ],
-            ['import_file' => $file]
+            ['import_file' => $file],
+            $isXmlHttpRequest ? ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'] : []
         );
 
         return $crawler;
@@ -989,5 +999,80 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         $this->expected = 'テスト①';
         $this->actual = $Product->getName();
         $this->verify();
+    }
+
+    /**
+     * @dataProvider splitCsvDataProvider
+     */
+    public function testSplitCsv($lineNo, $expecedFileNo)
+    {
+        list($header, $row) = $this->createCsvAsArray();
+        $csv = [$header];
+        for ($i = 0; $i < $lineNo; $i++) {
+            $csv[] = $row;
+        }
+        $this->filepath = $this->createCsvFromArray($csv);
+
+        $this->scenario('admin_product_csv_split', 'products.csv', true);
+
+        $response = $this->client->getResponse();
+        $this->assertTrue($response->isSuccessful());
+
+        $json = \json_decode($response->getContent(), true);
+        $this->assertTrue($json['success']);
+        $this->assertNotEmpty($json['file_name']);
+        $this->assertEquals($expecedFileNo, $json['max_file_no']);
+
+        $files = $this->getCsvTempFiles();
+        $this->assertEquals($expecedFileNo, count($files), $expecedFileNo.'ファイル生成されているはず');
+    }
+
+    public function splitCsvDataProvider()
+    {
+        return [
+            [0, 1],
+            [1, 1],
+            [99, 1],
+            [100, 1],
+            [101, 2],
+            [199, 2],
+            [200, 2],
+            [201, 3],
+        ];
+    }
+
+    public function testImportCsv()
+    {
+        $fileName = 'product.csv';
+        $fileNo = 1;
+
+        $this->filepath = $this->createCsvFromArray($this->createCsvAsArray());
+        copy($this->filepath, $this->eccubeConfig['eccube_csv_temp_realdir'].'/'.$fileName);
+
+        $this->client->request(
+            'POST',
+            $this->generateUrl('admin_product_csv_split_import'),
+            [
+                'file_name' => $fileName,
+                'file_no' => $fileNo
+            ],
+            [],
+            ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertTrue($response->isSuccessful());
+
+        $json = \json_decode($response->getContent(), true);
+        $this->assertTrue($json['success']);
+        $this->assertEquals('2行目〜2行目を登録しました', $json['success_message']);
+    }
+
+    private function getCsvTempFiles()
+    {
+        return Finder::create()
+            ->in($this->eccubeConfig['eccube_csv_temp_realdir'])
+            ->name('*.csv')
+            ->files();
     }
 }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

商品CSV登録にて、CSVを分割して処理するように対応。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

背景として、CSVの行数が多い場合に、時間がかかり登録が完了しない・メモリを使い切りシステムエラーが発生するなど、ユーザビリティに難がありました。今回のPRでは、以下のようにファイルを分割して登録するように処理方式を変更しています。

![Untitled](https://user-images.githubusercontent.com/8196725/102059339-1bc44080-3e34-11eb-8880-61c78035f124.png)

従来との仕様変更点として、1件でもエラーがあればすべてロールバックされていたのが、分割したファイルごとにトランザクションがかかる形になります。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

互換性保持のため、CSVの登録ロジック自体に変更はありません。
レスポンス返す部分のみ、ajaxでのリクエストの場合にはjsonで返すようにする修正を入れています。・

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

- ユニットテスト作成
- memory_limit：128Mで1万件のCSVを取り込めることを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

画面UIは以下のように作っています。

![csv-out](https://user-images.githubusercontent.com/8196725/102062568-46b09380-3e38-11eb-96b4-d53b3ac5bd03.gif)

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
