### PR TITLE
CSVインポートの時に文字列に含まれる改行コードを残すようにする

### DIFF
--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -1616,7 +1616,7 @@ class CsvImportController extends AbstractCsvImportController
 
             $data = $form['import_file']->getData();
             $src = new \SplFileObject($data->getRealPath());
-            $src->setFlags(\SplFileObject::READ_CSV | \SplFileObject::READ_AHEAD | \SplFileObject::SKIP_EMPTY | \SplFileObject::DROP_NEW_LINE);
+            $src->setFlags(\SplFileObject::READ_CSV | \SplFileObject::READ_AHEAD | \SplFileObject::SKIP_EMPTY);
 
             $fileNo = 1;
             $fileName = StringUtil::random(8);

--- a/src/Eccube/Service/CsvImportService.php
+++ b/src/Eccube/Service/CsvImportService.php
@@ -104,8 +104,7 @@ class CsvImportService implements \Iterator, \SeekableIterator, \Countable
         $this->file->setFlags(
             \SplFileObject::READ_CSV |
             \SplFileObject::SKIP_EMPTY |
-            \SplFileObject::READ_AHEAD |
-            \SplFileObject::DROP_NEW_LINE
+            \SplFileObject::READ_AHEAD
         );
         $this->file->setCsvControl(
             $delimiter,

--- a/tests/Eccube/Tests/Service/CsvImportServiceTest.php
+++ b/tests/Eccube/Tests/Service/CsvImportServiceTest.php
@@ -92,8 +92,11 @@ class CsvImportServiceTest extends AbstractServiceTestCase
         $file = new \SplFileObject(__DIR__.'/../../../Fixtures/data_blank_lines.csv');
         $CsvImportService = new CsvImportService($file);
         $CsvImportService->setColumnHeaders(['id', 'number', 'description']);
-
+        $blank_line = [ 0 => null ];
         foreach ($CsvImportService as $row) {
+            if ($row === $blank_line) {
+                continue;
+            }
             $this->assertNotNull($row['id']);
             $this->assertNotNull($row['number']);
             $this->assertNotNull($row['description']);


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
商品CSV登録時に商品説明等のCSVフィールド内改行が消えるのを修正します
#4647



## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
csvファイル読み出しのためのSplFileObjectを作る時にDROP_NEW_LINEフラグを付けないようにします。修正箇所は以下の二箇所です。

- Admin/Product/CsvImportController::splitCsv()で前処理としてアップロードされたcsvファイルを保存し直す時
- CsvImportServiceのコンストラクタで設定する時

また、以下のテストを修正しています。

- Eccube\Service\CsvImportService\testReadCsvFileWithTrailingBlankLines


## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
空行が含まれるCSVインポートを行うテストに関して、空行を検知して無視する処理を追加しています。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
CsvImportServiceはOrderのcsvインポートでも使用していますので、問題がないかを気にしています

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
