### PR TITLE
[4.2]ウィンドウ幅が630px未満の場合, 画像サイズが崩れるのを修正

### DIFF
--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -122,6 +122,40 @@ file that was distributed with this source code.
                 }
             });
 
+            // Core Web Vital の Cumulative Layout Shift(CLS)対策のため
+            // img タグに width, height が付与されている.
+            // 630px 未満の画面サイズでは縦横比が壊れるための対策
+            // see https://github.com/EC-CUBE/ec-cube/pull/5023
+            $('.ec-grid2__cell').hide();
+            var removeSize = function () {
+                $('.slide-item').height('');
+                $('.slide-item img')
+                    .removeAttr('width')
+                    .removeAttr('height')
+                    .removeAttr('style');
+            };
+            var slickInitial = function(slick) {
+                $('.ec-grid2__cell').fadeIn(1500);
+                var baseHeight = $(slick.target).height();
+                var baseWidth = $(slick.target).width();
+                var rate = baseWidth / baseHeight;
+
+                $('.slide-item').height(baseHeight * rate); // 余白を削除する
+                // transform を使用することでCLSの影響を受けないようにする
+                $('.slide-item img')
+                    .css(
+                        {
+                            'transform-origin': 'top left',
+                            'transform': 'scaleY(' + rate + ')',
+                            'transition': 'transform .1s'
+                        }
+                    );
+                // 正しいサイズに近くなったら属性を解除する
+                setTimeout(removeSize, 500);
+            };
+            $('.item_visual').on('init', slickInitial);
+            // リサイズ時は CLS の影響を受けないため属性を解除する
+            $(window).resize(removeSize);
             $('.item_visual').slick({
                 dots: false,
                 arrows: false,

--- a/src/Eccube/Resource/template/default/Product/list.twig
+++ b/src/Eccube/Resource/template/default/Product/list.twig
@@ -154,7 +154,7 @@ file that was distributed with this source code.
                         <li class="ec-shelfGrid__item">
                             <a href="{{ url('product_detail', {'id': Product.id}) }}">
                                 <p class="ec-shelfGrid__item-image">
-                                    <img src="{{ asset(Product.main_list_image|no_image_product, 'save_image') }}" alt="{{ Product.name }}" width="249" height="249"{% if loop.index > 5 %} loading="lazy"{% endif %}>
+                                    <img src="{{ asset(Product.main_list_image|no_image_product, 'save_image') }}" alt="{{ Product.name }}" {% if loop.index > 5 %} loading="lazy"{% endif %}>
                                 </p>
                                 <p>{{ Product.name }}</p>
                                 {% if Product.description_list %}


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
closes #5449
- ウィンドウ幅が630px未満の場合, 画像サイズが崩れるのを修正
- 商品一覧、商品詳細画面が該当する
- Core Web Vital の Cumulative Layout Shift(CLS)対策のため、以下の PR によって img タグの width, height が付与されたことによる影響
  - refs #5022
  - refs #5023 

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- 商品一覧は、width, height 属性を削除しても CLS のスコア低下が軽微なので、 width, height 属性を削除する
- 商品詳細は、CSS の transform を使用して、元のサイズ近くまで変形させた後に width, height 属性を削除する
   - transform を使用すれば、CLSの影響を受けない(https://web.dev/i18n/ja/cls/#-5)

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
画像が崩れず、CLSのスコアが0.1未満になっていることを確認

商品詳細
![image](https://user-images.githubusercontent.com/815715/180120899-ec80a82e-5b4d-4c2d-bb08-cb7aeaa1ed3b.png)

商品一覧
![image](https://user-images.githubusercontent.com/815715/180121207-3e7bf9cb-c02b-4c33-8b25-df095086bfc4.png)


## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
