### PR TITLE
連続するスラッシュが含まれる場合はエラーとなるように変更

### DIFF
--- a/src/Eccube/Form/Type/Admin/BlockType.php
+++ b/src/Eccube/Form/Type/Admin/BlockType.php
@@ -77,6 +77,9 @@ class BlockType extends AbstractType
                     new Assert\Regex([
                         'pattern' => '/^[0-9a-zA-Z\/_]+$/',
                     ]),
+                    new Assert\Regex([
+                        'pattern' => '/^(?!.*\/\/).+$/',
+                    ]),
                 ],
             ])
             ->add('block_html', TextareaType::class, [

--- a/tests/Eccube/Tests/Form/Type/Admin/BlockTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/BlockTypeTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Eccube\Tests\Form\Type\Admin;
+
+use Eccube\Entity\Master\DeviceType;
+use Eccube\Form\Type\Admin\BlockType;
+use Symfony\Component\HttpFoundation\Request;
+
+class BlockTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
+{
+    /** @var \Symfony\Component\Form\FormInterface */
+    protected $form;
+
+    /** @var array デフォルト値（正常系）を設定 */
+    protected $formData = [
+        'name' => 'new/Block_1',
+        'file_name' => 'file_name',
+        'block_html' => '<p>test</p>',
+        'DeviceType' => DeviceType::DEVICE_TYPE_MB,
+        'id' => 1,
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // CSRF tokenを無効にしてFormを作成
+        // ブロック登録・編集
+        $this->form = $this->formFactory
+            ->createBuilder(BlockType::class, null, [
+                'csrf_protection' => false,
+            ])
+            ->getForm();
+        self::$container->get('request_stack')->push(new Request());
+    }
+
+    public function testValidData()
+    {
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testInvalidNameBlank()
+    {
+        $this->formData['name'] = '';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form['name']->isValid());
+    }
+
+    public function testInvalidNameMaxLengthInvalid()
+    {
+        $str = str_repeat('S', $this->eccubeConfig['eccube_stext_len']).'S';
+        $this->formData['name'] = $str;
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form['name']->isValid());
+    }
+
+    public function testInvalidNameMaxLengthValid()
+    {
+        $str = str_repeat('S', $this->eccubeConfig['eccube_stext_len']);
+        $this->formData['name'] = $str;
+
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form['name']->isValid());
+    }
+
+    public function testInvalidFileNameBlank()
+    {
+        $this->formData['file_name'] = '';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form['file_name']->isValid());
+    }
+
+    public function testInvalidFileNameMaxLengthInvalid()
+    {
+        $str = str_repeat('S', $this->eccubeConfig['eccube_stext_len']).'S';
+        $this->formData['file_name'] = $str;
+
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form['file_name']->isValid());
+    }
+
+    public function testInvalidFileNameMaxLengthValid()
+    {
+        $str = str_repeat('S', $this->eccubeConfig['eccube_stext_len']);
+        $this->formData['file_name'] = $str;
+
+        $this->form->submit($this->formData);
+        $this->assertTrue($this->form['file_name']->isValid());
+    }
+
+    public function testInvalidFileNameCharacter()
+    {
+        $this->formData['file_name'] = 'new/Block_1.*{;';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form['file_name']->isValid());
+    }
+
+    public function testInvalidFileNameContinuousSlashes()
+    {
+        $this->formData['file_name'] = 'new//Block_1';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form['file_name']->isValid());
+    }
+
+    public function testInvalidBlockHtmlBlank()
+    {
+        $this->formData['block_html'] = '';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form['block_html']->isValid());
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#5562 のエラー対策

## 方針(Policy)
連続する「/」が含まれる場合はエラーを返すように変更

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
