### PR TITLE
会員パスワードの保存方法を変更

### DIFF
--- a/codeception/_support/Page/AbstractPage.php
+++ b/codeception/_support/Page/AbstractPage.php
@@ -35,7 +35,7 @@ abstract class AbstractPage
      */
     protected function goPage($url, $pageTitle = '')
     {
-        $this->tester->amOnPage('/'.$url);
+        $this->tester->amOnPage($url);
 
         return $this;
     }

--- a/codeception/_support/Page/Admin/CustomerEditPage.php
+++ b/codeception/_support/Page/Admin/CustomerEditPage.php
@@ -111,14 +111,14 @@ class CustomerEditPage extends AbstractAdminPageStyleGuide
 
     public function 入力_パスワード($value)
     {
-        $this->tester->fillField(['id' => 'admin_customer_password_first'], $value);
+        $this->tester->fillField(['id' => 'admin_customer_plain_password_first'], $value);
 
         return $this;
     }
 
     public function 入力_パスワード確認($value)
     {
-        $this->tester->fillField(['id' => 'admin_customer_password_second'], $value);
+        $this->tester->fillField(['id' => 'admin_customer_plain_password_second'], $value);
 
         return $this;
     }

--- a/codeception/_support/Page/Front/ProductDetailPage.php
+++ b/codeception/_support/Page/Front/ProductDetailPage.php
@@ -30,7 +30,7 @@ class ProductDetailPage extends AbstractFrontPage
     {
         $page = new self($I);
 
-        return $page->goPage('products/detail/'.$id);
+        return $page->goPage('/products/detail/'.$id);
     }
 
     public function カテゴリ選択($categories)

--- a/codeception/_support/Page/Front/TopPage.php
+++ b/codeception/_support/Page/Front/TopPage.php
@@ -22,7 +22,7 @@ class TopPage extends AbstractFrontPage
     {
         $page = new self($I);
 
-        return $page->goPage('');
+        return $page->goPage('/');
     }
 
     public function 新着情報選択($rowNum)

--- a/codeception/_support/Page/Install/InstallPage.php
+++ b/codeception/_support/Page/Install/InstallPage.php
@@ -25,7 +25,7 @@ class InstallPage extends AbstractInstallPage
     {
         $page = new self($I);
 
-        return $page->goPage('');
+        return $page->goPage('/');
     }
 
     public function step1_次へボタンをクリック()

--- a/codeception/acceptance/EF04CustomerCest.php
+++ b/codeception/acceptance/EF04CustomerCest.php
@@ -44,8 +44,8 @@ class EF04CustomerCest
             'entry[phone_number]' => '111-111-111',
             'entry[email][first]' => $new_email,
             'entry[email][second]' => $new_email,
-            'entry[password][first]' => 'password',
-            'entry[password][second]' => 'password',
+            'entry[plain_password][first]' => 'password',
+            'entry[plain_password][second]' => 'password',
             'entry[job]' => ['value' => '1'],
             'entry[user_policy_check]' => '1',
         ];
@@ -122,8 +122,8 @@ class EF04CustomerCest
             'entry[phone_number]' => '111-111-111',
             'entry[email][first]' => $customer->getEmail(), // 会員登録済みのメールアドレスを入力する
             'entry[email][second]' => $customer->getEmail(),
-            'entry[password][first]' => 'password',
-            'entry[password][second]' => 'password',
+            'entry[plain_password][first]' => 'password',
+            'entry[plain_password][second]' => 'password',
         ], ['css' => 'button.ec-blockBtn--action']);
 
         // 入力した会員情報を確認する。
@@ -152,8 +152,8 @@ class EF04CustomerCest
             'entry[phone_number]' => '111-111-111',
             'entry[email][first]' => $new_email,
             'entry[email][second]' => $new_email,
