### PR TITLE
商品一覧画面の商品画像を lazyload に対応

### DIFF
--- a/src/Eccube/Resource/template/default/Product/list.twig
+++ b/src/Eccube/Resource/template/default/Product/list.twig
@@ -154,7 +154,7 @@ file that was distributed with this source code.
                         <li class="ec-shelfGrid__item">
                             <a href="{{ url('product_detail', {'id': Product.id}) }}">
                                 <p class="ec-shelfGrid__item-image">
-                                    <img src="{{ asset(Product.main_list_image|no_image_product, 'save_image') }}">
+                                    <img src="{{ asset(Product.main_list_image|no_image_product, 'save_image') }}" loading="lazy">
                                 </p>
                                 <p>{{ Product.name }}</p>
                                 {% if Product.description_list %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

refs #4816

商品詳細画面の商品画像を lazyload に対応しました。

https://user-images.githubusercontent.com/16895409/111117606-16999d80-85ab-11eb-8db8-119ae277bc43.mov

## 方針(Policy)

一旦効果が大きそうな商品詳細画面のみ対応しています。

## 実装に関する補足(Appendix)

Generator は他のプルリクで修正していただいていますので、変更から除外しました。

alt 属性もつけたかったが、商品名で良いのかの議論もあるのでいったん保留。

## テスト（Test)

目視で確認

- 商品数: 209個
- ページあたりの商品数: 60個
- Chrome, Firefox, Safari

ただし Safari は lazyload 非対応のため全画像読み込みとなった

Lighthouse で確認したところ、いくつかの警告が改善できていた。
スコアにはほとんど変化なかった。

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
