### PR TITLE
データベースが常にsqliteになってしまって動かない不具合の修正

### DIFF
--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -130,6 +130,7 @@ class InstallerCommand extends Command
             $databaseUrl = 'sqlite:///var/eccube.db';
         }
         $this->envFileUpdater->databaseUrl = $this->io->ask('Database Url', $databaseUrl);
+        $databaseUrl = $this->envFileUpdater->databaseUrl;
 
         // DATABASE_SERVER_VERSION
         $this->envFileUpdater->serverVersion = $this->getDatabaseServerVersion($databaseUrl);
@@ -252,7 +253,7 @@ class InstallerCommand extends Command
         if (0 === strpos($databaseUrl, 'sqlite')) {
             return 'sqlite';
         }
-        if (0 === strpos($databaseUrl, 'postgres')) {
+        if (0 === strpos($databaseUrl, 'postgres') || 0 === strpos($databaseUrl, 'pgsql')) {
             return 'postgres';
         }
         if (0 === strpos($databaseUrl, 'mysql')) {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
``./bin/console eccube:install``でインタラクティブにインストールしようとすると、DBのURIがデフォルトのSQLiteに固定になりインストールできない。

## 相談（Discussion）
そもそも`./bin/console eccube:install`を今後も提供し続けていくのか疑問

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
