### PR TITLE
カートエンティティのgetCustomerの戻り値をnullableにする

### DIFF
--- a/src/Eccube/Entity/Cart.php
+++ b/src/Eccube/Entity/Cart.php
@@ -349,9 +349,9 @@ if (!class_exists('\Eccube\Entity\Cart')) {
         }
 
         /**
-         * @return Customer
+         * @return Customer|null
          */
-        public function getCustomer(): Customer
+        public function getCustomer(): ?Customer
         {
             return $this->Customer;
         }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
未ログイン状態で生成されたカートエンティティのgetCustomerを呼ぶとエラーになるため修正しました。
fixed #5226 

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
