### PR TITLE
電話番号、郵便番号バリデーションで不適切な文字が通過するので修正

### DIFF
--- a/src/Eccube/Controller/NonMemberShoppingController.php
+++ b/src/Eccube/Controller/NonMemberShoppingController.php
@@ -283,7 +283,7 @@ class NonMemberShoppingController extends AbstractShoppingController
             $data['customer_phone_number'],
             [
                 new Assert\NotBlank(),
-                new Assert\Type(['type' => 'numeric', 'message' => 'form_error.numeric_only']),
+                new Assert\Type(['type' => 'digit', 'message' => 'form_error.numeric_only']),
                 new Assert\Length(
                     ['max' => $this->eccubeConfig['eccube_tel_len_max']]
                 ),
@@ -294,7 +294,7 @@ class NonMemberShoppingController extends AbstractShoppingController
             $data['customer_postal_code'],
             [
                 new Assert\NotBlank(),
-                new Assert\Type(['type' => 'numeric', 'message' => 'form_error.numeric_only']),
+                new Assert\Type(['type' => 'digit', 'message' => 'form_error.numeric_only']),
                 new Assert\Length(
                     ['max' => $this->eccubeConfig['eccube_postal_code']]
                 ),

--- a/src/Eccube/Form/Type/PhoneNumberType.php
+++ b/src/Eccube/Form/Type/PhoneNumberType.php
@@ -69,7 +69,7 @@ class PhoneNumberType extends AbstractType
             ]);
 
             $constraints[] = new Assert\Type([
-                'type' => 'numeric',
+                'type' => 'digit',
                 'message' => 'form_error.numeric_only',
             ]);
 

--- a/src/Eccube/Form/Type/PostalType.php
+++ b/src/Eccube/Form/Type/PostalType.php
@@ -68,7 +68,7 @@ class PostalType extends AbstractType
             ]);
 
             $constraints[] = new Assert\Type([
-                'type' => 'numeric',
+                'type' => 'digit',
                 'message' => 'form_error.numeric_only',
             ]);
 

--- a/tests/Eccube/Tests/Form/Type/PhoneNumberTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/PhoneNumberTypeTest.php
@@ -135,6 +135,14 @@ class PhoneNumberTypeTest extends AbstractTypeTestCase
         $this->assertFalse($this->form->isValid());
     }
 
+    public function testInvalidNotDigitOnly()
+    {
+        $this->formData['phone_number'] = '0.3e2';
+        $this->form->submit($this->formData);
+
+        $this->assertFalse($this->form->isValid());
+    }
+
     public function testInvalidBlankOne()
     {
         $this->formData['phone_number'] = '';

--- a/tests/Eccube/Tests/Form/Type/PostalTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/PostalTypeTest.php
@@ -42,6 +42,14 @@ class PostalTypeTest extends AbstractTypeTestCase
         $this->assertTrue($this->form->isValid());
     }
 
+    public function testInvalidNotDigitOnly()
+    {
+        $this->formData['phone_number'] = '0.3e2';
+        $this->form->submit($this->formData);
+
+        $this->assertFalse($this->form->isValid());
+    }
+
     public function testInvalidLengthMax()
     {
         $this->formData['postal_code'] = str_repeat('1', $this->eccubeConfig['eccube_postal_code'] + 1);

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
@@ -287,6 +287,132 @@ class ShoppingControllerWithNonmemberTest extends AbstractShoppingControllerTest
 //        $this->assertMatchesRegularExpression('/111-111-111/', $this->parseMailCatcherSource($Message), '変更した FAX 番号が一致するか');
     }
 
