### PR TITLE
メンテナンストークンにSecure属性を設定する

### DIFF
--- a/src/Eccube/EventListener/MaintenanceListener.php
+++ b/src/Eccube/EventListener/MaintenanceListener.php
@@ -54,10 +54,10 @@ class MaintenanceListener implements EventSubscriberInterface
 
         $user = $this->requestContext->getCurrentUser();
         if ($user instanceof Entity\Member && $this->requestContext->isAdmin()) {
-            $cookie = new Cookie(
+            $cookie = (new Cookie(
                 SystemService::MAINTENANCE_TOKEN_KEY,
                 $this->systemService->getMaintenanceToken()
-            );
+            ))->withSecure(true);
             $response->headers->setCookie($cookie);
         }
     }


### PR DESCRIPTION
#5370 
メンテナンストークン設定時にSecue属性をオンの状態で設定するように修正