### PR TITLE
[OWASP ZAP] レイアウト管理のテストを追加

### DIFF
--- a/.github/workflows/penetration-test.yml
+++ b/.github/workflows/penetration-test.yml
@@ -14,6 +14,7 @@ jobs:
         group:
           - 'test/front_login/contact.test.ts'
           - 'test/front_guest/contact.test.ts'
+          - 'test/admin/content_layout.test.ts'
           - 'test/admin/order_mail.test.ts'
 
     steps:

--- a/zap/selenium/ci/TypeScript/test/admin/content_layout.test.ts
+++ b/zap/selenium/ci/TypeScript/test/admin/content_layout.test.ts
@@ -1,0 +1,46 @@
+import { test, expect, chromium, Page } from '@playwright/test';
+import { intervalRepeater } from '../../utils/Progress';
+import { ZapClient, Mode, ContextType, Risk, HttpMessage } from '../../utils/ZapClient';
+const zapClient = new ZapClient('http://127.0.0.1:8090');
+
+const baseURL = 'https://ec-cube/admin';
+const url = baseURL + '/content/layout';
+
+test.describe.serial('レイアウト管理>表示テスト', () => {
+  let page: Page;
+  test.beforeAll(async () => {
+    await zapClient.setMode(Mode.Protect);
+    await zapClient.newSession('/zap/wrk/sessions/admin_content_layout', true);
+    await zapClient.importContext(ContextType.Admin);
+
+    if (!await zapClient.isForcedUserModeEnabled()) {
+      await zapClient.setForcedUserModeEnabled();
+      expect(await zapClient.isForcedUserModeEnabled()).toBeTruthy();
+    }
+    const browser = await chromium.launch();
+    page = await browser.newPage();
+    await page.goto(url);
+  });
+
+  test('レイアウト管理ページを表示します', async () => {
+    await expect(page).toHaveTitle(/レイアウト管理/);
+  });
+
+  test('タイトルを確認します', async () => {
+    await page.textContent('.c-pageTitle__title')
+      .then(title => expect(title).toContain('レイアウト管理'));
+  });
+
+  test.describe('テストを実行します[GET] @attack', () => {
+    let scanId: number;
+    test('アクティブスキャンを実行します', async () => {
+      scanId = await zapClient.activeScanAsUser(url, 2, 55, false, null, 'GET');
+      await intervalRepeater(async () => await zapClient.getActiveScanStatus(scanId), 5000, page);
+    });
+
+    test('結果を確認します', async () => {
+      await zapClient.getAlerts(url, 0, 1, Risk.High)
+        .then(alerts => expect(alerts).toEqual([]));
+    });
+  });
+});


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
Owasp ZAP の自動スキャン、管理画面 コンテンツ管理 → レイアウト管理 に対する get のテストを追加しました
( /admin/content/layout )

## 方針(Policy)

## 実装に関する補足(Appendix)
GETアクセスし、正しいページかを確認後、スキャンをかけるのみの内容です

## テスト（Test)
クラウドIDEにてOwasp ZAPのスキャンが通ることを確認しています。

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト
- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
