### PR TITLE
APIインストール時に生成される鍵をパッケージから削除

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -28,6 +28,8 @@ rm -rf $WORKSPACE/.github
 rm -rf $WORKSPACE/zap
 rm -rf $WORKSPACE/docker-compose.owaspzap.yml
 rm -rf $WORKSPACE/package.sh
+rm -rf $WORKSPACE/app/PluginData/Api/oauth/private.key
+rm -rf $WORKSPACE/app/PluginData/Api/oauth/public.key
 find $WORKSPACE -name "dummy" -print0 | xargs -0 rm -rf
 find $WORKSPACE -name ".git*" -and ! -name ".gitkeep" -print0 | xargs -0 rm -rf
 find $WORKSPACE -name ".git*" -type d -print0 | xargs -0 rm -rf


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

- #5117 

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfoy のXXにならって作成、3系で同様の仕様があったため など -->

パッケージから鍵ファイルを削除し、EC-CUBEのインストールのタイミングで生成されるように修正しています。
## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

- 4.1-beta3のパッケージを展開
- app/PluginData/Api/oauth/private.key, public_keyを削除
- インストール画面を表示する
- app/PluginData/Api/oauth/配下にprivate.key, public_keyが生成されている

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
