### PR TITLE
無効にした商品規格がマイページ再注文から購入されてしまう不具合の修正

### DIFF
--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -369,6 +369,7 @@ front.shopping.out_of_stock_zero: 'Sorry, we do not have enough stock for %produ
 front.shopping.over_price_limit: Sorry, the quantity exceeds the max. purchase amount. Please reduce the purchase quantity.
 front.shopping.in_preparation: 'Sorry, %product% is not ready for shipment. Please contact us from the inquiry form. We are sorry for the inconvenience.'
 front.shopping.not_purchase: Sorry, your order includes item(s) currently unavailable. It has been deleted from your cart.
+front.shopping.not_purchase_product_class: 'Sorry, %product% is currently unavailable. It has been deleted from your cart.'
 front.shopping.price_changed: 'The selling price of %product% has been changed.'
 front.shopping.payment_total_invalid: The total amount is invalid.
 front.shopping.different_payment_methods: Sorry, your order includes items with different purchase methods, which are unable to be processed in one order.

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -369,6 +369,7 @@ front.shopping.out_of_stock_zero: '「%product%」の在庫が不足しており
 front.shopping.over_price_limit: 商品を購入できる金額の上限を超えております。数量を調整してください。
 front.shopping.in_preparation: '「%product%」はまだ配送の準備ができておりません。恐れ入りますがお問い合わせページよりお問い合わせください。'
 front.shopping.not_purchase: 現時点で購入できない商品が含まれておりました。該当商品をカートから削除しました。
+front.shopping.not_purchase_product_class: '「%product%」は現時点で購入できません。該当商品をカートから削除しました。'
 front.shopping.price_changed: '「%product%」の販売価格が変更されました。'
 front.shopping.payment_total_invalid: 合計金額が不正です。
 front.shopping.different_payment_methods: 支払い方法が異なる商品が含まれているため、同時に購入することはできません。

--- a/src/Eccube/Service/PurchaseFlow/Processor/ProductStatusValidator.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/ProductStatusValidator.php
@@ -33,7 +33,12 @@ class ProductStatusValidator extends ItemValidator
     protected function validate(ItemInterface $item, PurchaseContext $context)
     {
         if ($item->isProduct()) {
-            $Product = $item->getProductClass()->getProduct();
+            $ProductClass = $item->getProductClass();
+            if (!$item->getProductClass()->isVisible()) {
+                $this->throwInvalidItemException('front.shopping.not_purchase_product_class', $ProductClass);
+            }
+
+            $Product = $ProductClass->getProduct();
             if ($Product->getStatus()->getId() != ProductStatus::DISPLAY_SHOW) {
                 $this->throwInvalidItemException('front.shopping.not_purchase');
             }

--- a/tests/Eccube/Tests/Service/CartServiceTest.php
+++ b/tests/Eccube/Tests/Service/CartServiceTest.php
@@ -100,7 +100,7 @@ class CartServiceTest extends AbstractServiceTestCase
 
     public function testClear()
     {
-        $this->cartService->addProduct(1);
+        $this->cartService->addProduct(2);
         $this->purchaseFlow->validate($this->cartService->getCart(), new PurchaseContext());
         $this->cartService->save();
 
@@ -172,7 +172,7 @@ class CartServiceTest extends AbstractServiceTestCase
         // 同じ商品規格で同じ数量なら同じ明細とみなすようにする
         $this->cartService->setCartItemComparator(new CartServiceTest_CartItemComparator());
 
-        $ProductClass = $this->productClassRepository->find(1);
+        $ProductClass = $this->productClassRepository->find(2);
 
         $this->cartService->addProduct($ProductClass, 1);
         $this->purchaseFlow->validate($this->cartService->getCart(), new PurchaseContext());
@@ -185,7 +185,7 @@ class CartServiceTest extends AbstractServiceTestCase
         /* @var \Eccube\Entity\CartItem[] $CartItems */
         $CartItems = $this->cartService->getCart()->getCartItems();
         self::assertEquals(1, count($CartItems));
-        self::assertEquals(1, $CartItems[0]->getProductClassId());
+        self::assertEquals(2, $CartItems[0]->getProductClassId());
         self::assertEquals(2, $CartItems[0]->getQuantity());
 
         $this->cartService->addProduct($ProductClass, 1);
@@ -195,9 +195,9 @@ class CartServiceTest extends AbstractServiceTestCase
         /* @var \Eccube\Entity\CartItem[] $CartItems */
         $CartItems = $this->cartService->getCart()->getCartItems();
         self::assertEquals(2, count($CartItems));
-        self::assertEquals(1, $CartItems[0]->getProductClassId());
+        self::assertEquals(2, $CartItems[0]->getProductClassId());
         self::assertEquals(2, $CartItems[0]->getQuantity());
-        self::assertEquals(1, $CartItems[1]->getProductClassId());
+        self::assertEquals(2, $CartItems[1]->getProductClassId());
         self::assertEquals(1, $CartItems[1]->getQuantity());
     }
 

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/ProductStatusValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/ProductStatusValidatorTest.php
@@ -85,4 +85,17 @@ class ProductStatusValidatorTest extends EccubeTestCase
 
         self::assertEquals(0, $this->cartItem->getQuantity());
     }
+
+
+    /**
+     * 無効になっている商品規格の場合は明細の個数を0に設定する.
+     */
+    public function testProductClassVisibleFalse()
+    {
+        $this->ProductClass->setVisible(false);
+
+        $this->validator->execute($this->cartItem, new PurchaseContext());
+
+        self::assertEquals(0, $this->cartItem->getQuantity());
+    }
 }

