### PR TITLE
キャッシュ削除時のメンテナンスタイミングを調整

### DIFF
--- a/src/Eccube/Controller/Admin/Content/CacheController.php
+++ b/src/Eccube/Controller/Admin/Content/CacheController.php
@@ -14,6 +14,7 @@
 namespace Eccube\Controller\Admin\Content;
 
 use Eccube\Controller\AbstractController;
+use Eccube\Service\SystemService;
 use Eccube\Util\CacheUtil;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -26,15 +27,14 @@ class CacheController extends AbstractController
      * @Route("/%eccube_admin_route%/content/cache", name="admin_content_cache")
      * @Template("@admin/Content/cache.twig")
      */
-    public function index(Request $request, CacheUtil $cacheUtil)
+    public function index(Request $request, CacheUtil $cacheUtil, SystemService $systemService)
     {
         $builder = $this->formFactory->createBuilder(FormType::class);
         $form = $builder->getForm();
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $path = $this->container->getParameter('eccube_content_maintenance_file_path');
-            file_put_contents($path, null);
+            $systemService->switchMaintenance(true);
 
             $cacheUtil->clearCache();
 

--- a/src/Eccube/Controller/Admin/Content/CacheController.php
+++ b/src/Eccube/Controller/Admin/Content/CacheController.php
@@ -33,7 +33,12 @@ class CacheController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $path = $this->container->getParameter('eccube_content_maintenance_file_path');
+            file_put_contents($path, null);
+
             $cacheUtil->clearCache();
+
+            $this->addFlash('eccube.admin.disable_maintenance', '');
 
             $this->addSuccess('admin.common.delete_complete', 'admin');
         }

--- a/src/Eccube/Controller/Admin/Content/MaintenanceController.php
+++ b/src/Eccube/Controller/Admin/Content/MaintenanceController.php
@@ -16,6 +16,7 @@ namespace Eccube\Controller\Admin\Content;
 use Eccube\Controller\AbstractController;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Eccube\Service\SystemService;
@@ -71,5 +72,37 @@ class MaintenanceController extends AbstractController
             'form' => $form->createView(),
             'isMaintenance' => $isMaintenance,
         ];
+    }
+
+    /**
+     * メンテナンス解除
+     *
+     * キャッシュ管理やプラグインのインストール等の操作時にajax経由で解除する
+     * 権限管理設定でアクセス不可になるのを避けるため、ルーティングは/admin/disable_maintenanceで設定しています
+     *
+     * @Route("/%eccube_admin_route%/disable_maintenance/{mode}", requirements={"mode": "manual|auto_maintenance|auto_maintenance_update"}, name="admin_disable_maintenance", methods={"POST"})
+     */
+    public function disableMaintenance(Request $request, $mode, SystemService $systemService)
+    {
+        $this->isTokenValid();
+
+        if (!$request->isXmlHttpRequest()) {
+            throw new BadRequestHttpException();
+        }
+
+        if ($mode === 'manual') {
+            $path = $this->container->getParameter('eccube_content_maintenance_file_path');
+            if (file_exists($path)) {
+                unlink($this->container->getParameter('eccube_content_maintenance_file_path'));
+            }
+        } else {
+            $maintenanceMode = [
+                'auto_maintenance' => SystemService::AUTO_MAINTENANCE,
+                'auto_maintenance_update' => SystemService::AUTO_MAINTENANCE_UPDATE
+            ];
+            $systemService->disableMaintenance($maintenanceMode[$mode]);
+        }
+
+        return $this->json(['success' => true]);
     }
 }

--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -259,9 +259,6 @@ class OwnerStoreController extends AbstractController
         // .maintenanceファイルを設置
         $this->systemService->switchMaintenance(true);
 
-        // TERMINATE時のイベントを設定
-        $this->systemService->disableMaintenance(SystemService::AUTO_MAINTENANCE);
-
         $this->cacheUtil->clearCache();
 
         $pluginCode = $request->get('pluginCode');
@@ -294,9 +291,6 @@ class OwnerStoreController extends AbstractController
 
         // .maintenanceファイルを設置
         $this->systemService->switchMaintenance(true);
-
-        // TERMINATE時のイベントを設定
-        $this->systemService->disableMaintenance(SystemService::AUTO_MAINTENANCE);
 
         $this->cacheUtil->clearCache();
 
