### PR TITLE
ProductImage削除するときに実ファイルが存在するかどうか調べない

### DIFF
--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -186,7 +186,6 @@ class ProductType extends AbstractType
             $form = $event->getForm();
             $saveImgDir = $this->eccubeConfig['eccube_save_image_dir'];
             $tempImgDir = $this->eccubeConfig['eccube_temp_image_dir'];
-            $this->validateFilePath($form->get('delete_images'), [$saveImgDir, $tempImgDir]);
             $this->validateFilePath($form->get('add_images'), [$tempImgDir]);
         });
     }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
#4911
ProductImageの実ファイルが存在しない場合、管理画面から削除することができなくなっているため、管理画面からの削除をするときにProductImageの実ファイル存在チェックを行わないようにする。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
  ProductTypeで行っているファイルパスをチェックするバリデーションをイメージ削除についてはやらないことにする。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
