### PR TITLE
ファイル管理のファイル削除時、 select_file に空のパラメータを渡せないよう修正

### DIFF
--- a/src/Eccube/Controller/Admin/Content/FileController.php
+++ b/src/Eccube/Controller/Admin/Content/FileController.php
@@ -200,7 +200,7 @@ class FileController extends AbstractController
         $this->isTokenValid();
 
         $selectFile = $request->get('select_file');
-        if (is_null($selectFile) || $selectFile == '/') {
+        if ($selectFile === '' || $selectFile === null || $selectFile == '/') {
             return $this->redirectToRoute('admin_content_file');
         }
 

--- a/tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php
@@ -73,6 +73,20 @@ class FileControllerTest extends AbstractAdminWebTestCase
         $this->assertFalse(file_exists($filepath));
     }
 
+    /**
+     * `select_file` が空の場合は `admin_content_file` へリダイレクトする.
+     *
+     * see https://github.com/EC-CUBE/ec-cube/pull/5298
+     */
+    public function testDeleteWithEmpty()
+    {
+        $this->client->request(
+            'DELETE',
+            $this->generateUrl('admin_content_file_delete').'?select_file='
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('admin_content_file')));
+    }
+
     public function testIndexWithCreate()
     {
         $folder = 'create_folder';


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
- `select_file=` にすると user_data 以下が削除されてしまう

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- `is_null()` に空文字を渡すと false になるため `===` で判定する


## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
ユニットテストを追加

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
