### PR TITLE
PHPStan による静的解析の導入

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,7 @@ jobs:
           rm -rf $GITHUB_WORKSPACE/.coveralls.yml
           rm -rf $GITHUB_WORKSPACE/.php_cs.dist
           rm -rf $GITHUB_WORKSPACE/phpunit.xml.dist
+          rm -rf $GITHUB_WORKSPACE/phpstan.neon.dist
           rm -rf $GITHUB_WORKSPACE/app.json
           rm -rf $GITHUB_WORKSPACE/Procfile
           rm -rf $GITHUB_WORKSPACE/LICENSE.txt

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,36 @@
+name: PHPStan
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+    paths:
+      - '**'
+      - '!*.md'
+  pull_request:
+    paths:
+      - '**'
+      - '!*.md'
+
+jobs:
+  phpstan:
+    name: PHPStan
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+    - name: Setup PHP
+      uses: nanasess/setup-php@master
+      with:
+        php-version: '7.4'
+    - name: composer install
+      run: |
+        sudo composer selfupdate --1
+        composer install --dev --no-interaction -o --apcu-autoloader
+    - name: PHPStan
+      run: |
+        composer require phpstan/phpstan --dev
+        vendor/bin/phpstan analyze src/ --error-format=github

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ composer.phar
 *.php~
 .env
 .maintenance
+*.neon
 
 ###> symfony/phpunit-bridge ###
 .phpunit

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,6 @@
+parameters:
+  level: 0
+  ignoreErrors:
+    -
+      message: "#^Function twig_localized_date_filter not found\\.$#"
+      path: src/Eccube/Twig/Extension/IntlExtension.php

--- a/src/Eccube/EventListener/TransactionListener.php
+++ b/src/Eccube/EventListener/TransactionListener.php
@@ -13,7 +13,7 @@
 
 namespace Eccube\EventListener;
 
-use Doctrine\Dbal\Connection;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

3系より、静的解析ツールとして[Scrutinizer](https://scrutinizer-ci.com)を導入しているが、あまり活用されていない。
[PHPStan](https://phpstan.org) でチェックしたところ、明らかに問題のあるコードが発覚したため、 GitHub Actions に導入してみる

PHPStan については、以下が詳しい
- https://engineering.mercari.com/blog/entry/phpstan/
- [PHPで開発が捗るリアルタイムエラーチェック](https://qiita.com/tadsan/items/16aaaaaf4e99d0a994c9)


## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

- GitHub Actions で PHPStan の Workflow を実行する
- `phpstan.neon.dist` でデフォルトの設定をしておく
    - level: 0
    - `Twig_Extensions_Extension_Intl` で定義されている一部のグローバル関数を PHPStan が見つけてくれないため、エラーから除外
- PHPStan のエラーが発生した場合は、 Workflow をエラーとする

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

PHPStan で発見したエラーについては、別途 PR を作成します(https://github.com/EC-CUBE/ec-cube/pull/4838)

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

PHPStan のエラーで Workflow がエラーになることを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

実験的な導入なので、 GitHub Actions で `composer require phpstan/phpstan` を実行しているが、良さげなら require-dev に入れたい

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
