### PR TITLE
#4975 でのテストコードの不具合の修正

### DIFF
--- a/tests/Eccube/Tests/Repository/AbstractProductRepositoryTestCase.php
+++ b/tests/Eccube/Tests/Repository/AbstractProductRepositoryTestCase.php
@@ -85,6 +85,12 @@ abstract class AbstractProductRepositoryTestCase extends EccubeTestCase
      */
     protected function setProductTags(Product $Product, array $tagIds)
     {
+        $ProductTags = $Product->getProductTag();
+        foreach ($ProductTags as $ProductTag) {
+            $Product->removeProductTag($ProductTag);
+            $this->entityManager->remove($ProductTag);
+        }
+
         $Tags = $this->tagRepository->findBy(['id' => $tagIds]);
         foreach ($Tags as $Tag) {
             $ProductTag = new ProductTag();

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataAdminTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataAdminTest.php
@@ -376,6 +376,7 @@ class ProductRepositoryGetQueryBuilderBySearchDataAdminTest extends AbstractProd
         $Products[0]->setName('りんご');
         $this->setProductTags($Products[0], [1]);
         $this->setProductTags($Products[1], [1, 2]);
+        $this->setProductTags($Products[2], []);
         $this->entityManager->flush();
 
         // タグ 1 で検索


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
こちらの修正にて、ユニットテストが落ちてしまっていた件を修正しています
https://github.com/EC-CUBE/ec-cube/pull/4975

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
管理画面・タグ検索機能に関するユニットテストを修正しました

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
