### PR TITLE
class名指定時の崩れを修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Form/bootstrap_4_horizontal_layout.html.twig
+++ b/src/Eccube/Resource/template/admin/Form/bootstrap_4_horizontal_layout.html.twig
@@ -46,6 +46,6 @@ file that was distributed with this source code.
 {% endblock %}
 
 {%- block file_widget -%}
-    {%- set attr = attr|merge({class: (attr.class|default('') ~ 'form-control-file')|trim}) -%}
+    {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control-file')|trim}) -%}
     <input type="file" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
 {%- endblock -%}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
issue #5114 / PR #5125 の追加修正です

file_widget にクラス名を指定して呼び出された場合に、ファイルアップロードボタンの表示が崩れる(2つ表示される）問題に対応しました

対象ページ:
- 管理画面 商品CSV登録
- 管理画面 カテゴリCSV登録

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
