### PR TITLE
E2Eテスト改善 EA08SysteminfoCest

### DIFF
--- a/codeception/acceptance/EA08SysteminfoCest.php
+++ b/codeception/acceptance/EA08SysteminfoCest.php
@@ -42,6 +42,12 @@ class EA08SysteminfoCest
         $I->see('システム情報システム設定', '.c-pageTitle__titles');
 
         $I->see('システム情報', '#server_info_box__header > div > span');
+        $I->see('EC-CUBE', '#server_info_box__body_inner > div:nth-child(1) > div:first-child');
+        $I->see('サーバーOS', '#server_info_box__body_inner > div:nth-child(2) > div:first-child');
+        $I->see('DBサーバー', '#server_info_box__body_inner > div:nth-child(3) > div:first-child');
+        $I->see('WEBサーバー', '#server_info_box__body_inner > div:nth-child(4) > div:first-child');
+        $I->see('PHP', '#server_info_box__body_inner > div:nth-child(5) > div:first-child');
+        $I->see('User Agent', '#server_info_box__body_inner > div:nth-child(6) > div:first-child');
         $I->see('PHP情報', '#php_info_box__header > div > span');
 
         $I->expect('session.save_path をチェックします');
@@ -231,6 +237,7 @@ class EA08SysteminfoCest
         $config = Fixtures::get('config');
         $I->amOnPage('/'.$config['eccube_admin_route'].'/setting/system/member');
         $I->see('メンバー管理システム設定', '.c-pageTitle');
+        $I->see('administrator', '.card-body tbody tr:nth-child(1) td:nth-child(1)');
 
         $I->click('.c-primaryCol .card-body table tbody tr:nth-child(1) td:nth-child(6) .action-delete');
         $I->waitForElementVisible(['css' => '.c-primaryCol .card-body table tbody tr:nth-child(1) .modal']);
@@ -329,7 +336,7 @@ class EA08SysteminfoCest
 
     public function systeminfo_権限管理追加(AcceptanceTester $I)
     {
-        $I->wantTo('EA0805-UC01-T01 権限管理 - 追加');
+        $I->wantTo('EA0805-UC03-T01 / UC03-T02 権限管理 - 追加');
 
         AuthorityManagePage::go($I)
             ->行追加()
@@ -340,11 +347,16 @@ class EA08SysteminfoCest
         $I->see('保存しました', AuthorityManagePage::$完了メッセージ);
         $I->dontSee('コンテンツ管理', 'nav .c-mainNavArea__nav');
         $I->dontSee('オーナーズストア', 'nav .c-mainNavArea__nav');
+
+        // アクセスして確認
+        $config = Fixtures::get('config');
+        $I->amOnPage("/${config['eccube_admin_route']}/content/news");
+        $I->seeInTitle('アクセスできません');
     }
 
     public function systeminfo_権限管理削除(AcceptanceTester $I)
     {
-        $I->wantTo('EA0805-UC02-T01 権限管理 - 削除');
+        $I->wantTo('EA0805-UC03-T03 権限管理 - 削除');
 
         AuthorityManagePage::go($I)
             ->行削除(2)
@@ -354,11 +366,16 @@ class EA08SysteminfoCest
         $I->see('保存しました', AuthorityManagePage::$完了メッセージ);
         $I->see('コンテンツ管理', 'nav .c-mainNavArea__nav');
         $I->see('オーナーズストア', 'nav .c-mainNavArea__nav');
+
+        // アクセスして確認
+        $config = Fixtures::get('config');
+        $I->amOnPage("/${config['eccube_admin_route']}/content/news");
+        $I->seeInTitle('コンテンツ管理');
     }
 
     public function systeminfo_ログ表示(AcceptanceTester $I)
     {
-        $I->wantTo('EA0806-UC01-T01 ログ表示');
+        $I->wantTo('EA0806-UC02-T01 ログ表示');
 
         // 表示
         $config = Fixtures::get('config');
@@ -368,10 +385,34 @@ class EA08SysteminfoCest
         $option = $I->grabTextFrom('#admin_system_log_files option:nth-child(1)');
         $I->selectOption('#admin_system_log_files', $option);
 
-        $I->fillField(['id' => 'admin_system_log_line_max'], '1');
+        $I->fillField(['id' => 'admin_system_log_line_max'], '10');
         $I->click(['css' => '#form1 button']);
 
-        $I->seeInField(['id' => 'admin_system_log_line_max'], '1');
+        $logs = $I->grabTextFrom('.c-contentsArea textarea');
+        $I->assertLessThanOrEqual(10, count(explode("\n", $logs)), "ログ件数を確認");
+        $I->seeInField(['id' => 'admin_system_log_line_max'], '10');
+    }
+
+    public function systeminfo_ログ表示_異常(AcceptanceTester $I)
+    {
+        $I->wantTo('EA0806-UC02-T02 / UC02-T03 / UC02-T04 ログ表示異常');
+
+        $config = Fixtures::get('config');
+
+        $I->amOnPage('/'.$config['eccube_admin_route'].'/setting/system/log');
+        $I->fillField(['id' => 'admin_system_log_line_max'], '0');
+        $I->click(['css' => '#form1 button']);
+        $I->see('エラー', '#form1 .invalid-feedback');
+
+        $I->amOnPage('/'.$config['eccube_admin_route'].'/setting/system/log');
+        $I->fillField(['id' => 'admin_system_log_line_max'], '-1');
+        $I->click(['css' => '#form1 button']);
+        $I->see('エラー', '#form1 .invalid-feedback');
+
+        $I->amOnPage('/'.$config['eccube_admin_route'].'/setting/system/log');
+        $I->fillField(['id' => 'admin_system_log_line_max'], 'a');
+        $I->click(['css' => '#form1 button']);
+        $I->see('エラー', '#form1 .invalid-feedback');
     }
 
     public function systeminfo_マスターデータ管理(AcceptanceTester $I)


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
E2Eテスト改善 EA08SysteminfoCest
管理画面 システム設定関連の E2Eテストの追加・修正です

同時にテストケースも一部修正しています、PRは以下となります
https://github.com/EC-CUBE/eccube-specification/pull/75

該当するテストケース:
https://github.com/EC-CUBE/eccube-specification/blob/4.1/IntegrationTest/EA08_SystemInformation_%E7%B5%90%E5%90%88%E8%A9%A6%E9%A8%93%E9%A0%85%E7%9B%AE%E6%9B%B8.md

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
