### PR TITLE
issue#5082 無駄なログ出力の抑制 The "Symfony\Bridge\Doctrine\RegistryInterface"…

### DIFF
--- a/src/Eccube/Repository/AuthorityRoleRepository.php
+++ b/src/Eccube/Repository/AuthorityRoleRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\AuthorityRole;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * AuthorityRoleRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class AuthorityRoleRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, AuthorityRole::class);
     }

--- a/src/Eccube/Repository/BaseInfoRepository.php
+++ b/src/Eccube/Repository/BaseInfoRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\BaseInfo;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * BaseInfoRepository
@@ -27,9 +27,9 @@ class BaseInfoRepository extends AbstractRepository
     /**
      * BaseInfoRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      */
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, BaseInfo::class);
     }

--- a/src/Eccube/Repository/BlockPositionRepository.php
+++ b/src/Eccube/Repository/BlockPositionRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\BlockPosition;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * BlockPositionRepository
@@ -33,9 +33,9 @@ class BlockPositionRepository extends AbstractRepository
      * BlockPositionRepository constructor.
      *
      * @param BlockRepository $blockRepository
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      */
-    public function __construct(BlockRepository $blockRepository, RegistryInterface $registry)
+    public function __construct(BlockRepository $blockRepository, ManagerRegistry $registry)
     {
         parent::__construct($registry, BlockPosition::class);
         $this->blockRepository = $blockRepository;

--- a/src/Eccube/Repository/BlockRepository.php
+++ b/src/Eccube/Repository/BlockRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository;
 
 use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Block;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * BlocRepository
@@ -33,11 +33,11 @@ class BlockRepository extends AbstractRepository
     /**
      * BlockRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
-        RegistryInterface $registry,
+        ManagerRegistry $registry,
         EccubeConfig $eccubeConfig
     ) {
         parent::__construct($registry, Block::class);

--- a/src/Eccube/Repository/CartItemRepository.php
+++ b/src/Eccube/Repository/CartItemRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\CartItem;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * CartRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class CartItemRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, CartItem::class);
     }

--- a/src/Eccube/Repository/CartRepository.php
+++ b/src/Eccube/Repository/CartRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\Cart;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * CartRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class CartRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Cart::class);
     }

--- a/src/Eccube/Repository/CategoryRepository.php
+++ b/src/Eccube/Repository/CategoryRepository.php
@@ -17,7 +17,7 @@ use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Category;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * CategoryRepository
@@ -35,11 +35,11 @@ class CategoryRepository extends AbstractRepository
     /**
      * CategoryRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
-        RegistryInterface $registry,
+        ManagerRegistry $registry,
         EccubeConfig $eccubeConfig
     ) {
         parent::__construct($registry, Category::class);

--- a/src/Eccube/Repository/ClassCategoryRepository.php
+++ b/src/Eccube/Repository/ClassCategoryRepository.php
@@ -16,7 +16,7 @@ namespace Eccube\Repository;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Eccube\Entity\ClassCategory;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * ClasscategoryRepository
@@ -29,10 +29,10 @@ class ClassCategoryRepository extends AbstractRepository
     /**
      * ClassCategoryRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      */
     public function __construct(
-        RegistryInterface $registry
+        ManagerRegistry $registry
     ) {
         parent::__construct($registry, ClassCategory::class);
     }

--- a/src/Eccube/Repository/ClassNameRepository.php
+++ b/src/Eccube/Repository/ClassNameRepository.php
@@ -16,7 +16,7 @@ namespace Eccube\Repository;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Eccube\Entity\ClassName;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * ClassNameRepository
@@ -29,9 +29,9 @@ class ClassNameRepository extends AbstractRepository
     /**
      * ClassNameRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      */
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, ClassName::class);
     }

--- a/src/Eccube/Repository/CsvRepository.php
+++ b/src/Eccube/Repository/CsvRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\Csv;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * CsvRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class CsvRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Csv::class);
     }

--- a/src/Eccube/Repository/CustomerAddressRepository.php
+++ b/src/Eccube/Repository/CustomerAddressRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\CustomerAddress;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * CustomerAddressRepository
@@ -27,9 +27,9 @@ class CustomerAddressRepository extends AbstractRepository
     /**
      * CustomerAddressRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      */
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, CustomerAddress::class);
     }

