### PR TITLE
[4.2] パスワードの要件を PCI DSS ver4.0 に準拠させる 

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -49,7 +49,7 @@ parameters:
     eccube_csv_size: 5                 # post_max_size, upload_max_filesize に任せればよい？
     eccube_csv_temp_realdir: '%kernel.cache_dir%/%kernel.environment%/eccube' # upload_tmp_dir に任せればよい？
     eccube_csv_split_lines: 100
-    eccube_default_password: '**********'
+    eccube_default_password: 'abc********123'
     eccube_deliv_addr_max: 20
     eccube_deliv_date_end_max: 21
     eccube_id_max_len: 50
@@ -106,8 +106,10 @@ parameters:
     eccube_price_max: 2147483647
     eccube_tel_len_max: 14
     eccube_postal_code: 8
-    eccube_password_min_len: 8
+    eccube_password_min_len: 12
     eccube_password_max_len: 32
+    # see https://github.com/EC-CUBE/ec-cube2/blob/87e269314f92ebb169ea212bf304c9371bb12fd2/data/class/SC_CheckError.php#L889
+    eccube_password_pattern: '/\A(?=.*?[a-z])(?=.*?\d)[!-~]+\z/i'
     eccube_composer_memory_limit: 1536M
     eccube_order_mail_template_id: 1 #注文受付メール
     eccube_entry_confirm_mail_template_id: 2 #会員仮登録メール

--- a/codeception/_support/Page/Admin/SystemMemberEditPage.php
+++ b/codeception/_support/Page/Admin/SystemMemberEditPage.php
@@ -42,8 +42,8 @@ class SystemMemberEditPage extends AbstractAdminPageStyleGuide
             'name' => 'name',
             'department' => 'department',
             'login_id' => 'id',
-            'password' => 'password',
-            'password_second' => 'password',
+            'password' => 'password1234',
+            'password_second' => 'password1234',
             'authority' => 'システム管理者',
             'work' => 1,
         ];

--- a/codeception/_support/Page/Front/EntryPage.php
+++ b/codeception/_support/Page/Front/EntryPage.php
@@ -45,8 +45,8 @@ class EntryPage extends AbstractFrontPage
             'entry[phone_number]' => '1234567890',
             'entry[email][first]' => $email,
             'entry[email][second]' => $email,
-            'entry[plain_password][first]' => 'password',
-            'entry[plain_password][second]' => 'password',
+            'entry[plain_password][first]' => 'password1234',
+            'entry[plain_password][second]' => 'password1234',
             'entry[user_policy_check]' => '1',
         ];
         $this->tester->submitForm(['css' => '.ec-layoutRole__main form'], $form, ['css' => 'button.ec-blockBtn--action']);

--- a/codeception/acceptance/EA05CustomerCest.php
+++ b/codeception/acceptance/EA05CustomerCest.php
@@ -117,11 +117,11 @@ class EA05CustomerCest
             ->入力_番地_ビル名('ブリーゼタワー13F')
             ->入力_Eメール($email)
             ->入力_電話番号('111-111-111')
-            ->入力_パスワード('password')
-            ->入力_パスワード確認('password');
+            ->入力_パスワード('password1234')
+            ->入力_パスワード確認('password1234');
 
         $findPluginByCode = Fixtures::get('findPluginByCode');
