### PR TITLE
[OWASP ZAP] CSRFトークンが変更されてしまい手動リクエストが失敗するのを修正

### DIFF
--- a/zap/selenium/ci/TypeScript/test/front_guest/contact.test.ts
+++ b/zap/selenium/ci/TypeScript/test/front_guest/contact.test.ts
@@ -70,6 +70,13 @@ test.describe.serial('お問い合わせフォームのテストをします', (
     expect(completeRequestBody).toContain('mode=complete');
   });
 
+  test('CSRFトークン を取得し直します', async () => {
+    await page.goto(url);
+    const token = await page.inputValue('#contact__token');
+    completeRequestBody = completeRequestBody.replace(/contact%5B_token%5D=[a-zA-Z0-9\-_]+/, `contact%5B_token%5D=${token}`);
+    expect(completeRequestBody).toMatch(token);
+  });
+
   let completeMessage: HttpMessage;
   test('content-length を書き換えて手動リクエストを送信します', async () => {
     const requestHeader = message.requestHeader.replace(

--- a/zap/selenium/ci/TypeScript/test/front_login/contact.test.ts
+++ b/zap/selenium/ci/TypeScript/test/front_login/contact.test.ts
@@ -74,6 +74,13 @@ test.describe.serial('お問い合わせフォームのテストをします', (
     expect(completeRequestBody).toContain('mode=complete');
   });
 
+  test('CSRFトークン を取得し直します', async () => {
+    await page.goto(url);
+    const token = await page.inputValue('#contact__token');
+    completeRequestBody = completeRequestBody.replace(/contact%5B_token%5D=[a-zA-Z0-9\-_]+/, `contact%5B_token%5D=${token}`);
+    expect(completeRequestBody).toMatch(token);
+  });
+
   let completeMessage: HttpMessage;
   test('content-length を書き換えて手動リクエストを送信します', async () => {
     const requestHeader = confirmMessage.requestHeader.replace(


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
- お問い合わせフォーム表示の Active Scan によって、 CSRF トークンが変更されてしまうため、手動リクエストが失敗するのを防止する
- 以下 GitHub Actions が失敗する対策
  - https://github.com/EC-CUBE/ec-cube/runs/4923552722?check_suite_focus=true

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- 確認→完了画面のリクエストをする前に、最新の CSRF トークンを取得し直す
- 2系でも同様の対策をしている
   - https://github.com/EC-CUBE/ec-cube2/blob/1b2352290baf25aa31753f06d756ac49ca354f49/e2e-tests/test/front_login/contact.test.ts#L122-L125

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
- 手動リクエストが成功すれば、Active Scan 実行中は OWASP ZAP が自動的に CSRF トークンをハンドリングしてくれる

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
- ローカル環境の docker-compose で正常にスキャンできるのを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
