### PR TITLE
EC-CUBE4.1でメンバーのパスワードが更新できないバグ修正

### DIFF
--- a/codeception/acceptance/EA08SysteminfoCest.php
+++ b/codeception/acceptance/EA08SysteminfoCest.php
@@ -77,8 +77,8 @@ class EA08SysteminfoCest
         $I->fillField(['id' => 'admin_member_name'], 'admintest');
         $I->fillField(['id' => 'admin_member_department'], 'admintest department');
         $I->fillField(['id' => 'admin_member_login_id'], 'admintest');
-        $I->fillField(['id' => 'admin_member_password_first'], 'password');
-        $I->fillField(['id' => 'admin_member_password_second'], 'password');
+        $I->fillField(['id' => 'admin_member_plain_password_first'], 'password');
+        $I->fillField(['id' => 'admin_member_plain_password_second'], 'password');
         $I->selectOption(['id' => 'admin_member_Authority'], 'システム管理者');
         $I->selectOption(['id' => 'admin_member_Work_1'], '稼働');
         $I->click('#member_form .c-conversionArea__container button');
@@ -105,8 +105,8 @@ class EA08SysteminfoCest
         $I->fillField(['id' => 'admin_member_name'], 'admintest2');
         $I->fillField(['id' => 'admin_member_department'], 'admintest department');
         $I->fillField(['id' => 'admin_member_login_id'], 'admintest');
-        $I->fillField(['id' => 'admin_member_password_first'], 'password');
-        $I->fillField(['id' => 'admin_member_password_second'], 'password');
+        $I->fillField(['id' => 'admin_member_plain_password_first'], 'password');
+        $I->fillField(['id' => 'admin_member_plain_password_second'], 'password');
         $I->selectOption(['id' => 'admin_member_Authority'], 'システム管理者');
         $I->selectOption(['id' => 'admin_member_Work_1'], '稼働');
         $I->click('#member_form .c-conversionArea__container .c-conversionArea__leftBlockItem a');

--- a/src/Eccube/Controller/Admin/Setting/System/MemberController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/MemberController.php
@@ -94,9 +94,6 @@ class MemberController extends AbstractController
      */
     public function create(Request $request)
     {
-        $LoginMember = clone $this->tokenStorage->getToken()->getUser();
-        $this->entityManager->detach($LoginMember);
-
         $Member = new Member();
         $builder = $this->formFactory
             ->createBuilder(MemberType::class, $Member);
@@ -113,11 +110,11 @@ class MemberController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             $encoder = $this->encoderFactory->getEncoder($Member);
             $salt = $encoder->createSalt();
-            $rawPassword = $Member->getPassword();
-            $encodedPassword = $encoder->encodePassword($rawPassword, $salt);
+            $password = $Member->getPlainPassword();
+            $password = $encoder->encodePassword($password, $salt);
             $Member
                 ->setSalt($salt)
-                ->setPassword($encodedPassword);
+                ->setPassword($password);
 
             $this->memberRepository->save($Member);
 
@@ -134,8 +131,6 @@ class MemberController extends AbstractController
 
             return $this->redirectToRoute('admin_setting_system_member_edit', ['id' => $Member->getId()]);
         }
-
-        $this->tokenStorage->getToken()->setUser($LoginMember);
 
         return [
             'form' => $form->createView(),

--- a/src/Eccube/Entity/Member.php
+++ b/src/Eccube/Entity/Member.php
@@ -16,6 +16,7 @@ namespace Eccube\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 if (!class_exists('\Eccube\Entity\Member')) {
@@ -98,6 +99,12 @@ if (!class_exists('\Eccube\Entity\Member')) {
          * @ORM\Column(name="login_id", type="string", length=255)
          */
         private $login_id;
+
+        /**
+         * @Assert\NotBlank()
+         * @Assert\Length(max=4096)
+         */
+        private $plainPassword;
 
         /**
          * @var string
@@ -265,6 +272,26 @@ if (!class_exists('\Eccube\Entity\Member')) {
         public function getLoginId()
         {
             return $this->login_id;
+        }
+
+        /**
+         * @return string
+         */
+        public function getPlainPassword(): string
+        {
+            return $this->plainPassword;
+        }
+
+        /**
+         * @param string $password
+         *
+         * @return $this
+         */
+        public function setPlainPassword(string $password): self
+        {
+            $this->plainPassword = $password;
+
+            return $this;
         }
 
         /**

--- a/src/Eccube/Entity/Member.php
+++ b/src/Eccube/Entity/Member.php
@@ -275,9 +275,9 @@ if (!class_exists('\Eccube\Entity\Member')) {
         }
 
         /**
-         * @return string
+         * @return string|null
          */
-        public function getPlainPassword(): string
+        public function getPlainPassword(): ?string
         {
             return $this->plainPassword;
         }

--- a/src/Eccube/Form/Type/Admin/MemberType.php
+++ b/src/Eccube/Form/Type/Admin/MemberType.php
@@ -75,19 +75,6 @@ class MemberType extends AbstractType
                     new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
                 ],
             ])
