### PR TITLE
admin認証済みの場合はメンテナンスモードを回避するよう変更

### DIFF
--- a/index.php
+++ b/index.php
@@ -56,22 +56,6 @@ if ($trustedHosts) {
 $request = Request::createFromGlobals();
 
 $maintenanceFile = env('ECCUBE_MAINTENANCE_FILE_PATH', __DIR__.'/.maintenance');
-
-if (file_exists($maintenanceFile)) {
-    $pathInfo = \rawurldecode($request->getPathInfo());
-    $adminPath = env('ECCUBE_ADMIN_ROUTE', 'admin');
-    $adminPath = '/'.\trim($adminPath, '/').'/';
-    if (\strpos($pathInfo, $adminPath) !== 0) {
-        $locale = env('ECCUBE_LOCALE');
-        $templateCode = env('ECCUBE_TEMPLATE_CODE');
-        $baseUrl = \htmlspecialchars(\rawurldecode($request->getBaseUrl()), ENT_QUOTES);
-
-        header('HTTP/1.1 503 Service Temporarily Unavailable');
-        require __DIR__.'/maintenance.php';
-        return;
-    }
-}
-
 $kernel = new Kernel($env, $debug);
 $response = $kernel->handle($request);
 $response->send();

--- a/src/Eccube/EventListener/MaintenanceListener.php
+++ b/src/Eccube/EventListener/MaintenanceListener.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\EventListener;
+
+use Eccube\Entity\Member;
+use Eccube\Request\Context;
+use Eccube\Service\SystemService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+final class MaintenanceListener implements EventSubscriberInterface
+{
+    private const SESSION_KEY = '_security_admin';
+
+    /** @var Context */
+    private $context;
+
+    /** @var SystemService */
+    private $systemService;
+
+    public function __construct(Context $context, SystemService $systemService)
+    {
+        $this->context = $context;
+        $this->systemService = $systemService;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => 'onRequest',
+        ];
+    }
+
+    public function onRequest(GetResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        if ($this->context->isAdmin() || !$this->systemService->isMaintenanceMode()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        if ($this->isAdminAuthenticated($request)) {
+            return;
+        }
+
+        $locale = \env('ECCUBE_LOCALE');
+        $templateCode = \env('ECCUBE_TEMPLATE_CODE');
+        $baseUrl = htmlspecialchars(\rawurldecode($request->getBaseUrl()), ENT_QUOTES);
+
+        \ob_start();
+        require __DIR__ . '/../../../maintenance.php';
+        $response = new Response(\ob_get_clean(), 503);
+        $event->setResponse($response);
+    }
+
+    private function isAdminAuthenticated(Request $request): bool
+    {
+        $session = $request->hasPreviousSession() ? $request->getSession() : null;
+
+        if ($session === null || ($serializedToken = $session->get(self::SESSION_KEY)) === null) {
+            return false;
+        }
+
+        $unserializedToken = $this->safelyUnserialize($serializedToken);
+        $user = ($unserializedToken instanceof TokenInterface)
+            ? $unserializedToken->getUser()
+            : null;
+
+        return $user instanceof Member;
+    }
+
+    private function safelyUnserialize($serializedToken)
+    {
+        $e = $token = null;
+        $prevUnserializeHandler = \ini_set('unserialize_callback_func', __CLASS__ . '::handleUnserializeCallback');
+        $prevErrorHandler = \set_error_handler(function ($type, $msg, $file, $line, $context = []) use (&$prevErrorHandler) {
+            if (__FILE__ === $file) {
+                throw new \UnexpectedValueException($msg, 0x37313bc);
+            }
+
+            return $prevErrorHandler ? $prevErrorHandler($type, $msg, $file, $line, $context) : false;
+        });
+
+        try {
+            $token = \unserialize($serializedToken);
+        } catch (\Error $e) {
+        } catch (\Exception $e) {
+        }
+        \restore_error_handler();
+        \ini_set('unserialize_callback_func', $prevUnserializeHandler);
+        if ($e) {
+            if (!$e instanceof \UnexpectedValueException || 0x37313bc !== $e->getCode()) {
+                throw $e;
+            }
+        }
+
+        return $token;
+    }
+
+    /**
+     * @internal
+     */
+    public static function handleUnserializeCallback($class)
+    {
+        throw new \UnexpectedValueException('Class not found: ' . $class, 0x37313bc);
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#4839

(マージ先は #4901 の方針に従って4.0にしました)

## 方針(Policy)

セッションから管理画面の認証情報を取得する処理は以下を流用。
https://github.com/symfony/security/blob/v3.4.42/Http/Firewall/ContextListener.php

## テスト（Test)

ユニットテストなし。

## 相談（Discussion）

従来は`\Symfony\Component\HttpKernel\Kernel::boot()`の前に処理していたのが、その後の処理になるが問題ないか。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
