### PR TITLE
og:imageのURLで/が二重になるのを修正

### DIFF
--- a/src/Eccube/Resource/doctrine/import_csv/en/dtb_page.csv
+++ b/src/Eccube/Resource/doctrine/import_csv/en/dtb_page.csv
@@ -4,7 +4,7 @@ id,page_name,url,file_name,edit_type,author,description,keyword,create_date,upda
 2,All Products,product_list,Product/list,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,
 3,Product Details,product_detail,Product/detail,2,,,,2017-03-07 10:14:52,2017-03-07 10:14:52,,,page,"<meta property=""og:type"" content=""og:product"" />
 <meta property=""og:title"" content=""{{ Product.name }}"" />
-<meta property=""og:image"" content=""{{ url('homepage') }}{{ asset(Product.main_list_image|no_image_product, 'save_image') }}"" />
+<meta property=""og:image"" content=""{{ absolute_url(asset(Product.main_list_image|no_image_product, 'save_image')) }}"" />
 <meta property=""og:description"" content=""{{ Product.description_list|striptags }}"" />
 <meta property=""og:url"" content=""{{ url('product_detail', {'id': Product.id}) }}"" />
 <meta property=""product:price:amount"" content=""{{ Product.getPrice02IncTaxMin }}""/>

--- a/src/Eccube/Resource/doctrine/import_csv/ja/dtb_page.csv
+++ b/src/Eccube/Resource/doctrine/import_csv/ja/dtb_page.csv
@@ -4,7 +4,7 @@ id,page_name,url,file_name,edit_type,author,description,keyword,create_date,upda
 "2","商品一覧ページ","product_list","Product/list","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page",
 "3","商品詳細ページ","product_detail","Product/detail","2",,,,"2017-03-07 10:14:52","2017-03-07 10:14:52",,,"page","<meta property=""og:type"" content=""og:product"" />
 <meta property=""og:title"" content=""{{ Product.name }}"" />
-<meta property=""og:image"" content=""{{ url('homepage') }}{{ asset(Product.main_list_image|no_image_product, 'save_image') }}"" />
+<meta property=""og:image"" content=""{{ absolute_url(asset(Product.main_list_image|no_image_product, 'save_image')) }}"" />
 <meta property=""og:description"" content=""{{ Product.description_list|striptags }}"" />
 <meta property=""og:url"" content=""{{ url('product_detail', {'id': Product.id}) }}"" />
 <meta property=""product:price:amount"" content=""{{ Product.getPrice02IncTaxMin }}""/>


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
以下のように `https://example.com` 直後の `/` が二重になってしまっている。

変更前
```
<meta property="og:image" content="https://example.com//html/upload/save_image/sand-1.png" />
```
変更後
```
<meta property="og:image" content="https://example.com/html/upload/save_image/sand-1.png" />
```

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->



## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
