### PR TITLE
docker-composeでビルド時にnodejsのインストールにコケる不具合の対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM php:7.4-apache-bullseye
 
 ENV APACHE_DOCUMENT_ROOT /var/www/html
 
-RUN apt-get update \
-  && apt-get install --no-install-recommends -y \
+RUN apt update \
+  && apt upgrade -y \
+  && apt install --no-install-recommends -y \
     apt-transport-https \
     apt-utils \
     build-essential \
@@ -24,8 +25,8 @@ RUN apt-get update \
     unzip \
     zlib1g-dev \
     libwebp-dev \
-  && apt-get upgrade -y ca-certificates \
-  && apt-get clean \
+  && apt upgrade -y ca-certificates \
+  && apt clean \
   && rm -rf /var/lib/apt/lists/* \
   && echo "en_US.UTF-8 UTF-8" >/etc/locale.gen \
   && locale-gen \
@@ -39,8 +40,9 @@ RUN docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
 RUN pecl install apcu && echo "extension=apcu.so" > /usr/local/etc/php/conf.d/apc.ini
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
-  && apt-get install -y nodejs \
-  && apt-get clean \
+  && apt update \
+  && apt install -y nodejs \
+  && apt clean \
   ;
 
 RUN mkdir -p ${APACHE_DOCUMENT_ROOT} \


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
```docker-compose up -d```でビルドする時に

```console
E: Unable to locate package nodejs
```
でビルドがこける不具合の対応

あと``apt-get``古いんで``apt``に変更

## 実装に関する補足(Appendix)
installする前に``apt update``する。最初は``apt upgrade``もする様に。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
