### PR TITLE
[4.2] RESTRICT_FILE_UPLOADの警告が重複しないよう修正

### DIFF
--- a/src/Eccube/Controller/AbstractController.php
+++ b/src/Eccube/Controller/AbstractController.php
@@ -196,6 +196,19 @@ class AbstractController extends Controller
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function addFlash(string $type, $message): void
+    {
+        try {
+            parent::addFlash($type, $message);
+        } catch (\LogicException $e) {
+            // fallback session
+            $this->session->getFlashBag()->add($type, $message);
+        }
+    }
+
+    /**
      * @param string $targetPath
      */
     public function setLoginTargetPath($targetPath, $namespace = null)

--- a/src/Eccube/Controller/AbstractController.php
+++ b/src/Eccube/Controller/AbstractController.php
@@ -114,32 +114,62 @@ class AbstractController extends Controller
 
     public function addSuccess($message, $namespace = 'front')
     {
-        $this->session->getFlashBag()->add('eccube.'.$namespace.'.success', $message);
+        $this->addFlash('eccube.'.$namespace.'.success', $message);
+    }
+
+    public function addSuccessOnce($message, $namespace = 'front')
+    {
+        $this->addFlashOnce('eccube.'.$namespace.'.success', $message);
     }
 
     public function addError($message, $namespace = 'front')
     {
-        $this->session->getFlashBag()->add('eccube.'.$namespace.'.error', $message);
+        $this->addFlash('eccube.'.$namespace.'.error', $message);
+    }
+
+    public function addErrorOnce($message, $namespace = 'front')
+    {
+        $this->addFlashOnce('eccube.'.$namespace.'.error', $message);
     }
 
     public function addDanger($message, $namespace = 'front')
     {
-        $this->session->getFlashBag()->add('eccube.'.$namespace.'.danger', $message);
+        $this->addFlash('eccube.'.$namespace.'.danger', $message);
+    }
+
+    public function addDangerOnce($message, $namespace = 'front')
+    {
+        $this->addFlashOnce('eccube.'.$namespace.'.danger', $message);
     }
 
     public function addWarning($message, $namespace = 'front')
     {
-        $this->session->getFlashBag()->add('eccube.'.$namespace.'.warning', $message);
+        $this->addFlash('eccube.'.$namespace.'.warning', $message);
+    }
+
+    public function addWarningOnce($message, $namespace = 'front')
+    {
+        $this->addFlashOnce('eccube.'.$namespace.'.warning', $message);
     }
 
     public function addInfo($message, $namespace = 'front')
     {
-        $this->session->getFlashBag()->add('eccube.'.$namespace.'.info', $message);
+        $this->addFlash('eccube.'.$namespace.'.info', $message);
+    }
+
+    public function addInfoOnce($message, $namespace = 'front')
+    {
+        $this->addFlashOnce('eccube.'.$namespace.'.info', $message);
     }
 
     public function addRequestError($message, $namespace = 'front')
     {
-        $this->session->getFlashBag()->add('eccube.'.$namespace.'.request.error', $message);
+        $this->addFlash('eccube.'.$namespace.'.request.error', $message);
+    }
+
+    public function addRequestErrorOnce($message, $namespace = 'front')
+    {
+        $this->addFlashOnce('eccube.'.$namespace.'.request.error', $message);
     }
 
     public function clearMessage()
