### PR TITLE
納品書PDFで複数行になる商品明細がページをまたぐとレイアウトが崩れる

### DIFF
--- a/src/Eccube/Service/OrderPdfService.php
+++ b/src/Eccube/Service/OrderPdfService.php
@@ -353,6 +353,10 @@ class OrderPdfService extends TcpdfFpdi
 
         $this->Cell(0, 10, '', 0, 1, 'C', 0, '');
 
+        // 行頭近くの場合、表示崩れがあるためもう一個字下げする
+        if (270 <= $this->GetY()) {
+            $this->Cell(0, 10, '', 0, 1, 'C', 0, '');
+        }
         $this->SetFont(self::FONT_GOTHIC, 'B', 9);
         $this->MultiCell(0, 6, '＜ 備考 ＞', 'T', 2, 'L', 0, '');
 
@@ -667,6 +671,9 @@ class OrderPdfService extends TcpdfFpdi
             $i = 0;
             $h = 4;
             $this->Cell(5, $h, '', 0, 0, '', 0, '');
+            if ((277 - $this->getY()) < ($h * 4)) {
+                $this->checkPageBreak($this->PageBreakTrigger + 1);
+            }
 
             // Cellの高さを保持
             $cellHeight = 0;
@@ -679,6 +686,8 @@ class OrderPdfService extends TcpdfFpdi
                 // セル高さが最大値を保持する
                 if ($h >= $cellHeight) {
                     $cellHeight = $h;
+                } else {
+                    $this->checkPageBreak($this->PageBreakTrigger + 1);
                 }
 
                 // 最終列の場合は次の行へ移動


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
 #5326 納品書PDFで複数行になる商品明細がページをまたぐとレイアウトが崩れる問題を解消。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