-            'entry[password][first]' => 'password',
-            'entry[password][second]' => 'password',
+            'entry[plain_password][first]' => 'password',
+            'entry[plain_password][second]' => 'password',
         ], ['css' => 'button.ec-blockBtn--action']);
 
         // 入力した会員情報を確認する。
@@ -194,8 +194,8 @@ class EF04CustomerCest
             'entry[phone_number]' => '111-111-111',
             'entry[email][first]' => $new_email,
             'entry[email][second]' => $new_email,
-            'entry[password][first]' => 'password',
-            'entry[password][second]' => 'password',
+            'entry[plain_password][first]' => 'password',
+            'entry[plain_password][second]' => 'password',
             'entry[job]' => ['value' => '1'],
             'entry[user_policy_check]' => '1',
         ];

--- a/codeception/acceptance/EF05MypageCest.php
+++ b/codeception/acceptance/EF05MypageCest.php
@@ -152,8 +152,8 @@ class EF05MypageCest
             'entry[phone_number]' => '111-111-111',
             'entry[email][first]' => $new_email,
             'entry[email][second]' => $new_email,
-            'entry[password][first]' => 'password',
-            'entry[password][second]' => 'password',
+            'entry[plain_password][first]' => 'password',
+            'entry[plain_password][second]' => 'password',
         ];
 
         $findPluginByCode = Fixtures::get('findPluginByCode');

--- a/src/Eccube/Controller/Admin/Customer/CustomerEditController.php
+++ b/src/Eccube/Controller/Admin/Customer/CustomerEditController.php
@@ -14,6 +14,7 @@
 namespace Eccube\Controller\Admin\Customer;
 
 use Eccube\Controller\AbstractController;
+use Eccube\Entity\Customer;
 use Eccube\Entity\Master\CustomerStatus;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
@@ -56,6 +57,7 @@ class CustomerEditController extends AbstractController
         $this->entityManager->getFilters()->enable('incomplete_order_status_hidden');
         // 編集
         if ($id) {
+            /** @var Customer $Customer */
             $Customer = $this->customerRepository
                 ->find($id);
 
@@ -64,15 +66,12 @@ class CustomerEditController extends AbstractController
             }
 
             $oldStatusId = $Customer->getStatus()->getId();
-            // 編集用にデフォルトパスワードをセット
-            $previous_password = $Customer->getPassword();
-            $Customer->setPassword($this->eccubeConfig['eccube_default_password']);
+            $Customer->setPlainPassword($this->eccubeConfig['eccube_default_password']);
         // 新規登録
         } else {
             $Customer = $this->customerRepository->newCustomer();
 
             $oldStatusId = null;
-            $previous_password = null;
         }
 
         // 会員登録フォーム
@@ -97,14 +96,12 @@ class CustomerEditController extends AbstractController
 
             $encoder = $this->encoderFactory->getEncoder($Customer);
 