-            ->add('login_id', TextType::class, [
-                'constraints' => [
-                    new Assert\NotBlank(),
-                    new Assert\Length([
-                        'min' => $this->eccubeConfig['eccube_id_min_len'],
-                        'max' => $this->eccubeConfig['eccube_id_max_len'],
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => '/^[[:graph:][:space:]]+$/i',
-                        'message' => 'form_error.graph_only',
-                    ]),
-                ],
-            ])
             ->add('plain_password', RepeatedPasswordType::class, [
                 'first_options' => [
                     'label' => 'admin.setting.system.member.password',
@@ -115,6 +102,38 @@ class MemberType extends AbstractType
             ])
             ->add('two_factor_auth_enabled', ToggleSwitchType::class, [
             ]);
+
+        // login idの入力は新規登録時のみとし、編集時はdisabledにする
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
+            $form = $event->getForm();
+            $data = $event->getData();
+
+            $options = [
+                'constraints' => [
+                    new Assert\Length([
+                        'min' => $this->eccubeConfig['eccube_id_min_len'],
+                        'max' => $this->eccubeConfig['eccube_id_max_len'],
+                    ]),
+                    new Assert\Regex([
+                        'pattern' => '/^[[:graph:][:space:]]+$/i',
+                        'message' => 'form_error.graph_only',
+                    ]),
+                ],
+            ];
+
+            if ($data->getId() === null) {
+                $options['constraints'][] = new Assert\NotBlank();
+            } else {
+                $options['required'] = false;
+                $options['mapped'] = false;
+                $options['attr'] = [
+                    'disabled' => 'disabled'
+                ];
+                $options['data'] = $data->getLoginId();
+            }
+
+            $form->add('login_id', TextType::class, $options);
+        });
 
         $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
             /** @var Member $Member */

--- a/src/Eccube/Form/Type/Admin/MemberType.php
+++ b/src/Eccube/Form/Type/Admin/MemberType.php
@@ -88,7 +88,7 @@ class MemberType extends AbstractType
                     ]),
                 ],
             ])
-            ->add('plainPassword', RepeatedPasswordType::class, [
+            ->add('plain_password', RepeatedPasswordType::class, [
                 'first_options' => [
                     'label' => 'admin.setting.system.member.password',
                 ],

--- a/src/Eccube/Form/Type/Admin/MemberType.php
+++ b/src/Eccube/Form/Type/Admin/MemberType.php
@@ -88,7 +88,7 @@ class MemberType extends AbstractType
                     ]),
                 ],
             ])