--- a/tests/Eccube/Tests/Web/AbstractShoppingControllerTestCase.php
+++ b/tests/Eccube/Tests/Web/AbstractShoppingControllerTestCase.php
@@ -63,7 +63,7 @@ abstract class AbstractShoppingControllerTestCase extends AbstractWebTestCase
         return $form;
     }
 
-    protected function scenarioCartIn(Customer $Customer = null, $product_class_id = 1)
+    protected function scenarioCartIn(Customer $Customer = null, $product_class_id = 2)
     {
         if ($Customer) {
             $this->loginTo($Customer);

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -648,7 +648,7 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
         $price = 27777;
         $pointUse = 27777;
         /** @var ProductClass $ProductClass */
-        $ProductClass = $this->entityManager->getRepository(\Eccube\Entity\ProductClass::class)->find(1);
+        $ProductClass = $this->entityManager->getRepository(\Eccube\Entity\ProductClass::class)->find(2);
         $ProductClass->setPrice02($price);
         $this->entityManager->flush($ProductClass);
 
@@ -660,7 +660,7 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
         $COD2 = self::$container->get(Generator::class)->createPayment($Delivery, 'COD2', 0, 30001, 300000);
 
         // カート画面
-        $this->scenarioCartIn($Customer, 1);
+        $this->scenarioCartIn($Customer, 2);
 
         // 確認画面
         $this->scenarioConfirm($Customer);

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleNonmemberTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleNonmemberTest.php
@@ -198,8 +198,8 @@ class ShoppingControllerWithMultipleNonmemberTest extends AbstractShoppingContro
      */
     public function testAddMultiShippingWithOneAddressOneItemTwoQuantities()
     {
-        $this->scenarioCartIn(null, 1);
-        $this->scenarioCartIn(null, 1);
+        $this->scenarioCartIn(null, 2);
+        $this->scenarioCartIn(null, 2);
 
         $formData = $this->createNonmemberFormData();
         $this->scenarioInput($formData);


### PR DESCRIPTION

## 概要(Overview・Refs Issue)
#5210 

## 方針(Policy)
下記の場合、_「商品名(規格名含む)」は現時点で購入できません。該当商品をカートから削除しました。_ と表示され商品がカートから削除される。
・無効な商品規格をカートに追加する
・カートに追加している商品規格が無効に設定変更される

## テスト（Test)
・無効にした商品企画を注文履歴から再注文
・カートに追加済みの商品を無効に変更する

## 相談（Discussion）
ProductStatusValidatorに追記したのですが、新規クラスの方が良いでしょうか？

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