@@ -426,9 +420,6 @@ class OwnerStoreController extends AbstractController
     public function apiUpdate(Request $request)
     {
         $this->isTokenValid();
-
-        // TERMINATE時のイベントを設定
-        $this->systemService->disableMaintenance(SystemService::AUTO_MAINTENANCE_UPDATE);
 
         $this->cacheUtil->clearCache();
 

--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -277,13 +277,8 @@ class PluginController extends AbstractController
         if (!$request->query->has('maintenance_mode')) {
             // プラグイン管理の有効ボタンを押したとき
             $this->systemService->switchMaintenance(true); // auto_maintenanceと設定されたファイルを生成
-            // TERMINATE時のイベントを設定
-            $this->systemService->disableMaintenance(SystemService::AUTO_MAINTENANCE);
-        } else {
-            // プラグイン管理のアップデートを実行したとき
-            // TERMINATE時のイベントを設定
-            $this->systemService->disableMaintenance(SystemService::AUTO_MAINTENANCE_UPDATE);
         }
+
         $cacheUtil->clearCache();
 
         $log = null;
@@ -318,6 +313,8 @@ class PluginController extends AbstractController
                     } else {
                         $this->addError($message, 'admin');
 
+                        $this->addFlash('eccube.admin.disable_maintenance', '');
+
                         return $this->redirectToRoute('admin_store_plugin');
                     }
                 }
@@ -343,6 +340,8 @@ class PluginController extends AbstractController
             return $this->json(['success' => true, 'log' => $log]);
         } else {
             $this->addSuccess(trans('admin.store.plugin.enable.complete', ['%plugin_name%' => $Plugin->getName()]), 'admin');
+
+            $this->addFlash('eccube.admin.disable_maintenance', '');
 
             return $this->redirectToRoute('admin_store_plugin');
         }
@@ -372,8 +371,6 @@ class PluginController extends AbstractController
         } else {
             // プラグイン管理で無効ボタンを押したとき
             $this->systemService->switchMaintenance(true); // auto_maintenanceと設定されたファイルを生成
-            // TERMINATE時のイベントを設定
-            $this->systemService->disableMaintenance(SystemService::AUTO_MAINTENANCE);
         }
 
         $cacheUtil->clearCache();
@@ -393,6 +390,8 @@ class PluginController extends AbstractController
                     return $this->json(['message' => $message], 400);
                 } else {
                     $this->addError($message, 'admin');
+
+                    $this->addFlash('eccube.admin.disable_maintenance', '');
 
                     return $this->redirectToRoute('admin_store_plugin');
                 }
@@ -421,6 +420,8 @@ class PluginController extends AbstractController
             return $this->json(['success' => true, 'log' => $log]);
         } else {
             $this->addSuccess(trans('admin.store.plugin.disable.complete', ['%plugin_name%' => $Plugin->getName()]), 'admin');
+
+            $this->addFlash('eccube.admin.disable_maintenance', '');
 
             return $this->redirectToRoute('admin_store_plugin');
         }

--- a/src/Eccube/Resource/template/admin/Content/cache.twig
+++ b/src/Eccube/Resource/template/admin/Content/cache.twig
@@ -16,14 +16,14 @@ file that was distributed with this source code.
 {% block sub_title %}{{ 'admin.content.contents_management'|trans }}{% endblock %}
 
 {% block javascript %}
+{% if app.flashes('eccube.admin.disable_maintenance') %}
 <script>
-    $(function() {
-        {% for message in app.flashes('eccube.admin.disable_maintenance') %}
-        // メンテナンスモード解除
-        $.post("{{ url('admin_disable_maintenance', { 'mode': 'auto_maintenance' }) }}");
-        {% endfor %}
-    })
+$(function() {
+    // メンテナンスモード解除
+    $.post("{{ url('admin_disable_maintenance', { 'mode': 'auto_maintenance' }) }}");
+})
 </script>
+{% endif %}
 {% endblock %}
 
 {% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}

--- a/src/Eccube/Resource/template/admin/Content/cache.twig
+++ b/src/Eccube/Resource/template/admin/Content/cache.twig
@@ -20,7 +20,7 @@ file that was distributed with this source code.
     $(function() {
         {% for message in app.flashes('eccube.admin.disable_maintenance') %}
         // メンテナンスモード解除
-        $.post("{{ url('admin_disable_maintenance', { 'mode': 'manual' }) }}");
+        $.post("{{ url('admin_disable_maintenance', { 'mode': 'auto_maintenance' }) }}");
         {% endfor %}
     })
 </script>

--- a/src/Eccube/Resource/template/admin/Content/cache.twig
+++ b/src/Eccube/Resource/template/admin/Content/cache.twig
@@ -15,6 +15,17 @@ file that was distributed with this source code.
 {% block title %}{{ 'admin.content.cache_management'|trans }}{% endblock %}
 {% block sub_title %}{{ 'admin.content.contents_management'|trans }}{% endblock %}
 
