### PR TITLE
規格のラベルが表示されない不具合を修正

### DIFF
--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -339,12 +339,12 @@ file that was distributed with this source code.
                             <div class="ec-productRole__actions">
                                 {% if form.classcategory_id1 is defined %}
                                     <div class="ec-select">
-                                        {{ form_widget(form.classcategory_id1) }}
+                                        {{ form_row(form.classcategory_id1) }}
                                         {{ form_errors(form.classcategory_id1) }}
                                     </div>
                                     {% if form.classcategory_id2 is defined %}
                                         <div class="ec-select">
-                                            {{ form_widget(form.classcategory_id2) }}
+                                            {{ form_row(form.classcategory_id2) }}
                                             {{ form_errors(form.classcategory_id2) }}
                                         </div>
                                     {% endif %}


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
symfonyのバージョンが上がったからか、僕の環境依存なのか不明ですが、商品詳細画面で``form_widget()``では規格のラベルが表示されなくなった

## 方針(Policy)
``form_widget()``から``form_row()``に変更

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
出ないの僕だけですかね？

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
