### PR TITLE
Fixed/issue5111 サイトマップ 商品情報出力の際に、在庫切れ非表示オプションを有効にしても表示されるを改修

### DIFF
--- a/src/Eccube/Controller/SitemapController.php
+++ b/src/Eccube/Controller/SitemapController.php
@@ -13,7 +13,9 @@
 
 namespace Eccube\Controller;
 
+use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Page;
+use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\CategoryRepository;
 use Eccube\Repository\Master\ProductListOrderByRepository;
 use Eccube\Repository\PageRepository;
@@ -54,6 +56,11 @@ class SitemapController extends AbstractController
     private $router;
 
     /**
+     * @var BaseInfo
+     */
+    protected $BaseInfo;
+
+    /**
      * SitemapController constructor.
      */
     public function __construct(
@@ -61,13 +68,15 @@ class SitemapController extends AbstractController
         PageRepository $pageRepository,
         ProductListOrderByRepository $productListOrderByRepository,
         ProductRepository $productRepository,
-        RouterInterface $router
+        RouterInterface $router,
+        BaseInfoRepository $baseInfoRepository
     ) {
         $this->categoryRepository = $categoryRepository;
         $this->pageRepository = $pageRepository;
         $this->productListOrderByRepository = $productListOrderByRepository;
         $this->productRepository = $productRepository;
         $this->router = $router;
+        $this->BaseInfo = $baseInfoRepository->get();
     }
 
     /**
@@ -136,6 +145,10 @@ class SitemapController extends AbstractController
      */
     public function product(Request $request, PaginatorInterface $paginator)
     {
+        // Doctrine SQLFilter
+        if ($this->BaseInfo->isOptionNostockHidden()) {
+            $this->entityManager->getFilters()->enable('option_nostock_hidden');
+        }
         // フロントの商品一覧の条件で商品情報を取得
         $ProductListOrder = $this->productListOrderByRepository->find($this->eccubeConfig['eccube_product_order_newer']);
         $productQueryBuilder = $this->productRepository->getQueryBuilderBySearchData(['orderby' => $ProductListOrder]);


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)

#5111 サイトマップ 商品情報出力の際に、在庫切れ非表示オプションを有効にしても表示されるを改修

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
