### PR TITLE
受注編集時にすでに受注にセットされている顧客情報を書き換えない

### DIFF
--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -378,16 +378,15 @@ class OrderType extends AbstractType
             $Order->setPaymentMethod($Payment->getMethod());
         }
 
-        // 会員受注の場合、会員の性別/職業/誕生日をエンティティにコピーする
-        if ($Customer = $Order->getCustomer()) {
-            $Order->setSex($Customer->getSex());
-            $Order->setJob($Customer->getJob());
-            $Order->setBirth($Customer->getBirth());
-        }
-
         // 新規登録時は, 新規受付ステータスで登録する.
         if (null === $Order->getOrderStatus()) {
             $Order->setOrderStatus($this->orderStatusRepository->find(OrderStatus::NEW));
+            // 会員受注の場合、会員の性別/職業/誕生日をエンティティにコピーする
+            if ($Customer = $Order->getCustomer()) {
+                $Order->setSex($Customer->getSex());
+                $Order->setJob($Customer->getJob());
+                $Order->setBirth($Customer->getBirth());
+            }
         } else {
             // 編集時は, mapped => falseで定義しているため, フォームから変更後データを取得する.
             $form = $event->getForm();

--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -16,6 +16,8 @@ namespace Eccube\Tests\Web\Admin\Order;
 use Eccube\Common\Constant;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Customer;
+use Eccube\Entity\Master\Job;
+use Eccube\Entity\Master\Sex;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Entity\Master\RoundingType;
 use Eccube\Entity\Order;
@@ -607,5 +609,38 @@ class EditControllerTest extends AbstractEditControllerTestCase
         $Order = $this->orderRepository->findBy([], ['create_date' => 'DESC'])[0];
         self::assertEquals(10, $Order->getProductOrderItems()[0]->getTaxRate());
         self::assertEquals(100, $Order->getProductOrderItems()[0]->getTax());
+    }
+
+    public function testRoutingAdminOrderEditPostWithCustomerInfo()
+    {
+        $Customer = $this->createCustomer();
+        $Order = $this->createOrder($Customer);
+        $Order->setOrderStatus($this->entityManager->find(OrderStatus::class, OrderStatus::NEW));
+        $Order->setSex(null);
+        $Order->setJob(null);
+        $Order->setBirth(null);
+
+        $this->entityManager->flush($Order);
+
+        $Customer->setSex($this->entityManager->find(Sex::class, 1));
+        $Customer->setJob($this->entityManager->find(Job::class, 1));
+        $Customer->setBirth(new \DateTime());
+        $this->entityManager->flush($Customer);
+
+        $formData = $this->createFormData($Customer, $this->Product);
+        $this->client->request(
+            'POST',
+            $this->generateUrl('admin_order_edit', ['id' => $Order->getId()]),
+            [
+                'order' => $formData,
+                'mode' => 'register',
+            ]
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('admin_order_edit', ['id' => $Order->getId()])));
+
+        $EditedOrder = $this->orderRepository->find($Order->getId());
+        $this->assertNull($EditedOrder->getSex());
+        $this->assertNull($EditedOrder->getJob());
+        $this->assertNull($EditedOrder->getBirth());
     }
 }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
管理画面で受注を編集する時に、受注にセットされている顧客情報を、その時点の顧客情報で上書きしないようにします。
#4059 


## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

Issueでの議論では初回受注作成時の判定は `$Order->getId() `のチェックで行うということでしたが、すぐ後のコードで`null === $Order->getOrderStatus()`を用いて初回の作成を判定していたため、その中に処理をまとめました。


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
