### PR TITLE
postgresql利用時のtranslateのFROMの修正

### DIFF
--- a/src/Eccube/Doctrine/ORM/Query/Normalize.php
+++ b/src/Eccube/Doctrine/ORM/Query/Normalize.php
@@ -21,7 +21,7 @@ use Doctrine\ORM\Query\SqlWalker;
 class Normalize extends FunctionNode
 {
     protected $string;
-    public const FROM = 'あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんがぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽぁぃぅぇぉっゃゅょわいえー';
+    public const FROM = 'あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんがぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽぁぃぅぇぉっゃゅょゎゐゑー';
     public const TO = 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲンガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポァィゥェォッャュョヮヰヱー';
 
     public function parse(Parser $parser)

--- a/tests/Eccube/Tests/Doctrine/ORM/Query/NormalizeTest.php
+++ b/tests/Eccube/Tests/Doctrine/ORM/Query/NormalizeTest.php
@@ -23,10 +23,10 @@ class NormalizeTest extends EccubeTestCase
             ->select('p.id')->from('Eccube\Entity\Product', 'p')
             ->where('NORMALIZE(p.name) LIKE :name')
             ->getQuery()->getSql();
-        if ($this->entityManager->getConnection()->getDriver()->getName() === 'pdo_pgsql')
+        if ($this->entityManager->getConnection()->getDriver()->getDatabasePlatform()->getName() === 'postgresql')
         {
-            $this->assertTrue(strpos($sql, 'あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんがぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽぁぃぅぇぉっゃゅょゎゐゑー') !== false);
-            $this->assertTrue(strpos($sql, 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲンガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポァィゥェォッャュョヮヰヱー') !== false) ;
+            $this->assertStringContainsString('あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんがぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽぁぃぅぇぉっゃゅょゎゐゑー', $sql);
+            $this->assertStringContainsString('アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲンガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポァィゥェォッャュョヮヰヱー', $sql);
         }
     }
 }

--- a/tests/Eccube/Tests/Doctrine/ORM/Query/NormalizeTest.php
+++ b/tests/Eccube/Tests/Doctrine/ORM/Query/NormalizeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+ namespace Eccube\Tests\Doctrine\ORM\Query;
+
+use Eccube\Tests\EccubeTestCase;
+
+class NormalizeTest extends EccubeTestCase
+{
+    public function testGetSql()
+    {
+        $sql = $this->entityManager->createQueryBuilder()
+            ->select('p.id')->from('Eccube\Entity\Product', 'p')
+            ->where('NORMALIZE(p.name) LIKE :name')
+            ->getQuery()->getSql();
+        if ($this->entityManager->getConnection()->getDriver()->getName() === 'pdo_pgsql')
+        {
+            $this->assertTrue(strpos($sql, 'あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんがぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽぁぃぅぇぉっゃゅょゎゐゑー') !== false);
+            $this->assertTrue(strpos($sql, 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲンガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポァィゥェォッャュョヮヰヱー') !== false) ;
+        }
+    }
+}

--- a/tests/Eccube/Tests/Doctrine/ORM/Query/NormalizeTest.php
+++ b/tests/Eccube/Tests/Doctrine/ORM/Query/NormalizeTest.php
@@ -23,10 +23,20 @@ class NormalizeTest extends EccubeTestCase
             ->select('p.id')->from('Eccube\Entity\Product', 'p')
             ->where('NORMALIZE(p.name) LIKE :name')
             ->getQuery()->getSql();
-        if ($this->entityManager->getConnection()->getDriver()->getDatabasePlatform()->getName() === 'postgresql')
+        switch ($this->entityManager->getConnection()->getDriver()->getDatabasePlatform()->getName())
         {
-            $this->assertStringContainsString('あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんがぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽぁぃぅぇぉっゃゅょゎゐゑー', $sql);
-            $this->assertStringContainsString('アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲンガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポァィゥェォッャュョヮヰヱー', $sql);
+            case 'postgresql':
+                $this->assertStringContainsString('LOWER(TRANSLATE(', $sql);
+                $this->assertStringContainsString('あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんがぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽぁぃぅぇぉっゃゅょゎゐゑー', $sql);
+                $this->assertStringContainsString('アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲンガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポァィゥェォッャュョヮヰヱー', $sql);
+                break;
+            case 'mysql':
+                $this->assertStringContainsString('CONVERT(', $sql);
+                $this->assertStringContainsString('USING utf8) COLLATE utf8_unicode_ci', $sql);
+                break;
+            case 'sqlite':
+                $this->assertStringContainsString('LOWER(', $sql);
+                break;
         }
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

PostgreSQL使用時に使われるtranslate用のFROM文字列が一部間違っており、意図どおりにtranslateされず、「ウヰスキー」を「うゐすきー」で検索してもヒットしなかったりするので修正

## 方針(Policy)

最短で修正

## 実装に関する補足(Appendix)

特になし

## テスト（Test)

PostgreSQL固有の問題のため自動テストなし。
ローカルの環境で商品名に「ウヰスキー」を登録し、「うゐすきー」で検索した場合、修正前はヒットしないが、修正後はヒットすることを確認。

## 相談（Discussion）

特になし

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [X] 既存機能の仕様変更はありません
- [X] フックポイントの呼び出しタイミングの変更はありません
- [X] フックポイントのパラメータの削除・データ型の変更はありません
- [X] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [X] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [X] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
