### PR TITLE
Form/Type/Admin/OrderTypeの「company_name」が重複していたので片方を削除

### DIFF
--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -165,14 +165,6 @@ class OrderType extends AbstractType
                     new Assert\NotBlank(),
                 ],
             ])
-            ->add('company_name', TextType::class, [
-                'required' => false,
-                'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
-                ],
-            ])
             ->add('message', TextareaType::class, [
                 'required' => false,
                 'constraints' => [


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Form/Type/Admin/OrderTypeの「company_name」が重複していたので片方を削除。

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
