### PR TITLE
[WIP]支払い方法を変更した時に支払い方法のアンカーへ移動

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -205,11 +205,17 @@ class ShoppingController extends AbstractShoppingController
                 // リダイレクト先のチェック.
                 $pattern = '/^'.preg_quote($request->getBasePath(), '/').'/';
                 $redirectTo = preg_replace($pattern, '', $redirectTo);
+                //リダイレクト先にアンカーが設定されてたらflagmentに設定
+                $redirectTo = explode("#",$redirectTo);
+                $fragment = $redirectTo[1];
+                $redirectTo = $redirectTo[0];
+
                 $result = $router->match($redirectTo);
                 // パラメータのみ抽出
                 $params = array_filter($result, function ($key) {
                     return 0 !== \strpos($key, '_');
                 }, ARRAY_FILTER_USE_KEY);
+                $params['_fragment'] = $fragment;
 
                 log_info('[リダイレクト] リダイレクトを実行します.', [$result['_route'], $params]);
 

--- a/src/Eccube/Resource/template/default/Shopping/index.twig
+++ b/src/Eccube/Resource/template/default/Shopping/index.twig
@@ -344,7 +344,7 @@ file that was distributed with this source code.
                         <button type="button" class="ec-inlineBtn" data-trigger="click" data-path="{{ path('shopping_shipping_multiple') }}">{{ 'front.shopping.to_multiple'|trans }}</button>
                     </div>
                 </div>
-                <div class="ec-orderPayment">
+                <div class="ec-orderPayment" id="payment-method">
                     <div class="ec-rectHeading">
                         <h2>{{ 'front.shopping.payment_info'|trans }}</h2>
                     </div>
@@ -352,7 +352,7 @@ file that was distributed with this source code.
                         {% for key, child in form.Payment %}
                             <div style="display: block;">
                                 {% set Payment = form.Payment.vars.choices[key].data %}
-                                {{ form_widget(child, { 'attr': { 'data-trigger': 'change' }}) }}
+                                {{ form_widget(child, { 'attr': { 'data-trigger': 'change', 'data-path': '/shopping#payment-method' }}) }}
                                 {% if Payment.payment_image is not null %}
                                     <p><img src="{{ asset(Payment.payment_image, 'save_image') }}"></p>
                                 {% endif %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
支払い方法を変更した場合にページトップではなく支払い方法のアンカーへ

#5186 

## テスト（Test)
稼働しているコードですが、``ShoppingController::redirectTo()``を変えてるので他の環境だとエラーが出る可能性があるので確認してください。

## 相談（Discussion）
できればControllerのannotationでflagmentの設定したいけどよくわからん。

https://github.com/tao-s/ec-cube-1/commit/0f69bcdc01ef19ac8b8d1c665fe177c0d5401e3e#diff-21c4d1297a9e1961c312211f32d8c1184a995d79a993bc53535638dfceda5049R208
この辺りもっと良いやり方がありそう。あとこの書き方だとバグが出そう
```php
$redirectTo = explode("#",$redirectTo);
$fragment = $redirectTo[1];
$redirectTo = $redirectTo[0];
```

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 支払い方法を変更した際、確認ページへ遷移せず、支払い方法セクションへ移動できるようになりました。
  - アンカー付きのリダイレクトに対応しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->