### PR TITLE
[4.2] ComposerApi をコールする際は symfony/flex を無効化する

### DIFF
--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -105,16 +105,23 @@ class ComposerApiService implements ComposerServiceInterface
     {
         $packageName = explode(' ', trim($packageName));
 
-        return $this->runCommand([
-            'command' => 'require',
-            'packages' => $packageName,
-            '--no-interaction' => true,
-            '--profile' => true,
-            '--prefer-dist' => true,
-            '--update-with-dependencies' => true,
-            '--no-scripts' => true,
-            '--update-no-dev' => env('APP_ENV') === 'prod',
-        ], $output);
+        $this->init();
+        $this->execConfig('allow-plugins.symfony/flex', ['false']);
+
+        try {
+            return $this->runCommand([
+                'command' => 'require',
+                'packages' => $packageName,
+                '--no-interaction' => true,
+                '--profile' => true,
+                '--prefer-dist' => true,
+                '--update-with-dependencies' => true,
+                '--no-scripts' => true,
+                '--update-no-dev' => env('APP_ENV') === 'prod',
+            ], $output, false);
+        } finally {
+            $this->execConfig('allow-plugins.symfony/flex', ['true']);
+        }
     }
 
     /**
@@ -135,7 +142,11 @@ class ComposerApiService implements ComposerServiceInterface
 
         $packageName = explode(' ', trim($packageName));
 
-        return $this->runCommand([
+        $this->init();
+        $this->execConfig('allow-plugins.symfony/flex', ['false']);
+
+        try {
+            return $this->runCommand([
             'command' => 'remove',
             'packages' => $packageName,
             '--ignore-platform-reqs' => true,
@@ -143,7 +154,10 @@ class ComposerApiService implements ComposerServiceInterface
             '--profile' => true,
             '--no-scripts' => true,
             '--update-no-dev' => env('APP_ENV') === 'prod',
-        ], $output);
+            ], $output, false);
+        } finally {
+            $this->execConfig('allow-plugins.symfony/flex', ['true']);
+        }
     }
 
     /**
@@ -158,14 +172,21 @@ class ComposerApiService implements ComposerServiceInterface
      */
     public function execUpdate($dryRun, $output = null)
     {
-        $this->runCommand([
+        $this->init();
+        $this->execConfig('allow-plugins.symfony/flex', ['false']);
+
+        try {
+            $this->runCommand([
             'command' => 'update',
             '--no-interaction' => true,
             '--profile' => true,
             '--no-scripts' => true,
             '--dry-run' => (bool) $dryRun,
             '--no-dev' => env('APP_ENV') === 'prod',
-        ], $output);
+            ], $output, false);
+        } finally {
+            $this->execConfig('allow-plugins.symfony/flex', ['true']);
+        }
     }
 
     /**
@@ -180,14 +201,22 @@ class ComposerApiService implements ComposerServiceInterface
      */
     public function execInstall($dryRun, $output = null)
     {
-        $this->runCommand([
+        $this->init();
+        $this->execConfig('allow-plugins.symfony/flex', ['false']);
+
+        try {
+            $this->runCommand([
             'command' => 'install',
             '--no-interaction' => true,
             '--profile' => true,
             '--no-scripts' => true,
             '--dry-run' => (bool) $dryRun,
             '--no-dev' => env('APP_ENV') === 'prod',
-        ], $output);
+            ], $output, false);
+        } finally {
+            $this->execConfig('allow-plugins.symfony/flex', ['true']);
+        }
+
     }
 
     /**


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
Web API プラグイン等、 Symfony bundle に依存するプラグインをインストールした場合、 symfony/flex によって `app/config/eccube/bundles.php` に bundle のクラスが追加される。
しかし、プラグイン削除時、 bundle によっては `app/config/eccube/bundles.php` の設定が削除されず残ってしまう場合がある。

これを防ぐため、 EC-CUBE から ComposerAPI をコールする際は一時的に symfony/flex を無効化する

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

ComposerApiService でComposerAPI をコールする際、 `composer config allow-plugins.symfony/flex false` を実行する。
finally 句で `composer config allow-plugins.symfony/flex true` を実行する 

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
Web API プラグインは以下のPRの取り込みも必要
https://github.com/EC-CUBE/eccube-api4/pull/130

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
plugin-test GitHub Actions の Bundle 関連のテストを修正

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
