### PR TITLE
定休日カレンダーの編集時にキャンセルすると編集中のタイトル/日付のままになるバグ修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Setting/Shop/calendar.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/calendar.twig
@@ -15,7 +15,7 @@ file that was distributed with this source code.
 {% block title %}{{ 'admin.setting.shop.calendar_setting'|trans }}{% endblock %}
 {% block sub_title %}{{ 'admin.setting.shop'|trans }}{% endblock %}
 
-{#{% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}#}
+{% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
 
 {% block stylesheet %}
     <style type="text/css">
@@ -44,10 +44,7 @@ file that was distributed with this source code.
             });
 
             $('.calendar_list_item .cancel').click(function() {
-                var id = $(this).data('id');
-                var tr = $('#ex-calendar-' + id);
-                $(tr).find('.edit').hide();
-                $(tr).find('.list').show();
+                location.href = '{{ url('admin_setting_shop_calendar') }}';
             });
         });
     </script>
@@ -160,7 +157,7 @@ file that was distributed with this source code.
                                                                                 {{ 'admin.common.delete_modal__title'|trans }}
                                                                             </h5>
                                                                             <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Close">
-                                                                                
+
                                                                             </button>
                                                                         </div>
                                                                         <div class="modal-body text-start">

--- a/src/Eccube/Resource/template/admin/Setting/Shop/calendar.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/calendar.twig
@@ -156,9 +156,7 @@ file that was distributed with this source code.
                                                                             <h5 class="modal-title fw-bold">
                                                                                 {{ 'admin.common.delete_modal__title'|trans }}
                                                                             </h5>
-                                                                            <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Close">
-
-                                                                            </button>
+                                                                            <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Close"></button>
                                                                         </div>
                                                                         <div class="modal-body text-start">
                                                                             <p class="text-start modal-message">{{ 'admin.common.delete_modal__message'|trans({ "%name%" : Calendar.title }) }}</p>


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

こちらのissueの対応です。
https://github.com/EC-CUBE/ec-cube/issues/5492

POSTデータをクリアさせるため、キャンセルボタンを押したときに定休日カレンダー設定ページに再アクセスするように修正しました。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
