### PR TITLE
お問い合わせ内容フォームラベルをform.contentsに修正

### DIFF
--- a/src/Eccube/Resource/template/default/Contact/index.twig
+++ b/src/Eccube/Resource/template/default/Contact/index.twig
@@ -111,7 +111,7 @@ file that was distributed with this source code.
                         </dl>
                         <dl>
                             <dt>
-                                {{ form_label(form.email, 'front.contact.inquiry_contents', { 'label_attr': { 'class': 'ec-label' }}) }}
+                                {{ form_label(form.contents, 'front.contact.inquiry_contents', { 'label_attr': { 'class': 'ec-label' }}) }}
                             </dt>
                             <dd>
                                 <div class="ec-input{{ has_errors(form.contents) ? ' error' }}">


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
 #5232

## 方針(Policy)
お問い合わせ画面の「お問い合わせ内容」フォームラベルを「form.email」から「form.contents」に修正

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
