### PR TITLE
RememberMeトークンでログインした場合はパスワード再発行画面にアクセス可能とする

### DIFF
--- a/src/Eccube/Controller/ForgotController.php
+++ b/src/Eccube/Controller/ForgotController.php
@@ -78,7 +78,7 @@ class ForgotController extends AbstractController
      */
     public function index(Request $request)
     {
-        if ($this->isGranted('ROLE_USER')) {
+        if ($this->isGranted('IS_AUTHENTICATED_FULLY')) {
             throw new HttpException\NotFoundHttpException();
         }
 
@@ -150,7 +150,7 @@ class ForgotController extends AbstractController
      */
     public function complete(Request $request)
     {
-        if ($this->isGranted('ROLE_USER')) {
+        if ($this->isGranted('IS_AUTHENTICATED_FULLY')) {
             throw new HttpException\NotFoundHttpException();
         }
 
@@ -165,7 +165,7 @@ class ForgotController extends AbstractController
      */
     public function reset(Request $request, $reset_key)
     {
-        if ($this->isGranted('ROLE_USER')) {
+        if ($this->isGranted('IS_AUTHENTICATED_FULLY')) {
             throw new HttpException\NotFoundHttpException();
         }
 


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
#5379 の修正

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
IS_AUTHENTICATED_REMEMBERED(「次回から自動的にログインする」で自動的にログイン状態)の場合は
パスワードが分からないとアクセスできない画面があるため、パスワード再発行画面を利用できるようにしても良いと思うのですがどうでしょうか？

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
IS_AUTHENTICATED_FULLYのみパスワード再発行画面にアクセス禁止を残しています。
特にアクセスする必要がないため。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
予め「次回から自動的にログインする」にチェックを入れてログイン
その後eccubeセッションクッキーを消してRememerMeトークンでログインし、
手動でパスワード再発行できるかの動作確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