+{% block javascript %}
+<script>
+    $(function() {
+        {% for message in app.flashes('eccube.admin.disable_maintenance') %}
+        // メンテナンスモード解除
+        $.post("{{ url('admin_disable_maintenance', { 'mode': 'manual' }) }}");
+        {% endfor %}
+    })
+</script>
+{% endblock %}
+
 {% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
 
 {% block main %}

--- a/src/Eccube/Resource/template/admin/Store/plugin_confirm.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_confirm.twig
@@ -42,6 +42,9 @@ $(function() {
                         ctx.progressBar.css('width', ((ctx.currentCount/ctx.totalCount + 0.5/ctx.totalCount)*100) + '%');
                         ctx.log(data.log);
                     })
+                }).then(function() {
+                    // メンテナンスモード解除
+                    return $.post("{{ url('admin_disable_maintenance', { 'mode': 'auto_maintenance' }) }}", ctx.plugin);
                 });
             }
         },
@@ -81,6 +84,9 @@ $(function() {
                         ctx.progressBar.css('width', '80%');
                         ctx.log(data.log);
                     })
+                }).then(function() {
+                    // メンテナンスモード解除
+                    return $.post("{{ url('admin_disable_maintenance', { 'mode': 'auto_maintenance_update' }) }}", ctx.plugin);
                 });
             }
         }

--- a/src/Eccube/Resource/template/admin/Store/plugin_table_official.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_table_official.twig
@@ -31,27 +31,27 @@ $(function() {
                 });
             },
             function(res) {
-                $.post("{{ url('admin_disable_maintenance', { 'mode': 'auto_maintenance' }) }}").then(function() {
-                    if (res.responseJSON.message) {
-                        message.text(res.responseJSON.message);
-                    } else {
-                        message.text('削除に失敗しました。');
-                    }
-                    if (res.responseJSON.log) {
-                        $('#deleteLog').text(res.responseJSON.log);
-                    }
-                    $('#deleteLogPane').show();
-                    progress.hide();
-                    footer.show().find('button').toggle();
-                });
+                if (res.responseJSON.message) {
+                    message.text(res.responseJSON.message);
+                } else {
+                    message.text('削除に失敗しました。');
+                }
+                if (res.responseJSON.log) {
+                    $('#deleteLog').text(res.responseJSON.log);
+                }
+                $('#deleteLogPane').show();
+                progress.hide();
+                footer.show().find('button').toggle();
+
+                $.post("{{ url('admin_disable_maintenance', { 'mode': 'auto_maintenance' }) }}");
             }
         );
     });
 
-    {% for message in app.flashes('eccube.admin.disable_maintenance') %}
+    {% if app.flashes('eccube.admin.disable_maintenance') %}
         // メンテナンスモード解除
         $.post("{{ url('admin_disable_maintenance', { 'mode': 'auto_maintenance' }) }}");
-    {% endfor %}
+    {% endif %}
 });
 </script>
 {% if Plugins|length > 0 %}

--- a/src/Eccube/Resource/template/admin/Store/plugin_table_official.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_table_official.twig
@@ -22,27 +22,36 @@ $(function() {
         var progress = $('div.progress', modal).show();
         $.ajax({url: currentPlugin['deleteUrl'], type: 'delete'}).then(
             function(data) {
-                message.text('削除が完了しました。');
-                $('#deleteLog').text(data.log);
-                $('#deleteLogPane').show();
-                progress.hide();
-                footer.show().find('button').toggle();
+                $.post("{{ url('admin_disable_maintenance', { 'mode': 'auto_maintenance' }) }}").then(function() {
+                    message.text('削除が完了しました。');
+                    $('#deleteLog').text(data.log);
+                    $('#deleteLogPane').show();
+                    progress.hide();
+                    footer.show().find('button').toggle();
+                });
             },
             function(res) {
-                if (res.responseJSON.message) {
-                    message.text(res.responseJSON.message);
-                } else {
-                    message.text('削除に失敗しました。');
-                }
-                if (res.responseJSON.log) {
-                    $('#deleteLog').text(res.responseJSON.log);
-                }
-                progress.hide();
-                $('#deleteLogPane').show();
-                footer.show().find('button').toggle();
+                $.post("{{ url('admin_disable_maintenance', { 'mode': 'auto_maintenance' }) }}").then(function() {
+                    if (res.responseJSON.message) {
+                        message.text(res.responseJSON.message);
+                    } else {
+                        message.text('削除に失敗しました。');
+                    }
+                    if (res.responseJSON.log) {
+                        $('#deleteLog').text(res.responseJSON.log);
+                    }
+                    $('#deleteLogPane').show();
+                    progress.hide();
+                    footer.show().find('button').toggle();
+                });
             }
         );
     });
