### PR TITLE
商品詳細ページに構造化データを追加

### DIFF
--- a/codeception/acceptance/EF02ProductCest.php
+++ b/codeception/acceptance/EF02ProductCest.php
@@ -183,6 +183,19 @@ class EF02ProductCest
         $I->assertRegExp('/\/upload\/save_image\/sand-2\.png$/', $img, $img.' が見つかりません');
     }
 
+    /**
+     * @group EF0202-UC01-T04
+     */
+    public function product_商品詳細構造化データ(\AcceptanceTester $I)
+    {
+        $I->wantTo('EF0202-UC01-T04 商品詳細 構造化データ'); // todo
+
+        ProductDetailPage::go($I, 1);
+        $html = $I->grabAttributeFrom('script[type="application/ld+json"]', 'innerHTML');
+        $json_ld = json_decode((string)$html);
+        $I->assertEquals($json_ld->name, '彩のジェラートCUBE');
+    }
+
     public function product_商品詳細カート1(\AcceptanceTester $I)
     {
         $I->wantTo('EF0202-UC02-T01 商品詳細 カート 注文数＜販売制限数＜在庫数の注文');

--- a/codeception/acceptance/EF02ProductCest.php
+++ b/codeception/acceptance/EF02ProductCest.php
@@ -183,19 +183,6 @@ class EF02ProductCest
         $I->assertRegExp('/\/upload\/save_image\/sand-2\.png$/', $img, $img.' が見つかりません');
     }
 
-    /**
-     * @group EF0202-UC01-T04
-     */
-    public function product_商品詳細構造化データ(\AcceptanceTester $I)
-    {
-        $I->wantTo('EF0202-UC01-T04 商品詳細 構造化データ'); // todo
-
-        ProductDetailPage::go($I, 1);
-        $html = $I->grabAttributeFrom('script[type="application/ld+json"]', 'innerHTML');
-        $json_ld = json_decode((string)$html);
-        $I->assertEquals($json_ld->name, '彩のジェラートCUBE');
-    }
-
     public function product_商品詳細カート1(\AcceptanceTester $I)
     {
         $I->wantTo('EF0202-UC02-T01 商品詳細 カート 注文数＜販売制限数＜在庫数の注文');

--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -227,12 +227,12 @@ file that was distributed with this source code.
                 "{{ url('homepage') }}{{ asset(no_image_product, 'save_image') }}"
             {% endfor %}
         ],
-        "description": "{{ Product.description_list | default(Product.description_detail) | striptags | replace({"\n": '', "\r": ''}, '') }}",
+        "description": "{{ Product.description_list | default(Product.description_detail) | striptags | replace({'\n': '', '\r': ''}) }}",
         "sku": "{{ Product.code_min }}",
         "offers": {
             "@type": "Offer",
             "url": "{{ url('product_detail', {'id': Product.id}) }}",
-            "priceCurrency": "JPY",
+            "priceCurrency": "{{ eccube_config.currency }}",
             "price": {{ Product.getPrice02IncTaxMin }},
             "availability": "{{ Product.stock_find ? "InStock" : "OutOfStock" }}"
         }

--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -224,11 +224,13 @@ file that was distributed with this source code.
                 "{{ app.request.schemeAndHttpHost }}{{ asset(img, 'save_image') }}"{% if not loop.last %},{% endif %}
 
             {% else %}
-                "{{ app.request.schemeAndHttpHost }}{{ asset(no_image_product, 'save_image') }}"
+                "{{ app.request.schemeAndHttpHost }}{{ asset(''|no_image_product, 'save_image') }}"
             {% endfor %}
         ],
-        "description": "{{ Product.description_list | default(Product.description_detail) | striptags | replace({'\n': '', '\r': ''}) }}",
+        "description": "{{ Product.description_list | default(Product.description_detail) | replace({'\n': '', '\r': ''}) | slice(0,300) }}",
+        {% if Product.code_min %}
         "sku": "{{ Product.code_min }}",
