### PR TITLE
管理画面受注検索画面の複合検索の不具合修正

### DIFF
--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -118,11 +118,11 @@ class OrderRepository extends AbstractRepository
             }
             $qb
                 ->andWhere('o.id = :multi OR CONCAT(o.name01, o.name02) LIKE :likemulti OR '.
-                    "CONCAT(COALESCE(o.kana01, ''), COALESCE(o.kana02, '')) LIKE :likemulti OR o.company_name LIKE :company_name OR ".
+                    "CONCAT(COALESCE(o.kana01, ''), COALESCE(o.kana02, '')) LIKE :likemulti OR o.company_name LIKE :multi_company_name OR ".
                     'o.order_no LIKE :likemulti OR o.email LIKE :likemulti OR o.phone_number LIKE :likemulti')
                 ->setParameter('multi', $multi)
                 ->setParameter('likemulti', '%'.$clean_key_multi.'%')
-                ->setParameter('company_name', '%'.$searchData['multi'].'%'); // 会社名はスペースを除去せず検索
+                ->setParameter('multi_company_name', '%'.$searchData['multi'].'%'); // 会社名はスペースを除去せず検索
         }
 
         // order_id_end

--- a/tests/Eccube/Tests/Repository/OrderRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryTest.php
@@ -16,6 +16,8 @@ namespace Eccube\Tests\Repository;
 use Eccube\Entity\Customer;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Entity\Order;
+use Eccube\Entity\Payment;
+use Eccube\Entity\Shipping;
 use Eccube\Repository\OrderRepository;
 use Eccube\Tests\EccubeTestCase;
 
@@ -200,6 +202,124 @@ class OrderRepositoryTest extends EccubeTestCase
             ['company_name', '株式会社　会社名', 1], // 全角スペース
             ['company_name', '姓', 0],
             ['company_name', 'セイ', 0],
