### PR TITLE
カレンダーの翌月判定の誤りを修正

### DIFF
--- a/codeception/acceptance/EA07BasicinfoCest.php
+++ b/codeception/acceptance/EA07BasicinfoCest.php
@@ -403,7 +403,7 @@ class EA07BasicinfoCest
         // 定休日を設定
         $holidays = [
             '定休日1' => Carbon::now()->day(1), // 今月1日
-            '定休日2' => Carbon::now()->addMonth(1)->day(28), // 翌月28日
+            '定休日2' => Carbon::now()->startOfMonth()->addMonth(1)->day(28), // 翌月28日
         ];
 
         foreach ($holidays as $title => $date) {

--- a/codeception/acceptance/EA07BasicinfoCest.php
+++ b/codeception/acceptance/EA07BasicinfoCest.php
@@ -426,11 +426,11 @@ class EA07BasicinfoCest
         $I->see('カレンダー', ['class' => 'ec-layoutRole__mainBottom']);
 
         // フロント画面で定休日にクラス .ec-calendar__holiday が設定されていることを確認
-        $I->seeElement(['xpath' => '//table[@id="this-month-table"]//td[@class="ec-calendar__holiday"][text()="'.$holidays['定休日1']->format('j').'"]']);
-        $I->seeElement(['xpath' => '//table[@id="next-month-table"]//td[@class="ec-calendar__holiday"][text()="'.$holidays['定休日2']->format('j').'"]']);
+        $I->seeElement(['xpath' => '//table[@id="this-month-table"]//td[contains(@class,"ec-calendar__holiday")][text()="'.$holidays['定休日1']->format('j').'"]']);
+        $I->seeElement(['xpath' => '//table[@id="next-month-table"]//td[contains(@class,"ec-calendar__holiday")][text()="'.$holidays['定休日2']->format('j').'"]']);
 
         // 今日の日付にクラス .ec-calendar__today が設定されていることを確認
-        $I->seeElement(['xpath' => '//table[@id="this-month-table"]//td[@class="ec-calendar__today"][text()="'.Carbon::now()->format('j').'"]']);
+        $I->seeElement(['xpath' => '//table[@id="this-month-table"]//td[contains(@class,"ec-calendar__today")][text()="'.Carbon::now()->format('j').'"]']);
     }
 
     /**

--- a/src/Eccube/Controller/Block/CalendarController.php
+++ b/src/Eccube/Controller/Block/CalendarController.php
@@ -43,8 +43,8 @@ class CalendarController extends AbstractController
     {
         $today = Carbon::now();
         $firstDateOfThisMonth = $today->copy()->startOfMonth();
-        $firstDateOfNextMonth = $today->copy()->addMonth(1)->startOfMonth();
-        $endDateOfNextMonth = $today->copy()->addMonth(1)->endOfMonth();
+        $firstDateOfNextMonth = $today->copy()->startOfMonth()->addMonth(1)->startOfMonth();
+        $endDateOfNextMonth = $today->copy()->startOfMonth()->addMonth(1)->endOfMonth();
 
         // 2ヶ月間の定休日を取得
         $HolidaysOfTwoMonths = $this->calendarRepository->getHolidayList($firstDateOfThisMonth, $endDateOfNextMonth);
@@ -65,7 +65,7 @@ class CalendarController extends AbstractController
         $thisMonthCalendar = $this->setHolidayAndTodayFlag($thisMonthCalendar, $holidayListOfTwoMonths, $today->copy());
 
         // 来月のカレンダー配列に定休日フラグを設定
-        $nextMonthCalendar = $this->setHolidayAndTodayFlag($nextMonthCalendar, $holidayListOfTwoMonths, $today->copy()->addMonth(1));
+        $nextMonthCalendar = $this->setHolidayAndTodayFlag($nextMonthCalendar, $holidayListOfTwoMonths, $today->copy()->startOfMonth()->addMonth(1));
 
         // 各カレンダータイトルを作成
         $monthFormat = $this->translator->trans('front.block.calendar.month_format');

--- a/tests/Eccube/Tests/Web/Block/CalendarControllerTest.php
+++ b/tests/Eccube/Tests/Web/Block/CalendarControllerTest.php
@@ -28,7 +28,7 @@ class CalendarControllerTest extends AbstractWebTestCase
     public function testThisMonthTitle()
     {
         $crawler = $this->client->request('GET', $this->generateUrl('block_calendar'));
-        $this->expected = Carbon::now()->format('Y年n月');
+        $this->expected = Carbon::now()->startOfMonth()->format('Y年n月');
         $this->actual = $crawler->filter('#this-month-title')->text();
         $this->verify();
     }
@@ -36,7 +36,7 @@ class CalendarControllerTest extends AbstractWebTestCase
     public function testNextMonthTitle()
     {
         $crawler = $this->client->request('GET', $this->generateUrl('block_calendar'));
-        $this->expected = Carbon::now()->addMonth(1)->format('Y年n月');
+        $this->expected = Carbon::now()->startOfMonth()->addMonth(1)->format('Y年n月');
         $this->actual = $crawler->filter('#next-month-title')->text();
         $this->verify();
     }
@@ -48,7 +48,6 @@ class CalendarControllerTest extends AbstractWebTestCase
             ->setHoliday(new \DateTime(Carbon::now()->format('Y-m-d')));
         $this->entityManager->persist($Calendar);
         $this->entityManager->flush();
-        dump($Calendar);
 
         $crawler = $this->client->request('GET', $this->generateUrl('block_calendar'));
         $this->expected = Carbon::now()->format('j');


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

月末での翌月判定に誤りがあり、翌月ではなく翌々月のカレンダーが表示される問題を修正しました。

![image](https://user-images.githubusercontent.com/8196725/151760192-d99a6c61-8381-4e73-9882-3203d644421d.png)

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

以下のように翌月の1日を取得しようとしているが、

`$firstDateOfNextMonth = $today->copy()->addMonth(1)->startOfMonth();`

1/31に実行した場合、addMonth(1)では2/31と判定され、存在しない日付のため3月と判定される。

以下のように、月初から翌月を求めるように修正する
`$firstDateOfNextMonth = $today->copy()->startOfMonth()->addMonth(1)->startOfMonth();`

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