-            if ($Customer->getPassword() === $this->eccubeConfig['eccube_default_password']) {
-                $Customer->setPassword($previous_password);
-            } else {
+            if ($Customer->getPlainPassword() !== $this->eccubeConfig['eccube_default_password']) {
                 if ($Customer->getSalt() === null) {
                     $Customer->setSalt($encoder->createSalt());
                     $Customer->setSecretKey($this->customerRepository->getUniqueSecretKey());
                 }
-                $Customer->setPassword($encoder->encodePassword($Customer->getPassword(), $Customer->getSalt()));
+                $Customer->setPassword($encoder->encodePassword($Customer->getPlainPassword(), $Customer->getSalt()));
             }
 
             // 退会ステータスに更新の場合、ダミーのアドレスに更新

--- a/src/Eccube/Controller/EntryController.php
+++ b/src/Eccube/Controller/EntryController.php
@@ -170,7 +170,7 @@ class EntryController extends AbstractController
 
                     $encoder = $this->encoderFactory->getEncoder($Customer);
                     $salt = $encoder->createSalt();
-                    $password = $encoder->encodePassword($Customer->getPassword(), $salt);
+                    $password = $encoder->encodePassword($Customer->getPlainPassword(), $salt);
                     $secretKey = $this->customerRepository->getUniqueSecretKey();
 
                     $Customer

--- a/src/Eccube/Entity/Customer.php
+++ b/src/Eccube/Entity/Customer.php
@@ -16,6 +16,7 @@ namespace Eccube\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 if (!class_exists('\Eccube\Entity\Customer')) {
@@ -115,6 +116,12 @@ if (!class_exists('\Eccube\Entity\Customer')) {
          * @ORM\Column(name="birth", type="datetimetz", nullable=true)
          */
         private $birth;
+
+        /**
+         * @Assert\NotBlank()
+         * @Assert\Length(max=4096)
+         */
+        private $plain_password;
 
         /**
          * @var string|null
@@ -607,6 +614,25 @@ if (!class_exists('\Eccube\Entity\Customer')) {
         public function getBirth()
         {
             return $this->birth;
+        }
+
+        /**
+         * @param string|null $password
+         * @return $this
+         */
+        public function setPlainPassword(?string $password): self
+        {
+            $this->plain_password = $password;
+
+            return $this;
+        }
+
+        /**
+         * @return string|null
+         */
+        public function getPlainPassword(): ?string
+        {
+            return $this->plain_password;
         }
 
         /**

--- a/src/Eccube/Form/Type/Admin/CustomerType.php
+++ b/src/Eccube/Form/Type/Admin/CustomerType.php
@@ -114,7 +114,7 @@ class CustomerType extends AbstractType
                     ]),
                 ],
             ])
-            ->add('password', RepeatedPasswordType::class, [
+            ->add('plain_password', RepeatedPasswordType::class, [
                 // 'type' => 'password',
                 'first_options' => [
                     'label' => 'member.label.pass',
@@ -155,8 +155,8 @@ class CustomerType extends AbstractType
             $form = $event->getForm();
             /** @var Customer $Customer */
             $Customer = $event->getData();
-            if ($Customer->getPassword() != '' && $Customer->getPassword() == $Customer->getEmail()) {
-                $form['password']['first']->addError(new FormError(trans('common.password_eq_email')));
+            if ($Customer->getPlainPassword() != '' && $Customer->getPlainPassword() == $Customer->getEmail()) {
+                $form['plain_password']['first']->addError(new FormError(trans('common.password_eq_email')));
             }
         });
 

--- a/src/Eccube/Form/Type/Front/EntryType.php
+++ b/src/Eccube/Form/Type/Front/EntryType.php
@@ -76,7 +76,7 @@ class EntryType extends AbstractType
                 'required' => true,
             ])
             ->add('email', RepeatedEmailType::class)
-            ->add('password', RepeatedPasswordType::class)
+            ->add('plain_password', RepeatedPasswordType::class)
             ->add('birth', BirthdayType::class, [
                 'required' => false,
                 'input' => 'datetime',
@@ -119,8 +119,8 @@ class EntryType extends AbstractType
             $form = $event->getForm();
             /** @var Customer $Customer */
             $Customer = $event->getData();
-            if ($Customer->getPassword() != '' && $Customer->getPassword() == $Customer->getEmail()) {
-                $form['password']['first']->addError(new FormError(trans('common.password_eq_email')));
+            if ($Customer->getPlainPassword() != '' && $Customer->getPlainPassword() == $Customer->getEmail()) {
+                $form['plain_password']['first']->addError(new FormError(trans('common.password_eq_email')));
             }
         });
     }

--- a/src/Eccube/Resource/template/admin/Customer/edit.twig
+++ b/src/Eccube/Resource/template/admin/Customer/edit.twig
@@ -180,8 +180,8 @@ file that was distributed with this source code.
                                         <span class="badge badge-primary ml-1">{{ 'admin.common.required'|trans }}</span>
                                     </div>
                                     <div class="col">