-        $Plugin = $findPluginByCode('MailMagazine');
+        $Plugin = $findPluginByCode('MailMagazine42');
         if ($Plugin) {
             $I->amGoingTo('メルマガプラグインを発見したため、メルマガを購読します');
             $I->click('#admin_customer_mailmaga_flg_0');

--- a/codeception/acceptance/EA08SysteminfoCest.php
+++ b/codeception/acceptance/EA08SysteminfoCest.php
@@ -91,8 +91,8 @@ class EA08SysteminfoCest
         $I->fillField(['id' => 'admin_member_name'], 'admintest');
         $I->fillField(['id' => 'admin_member_department'], 'admintest department');
         $I->fillField(['id' => 'admin_member_login_id'], 'admintest');
-        $I->fillField(['id' => 'admin_member_plain_password_first'], 'password');
-        $I->fillField(['id' => 'admin_member_plain_password_second'], 'password');
+        $I->fillField(['id' => 'admin_member_plain_password_first'], 'password1234');
+        $I->fillField(['id' => 'admin_member_plain_password_second'], 'password1234');
         $I->selectOption(['id' => 'admin_member_Authority'], 'システム管理者');
         $I->selectOption(['id' => 'admin_member_Work_1'], '稼働');
         $I->click('#member_form .c-conversionArea__container button');
@@ -119,8 +119,8 @@ class EA08SysteminfoCest
         $I->fillField(['id' => 'admin_member_name'], 'admintest2');
         $I->fillField(['id' => 'admin_member_department'], 'admintest department');
         $I->fillField(['id' => 'admin_member_login_id'], 'admintest');
-        $I->fillField(['id' => 'admin_member_plain_password_first'], 'password');
-        $I->fillField(['id' => 'admin_member_plain_password_second'], 'password');
+        $I->fillField(['id' => 'admin_member_plain_password_first'], 'password1234');
+        $I->fillField(['id' => 'admin_member_plain_password_second'], 'password1234');
         $I->selectOption(['id' => 'admin_member_Authority'], 'システム管理者');
         $I->selectOption(['id' => 'admin_member_Work_1'], '稼働');
         $I->click('#member_form .c-conversionArea__container .c-conversionArea__leftBlockItem a');
@@ -380,7 +380,7 @@ class EA08SysteminfoCest
 
         // 店舗オーナーでログインし、ナビに表示されないことを確認
         $I->logoutAsAdmin();
-        $I->loginAsAdmin('shop_owner', 'password');
+        $I->loginAsAdmin('shop_owner', 'password1234');
         $I->click(['css' => 'a[href="#nav-setting"]']);
         $I->wait(1);
         $I->dontSee('システム設定', '#nav-setting');
@@ -401,7 +401,7 @@ class EA08SysteminfoCest
 
         // 店舗オーナーアカウントでアクセスできることを確認
         $I->logoutAsAdmin();
-        $I->loginAsAdmin('shop_owner', 'password');
+        $I->loginAsAdmin('shop_owner', 'password1234');
 
         $I->click(['css' => 'a[href="#nav-setting"]']);
         $I->wait(1);

--- a/codeception/acceptance/EF04CustomerCest.php
+++ b/codeception/acceptance/EF04CustomerCest.php
@@ -46,8 +46,8 @@ class EF04CustomerCest
             'entry[phone_number]' => '111-111-111',
             'entry[email][first]' => $new_email,
             'entry[email][second]' => $new_email,
-            'entry[plain_password][first]' => 'password',
-            'entry[plain_password][second]' => 'password',
+            'entry[plain_password][first]' => 'password1234',
+            'entry[plain_password][second]' => 'password1234',
             'entry[job]' => ['value' => '1'],
             'entry[user_policy_check]' => '1',
         ];
@@ -125,8 +125,8 @@ class EF04CustomerCest
             'entry[phone_number]' => '111-111-111',
             'entry[email][first]' => $customer->getEmail(), // 会員登録済みのメールアドレスを入力する
             'entry[email][second]' => $customer->getEmail(),
-            'entry[plain_password][first]' => 'password',
-            'entry[plain_password][second]' => 'password',
+            'entry[plain_password][first]' => 'password1234',
+            'entry[plain_password][second]' => 'password1234',
         ], ['css' => 'button.ec-blockBtn--action']);
 
         // 入力した会員情報を確認する。
@@ -155,8 +155,8 @@ class EF04CustomerCest
             'entry[phone_number]' => '111-111-111',
             'entry[email][first]' => $new_email,
             'entry[email][second]' => $new_email,
-            'entry[plain_password][first]' => 'password',
-            'entry[plain_password][second]' => 'password',
+            'entry[plain_password][first]' => 'password1234',
+            'entry[plain_password][second]' => 'password1234',
         ], ['css' => 'button.ec-blockBtn--action']);
 
         // 入力した会員情報を確認する。
