### PR TITLE
webp画像が存在する場合に、.jpgや.pngでアクセスが来てもwebpを返す様に変更

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -10,6 +10,10 @@ DirectoryIndex index.php index.html .ht
     allow from all
 </Files>
 
+<IfModule mod_setenvif.c>
+  SetEnvIf Request_URI "\.(jpe?g|png)$" _image_request
+</IfModule>
+
 <IfModule mod_headers.c>
     # クリックジャッキング対策
     Header always set X-Frame-Options SAMEORIGIN
@@ -17,6 +21,9 @@ DirectoryIndex index.php index.html .ht
     # XSS対策
     Header set X-XSS-Protection "1; mode=block"
     Header set X-Content-Type-Options nosniff
+
+    #webpにvaray
+    Header append Vary Accept env=_image_request
 </IfModule>
 
 # デザインテンプレートを適用するため10Mで設定 
@@ -31,6 +38,12 @@ DirectoryIndex index.php index.html .ht
     #Options +FollowSymLinks +SymLinksIfOwnerMatch
 
     RewriteEngine On
+    
+    # Acceptヘッダがimage/webpを含む場合
+    RewriteCond %{HTTP_ACCEPT} image/webp
+    RewriteCond %{SCRIPT_FILENAME}.webp -f
+    # *.jpg、*.pngファイルを*.webpファイルに内部的にルーティングする
+    RewriteRule .(jpe?g|png)$ %{SCRIPT_FILENAME}.webp [T=image/webp]
 
     # Authorization ヘッダが取得できない環境への対応
     RewriteCond %{HTTP:Authorization} ^(.*)
@@ -53,6 +66,10 @@ DirectoryIndex index.php index.html .ht
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !^(.*)\.(gif|png|jpe?g|css|ico|js|svg|map)$ [NC]
     RewriteRule ^(.*)$ index.php [QSA,L]
+</IfModule>
+<IfModule mod_mime.c>
+  # 拡張子.webpファイルはContent-Typeとしてimage/webpを返す
+  AddType image/webp .webp
 </IfModule>
 
 # 管理画面へのBasic認証サンプル


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
Web Core Vitalsの改善のためにwebp対応した場合の設定を.htaccessに追加

ref: #4896 #4807

## 方針(Policy)
aaa.jpgがあったらaaa.jpg.webpが生成される想定での設定です。

## 実装に関する補足(Appendix)
ファイルアップロード時か、バッチでやるかは不明ですが、自動でwebp画像が生成される想定です

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
