### PR TITLE
CSV出力時にメモリを使い切ってしまう問題を修正

### DIFF
--- a/src/Eccube/Service/CsvExportService.php
+++ b/src/Eccube/Service/CsvExportService.php
@@ -333,8 +333,6 @@ class CsvExportService
             // スカラ値の場合はそのまま.
             return $data;
         }
-
-        return null;
     }
 
     /**

--- a/src/Eccube/Service/CsvExportService.php
+++ b/src/Eccube/Service/CsvExportService.php
@@ -282,7 +282,9 @@ class CsvExportService
         $query = $this->qb->getQuery();
         foreach ($query->getResult() as $iterableResult) {
             $closure($iterableResult, $this);
-            $this->entityManager->clear();
+            // https://github.com/EC-CUBE/ec-cube/issues/4775
+            // entityManager::detach内のtrigger errorを避けるため、UnitOfWork::detachを直接呼び出す
+            $this->entityManager->getUnitOfWork()->detach($iterableResult);
             $query->free();
             flush();
         }

--- a/src/Eccube/Service/CsvExportService.php
+++ b/src/Eccube/Service/CsvExportService.php
@@ -282,7 +282,7 @@ class CsvExportService
         $query = $this->qb->getQuery();
         foreach ($query->getResult() as $iterableResult) {
             $closure($iterableResult, $this);
-            $this->entityManager->detach($iterableResult);
+            $this->entityManager->clear();
             $query->free();
             flush();
         }
@@ -317,16 +317,12 @@ class CsvExportService
 
         // one to one の場合は, dtb_csv.reference_field_name, 合致する結果を取得する.
         if ($data instanceof \Eccube\Entity\AbstractEntity) {
-            if (EntityUtil::isNotEmpty($data)) {
-                return $data->offsetGet($Csv->getReferenceFieldName());
-            }
+            return $data->offsetGet($Csv->getReferenceFieldName());
         } elseif ($data instanceof \Doctrine\Common\Collections\Collection) {
             // one to manyの場合は, カンマ区切りに変換する.
             $array = [];
             foreach ($data as $elem) {
-                if (EntityUtil::isNotEmpty($elem)) {
-                    $array[] = $elem->offsetGet($Csv->getReferenceFieldName());
-                }
+                $array[] = $elem->offsetGet($Csv->getReferenceFieldName());
             }
 
             return implode($this->eccubeConfig['eccube_csv_export_multidata_separator'], $array);


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

#4775 の対応
商品・カテゴリ・受注・会員CSVを対応しました。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

trigger_errorが発生するメソッドを利用しないように修正

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

EntityManager::clearメソッドを利用した場合、ManyToOneの出力(性別など)が欠落する問題が発生したため、UnitOfWork::detachを利用するようにしています。※EntityManager::detachと挙動は同じ

https://github.com/EC-CUBE/ec-cube/pull/4815/commits/01d6b1543247dea1fccfc10a9a185018bd8abc8d

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

- memory_limit 128MBで商品点数 15,262件/15,262件を出力できることを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
