### PR TITLE
eccube:install コマンドでは Api プラグインを有効化しない

### DIFF
--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -226,7 +226,6 @@ class InstallerCommand extends Command
             'doctrine:schema:create',
             'eccube:fixtures:load',
             'cache:clear --no-warmup',
-            'eccube:plugin:enable --code=Api || true', // APIプラグインはデフォルトで有効化
         ];
 
         // コンテナを再ロードするため別プロセスで実行する.


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

eccube:install コマンドでは Api プラグインを有効化しない

関連

- #4787
- #4733
- https://github.com/EC-CUBE/ec-cube/commit/eff1fb94a59d3752b162c3ee4a874a2680478b12

## 方針(Policy)

コマンドは開発者用かつ必要ならコマンドで有効化ができるのでデフォルトでは有効化しない

## テスト（Test)

ローカルで問題なく EC-CUBE がインストールできることを確認

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
