### PR TITLE
重複したステートメントを削除

### DIFF
--- a/src/Eccube/Service/OrderHelper.php
+++ b/src/Eccube/Service/OrderHelper.php
@@ -302,7 +302,6 @@ class OrderHelper
     public function removeSession()
     {
         $this->session->remove(self::SESSION_ORDER_ID);
-        $this->session->remove(self::SESSION_ORDER_ID);
         $this->session->remove(self::SESSION_NON_MEMBER);
         $this->session->remove(self::SESSION_NON_MEMBER_ADDRESSES);
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#5060

Service/OrderHelper.php に重複した行があったので片方を削除する
```
    public function removeSession()
    {
        $this->session->remove(self::SESSION_ORDER_ID);
        $this->session->remove(self::SESSION_ORDER_ID);
```

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
