### PR TITLE
E2Eテスト追加 商品一覧／受注一覧／会員一覧ページのソート機能

### DIFF
--- a/codeception/_support/Page/Admin/CustomerManagePage.php
+++ b/codeception/_support/Page/Admin/CustomerManagePage.php
@@ -132,4 +132,34 @@ class CustomerManagePage extends AbstractAdminPageStyleGuide
     {
         return $this->tester->grabTextFrom("#search_form > div.c-contentsArea__cols > div > div > div.card.rounded.border-0.mb-4 > div > table > tbody > tr:nth-child(${rowNum}) > td.align-middle.pl-3");
     }
+
+    public function assertSortedIdList($order)
+    {
+        $values = $this->tester->grabMultiple('.c-contentsArea__primaryCol tr > td:nth-child(1)');
+
+        $expect = $values;
+        if ($order === 'asc') {
+            sort($expect);
+        } else {
+            rsort($expect);
+        }
+
+        $this->tester->assertEquals($expect, $values);
+    }
+    public function assertSortedNameList($order)
+    {
+        $values = array_map(function($s) {
+            // 一覧の会員名の文字列から姓だけを抽出
+            return preg_replace('/ .*$/', '', $s);
+        }, $this->tester->grabMultiple('.c-contentsArea__primaryCol tr > td:nth-child(2)'));
+
+        $expect = $values;
+        if ($order === 'asc') {
+            sort($expect);
+        } else {
+            rsort($expect);
+        }
+
+        $this->tester->assertEquals($expect, $values);
+    }
 }

--- a/codeception/_support/Page/Admin/CustomerManagePage.php
+++ b/codeception/_support/Page/Admin/CustomerManagePage.php
@@ -146,6 +146,7 @@ class CustomerManagePage extends AbstractAdminPageStyleGuide
 
         $this->tester->assertEquals($expect, $values);
     }
+
     public function assertSortedNameList($order)
     {
         $values = array_map(function($s) {

--- a/codeception/_support/Page/Admin/OrderManagePage.php
+++ b/codeception/_support/Page/Admin/OrderManagePage.php
@@ -287,7 +287,7 @@ class OrderManagePage extends AbstractAdminPageStyleGuide
         $expect = $values;
         usort($expect, function ($a, $b) {
             // order_status でソート
-            $statusList = ['新規受付', '入金済み', '対応中', '注文取消し', '発送済み', '決済処理中', '購入処理中', '返品'];
+            $statusList = ['新規受付', '注文取消し', '対応中', '発送済み', '入金済み', '決済処理中', '購入処理中', '返品'];
             return array_search($a, $statusList) > array_search($b, $statusList);
         });
 

--- a/codeception/_support/Page/Admin/OrderManagePage.php
+++ b/codeception/_support/Page/Admin/OrderManagePage.php
@@ -280,4 +280,38 @@ class OrderManagePage extends AbstractAdminPageStyleGuide
 
         return $this;
     }
+
+    public function assertSortedStatusList($order)
+    {
+        $values = $this->tester->grabMultiple('.c-contentsArea__primaryCol tr > td:nth-child(4)');
+        $expect = $values;
+        usort($expect, function ($a, $b) {
+            // order_status でソート
+            $statusList = ['新規受付', '入金済み', '対応中', '注文取消し', '発送済み', '決済処理中', '購入処理中', '返品'];
+            return array_search($a, $statusList) > array_search($b, $statusList);
+        });
+
+        if ($order === 'desc') {
+            $expect = array_reverse($expect);
+        }
+
+        $this->tester->assertEquals($expect, $values);
+    }
+
+    public function assertSortedPriceList($order)
+    {
+        $values = array_map(function($s) {
+            // 一覧の購入金額の文字列から金額だけを抽出
+            return preg_replace('/\D/', '', $s);
+        }, $this->tester->grabMultiple('.c-contentsArea__primaryCol tr > td:nth-child(5)'));
+
+        $expect = $values;
+        if ($order === 'asc') {
+            sort($expect);
+        } else {
+            rsort($expect);
+        }
+
+        $this->tester->assertEquals($expect, $values);
+    }
 }

--- a/codeception/_support/Page/Admin/OrderManagePage.php
+++ b/codeception/_support/Page/Admin/OrderManagePage.php
@@ -302,7 +302,7 @@ class OrderManagePage extends AbstractAdminPageStyleGuide
     {
         $values = array_map(function($s) {
             // 一覧の購入金額の文字列から金額だけを抽出
-            return preg_replace('/\D/', '', $s);
+            return (int)preg_replace('/(\n.*|\D)/', '', $s);
         }, $this->tester->grabMultiple('.c-contentsArea__primaryCol tr > td:nth-child(5)'));
 
         $expect = $values;

--- a/codeception/_support/Page/Admin/ProductManagePage.php
+++ b/codeception/_support/Page/Admin/ProductManagePage.php
@@ -277,4 +277,18 @@ class ProductManagePage extends AbstractAdminPageStyleGuide
 
         return $this;
     }
+
+    public function assertSortedList($index, $order)
+    {
+        $values = $this->tester->grabMultiple('.c-contentsArea__primaryCol tr > td:nth-child('.$index.')');
+
+        $expect = $values;
+        if ($order === 'asc') {
+            sort($expect);
+        } else {
+            rsort($expect);
+        }
+
+        $this->tester->assertEquals($expect, $values);
+    }
 }

