### PR TITLE
商品画像アップロード時のリサイズ処理

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -124,3 +124,6 @@ parameters:
     eccube_result_cache_lifetime: 3600 # doctrineのresult cacheのlifetime.
     eccube_result_cache_lifetime_short: 10  # doctrineのresult cacheのlifetime. 商品一覧画面など長期間キャッシュできない箇所で使用する.
     eccube_content_maintenance_file_path: '%env(ECCUBE_MAINTENANCE_FILE_PATH)%'
+    eccube_product_image_resize: true
+    eccube_product_image_jpg_quality: 75
+    eccube_product_image_png_quality: 6

--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -124,6 +124,6 @@ parameters:
     eccube_result_cache_lifetime: 3600 # doctrineのresult cacheのlifetime.
     eccube_result_cache_lifetime_short: 10  # doctrineのresult cacheのlifetime. 商品一覧画面など長期間キャッシュできない箇所で使用する.
     eccube_content_maintenance_file_path: '%env(ECCUBE_MAINTENANCE_FILE_PATH)%'
-    eccube_product_image_resize: false
+    eccube_product_image_resize: true
     eccube_product_image_jpg_quality: 75
     eccube_product_image_png_quality: 6

--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -124,6 +124,6 @@ parameters:
     eccube_result_cache_lifetime: 3600 # doctrineのresult cacheのlifetime.
     eccube_result_cache_lifetime_short: 10  # doctrineのresult cacheのlifetime. 商品一覧画面など長期間キャッシュできない箇所で使用する.
     eccube_content_maintenance_file_path: '%env(ECCUBE_MAINTENANCE_FILE_PATH)%'
-    eccube_product_image_resize: true
+    eccube_product_image_resize: false
     eccube_product_image_jpg_quality: 75
     eccube_product_image_png_quality: 6

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -173,7 +173,7 @@ class ProductController extends AbstractController
          * - デフォルト値
          * また, セッションに保存する際は mtb_page_maxと照合し, 一致した場合のみ保存する.
          **/
-        $page_count = $this->session->get('eccube.admin.order.search.page_count',
+        $page_count = $this->session->get('eccube.admin.product.search.page_count',
             $this->eccubeConfig->get('eccube_default_page_count'));
 
         $page_count_param = (int) $request->get('page_count');
@@ -183,7 +183,7 @@ class ProductController extends AbstractController
             foreach ($pageMaxis as $pageMax) {
                 if ($page_count_param == $pageMax->getName()) {
                     $page_count = $pageMax->getName();
-                    $this->session->set('eccube.admin.order.search.page_count', $page_count);
+                    $this->session->set('eccube.admin.product.search.page_count', $page_count);
                     break;
                 }
             }
@@ -330,10 +330,7 @@ class ProductController extends AbstractController
                         throw new UnsupportedMediaTypeHttpException();
                     }
 
-                    $filename = date('mdHis').uniqid('_').'.'.$extension;
-                    $image->move($this->eccubeConfig['eccube_temp_image_dir'], $filename);
-                    $files[] = $filename;
-
+                    // リサイズ処理の可否（'eccube_product_image_resize'）
                     if ($this->eccubeConfig->get('eccube_product_image_resize')) {
 
                         // 加工前の画像の情報を取得
@@ -367,6 +364,7 @@ class ProductController extends AbstractController
                         // 保存先を指定
                         $resize_path = $this->eccubeConfig['eccube_temp_image_dir'] . '/' . $filename;
 
+                        // 画像形式ごとの処理
                         switch ($type) {
                             case IMAGETYPE_JPEG:
                                 imagejpeg($canvas, $resize_path, $this->eccubeConfig->get('eccube_product_image_jpg_quality'));
@@ -383,6 +381,12 @@ class ProductController extends AbstractController
 
                         imagedestroy($origin_image);
                         imagedestroy($canvas);
+
+                    } else {
+
+                        $filename = date('mdHis').uniqid('_').'.'.$extension;
+                        $image->move($this->eccubeConfig['eccube_temp_image_dir'], $filename);
+                        $files[] = $filename;
                     }
                 }
             }

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -330,67 +330,62 @@ class ProductController extends AbstractController
                         throw new UnsupportedMediaTypeHttpException();
                     }
 