--- a/src/Eccube/Repository/CustomerFavoriteProductRepository.php
+++ b/src/Eccube/Repository/CustomerFavoriteProductRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository;
 
 use Doctrine\ORM\QueryBuilder;
 use Eccube\Entity\CustomerFavoriteProduct;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * CustomerFavoriteProductRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class CustomerFavoriteProductRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, CustomerFavoriteProduct::class);
     }

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -20,7 +20,7 @@ use Eccube\Entity\Customer;
 use Eccube\Entity\Master\CustomerStatus;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Util\StringUtil;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
@@ -59,7 +59,7 @@ class CustomerRepository extends AbstractRepository
     /**
      * CustomerRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      * @param Queries $queries
      * @param EntityManagerInterface $entityManager
      * @param OrderRepository $orderRepository
@@ -67,7 +67,7 @@ class CustomerRepository extends AbstractRepository
      * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
-        RegistryInterface $registry,
+        ManagerRegistry $registry,
         Queries $queries,
         EntityManagerInterface $entityManager,
         OrderRepository $orderRepository,

--- a/src/Eccube/Repository/DeliveryDurationRepository.php
+++ b/src/Eccube/Repository/DeliveryDurationRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\DeliveryDuration;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * DeliveryDurationRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class DeliveryDurationRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, DeliveryDuration::class);
     }

--- a/src/Eccube/Repository/DeliveryFeeRepository.php
+++ b/src/Eccube/Repository/DeliveryFeeRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\DeliveryFee;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * DelivFeeRepository
@@ -27,9 +27,9 @@ class DeliveryFeeRepository extends AbstractRepository
     /**
      * DeliveryFeeRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      */
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, DeliveryFee::class);
     }

--- a/src/Eccube/Repository/DeliveryRepository.php
+++ b/src/Eccube/Repository/DeliveryRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository;
 
 use Eccube\Entity\Delivery;
 use Eccube\Entity\Payment;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * DelivRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class DeliveryRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Delivery::class);
     }

--- a/src/Eccube/Repository/DeliveryTimeRepository.php
+++ b/src/Eccube/Repository/DeliveryTimeRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\DeliveryTime;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * DelivTimeRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class DeliveryTimeRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, DeliveryTime::class);
     }

--- a/src/Eccube/Repository/LayoutRepository.php
+++ b/src/Eccube/Repository/LayoutRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository;
 
 use Doctrine\ORM\NoResultException;
 use Eccube\Entity\Layout;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * LayoutRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class LayoutRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Layout::class);
     }

--- a/src/Eccube/Repository/LoginHistoryRepository.php
+++ b/src/Eccube/Repository/LoginHistoryRepository.php
@@ -16,7 +16,7 @@ namespace Eccube\Repository;
 use Eccube\Doctrine\Query\Queries;
 use Eccube\Entity\LoginHistory;
 use Eccube\Util\StringUtil;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * LoginHistoryRepository
@@ -35,7 +35,7 @@ class LoginHistoryRepository extends AbstractRepository
      * LoginHistoryRepository constructor.
      */
     public function __construct(
-        RegistryInterface $registry,
+        ManagerRegistry $registry,
         Queries $queries
     ) {
         parent::__construct($registry, LoginHistory::class);

--- a/src/Eccube/Repository/MailHistoryRepository.php
+++ b/src/Eccube/Repository/MailHistoryRepository.php
@@ -16,7 +16,7 @@ namespace Eccube\Repository;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Eccube\Entity\MailHistory;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * MailHistoryRepository
@@ -29,9 +29,9 @@ class MailHistoryRepository extends AbstractRepository
     /**
      * MailHistoryRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      */
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, MailHistory::class);
     }

--- a/src/Eccube/Repository/MailTemplateRepository.php
+++ b/src/Eccube/Repository/MailTemplateRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\MailTemplate;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * MailTemplateRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class MailTemplateRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, MailTemplate::class);
     }

--- a/src/Eccube/Repository/Master/AuthorityRepository.php
+++ b/src/Eccube/Repository/Master/AuthorityRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\Authority;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * AuthorityRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class AuthorityRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Authority::class);
     }

--- a/src/Eccube/Repository/Master/CountryRepository.php
+++ b/src/Eccube/Repository/Master/CountryRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\Country;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * CountryRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class CountryRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Country::class);
     }

--- a/src/Eccube/Repository/Master/CsvTypeRepository.php
+++ b/src/Eccube/Repository/Master/CsvTypeRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\CsvType;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * CsvTypeRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class CsvTypeRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, CsvType::class);
     }

