### PR TITLE
TRUSTED_HOSTSを標準で有効にするように対応

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -83,6 +83,7 @@ jobs:
           DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
         run: |
           echo "APP_ENV=${APP_ENV}" > .env
+          echo "TRUSTED_HOSTS=127.0.0.1,localhost" >> .env
           bin/console doctrine:database:create --env=dev
           bin/console doctrine:schema:create --env=dev
           bin/console eccube:fixtures:load --env=dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       DATABASE_SERVER_VERSION: 3
       MAILER_URL: "smtp://mailcatcher:1025"
       ECCUBE_AUTH_MAGIC: "<change.me>"
+      # TRUSTED_HOSTS: '^127.0.0.1$$,^localhost$$'
       # ECCUBE_LOCALE: "ja"
       # ECCUBE_TIMEZONE: "Asia/Tokyo"
       # ECCUBE_CURRENCY: "JPY"

--- a/dockerbuild/docker-php-entrypoint
+++ b/dockerbuild/docker-php-entrypoint
@@ -1,9 +1,7 @@
 #!/bin/sh
 set -e
 
-if [ -n "${APP_ENV}" ]; then
-    echo "SetEnv APP_ENV ${APP_ENV}" >> /etc/apache2/conf-enabled/app_env.conf
-fi
+echo "PassEnv APP_ENV APP_DEBUG TRUSTED_PROXIES TRUSTED_HOSTS" > /etc/apache2/conf-enabled/eccube_env.conf
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then

--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -63,6 +63,7 @@ class InstallerCommand extends Command
             public $adminRoute;
             public $templateCode;
             public $locale;
+            public $trustedHosts;
 
             public $envDir;
 
@@ -78,6 +79,7 @@ class InstallerCommand extends Command
                             'ECCUBE_ADMIN_ROUTE' => $this->adminRoute,
                             'ECCUBE_TEMPLATE_CODE' => $this->templateCode,
                             'ECCUBE_LOCALE' => $this->locale,
+                            'TRUSTED_HOSTS' => $this->trustedHosts,
                         ];
             }
 
@@ -123,6 +125,10 @@ class InstallerCommand extends Command
             ' $ php bin/console eccube:install --no-interaction',
             '',
         ]);
+
+        // TRUSTED_HOSTS
+        $trustedHosts = env('TRUSTED_HOSTS', '^127\\.0\\.0\\.1$,^localhost$');
+        $this->envFileUpdater->trustedHosts = $this->io->ask('Trusted hosts. ex) www.example.com, localhost ...etc', $trustedHosts);
 
         // DATABASE_URL
         $databaseUrl = $this->container->getParameter('eccube_database_url');

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -76,6 +76,7 @@ class SecurityController extends AbstractController
                 'ECCUBE_ADMIN_ALLOW_HOSTS' => "'{$adminAllowHosts}'",
                 'ECCUBE_ADMIN_DENY_HOSTS' => "'{$adminDenyHosts}'",
                 'ECCUBE_FORCE_SSL' => $data['force_ssl'] ? 'true' : 'false',
+                'TRUSTED_HOSTS' => $data['trusted_hosts'],
             ]);
 
             file_put_contents($envFile, $env);

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -485,6 +485,7 @@ class InstallController extends AbstractController
             'ECCUBE_COOKIE_PATH' => $request->getBasePath() ? $request->getBasePath() : '/',
             'ECCUBE_TEMPLATE_CODE' => 'default',
             'ECCUBE_LOCALE' => 'ja',
+            'TRUSTED_HOSTS' => '^'.str_replace('.', '\\.', $request->getHost()).'$',
         ];
 
         $env = StringUtil::replaceOrAddEnv($env, $replacement);

--- a/src/Eccube/Form/Type/Admin/SecurityType.php
+++ b/src/Eccube/Form/Type/Admin/SecurityType.php
@@ -96,6 +96,16 @@ class SecurityType extends AbstractType
                 'required' => false,
                 'data' => $this->eccubeConfig->get('eccube_force_ssl'),
             ])