+    /**
+     * 非会員情報入力→注文者情報変更
+     */
+    public function testCustomer()
+    {
+        $this->scenarioCartIn();
+
+        $formData = $this->createNonmemberFormData();
+        $this->scenarioInput($formData);
+        $this->client->followRedirect();
+
+        $crawler = $this->scenarioConfirm();
+        $this->expected = 'ご注文手続き';
+        $this->actual = $crawler->filter('.ec-pageHeader h1')->text();
+        $this->verify();
+
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $faker = $this->getFaker();
+        $crawler = $this->client->request(
+            'POST',
+            '/shopping/customer',
+            [
+                'customer_name01' => $faker->lastName,
+                'customer_name02' => $faker->firstName,
+                'customer_kana01' => $faker->lastKanaName,
+                'customer_kana02' => $faker->firstKanaName,
+                'customer_company_name' => $faker->company,
+                'customer_phone_number' => str_replace('-', '', $faker->phoneNumber),
+                'customer_postal_code' => str_replace('-', '', $faker->postcode),
+                'customer_pref' => '秋田県',
+                'customer_addr01' => $faker->city,
+                'customer_addr02' => $faker->streetAddress,
+                'customer_email' => $faker->safeEmail
+            ],
+            [],
+            ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'],
+        );
+
+        $this->assertEquals('OK', json_decode($this->client->getResponse()->getContent())->status);
+    }
+
+    /**
+     * 非会員情報入力→注文者情報変更_不正電話番号
+     */
+    public function testCustomerNonDigitPhoneNumber()
+    {
+        $this->scenarioCartIn();
+
+        $formData = $this->createNonmemberFormData();
+        $this->scenarioInput($formData);
+        $this->client->followRedirect();
+
+        $crawler = $this->scenarioConfirm();
+        $this->expected = 'ご注文手続き';
+        $this->actual = $crawler->filter('.ec-pageHeader h1')->text();
+        $this->verify();
+
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $faker = $this->getFaker();
+        $crawler = $this->client->request(
+            'POST',
+            '/shopping/customer',
+            [
+                'customer_name01' => $faker->lastName,
+                'customer_name02' => $faker->firstName,
+                'customer_kana01' => $faker->lastKanaName,
+                'customer_kana02' => $faker->firstKanaName,
+                'customer_company_name' => $faker->company,
+                'customer_phone_number' => '3.0e2',
+                'customer_postal_code' => str_replace('-', '', $faker->postcode),
+                'customer_pref' => '秋田県',
+                'customer_addr01' => $faker->city,
+                'customer_addr02' => $faker->streetAddress,
+                'customer_email' => $faker->safeEmail
+            ],
+            [],
+            ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'],
+        );
+
+        $this->assertEquals('NG', json_decode($this->client->getResponse()->getContent())->status);
+    }
+
+    /**
+     * 非会員情報入力→注文者情報変更_不正郵便番号
+     */
+    public function testCustomerNonDigitPoastalCode()
+    {
+        $this->scenarioCartIn();
+
+        $formData = $this->createNonmemberFormData();
+        $this->scenarioInput($formData);
+        $this->client->followRedirect();
+
+        $crawler = $this->scenarioConfirm();
+        $this->expected = 'ご注文手続き';
+        $this->actual = $crawler->filter('.ec-pageHeader h1')->text();
+        $this->verify();
+
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $faker = $this->getFaker();
+        $crawler = $this->client->request(
+            'POST',
+            '/shopping/customer',
+            [
+                'customer_name01' => $faker->lastName,
+                'customer_name02' => $faker->firstName,
+                'customer_kana01' => $faker->lastKanaName,
+                'customer_kana02' => $faker->firstKanaName,
+                'customer_company_name' => $faker->company,
+                'customer_phone_number' => str_replace('-', '', $faker->phoneNumber),
+                'customer_postal_code' => '3.0e2',
+                'customer_pref' => '秋田県',
+                'customer_addr01' => $faker->city,
+                'customer_addr02' => $faker->streetAddress,
+                'customer_email' => $faker->safeEmail
+            ],
+            [],
+            ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'],
+        );
+
+        $this->assertEquals('NG', json_decode($this->client->getResponse()->getContent())->status);
+    }
+
     public function createNonmemberFormData()
     {
         $faker = $this->getFaker();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

郵便番号、電話番号のバリデーションにis_numericが使われているため、番号としてはありえない「3.0e2」などの値が通過してしまいます。
これが原因で、ユーザーが間違ってピリオドなどを入力してしまったときなどに検出できないことがあります。

ctype_digitに置き換えたほうが厳密に数字だけチェックできますし、置き換えたからといって使い勝手が悪くなることもありません。

## テスト（Test)

自動テスト用のテストコードを書きました。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
