### PR TITLE
管理画面 商品のタグによる絞り込み

### DIFF
--- a/src/Eccube/Form/Type/Admin/SearchProductType.php
+++ b/src/Eccube/Form/Type/Admin/SearchProductType.php
@@ -16,10 +16,13 @@ namespace Eccube\Form\Type\Admin;
 use Eccube\Entity\Category;
 use Eccube\Entity\Master\ProductStatus;
 use Eccube\Entity\ProductStock;
+use Eccube\Entity\Tag;
 use Eccube\Form\Type\Master\CategoryType as MasterCategoryType;
 use Eccube\Form\Type\Master\ProductStatusType;
 use Eccube\Repository\CategoryRepository;
 use Eccube\Repository\Master\ProductStatusRepository;
+use Eccube\Repository\TagRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
@@ -40,15 +43,25 @@ class SearchProductType extends AbstractType
     protected $categoryRepository;
 
     /**
+     * @var TagRepository
+     */
+    protected $tagRepository;
+
+    /**
      * SearchProductType constructor.
      *
      * @param ProductStatusRepository $productStatusRepository
      * @param CategoryRepository $categoryRepository
+     * @param TagRepository $tagRepository
      */
-    public function __construct(ProductStatusRepository $productStatusRepository, CategoryRepository $categoryRepository)
-    {
+    public function __construct(
+        ProductStatusRepository $productStatusRepository,
+        CategoryRepository $categoryRepository,
+        TagRepository $tagRepository
+    ) {
         $this->productStatusRepository = $productStatusRepository;
         $this->categoryRepository = $categoryRepository;
+        $this->tagRepository = $tagRepository;
     }
 
     /**
@@ -91,6 +104,15 @@ class SearchProductType extends AbstractType
                 ],
                 'expanded' => true,
                 'multiple' => true,
+            ])
+            ->add('tag_id', EntityType::class, [
+                'class' => Tag::class,
+                'label' => 'admin.product.tag',
+                'placeholder' => 'common.select__all_products',
+                'choice_label' => 'name',
+                'required' => false,
+                'multiple' => false,
+                'expanded' => false,
             ])
             ->add('create_date_start', DateType::class, [
                 'label' => 'admin.common.create_date__start',

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -303,6 +303,14 @@ class ProductRepository extends AbstractRepository
             }
         }
 
+        // tag
+        if (!empty($searchData['tag_id']) && $searchData['tag_id']) {
+            $qb
+                ->innerJoin('p.ProductTag', 'pt')
+                ->andWhere('pt.Tag = :tag_id')
+                ->setParameter('tag_id', $searchData['tag_id']);
+        }
+
         // crate_date
         if (!empty($searchData['create_datetime_start']) && $searchData['create_datetime_start']) {
             $date = $searchData['create_datetime_start'];

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -229,6 +229,13 @@ file that was distributed with this source code.
                         </div>
                     </div>
                     <div class="col-6">
+                        <div class="form-row mb-2">
+                            <div class="col-6">
+                                <label class="col-form-label">{{ 'admin.product.tag'|trans }}</label>
+                                {{ form_widget(searchForm.tag_id) }}
+                                {{ form_errors(searchForm.tag_id) }}
+                            </div>
+                        </div>
                         <div class="mb-2">
                             <label class="col-form-label">
                                 {{ 'admin.common.create_date'|trans }}

--- a/tests/Eccube/Tests/Repository/AbstractProductRepositoryTestCase.php
+++ b/tests/Eccube/Tests/Repository/AbstractProductRepositoryTestCase.php
@@ -14,8 +14,11 @@
 namespace Eccube\Tests\Repository;
 
 use Eccube\Entity\CustomerFavoriteProduct;
-use Eccube\Tests\EccubeTestCase;
+use Eccube\Entity\Product;
+use Eccube\Entity\ProductTag;
 use Eccube\Repository\ProductRepository;
+use Eccube\Repository\TagRepository;
+use Eccube\Tests\EccubeTestCase;
 
 /**
  * ProductRepository test cases.
@@ -30,6 +33,11 @@ abstract class AbstractProductRepositoryTestCase extends EccubeTestCase
     protected $productRepository;
 
     /**
+     * @var TagRepository
+     */
+    protected $tagRepository;
+
+    /**
      * {@inheritdoc}
      */
     public function setUp()
@@ -37,6 +45,7 @@ abstract class AbstractProductRepositoryTestCase extends EccubeTestCase
         parent::setUp();
 
         $this->productRepository = $this->entityManager->getRepository(\Eccube\Entity\Product::class);
+        $this->tagRepository = $this->entityManager->getRepository(\Eccube\Entity\Tag::class);
 
         $tables = [
             'dtb_product_image',
@@ -64,6 +73,26 @@ abstract class AbstractProductRepositoryTestCase extends EccubeTestCase
             $Fav->setProduct($Product)
                 ->setCustomer($Customer);
             $this->entityManager->persist($Fav);
+        }
+        $this->entityManager->flush();
+    }
+
+    /**
+     * 商品にタグをつける
+     *
+     * @param Product $Product
+     * @param array $tagIds
+     */
+    protected function setProductTags(Product $Product, array $tagIds)
+    {
+        $Tags = $this->tagRepository->findBy(['id' => $tagIds]);
+        foreach ($Tags as $Tag) {
+            $ProductTag = new ProductTag();
+            $ProductTag
+                ->setProduct($Product)
+                ->setTag($Tag);
+            $Product->addProductTag($ProductTag);
+            $this->entityManager->persist($ProductTag);
         }
         $this->entityManager->flush();
     }

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataAdminTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataAdminTest.php
@@ -366,4 +366,53 @@ class ProductRepositoryGetQueryBuilderBySearchDataAdminTest extends AbstractProd
             $this->verify();
         }
     }