+
+    {% for message in app.flashes('eccube.admin.disable_maintenance') %}
+        // メンテナンスモード解除
+        $.post("{{ url('admin_disable_maintenance', { 'mode': 'auto_maintenance' }) }}");
+    {% endfor %}
 });
 </script>
 {% if Plugins|length > 0 %}

--- a/src/Eccube/Resource/template/admin/Store/plugin_table_official.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_table_official.twig
@@ -42,8 +42,6 @@ $(function() {
                 $('#deleteLogPane').show();
                 progress.hide();
                 footer.show().find('button').toggle();
-
-                $.post("{{ url('admin_disable_maintenance', { 'mode': 'auto_maintenance' }) }}");
             }
         );
     });

--- a/tests/Eccube/Tests/Web/Admin/Content/MaintenanceControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/MaintenanceControllerTest.php
@@ -15,9 +15,6 @@ namespace Eccube\Tests\Web\Admin\Content;
 
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 
-/**
- * @group cache-clear
- */
 class MaintenanceControllerTest extends AbstractAdminWebTestCase
 {
     private $maintenance_file_path;

--- a/tests/Eccube/Tests/Web/Admin/Content/MaintenanceControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/MaintenanceControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Web\Admin\Content;
+
+use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+
+/**
+ * @group cache-clear
+ */
+class MaintenanceControllerTest extends AbstractAdminWebTestCase
+{
+    private $maintenance_file_path;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->maintenance_file_path
+            = $this->container->getParameter('eccube_content_maintenance_file_path');
+
+        if (file_exists($this->maintenance_file_path)) {
+            unlink($this->maintenance_file_path);
+        }
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        if (file_exists($this->maintenance_file_path)) {
+            unlink($this->maintenance_file_path);
+        }
+    }
+
+    public function testIndex()
+    {
+        $crawler = $this->client->request('GET',
+            $this->generateUrl('admin_content_maintenance')
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertFalse(file_exists($this->maintenance_file_path));
+        $this->assertSame('有効にする', $crawler->filter('button.btn-ec-conversion')->text());
+
+        touch($this->maintenance_file_path);
+
+        $crawler = $this->client->request('GET',
+            $this->generateUrl('admin_content_maintenance')
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertTrue(file_exists($this->maintenance_file_path));
+        $this->assertSame('無効にする', $crawler->filter('button.btn-ec-conversion')->text());
+    }
+
+    public function testDisableMaintenance()
+    {
+        touch($this->maintenance_file_path);
+
+        $crawler = $this->client->request('GET',
+            $this->generateUrl('admin_content_maintenance')
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertTrue(file_exists($this->maintenance_file_path));
+        $this->assertSame('無効にする', $crawler->filter('button.btn-ec-conversion')->text());
+
+        $crawler = $this->client->request('POST',
+            $this->generateUrl('admin_disable_maintenance', ['mode' => 'manual']),
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+                'CONTENT_TYPE' => 'application/json',
+            ]
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $crawler = $this->client->request('GET',
+            $this->generateUrl('admin_content_maintenance')
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertFalse(file_exists($this->maintenance_file_path));
+        $this->assertSame('有効にする', $crawler->filter('button.btn-ec-conversion')->text());
+    }
+}


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

#4831

プラグインのインストール時など、メンテナンス解除のタイミングが早すぎるため、キャッシュが破損する場合がある。

現状のフローは以下の通り。
3のタイミングでメンテナンスが解除されるため、フロントからのアクセスが発生しているとキャッシュが破損する場合がある。

<img src="https://user-images.githubusercontent.com/8196725/125762033-faa483ae-1d59-4d8c-afea-6b4a1fc3a9a6.png" width="400px">

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

キャッシュが生成されるまで、メンテナンス状態を維持する。
キャッシュ削除後、ajaxの別リクエストでメンテナンス解除をするように対応。

<img src="https://user-images.githubusercontent.com/8196725/125765055-307e302a-df24-48b1-aa5c-e9fb91a913c8.png" width="400px">

以下の機能で対応しています。
- プラグインのインストール/有効化/無効化/削除
- コンテンツ管理＞キャッシュ削除

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

権限管理設定でアクセス不可になるのを避けるため、メンテナンス管理のルーティングは/admin/disable_maintenanceで設定しています

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

- メンテナンス管理のユニットテストを追加

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

#4831 に記載の通り、Apache + mod_phpではキャッシュ破損は解消されそうですが、php-fpmでは解消されないかもしれません。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