+        ];
+    }
+
+    /**
+     * AND 条件についてテストします。
+     *
+     * すべて一致する検索条件を、1項目ずつ一致しない値に置き換えて確認します。
+     *
+     * @dataProvider dataGetQueryBuilderBySearchDataForAdmin_testAndCondition
+     */
+    public function testGetQueryBuilderBySearchDataForAdmin_testAndCondition(array $searchWord, int $expected)
+    {
+        // 基本の検索条件に一致するデータを作成します
+        $this->Order
+            ->setOrderStatus($this->entityManager->getReference(OrderStatus::class, OrderStatus::NEW))
+            ->setName01('姓')
+            ->setName02('名')
+            ->setKana01('セイ')
+            ->setKana02('メイ')
+            ->setCompanyName('会社名')
+            ->setEmail('alice@example.com')
+            ->setPhoneNumber('00000000000')
+            ->setPayment($this->entityManager->getReference(Payment::class, 1))
+            ->setOrderDate(new \DateTime('2022-01-01T10:00:00Z'))
+            ->setPaymentDate(new \DateTime('2022-02-01T10:00:00Z'))
+            ->setPaymentTotal('1000');
+        $Shipping = $this->Order->getShippings()[0];
+        $Shipping
+            ->setTrackingNumber('12345')
+            ->setMailSendDate(null)
+            ->setShippingDeliveryDate(new \DateTime('2022-03-01T10:00:00Z'));
+        $OrderItem = $this->Order->getOrderItems()[0];
+        $OrderItem
+            ->setProductName('商品名');
+        $this->orderRepository->save($this->Order);
+        $this->entityManager->flush();
+
+        // 基本の検索条件 (すべて一致する条件)
+        $baseSearchData = [
+            'multi' => '姓',
+            'status' => [OrderStatus::NEW],
+            'name' => '姓',
+            'kana' =>'セイ',
+            'company_name' => '会社名',
+            'email' => 'alice@example.com',
+            'phone_number' => '00000000000',
+            'order_no' => $this->Order->getOrderNo(),
+            'tracking_number' => '12345',
+            'shipping_mail' => [Shipping::SHIPPING_MAIL_UNSENT],
+            'payment' => [1],
+            'order_datetime_start' => new \DateTime('2022-01-01T10:00:00Z'),
+            'order_datetime_end' => new \DateTime('2022-01-01T10:00:01Z'),
+            'payment_datetime_start' => new \DateTime('2022-02-01T10:00:00Z'),
+            'payment_datetime_end' => new \DateTime('2022-02-01T10:00:01Z'),
+            'update_datetime_start' => 'PT0S',
+            'update_datetime_end' => 'PT1S',
+            'shipping_delivery_datetime_start' => new \DateTime('2022-03-01T10:00:00Z'),
+            'shipping_delivery_datetime_end' => new \DateTime('2022-03-01T10:00:01Z'),
+            'payment_total_start' => '1000',
+            'payment_total_end' => '1000',
+            'buy_product_name' => '商品名',
+        ];
+
+        $searchData = array_merge($baseSearchData, $searchWord);
+
+        // dataProvider 内で直接指定することが難しい値を変換します
+        if (isset($searchData['payment'])) {
+            $searchData['payment'] = \array_map(function ($item) {
+                return $this->entityManager->getReference(Payment::class, $item);
+            }, $searchData['payment']);
+        }
+        if (isset($searchData['update_datetime_start'])) {
+            $searchData['update_datetime_start'] = $this->Order->getUpdateDate()
+                ->add(new \DateInterval($searchData['update_datetime_start']))
+                ->format('c');
+        }
+        if (isset($searchData['update_datetime_end'])) {
+            $searchData['update_datetime_end'] = $this->Order->getUpdateDate()
+                ->add(new \DateInterval($searchData['update_datetime_end']))
+                ->format('c');
+        }
+
+        $actual = $this->orderRepository->getQueryBuilderBySearchDataForAdmin($searchData)
+            ->getQuery()
+            ->getResult();
+
+        self::assertCount($expected, $actual);
+    }
+
+    public function dataGetQueryBuilderBySearchDataForAdmin_testAndCondition()
+    {
+        return [
+            // 基本の検索条件で検索結果が返ってくること
+            [[], 1],
+
+            // 1 項目ずつ一致しない条件に置き換えると検索結果が返ってこないこと
+            [['status' => [OrderStatus::CANCEL]], 0],
+            [['multi' => '一致しないキーワード'], 0],
+            [['name' =>  '一致しないキーワード'], 0],
+            [['kana' =>  '一致しないキーワード'], 0],
+            [['company_name' =>  '一致しないキーワード'], 0],
+            [['email' =>  '一致しないキーワード'], 0],
+            [['phone_number' =>  '11111111111'], 0],
+            [['order_no' =>  '一致しないキーワード'], 0],
+            [['tracking_number' =>  '一致しないキーワード'], 0],
+            [['shipping_mail' =>  [Shipping::SHIPPING_MAIL_SENT]], 0],
+            [['payment' => [2]], 0],
+            [['order_datetime_start' => new \DateTime('2022-01-01T10:00:01Z')], 0],
+            [['order_datetime_end' => new \DateTime('2022-01-01T10:00:00Z')], 0],
+            [['payment_datetime_start' => new \DateTime('2022-02-01T10:00:01Z')], 0],
+            [['payment_datetime_end' => new \DateTime('2022-02-01T10:00:00Z')], 0],
+            [['update_datetime_start' => 'PT1S'], 0],
+            [['update_datetime_end' => 'PT0S'], 0],
+            [['shipping_delivery_datetime_start' => new \DateTime('2022-03-01T10:00:01Z')], 0],
+            [['shipping_delivery_datetime_end' => new \DateTime('2022-03-01T10:00:00Z')], 0],
+            [['payment_total_start' => '1001'], 0],
+            [['payment_total_end' => '999'], 0],
+            [['buy_product_name' => '一致しないキーワード'], 0],
         ];
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
管理画面受注検索の multi と会社名を両方指定した際に、 multi の入力内容が検索結果に反映されないケースがある

**検索条件**

| 項目                                               | 値            |
| -------------------------------------------------- | ------------- |
| 注文番号・お名前・会社名・メールアドレス・電話番号 | 原田 太一     |
| 詳細検索: 会社名                                   | 株式会社 山口 |

**受注**

| 氏名      | 会社名        |
| --------- | ------------- |
| 原田 太一 | 株式会社 山口 |
| 小林 明美 | 株式会社 山口 |

としたときに、氏名と会社名が一致する1件のみが出力されるはずですが、
2件とも出力される状態になっています。

## 方針(Policy)
SQL のパラメーターが競合しているので、 multi の方のパラメーター名を修正

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
初めて PR 送るので、何か間違っていたら教えていただきたいです。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