@@ -197,8 +197,8 @@ class EF04CustomerCest
             'entry[phone_number]' => '111-111-111',
             'entry[email][first]' => $new_email,
             'entry[email][second]' => $new_email,
-            'entry[plain_password][first]' => 'password',
-            'entry[plain_password][second]' => 'password',
+            'entry[plain_password][first]' => 'password1234',
+            'entry[plain_password][second]' => 'password1234',
             'entry[job]' => ['value' => '1'],
             'entry[user_policy_check]' => '1',
         ];

--- a/codeception/acceptance/EF05MypageCest.php
+++ b/codeception/acceptance/EF05MypageCest.php
@@ -153,8 +153,8 @@ class EF05MypageCest
             'entry[phone_number]' => '111-111-111',
             'entry[email][first]' => $new_email,
             'entry[email][second]' => $new_email,
-            'entry[plain_password][first]' => 'password',
-            'entry[plain_password][second]' => 'password',
+            'entry[plain_password][first]' => 'password1234',
+            'entry[plain_password][second]' => 'password1234',
         ];
 
         $findPluginByCode = Fixtures::get('findPluginByCode');

--- a/src/Eccube/Form/Type/Admin/ChangePasswordType.php
+++ b/src/Eccube/Form/Type/Admin/ChangePasswordType.php
@@ -66,8 +66,8 @@ class ChangePasswordType extends AbstractType
                         'max' => $this->eccubeConfig['eccube_password_max_len'],
                     ]),
                     new Assert\Regex([
-                        'pattern' => '/^[[:graph:][:space:]]+$/i',
-                        'message' => 'form_error.graph_only',
+                        'pattern' => $this->eccubeConfig['eccube_password_pattern'],
+                        'message' => 'form_error.password_pattern_invalid',
                     ]),
                 ],
             ])

--- a/src/Eccube/Form/Type/Install/Step3Type.php
+++ b/src/Eccube/Form/Type/Install/Step3Type.php
@@ -96,8 +96,8 @@ class Step3Type extends AbstractType
                         'max' => $this->eccubeConfig['eccube_password_max_len'],
                     ]),
                     new Assert\Regex([
-                        'pattern' => '/^[[:graph:][:space:]]+$/i',
-                        'message' => 'form_error.graph_only',
+                        'pattern' => $this->eccubeConfig['eccube_password_pattern'],
+                        'message' => 'form_error.password_pattern_invalid',
                     ]),
                 ],
             ])

--- a/src/Eccube/Form/Type/RepeatedPasswordType.php
+++ b/src/Eccube/Form/Type/RepeatedPasswordType.php
@@ -57,8 +57,8 @@ class RepeatedPasswordType extends AbstractType
                         'max' => $this->eccubeConfig['eccube_password_max_len'],
                     ]),
                     new Assert\Regex([
-                        'pattern' => '/^[[:graph:][:space:]]+$/i',
-                        'message' => 'form_error.graph_only',
+                        'pattern' => $this->eccubeConfig['eccube_password_pattern'],
+                        'message' => 'form_error.password_pattern_invalid',
                     ]),
                 ],
             ],

--- a/src/Eccube/Resource/locale/validators.en.yaml
+++ b/src/Eccube/Resource/locale/validators.en.yaml
@@ -42,6 +42,7 @@ form_error.same_email: Please enter the same email address.
 form_error.admin_is_not_available: Do not use "admin" as the directory name.
 form_error.member_already_exists: This ID is already registered.
 form_error.customer_already_exists:  This email address can not be used.
+form_error.password_pattern_invalid: Please use one alphanumeric character each.
 
 #------------------------------------------------------------------------------------
 # Deplicated

--- a/src/Eccube/Resource/locale/validators.ja.yaml
+++ b/src/Eccube/Resource/locale/validators.ja.yaml
@@ -42,6 +42,7 @@ form_error.same_email: 同じメールアドレスを入力してください。
 form_error.admin_is_not_available: ディレクトリ名に「admin」を使用することはできません。
 form_error.member_already_exists: 既に利用されているログインIDです。
 form_error.customer_already_exists:  このメールアドレスは利用できません。
