### PR TITLE
Docker のPHPバージョン、 DATABASE_SERVER_VERSION を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache-stretch
+FROM php:7.4-apache-bullseye
 
 ENV APACHE_DOCUMENT_ROOT /var/www/html
 
@@ -32,7 +32,7 @@ RUN apt-get update \
   ;
 
 RUN docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
-  && docker-php-ext-configure gd --with-freetype-dir=/usr/include/freetype2 --with-png-dir=/usr/include --with-jpeg-dir=/usr/include --with-webp-dir=/usr/include \
+  && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
   && docker-php-ext-install -j$(nproc) zip gd mysqli pdo_mysql opcache intl pgsql pdo_pgsql \
   ;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-apache-stretch
+FROM php:7.4-apache-stretch
 
 ENV APACHE_DOCUMENT_ROOT /var/www/html
 

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -10,7 +10,7 @@ services:
       - mysql
     environment:
       DATABASE_URL: "mysql://dbuser:secret@mysql/eccubedb"
-      DATABASE_SERVER_VERSION: 10
+      DATABASE_SERVER_VERSION: 5.7
 
   mysql:
     image: mysql:5.7

--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -10,10 +10,10 @@ services:
       - postgres
     environment:
       DATABASE_URL: "postgres://dbuser:secret@postgres/eccubedb"
-      DATABASE_SERVER_VERSION: 10
+      DATABASE_SERVER_VERSION: 14
 
   postgres:
-    image: postgres:10
+    image: postgres:14
     environment:
       POSTGRES_DB: eccubedb
       POSTGRES_USER: dbuser


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
- refs #5026 
- Dockerfile のベースイメージを php:7.4-apache-blueseye に変更
   - PHP7.4 から stretch はサポートされなくなったため 
   - configure オプションを修正
- docker-compose.pgsql.yml のイメージを postgres:14 に変更
- docker-compose.mysql.yml の DATABASE_SERVER_VERSION が間違っていたのを修正


## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
#5026 に合わせる

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
dockerbuild の GitHub Actions が通るのを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
