### PR TITLE
注文手続でフォームエラーが返ると fatal error となる不具合を修正

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -309,7 +309,7 @@ class ShoppingController extends AbstractShoppingController
         log_info('[注文確認] フォームエラーのため, 注文手続画面を表示します.', [$Order->getId()]);
 
         $template = new Template([
-            'owner' => [self::class, 'confirm'],
+            'owner' => [$this, 'confirm'],
             'template' => 'Shopping/index.twig'
         ]);
         $request->attributes->set('_template', $template);

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -308,8 +308,11 @@ class ShoppingController extends AbstractShoppingController
 
         log_info('[注文確認] フォームエラーのため, 注文手続画面を表示します.', [$Order->getId()]);
 
-        // FIXME @Templateの差し替え.
-        $request->attributes->set('_template', new Template(['template' => 'Shopping/index.twig']));
+        $template = new Template([
+            'owner' => [self::class, 'confirm'],
+            'template' => 'Shopping/index.twig'
+        ]);
+        $request->attributes->set('_template', $template);
 
         return [
             'form' => $form->createView(),


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
注文手続きのフォームでエラーが返ると fatal error となる。
ShoppingController の confirm アクションでは、フォームエラーの場合にテンプレートを差し替えてフォームを表示するよう意図されているが、パラメーターが不十分なためにエラーとなっている。

## 方針(Policy)
エラーとなっている箇所で必要とされているパラメーターを、テンプレート差し替えの際に提供する。

## 実装に関する補足(Appendix)
注文手続きで「お問い合わせ」欄に3,001文字以上入力して送信すると再現できます。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