+        {% endif %}
         "offers": {
             "@type": "Offer",
             "url": "{{ url('product_detail', {'id': Product.id}) }}",

--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -221,10 +221,10 @@ file that was distributed with this source code.
         "name": "{{ Product.name }}",
         "image": [
             {% for img in Product.ProductImage %}
-                "{{ url('homepage') }}{{ asset(img, 'save_image') }}" {% if not loop.last %},{% endif %}
+                "{{ app.request.schemeAndHttpHost }}{{ asset(img, 'save_image') }}"{% if not loop.last %},{% endif %}
 
             {% else %}
-                "{{ url('homepage') }}{{ asset(no_image_product, 'save_image') }}"
+                "{{ app.request.schemeAndHttpHost }}{{ asset(no_image_product, 'save_image') }}"
             {% endfor %}
         ],
         "description": "{{ Product.description_list | default(Product.description_detail) | striptags | replace({'\n': '', '\r': ''}) }}",

--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -214,6 +214,30 @@ file that was distributed with this source code.
             $('.ec-modal').hide()
         });
     </script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org/",
+        "@type": "Product",
+        "name": "{{ Product.name }}",
+        "image": [
+            {% for img in Product.ProductImage %}
+                "{{ url('homepage') }}{{ asset(img, 'save_image') }}" {% if not loop.last %},{% endif %}
+
+            {% else %}
+                "{{ url('homepage') }}{{ asset(no_image_product, 'save_image') }}"
+            {% endfor %}
+        ],
+        "description": "{{ Product.description_list | default(Product.description_detail) | striptags | replace({"\n": '', "\r": ''}, '') }}",
+        "sku": "{{ Product.code_min }}",
+        "offers": {
+            "@type": "Offer",
+            "url": "{{ url('product_detail', {'id': Product.id}) }}",
+            "priceCurrency": "JPY",
+            "price": {{ Product.getPrice02IncTaxMin }},
+            "availability": "{{ Product.stock_find ? "InStock" : "OutOfStock" }}"
+        }
+    }
+    </script>
 {% endblock %}
 
 {% block main %}

--- a/tests/Eccube/Tests/Web/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/ProductControllerTest.php
@@ -250,4 +250,31 @@ class ProductControllerTest extends AbstractWebTestCase
         $html = $crawler->filter('div.ec-productRole__profile')->html();
         $this->assertContains('お気に入りに追加済です', $html);
     }
+
+    /**
+     * 商品詳細ページの構造化データ
+     */
+    public function testProductStructureData()
+    {
+        $crawler = $this->client->request('GET', $this->generateUrl('product_detail', ['id' => 2]));
+        $json = json_decode(html_entity_decode($crawler->filter('script[type="application/ld+json"]')->html()));
+        $this->assertEquals('Product', $json->{'@type'});
+        $this->assertEquals('チェリーアイスサンド', $json->name);
+        $this->assertEquals(3080, $json->offers->price);
+        $this->assertEquals('InStock', $json->offers->availability);
+
+        // 在庫なし商品のテスト
+        $Product = $this->createProduct('Product no stock', 1);
+        $ProductClass = $Product->getProductClasses()->first();
+        $ProductClass->setStockUnlimited(false);
+        $ProductClass->setStock(0);
+        $ProductStock = $ProductClass->getProductStock();
+        $ProductStock->setStock(0);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', $this->generateUrl('product_detail', ['id' => $Product->getId()]));
+        $json = json_decode(html_entity_decode($crawler->filter('script[type="application/ld+json"]')->html()));
+        $this->assertEquals('Product no stock', $json->name);
+        $this->assertEquals('OutOfStock', $json->offers->availability);
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
4.1 feature 向けのPRです。

商品詳細ページに、構造化データ (JSON-LD形式) を埋め込みます

## 方針(Policy)
SEO的な観点で、商品詳細ページに構造化データの JSON を追加します。

構造化データに関するドキュメント
https://developers.google.com/search/docs/data-types/product?hl=ja

関連issue
https://github.com/EC-CUBE/ec-cube/issues/4807

## 実装に関する補足(Appendix)

## テスト（Test)
商品詳細ページにおいて、JSON+LDの内容を確認するWebテストを追加しました。

また、構造化データテストツールにて、設定したJSON-LD形式にエラーのないことを確認しています。
(一部警告あり → 推奨フィールドに設定できる値がないため)
https://search.google.com/structured-data/testing-tool

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか

### 新機能追加に伴う競合確認

- [x] プラグインとの競合がないか
- [x] プラグインからのマイグレーションが必要か