### PR TITLE
購入確認画面での不明なspanの閉じタグを削除

### DIFF
--- a/src/Eccube/Resource/template/default/Shopping/confirm.twig
+++ b/src/Eccube/Resource/template/default/Shopping/confirm.twig
@@ -69,13 +69,13 @@ file that was distributed with this source code.
                     <h2>{{ 'front.shopping.customer_info'|trans }}</h2>
                 </div>
                 <div class="ec-orderAccount__account">
-                    <p class="ec-halfInput">{{ 'common.name.prefix'|trans }}{{ Order.name01 }} {{ Order.name02 }}</span>{{ 'common.name.suffix'|trans }}</p>
-                    <p class="ec-halfInput">{{ Order.kana01 }}</span> {{ Order.kana02 }}</p>
-                    <p class="ec-input">{{ Order.companyName }}</span></p>
+                    <p class="ec-halfInput">{{ 'common.name.prefix'|trans }}{{ Order.name01 }} {{ Order.name02 }}{{ 'common.name.suffix'|trans }}</p>
+                    <p class="ec-halfInput">{{ Order.kana01 }} {{ Order.kana02 }}</p>
+                    <p class="ec-input">{{ Order.companyName }}</p>
                     <p class="ec-zipInput">{{ 'common.postal_symbol'|trans }}{{ Order.postal_code }}</p>
                     <p class="ec-input">{{ Order.pref }}{{ Order.addr01 }}{{ Order.addr02 }}</p>
-                    <p class="ec-telInput">{{ Order.phone_number }}</span></p>
-                    <p class="ec-input">{{ Order.email }}</span></p>
+                    <p class="ec-telInput">{{ Order.phone_number }}</p>
+                    <p class="ec-input">{{ Order.email }}</p>
                 </div>
             </div>
             <div class="ec-orderDelivery">


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
購入確認画面に``</span>``のゴミがあるのを削除


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
