### PR TITLE
フロント側での商品情報表示を制御する拡張機構

### DIFF
--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -28,6 +28,7 @@ services:
           $shoppingPurchaseFlow: '@eccube.purchase.flow.shopping'
           $orderPurchaseFlow: '@eccube.purchase.flow.order'
           $_orderStateMachine: '@state_machine.order'
+          $productVisibilities: '@eccube.product.visibilities'
 
 
     # makes classes in src/ available to be used as services
@@ -180,3 +181,6 @@ services:
     Eccube\Session\Storage\Handler\SameSiteNoneCompatSessionHandler:
         arguments:
             - '@native_file_session_handler'
+
+    eccube.product.visibilities:
+        class: ArrayObject

--- a/src/Eccube/DependencyInjection/Compiler/ProductVisibilityPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/ProductVisibilityPass.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\DependencyInjection\Compiler;
+
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ProductVisibilityPass implements CompilerPassInterface
+{
+    const TAG = 'eccube.product.visibility';
+
+    public function process(ContainerBuilder $container)
+    {
+        $visibilitiesDef = $container->getDefinition('eccube.product.visibilities');
+        $ids = $container->findTaggedServiceIds(self::TAG);
+        foreach ($ids as $id => $tag) {
+            $visibilitiesDef->addMethodCall('append', [new Reference($id)]);
+        }
+    }
+}

--- a/src/Eccube/Doctrine/Query/WhereClause.php
+++ b/src/Eccube/Doctrine/Query/WhereClause.php
@@ -287,6 +287,52 @@ class WhereClause
     }
 
     /**
+     * AND演算子のファクトリメソッド。
+     * Example:
+     *      WhereClause::and(
+     *          WhereClause::eq('status', ':status', '1'),
+     *          WhereClause::eq('price', ':price', 1000),
+     *      )
+     * @param WhereClause ...$list
+     * @return WhereClause
+     */
+    public static function and(WhereClause ...$list)
+    {
+        $expr = array_map(function(WhereClause  $wc) {
+            return $wc->expr;
+        }, $list);
+
+        $params = array_reduce($list, function($result, WhereClause $wc) {
+            return $wc->params ? array_merge($result, $wc->params) : $result;
+        }, []);
+
+        return new WhereClause(self::expr()->andX(...$expr), $params);
+    }
+
+    /**
+     * OR演算子のファクトリメソッド。
+     * Example:
+     *      WhereClause::or(
+     *          WhereClause::eq('status', ':status1', '1'),
+     *          WhereClause::eq('status', ':status2', '2'),
+     *      )
+     * @param WhereClause ...$list
+     * @return WhereClause
+     */
+    public static function or(WhereClause ...$list)
+    {
+        $expr = array_map(function(WhereClause  $wc) {
+            return $wc->expr;
+        }, $list);
+
+        $params = array_reduce($list, function($result, WhereClause $wc) {
+            return $wc->params ? array_merge($result, $wc->params) : $result;
+        }, []);
+
+        return new WhereClause(self::expr()->orX(...$expr), $params);
+    }
+
+    /**
      * @return Expr
      */
     private static function expr()

--- a/src/Eccube/Entity/Product.php
+++ b/src/Eccube/Entity/Product.php
@@ -13,6 +13,7 @@
 
 namespace Eccube\Entity;
 
+use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -495,14 +496,14 @@ if (!class_exists('\Eccube\Entity\Product')) {
         private $free_area;
 
         /**
-         * @var \DateTime
+         * @var DateTime
          *
          * @ORM\Column(name="create_date", type="datetimetz")
          */
         private $create_date;
 
         /**
-         * @var \DateTime
+         * @var DateTime
          *
          * @ORM\Column(name="update_date", type="datetimetz")
          */
@@ -565,6 +566,21 @@ if (!class_exists('\Eccube\Entity\Product')) {
          * })
          */
         private $Status;
+
+
+        /**
+         * @var DateTime
+         *
+         * @ORM\Column(name="publish_start", type="datetimetz", nullable=true)
+         */
+        private $publishStart;
+
+        /**
+         * @var DateTime
+         *
+         * @ORM\Column(name="publish_end", type="datetimetz", nullable=true)
+         */
+        private $publishEnd;
 
         /**
          * Constructor
@@ -780,7 +796,7 @@ if (!class_exists('\Eccube\Entity\Product')) {
         /**
          * Set createDate.
          *
-         * @param \DateTime $createDate
+         * @param DateTime $createDate
          *
          * @return Product
          */
