### PR TITLE
月末が土日で金曜日にテストがエラーになるのを修正

### DIFF
--- a/tests/Eccube/Tests/Web/Block/CalendarControllerTest.php
+++ b/tests/Eccube/Tests/Web/Block/CalendarControllerTest.php
@@ -62,7 +62,7 @@ class CalendarControllerTest extends AbstractWebTestCase
 
         if ($targetHoliday->isSaturday()) {
             if (!$targetHoliday->copy()->addDay(2)->isCurrentMonth()) {
-                $targetHoliday = $targetHoliday->addDay(-1);
+                $targetHoliday = $targetHoliday->addDay(-2);
             } else {
                 $targetHoliday = $targetHoliday->addDay(2);
             }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
月末が土日で前日の金曜日にカレンダーのテストがエラーになるのを修正
本日以外が定休日になった場合のHTMLマークアップをチェックするテストだが、月末が土日で、前日の金曜日にテストを実行すると、本日が定休日として設定されてしまう

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
本日が定休日として設定されないよう、昨日を定休日に設定する

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
2022/7/29(金)にテストを実行してエラーにならないことを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
`Carbon::isToday()` とかでチェックした方がよいか？

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