--- a/src/Eccube/Repository/Master/CustomerOrderStatusRepository.php
+++ b/src/Eccube/Repository/Master/CustomerOrderStatusRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\CustomerOrderStatus;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * CustomerOrderStatusRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class CustomerOrderStatusRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, CustomerOrderStatus::class);
     }

--- a/src/Eccube/Repository/Master/CustomerStatusRepository.php
+++ b/src/Eccube/Repository/Master/CustomerStatusRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\CustomerStatus;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * CustomerStatusRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class CustomerStatusRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, CustomerStatus::class);
     }

--- a/src/Eccube/Repository/Master/DeviceTypeRepository.php
+++ b/src/Eccube/Repository/Master/DeviceTypeRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\DeviceType;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * DeviceTypeRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class DeviceTypeRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, DeviceType::class);
     }

--- a/src/Eccube/Repository/Master/JobRepository.php
+++ b/src/Eccube/Repository/Master/JobRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\Job;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * JobRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class JobRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Job::class);
     }

--- a/src/Eccube/Repository/Master/LoginHistoryStatusRepository.php
+++ b/src/Eccube/Repository/Master/LoginHistoryStatusRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\LoginHistoryStatus;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * LoginHistoryStatusRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class LoginHistoryStatusRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, LoginHistoryStatus::class);
     }

--- a/src/Eccube/Repository/Master/OrderItemTypeRepository.php
+++ b/src/Eccube/Repository/Master/OrderItemTypeRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\OrderItemType;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * OrderItemTypeRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class OrderItemTypeRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, OrderItemType::class);
     }

--- a/src/Eccube/Repository/Master/OrderStatusColorRepository.php
+++ b/src/Eccube/Repository/Master/OrderStatusColorRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\OrderStatusColor;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * OrderStatusColorRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class OrderStatusColorRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, OrderStatusColor::class);
     }

--- a/src/Eccube/Repository/Master/OrderStatusRepository.php
+++ b/src/Eccube/Repository/Master/OrderStatusRepository.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * OrderStatusRepository
@@ -30,9 +30,9 @@ class OrderStatusRepository extends AbstractRepository
     /**
      * OrderStatusRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      */
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, OrderStatus::class);
     }

--- a/src/Eccube/Repository/Master/PageMaxRepository.php
+++ b/src/Eccube/Repository/Master/PageMaxRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\PageMax;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * PageMaxRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class PageMaxRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, PageMax::class);
     }

--- a/src/Eccube/Repository/Master/PrefRepository.php
+++ b/src/Eccube/Repository/Master/PrefRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\Pref;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * PrefRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class PrefRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Pref::class);
     }

--- a/src/Eccube/Repository/Master/ProductListMaxRepository.php
+++ b/src/Eccube/Repository/Master/ProductListMaxRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\ProductListMax;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * ProductListMaxRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class ProductListMaxRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, ProductListMax::class);
     }

--- a/src/Eccube/Repository/Master/ProductListOrderByRepository.php
+++ b/src/Eccube/Repository/Master/ProductListOrderByRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\ProductListOrderBy;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * ProductListOrderByRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class ProductListOrderByRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, ProductListOrderBy::class);
     }

--- a/src/Eccube/Repository/Master/ProductStatusRepository.php
+++ b/src/Eccube/Repository/Master/ProductStatusRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\ProductStatus;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * ProductStatusRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class ProductStatusRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, ProductStatus::class);
     }

--- a/src/Eccube/Repository/Master/RoundingTypeRepository.php
+++ b/src/Eccube/Repository/Master/RoundingTypeRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\RoundingType;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * RoundingTypeRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class RoundingTypeRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, RoundingType::class);
     }

--- a/src/Eccube/Repository/Master/SaleTypeRepository.php
+++ b/src/Eccube/Repository/Master/SaleTypeRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\SaleType;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * SaleTypeRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class SaleTypeRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, SaleType::class);
     }

--- a/src/Eccube/Repository/Master/SexRepository.php
+++ b/src/Eccube/Repository/Master/SexRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\Sex;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * SexRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class SexRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Sex::class);
     }

--- a/src/Eccube/Repository/Master/TaxDisplayTypeRepository.php
+++ b/src/Eccube/Repository/Master/TaxDisplayTypeRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\TaxDisplayType;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * TaxDisplayTypeRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class TaxDisplayTypeRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, TaxDisplayType::class);
     }

