### PR TITLE
ご注文手続き画面で商品種別が入れ替わる問題の修正

### DIFF
--- a/src/Eccube/Controller/ShippingMultipleController.php
+++ b/src/Eccube/Controller/ShippingMultipleController.php
@@ -344,7 +344,10 @@ class ShippingMultipleController extends AbstractShoppingController
                 }
 
                 $this->cartPurchaseFlow->validate($Cart, new PurchaseContext($Cart, $this->getUser()));
-                $this->cartService->save();
+
+                // 注文フローで取得されるカートの入れ替わりを防止する
+                // @see https://github.com/EC-CUBE/ec-cube/issues/4293
+                $this->cartService->setPrimary($Cart->getCartKey());
             }
 
             return $this->redirectToRoute('shopping');

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -125,7 +125,10 @@ class ShoppingController extends AbstractShoppingController
 
             // 受注明細と同期をとるため, CartPurchaseFlowを実行する
             $cartPurchaseFlow->validate($Cart, new PurchaseContext($Cart, $this->getUser()));
-            $this->cartService->save();
+
+            // 注文フローで取得されるカートの入れ替わりを防止する
+            // @see https://github.com/EC-CUBE/ec-cube/issues/4293
+            $this->cartService->setPrimary($Cart->getCartKey());
         }
 
         // マイページで会員情報が更新されていれば, Orderの注文者情報も更新する.


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
下記のタイミングで注文手続き画面の商品種別が入れ替わってしまう問題の修正
- 複数配送を設定する場合 (#4293)
- PurchaseFlowがwarningで返ってきた場合(Issue無し)


## 方針(Policy)
注文フロー内でセッションに保存しているカートキーの先頭が変わらないようにする

実際は先頭にあるカートが優先されるという仕組みを変えた方がいい気がしますが、影響範囲が大きそうなので最低限の修正で暫定対応する方針

今までどんな仕組みになっていたかと思ったのですが、そう言えば３系ではカート１つしかなかったんですね‥。
もしセッションのcart_keysの順番に依存しないようにするなら、どのカートor受注がアクティブかということをセッションに持たせる等になるのでしょうか。

このPRでは `$this->cartService->save();`の代わりに `$this->cartService->setPrimary($Cart->getCartKey());` を実行して対象のカートが先頭で保存されるようにしています。(saveはsetPrimary内部で実行されています)

そもそも注文フロー内ではOrder.pre_order_idからカートを取得すればいいのではとも思いましたが
考えてみると下記のコードのように購入処理中の受注を取得するために先にカート情報を取得しているので大変そうだなと。

https://github.com/EC-CUBE/ec-cube/blob/4e213a879ac278ea8b9dbef1be85654b7e368c50/src/Eccube/Controller/ShoppingController.php#L250-L257


## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
warningの方は@ShoppingFlowで$this->throwInvalidItemException('エラー', true);を実行してみて確認

## 相談（Discussion）
良い解決方法があれば教えて欲しいです。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