-                                        {{ form_widget(form.password.first, { type : 'password'}) }}
-                                        {{ form_errors(form.password.first) }}
+                                        {{ form_widget(form.plain_password.first, { type : 'password'}) }}
+                                        {{ form_errors(form.plain_password.first) }}
                                     </div>
                                 </div>
                                 <div class="row mb-2">
@@ -190,8 +190,8 @@ file that was distributed with this source code.
                                         <span class="badge badge-primary ml-1">{{ 'admin.common.required'|trans }}</span>
                                     </div>
                                     <div class="col">
-                                        {{ form_widget(form.password.second, { type : 'password'}) }}
-                                        {{ form_errors(form.password.second) }}
+                                        {{ form_widget(form.plain_password.second, { type : 'password'}) }}
+                                        {{ form_errors(form.plain_password.second) }}
                                     </div>
                                 </div>
                                 <div class="row mb-2">

--- a/src/Eccube/Resource/template/default/Entry/confirm.twig
+++ b/src/Eccube/Resource/template/default/Entry/confirm.twig
@@ -91,12 +91,12 @@ file that was distributed with this source code.
                         </dl>
                         <dl>
                             <dt>
-                                {{ form_label(form.password, 'common.password', { 'label_attr': { 'class': 'ec-label' }}) }}
+                                {{ form_label(form.plain_password, 'common.password', { 'label_attr': { 'class': 'ec-label' }}) }}
                             </dt>
                             <dd>
                                 ********
-                                {{ form_widget(form.password.first, { type : 'hidden' }) }}
-                                {{ form_widget(form.password.second, { type : 'hidden' }) }}
+                                {{ form_widget(form.plain_password.first, { type : 'hidden' }) }}
+                                {{ form_widget(form.plain_password.second, { type : 'hidden' }) }}
                             </dd>
                         </dl>
                         <dl>

--- a/src/Eccube/Resource/template/default/Entry/index.twig
+++ b/src/Eccube/Resource/template/default/Entry/index.twig
@@ -125,22 +125,22 @@ file that was distributed with this source code.
                         </dl>
                         <dl>
                             <dt>
-                                {{ form_label(form.password, 'common.password', { 'label_attr': {'class': 'ec-label' }}) }}
+                                {{ form_label(form.plain_password, 'common.password', { 'label_attr': {'class': 'ec-label' }}) }}
                             </dt>
                             <dd>
