### PR TITLE
E2Eテスト改善 EA06 incomplete 項目の対応

### DIFF
--- a/codeception/_data/upload.php
+++ b/codeception/_data/upload.php
@@ -1,0 +1,2 @@
+<?php
+echo "hello";

--- a/codeception/_support/Page/Admin/BlockManagePage.php
+++ b/codeception/_support/Page/Admin/BlockManagePage.php
@@ -37,11 +37,22 @@ class BlockManagePage extends AbstractAdminPageStyleGuide
 
     public function 編集($rowNum)
     {
-        $this->tester->click("#page_admin_content_block > div > div.c-contentsArea > div.c-contentsArea__cols > div > div.c-primaryCol > div > div > div > ul > li:nth-child(${rowNum}) > div > div.col-auto.text-right > a:nth-child(1)");
+        $rowNum++;
+        $this->tester->click(".c-contentsArea .list-group > li:nth-child(${rowNum}) a[data-original-title=編集]");
     }
 
     public function 削除($rowNum)
     {
-        $this->tester->click("#page_admin_content_block > div > div.c-contentsArea > div.c-contentsArea__cols > div > div.c-primaryCol > div > div > div > ul > li:nth-child(${rowNum}) > div > div.col-auto.text-right > a.btn.btn-ec-actionIcon.mr-3.disabled");
+        $rowNum++;
+        $this->tester->click(".c-contentsArea .list-group > li:nth-child(${rowNum}) [data-original-title=削除] a");
+        return $this;
+    }
+
+    public function ポップアップを受け入れます()
+    {
+        $this->tester->waitForElementVisible(['css' => '.modal.show']);
+        $this->tester->click('.modal.show .btn-ec-delete');
+
+        return $this;
     }
 }

--- a/codeception/_support/Page/Admin/LayoutEditPage.php
+++ b/codeception/_support/Page/Admin/LayoutEditPage.php
@@ -131,4 +131,11 @@ class LayoutEditPage extends AbstractAdminPageStyleGuide
 
         return $this;
     }
+
+    public function 端末種別($text)
+    {
+        $this->tester->selectOption(['css' => '#admin_layout_DeviceType'], ['text' => $text]);
+
+        return $this;
+    }
 }