--- a/src/Eccube/Repository/Master/TaxTypeRepository.php
+++ b/src/Eccube/Repository/Master/TaxTypeRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\TaxType;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * TaxTypeRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class TaxTypeRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, TaxType::class);
     }

--- a/src/Eccube/Repository/Master/WorkRepository.php
+++ b/src/Eccube/Repository/Master/WorkRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository\Master;
 
 use Eccube\Entity\Master\Work;
 use Eccube\Repository\AbstractRepository;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * WorkRepository
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class WorkRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Work::class);
     }

--- a/src/Eccube/Repository/MemberRepository.php
+++ b/src/Eccube/Repository/MemberRepository.php
@@ -16,7 +16,7 @@ namespace Eccube\Repository;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Eccube\Entity\Member;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * MemberRepository
@@ -26,7 +26,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class MemberRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Member::class);
     }

--- a/src/Eccube/Repository/NewsRepository.php
+++ b/src/Eccube/Repository/NewsRepository.php
@@ -18,7 +18,7 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Eccube\Entity\News;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * NewsRepository
@@ -28,7 +28,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class NewsRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, News::class);
     }

--- a/src/Eccube/Repository/OrderItemRepository.php
+++ b/src/Eccube/Repository/OrderItemRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\OrderItem;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * OrderItemRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class OrderItemRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, OrderItem::class);
     }

--- a/src/Eccube/Repository/OrderPdfRepository.php
+++ b/src/Eccube/Repository/OrderPdfRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository;
 
 use Eccube\Entity\Member;
 use Eccube\Entity\OrderPdf;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * OrderPdfRepository.
@@ -25,7 +25,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class OrderPdfRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, OrderPdf::class);
     }

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -21,7 +21,7 @@ use Eccube\Entity\Master\OrderStatus;
 use Eccube\Entity\Order;
 use Eccube\Entity\Shipping;
 use Eccube\Util\StringUtil;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * OrderRepository
@@ -39,10 +39,10 @@ class OrderRepository extends AbstractRepository
     /**
      * OrderRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      * @param Queries $queries
      */
-    public function __construct(RegistryInterface $registry, Queries $queries)
+    public function __construct(ManagerRegistry $registry, Queries $queries)
     {
         parent::__construct($registry, Order::class);
         $this->queries = $queries;

--- a/src/Eccube/Repository/PageLayoutRepository.php
+++ b/src/Eccube/Repository/PageLayoutRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\PageLayout;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * PageLayoutRepository
@@ -27,9 +27,9 @@ class PageLayoutRepository extends AbstractRepository
     /**
      * PageLayoutRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      */
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, PageLayout::class);
     }

--- a/src/Eccube/Repository/PageRepository.php
+++ b/src/Eccube/Repository/PageRepository.php
@@ -16,7 +16,7 @@ namespace Eccube\Repository;
 use Doctrine\ORM\NoResultException;
 use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Page;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -53,11 +53,11 @@ class PageRepository extends AbstractRepository
     /**
      * PageRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      * @param EccubeConfig $eccubeConfig
      * @param ContainerInterface $container
      */
-    public function __construct(RegistryInterface $registry, EccubeConfig $eccubeConfig, ContainerInterface $container)
+    public function __construct(ManagerRegistry $registry, EccubeConfig $eccubeConfig, ContainerInterface $container)
     {
         parent::__construct($registry, Page::class);
         $this->eccubeConfig = $eccubeConfig;

--- a/src/Eccube/Repository/PaymentOptionRepository.php
+++ b/src/Eccube/Repository/PaymentOptionRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\PaymentOption;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * PaymentOptionRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class PaymentOptionRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, PaymentOption::class);
     }

--- a/src/Eccube/Repository/PaymentRepository.php
+++ b/src/Eccube/Repository/PaymentRepository.php
@@ -15,7 +15,7 @@ namespace Eccube\Repository;
 
 use Doctrine\ORM\Query;
 use Eccube\Entity\Payment;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * PaymentRepository
@@ -28,9 +28,9 @@ class PaymentRepository extends AbstractRepository
     /**
      * PaymentRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      */
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Payment::class);
     }

--- a/src/Eccube/Repository/PluginRepository.php
+++ b/src/Eccube/Repository/PluginRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\Plugin;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * PluginRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class PluginRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Plugin::class);
     }

--- a/src/Eccube/Repository/ProductCategoryRepository.php
+++ b/src/Eccube/Repository/ProductCategoryRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\ProductCategory;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * ProductCategoryRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class ProductCategoryRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, ProductCategory::class);
     }

