### PR TITLE
イベントの送出がデータ登録時のみで更新時には行われていないのを修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ClassCategoryController.php
+++ b/src/Eccube/Controller/Admin/Product/ClassCategoryController.php
@@ -133,6 +133,18 @@ class ClassCategoryController extends AbstractController
                 $editForm->handleRequest($request);
                 if ($editForm->isSubmitted() && $editForm->isValid()) {
                     $this->classCategoryRepository->save($editForm->getData());
+
+                    $event = new EventArgs(
+                        [
+                            'form' => $form,
+                            'editForm' => $editForm,
+                            'ClassName' => $ClassName,
+                            'TargetClassCategory' => $TargetClassCategory,
+                        ],
+                        $request
+                    );
+                    $this->eventDispatcher->dispatch($event, EccubeEvents::ADMIN_PRODUCT_CLASS_CATEGORY_INDEX_COMPLETE);
+
                     $this->addSuccess('admin.common.save_complete', 'admin');
 
                     return $this->redirectToRoute('admin_product_class_category', ['class_name_id' => $ClassName->getId()]);

--- a/src/Eccube/Controller/Admin/Product/ClassNameController.php
+++ b/src/Eccube/Controller/Admin/Product/ClassNameController.php
@@ -115,6 +115,16 @@ class ClassNameController extends AbstractController
                 if ($editForm->isSubmitted() && $editForm->isValid()) {
                     $this->classNameRepository->save($editForm->getData());
 
+                    $event = new EventArgs(
+                        [
+                            'form' => $form,
+                            'editForm' => $editForm,
+                            'TargetClassName' => $editForm->getData(),
+                        ],
+                        $request
+                    );
+                    $this->eventDispatcher->dispatch($event, EccubeEvents::ADMIN_PRODUCT_CLASS_NAME_INDEX_COMPLETE);
+
                     $this->addSuccess('admin.common.save_complete', 'admin');
 
                     return $this->redirectToRoute('admin_product_class_name');


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
規格名、規格カテゴリについて、登録時はイベント送出されているが更新時にはイベントが送出されていない。
更新時にもイベントを送出するように修正。

## 方針(Policy)
本当は4.1系でもこのイベントが欲しいのですが、
既存のEventListenerで登録時の処理しか考慮していないものがあると
動作に影響がありそうなので、4.2へのリクエストとさせていただいています。

## 実装に関する補足(Appendix)
編集時に送出するEventArgsの形式はAdmin/CategoryControllerに合わせて
登録時のEventArgsに'editForm'を追加する形にしています。

## テスト（Test)
以下のようなテスト用のListenerを作成し、
- 作成時、更新時にイベントが送信されていること。
- editFormの有無で作成／更新の区別がつくこと。
- 更新時はeditFormの内容が取得できること。

を確認しています。

```
namespace Customize\EventListener;

use Eccube\Event\EccubeEvents;
use Eccube\Event\EventArgs;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;

class TestListener implements EventSubscriberInterface
{
    public static function getSubscribedEvents(): array
    {
        return [
            EccubeEvents::ADMIN_PRODUCT_CLASS_NAME_INDEX_COMPLETE => 'onAdminProductClassNameIndexComplete',
            EccubeEvents::ADMIN_PRODUCT_CLASS_CATEGORY_INDEX_COMPLETE => 'onAdminProductClassCategoryIndexComplete',
        ];
    }

    public function onAdminProductClassNameIndexComplete(EventArgs $event): void
    {
        $form = $event->getArgument('form');
        $TargetClassName = $event->getArgument('TargetClassName');

        error_log(
            sprintf(
                'TargetClassName: %d %s',
                $TargetClassName->getId(),
                $TargetClassName->getName(),
            )
        );

        if ($event->hasArgument('editForm')) {
            error_log('edit');
            $editForm = $event->getArgument('editForm');

            error_log('Form input(name) ' . $editForm->get('name')->getData());
        } else {
            error_log('create');
            error_log('Form input(name) ' . $form->get('name')->getData());
        }
    }

    public function onAdminProductClassCategoryIndexComplete(EventArgs $event): void
    {
        $form = $event->getArgument('form');
        $ClassName = $event->getArgument('ClassName');
        $TargetClassCategory = $event->getArgument('TargetClassCategory');

        error_log('ClassName: ' . $ClassName->getName());
        error_log(
            sprintf(
                'TargetClassCategory: %d %s',
                $TargetClassCategory->getId(),
                $TargetClassCategory->getName(),
            )
        );

        if ($event->hasArgument('editForm')) {
            error_log('edit');
            $editForm = $event->getArgument('editForm');

            error_log('Form input(name) ' . $editForm->get('name')->getData());
        } else {
            error_log('create');
            error_log('Form input(name) ' . $form->get('name')->getData());
        }
    }
}
```

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