+
+    public function testTagSearch()
+    {
+        // データの事前準備
+        // * 商品1 に タグ 1 を設定
+        // * 商品2 に タグ 1, 2 を設定
+        $Products = $this->productRepository->findAll();
+        $Products[0]->setName('りんご');
+        $this->setProductTags($Products[0], [1]);
+        $this->setProductTags($Products[1], [1, 2]);
+        $this->entityManager->flush();
+
+        // タグ 1 で検索
+        $this->searchData = [
+            'tag_id' => 1,
+        ];
+        $this->scenario();
+        $this->assertCount(2, $this->Results);
+
+        // タグ 2 で検索
+        $this->searchData = [
+            'tag_id' => 2,
+        ];
+        $this->scenario();
+        $this->assertCount(1, $this->Results);
+
+        // タグ 3 で検索
+        $this->searchData = [
+            'tag_id' => 3,
+        ];
+        $this->scenario();
+        $this->assertCount(0, $this->Results);
+
+        // 文字列とのAND検索 → 結果あり
+        $this->searchData = [
+            'id' => 'りんご',
+            'tag_id' => 1,
+        ];
+        $this->scenario();
+        $this->assertCount(1, $this->Results);
+
+        // 文字列とのAND検索 → 結果0件
+        $this->searchData = [
+            'id' => 'りんご',
+            'tag_id' => 2,
+        ];
+        $this->scenario();
+        $this->assertCount(0, $this->Results);
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
4.1-feature 向けのPRです。
管理画面の商品一覧にて、タグによる商品の絞り込みを行えるようにします。
https://github.com/EC-CUBE/ec-cube/issues/4862

![スクリーンショット 2021-03-18 15 36 27](https://user-images.githubusercontent.com/73213/111584021-a1bfa100-8800-11eb-968f-68e774b52f26.png)

## 方針(Policy)
ひとまず #4862 タグ検索機能に関し、管理画面部分のみのPRを作成しました。

フロント画面の検索については別途作成 #4976 

## 実装に関する補足(Appendix)

## テスト（Test)
タグ単体の絞り込みと、タグ・商品名のAND検索について、
テストコードを記述しています。

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか

### 新機能追加に伴う競合確認

- [x] プラグインとの競合がないか
    - <https://www.ec-cube.net/products/detail.php?product_id=2014> → 管理画面にタグの検索ボックスが2つ表示されるが、検索自体は動作問題なし
- [x] プラグインからのマイグレーションが必要か