--- a/codeception/acceptance/EA03ProductCest.php
+++ b/codeception/acceptance/EA03ProductCest.php
@@ -186,6 +186,32 @@ class EA03ProductCest
         $I->assertNotContains('フリーエリア', $csvHeader);
     }
 
+    public function product_一覧でのソート(AcceptanceTester $I)
+    {
+        $I->wantTo('EA0301-UC03-T01 一覧でのソート');
+        $page = ProductManagePage::go($I);
+
+        // 商品一覧・ID横の上矢印をクリック
+        $I->click('[data-sortkey="product_id"]');
+        $I->seeElement('.listSort-current[data-sortkey="product_id"] .fa-arrow-up');
+        $page->assertSortedList(2, 'asc');
+
+        // ID横の下矢印をクリック
+        $I->click('[data-sortkey="product_id"]');
+        $I->seeElement('.listSort-current[data-sortkey="product_id"] .fa-arrow-down');
+        $page->assertSortedList(2, 'desc');
+
+        // 更新日横の上矢印をクリック
+        $I->click('[data-sortkey="update_date"]');
+        $I->seeElement('.listSort-current[data-sortkey="update_date"] .fa-arrow-up');
+        $page->assertSortedList(10, 'asc');
+
+        // 更新日横の下矢印をクリック
+        $I->click('[data-sortkey="update_date"]');
+        $I->seeElement('.listSort-current[data-sortkey="update_date"] .fa-arrow-down');
+        $page->assertSortedList(10, 'desc');
+    }
+
     public function product_一覧からの規格編集規格なし失敗(AcceptanceTester $I)
     {
         $I->wantTo('EA0310-UC01-T02 一覧からの規格編集 規格なし 失敗');

--- a/codeception/acceptance/EA04OrderCest.php
+++ b/codeception/acceptance/EA04OrderCest.php
@@ -244,6 +244,32 @@ class EA04OrderCest
         $I->assertEquals($OrderNumForDontDel, $OrderListPage->一覧_注文番号(1));
     }
 