+form_error.password_pattern_invalid: 英数字をそれぞれ1種類使用してください。
 
 #------------------------------------------------------------------------------------
 # Deplicated

--- a/tests/Eccube/Tests/Form/Type/Admin/CustomerTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/CustomerTypeTest.php
@@ -38,13 +38,13 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
             'addr02' => '梅田',
         ],
         'phone_number' => '012-345-6789',
-        'email' => 'default@example.com',
+        'email' => 'default1@example.com',
         'sex' => 1,
         'job' => 1,
         'birth' => '1983-2-14',
         'plain_password' => [
-            'first' => 'password',
-            'second' => 'password',
+            'first' => 'password1234',
+            'second' => 'password1234',
         ],
         'status' => 1,
         'note' => 'note',
@@ -200,8 +200,8 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testValidPasswordMinLength()
     {
-        $this->formData['plain_password']['first'] = str_repeat('a', $this->eccubeConfig['eccube_password_min_len']);
-        $this->formData['plain_password']['second'] = str_repeat('a', $this->eccubeConfig['eccube_password_min_len']);
+        $this->formData['plain_password']['first'] = str_repeat('a', $this->eccubeConfig['eccube_password_min_len'] - 1).'1';
+        $this->formData['plain_password']['second'] = str_repeat('a', $this->eccubeConfig['eccube_password_min_len'] - 1).'1';
 
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());
@@ -220,8 +220,8 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
 
     public function testValidPasswordMaxLength()
     {
-        $this->formData['plain_password']['first'] = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
-        $this->formData['plain_password']['second'] = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
+        $this->formData['plain_password']['first'] = str_repeat('a', $this->eccubeConfig['eccube_password_max_len'] - 1).'1';
+        $this->formData['plain_password']['second'] = str_repeat('a', $this->eccubeConfig['eccube_password_max_len'] - 1).'1';
 
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());
@@ -235,6 +235,28 @@ class CustomerTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         $this->formData['plain_password']['second'] = $password;
 
         $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidPasswordAlphabetOnly()
