### PR TITLE
フォルダ名に関するエラーメッセージ

### DIFF
--- a/src/Eccube/Controller/Admin/Content/FileController.php
+++ b/src/Eccube/Controller/Admin/Content/FileController.php
@@ -149,7 +149,7 @@ class FileController extends AbstractController
                     new Assert\Regex([
                         'pattern' => '/[^[:alnum:]_.\\-]/',
                         'match' => false,
-                        'message' => 'file.text.error.folder_symbol',
+                        'message' => 'admin.content.file.folder_name_symbol_error',
                     ]),
                     new Assert\Regex([
                         'pattern' => "/^\.(.*)$/",

--- a/src/Eccube/Controller/Admin/Content/FileController.php
+++ b/src/Eccube/Controller/Admin/Content/FileController.php
@@ -154,7 +154,7 @@ class FileController extends AbstractController
                     new Assert\Regex([
                         'pattern' => "/^\.(.*)$/",
                         'match' => false,
-                        'message' => 'file.text.error.folder_period',
+                        'message' => 'admin.content.file.folder_name_period_error',
                     ]),
                 ],
             ])

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -966,6 +966,7 @@ admin.content.file.updated: Update
 admin.content.file.directory_tree: Directories
 admin.content.file.upload_complete: %success% file upload completed. (%success%/%count%)
 admin.content.file.upload_error: Failed to upload %file_name%. (%error%)
+admin.content.file.folder_name_symbol_error: The folder name contains invalid characters.
 admin.content.layout_delete: Delete Layouts
 admin.content.layout_no_page: Page not registered
 admin.content.layout__card_title: Layout Overview

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -967,6 +967,7 @@ admin.content.file.directory_tree: Directories
 admin.content.file.upload_complete: %success% file upload completed. (%success%/%count%)
 admin.content.file.upload_error: Failed to upload %file_name%. (%error%)
 admin.content.file.folder_name_symbol_error: The folder name contains invalid characters.
+admin.content.file.folder_name_period_error: Folder names beginning with a period(.) are not allowed.
 admin.content.layout_delete: Delete Layouts
 admin.content.layout_no_page: Page not registered
 admin.content.layout__card_title: Layout Overview

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -967,6 +967,7 @@ admin.content.file.directory_tree: フォルダ構成
 admin.content.file.upload_complete: %success%件のファイルをアップロードしました。(%success%/%count%)
 admin.content.file.upload_error: %file_name% のアップロードに失敗しました。(%error%)
 admin.content.file.folder_name_symbol_error: 使用できない文字が含まれています。
+admin.content.file.folder_name_period_error: ピリオド(.)で始まる名前は使用できません。
 admin.content.layout_delete: レイアウトを削除
 admin.content.layout_no_page: ページが登録されていません
 admin.content.layout__card_title: レイアウト概要

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -966,6 +966,7 @@ admin.content.file.updated: 更新
 admin.content.file.directory_tree: フォルダ構成
 admin.content.file.upload_complete: %success%件のファイルをアップロードしました。(%success%/%count%)
 admin.content.file.upload_error: %file_name% のアップロードに失敗しました。(%error%)
+admin.content.file.folder_name_symbol_error: 使用できない文字が含まれています。
 admin.content.layout_delete: レイアウトを削除
 admin.content.layout_no_page: ページが登録されていません
 admin.content.layout__card_title: レイアウト概要


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
#4552
フォルダ作成時につける名前のエラーを表示する

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
文字列のコードだけが出る状態だったのでResource/locale/message.ja.yamlにメッセージの内容を追加する。
文字列のコードを、コンテンツ管理画面で使うその他のメッセージと合わせる。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
