### PR TITLE
受注登録画面で商品の削除、追加を行うとエラーになる不具合を修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -106,6 +106,10 @@ file that was distributed with this source code.
             $collectionHolder = $('#table-form-field');
             index = $collectionHolder.find('tbody > tr').length;
             formIdPrefix = '#order_OrderItems_';
+            if (index > 0) {
+                let row = '#' + $collectionHolder.find('tbody > tr').last().data("row");
+                index = row.replace(formIdPrefix, '');
+            }
 
             $(document).on('click', '.delete', function(e) {
                 // 商品削除
@@ -739,7 +743,7 @@ file that was distributed with this source code.
                                     <tbody>
                                     {% for orderItemForm in form.OrderItems %}
                                         {% set OrderItem = orderItemForm.vars.data %}
-                                        <tr>
+                                        <tr data-row="{{ orderItemForm.vars.id }}">
                                             {# hidden values #}
                                             {{ form_widget(orderItemForm.ProductClass) }}
                                             {{ form_widget(orderItemForm.order_item_type) }}


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
[#5539](https://github.com/EC-CUBE/ec-cube/issues/5539)のissueに対応しました。

商品A (id:order_OrderItems_0)
商品B (id:order_OrderItems_1)
送料 (id:order_OrderItems_2)
手数料 (id:order_OrderItems_3)
という登録があり、そこから商品B、送料を削除すると

商品A (id:order_OrderItems_0)
手数料 (id:order_OrderItems_3)
となります。

この状態でアイテムを追加しようとする場合
これまでは、行数＋1(=3)でindexを決定しており
すでにid:order_OrderItems_3が存在するため、Formは空で送信されていました。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
単純に行数からindexを決定せずに、各行にidを持たせ、最後の行のidからindexを取得するように変更しました。 

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
既存の受注の更新、新規の受注の追加で動作することを確認しました。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
