### PR TITLE
webp対応時に拡張子の大文字小文字を区別しない修正

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -18,7 +18,7 @@ DirectoryIndex index.php index.html .ht
 </FilesMatch>
 
 <IfModule mod_setenvif.c>
-  SetEnvIf Request_URI "\.(jpe?g|png)$" _image_request
+  SetEnvIf Request_URI "\.(jpe?g|png)$" _image_request [NC]
 </IfModule>
 
 <IfModule mod_headers.c>
@@ -50,7 +50,7 @@ DirectoryIndex index.php index.html .ht
     RewriteCond %{HTTP_ACCEPT} image/webp
     RewriteCond %{SCRIPT_FILENAME}.webp -f
     # *.jpg、*.pngファイルを*.webpファイルに内部的にルーティングする
-    RewriteRule .(jpe?g|png)$ %{SCRIPT_FILENAME}.webp [T=image/webp]
+    RewriteRule .(jpe?g|png)$ %{SCRIPT_FILENAME}.webp [T=image/webp,NC]
 
     # Authorization ヘッダが取得できない環境への対応
     RewriteCond %{HTTP:Authorization} ^(.*)


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
拡張子が大文字だとwebpが無視されていたため、NCオプションの追加


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
