### PR TITLE
ポイント付与比率の下限を1から0に変更する

### DIFF
--- a/src/Eccube/Form/Type/Admin/ShopMasterType.php
+++ b/src/Eccube/Form/Type/Admin/ShopMasterType.php
@@ -183,7 +183,7 @@ class ShopMasterType extends AbstractType
                         'message' => 'form_error.numeric_only',
                     ]),
                     new Assert\Range([
-                        'min' => 1,
+                        'min' => 0,
                         'max' => 100,
                     ]),
                 ],

--- a/tests/Eccube/Tests/Form/Type/Admin/ShopMasterTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/ShopMasterTypeTest.php
@@ -128,4 +128,32 @@ class ShopMasterTypeTest extends AbstractTypeTestCase
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
+
+    public function testValidBasicPointRateRange_Min()
+    {
+        $this->formData['basic_point_rate'] = '0';
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testValidBasicPointRateRange_Max()
+    {
+        $this->formData['basic_point_rate'] = '100';
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testInValidBasicPointRateRange_Min()
+    {
+        $this->formData['basic_point_rate'] = '-1';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInValidBasicPointRateRange_Max()
+    {
+        $this->formData['basic_point_rate'] = '101';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
 }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
ポイントの付与率を0で設定したい #4780
1から0に変更しました。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
