### PR TITLE
管理画面のお知らせのE2Eテストをリダイレクトに対応

### DIFF
--- a/codeception/acceptance/EA01TopCest.php
+++ b/codeception/acceptance/EA01TopCest.php
@@ -82,10 +82,10 @@ class EA01TopCest
         // お知らせの記事をクリックすると設定されたURLに遷移することを確認
         $I->switchToIFrame('information');
         $selector = '.news_area .link_list .tableish a:nth-child(1)';
-        $url = $I->grabAttributeFrom($selector, 'href');
+        $url = $I->executeJS('return location.href');
         $I->click(['css' => $selector]);
         $I->switchToNewWindow();
-        $I->assertEquals($url, $I->executeJS('return location.href'), $url.' が一致しません');
+        $I->assertNotEquals($url, $I->executeJS('return location.href'), $url.' から遷移していません。');
         $I->switchToWindow();
 
         // ショップ情報の在庫切れ商品をクリックすると商品管理ページに遷移することを確認


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

管理画面のお知らせのE2Eテストをリダイレクトに対応しました。

Fixes https://github.com/EC-CUBE/ec-cube/issues/4982
Fixes https://github.com/EC-CUBE/ec-cube/issues/4988

## 方針(Policy)

「遷移先のURLへ遷移したか」
ではなく
「元のURLではないURLに遷移しているか」
で判定をするようにしました。

## 実装に関する補足(Appendix)

## テスト（Test)

落ちていたテストが通ることを確認しました。

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
