### PR TITLE
ゲスト購入時、「ご注文手続き」の「お届け先を追加する」押下時にシステムエラーが発生する不具合の修正

### DIFF
--- a/src/Eccube/Controller/NonMemberShoppingController.php
+++ b/src/Eccube/Controller/NonMemberShoppingController.php
@@ -185,21 +185,19 @@ class NonMemberShoppingController extends AbstractShoppingController
 
             $this->entityManager->flush();
 
-            $Customer = new Customer();
-            $Customer
-                ->setName01($data['customer_name01'])
-                ->setName02($data['customer_name02'])
-                ->setKana01($data['customer_kana01'])
-                ->setKana02($data['customer_kana02'])
-                ->setCompanyName($data['customer_company_name'])
-                ->setPhoneNumber($data['customer_phone_number'])
-                ->setPostalCode($data['customer_postal_code'])
-                ->setPref($pref)
-                ->setAddr01($data['customer_addr01'])
-                ->setAddr02($data['customer_addr02'])
-                ->setEmail($data['customer_email']);
-
-            $this->session->set(OrderHelper::SESSION_NON_MEMBER, $Customer);
+            $this->session->set(OrderHelper::SESSION_NON_MEMBER, [
+                'name01' => $data['customer_name01'],
+                'name02' => $data['customer_name02'],
+                'kana01' => $data['customer_kana01'],
+                'kana02' => $data['customer_kana02'],
+                'company_name' => $data['customer_company_name'],
+                'phone_number' => $data['customer_phone_number'],
+                'postal_code' => $data['customer_postal_code'],
+                'pref' => $pref,
+                'addr01' => $data['customer_addr01'],
+                'addr02' => $data['customer_addr02'],
+                'email' => $data['customer_email'],
+            ]);
 
             $event = new EventArgs(
                 [


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
ゲストで購入の場合「ご注文手続き」ページの「お届け先を追加する」を押すとシステムエラー
再現方法は下記を参考お願いします。
issue: #5229
よろしくお願いいたします
