### PR TITLE
console e:f:generate が動作しないのを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
   ;
 
 RUN docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
+  && docker-php-ext-configure gd --with-freetype-dir=/usr/include/freetype2 --with-png-dir=/usr/include --with-jpeg-dir=/usr/include \
   && docker-php-ext-install -j$(nproc) zip gd mysqli pdo_mysql opcache intl pgsql pdo_pgsql \
   ;
 

--- a/dockerbuild/php.ini
+++ b/dockerbuild/php.ini
@@ -3,3 +3,4 @@ opcache.max_accelerated_files = 20000
 opcache.memory_consumption=256
 realpath_cache_size = 4096K
 realpath_cache_ttl = 600
+memory_limit = 512M

--- a/src/Eccube/Command/GenerateDummyDataCommand.php
+++ b/src/Eccube/Command/GenerateDummyDataCommand.php
@@ -13,7 +13,7 @@
 
 namespace Eccube\Command;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Repository\DeliveryRepository;
 use Eccube\Repository\ProductRepository;
@@ -48,7 +48,7 @@ class GenerateDummyDataCommand extends Command
      */
     protected $productRepository;
 
-    public function __construct(Generator $generator = null, EntityManager $entityManager = null, DeliveryRepository $deliveryRepository = null, ProductRepository $productRepository = null)
+    public function __construct(Generator $generator = null, EntityManagerInterface $entityManager = null, DeliveryRepository $deliveryRepository = null, ProductRepository $productRepository = null)
     {
         parent::__construct();
         $this->generator = $generator;


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
dockerコンテナ内での
```
bin/console e:f:generate
```
が、以下の複数のエラーで動作しない
- bheller/images-generator 内のGD2関数が定義されていない
- GenerateDummyDataCommandのautowiringで、$entityManagerがnull
- オプションなし実行で、PHPのメモリー上限に達している

## 方針(Policy)
dockerを利用したダミーデータを正常に作成できること。
bin/console e:f:generate　を、オプションなしで正常に動作させられること。

## 実装に関する補足(Appendix)
以下の件については、他にも利用されている箇所がないか要確認
```
// 動作しない
EntityManager $entityManager
//　動作する
EntityManagerInterface $entityManager
```

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
ピュアなインストール状態でのコマンド動作を確認した。
```
docker-compose exec ec-cube bin/console e:f:generate
```

## 相談（Discussion）
オプションなしで実行できる方針の場合に、
phpのメモリーリミットを変更は、この方針で問題ないか。

修正パターン候補は以下かと思います。
1. php.iniでメモリーリミットを変更する (今回の修正パターン)
1. オプションなし実行の場合の生成ダミーデータ量を調整する

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