--- a/src/Eccube/Repository/ProductClassRepository.php
+++ b/src/Eccube/Repository/ProductClassRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\ProductClass;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * ProductClassRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class ProductClassRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, ProductClass::class);
     }

--- a/src/Eccube/Repository/ProductImageRepository.php
+++ b/src/Eccube/Repository/ProductImageRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\ProductImage;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * ProductImageRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class ProductImageRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, ProductImage::class);
     }

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -19,7 +19,7 @@ use Eccube\Doctrine\Query\Queries;
 use Eccube\Entity\Product;
 use Eccube\Entity\ProductStock;
 use Eccube\Util\StringUtil;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * ProductRepository
@@ -42,12 +42,12 @@ class ProductRepository extends AbstractRepository
     /**
      * ProductRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      * @param Queries $queries
      * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
-        RegistryInterface $registry,
+        ManagerRegistry $registry,
         Queries $queries,
         EccubeConfig $eccubeConfig
     ) {

--- a/src/Eccube/Repository/ProductStockRepository.php
+++ b/src/Eccube/Repository/ProductStockRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\ProductStock;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * ProductClassRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class ProductStockRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, ProductStock::class);
     }

--- a/src/Eccube/Repository/ProductTagRepository.php
+++ b/src/Eccube/Repository/ProductTagRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\ProductTag;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * ProductTagRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class ProductTagRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, ProductTag::class);
     }

--- a/src/Eccube/Repository/ShippingRepository.php
+++ b/src/Eccube/Repository/ShippingRepository.php
@@ -16,7 +16,7 @@ namespace Eccube\Repository;
 use Doctrine\ORM\QueryBuilder;
 use Eccube\Entity\Shipping;
 use Eccube\Util\StringUtil;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * ShippingRepository
@@ -26,7 +26,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class ShippingRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Shipping::class);
     }

--- a/src/Eccube/Repository/TagRepository.php
+++ b/src/Eccube/Repository/TagRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\Tag;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * TagRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class TagRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Tag::class);
     }

--- a/src/Eccube/Repository/TaxRuleRepository.php
+++ b/src/Eccube/Repository/TaxRuleRepository.php
@@ -19,7 +19,7 @@ use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Customer;
 use Eccube\Entity\Master\RoundingType;
 use Eccube\Entity\TaxRule;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
@@ -51,14 +51,14 @@ class TaxRuleRepository extends AbstractRepository
     /**
      * TaxRuleRepository constructor.
      *
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      * @param TokenStorageInterface $tokenStorage
      * @param AuthorizationCheckerInterface $authorizationChecker
      * @param BaseInfoRepository $baseInfoRepository
      * @param EccubeConfig $eccubeConfig
      */
     public function __construct(
-        RegistryInterface $registry,
+        ManagerRegistry $registry,
         TokenStorageInterface $tokenStorage,
         AuthorizationCheckerInterface $authorizationChecker,
         BaseInfoRepository $baseInfoRepository,

--- a/src/Eccube/Repository/TemplateRepository.php
+++ b/src/Eccube/Repository/TemplateRepository.php
@@ -14,7 +14,7 @@
 namespace Eccube\Repository;
 
 use Eccube\Entity\Template;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * TemplateRepository
@@ -24,7 +24,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
  */
 class TemplateRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Template::class);
     }


### PR DESCRIPTION
… service alias is deprecated, use "Doctrine\Persistence\ManagerRegistry" instead. fixed

	- https://stackoverflow.com/questions/58954082/symfony-4-no-such-service-exists-for-objectmanager-after-composer-update#answer-58994043

## 概要(Overview・Refs Issue)

issue #5082 のバグ出力の抑制で、リポジトリの定義を変更しました。

### 変更前

<img width="1480" alt="SS-screenshot- 2021-09-03 14 54 29" src="https://user-images.githubusercontent.com/2732196/131959076-3737eda6-8d97-419e-893e-7335cf44704d.png">
<img width="869" alt="SS-screenshot- 2021-09-03 14 54 59" src="https://user-images.githubusercontent.com/2732196/131959086-d9008887-d08a-4aab-9c5a-76935b93d780.png">


### 変更後

<img width="1494" alt="SS-screenshot- 2021-09-03 14 53 23" src="https://user-images.githubusercontent.com/2732196/131959099-02ef4847-6843-48a2-a72f-32daf8ebfdfc.png">


## 方針(Policy)

symfony3.4 

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
