### PR TITLE
Fixed 基本設定画面のgood_tradedとmessageの文字数制限の修正 #5193

### DIFF
--- a/src/Eccube/Form/Type/Admin/ShopMasterType.php
+++ b/src/Eccube/Form/Type/Admin/ShopMasterType.php
@@ -134,7 +134,7 @@ class ShopMasterType extends AbstractType
                 'required' => false,
                 'constraints' => [
                     new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_lltext_len'],
+                        'max' => $this->eccubeConfig['eccube_ltext_len'],
                     ]),
                 ],
             ])
@@ -142,7 +142,7 @@ class ShopMasterType extends AbstractType
                 'required' => false,
                 'constraints' => [
                     new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_lltext_len'],
+                        'max' => $this->eccubeConfig['eccube_ltext_len'],
                     ]),
                 ],
             ])

--- a/tests/Eccube/Tests/Form/Type/Admin/ShopMasterTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/ShopMasterTypeTest.php
@@ -156,4 +156,16 @@ class ShopMasterTypeTest extends AbstractTypeTestCase
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
+    public function testInValidGoodTradedMaxLength()
+    {
+        $this->formData['good_traded'] = str_repeat('1', $this->eccubeConfig['eccube_ltext_len'] + 1);
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+    public function testInValidMessageMaxLength()
+    {
+        $this->formData['message'] = str_repeat('1', $this->eccubeConfig['eccube_ltext_len'] + 1);
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
 }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
基本設定画面のgood_tradedとmessageの文字数制限の修正 #5193

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
ユニットテストを追加しています。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

- 上限値が、4000から3000に変更となるが、既存への影響はどれくらいのものか。
- ※4000文字まで設定されているものかどうか。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
