### PR TITLE
フロント検索ボックス、商品のタグ名による絞り込み

### DIFF
--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -158,8 +158,18 @@ class ProductRepository extends AbstractRepository
                 $qb
                     ->andWhere(sprintf('NORMALIZE(p.name) LIKE NORMALIZE(:%s) OR
                         NORMALIZE(p.search_word) LIKE NORMALIZE(:%s) OR
-                        EXISTS (SELECT wpc%d FROM \Eccube\Entity\ProductClass wpc%d WHERE p = wpc%d.Product AND NORMALIZE(wpc%d.code) LIKE NORMALIZE(:%s))',
-                        $key, $key, $index, $index, $index, $index, $key))
+                        EXISTS (SELECT wpc%d FROM \Eccube\Entity\ProductClass wpc%d WHERE p = wpc%d.Product AND NORMALIZE(wpc%d.code) LIKE NORMALIZE(:%s)) OR
+                        EXISTS (
+                            SELECT wpt%d from \Eccube\Entity\ProductTag wpt%d
+                            WHERE p = wpt%d.Product AND
+                                wpt%d.Tag IN (
+                                    SELECT wt%d FROM \Eccube\Entity\Tag wt%d
+                                    WHERE NORMALIZE(wt%d.name) LIKE NORMALIZE(:%s)
+                                )
+                        )',
+                        $key, $key,
+                        $index, $index, $index, $index, $key,
+                        $index, $index, $index, $index, $index, $index, $index, $key))
                     ->setParameter($key, '%'.$keyword.'%');
             }
         }

--- a/tests/Eccube/Tests/Repository/AbstractProductRepositoryTestCase.php
+++ b/tests/Eccube/Tests/Repository/AbstractProductRepositoryTestCase.php
@@ -85,6 +85,12 @@ abstract class AbstractProductRepositoryTestCase extends EccubeTestCase
      */
     protected function setProductTags(Product $Product, array $tagIds)
     {
+        $ProductTags = $Product->getProductTag();
+        foreach ($ProductTags as $ProductTag) {
+            $Product->removeProductTag($ProductTag);
+            $this->entityManager->remove($ProductTag);
+        }
+
         $Tags = $this->tagRepository->findBy(['id' => $tagIds]);
         foreach ($Tags as $Tag) {
             $ProductTag = new ProductTag();

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataAdminTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataAdminTest.php
@@ -376,6 +376,7 @@ class ProductRepositoryGetQueryBuilderBySearchDataAdminTest extends AbstractProd
         $Products[0]->setName('りんご');
         $this->setProductTags($Products[0], [1]);
         $this->setProductTags($Products[1], [1, 2]);
+        $this->setProductTags($Products[2], []);
         $this->entityManager->flush();
 
         // タグ 1 で検索

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
@@ -393,4 +393,51 @@ class ProductRepositoryGetQueryBuilderBySearchDataTest extends AbstractProductRe
         }
         $this->verify();
     }
+
+    public function testTagSearch()
+    {
+        // データの事前準備
+        // * 商品A に タグ 1 を設定
+        // * 商品B に タグ 2, 2 を設定
+        $Products = $this->productRepository->findAll();
+        $Products[1]->setName('りんご');
+        $this->setProductTags($Products[1], [1]);
+        $this->setProductTags($Products[2], [1, 2]);
+        $this->entityManager->flush();
+
+        // タグ 1 で検索
+        $this->searchData = [
+            'name' => '新商品',
+        ];
+        $this->scenario();
+        $this->assertCount(2, $this->Results);
+
+        // タグ 2 で検索
+        $this->searchData = [
+            'name' => 'おすすめ商品',
+        ];
+        $this->scenario();
+        $this->assertCount(1, $this->Results);
+
+        // タグ 1 and タグ 2 で検索
+        $this->searchData = [
+            'name' => '新商品 おすすめ商品',
+        ];
+        $this->scenario();
+        $this->assertCount(1, $this->Results);
+
+        // タグ 1 and 商品名 で検索
+        $this->searchData = [
+            'name' => '新商品 りんご',
+        ];
+        $this->scenario();
+        $this->assertCount(1, $this->Results);
+
+        // タグ 3 で検索
+        $this->searchData = [
+            'name' => '限定品',
+        ];
+        $this->scenario();
+        $this->assertCount(0, $this->Results);
+    }
 }

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
@@ -401,8 +401,9 @@ class ProductRepositoryGetQueryBuilderBySearchDataTest extends AbstractProductRe
         // * 商品B に タグ 2, 2 を設定
         $Products = $this->productRepository->findAll();
         $Products[1]->setName('りんご');
-        $this->setProductTags($Products[1], [1]);
-        $this->setProductTags($Products[2], [1, 2]);
+        $this->setProductTags($Products[0], [1]);
+        $this->setProductTags($Products[1], [1, 2]);
+        $this->setProductTags($Products[2], []);
         $this->entityManager->flush();
 
         // タグ 1 で検索


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
4.1-feature 向けのPRです。
フロントの検索ボックスにて、タグ名での検索を行えるようにします
#4862
いったんPR作成しましたが、ちょっとクエリ記述部分が悩ましいのでご意見いただけたらと思います。

## 方針(Policy)
商品に付与されたタグ名を、検索ボックスからの検索対象にします。

例: 「新商品」タグが付与された商品は、「新商品」という文字列で検索した場合、検索にひっかかるようになる

フロントの見た目・UI変更はありません。

## 実装に関する補足(Appendix)
管理画面側のタグ検索は別PRにて
https://github.com/EC-CUBE/ec-cube/pull/4975

## テスト（Test)
タグ名による検索、複数のタグ名でのand検索、タグ名と商品名のand検索、のテストを追加しています

## 相談（Discussion）
現状の検索処理 ProductRepository の `getQueryBuilderBySearchData()` では、規格の商品コードを検索対象としています。
今回はそれと同様にタグ名を検索対象とするよう、直後にSQLを追記しました。
が、SQLの記述が長くなってきましてこれで良いのか判断しかねています。

たとえばクエリビルダの `expr()->orX()` あたりを使って分割・書き換えたほうがよいか、
他になにかよい手があればアドバイスいただきたい感じです

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか

### 新機能追加に伴う競合確認

- [x] プラグインとの競合がないか → 検索の挙動に問題ありませんでした
    - https://www.ec-cube.net/products/detail.php?product_id=1862
    - https://www.ec-cube.net/products/detail.php?product_id=2157
    - https://www.ec-cube.net/products/detail.php?product_id=1709
    - https://www.ec-cube.net/products/detail.php?product_id=2156
- [x] プラグインからのマイグレーションが必要か

3件タグ関連のプラグインあり、調査してチェック