-                                <div class="ec-input{{ has_errors(form.password.first) ? ' error' }}">
-                                    {{ form_widget(form.password.first, {
+                                <div class="ec-input{{ has_errors(form.plain_password.first) ? ' error' }}">
+                                    {{ form_widget(form.plain_password.first, {
                                         'attr': { 'placeholder': 'common.password_sample'|trans({ '%min%': eccube_config.eccube_password_min_len, '%max%': eccube_config.eccube_password_max_len }) },
                                         'type': 'password'
                                     }) }}
-                                    {{ form_errors(form.password.first) }}
+                                    {{ form_errors(form.plain_password.first) }}
                                 </div>
-                                <div class="ec-input{{ has_errors(form.password.second) ? ' error' }}">
-                                    {{ form_widget(form.password.second, {
+                                <div class="ec-input{{ has_errors(form.plain_password.second) ? ' error' }}">
+                                    {{ form_widget(form.plain_password.second, {
                                         'attr': { 'placeholder': 'common.repeated_confirm'|trans },
                                         'type': 'password'
                                     }) }}
-                                    {{ form_errors(form.password.second) }}
+                                    {{ form_errors(form.plain_password.second) }}
                                 </div>
                             </dd>
                         </dl>

--- a/src/Eccube/Resource/template/default/Mypage/change.twig
+++ b/src/Eccube/Resource/template/default/Mypage/change.twig
@@ -132,22 +132,22 @@ file that was distributed with this source code.
                                 </dl>
                                 <dl>
                                     <dt>
-                                        {{ form_label(form.password, 'common.password', { 'label_attr': {'class': 'ec-label' }}) }}
+                                        {{ form_label(form.plain_password, 'common.password', { 'label_attr': {'class': 'ec-label' }}) }}
                                     </dt>
                                     <dd>
-                                        <div class="ec-input{{ has_errors(form.password.first) ? ' error' }}">
-                                            {{ form_widget(form.password.first, {
+                                        <div class="ec-input{{ has_errors(form.plain_password.first) ? ' error' }}">
+                                            {{ form_widget(form.plain_password.first, {
                                                 'attr': { 'placeholder': 'common.password_sample'|trans({ '%min%': eccube_config.eccube_password_min_len, '%max%': eccube_config.eccube_password_max_len }) },
                                                 'type': 'password'
                                             }) }}
-                                            {{ form_errors(form.password.first) }}
+                                            {{ form_errors(form.plain_password.first) }}
                                         </div>
-                                        <div class="ec-input{{ has_errors(form.password.second) ? ' error' }}">
-                                            {{ form_widget(form.password.second, {
+                                        <div class="ec-input{{ has_errors(form.plain_password.second) ? ' error' }}">
+                                            {{ form_widget(form.plain_password.second, {
                                                 'attr': { 'placeholder': 'common.repeated_confirm'|trans },
                                                 'type': 'password'
                                             }) }}
-                                            {{ form_errors(form.password.second) }}
+                                            {{ form_errors(form.plain_password.second) }}
                                         </div>
                                     </dd>
                                 </dl>

--- a/tests/Eccube/Tests/Form/Type/Admin/CustomerTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/CustomerTypeTest.php
@@ -42,7 +42,7 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         'sex' => 1,
         'job' => 1,
         'birth' => '1983-2-14',
-        'password' => [
+        'plain_password' => [
             'first' => 'password',
             'second' => 'password',
         ],
@@ -200,8 +200,8 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testValidPasswordMinLength()
     {
-        $this->formData['password']['first'] = str_repeat('a', $this->eccubeConfig['eccube_password_min_len']);
-        $this->formData['password']['second'] = str_repeat('a', $this->eccubeConfig['eccube_password_min_len']);
+        $this->formData['plain_password']['first'] = str_repeat('a', $this->eccubeConfig['eccube_password_min_len']);
+        $this->formData['plain_password']['second'] = str_repeat('a', $this->eccubeConfig['eccube_password_min_len']);
 
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());
@@ -211,8 +211,8 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
     {
         $password = str_repeat('a', $this->eccubeConfig['eccube_password_min_len'] - 1);
 
-        $this->formData['password']['first'] = $password;
-        $this->formData['password']['second'] = $password;
+        $this->formData['plain_password']['first'] = $password;
+        $this->formData['plain_password']['second'] = $password;
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
@@ -220,8 +220,8 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testValidPasswordMaxLength()
     {
-        $this->formData['password']['first'] = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
-        $this->formData['password']['second'] = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
+        $this->formData['plain_password']['first'] = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
+        $this->formData['plain_password']['second'] = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
 
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());
@@ -231,8 +231,8 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
     {
         $password = str_repeat('a', $this->eccubeConfig['eccube_password_max_len'] + 1);
 
-        $this->formData['password']['first'] = $password;
-        $this->formData['password']['second'] = $password;
+        $this->formData['plain_password']['first'] = $password;
+        $this->formData['plain_password']['second'] = $password;
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
@@ -240,8 +240,8 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInvalidPasswordEqualEmail()
     {
-        $this->formData['password']['first'] = $this->formData['email'];
-        $this->formData['password']['second'] = $this->formData['email'];
+        $this->formData['plain_password']['first'] = $this->formData['email'];
+        $this->formData['plain_password']['second'] = $this->formData['email'];
 
         $this->form->submit($this->formData);
         $this->assertEquals(trans('common.password_eq_email'), $this->form->getErrors(true)[0]->getMessage());

--- a/tests/Eccube/Tests/Form/Type/Front/EntryTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Front/EntryTypeTest.php
@@ -42,7 +42,7 @@ class EntryTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
             'first' => 'eccube@example.com',
             'second' => 'eccube@example.com',
         ],
-        'password' => [
+        'plain_password' => [
             'first' => '12345678',
             'second' => '12345678',
         ],
@@ -180,8 +180,8 @@ class EntryTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testInvalidPasswordEqualEmail()
     {
-        $this->formData['password']['first'] = $this->formData['email']['first'];
-        $this->formData['password']['second'] = $this->formData['email']['first'];
+        $this->formData['plain_password']['first'] = $this->formData['email']['first'];
+        $this->formData['plain_password']['second'] = $this->formData['email']['first'];
 
         $this->form->submit($this->formData);
         $this->assertEquals(trans('common.password_eq_email'), $this->form->getErrors(true)[0]->getMessage());

--- a/tests/Eccube/Tests/Web/Admin/Customer/CustomerEditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Customer/CustomerEditControllerTest.php
@@ -54,7 +54,7 @@ class CustomerEditControllerTest extends AbstractAdminWebTestCase
             'address' => ['pref' => '5', 'addr01' => $faker->city, 'addr02' => $faker->streetAddress],
             'phone_number' => $faker->phoneNumber,
             'email' => $email,
-            'password' => ['first' => $password, 'second' => $password],
+            'plain_password' => ['first' => $password, 'second' => $password],
             'birth' => $birth->format('Y').'-'.$birth->format('n').'-'.$birth->format('j'),
             'sex' => 1,
             'job' => 1,

--- a/tests/Eccube/Tests/Web/EntryControllerTest.php
+++ b/tests/Eccube/Tests/Web/EntryControllerTest.php
@@ -52,7 +52,7 @@ class EntryControllerTest extends AbstractWebTestCase
                 'first' => $email,
                 'second' => $email,
             ],
-            'password' => [
+            'plain_password' => [
                 'first' => $password,
                 'second' => $password,
             ],

--- a/tests/Eccube/Tests/Web/Mypage/ChangeControllerTest.php
+++ b/tests/Eccube/Tests/Web/Mypage/ChangeControllerTest.php
@@ -57,7 +57,7 @@ class ChangeControllerTest extends AbstractWebTestCase
                 'first' => $email,
                 'second' => $email,
             ],
-            'password' => [
+            'plain_password' => [
                 'first' => $password,
                 'second' => $password,
             ],

--- a/tests/Eccube/Tests/Web/Mypage/ChangeControllerTest.php
+++ b/tests/Eccube/Tests/Web/Mypage/ChangeControllerTest.php
@@ -108,7 +108,7 @@ class ChangeControllerTest extends AbstractWebTestCase
         $this->loginTo($this->Customer);
 
         $form = $this->createFormData();
-        $form['password'] = [
+        $form['plain_password'] = [
             'first' => $this->eccubeConfig['eccube_default_password'],
             'second' => $this->eccubeConfig['eccube_default_password'],
         ];


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

現在のパスワード更新処理だと、

https://github.com/EC-CUBE/ec-cube/blob/9a9ebd3fa14733d3effa8d07428eb61c1b4281d1/src/Eccube/Controller/Mypage/ChangeController.php#L64-L116

UsernamePasswordToken以外のTokenクラスでログインした場合、
マイページの会員情報編集ページにアクセスするとログアウトしてしまいます。

たとえば、ソーシャルログインプラグインだとGuardTokenInterfaceを実装したTokenクラスでログインすることになるのですが、この場合マイページの会員情報編集ページにアクセスするとログアウトします。


おそらくですが、ログイン情報をデタッチすることが原因のようなので
パスワード変更処理を見直しました。

```
$this->entityManager->detach($LoginCustomer);
```

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

パスワードのinputのname属性を、```password``` から ```plain_password``` に変更したので、
Backward compatibility testing to Front templateテストは落ちてしまいます。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