+    {
+        $password = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
+
+        $this->formData['plain_password']['first'] = $password;
+        $this->formData['plain_password']['second'] = $password;
+        $this->form->submit($this->formData);
+
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidPasswordNumericOnly()
+    {
+        $password = str_repeat('1', $this->eccubeConfig['eccube_password_max_len']);
+
+        $this->formData['plain_password']['first'] = $password;
+        $this->formData['plain_password']['second'] = $password;
+        $this->form->submit($this->formData);
+
         $this->assertFalse($this->form->isValid());
     }
 

--- a/tests/Eccube/Tests/Form/Type/Admin/MemberTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/MemberTypeTest.php
@@ -28,8 +28,8 @@ class MemberTypeTest extends AbstractTypeTestCase
         'department' => 'EC-CUBE事業部',
         'login_id' => 'takahashi',
         'plain_password' => [
-            'first' => 'password',
-            'second' => 'password',
+            'first' => 'password1234',
+            'second' => 'password1234',
         ],
         'Authority' => 1,
         'Work' => 1,

--- a/tests/Eccube/Tests/Form/Type/Front/EntryTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Front/EntryTypeTest.php
@@ -39,12 +39,12 @@ class EntryTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         ],
         'phone_number' => '012-345-6789',
         'email' => [
-            'first' => 'eccube@example.com',
-            'second' => 'eccube@example.com',
+            'first' => 'eccube1@example.com',
+            'second' => 'eccube1@example.com',
         ],
         'plain_password' => [
-            'first' => '12345678',
-            'second' => '12345678',
+            'first' => '1234567890ab',
+            'second' => '1234567890ab',
         ],
         'birth' => [
             'year' => '1980',

--- a/tests/Eccube/Tests/Form/Type/Front/PasswordResetTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Front/PasswordResetTypeTest.php
@@ -24,8 +24,8 @@ class PasswordResetTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
     protected $formData = [
         'login_email' => 'hideki_okajima@ec-cube.co.jp',
         'password' => [
-            'first' => 'password',
-            'second' => 'password',
+            'first' => 'password1234',
+            'second' => 'password1234',
         ],
     ];
 

--- a/tests/Eccube/Tests/Form/Type/Install/Step3TypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Install/Step3TypeTest.php
@@ -30,7 +30,7 @@ class Step3TypeTest extends AbstractTypeTestCase
         'shop_name' => '店舗名',
         'email' => 'eccube@example.com',
         'login_id' => 'administrator',
-        'login_pass' => 'administrator',
+        'login_pass' => 'administrator1',
         'admin_dir' => 'administrator',
         'admin_force_ssl' => true,
         'admin_allow_hosts' => '1.1.1.1',
@@ -150,7 +150,7 @@ class Step3TypeTest extends AbstractTypeTestCase
 
     public function testVallidLoginPassMin()
     {
-        $this->formData['login_pass'] = str_repeat('a', $this->eccubeConfig['eccube_password_min_len']);
+        $this->formData['login_pass'] = str_repeat('a', $this->eccubeConfig['eccube_password_min_len'] - 1).'1';
 
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());
@@ -158,7 +158,7 @@ class Step3TypeTest extends AbstractTypeTestCase
 
     public function testVallidLoginPassMax()
     {
-        $this->formData['login_pass'] = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
+        $this->formData['login_pass'] = str_repeat('a', $this->eccubeConfig['eccube_password_max_len'] - 1).'1';
 
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());
@@ -169,6 +169,26 @@ class Step3TypeTest extends AbstractTypeTestCase
         $this->formData['login_pass'] = str_repeat('あ', $this->eccubeConfig['eccube_password_max_len']);
 
         $this->form->submit($this->formData);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidAlphabetOnly()
+    {
+        $password = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
+
+        $this->formData['login_pass'] = $password;
+        $this->form->submit($this->formData);
+
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidNumericOnly()
+    {
+        $password = str_repeat('1', $this->eccubeConfig['eccube_password_max_len']);
+
+        $this->formData['login_pass'] = $password;
+        $this->form->submit($this->formData);
+
         $this->assertFalse($this->form->isValid());
     }
 
@@ -198,15 +218,15 @@ class Step3TypeTest extends AbstractTypeTestCase
 
     public function testVallidAdminDirMin()
     {
-        $this->formData['login_pass'] = str_repeat('a', $this->eccubeConfig['eccube_password_min_len']);
+        $this->formData['admin_dir'] = str_repeat('a', $this->eccubeConfig['eccube_password_min_len']);
 
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());
     }
 
-    public function testVallidAdminDirMax()
+    public function testValidAdminDirMax()
     {
-        $this->formData['login_pass'] = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
+        $this->formData['admin_dir'] = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
 
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());

--- a/tests/Eccube/Tests/Form/Type/RepeatedPasswordTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/RepeatedPasswordTypeTest.php
@@ -24,8 +24,8 @@ class RepeatedPasswordTypeTest extends AbstractTypeTestCase
     /** @var array デフォルト値（正常系）を設定 */
     protected $formData = [
         'password' => [
-            'first' => 'eccube@example.com',
-            'second' => 'eccube@example.com',
+            'first' => 'eccube1@example.com',
+            'second' => 'eccube1@example.com',
         ],
     ];
 
@@ -125,15 +125,36 @@ class RepeatedPasswordTypeTest extends AbstractTypeTestCase
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testValidSpace()
+    public function testInvalidSpace()
     {
-        // これも通っていいのか？
-        $password = '1234 \n\s\t78';
+        $password = "1234 \n\s\t78a";
 
         $this->formData['password']['first'] = $password;
         $this->formData['password']['second'] = $password;
         $this->form->submit($this->formData);
 
-        $this->assertTrue($this->form->isValid());
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidAlphabetOnly()
+    {
+        $password = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
+
+        $this->formData['password']['first'] = $password;
+        $this->formData['password']['second'] = $password;
+        $this->form->submit($this->formData);
+
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testInvalidNumericOnly()
+    {
+        $password = str_repeat('1', $this->eccubeConfig['eccube_password_max_len']);
+
+        $this->formData['password']['first'] = $password;
+        $this->formData['password']['second'] = $password;
+        $this->form->submit($this->formData);
+
+        $this->assertFalse($this->form->isValid());
     }
 }

--- a/tests/Eccube/Tests/Web/Admin/Customer/CustomerEditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Customer/CustomerEditControllerTest.php
@@ -43,7 +43,7 @@ class CustomerEditControllerTest extends AbstractAdminWebTestCase
     {
         $faker = $this->getFaker();
         $email = $faker->safeEmail;
-        $password = $faker->lexify('????????');
+        $password = $faker->lexify('????????????').'a1';
         $birth = $faker->dateTimeBetween;
 
         $form = [
@@ -55,7 +55,7 @@ class CustomerEditControllerTest extends AbstractAdminWebTestCase
             'phone_number' => $faker->phoneNumber,
             'email' => $email,
             'plain_password' => ['first' => $password, 'second' => $password],
-            'birth' => $birth->format('Y').'-'.$birth->format('n').'-'.$birth->format('j'),
+            'birth' => $birth->format('Y').'-'.$birth->format('m').'-'.$birth->format('d'),
             'sex' => 1,
             'job' => 1,
             'status' => 1,

--- a/tests/Eccube/Tests/Web/Admin/IndexControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/IndexControllerTest.php
@@ -191,7 +191,7 @@ class IndexControllerTest extends AbstractAdminWebTestCase
     {
         $faker = $this->getFaker();
 
-        $password = $faker->lexify('????????');
+        $password = $faker->lexify('????????????').'a1';
 
         $form = [
             'current_password' => 'password',

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/MemberControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/MemberControllerTest.php
@@ -175,12 +175,12 @@ class MemberControllerTest extends AbstractAdminWebTestCase
         // before
         $formData = $this->createFormData();
         $formData['plain_password'] = [
-            'first' => '**********',
-            'second' => '**********',
+            'first' => $this->eccubeConfig['eccube_default_password'],
+            'second' => $this->eccubeConfig['eccube_default_password'],
         ];
         $Member = $this->createMember();
         $loginId = $Member->getLoginId();
-        $Member->setPassword('**********');
+        $Member->setPassword($this->eccubeConfig['eccube_default_password']);
         $this->entityManager->persist($Member);
         $this->entityManager->flush();
         $mid = $Member->getId();
@@ -373,8 +373,8 @@ class MemberControllerTest extends AbstractAdminWebTestCase
             'department' => $faker->word,
             'login_id' => 'logintest',
             'plain_password' => [
-                'first' => 'password',
-                'second' => 'password',
+                'first' => 'password1234',
+                'second' => 'password1234',
             ],
             'Authority' => rand(0, 1),
             'Work' => rand(0, 1),

--- a/tests/Eccube/Tests/Web/EntryControllerTest.php
+++ b/tests/Eccube/Tests/Web/EntryControllerTest.php
@@ -31,7 +31,7 @@ class EntryControllerTest extends AbstractWebTestCase
     {
         $faker = $this->getFaker();
         $email = $faker->safeEmail;
-        $password = $faker->lexify('????????');
+        $password = $faker->lexify('????????????').'a1';
         $birth = $faker->dateTimeBetween;
 
         $form = [

--- a/tests/Eccube/Tests/Web/Mypage/ChangeControllerTest.php
+++ b/tests/Eccube/Tests/Web/Mypage/ChangeControllerTest.php
@@ -33,7 +33,7 @@ class ChangeControllerTest extends AbstractWebTestCase
     {
         $faker = $this->getFaker();
         $email = $faker->safeEmail;
-        $password = $faker->lexify('????????');
+        $password = $faker->lexify('????????????').'a1';
         $birth = $faker->dateTimeBetween;
 
         $form = [


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
パスワードの要件を PCI DSS ver4.0 に準拠させる 

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- 12文字以上
- 数字とアルファベットの両方が含まれること

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
- パスワードフォーマットの正規表現は[2系のもの](https://github.com/EC-CUBE/ec-cube2/blob/87e269314f92ebb169ea212bf304c9371bb12fd2/data/class/SC_CheckError.php#L889)を移植
- `eccube_default_password` も英数字混在12文字以上にする必要がある

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
ユニットテストを追加

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
