### PR TITLE
認証キー発行処理をcookieに依存しない実装に変更

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -11,7 +11,7 @@ parameters:
     env(ECCUBE_COOKIE_PATH): '/'
     env(ECCUBE_COOKIE_LIFETIME): '0'
     env(ECCUBE_GC_MAXLIFETIME): '1440'
-    env(ECCUBE_PACKAGE_API_URL): 'https://package-api-c2.ec-cube.net'
+    env(ECCUBE_PACKAGE_API_URL): 'https://package-api-c2.ec-cube.net/v42'
     env(ECCUBE_OWNERS_STORE_URL): 'https://www.ec-cube.net'
     env(ECCUBE_MAINTENANCE_FILE_PATH): '%kernel.project_dir%/.maintenance'
     env(ECCUBE_2FA_ENABLED): '1'

--- a/src/Eccube/Resource/template/admin/Store/authentication_setting.twig
+++ b/src/Eccube/Resource/template/admin/Store/authentication_setting.twig
@@ -31,7 +31,21 @@ file that was distributed with this source code.
 <script>
 
     function refreshCaptchaImage() {
-        $('#captcha_image').attr('src', "{{ eccube_config.eccube_package_api_url }}/captcha" + '?' + new Date().getTime())
+        var xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function() {
+            if (this.readyState == 4 && this.status == 200) {
+                var captcha = document.getElementById("captcha_image");
+                var url = window.URL || window.webkitURL;
+                captcha.src = url.createObjectURL(this.response);
+
+                var captcha_id = document.getElementById("captcha_id");
+                captcha_id.value = this.getResponseHeader('x-eccube-captcha-id');
+            }
+        }
+
+        xhr.open('GET', '{{ eccube_config.eccube_package_api_url }}/captcha' + '?' + new Date().getTime());
+        xhr.responseType = 'blob';
+        xhr.send();
     }
 
     $('#captcha').on('show.bs.modal', function() {
@@ -45,13 +59,11 @@ file that was distributed with this source code.
             dataType: 'json',
             cache: false,
             data: {
+                "captcha_id": $('#captcha_id').val(),
                 "captcha": $('#captcha_text').val(),
                 "eccube_url": '{{ eccubeUrl }}',
                 "eccube_version": "{{ constant('Eccube\\Common\\Constant::VERSION') }}",
                 "eccube_shop_name": "{{ eccubeShopName }}"
-            },
-            xhrFields: {
-                withCredentials: true
             }
         }).done(function(data) {
             $('#captcha').modal('hide');
@@ -164,6 +176,7 @@ file that was distributed with this source code.
                         <img id="captcha_image" class="mb-2" src="#">
                         <button id="captcha-refresh" type="button" class="btn btn-default"><i class="fa fa-refresh" aria-hidden="true"></i></button>
                         <input type="text" id="captcha_text" value="" class="form-control" placeholder="{{ 'admin.store.setting.captcha_message'|trans }}"/>
+                        <input type="hidden" id="captcha_id" value=""/>
                         <span id="captcha_error" class="invalid-feedback" style="display: none">
                             <span class="mb-0 d-block">
                                 <span class="initialism form-error-icon badge badge-danger">{{ 'admin.store.setting.captcha_error'|trans }}</span> <span class="form-error-message">{{ 'admin.store.setting.invalid_captcha'|trans }}</span>


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

#4416

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

キャプチャ文字列の保持をセッションを使って実装していたが、セッションCookieがサードパーティーCookieとなるためsafariで動作していなかった。

package-api側をCookieに依存しない実装に変更し、クライアントであるEC-CUBE側もそれに合わせて追随

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

キャプチャ画像リクエスト時に、x-eccube-captcha-idというレスポンスヘッダが返されます。
認証キー発行リクエスト時にx-eccube-captcha-idの値とキャプチャ文字列をセットで渡すことで、キャプチャ文字列の照合を行います。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

以下ブラウザで動作することを確認しています。

- safari
- chrome のシークレットモード

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
