### PR TITLE
ファイル管理で名前の重複するディレクトリを作ろうとした時にエラーメッセージを出す

### DIFF
--- a/src/Eccube/Controller/Admin/Content/FileController.php
+++ b/src/Eccube/Controller/Admin/Content/FileController.php
@@ -178,7 +178,11 @@ class FileController extends AbstractController
             $nowDir = $this->checkDir($nowDir, $topDir)
                 ? $this->normalizePath($nowDir)
                 : $topDir;
-            $fs->mkdir($nowDir.'/'.$filename);
+            $newFilePath = $nowDir.'/'.$filename;
+            if (file_exists($newFilePath)) {
+                throw new IOException(trans('admin.content.file.dir_exists', [ '%file_name%' => $filename, ]));
+            }
+            $fs->mkdir($newFilePath);
 
             $this->addSuccess('admin.common.create_complete', 'admin');
         } catch (IOException $e) {

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -966,6 +966,7 @@ admin.content.file.updated: Update
 admin.content.file.directory_tree: Directories
 admin.content.file.upload_complete: %success% file upload completed. (%success%/%count%)
 admin.content.file.upload_error: Failed to upload %file_name%. (%error%)
+admin.content.file.dir_exists: %file_name% is already exists.
 admin.content.layout_delete: Delete Layouts
 admin.content.layout_no_page: Page not registered
 admin.content.layout__card_title: Layout Overview

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -966,6 +966,7 @@ admin.content.file.updated: 更新
 admin.content.file.directory_tree: フォルダ構成
 admin.content.file.upload_complete: %success%件のファイルをアップロードしました。(%success%/%count%)
 admin.content.file.upload_error: %file_name% のアップロードに失敗しました。(%error%)
+admin.content.file.dir_exists: %file_name% は既に使用されています。別のフォルダ名を入力してください
 admin.content.layout_delete: レイアウトを削除
 admin.content.layout_no_page: ページが登録されていません
 admin.content.layout__card_title: レイアウト概要

--- a/tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php
@@ -92,6 +92,45 @@ class FileControllerTest extends AbstractAdminWebTestCase
         $this->assertTrue(is_dir($this->getUserDataDir().'/'.$folder));
     }
 
+    /**
+     * 名前の重複するディレクトリを作る
+     */
+    public function testIndexWithCreateDuplicateDir()
+    {
+        $folder = 'create_folder';
+        $this->client->request(
+            'POST',
+            $this->generateUrl('admin_content_file'),
+            [
+                'form' => [
+                    '_token' => 'dummy',
+                    'create_file' => $folder,
+                    'file' => '',
+                ],
+                'mode' => 'create',
+                'now_dir' => $this->getUserDataDir(),
+            ]
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertTrue(is_dir($this->getUserDataDir().'/'.$folder));
+        $crawler = $this->client->request(
+            'POST',
+            $this->generateUrl('admin_content_file'),
+            [
+                'form' => [
+                    '_token' => 'dummy',
+                    'create_file' => $folder,
+                    'file' => '',
+                ],
+                'mode' => 'create',
+                'now_dir' => $this->getUserDataDir(),
+            ]
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertTrue(is_dir($this->getUserDataDir().'/'.$folder));
+        $this->assertCount(1, $crawler->filter('p.errormsg'));
+    }
+
     public function testIndexWithUpload()
     {
         $filepath1 = $this->getUserDataDir().'/../aaa.html';


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
ファイル管理で重複するディレクトリを作ろうとした時にエラーメッセージを出すようにしました
#4758

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
ディレクトリを作る前に同じ名前のファイル・ディレクトリの存在をチェックします。


## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
同じ名前で二回ディレクトリを作成し、画面内にp.errormsgの要素が存在することを調べるテストを追加しました。


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
