### PR TITLE
マスタデータのEntityを拡張すると、マスタデータ管理ページでテーブルを選択できなくなる問題の対策

### DIFF
--- a/src/Eccube/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/src/Eccube/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -76,9 +76,17 @@ class AnnotationDriver extends \Doctrine\ORM\Mapping\Driver\AnnotationDriver
                     $sourceFile = str_replace('\\', '/', $sourceFile);
                     $projectDir = str_replace('\\', '/', $projectDir);
                 }
-                // Replace /path/to/ec-cube to proxies path
-                $proxyFile = str_replace($projectDir, $this->trait_proxies_directory, $path).'/'.basename($sourceFile);
-                if (file_exists($proxyFile)) {
+
+                $entityPath = $projectDir . '/src/Eccube/Entity/';
+                $proxyFile = null;
+                if (strpos($sourceFile, $entityPath) === 0) {
+                    // Entity class
+                    $entityClass = substr($sourceFile, strlen($entityPath));
+                    // Replace /path/to/ec-cube to proxies path
+                    $proxyFile = str_replace($projectDir, $this->trait_proxies_directory, $path).'/'.$entityClass;
+                }
+
+                if ($proxyFile !== null && file_exists($proxyFile)) {
                     require_once $proxyFile;
 
                     $sourceFile = $proxyFile;


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#5400 の修正

## 方針(Policy)
Proxyファイルのパスを生成する際、basename($sourceFile)ではなく、
$entityClass = substr($sourceFile, strlen($projectDir . '/src/Eccube/Entity/'));
として$sourceFileから先頭の/var/www/ec-cube/src/Eccube/Entity/を除去するように
変更しました。

## 実装に関する補足(Appendix)
(1)
basename()からsubstrに()よる部分的なパスの除去に変更になっていますが、
入力値である$sourceFileはRecursiveDirectoryIteratorにより生成されるデータであるため、directory traversalの問題は発生しないと考えます。

(2)
従来のコードではあらゆるファイルに対してProxyファイルのパスを生成して、
Proxyファイルの有無をチェックしていましたが、

$entityPath = $projectDir . '/src/Eccube/Entity/';
if (strpos($sourceFile, $entityPath) === 0) {
}

のようにしてEntity配下のクラスについてのみProxyファイルのパスを生成して、
Proxyファイルの有無チェックが動作するように変更しています。

探索対象である$this->pathsは外部から指定できるので、
将来、['/var/www/ec-cube/src/Eccube/']のようにEntity以外のクラスも含むパスを
指定して呼び出された場合にも正しく動作させるためです。


## テスト（Test)
(1)
プラグインから
Plugin/[Plugin code]/Entity/Master/DeviceTypeTrait.php
のようにしてマスタデータのEntityを拡張し、
\Eccube\Doctrine\ORM\Mapping\Driver\AnnotationDriver::getAllClassNames()
が返すクラス一覧に'Eccube\Entity\Master\DeviceType'が含まれるようになった
ことを確認。

(2)
管理画面のマスタデータ管理のプルダウンにmtb_device_typeが表示されるようになったことを確認。

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
