### PR TITLE
受注登録でお届け先に氏名が表示されない #4980

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -511,7 +511,7 @@ file that was distributed with this source code.
                                     {% for shipping in Order.Shippings %}
                                         <div class="col">
                                             <span class="mr-5">{{ 'admin.order.delivery'|trans }}({{ loop.index }})</span>
-                                            {% set shipping_name = shipping.full_name ~ '(' ~ shipping.full_name_kana ~ ')' ~ shipping.company_name is not null ? shipping.company_name : '' %}
+                                            {% set shipping_name = shipping.full_name ~ ' ' ~ '(' ~ shipping.full_name_kana ~ ')' ~ ' ' ~ (shipping.company_name is not null ? shipping.company_name : '') %}
                                             {% set shipping_addr = 'admin.common.postal_symbol'|trans ~ shipping.postal_code ~ ' ' ~ shipping.pref ~ shipping.addr01 ~ shipping.addr02 %}
                                             {% set shipping_date = shipping.shipping_date is not null ? shipping.shipping_date|date_day : '' %}
                                             {{ shipping_name }} {{ shipping_addr }} {{ shipping.phone_number }} {{ shipping_date }}

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -511,7 +511,7 @@ file that was distributed with this source code.
                                     {% for shipping in Order.Shippings %}
                                         <div class="col">
                                             <span class="mr-5">{{ 'admin.order.delivery'|trans }}({{ loop.index }})</span>
-                                            {% set shipping_name = shipping.full_name ~ ' ' ~ '(' ~ shipping.full_name_kana ~ ')' ~ ' ' ~ (shipping.company_name is not null ? shipping.company_name : '') %}
+                                            {% set shipping_name = shipping.full_name ~ '(' ~ shipping.full_name_kana ~ ')' ~ (shipping.company_name is not null ? ' ' ~ shipping.company_name : '') %}
                                             {% set shipping_addr = 'admin.common.postal_symbol'|trans ~ shipping.postal_code ~ ' ' ~ shipping.pref ~ shipping.addr01 ~ shipping.addr02 %}
                                             {% set shipping_date = shipping.shipping_date is not null ? shipping.shipping_date|date_day : '' %}
                                             {{ shipping_name }} {{ shipping_addr }} {{ shipping.phone_number }} {{ shipping_date }}


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
受注登録でお届け先に氏名が表示されない #4980

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
手動で会社名を入れない受注データを作成し、氏名が表示できることを確認しました。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
