### PR TITLE
Symfony5.4からUsernamePasswordTokenのコンストラクタの引数が変更されたので修正

### DIFF
--- a/src/Eccube/Controller/EntryController.php
+++ b/src/Eccube/Controller/EntryController.php
@@ -316,7 +316,7 @@ class EntryController extends AbstractController
         }
 
         // 本会員登録してログイン状態にする
-        $token = new UsernamePasswordToken($Customer, null, 'customer', ['ROLE_USER']);
+        $token = new UsernamePasswordToken($Customer, 'customer', ['ROLE_USER']);
         $this->tokenStorage->setToken($token);
         $request->getSession()->migrate(true);
 

--- a/tests/Eccube/Tests/Web/AbstractWebTestCase.php
+++ b/tests/Eccube/Tests/Web/AbstractWebTestCase.php
@@ -64,7 +64,7 @@ abstract class AbstractWebTestCase extends EccubeTestCase
             $firewall = 'customer';
             $role = ['ROLE_USER'];
         }
-        $token = new UsernamePasswordToken($User, null, $firewall, $role);
+        $token = new UsernamePasswordToken($User, $firewall, $role);
 
         $session = $this->client->getContainer()->get('session');
         $session->set('_security_'.$firewall, serialize($token));


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
Symfony5.4からUsernamePasswordTokenのコンストラクタの引数の$credentialsが非推奨になったので修正しました。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