@@ -151,6 +181,18 @@ class AbstractController extends Controller
     {
         $this->clearMessage();
         $this->addWarning('admin.common.delete_error_already_deleted', 'admin');
+    }
+
+    public function hasMessage(string $type): bool
+    {
+        return $this->session->getFlashBag()->has($type);
+    }
+
+    public function addFlashOnce(string $type, $message): void
+    {
+        if (!$this->hasMessage($type)) {
+            $this->addFlash($type, $message);
+        }
     }
 
     /**

--- a/src/Eccube/Controller/Admin/Content/BlockController.php
+++ b/src/Eccube/Controller/Admin/Content/BlockController.php
@@ -83,7 +83,7 @@ class BlockController extends AbstractController
      */
     public function edit(Request $request, Environment $twig, FileSystem $fs, CacheUtil $cacheUtil, $id = null)
     {
-        $this->addInfo('admin.common.restrict_file_upload_info', 'admin');
+        $this->addInfoOnce('admin.common.restrict_file_upload_info', 'admin');
 
         $DeviceType = $this->deviceTypeRepository
             ->find(DeviceType::DEVICE_TYPE_PC);

--- a/src/Eccube/Controller/Admin/Content/CssController.php
+++ b/src/Eccube/Controller/Admin/Content/CssController.php
@@ -30,7 +30,7 @@ class CssController extends AbstractController
      */
     public function index(Request $request)
     {
-        $this->addInfo('admin.common.restrict_file_upload_info', 'admin');
+        $this->addInfoOnce('admin.common.restrict_file_upload_info', 'admin');
 
         $builder = $this->formFactory
             ->createBuilder(FormType::class)

--- a/src/Eccube/Controller/Admin/Content/FileController.php
+++ b/src/Eccube/Controller/Admin/Content/FileController.php
@@ -57,7 +57,7 @@ class FileController extends AbstractController
      */
     public function index(Request $request)
     {
-        $this->addInfo('admin.common.restrict_file_upload_info', 'admin');
+        $this->addInfoOnce('admin.common.restrict_file_upload_info', 'admin');
 
         $form = $this->formFactory->createBuilder(FormType::class)
             ->add('file', FileType::class, [

--- a/src/Eccube/Controller/Admin/Content/JsController.php
+++ b/src/Eccube/Controller/Admin/Content/JsController.php
@@ -30,7 +30,7 @@ class JsController extends AbstractController
      */
     public function index(Request $request)
     {
-        $this->addInfo('admin.common.restrict_file_upload_info', 'admin');
+        $this->addInfoOnce('admin.common.restrict_file_upload_info', 'admin');
 
         $builder = $this->formFactory
             ->createBuilder(FormType::class)

--- a/src/Eccube/Controller/Admin/Content/PageController.php
+++ b/src/Eccube/Controller/Admin/Content/PageController.php
@@ -93,7 +93,7 @@ class PageController extends AbstractController
      */
     public function edit(Request $request, Environment $twig, RouterInterface $router, CacheUtil $cacheUtil, $id = null)
     {
-        $this->addInfo('admin.common.restrict_file_upload_info', 'admin');
+        $this->addInfoOnce('admin.common.restrict_file_upload_info', 'admin');
 
         if (null === $id) {
             $Page = $this->pageRepository->newPage();

--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -485,7 +485,7 @@ class PluginController extends AbstractController
      */
     public function install(Request $request, CacheUtil $cacheUtil)
     {
-        $this->addInfo('admin.common.restrict_file_upload_info', 'admin');
+        $this->addInfoOnce('admin.common.restrict_file_upload_info', 'admin');
 
         $form = $this->formFactory
             ->createBuilder(PluginLocalInstallType::class)

--- a/src/Eccube/Controller/Admin/Store/TemplateController.php
+++ b/src/Eccube/Controller/Admin/Store/TemplateController.php
@@ -219,7 +219,7 @@ class TemplateController extends AbstractController
      */
     public function install(Request $request)
     {
-        $this->addInfo('admin.common.restrict_file_upload_info', 'admin');
+        $this->addInfoOnce('admin.common.restrict_file_upload_info', 'admin');
 
         $form = $this->formFactory
             ->createBuilder(TemplateType::class)


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
closes #5411 
RESTRICT_FILE_UPLOADの警告が重複しないよう修正

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- flashbag が1回だけ表示されるメソッドを追加
- 表示箇所を上記メソッドに変更

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
メッセージが表示しないのを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