+            ->add('trusted_hosts', TextType::class, [
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Regex([
+                        'pattern' => '/^[\x21-\x7e]+$/',
+                    ]),
+                ],
+                'data' => env('TRUSTED_HOSTS'),
+            ])
             ->addEventListener(FormEvents::POST_SUBMIT, function ($event) {
                 $form = $event->getForm();
                 $data = $form->getData();

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -1303,6 +1303,11 @@ admin.setting.system.security.ip_limit_invalid_ipv4: '%ip% is not an IPv4 addres
 admin.setting.system.security.ip_limit_invalid_https: 'http is not allowed to do this setting.'
 admin.setting.system.security.admin_url_warning: Please set the Admin Console URL that is hard to guess for security.
 admin.setting.system.security.not_found_env_file: .env file not found. If you do not use the .env file you can not change security config in Admin Console.
+admin.setting.system.security.trusted_hosts: Trusted hosts
+admin.setting.system.security.trusted_hosts_sample: ^example\.com$,^example\.org$
+admin.setting.system.security.trusted_hosts_description: |
+  Deny access to non-trusted hosts.
+  If you want to set more than one, enter them separated by commas. You can also specify it with a regular expression.
 
 #------------------------------------------------------------------------------------
 # Settings : System : Login History
@@ -1682,6 +1687,7 @@ tooltip.setting.system.security.admin_url: Set the URL to sign in to the Admin C
 tooltip.setting.system.security.ip_limit: Restricting IP addresses which are allowed to sign in to the Admin Console.
 tooltip.setting.system.security.ip_limit_deny: IP addresses where access to the Admin Console is denied.
 tooltip.setting.system.security.force_ssl: Restricting the access to the storefront and Admin Console to via SSL(https).
+tooltip.setting.system.security.trusted_hosts: Deny access to non-trusted hosts.
 tooltip.setting.system.login_history.multi_search_label: You can filter the list with keywords. For more search options, open [Advanced Search].
 tooltip.setting.system.log_display: Here you can check logs such as access logs and error logs etc.
 tooltip.setting.system.master_data_management: Manage all Master Data here.

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -1303,6 +1303,11 @@ admin.setting.system.security.ip_limit_invalid_ipv4: '%ip%はIPv4アドレスで
 admin.setting.system.security.ip_limit_invalid_https: 'httpの場合には設定できません。'
 admin.setting.system.security.admin_url_warning: 管理画面URLは、セキュリティのため推測されにくいものを設定してください。
 admin.setting.system.security.not_found_env_file: .envファイルが見つかりません。.envを利用していない場合はセキュリティ設定を管理画面から変更できません。
+admin.setting.system.security.trusted_hosts: 信頼できるホスト名
+admin.setting.system.security.trusted_hosts_sample: ^example\.com$,^example\.org$
+admin.setting.system.security.trusted_hosts_description: |
+  設定されたホスト名以外でのアクセスを拒否します。
+  複数設定する場合はカンマ区切りで入力してください。正規表現での指定も可能です。
 
 #------------------------------------------------------------------------------------
 # 設定：システム設定：セキュリティ管理
@@ -1682,6 +1687,7 @@ tooltip.setting.system.security.admin_url: 管理画面にログインするた�
 tooltip.setting.system.security.ip_limit: 管理画面にログインできる接続元のIPアドレスを制限します。
 tooltip.setting.system.security.ip_limit_deny: 管理画面へのアクセスを拒否する接続元のIPアドレスを指定します。
 tooltip.setting.system.security.force_ssl: ショップサイトと管理画面への接続をSSL(https)での接続に制限します。
+tooltip.setting.system.security.trusted_hosts: 設定されたホスト名以外でのアクセスを拒否します。
 tooltip.setting.system.login_history.multi_search_label: 情報を入力して一覧の絞り込み検索ができます。より詳細な条件を指定するには［詳細検索］を開いてください。
 tooltip.setting.system.log_display: アクセスやエラー状況などのログを確認できます。
 tooltip.setting.system.master_data_management: 各種マスターデータを管理します。

--- a/src/Eccube/Resource/template/admin/Setting/System/security.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/security.twig
@@ -104,6 +104,19 @@ file that was distributed with this source code.
                                         {% endif %}
                                     </div>
                                 </div>
+                                <!-- TRUSTED_HOSTS -->
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <div class="d-inline-block" data-tooltip="true" data-placement="top" title="{{ 'tooltip.setting.system.security.trusted_hosts'|trans }}">
+                                            <span>{{ 'admin.setting.system.security.trusted_hosts'|trans }}</span><i class="fa fa-question-circle fa-lg ml-1"></i>
+                                        </div>
+                                    </div>
+                                    <div class="col">
+                                        {{ form_widget(form.trusted_hosts, { 'attr': { 'placeholder': 'admin.setting.system.security.trusted_hosts_sample'|trans }}) }}
+                                        {{ form_errors(form.trusted_hosts) }}
+                                        <p>{{ 'admin.setting.system.security.trusted_hosts_description'|trans|nl2br }}</p>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div><!-- /.card -->

--- a/tests/Eccube/Tests/Form/Type/Admin/SecurityTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SecurityTypeTest.php
@@ -30,6 +30,7 @@ class SecurityTypeTest extends AbstractTypeTestCase
         'admin_route_dir' => 'admin',
         'admin_allow_hosts' => '',
         'admin_deny_hosts' => '',
+        'trusted_hosts' => 'localhost',
     ];
 
     public function setUp()
@@ -124,5 +125,12 @@ class SecurityTypeTest extends AbstractTypeTestCase
             ['admin&', false],
             ['admin?', false],
         ];
+    }
+
+    public function testTrustedHosts()
+    {
+        $this->formData['trusted_hosts'] = '^127\.0\.0.1$,^localhost$';
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
     }
 }

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/SecurityControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/SecurityControllerTest.php
@@ -117,6 +117,7 @@ class SecurityControllerTest extends AbstractAdminWebTestCase
             'admin_route_dir' => 'admintest',
             'admin_allow_hosts' => '127.0.0.1',
             'admin_deny_hosts' => '127.0.0.1',
+            'trusted_hosts' => '^127\.0\.0\.1$,^localhost$',
         ];
 
         return $formData;


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

TRUSTED_HOSTS設定を標準で有効にするように対応しました。

参考：
https://symfony.com/doc/4.4/reference/configuration/framework.html#trusted-hosts

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

インストール時に、.envにてTRUSTED_HOSTSが設定されるようになります。

- Webインストーラ
  - インストーラにアクセスしたドメインをTRUSTED_HOSTSとして設定します。
- コマンドラインインストーラ
  - 対話形式でのインストール時、TRUSTED_HOSTSを設定できるようになります。デフォルトでは127.0.0.1,localhostが設定されます。

またインストール後は、管理画面＞システム設定＞セキュリティ設定で設定変更が可能です。

.envでのTRUSTED_HOSTの記載例

```
TRUSTED_HOSTS=www.example.com
# 複数指定時はカンマ区切りで設定
TRUSTED_HOSTS=a.example.com,b.example.com 
# 正規表現も利用可能
TRUSTED_HOSTS=^a\.example\.com$
```

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

- FormType/Controllerのテストを追加・修正
- TrustedHostが必須項目となるため、e2eではデフォルト値を設定

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
