### PR TITLE
受注登録時に電話番号のバリデーションを効くように修正

### DIFF
--- a/src/Eccube/Form/Type/PhoneNumberType.php
+++ b/src/Eccube/Form/Type/PhoneNumberType.php
@@ -17,7 +17,6 @@ use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TelType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -56,8 +55,7 @@ class PhoneNumberType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $eccubeConfig = $this->eccubeConfig;
-        $constraints = function (Options $options) use ($eccubeConfig) {
+        $resolver->setNormalizer('constraints', function($options, $value) {
             $constraints = [];
             // requiredがtrueに指定されている場合, NotBlankを追加
             if (isset($options['required']) && true === $options['required']) {
@@ -65,7 +63,7 @@ class PhoneNumberType extends AbstractType
             }
 
             $constraints[] = new Assert\Length([
-                'max' => $eccubeConfig['eccube_tel_len_max'],
+                'max' => $this->eccubeConfig['eccube_tel_len_max'],
             ]);
 
             $constraints[] = new Assert\Type([
@@ -73,12 +71,10 @@ class PhoneNumberType extends AbstractType
                 'message' => 'form_error.numeric_only',
             ]);
 
-            return $constraints;
-        };
+            return array_merge($constraints, $value);
+        });
 
         $resolver->setDefaults([
-            'options' => ['constraints' => []],
-            'constraints' => $constraints,
             'attr' => [
                 'placeholder' => 'common.phone_number_sample',
             ],

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
@@ -162,4 +162,11 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
     }
+
+    public function testInvalidPhoneNumberTooLong() {
+        $this->formData['phone_number'] = '0123456789012345';
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form['phone_number']->isValid());
+    }
 }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
受注登録画面で電話番号に15桁以上の数字を入れて登録するとシステムエラーになる。

`PhoneNumberType` では `OptionsResolver#setDefaults` を使用して制約を設定しているが、 `OrderType` では `phone_number` に対して `NotBlank` だけを設定している。`PhoneNumberType` のデフォルト制約と `OrderType`で追加している制約がマージされるのが望ましいが、現状は `OrderType` で設定した制約のみになっている。

https://github.com/EC-CUBE/ec-cube/blob/9101b77894bb59a317f6dbdd879e9839831d68f8/src/Eccube/Form/Type/PhoneNumberType.php#L79-L87
https://github.com/EC-CUBE/ec-cube/blob/5810418132ace58657011aeddb0d203b27faa7de/src/Eccube/Form/Type/Admin/OrderType.php#L162-L167

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

`OptionsResolver#setNormalizer`を使って制約がマージされるようにしました。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

他にも同様の箇所がありそうです。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
