### PR TITLE
4.1-beta3 : 管理画面 ファイルアップロード UI の修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Form/bootstrap_4_horizontal_layout.html.twig
+++ b/src/Eccube/Resource/template/admin/Form/bootstrap_4_horizontal_layout.html.twig
@@ -45,3 +45,7 @@ file that was distributed with this source code.
     {% endif %}
 {% endblock %}
 
+{%- block file_widget -%}
+    {%- set attr = attr|merge({class: (attr.class|default('') ~ 'form-control-file')|trim}) -%}
+    <input type="file" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
+{%- endblock -%}

--- a/src/Eccube/Resource/template/admin/Store/plugin_install.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_install.twig
@@ -15,6 +15,8 @@ file that was distributed with this source code.
 {% block title %}独自プラグインのアップロード{% endblock %}
 {% block sub_title %}オーナーズストア{% endblock %}
 
+{% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
+
 {% block main %}
     <form id="upload-form" class="" method="post" action="{{ url('admin_store_plugin_install') }}" enctype="multipart/form-data">
         {{ form_widget(form._token) }}

--- a/src/Eccube/Resource/template/admin/Store/plugin_table.twig
+++ b/src/Eccube/Resource/template/admin/Store/plugin_table.twig
@@ -32,6 +32,7 @@ $(function() {
             <tbody>
             {% for Plugin in Plugins %}
                 {% set form = plugin_forms[Plugin.id] %}
+                {% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
                 <form id="{{ form.vars.name }}" name="{{ form.vars.name }}" method="post" action=""
                       enctype="multipart/form-data">
                     <tr class="{% if Plugin.enabled == false %}active{% endif %}">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
4.1 beta3 にて、管理画面のファイルアップロードの UI が 4.0と異なっていた問題に対応しました

### 関連issue
https://github.com/EC-CUBE/ec-cube/issues/5114

## 方針(Policy)
file_widget で出力されるHTMLコードは 4.0 と 4.1 とで差異があったため、bootstrap_4_horizontal_layout.html.twig にて新規に file_widget ブロックを作成し、出力されるHTMLを 4.0時と同等にする （CSSは変更しない）

管理画面の widget 追加のみのため、フロントには影響なしの想定

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
