### PR TITLE
fix issue/5364 - Entity拡張でproxyが正しく生成されない場合がある

### DIFF
--- a/src/Eccube/Service/EntityProxyService.php
+++ b/src/Eccube/Service/EntityProxyService.php
@@ -192,7 +192,7 @@ class EntityProxyService
             foreach ($traits as $trait) {
                 $anno = $reader->getClassAnnotation(new \ReflectionClass($trait), EntityExtension::class);
                 if ($anno) {
-                    $proxies[$anno->value][] = $trait;
+                    $proxies[preg_match('/^\\\/i',$anno->value) ? $anno->value : '\\'.$anno->value][] = $trait;
                 }
             }
             $proxySets[] = $proxies;

--- a/src/Eccube/Service/EntityProxyService.php
+++ b/src/Eccube/Service/EntityProxyService.php
@@ -192,7 +192,9 @@ class EntityProxyService
             foreach ($traits as $trait) {
                 $anno = $reader->getClassAnnotation(new \ReflectionClass($trait), EntityExtension::class);
                 if ($anno) {
-                    $proxies[preg_match('/^\\\/i',$anno->value) ? $anno->value : '\\'.$anno->value][] = $trait;
+                    $class = str_replace('\\\\', '\\', $anno->value);
+                    $class = ltrim($class, '\\');
+                    $proxies[$class][] = $trait;
                 }
             }
             $proxySets[] = $proxies;


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
https://github.com/EC-CUBE/ec-cube/issues/5364 の修正
## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
1つの文字の違いにより、$proxySets変数を作成した後、キーが異なるため、2つの特性ファイルは同じグループにソートすることができませんでした。

"Eccube\Entity\Customer" => array:1 [
      0 => ""\Customize\Entity\CustomerTraitA"
    ]
"\Eccube\Entity\Customer" => array:1 [
  0 => ""\Customize\Entity\CustomerTraitB"
]

解決方法:  同じキーに入れて同じグループにソートされます
## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