-            ->add('password', RepeatedPasswordType::class, [
+            ->add('plainPassword', RepeatedPasswordType::class, [
                 'first_options' => [
                     'label' => 'admin.setting.system.member.password',
                 ],

--- a/src/Eccube/Resource/template/admin/Setting/System/member_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/member_edit.twig
@@ -87,9 +87,9 @@ file that was distributed with this source code.
                                     <div class="col">
                                         <div class="row">
                                             <div class="col">
-                                                {{ form_widget(form.password.first, { type : 'password'}) }}
+                                                {{ form_widget(form.plainPassword.first, { type : 'password'}) }}
                                             </div>
-                                            {{ form_errors(form.password.first) }}
+                                            {{ form_errors(form.plainPassword.first) }}
                                         </div>
                                     </div>
                                 </div>
@@ -101,9 +101,9 @@ file that was distributed with this source code.
                                     <div class="col">
                                         <div class="row">
                                             <div class="col">
-                                                {{ form_widget(form.password.second, { type : 'password'}) }}
+                                                {{ form_widget(form.plainPassword.second, { type : 'password'}) }}
                                             </div>
-                                            {{ form_errors(form.password.second) }}
+                                            {{ form_errors(form.plainPassword.second) }}
                                         </div>
                                     </div>
                                 </div>

--- a/src/Eccube/Resource/template/admin/Setting/System/member_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/member_edit.twig
@@ -87,9 +87,9 @@ file that was distributed with this source code.
                                     <div class="col">
                                         <div class="row">
                                             <div class="col">
-                                                {{ form_widget(form.plainPassword.first, { type : 'password'}) }}
+                                                {{ form_widget(form.plain_password.first, { type : 'password'}) }}
                                             </div>
-                                            {{ form_errors(form.plainPassword.first) }}
+                                            {{ form_errors(form.plain_password.first) }}
                                         </div>
                                     </div>
                                 </div>
@@ -101,9 +101,9 @@ file that was distributed with this source code.
                                     <div class="col">
                                         <div class="row">
                                             <div class="col">
-                                                {{ form_widget(form.plainPassword.second, { type : 'password'}) }}
+                                                {{ form_widget(form.plain_password.second, { type : 'password'}) }}
                                             </div>
-                                            {{ form_errors(form.plainPassword.second) }}
+                                            {{ form_errors(form.plain_password.second) }}
                                         </div>
                                     </div>
                                 </div>

--- a/tests/Eccube/Tests/Form/Type/Admin/MemberTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/MemberTypeTest.php
@@ -26,7 +26,7 @@ class MemberTypeTest extends AbstractTypeTestCase
         'name' => 'タカハシ',
         'department' => 'EC-CUBE事業部',
         'login_id' => 'takahashi',
-        'password' => [
+        'plain_password' => [
             'first' => 'password',
             'second' => 'password',
         ],

--- a/tests/Eccube/Tests/Form/Type/Admin/MemberTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/MemberTypeTest.php
@@ -13,6 +13,7 @@
 
 namespace Eccube\Tests\Form\Type\Admin;
 
+use Eccube\Entity\Member;
 use Eccube\Form\Type\Admin\MemberType;
 use Eccube\Tests\Form\Type\AbstractTypeTestCase;
 
@@ -40,7 +41,7 @@ class MemberTypeTest extends AbstractTypeTestCase
 
         // CSRF tokenを無効にしてFormを作成
         $this->form = $this->formFactory
-            ->createBuilder(MemberType::class, null, [
+            ->createBuilder(MemberType::class, new Member(), [
                 'csrf_protection' => false,
             ])
             ->getForm();
@@ -182,5 +183,24 @@ class MemberTypeTest extends AbstractTypeTestCase
         $this->form->submit($this->formData);
 
         $this->assertFalse($this->form->isValid());
+    }
+
+    public function testLoginIdNotChanged()
+    {
+        $Member = $this->createMember();
+        $loginId = $Member->getLoginId();
+
+        $this->form = $this->formFactory
+            ->createBuilder(MemberType::class, $Member, [
+                'csrf_protection' => false,
+            ])
+            ->getForm();
+
+        $this->form->submit($this->formData);
+
+        $this->assertTrue($this->form->isValid());
+
+        // login_idが変更されないことを確認
+        $this->assertSame($Member->getLoginId(), $loginId);
     }
 }

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/MemberControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/MemberControllerTest.php
@@ -179,6 +179,7 @@ class MemberControllerTest extends AbstractAdminWebTestCase
             'second' => '**********',
         ];
         $Member = $this->createMember();
+        $loginId = $Member->getLoginId();
         $Member->setPassword('**********');
         $this->entityManager->persist($Member);
         $this->entityManager->flush();
@@ -193,16 +194,19 @@ class MemberControllerTest extends AbstractAdminWebTestCase
         $redirectUrl = $this->generateUrl('admin_setting_system_member_edit', ['id' => $Member->getId()]);
         $this->assertTrue($this->client->getResponse()->isRedirect($redirectUrl));
 
-        $this->actual = $Member->getLoginId();
-        $this->expected = $formData['login_id'];
+        $this->actual = $Member->getName();
+        $this->expected = $formData['name'];
         $this->verify();
+
+        // login_idが変更されないことを確認
+        $this->assertSame($Member->getLoginId(), $loginId);
     }
 
     public function testMemberEditSubmitFail()
     {
         // before
         $formData = $this->createFormData();
-        $formData['login_id'] = '';
+        $formData['name'] = '';
         $Member = $this->createMember();
         $Member->setPassword('**********');
         $this->entityManager->persist($Member);

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/MemberControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/MemberControllerTest.php
@@ -174,7 +174,7 @@ class MemberControllerTest extends AbstractAdminWebTestCase
     {
         // before
         $formData = $this->createFormData();
-        $formData['password'] = [
+        $formData['plain_password'] = [
             'first' => '**********',
             'second' => '**********',
         ];
@@ -342,7 +342,7 @@ class MemberControllerTest extends AbstractAdminWebTestCase
             'name' => $faker->word,
             'department' => $faker->word,
             'login_id' => 'logintest',
-            'password' => [
+            'plain_password' => [
                 'first' => 'password',
                 'second' => 'password',
             ],


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

EC-CUBE4.1になってメンバーのパスワードが更新できなくなっていたので修正しました。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
