### PR TITLE
SEO関連メタタグの設定

### DIFF
--- a/src/Eccube/Resource/template/default/default_frame.twig
+++ b/src/Eccube/Resource/template/default/default_frame.twig
@@ -17,14 +17,14 @@ file that was distributed with this source code.
     <title>{{ BaseInfo.shop_name }}{% if subtitle is defined and subtitle is not empty %} / {{ subtitle }}{% elseif title is defined and title is not empty %} / {{ title }}{% endif %}</title>
     {% if Page.meta_tags is not empty %}
         {{ include(template_from_string(Page.meta_tags)) }}
+        {% if Page.description is not empty %}
+            <meta name="description" content="{{ Page.description }}">
+        {% endif %}
     {% else %}
         {{ include('meta.twig') }}
     {% endif %}
     {% if Page.author is not empty %}
         <meta name="author" content="{{ Page.author }}">
-    {% endif %}
-    {% if Page.description is not empty %}
-        <meta name="description" content="{{ Page.description }}">
     {% endif %}
     {% if Page.keyword is not empty %}
         <meta name="keywords" content="{{ Page.keyword }}">

--- a/src/Eccube/Resource/template/default/meta.twig
+++ b/src/Eccube/Resource/template/default/meta.twig
@@ -1,4 +1,4 @@
-{% if Product is defined %}
+{% if app.request.get('_route') == 'product_detail' %}
     {% set meta_og_type = "og:product" %}
     {% set meta_description = Product.description_list | default(Product.description_detail) | default(Page.description) %}
     {% set meta_canonical = url('product_detail', {'id': Product.id}) %}
@@ -8,17 +8,17 @@
     <meta property="product:price:currency" content="{{ eccube_config.currency }}"/>
     <meta property="product:product_link" content="{{ url('product_detail', {'id': Product.id}) }}"/>
     <meta property="product:retailer_title" content="{{ BaseInfo.shop_name }}"/>
-{% elseif Category is defined %}
-    {% set meta_og_type = 'article' %}
-    {% set meta_description = Page.description %}
+{% elseif app.request.get('_route') == 'product_list' %}
     {% set meta_canonical = url('product_list', {'category_id': Category.id|default(null)}) %}
-{% elseif Page is defined %}
-    {% set meta_og_type = (app.request.get('_route') == 'homepage') ? 'website' : 'article' %}
-    {% set meta_description = Page.description %}
+{% elseif app.request.get('_route') == 'homepage' %}
+    {% set meta_og_type = 'website' %}
+    {% set meta_canonical = url('homepage') %}
 {% endif %}
-<meta property="og:type" content="{{ meta_og_type }}"/>
+
+<meta property="og:type" content="{{ meta_og_type|default('article') }}"/>
 <meta property="og:site_name" content="{{ BaseInfo.shop_name }}"/>
-{% if meta_description|default() %}
+{% set meta_description = meta_description | default(Page.description) %}
+{% if meta_description %}
     <meta name="description" content="{{ meta_description|striptags|slice(0,120) }}">
     <meta property="og:description" content="{{ meta_description|striptags|slice(0,120) }}"/>
 {% endif %}

--- a/tests/Eccube/Tests/Web/TopControllerTest.php
+++ b/tests/Eccube/Tests/Web/TopControllerTest.php
@@ -13,9 +13,10 @@
 
 namespace Eccube\Tests\Web;
 
+use Eccube\Entity\BaseInfo;
+use Eccube\Entity\Page;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\PageRepository;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class TopControllerTest extends AbstractWebTestCase
 {
@@ -39,11 +40,15 @@ class TopControllerTest extends AbstractWebTestCase
     {
         // description を設定
         $description = 'あのイーハトーヴォのすきとおった風、夏でも底に冷たさをもつ青いそら、うつくしい森で飾られたモリーオ市、郊外のぎらぎらひかる草の波。';
-        $page = $this->container->get(PageRepository::class)->getByUrl('homepage');
+        /** @var PageRepository $pageRepository */
+        $pageRepository = $this->entityManager->getRepository(Page::class);
+        $page = $pageRepository->getByUrl('homepage');
         $page->setDescription($description);
         $this->entityManager->flush();
 
-        $shopName = $this->container->get(BaseInfoRepository::class)->get()->getShopName();
+        /** @var BaseInfoRepository $baseInfoRepository */
+        $baseInfoRepository = $this->entityManager->getRepository(BaseInfo::class);
+        $shopName = $baseInfoRepository->get()->getShopName();
         $expected_desc = mb_substr($description, 0, 120, 'utf-8');
 
         $crawler = $this->client->request('GET', $this->generateUrl('homepage'));


### PR DESCRIPTION
4.1 feature向けのPRです

## 概要(Overview・Refs Issue)
SEOやSNSシェア対応のため、metaタグ関連の以下を設定します

- 全般
  - og:type
  - og:sitename
- 商品詳細ページ (商品ごとに設定)
  - description および og:description
  - og:image
  - canonical および  og:url

## 方針(Policy)

メタ関連の新規twigファイル meta.twig を作成しました。
4.0系では「ページ管理」のメタ設定 → metatag にてタグを設定していますが、タグのテンプレートとしては twig 側にあったほうがカスタマイズしやすいかと考えました。
(互換性のため、「ページ管理」の metatag に値が設定されている場合はそちらを優先し、空の場合のみ meta.twig ファイルを読み込むようにしています)

## 実装に関する補足(Appendix)
商品詳細の description と og:description は、以下から設定しています (上のものが優先される)
- 商品説明 (一覧)
- 商品説明
- 「ページ管理」のメタ設定

## テスト（Test)
Webテストを追加しています。

## 相談（Discussion）
デフォルトの og:image 画像を設定したいが、どのような実装方法がよいか
- favicon のようにデフォルト画像をあらかじめ用意して metaタグに設定しておき、ファイル管理から差し替えられるようにする？
- PDFロゴ画像のように、空白の画像をデフォルトとする？ https://github.com/EC-CUBE/ec-cube/issues/4824
その他よい方法がありましたら。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか

### 新機能追加に伴う競合確認

- [x] プラグインとの競合がないか
- [ ] プラグインからのマイグレーションが必要か