+    public function order_一覧でのソート(AcceptanceTester $I)
+    {
+        $I->wantTo('EA0401-UC09-T01 一覧でのソート');
+        $page = OrderManagePage::go($I);
+
+        // 対応状況横の上矢印をクリック
+        $I->click('a[data-sortkey="order_status"]');
+        $I->seeElement('.listSort-current[data-sortkey="order_status"] .fa-arrow-up');
+        $page->assertSortedStatusList('asc');
+
+        // 対応状況横の下矢印をクリック
+        $I->click('a[data-sortkey="order_status"]');
+        $I->seeElement('.listSort-current[data-sortkey="order_status"] .fa-arrow-down');
+        $page->assertSortedStatusList('desc');
+
+        // 購入金額横の上矢印をクリック
+        $I->click('[data-sortkey="purchase_price"]');
+        $I->seeElement('.listSort-current[data-sortkey="purchase_price"] .fa-arrow-up');
+        $page->assertSortedPriceList('asc');
+
+        // 購入金額横の下矢印をクリック
+        $I->click('a[data-sortkey="purchase_price"]');
+        $I->seeElement('.listSort-current[data-sortkey="purchase_price"] .fa-arrow-down');
+        $page->assertSortedPriceList('desc');
+    }
+
     /**
      * @group vaddy
      */

--- a/codeception/acceptance/EA05CustomerCest.php
+++ b/codeception/acceptance/EA05CustomerCest.php
@@ -70,6 +70,32 @@ class EA05CustomerCest
         $I->see('検索条件に誤りがあります', CustomerManagePage::$検索結果_エラーメッセージ);
     }
 
+    public function customer_一覧でのソート(AcceptanceTester $I)
+    {
+        $I->wantTo('EA0501-UC07-T01 一覧でのソート');
+        $page = CustomerManagePage::go($I);
+
+        // ID横の上矢印をクリック
+        $I->click('a[data-sortkey="customer_id"]');
+        $I->seeElement('.listSort-current[data-sortkey="customer_id"] .fa-arrow-up');
+        $page->assertSortedIdList('asc');
+
+        // ID横の下矢印をクリック
+        $I->click('a[data-sortkey="customer_id"]');
+        $I->seeElement('.listSort-current[data-sortkey="customer_id"] .fa-arrow-down');
+        $page->assertSortedIdList('desc');
+
+        // 名前横の上矢印をクリック
+        $I->click('[data-sortkey="name"]');
+        $I->seeElement('.listSort-current[data-sortkey="name"] .fa-arrow-up');
+        $page->assertSortedNameList('asc');
+
+        // 名前横の下矢印をクリック
+        $I->click('a[data-sortkey="name"]');
+        $I->seeElement('.listSort-current[data-sortkey="name"] .fa-arrow-down');
+        $page->assertSortedNameList('desc');
+    }
+
     /**
      * @group vaddy
      */


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
4.1.2 にて追加された、管理画面・商品一覧ページのソート機能のE2Eテスト

## 方針(Policy)

## 実装に関する補足(Appendix)

対象のPR https://github.com/EC-CUBE/ec-cube/pull/5038
対象の結合テスト項目

- [EA0301-UC03-T01](https://github.com/EC-CUBE/eccube-specification/blob/4.1/IntegrationTest/EA03_Product_%E7%B5%90%E5%90%88%E8%A9%A6%E9%A8%93%E9%A0%85%E7%9B%AE%E6%9B%B8.md#ea0301-uc03-t01-%E4%B8%80%E8%A6%A7%E3%81%A7%E3%81%AE%E3%82%BD%E3%83%BC%E3%83%88)
- [EA0401-UC09-T01](https://github.com/EC-CUBE/eccube-specification/blob/4.1/IntegrationTest/EA04_Order_%E7%B5%90%E5%90%88%E8%A9%A6%E9%A8%93%E9%A0%85%E7%9B%AE%E6%9B%B8.md#ea0401-uc09-t01-%E4%B8%80%E8%A6%A7%E3%81%A7%E3%81%AE%E3%82%BD%E3%83%BC%E3%83%88)
- [EA0501-UC07-T01](https://github.com/EC-CUBE/eccube-specification/blob/4.1/IntegrationTest/EA05_Customer_%E7%B5%90%E5%90%88%E8%A9%A6%E9%A8%93%E9%A0%85%E7%9B%AE%E6%9B%B8.md#ea0501-uc07-t01-%E4%B8%80%E8%A6%A7%E3%81%A7%E3%81%AE%E3%82%BD%E3%83%BC%E3%83%88)

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
