### PR TITLE
商品一覧・編集画面の規格情報並び順をsort_noで制御

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -274,7 +274,7 @@ class ProductController extends AbstractController
     /**
      * @Route("/%eccube_admin_route%/product/classes/{id}/load", name="admin_product_classes_load", methods={"GET"}, requirements={"id" = "\d+"})
      * @Template("@admin/Product/product_class_popup.twig")
-     * @ParamConverter("Product")
+     * @ParamConverter("Product", options={"repository_method":"findWithSortedClassCategories"})
      */
     public function loadProductClasses(Request $request, Product $Product)
     {
@@ -291,9 +291,7 @@ class ProductController extends AbstractController
         if ($Product->hasProductClass()) {
             $class = $Product->getProductClasses();
             foreach ($class as $item) {
-                if ($item['visible']) {
-                    $data[] = $item;
-                }
+                $data[] = $item;
             }
         }
 
@@ -373,7 +371,7 @@ class ProductController extends AbstractController
             $ProductClass->setProductStock($ProductStock);
             $ProductStock->setProductClass($ProductClass);
         } else {
-            $Product = $this->productRepository->find($id);
+            $Product = $this->productRepository->findWithSortedClassCategories($id);
             $ProductClass = null;
             $ProductStock = null;
             if (!$Product) {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
商品一覧・編集画面で規格情報テーブルの並び順が制御されておらず分かりにくい問題を修正。
#4890
https://xoops.ec-cube.net/modules/newbb/viewtopic.php?viewmode=flat&topic_id=25205&forum=9


## 方針(Policy)
既存のProductRepository::findWithSortedClassCategoriesを使用


## 実装に関する補足(Appendix)
visible=1のレコードしか取得されなくなるのでコントローラでのvisibleチェックは削除しました（商品一覧画面）
ただ、Customizeディレクトリでadmin_product_product_editのルーティングをオーバーライドしていてtwigはそのまま使っている場合に挙動が変わるのを防ぐため、twigでのvisibleチェックは残しています。(商品編集画面）
https://github.com/EC-CUBE/ec-cube/blob/e20433c5645299d6f83b66f3e129d1c49dfda398/src/Eccube/Resource/template/admin/Product/product.twig#L627


## テスト（Test)
規格分類を並び替えて動作確認


## 相談（Discussion）


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
