### PR TITLE
[OWASP ZAP] macOS で Playwright がエラーになるのを修正

### DIFF
--- a/zap/selenium/ci/TypeScript/README.md
+++ b/zap/selenium/ci/TypeScript/README.md
@@ -42,7 +42,7 @@ docker-compose up -d ec-cube
 ## yarn でテストを実行します。
 cd zap/selenium/ci/TypeScript
 yarn install && yarn playwright install # (初回のみ)
-HTTP_PROXY=127.0.0.1:8090 HTTPS_PROXY=127.0.0.1:8090 yarn playwright test
+yarn playwright test
 
 ## (Optional) 個別にテストする場合は、テストのファイル名を指定してください。
 yarn playwright test test/front_guest/contact.test.ts

--- a/zap/selenium/ci/TypeScript/README.md
+++ b/zap/selenium/ci/TypeScript/README.md
@@ -34,7 +34,7 @@ docker-compose exec -T ec-cube bin/console eccube:fixtures:generate --products=5
 docker-compose exec -T ec-cube bin/console doctrine:query:sql "UPDATE dtb_customer SET email = 'zap_user@example.com' WHERE id = 1;"
 
 ## 環境変数 APP_ENV=prod に設定します
-sed -i 's!APP_ENV: "dev"!APP_ENV: "prod"!g' docker-compose.yml
+sed -i.bak 's!APP_ENV: "dev"!APP_ENV: "prod"!g' docker-compose.yml
 
 ## ec-cube コンテナを再起動し、設定を反映します。
 docker-compose up -d ec-cube

--- a/zap/selenium/ci/TypeScript/README.md
+++ b/zap/selenium/ci/TypeScript/README.md
@@ -42,10 +42,10 @@ docker-compose up -d ec-cube
 ## yarn でテストを実行します。
 cd zap/selenium/ci/TypeScript
 yarn install && yarn playwright install # (初回のみ)
-yarn playwright test
+HTTP_PROXY=127.0.0.1:8090 HTTPS_PROXY=127.0.0.1:8090 yarn playwright test
 
 ## (Optional) 個別にテストする場合は、テストのファイル名を指定してください。
-yarn playwright test test/front_guest/contact.test.ts
+HTTP_PROXY=127.0.0.1:8090 HTTPS_PROXY=127.0.0.1:8090 yarn playwright test test/front_guest/contact.test.ts
 ```
 
 ####  実行中に OWASP ZAP を操作したい場合
@@ -69,7 +69,7 @@ yarn playwright test test/front_guest/contact.test.ts
 以下のように playwright に `--headed` オプションを付与することで Chrome が実際に起動し、実行状況を確認できます。
 
 ``` shell
-yarn playwright test test/front_guest/contact.test.ts --headed
+HTTP_PROXY=127.0.0.1:8090 HTTPS_PROXY=127.0.0.1:8090 yarn playwright test test/front_guest/contact.test.ts --headed
 ```
 
 また、 [`page.pause()`](https://playwright.dev/docs/api/class-page#page-pause)をテストコードに埋め込めばステップ実行も可能です。

--- a/zap/selenium/ci/TypeScript/playwright.config.ts
+++ b/zap/selenium/ci/TypeScript/playwright.config.ts
@@ -42,7 +42,10 @@ const config: PlaywrightTestConfig = {
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-    ignoreHTTPSErrors: true
+    ignoreHTTPSErrors: true,
+    proxy: {
+      server: process.env.HTTP_PROXY ? `http://${process.env.HTTP_PROXY}` : 'http://127.0.0.1:8090'
+    }
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
- macOS では 環境変数から proxy の情報を渡せないため、playwright の実行がエラーになってしまう
  - see https://github.com/EC-CUBE/ec-cube/pull/5183#issuecomment-1019841464

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- playwright.config.ts で proxy の設定をするよう修正
  - 環境変数 HTTP_PROXY が設定されている場合は、その情報を引き継ぐ

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
- GitHub Actions では環境変数から proxy の情報を渡さないと `RequestError: Error: getaddrinfo EAI_AGAIN undefined` になってしまう
  - Linux のローカル環境(WSL2など)でも同様に環境変数 `HTTP_PROXY` 及び `HTTPS_PROXY` を渡す必要がある


## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
macOS 12.1 で、正常に実行できることを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
