### PR TITLE
Change publish_date to include seconds.

### DIFF
--- a/src/Eccube/Form/Type/Admin/NewsType.php
+++ b/src/Eccube/Form/Type/Admin/NewsType.php
@@ -47,6 +47,7 @@ class NewsType extends AbstractType
                 'widget' => 'single_text',
                 'input' => 'datetime',
                 'years' => range($this->eccubeConfig['eccube_news_start_year'], date('Y') + 3),
+                'with_seconds' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
                 ],

--- a/src/Eccube/Resource/template/admin/Content/news.twig
+++ b/src/Eccube/Resource/template/admin/Content/news.twig
@@ -48,7 +48,7 @@ file that was distributed with this source code.
                                 <li class="list-group-item sortable-item" data-id="{{ News.id }}">
                                     <div class="row justify-content-around">
                                         <div class="col-2 d-flex align-items-center">
-                                            <span>{{ News.publishDate|date_min }}</span></div>
+                                            <span>{{ News.publishDate|date('Y/m/d H:i:s') }}</span></div>
                                         <div class="col-1 d-flex align-items-center">{{ News.visible ? 'admin.content.news.display_status__show'|trans : 'admin.content.news.display_status__hide'|trans }}</div>
                                         <div class="col d-flex align-items-center"><a
                                                     href="{{ url('admin_content_news_edit', {id: News.id}) }}">{{ News.title }}</a>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#5544 のエラーを修正

## 方針(Policy)
原因は、with_seconds のデフォルトが false なのに input のフォーマットが秒を含むものだったため
フォーマットから秒を除くとなるとDatePickerの変更など影響が大きいため、最も簡単に修正できる方法をとった

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