--- a/codeception/_support/Page/Admin/LayoutManagePage.php
+++ b/codeception/_support/Page/Admin/LayoutManagePage.php
@@ -15,6 +15,8 @@ namespace Page\Admin;
 
 class LayoutManagePage extends AbstractAdminPageStyleGuide
 {
+    public static $登録完了メッセージ = ['css' => '.c-contentsArea .alert'];
+
     public function __construct(\AcceptanceTester $I)
     {
         parent::__construct($I);
@@ -34,10 +36,10 @@ class LayoutManagePage extends AbstractAdminPageStyleGuide
 
     public function 削除($layoutName)
     {
-        $this->tester->getScenario()->incomplete('未実装：レイアウトの削除は未実装');
-
-        $this->tester->click(['xpath' => "//div[@id='sortable_list_box__list']//div[@class='item_pattern td'][translate(text(), ' \r\n', '')='${layoutName}']/parent::node()/div[@class='icon_edit td']/div/span"]);
-        $this->tester->click(['xpath' => "//div[@id='sortable_list_box__list']//div[@class='item_pattern td'][translate(text(), ' \r\n', '')='${layoutName}']/parent::node()/div[@class='icon_edit td']/div/ul/li[2]/span"]);
+        $this->tester->click(['xpath' => "//button[contains(@data-message, '「{$layoutName}」を削除')]"]);
+        $this->tester->waitForElementVisible(['css' => '.modal.show']);
+        $this->tester->wait(1);
+        $this->tester->click('.modal.show .btn-ec-delete');
     }
 
     public function 新規登録()

--- a/codeception/_support/Page/Admin/NewsEditPage.php
+++ b/codeception/_support/Page/Admin/NewsEditPage.php
@@ -26,8 +26,8 @@ class NewsEditPage extends AbstractAdminPage
     public static function of($I)
     {
         $page = new self($I);
-        $page->atPage('コンテンツ管理新着情報管理');
-        $page->tester->see('新着情報登録・編集', '.c-container .c-contentsArea .c-contentsArea__cols .card-header');
+        $page->atPage('新着情報管理コンテンツ管理');
+        $page->tester->see('新着情報', '.c-container .c-contentsArea .c-contentsArea__cols .card-header');
 
         return $page;
     }

--- a/codeception/_support/Page/Admin/NewsManagePage.php
+++ b/codeception/_support/Page/Admin/NewsManagePage.php
@@ -29,33 +29,31 @@ class NewsManagePage extends AbstractAdminPage
     {
         $page = new self($I);
 
-        return $page->goPage('/content/news', 'コンテンツ管理新着情報管理');
+        return $page->goPage('/content/news', '新着情報管理コンテンツ管理');
     }
 
     public static function at($I)
     {
         $page = new self($I);
 
-        return $page->atPage('コンテンツ管理新着情報管理');
+        return $page->atPage('新着情報管理コンテンツ管理');
     }
 
     public function 新規登録()
     {
-        $this->tester->click('.c-contentsArea .c-contentsArea__cols .c-contentsArea__primaryCol .justify-content-between #addNew
-        ');
+        $this->tester->click('#addNew');
     }
 
     public function 一覧_編集($rowNum)
     {
-        $this->tester->click(" ul .list-group li:nth-child(${rowNum})
-     div > div :nth-child(4) > a");
+        $this->tester->click(".c-contentsArea .list-group > li:nth-child(${rowNum}) a[title=編集]");
 
         return $this;
     }
 
     public function 一覧_タイトル($rowNum)
     {
-        return $this->tester->grabTextFrom(['css' => "ul.list-group li:nth-child(${rowNum}) div > div:nth-child(4) a"]);
+        return $this->tester->grabTextFrom(['css' => ".c-contentsArea .list-group li:nth-child(${rowNum}) a:nth-of-type(1)"]);
     }
 
     public function 一覧_下へ($rowNum)
@@ -68,16 +66,15 @@ class NewsManagePage extends AbstractAdminPage
 
     public function 一覧_削除($rowNum)
     {
-        $this->tester->click("ul.list-group li:nth-child(${rowNum}) div > div:nth-child(5) > div > div:nth-child(3) > a.btn-ec-actionIcon");
+        $this->tester->click(".c-contentsArea .list-group > li:nth-child(${rowNum}) [title=削除] a");
 
         return $this;
     }
 
     public function ポップアップを受け入れます($rowNum)
     {
-        $modal = "ul.list-group li:nth-child(${rowNum}) div > div:nth-child(5) > div > div:nth-child(3) div.modal";
-        $this->tester->waitForElementVisible(['css' => $modal]);
-        $this->tester->click($modal.' .modal-footer a.btn-ec-delete');
+        $this->tester->waitForElementVisible(['css' => '.modal.show']);
+        $this->tester->click('.modal.show .btn-ec-delete');
 
         return $this;
     }

--- a/codeception/acceptance/EA06ContentsManagementCest.php
+++ b/codeception/acceptance/EA06ContentsManagementCest.php
@@ -260,7 +260,7 @@ class EA06ContentsManagementCest
         LayoutEditPage::at($I)
             ->レイアウト名($layoutName)
             ->端末種別('PC')
-            ->ブロックを移動('ロゴ', '#position_3')
+            ->ブロックを移動('新着情報', '#position_3')
             ->登録();
         $I->see('保存しました');
 
@@ -274,20 +274,21 @@ class EA06ContentsManagementCest
             ->登録();
         $I->see('保存しました', PageEditPage::$登録完了メッセージ);
 
-        // 作成したページの表示確認
+        // 作成したページの表示確認 (新着情報がヘッダエリアに表示されていることを確認)
         $I->amOnPage('/user_data/'.$pageName);
-        $I->grabTextFrom('.ec-layoutRole__header .ec-headerTitle');
+        $I->seeElement('.ec-layoutRole__header .ec-newsRole');
 
         // 編集
         LayoutManagePage::go($I)->レイアウト編集($layoutName);
         LayoutEditPage::at($I)
-            ->ブロックを移動('ロゴ', '#position_4')
+            ->ブロックを移動('新着情報', '#position_10')
             ->登録();
         $I->see('保存しました', LayoutEditPage::$登録完了メッセージ);
 
-        // 編集したページの表示確認 (ブロックの位置が移動されていることを確認)
+        // 編集したページの表示確認 (新着情報がフッタエリアに表示されていることを確認)
         $I->amOnPage('/user_data/'.$pageName);
-        $I->grabTextFrom('.ec-layoutRole__contentTop .ec-headerTitle');
+        $I->seeElement('.ec-layoutRole__footer .ec-newsRole');
+        $I->dontSeeElement('.ec-layoutRole__header .ec-newsRole');
 
         // レイアウトの削除 → レイアウトを適用したページがあるため削除できない
         LayoutManagePage::go($I)->削除($layoutName);

--- a/codeception/acceptance/EA06ContentsManagementCest.php
+++ b/codeception/acceptance/EA06ContentsManagementCest.php
@@ -45,10 +45,9 @@ class EA06ContentsManagementCest
 
     public function contentsmanagement_新着情報管理(AcceptanceTester $I)
     {
-        $I->getScenario()->incomplete('未実装：新着情報管理は未実装');
-
         $I->wantTo('EA0601-UC01-T01(& UC02-T01/UC02-T02/UC03-T01) 新着情報管理（作成・編集・削除）');
 
+        // EA0601-UC01-T01_新着情報管理（新規作成）
         NewsManagePage::go($I)->新規登録();
 
         NewsEditPage::of($I)
@@ -57,27 +56,26 @@ class EA06ContentsManagementCest
             ->入力_本文('newsnewsnewsnewsnews')
             ->登録();
 
-        $NewsListPage = NewsManagePage::at($I);
         $I->see('保存しました', NewsManagePage::$登録完了メッセージ);
 
-        $NewsListPage->一覧_編集(2);
+        // EA0601-UC02-T01_新着情報管理（編集）
+        NewsManagePage::go($I)->一覧_編集(2);
+        $new_title = 'news_title ' . uniqid();
 
         NewsEditPage::of($I)
-            ->入力_タイトル('news_title2')
+            ->入力_タイトル($new_title)
             ->登録();
 
-        $NewsListPage = NewsManagePage::at($I);
-        $I->see('新着情報を保存しました。', NewsManagePage::$登録完了メッセージ);
-        $I->assertEquals('news_title2', $NewsListPage->一覧_タイトル(2));
+        $I->see('保存しました', NewsManagePage::$登録完了メッセージ);
 
-        $I->assertEquals('news_title2', $NewsListPage->一覧_タイトル(2));
+        $NewsListPage = NewsManagePage::go($I);
+        $I->assertEquals($new_title, $NewsListPage->一覧_タイトル(2));
 
-        $I->assertEquals('news_title2', $NewsListPage->一覧_タイトル(2));
-
+        // EA0601-UC03-T01_新着情報管理（削除）
         $NewsListPage->一覧_削除(2);
         $NewsListPage->ポップアップを受け入れます(2);
 
-        $I->assertNotEquals('news_title2', $NewsListPage->一覧_タイトル(2));
+        $I->assertNotEquals($new_title, $NewsListPage->一覧_タイトル(2));
     }
 
     /**
@@ -145,9 +143,19 @@ class EA06ContentsManagementCest
         }
     }
 
+    public function contentsmanagement_ファイル管理_php(AcceptanceTester $I)
+    {
+        $I->wantTo('EA0602-UC01-T09_ファイル管理（phpファイルのアップロード）');
+        FileManagePage::go($I)
+            ->入力_ファイル('upload.php')
+            ->アップロード();
+
+        $I->see('phpファイルはアップロードできません', '#form1 .errormsg');
+    }
+
     public function contentsmanagement_ページ管理(AcceptanceTester $I)
     {
-        $I->wantTo('EA0603-UC01-T01(& UC01-T02/UC01-T03/UC01-T04/UC01-T05) ページ管理');
+        $I->wantTo('EA0603-UC01-T01(& UC01-T02/UC01-T03) ページ管理');
         $faker = Fixtures::get('faker');
         $page = 'page_'.$faker->word;
         PageManagePage::go($I)->新規入力();
@@ -227,6 +235,8 @@ class EA06ContentsManagementCest
 
     public function contentsmanagement_レイアウト管理(AcceptanceTester $I)
     {
+        $I->wantTo('EA0605-UC01-T01_レイアウト管理（新規作成）');
+
         // レイアウト名を未入力で登録
         LayoutManagePage::go($I)->新規登録();
         LayoutEditPage::at($I)
@@ -246,7 +256,7 @@ class EA06ContentsManagementCest
 
     public function contentsmanagement_検索未使用ブロック(AcceptanceTester $I)
     {
-        $I->wantTo('EA0603-UC01-T06 検索未使用ブロック');
+        $I->wantTo('EA0605-UC01-T04_レイアウト管理（未使用ブロックの検索）');
         $layoutName = '下層ページ用レイアウト';
         /* レイアウト編集 */
         LayoutManagePage::go($I)->レイアウト編集($layoutName);
@@ -265,10 +275,11 @@ class EA06ContentsManagementCest
 
     public function contentsmanagement_ブロック管理(AcceptanceTester $I)
     {
-        $I->wantTo('EA0603-UC01-T01(& UC01-T02/UC01-T03) ブロック管理');
+        $I->wantTo('EA0604-UC01-T01(& UC01-T02/UC01-T03) ブロック管理');
         $faker = Fixtures::get('faker');
         $block = $faker->word.'_block';
-        /* 作成 */
+
+        // EA0604-UC01-T01_ブロック管理（新規作成）
         BlockManagePage::go($I)->新規入力();
         BlockEditPage::at($I)
             ->入力_ブロック名($block)
@@ -283,11 +294,10 @@ class EA06ContentsManagementCest
             ->ブロックを移動($block, '#position_3')
             ->登録();
 
-        $I->getScenario()->incomplete('未実装：ブロックの更新は未実装');
         $I->amOnPage('/');
         $I->see('block1', ['id' => $block]);
 
-        /* 編集 */
+        // EA0604-UC01-T02_ブロック管理（ブロック編集）
         BlockManagePage::go($I)->編集(1);
         BlockEditPage::at($I)
             ->入力_データ('<div id='.$block.'>welcome</div>')
@@ -297,9 +307,10 @@ class EA06ContentsManagementCest
         $I->amOnPage('/');
         $I->see('welcome', ['id' => $block]);
 
-        /* 削除 */
-        BlockManagePage::go($I)->削除(1);
-        $I->acceptPopup();
+        // EA0604-UC01-T03_ブロック管理（削除）
+        BlockManagePage::go($I)
+            ->削除(1)
+            ->ポップアップを受け入れます();
 
         $I->amOnPage('/');
         $I->dontSeeElement(['id' => $block]);


### PR DESCRIPTION
E2Eテスト改善 EA06ContentsManagementCest
管理画面 コンテンツ管理ページの E2Eテストの追加・修正です

- EA0601-UC01-T01_新着情報管理（新規作成）
- EA0601-UC02-T01_新着情報管理（編集）
- EA0601-UC03-T01_新着情報管理（削除）
- EA0602-UC01-T09_ファイル管理（phpファイルのアップロード）
- EA0605-UC01-T01_レイアウト管理（新規作成）
- EA0605-UC01-T02_レイアウト管理（編集）
- EA0605-UC01-T03_レイアウト管理（削除）

該当するテストケース
https://github.com/EC-CUBE/eccube-specification/blob/4.1/IntegrationTest/EA06_ContentManagement_%E7%B5%90%E5%90%88%E8%A9%A6%E9%A8%93%E9%A0%85%E7%9B%AE%E6%9B%B8.md