### PR TITLE
カートの合計価格がeccube_max_total_feeを超える時にカートから商品を取り除いて正常に続行する

### DIFF
--- a/src/Eccube/Service/CartService.php
+++ b/src/Eccube/Service/CartService.php
@@ -280,11 +280,17 @@ class CartService
     {
         foreach ($this->getCarts() as $Cart) {
             foreach ($Cart->getCartItems() as $i) {
-                $this->entityManager->remove($i);
-                $this->entityManager->flush($i);
+                // remove()をする前にオブジェクトの状態を確認する
+                if ($this->entityManager->getUnitOfWork()->getEntityState($i) === UnitOfWork::STATE_MANAGED) {
+                    $this->entityManager->remove($i);
+                    $this->entityManager->flush($i);
+                }
             }
-            $this->entityManager->remove($Cart);
-            $this->entityManager->flush($Cart);
+            // remove()をする前にオブジェクトの状態を確認する
+            if ($this->entityManager->getUnitOfWork()->getEntityState($Cart) === UnitOfWork::STATE_MANAGED) {
+                $this->entityManager->remove($Cart);
+                $this->entityManager->flush($Cart);
+            }
         }
         $this->carts = [];
 


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
#4498
カートに追加した商品の合計金額がeccube_max_total_feeを超える時に500エラーが発生していたため、カートから該当の商品を削除してメッセージを出すように変更します。

## 方針(Policy)
  
カートの合計金額がeccube_max_total_feeを超えるようなaddCart()処理で例外が発生しているので、正常に続行するようにする。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

エラーの直接の原因は、restoreCarts()でUnitOfWork::STATE_NEWのオブジェクトに対してEntityManeger::remove()を行おうとしていたためです。
問題が発生していたのはaddProduct()後のカート正規化処理(PurchaseFlow::validate)でエラーが発生した場合に呼び出されるremoveProduct()の中で使われているrestoreCartsで、その時点ではまだCartが保存されていないために上記エラーとなっていました。
これを回避するために、remove()の前にオブジェクトの管理状態をみるようにしました。

また、removeProduct()が行われた後のCartについて、再度、正規化処理を行っています。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
問題の商品を削除した後に再度カートの正規化を行うようにしましたが、Cartsに関するループをもう一回やることになってしまい、冗長な処理になってしまいました。実際コードインスペクションの評価も下がってしまっています。もう少しきれいな実装にできないかと考えているのですが、まだできていません。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