@@ -794,7 +810,7 @@ if (!class_exists('\Eccube\Entity\Product')) {
         /**
          * Get createDate.
          *
-         * @return \DateTime
+         * @return DateTime
          */
         public function getCreateDate()
         {
@@ -804,7 +820,7 @@ if (!class_exists('\Eccube\Entity\Product')) {
         /**
          * Set updateDate.
          *
-         * @param \DateTime $updateDate
+         * @param DateTime $updateDate
          *
          * @return Product
          */
@@ -818,7 +834,7 @@ if (!class_exists('\Eccube\Entity\Product')) {
         /**
          * Get updateDate.
          *
-         * @return \DateTime
+         * @return DateTime
          */
         public function getUpdateDate()
         {
@@ -1072,6 +1088,38 @@ if (!class_exists('\Eccube\Entity\Product')) {
         public function getStatus()
         {
             return $this->Status;
+        }
+
+        /**
+         * @return DateTime
+         */
+        public function getPublishStart()
+        {
+            return $this->publishStart;
+        }
+
+        /**
+         * @param DateTime $publishStart
+         */
+        public function setPublishStart(DateTime $publishStart)
+        {
+            $this->publishStart = $publishStart;
+        }
+
+        /**
+         * @return DateTime
+         */
+        public function getPublishEnd()
+        {
+            return $this->publishEnd;
+        }
+
+        /**
+         * @param DateTime $publishEnd
+         */
+        public function setPublishEnd(DateTime $publishEnd)
+        {
+            $this->publishEnd = $publishEnd;
         }
     }
 }

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -20,6 +20,7 @@ use Eccube\DependencyInjection\Compiler\AutoConfigurationTagPass;
 use Eccube\DependencyInjection\Compiler\NavCompilerPass;
 use Eccube\DependencyInjection\Compiler\PaymentMethodPass;
 use Eccube\DependencyInjection\Compiler\PluginPass;
+use Eccube\DependencyInjection\Compiler\ProductVisibilityPass;
 use Eccube\DependencyInjection\Compiler\PurchaseFlowPass;
 use Eccube\DependencyInjection\Compiler\QueryCustomizerPass;
 use Eccube\DependencyInjection\Compiler\TwigBlockPass;
@@ -31,6 +32,7 @@ use Eccube\Doctrine\DBAL\Types\UTCDateTimeTzType;
 use Eccube\Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Eccube\Doctrine\Query\QueryCustomizer;
 use Eccube\Service\Payment\PaymentMethodInterface;
+use Eccube\Service\Product\ProductVisibility;
 use Eccube\Service\PurchaseFlow\DiscountProcessor;
 use Eccube\Service\PurchaseFlow\ItemHolderPostValidator;
 use Eccube\Service\PurchaseFlow\ItemHolderPreprocessor;
@@ -256,6 +258,10 @@ class Kernel extends BaseKernel
         $container->registerForAutoconfiguration(PurchaseProcessor::class)
             ->addTag(PurchaseFlowPass::PURCHASE_PROCESSOR_TAG);
         $container->addCompilerPass(new PurchaseFlowPass());
+
+        $container->registerForAutoconfiguration(ProductVisibility::class)
+            ->addTag(ProductVisibilityPass::TAG);
+        $container->addCompilerPass(new ProductVisibilityPass());
     }
 
     protected function addEntityExtensionPass(ContainerBuilder $container)

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -132,8 +132,7 @@ class ProductRepository extends AbstractRepository
      */
     public function getQueryBuilderBySearchData($searchData)
     {
-        $qb = $this->createQueryBuilder('p')
-            ->andWhere('p.Status = 1');
+        $qb = $this->createQueryBuilder('p');
 
         // category
         $categoryJoin = false;

--- a/src/Eccube/Service/Product/ProductVisibility.php
+++ b/src/Eccube/Service/Product/ProductVisibility.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Product;
+
+
+use Eccube\Doctrine\Query\WhereCustomizer;
+use Eccube\Entity\Product;
+use Eccube\Repository\QueryKey;
+
+abstract class ProductVisibility extends WhereCustomizer
+{
+    /**
+     * @param Product $Product
+     * @return boolean
+     */
+    public abstract function checkVisibility(Product $Product);
+
+    public function getQueryKey()
+    {
+        return QueryKey::PRODUCT_SEARCH;
+    }
+
+}

--- a/src/Eccube/Service/Product/PublishTermVisibility.php
+++ b/src/Eccube/Service/Product/PublishTermVisibility.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Product;
+
+
+use DateTime;
+use Eccube\Doctrine\Query\WhereClause;
+use Eccube\Entity\Product;
+
+class PublishTermVisibility extends ProductVisibility
+{
+    public function checkVisibility(Product $Product)
+    {
+        $now = new DateTime();
+
+        if ($Product->getPublishStart() && $Product->getPublishEnd()) {
+            return $Product->getPublishStart() <= $now && $Product->getPublishEnd() > $now;
+        } elseif ($Product->getPublishStart()) {
+            return $Product->getPublishStart() <= $now;
+        } elseif ($Product->getPublishEnd()) {
+            return $Product->getPublishEnd() > $now;
+        }
+
+        return true;
+    }
+
+    protected function createStatements($params, $queryKey)
+    {
+        $now = new DateTime();
+
+        $start = WhereClause::lt('p.publishStart', ':publishStart', $now);
+        $end = WhereClause::gte('p.publishEnd', ':publishEnd', $now);
+        $startIsNull = WhereClause::isNull('p.publishEnd');
+        $endIsNull = WhereClause::isNull('p.publishStart');
+
+        return [WhereClause::or(
+            WhereClause::and($start, $end),
+            WhereClause::and($start, $startIsNull),
+            WhereClause::and($endIsNull, $end),
+            WhereClause::and($startIsNull, $endIsNull)
+        )];
+    }
+}

--- a/src/Eccube/Service/Product/StatusVisibility.php
+++ b/src/Eccube/Service/Product/StatusVisibility.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Product;
+
+
+use Eccube\Doctrine\Query\WhereClause;
+use Eccube\Entity\Master\ProductStatus;
+use Eccube\Entity\Product;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class StatusVisibility extends ProductVisibility
+{
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    public function __construct(SessionInterface $session)
+    {
+        $this->session = $session;
+    }
+
+    public function checkVisibility(Product $Product)
+    {
+        $is_admin = $this->session->has('_security_admin');
+
+        // 管理ユーザの場合はステータスやオプションにかかわらず閲覧可能.
+        if (!$is_admin) {
+            // 在庫なし商品の非表示オプションが有効な場合.
+            // if ($this->BaseInfo->isOptionNostockHidden()) {
+            //     if (!$Product->getStockFind()) {
+            //         return false;
+            //     }
+            // }
+            // 公開ステータスでない商品は表示しない.
+            if ($Product->getStatus()->getId() !== ProductStatus::DISPLAY_SHOW) {
+                return false;
+            }
+        }
+
+        return true;
+
+    }
+
+    protected function createStatements($params, $queryKey)
+    {
+        return [
+            WhereClause::eq('p.Status', ':ProductStatus', ProductStatus::DISPLAY_SHOW)
+        ];
+    }
+
+}

--- a/tests/Eccube/Tests/Doctrine/Query/WhereClauseTest.php
+++ b/tests/Eccube/Tests/Doctrine/Query/WhereClauseTest.php
@@ -181,6 +181,32 @@ class WhereClauseTest extends EccubeTestCase
         self::assertEquals([new Parameter('Name', '0')], $this->getParams($actual));
     }
 
+    public function testAnd()
+    {
+        $actual = WhereClause::and(
+            WhereClause::eq('name', ':Name', '0'),
+            WhereClause::eq('price', ':Price', 1000)
+        );
+        self::assertEquals('name = :Name AND price = :Price', $this->asString($actual));
+        self::assertEquals(
+            [new Parameter('Name', '0'), new Parameter('Price', 1000)],
+            $this->getParams($actual)
+        );
+    }
+
+    public function testOr()
+    {
+        $actual = WhereClause::or(
+            WhereClause::eq('name', ':Name', '0'),
+            WhereClause::eq('price', ':Price', 1000)
+        );
+        self::assertEquals('name = :Name OR price = :Price', $this->asString($actual));
+        self::assertEquals(
+            [new Parameter('Name', '0'), new Parameter('Price', 1000)],
+            $this->getParams($actual)
+        );
+    }
+
     /*
      * Helper methods.
      */


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
デフォルトでは商品情報はステータス(公開/非公開/廃番)によってフロントでの表示/非表示を切り替えているが、プラグインやカスタマイズで他の条件で表示制御を拡張できるようにする。


## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

### 商品の可視性を定義する抽象クラスProductVisibilityを追加
https://github.com/kiy0taka/ec-cube/blob/5f956d8506a496c15e6e80e5538a00bc2ef73645/src/Eccube/Service/Product/ProductVisibility.php

実装するメソッドは2つ

- checkVisibility(Product)
  - 商品単体の可視性を判定する
- createStatements($params, $queryKey)
  - `WhereCustomizer` で定義しているメソッド
  - 一覧検索時の条件を追加する

すべてのProductVisibilityが表示を許可しないとフロントに表示されない。

### 実装サンプル

#### デフォルトの商品ステータスでの表示制御
https://github.com/EC-CUBE/ec-cube/blob/1b1a3b28cd79cd67e30b793f9d3290a45937487a/src/Eccube/Service/Product/StatusVisibility.php

#### #4852 のサンプル実装
https://github.com/kiy0taka/ec-cube/blob/5f956d8506a496c15e6e80e5538a00bc2ef73645/src/Eccube/Service/Product/PublishTermVisibility.php

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
