### PR TITLE
[4.2]ArrayAccess の deprecated を修正

### DIFF
--- a/src/Eccube/Common/EccubeConfig.php
+++ b/src/Eccube/Common/EccubeConfig.php
@@ -50,12 +50,10 @@ class EccubeConfig implements \ArrayAccess
     /**
      * @param $key
      * @param $value
-     *
-     * @return mixed
      */
     public function set($key, $value)
     {
-        return $this->container->setParameter($key, $value);
+        $this->container->setParameter($key, $value);
     }
 
     /**
@@ -63,6 +61,7 @@ class EccubeConfig implements \ArrayAccess
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->has($offset);
@@ -73,6 +72,7 @@ class EccubeConfig implements \ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset);
@@ -82,6 +82,7 @@ class EccubeConfig implements \ArrayAccess
      * @param mixed $offset
      * @param mixed $value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->set($offset, $value);
@@ -92,6 +93,7 @@ class EccubeConfig implements \ArrayAccess
      *
      * @throws \Exception
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         throw new \Exception();

--- a/src/Eccube/Entity/AbstractEntity.php
+++ b/src/Eccube/Entity/AbstractEntity.php
@@ -28,6 +28,7 @@ use Symfony\Component\Serializer\Serializer;
 /** @MappedSuperclass */
 abstract class AbstractEntity implements \ArrayAccess
 {
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $inflector = new Inflector(new NoopWordInflector(), new NoopWordInflector());
@@ -39,10 +40,12 @@ abstract class AbstractEntity implements \ArrayAccess
             || method_exists($this, "has$method");
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $inflector = new Inflector(new NoopWordInflector(), new NoopWordInflector());
@@ -59,6 +62,7 @@ abstract class AbstractEntity implements \ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
     }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
closes #5425 
PHP8.1 で ArrayAccess を実装したクラスで deprecated が出るのを修正

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- `#[\ReturnTypeWillChange]` を付与

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
