### PR TITLE
fixed タグ管理の項目追加の自動表示位置が誤り #4981

### DIFF
--- a/src/Eccube/Resource/template/admin/Product/tag.twig
+++ b/src/Eccube/Resource/template/admin/Product/tag.twig
@@ -146,11 +146,6 @@ file that was distributed with this source code.
                                             {{ form_widget(form.name) }}
                                             {{ form_errors(form.name) }}
                                         </div>
-                                        <div class="col-auto align-items-center">
-                                            <button class="btn btn-ec-regular" type="submit">
-                                                {{ 'admin.common.create__new'|trans }}
-                                            </button>
-                                        </div>
 
                                         {# エンティティ拡張の自動出力 #}
                                         {% for f in form|filter(f => f.vars.eccube_form_options.auto_render) %}
@@ -167,7 +162,13 @@ file that was distributed with this source code.
                                                 </div>
                                             {% endif %}
                                         {% endfor %}
-                                    </form>
+
+                                        <div class="col-auto align-items-center">
+                                            <button class="btn btn-ec-regular" type="submit">
+                                                {{ 'admin.common.create__new'|trans }}
+                                            </button>
+                                        </div>
+                                  </form>
                                 </li>
                                 <li class="list-group-item">
                                     <div class="row">


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
タグ管理の項目追加の自動表示位置が誤り #4981

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
- 規格管理
エンティティ拡張の自動出力がなかったため修正していません。

- カテゴリ管理
追加するコンテンツの内容上、エンティティ拡張の自動出力の位置は変更する必要がないと判断しました。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