-						// 2019-10-07 Add Start
-						// 加工前の画像の情報を取得
-						list($origin_w, $origin_h, $type) = getimagesize($image);
+                    if ($this->eccubeConfig->get('eccube_product_image_resize')) {
 
-						// 加工前のファイルをフォーマット別に読み出す
-						switch ($type) {
-							case IMAGETYPE_JPEG:
-								$origin_image = imagecreatefromjpeg($image);
-								break;
+                        // 加工前の画像の情報を取得
+                        list($origin_w, $origin_h, $type) = getimagesize($image);
 
-							case IMAGETYPE_PNG:
-								$origin_image = imagecreatefrompng($image);
-								break;
+                        // 加工前のファイルをフォーマット別に読み出す
+                        switch ($type) {
+                            case IMAGETYPE_JPEG:
+                                $origin_image = imagecreatefromjpeg($image);
+                                break;
 
-							case IMAGETYPE_GIF:
-								$origin_image = imagecreatefromgif($image);
-								break;
+                            case IMAGETYPE_PNG:
+                                $origin_image = imagecreatefrompng($image);
+                                break;
 
-							default:
-								throw new RuntimeException('対応していないファイル形式です。: ', $type);
-						}
+                            case IMAGETYPE_GIF:
+                                $origin_image = imagecreatefromgif($image);
+                                break;
 
-						// 新しく描画するキャンバスを作成
-						$canvas = imagecreatetruecolor($origin_w, $origin_h);
-						imagecopyresampled($canvas, $origin_image, 0,0,0,0, $origin_w, $origin_h, $origin_w, $origin_h);
+                            default:
+                                throw new RuntimeException('対応していないファイル形式です。: ', $type);
+                        }
 
-						$filename = date('mdHis').uniqid('_').'.'.$extension;
-						$files[] = $filename;
+                        // 新しく描画するキャンバスを作成
+                        $canvas = imagecreatetruecolor($origin_w, $origin_h);
+                        imagecopyresampled($canvas, $origin_image, 0,0,0,0, $origin_w, $origin_h, $origin_w, $origin_h);
 
-						// 保存先を指定
-						$resize_path = $this->eccubeConfig['eccube_temp_image_dir'] . '/' . $filename;
+                        $filename = date('mdHis').uniqid('_').'.'.$extension;
+                        $files[] = $filename;
 
-						switch ($type) {
-							case IMAGETYPE_JPEG:
-								imagejpeg($canvas, $resize_path, 60);
-								break;
+                        // 保存先を指定
+                        $resize_path = $this->eccubeConfig['eccube_temp_image_dir'] . '/' . $filename;
 
-							case IMAGETYPE_PNG:
-								imagepng($canvas, $resize_path, 9);
-								break;
+                        switch ($type) {
+                            case IMAGETYPE_JPEG:
+                                imagejpeg($canvas, $resize_path, $this->eccubeConfig->get('eccube_product_image_jpg_quality'));
+                                break;
 
-							case IMAGETYPE_GIF:
-								imagegif($canvas, $resize_path);
-								break;
+                            case IMAGETYPE_PNG:
+                                imagepng($canvas, $resize_path, $this->eccubeConfig->get('eccube_product_image_png_quality'));
+                                break;
 
-						}
+                            case IMAGETYPE_GIF:
+                                imagegif($canvas, $resize_path);
+                                break;
+                        }
 
-						imagedestroy($origin_image);
-						imagedestroy($canvas);
-						// 2019-10-07 Add End
+                        imagedestroy($origin_image);
+                        imagedestroy($canvas);
+                    } else {
 
-						/* 2019-10-08 Comment Out ↓
-						// 拡張子
-						$extension = $image->getClientOriginalExtension();
-						if (!in_array(strtolower($extension), $allowExtensions)) {
-							throw new UnsupportedMediaTypeHttpException();
-						}
-						$filename = date('mdHis').uniqid('_').'.'.$extension;
-						$canvas->move($this->eccubeConfig['eccube_temp_image_dir'], $filename);
-						$files[] = $filename;
-						2019-10-08 Comment Out ↑ */
+                        $filename = date('mdHis').uniqid('_').'.'.$extension;
+                        $image->move($this->eccubeConfig['eccube_temp_image_dir'], $filename);
+                        $files[] = $filename;
+
+                    }
                 }
             }
         }

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -330,6 +330,10 @@ class ProductController extends AbstractController
                         throw new UnsupportedMediaTypeHttpException();
                     }
 
+                    $filename = date('mdHis').uniqid('_').'.'.$extension;
+                    $image->move($this->eccubeConfig['eccube_temp_image_dir'], $filename);
+                    $files[] = $filename;
+
                     if ($this->eccubeConfig->get('eccube_product_image_resize')) {
 
                         // 加工前の画像の情報を取得
@@ -379,12 +383,6 @@ class ProductController extends AbstractController
 
                         imagedestroy($origin_image);
                         imagedestroy($canvas);
-                    } else {
-
-                        $filename = date('mdHis').uniqid('_').'.'.$extension;
-                        $image->move($this->eccubeConfig['eccube_temp_image_dir'], $filename);
-                        $files[] = $filename;
-
                     }
                 }
             }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
#4347

## 方針(Policy)
2系であった画像アップロード時のリサイズ処理について、
4系ではアップロード画像の幅、高さやサイズの指定が運用レベルで加工が必要なため
アップロード時に、パラメータで指定した画像ファイルに加工する。

## 実装に関する補足(Appendix)
アップロード後の画像サイズや、jpg、pngファイルの圧縮率の指示がベタ書きなっています。

## テスト（Test)
既に実稼働の環境での要望があり、実稼働サイトのプレビューサイトで、各画像ファイルのアップロードテストを行い、実稼働の環境に適用しています。

## 相談（Discussion）