### PR TITLE
self::$containerがSymfony5.3から非推奨なのでstatic::getContainer()に変更しました

### DIFF
--- a/tests/Eccube/Tests/Command/DeleteCartsCommandTest.php
+++ b/tests/Eccube/Tests/Command/DeleteCartsCommandTest.php
@@ -46,7 +46,7 @@ class DeleteCartsCommandTest extends EccubeTestCase
         self::assertNotNull($this->entityManager->find(Cart::class, $id));
 
         /** @var DeleteCartsCommand $command */
-        $command = self::$container->get(DeleteCartsCommand::class);
+        $command = static::getContainer()->get(DeleteCartsCommand::class);
 
         $tester = new CommandTester($command);
         $tomorrow = new \DateTime('+2day');
@@ -81,7 +81,7 @@ class DeleteCartsCommandTest extends EccubeTestCase
         self::assertNotNull($this->entityManager->find(Cart::class, $id));
 
         /** @var DeleteCartsCommand $command */
-        $command = self::$container->get(DeleteCartsCommand::class);
+        $command = static::getContainer()->get(DeleteCartsCommand::class);
 
         $tester = new CommandTester($command);
         $tomorrow = new \DateTime('yesterday');

--- a/tests/Eccube/Tests/Command/UpdateSchemaDoctrineCommandTest.php
+++ b/tests/Eccube/Tests/Command/UpdateSchemaDoctrineCommandTest.php
@@ -58,14 +58,14 @@ class UpdateSchemaDoctrineCommandTest extends EccubeTestCase
             $this->markTestSkipped('does not support of '.$platform);
         }
         $files = Finder::create()
-            ->in(self::$container->getParameter('kernel.project_dir').'/app/proxy/entity')
+            ->in(static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity')
             ->files();
         $f = new Filesystem();
         $f->remove($files);
 
         $this->pluginRepository = $this->entityManager->getRepository(\Eccube\Entity\Plugin::class);
-        $this->pluginService = self::$container->get(PluginService::class);
-        $this->schemaService = self::$container->get(SchemaService::class);
+        $this->pluginService = static::getContainer()->get(PluginService::class);
+        $this->schemaService = static::getContainer()->get(SchemaService::class);
     }
 
     protected function tearDown(): void

--- a/tests/Eccube/Tests/Doctrine/ORM/Tools/PaginationTest.php
+++ b/tests/Eccube/Tests/Doctrine/ORM/Tools/PaginationTest.php
@@ -63,7 +63,7 @@ class PaginationTest extends EccubeTestCase
         parent::setUp();
 
         $this->productRepository = $this->entityManager->getRepository(\Eccube\Entity\Product::class);
-        $this->paginator = self::$container->get(PaginatorInterface::class);
+        $this->paginator = static::getContainer()->get(PaginatorInterface::class);
         $this->tagRepository = $this->entityManager->getRepository(\Eccube\Entity\Tag::class);
         $this->memberRepository = $this->entityManager->getRepository(\Eccube\Entity\Member::class);
 

--- a/tests/Eccube/Tests/Doctrine/TimeZone/TimeZoneTest.php
+++ b/tests/Eccube/Tests/Doctrine/TimeZone/TimeZoneTest.php
@@ -81,7 +81,7 @@ class TimeZoneTest extends EccubeTestCase
         $this->entityManager->flush($product);
 
         // jstでcreate dateを登録
-        $timezone = new \DateTimeZone(self::$container->getParameter('timezone'));
+        $timezone = new \DateTimeZone(static::getContainer()->getParameter('timezone'));
         $createDate = new \DateTime('2000-01-01 00:00:00', $timezone);
 
         $product->setCreateDate($createDate);
@@ -123,7 +123,7 @@ class TimeZoneTest extends EccubeTestCase
         $this->assertEquals($expected, $actual->format('Y-m-d H:i:s'));
 
         // convertToPHPValueでjst時刻に変換可能
-        $timezone = new \DateTimeZone(self::$container->getParameter('timezone'));
+        $timezone = new \DateTimeZone(static::getContainer()->getParameter('timezone'));
         $expected = new \DateTime('2000-01-01 00:00:00', $timezone);
         $actual = $this->entityManager->getConnection()->convertToPHPValue($product['create_date'], 'datetimetz');
 
@@ -133,7 +133,7 @@ class TimeZoneTest extends EccubeTestCase
     public function testDbalInsert()
     {
         // jstで登録
-        $timezone = new \DateTimeZone(self::$container->getParameter('timezone'));
+        $timezone = new \DateTimeZone(static::getContainer()->getParameter('timezone'));
         $createDate = new \DateTime('2000-01-01 00:00:00', $timezone);
         $updateDate = new \DateTime('2000-01-01 00:00:00', $timezone);
 

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -60,8 +60,8 @@ abstract class EccubeTestCase extends WebTestCase
     {
         parent::setUp();
         $this->client = static::createClient();
-        $this->entityManager = self::$container->get('doctrine')->getManager();
-        $this->eccubeConfig = self::$container->get(EccubeConfig::class);
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+        $this->eccubeConfig = static::getContainer()->get(EccubeConfig::class);
     }
 
     /**
@@ -109,7 +109,7 @@ abstract class EccubeTestCase extends WebTestCase
      */
     public function createMember($username = null)
     {
-        return self::$container->get(Generator::class)->createMember($username);
+        return static::getContainer()->get(Generator::class)->createMember($username);
     }
 
     /**
@@ -121,7 +121,7 @@ abstract class EccubeTestCase extends WebTestCase
      */
     public function createCustomer($email = null)
     {
-        return self::$container->get(Generator::class)->createCustomer($email);
+        return static::getContainer()->get(Generator::class)->createCustomer($email);
     }
 
     /**
@@ -134,7 +134,7 @@ abstract class EccubeTestCase extends WebTestCase
      */
     public function createCustomerAddress(Customer $Customer, $is_nonmember = false)
     {
-        return self::$container->get(Generator::class)->createCustomerAddress($Customer, $is_nonmember);
+        return static::getContainer()->get(Generator::class)->createCustomerAddress($Customer, $is_nonmember);
     }
 
     /**
@@ -146,7 +146,7 @@ abstract class EccubeTestCase extends WebTestCase
      */
     public function createNonMember($email = null)
     {
-        return self::$container->get(Generator::class)->createNonMember($email);
+        return static::getContainer()->get(Generator::class)->createNonMember($email);
     }
 
     /**
@@ -159,7 +159,7 @@ abstract class EccubeTestCase extends WebTestCase
      */
     public function createProduct($product_name = null, $product_class_num = 3)
     {
-        return self::$container->get(Generator::class)->createProduct($product_name, $product_class_num);
+        return static::getContainer()->get(Generator::class)->createProduct($product_name, $product_class_num);
     }
 
     /**
@@ -175,7 +175,7 @@ abstract class EccubeTestCase extends WebTestCase
         $ProductClasses = $Product->getProductClasses();
 
         // 後方互換のため最初の1つのみ渡す
-        return self::$container->get(Generator::class)->createOrder($Customer, [$ProductClasses[0]]);
+        return static::getContainer()->get(Generator::class)->createOrder($Customer, [$ProductClasses[0]]);
     }
 
     /**
@@ -188,7 +188,7 @@ abstract class EccubeTestCase extends WebTestCase
      */
     public function createOrderWithProductClasses(Customer $Customer, array $ProductClasses)
     {
-        return self::$container->get(Generator::class)->createOrder($Customer, $ProductClasses);
+        return static::getContainer()->get(Generator::class)->createOrder($Customer, $ProductClasses);
     }
 
     /**
@@ -204,7 +204,7 @@ abstract class EccubeTestCase extends WebTestCase
      */
     public function createPayment(\Eccube\Entity\Delivery $Delivery, $method, $charge = 0, $rule_min = 0, $rule_max = 999999999)
     {
-        return self::$container->get(Generator::class)->createPayment($Delivery, $method, $charge, $rule_min, $rule_max);
+        return static::getContainer()->get(Generator::class)->createPayment($Delivery, $method, $charge, $rule_min, $rule_max);
     }
 
     /**
@@ -214,7 +214,7 @@ abstract class EccubeTestCase extends WebTestCase
      */
     public function createPage()
     {
-        return self::$container->get(Generator::class)->createPage();
+        return static::getContainer()->get(Generator::class)->createPage();
     }
 
     /**
@@ -224,7 +224,7 @@ abstract class EccubeTestCase extends WebTestCase
      */
     public function createLoginHistory($user_name, $client_ip = null, $status = 0, $Member = null)
     {
-        return self::$container->get(Generator::class)->createLoginHistory($user_name, $client_ip, $status, $Member);
+        return static::getContainer()->get(Generator::class)->createLoginHistory($user_name, $client_ip, $status, $Member);
     }
 
     /**
@@ -288,7 +288,7 @@ abstract class EccubeTestCase extends WebTestCase
      */
     protected function generateUrl($route, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        return self::$container->get('router')->generate($route, $parameters, $referenceType);
+        return static::getContainer()->get('router')->generate($route, $parameters, $referenceType);
     }
 
     /**
@@ -306,6 +306,6 @@ abstract class EccubeTestCase extends WebTestCase
      */
     protected function getCsrfToken($csrfTokenId)
     {
-        return self::$container->get('security.csrf.token_manager')->getToken($csrfTokenId);
+        return static::getContainer()->get('security.csrf.token_manager')->getToken($csrfTokenId);
     }
 }

--- a/tests/Eccube/Tests/Entity/OrderTest.php
+++ b/tests/Eccube/Tests/Entity/OrderTest.php
@@ -53,7 +53,7 @@ class OrderTest extends EccubeTestCase
         $this->Order = $this->createOrder($this->Customer);
         $this->TaxRule = $this->entityManager->getRepository(TaxRule::class)->getByRule();
         $this->rate = $this->TaxRule->getTaxRate();
-        $this->taxRuleService = self::$container->get(TaxRuleService::class);
+        $this->taxRuleService = static::getContainer()->get(TaxRuleService::class);
     }
 
     public function testConstructor()
@@ -128,7 +128,7 @@ class OrderTest extends EccubeTestCase
     {
         $faker = $this->getFaker();
         /** @var Order $Order */
-        $Order = self::$container->get(Generator::class)->createOrder(
+        $Order = static::getContainer()->get(Generator::class)->createOrder(
             $this->Customer,
             [],
             null,

--- a/tests/Eccube/Tests/Form/Type/AbstractTypeTestCase.php
+++ b/tests/Eccube/Tests/Form/Type/AbstractTypeTestCase.php
@@ -26,6 +26,6 @@ abstract class AbstractTypeTestCase extends EccubeTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->formFactory = self::$container->get('form.factory');
+        $this->formFactory = static::getContainer()->get('form.factory');
     }
 }

--- a/tests/Eccube/Tests/Form/Type/Admin/LogTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/LogTypeTest.php
@@ -32,7 +32,7 @@ class LogTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         parent::setUp();
 
         $this->fileName = '_test_site_'.date('YmdHis').'.log';
-        $this->logTest = self::$container->getParameter('kernel.logs_dir').'/test/'.$this->fileName;
+        $this->logTest = static::getContainer()->getParameter('kernel.logs_dir').'/test/'.$this->fileName;
 
         // Check and create the file to test if it does not exist
         if (!file_exists($this->logTest)) {

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
@@ -75,7 +75,7 @@ class OrderTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
                 'csrf_protection' => false,
             ])
             ->getForm();
-        self::$container->get('request_stack')->push(new Request());
+        static::getContainer()->get('request_stack')->push(new Request());
     }
 
     public function testInValidData()

--- a/tests/Eccube/Tests/Form/Type/Admin/PaymentRegisterTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/PaymentRegisterTypeTest.php
@@ -40,7 +40,7 @@ class PaymentRegisterTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCa
                 'csrf_protection' => false,
             ])
             ->getForm();
-        self::$container->get('request_stack')->push(new Request());
+        static::getContainer()->get('request_stack')->push(new Request());
     }
 
     public function testValidData()

--- a/tests/Eccube/Tests/Form/Type/Front/CustomerLoginTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Front/CustomerLoginTypeTest.php
@@ -32,7 +32,7 @@ class CustomerLoginTypeTest extends \Eccube\Tests\Form\Type\AbstractTypeTestCase
         parent::setUp();
 
         $request = Request::createFromGlobals();
-        self::$container->get('request_stack')->push($request);
+        static::getContainer()->get('request_stack')->push($request);
 
         // CSRF tokenを無効にしてFormを作成
         $this->form = $this->formFactory

--- a/tests/Eccube/Tests/Form/Type/Shopping/OrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Shopping/OrderTypeTest.php
@@ -28,7 +28,7 @@ class OrderTypeTest extends AbstractTypeTestCase
     {
         parent::setUp();
         $this->paymentRepository = $this->entityManager->getRepository(Payment::class);
-        $this->orderType = self::$container->get(OrderType::class);
+        $this->orderType = static::getContainer()->get(OrderType::class);
     }
 
     /**

--- a/tests/Eccube/Tests/Form/Validator/EmailValidatorTest.php
+++ b/tests/Eccube/Tests/Form/Validator/EmailValidatorTest.php
@@ -25,7 +25,7 @@ class EmailValidatorTest extends AbstractTypeTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->validator = self::$container->get('validator');
+        $this->validator = static::getContainer()->get('validator');
     }
 
     /**

--- a/tests/Eccube/Tests/Form/Validator/TwigLintValidatorTest.php
+++ b/tests/Eccube/Tests/Form/Validator/TwigLintValidatorTest.php
@@ -25,7 +25,7 @@ class TwigLintValidatorTest extends AbstractTypeTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->validator = self::$container->get('validator');
+        $this->validator = static::getContainer()->get('validator');
     }
 
     public function testValidTemplate()

--- a/tests/Eccube/Tests/Repository/MemberRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/MemberRepositoryTest.php
@@ -36,7 +36,7 @@ class MemberRepositoryTest extends EccubeTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->encoderFactory = self::$container->get('security.encoder_factory');
+        $this->encoderFactory = static::getContainer()->get('security.encoder_factory');
         $this->memberRepo = $this->entityManager->getRepository(\Eccube\Entity\Member::class);
         $this->Member = $this->memberRepo->find(1);
         $Work = $this->entityManager->getRepository('Eccube\Entity\Master\Work')

--- a/tests/Eccube/Tests/Repository/PageRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/PageRepositoryTest.php
@@ -29,9 +29,9 @@ class PageRepositoryTest extends EccubeTestCase
     {
         parent::setUp();
         $this->pageRepo = $this->entityManager->getRepository(\Eccube\Entity\Page::class);
-        $this->userDataRealDir = self::$container->getParameter('eccube_theme_user_data_dir');
-        $this->templateRealDir = self::$container->getParameter('eccube_theme_app_dir');
-        $this->templateDefaultRealDir = self::$container->getParameter('eccube_theme_src_dir');
+        $this->userDataRealDir = static::getContainer()->getParameter('eccube_theme_user_data_dir');
+        $this->templateRealDir = static::getContainer()->getParameter('eccube_theme_app_dir');
+        $this->templateDefaultRealDir = static::getContainer()->getParameter('eccube_theme_src_dir');
     }
 
     public function testGetByUrl()

--- a/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
+++ b/tests/Eccube/Tests/Repository/ProductRepositoryGetQueryBuilderBySearchDataTest.php
@@ -71,7 +71,7 @@ class ProductRepositoryGetQueryBuilderBySearchDataTest extends AbstractProductRe
 
         $this->categoryRepository = $this->entityManager->getRepository(\Eccube\Entity\Category::class);
         $this->productListOrderByRepository = $this->entityManager->getRepository(\Eccube\Entity\Master\ProductListOrderBy::class);
-        $this->paginator = self::$container->get('knp_paginator');
+        $this->paginator = static::getContainer()->get('knp_paginator');
 
         $this->ProductListMax = new ProductListMax();
         $this->ProductListOrderBy = new ProductListOrderBy();

--- a/tests/Eccube/Tests/Repository/ShippingRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/ShippingRepositoryTest.php
@@ -139,7 +139,7 @@ class ShippingRepositoryTest extends EccubeTestCase
             $this->Shippings[$i] = $Shipping;
         }
 
-        $purchaseFlow = self::$container->get('eccube.purchase.flow.order');
+        $purchaseFlow = static::getContainer()->get('eccube.purchase.flow.order');
         $purchaseFlow->validate($this->Order, new PurchaseContext($this->Order));
         $this->entityManager->flush();
     }

--- a/tests/Eccube/Tests/Security/Voter/AuthorityVoterTest.php
+++ b/tests/Eccube/Tests/Security/Voter/AuthorityVoterTest.php
@@ -39,7 +39,7 @@ class AuthorityVoterTest extends EccubeTestCase
     {
         parent::setUp();
         $this->authorityRoleRepository = $this->entityManager->getRepository(\Eccube\Entity\AuthorityRole::class);
-        $this->eccubeConfig = self::$container->get(EccubeConfig::class);
+        $this->eccubeConfig = static::getContainer()->get(EccubeConfig::class);
     }
 
     /**

--- a/tests/Eccube/Tests/Service/CartServiceTest.php
+++ b/tests/Eccube/Tests/Service/CartServiceTest.php
@@ -80,11 +80,11 @@ class CartServiceTest extends AbstractServiceTestCase
     {
         parent::setUp();
 
-        $this->cartService = self::$container->get(CartService::class);
+        $this->cartService = static::getContainer()->get(CartService::class);
         $this->saleTypeRepository = $this->entityManager->getRepository(\Eccube\Entity\Master\SaleType::class);
         $this->orderRepository = $this->entityManager->getRepository(\Eccube\Entity\Order::class);
         $this->productClassRepository = $this->entityManager->getRepository(\Eccube\Entity\ProductClass::class);
-        $this->purchaseFlow = self::$container->get('eccube.purchase.flow.cart');
+        $this->purchaseFlow = static::getContainer()->get('eccube.purchase.flow.cart');
 
         $this->SaleType1 = $this->saleTypeRepository->find(1);
         $this->SaleType2 = $this->saleTypeRepository->find(2);

--- a/tests/Eccube/Tests/Service/CsvExportServiceTest.php
+++ b/tests/Eccube/Tests/Service/CsvExportServiceTest.php
@@ -48,7 +48,7 @@ class CsvExportServiceTest extends AbstractServiceTestCase
     {
         parent::setUp();
 
-        $this->csvExportService = self::$container->get(CsvExportService::class);
+        $this->csvExportService = static::getContainer()->get(CsvExportService::class);
         $this->csvRepository = $this->entityManager->getRepository(\Eccube\Entity\Csv::class);
         $this->orderRepository = $this->entityManager->getRepository(\Eccube\Entity\Order::class);
 

--- a/tests/Eccube/Tests/Service/EntityProxyServiceTest.php
+++ b/tests/Eccube/Tests/Service/EntityProxyServiceTest.php
@@ -41,7 +41,7 @@ class EntityProxyServiceTest extends EccubeTestCase
     {
         parent::setUp();
 
-        $this->entityProxyService = self::$container->get(EntityProxyService::class);
+        $this->entityProxyService = static::getContainer()->get(EntityProxyService::class);
 
         $this->tempOutputDir = tempnam(sys_get_temp_dir(), 'ProxyGeneratorTest');
         unlink($this->tempOutputDir);

--- a/tests/Eccube/Tests/Service/MailServiceTest.php
+++ b/tests/Eccube/Tests/Service/MailServiceTest.php
@@ -63,11 +63,11 @@ class MailServiceTest extends AbstractServiceTestCase
         $this->Customer = $this->createCustomer();
         $this->Order = $this->createOrder($this->Customer);
         $this->BaseInfo = $this->entityManager->find(BaseInfo::class, 1);
-        $this->mailService = self::$container->get(MailService::class);
+        $this->mailService = static::getContainer()->get(MailService::class);
 
         $request = Request::createFromGlobals();
-        self::$container->get('request_stack')->push($request);
-        $twig = self::$container->get('twig');
+        static::getContainer()->get('request_stack')->push($request);
+        $twig = static::getContainer()->get('twig');
         $twig->addGlobal('BaseInfo', $this->BaseInfo);
     }
 

--- a/tests/Eccube/Tests/Service/OrderHelperTest.php
+++ b/tests/Eccube/Tests/Service/OrderHelperTest.php
@@ -29,12 +29,12 @@ class OrderHelperTest extends EccubeTestCase
     {
         parent::setUp();
 
-        $this->helper = self::$container->get(OrderHelper::class);
+        $this->helper = static::getContainer()->get(OrderHelper::class);
     }
 
     public function testNewInstance()
     {
-        $this->assertInstanceOf(OrderHelper::class, $this->helper = self::$container->get(OrderHelper::class));
+        $this->assertInstanceOf(OrderHelper::class, $this->helper = static::getContainer()->get(OrderHelper::class));
     }
 
     /**

--- a/tests/Eccube/Tests/Service/OrderStateMachineTest.php
+++ b/tests/Eccube/Tests/Service/OrderStateMachineTest.php
@@ -30,7 +30,7 @@ class OrderStateMachineTest extends EccubeTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->stateMachine = self::$container->get(OrderStateMachine::class);
+        $this->stateMachine = static::getContainer()->get(OrderStateMachine::class);
     }
 
     /**

--- a/tests/Eccube/Tests/Service/Payment/PaymentMethodTest.php
+++ b/tests/Eccube/Tests/Service/Payment/PaymentMethodTest.php
@@ -25,7 +25,7 @@ class PaymentMethodTest extends EccubeTestCase
         $Order = $this->createOrder($Customer);
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Test\FormInterface')->getMock();
-        $paymentMethod = self::$container->get($Order->getPayment()->getMethodClass());
+        $paymentMethod = static::getContainer()->get($Order->getPayment()->getMethodClass());
         $paymentMethod->setFormType($form);
         $paymentMethod->setOrder($Order);
 

--- a/tests/Eccube/Tests/Service/PluginServiceTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceTest.php
@@ -45,7 +45,7 @@ class PluginServiceTest extends AbstractServiceTestCase
     {
         parent::setUp();
 
-        $this->service = self::$container->get(PluginService::class);
+        $this->service = static::getContainer()->get(PluginService::class);
         $this->pluginRepository = $this->entityManager->getRepository(\Eccube\Entity\Plugin::class);
     }
 
@@ -54,7 +54,7 @@ class PluginServiceTest extends AbstractServiceTestCase
         $dirs = [];
         $finder = new Finder();
         $iterator = $finder
-            ->in(self::$container->getParameter('kernel.project_dir').'/app/Plugin')
+            ->in(static::getContainer()->getParameter('kernel.project_dir').'/app/Plugin')
             ->name('dummy*')
             ->directories();
         foreach ($iterator as $dir) {
@@ -66,7 +66,7 @@ class PluginServiceTest extends AbstractServiceTestCase
         }
 
         $files = Finder::create()
-            ->in(self::$container->getParameter('kernel.project_dir').'/app/proxy/entity')
+            ->in(static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity')
             ->files();
         $f = new Filesystem();
         $f->remove($files);

--- a/tests/Eccube/Tests/Service/PluginServiceWithEntityExtensionTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceWithEntityExtensionTest.php
@@ -51,7 +51,7 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
         parent::setUp();
 
         $this->mockSchemaService = $this->createMock(SchemaService::class);
-        $this->service = self::$container->get(PluginService::class);
+        $this->service = static::getContainer()->get(PluginService::class);
         $rc = new \ReflectionClass($this->service);
         $prop = $rc->getProperty('schemaService');
         $prop->setAccessible(true);
@@ -64,7 +64,7 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
     {
         $finder = new Finder();
         $iterator = $finder
-            ->in(self::$container->getParameter('kernel.project_dir').'/app/Plugin')
+            ->in(static::getContainer()->getParameter('kernel.project_dir').'/app/Plugin')
             ->name('dummy*')
             ->directories();
 
@@ -78,7 +78,7 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
         }
 
         $files = Finder::create()
-            ->in(self::$container->getParameter('kernel.project_dir').'/app/proxy/entity')
+            ->in(static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity')
             ->files();
         $f = new Filesystem();
         $f->remove($files);
@@ -107,7 +107,7 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
         $this->service->install($fileA);
 
         // Proxyは生成されない
-        self::assertFalse(file_exists(self::$container->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php'));
+        self::assertFalse(file_exists(static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php'));
     }
 
     /**
@@ -128,7 +128,7 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
 
         // Traitは有効
         self::assertContainsTrait(
-            self::$container->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
+            static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
             "Plugin\\${configA['code']}\\Entity\\HogeTrait");
     }
 
@@ -153,7 +153,7 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
 
         // Traitは無効
         self::assertNotContainsTrait(
-            self::$container->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
+            static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
             "Plugin\\${configA['code']}\\Entity\\HogeTrait");
     }
 
@@ -184,7 +184,7 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
 
         // Traitは無効
         self::assertNotContainsTrait(
-            self::$container->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
+            static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
             "Plugin\\${configA['code']}\\Entity\\HogeTrait");
     }
 
@@ -212,7 +212,7 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
 
         // Traitは無効
         self::assertNotContainsTrait(
-            self::$container->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
+            static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
             "Plugin\\${configA['code']}\\Entity\\HogeTrait");
     }
 
@@ -241,12 +241,12 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
         // 有効化
         $this->service->enable($pluginEnabled);
 
-        self::assertNotContainsTrait(self::$container->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
+        self::assertNotContainsTrait(static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
             "Plugin\\${configDisabled['code']}\\Entity\\HogeTrait",
             '無効状態プラグインのTraitは利用されないはず');
 
         // 無効化状態のTraitは利用されないはず
-        self::assertContainsTrait(self::$container->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
+        self::assertContainsTrait(static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
             "Plugin\\${configEnabled['code']}\\Entity\\HogeTrait",
             '有効状態のプラグインは利用されるはず');
     }

--- a/tests/Eccube/Tests/Service/PluginServiceWithExceptionTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceWithExceptionTest.php
@@ -45,7 +45,7 @@ class PluginServiceWithExceptionTest extends AbstractServiceTestCase
         parent::setUp();
 
         $this->pluginRepository = $this->entityManager->getRepository(\Eccube\Entity\Plugin::class);
-        $this->pluginService = self::$container->get(PluginService::class);
+        $this->pluginService = static::getContainer()->get(PluginService::class);
     }
 
     // インストーラが例外を上げた場合ロールバックできるか

--- a/tests/Eccube/Tests/Service/PurchaseFlow/ItemCollectionTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/ItemCollectionTest.php
@@ -42,7 +42,7 @@ class ItemCollectionTest extends EccubeTestCase
         $Product = $this->createProduct();
         $ProductClasses = $Product->getProductClasses()->toArray();
         $Customer = $this->createCustomer();
-        $this->ItemHolder = self::$container->get(Generator::class)->createOrder($Customer, $ProductClasses);
+        $this->ItemHolder = static::getContainer()->get(Generator::class)->createOrder($Customer, $ProductClasses);
         $this->Items = $this->ItemHolder->getItems()->toArray();
     }
 

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DeliveryFeeProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DeliveryFeeProcessorTest.php
@@ -51,7 +51,7 @@ class DeliveryFeeProcessorTest extends EccubeTestCase
 
     public function testProcess()
     {
-        $processor = self::$container->get(DeliveryFeePreprocessor::class);
+        $processor = static::getContainer()->get(DeliveryFeePreprocessor::class);
         $Order = $this->createOrder($this->createCustomer());
         /*
          * @var OrderItem
@@ -76,9 +76,9 @@ class DeliveryFeeProcessorTest extends EccubeTestCase
         $this->entityManager->persist($this->ProductClass);
         $this->entityManager->flush($this->ProductClass);
 
-        $processor = self::$container->get(DeliveryFeePreprocessor::class);
+        $processor = static::getContainer()->get(DeliveryFeePreprocessor::class);
         /** @var Order $Order */
-        $Order = self::$container->get(Generator::class)->createOrder($this->createCustomer(), [$this->ProductClass]);
+        $Order = static::getContainer()->get(Generator::class)->createOrder($this->createCustomer(), [$this->ProductClass]);
 
         $quantity = 0;
         foreach ($Order->getOrderItems() as $orderItem) {

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DeliverySettingValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/DeliverySettingValidatorTest.php
@@ -52,7 +52,7 @@ class DeliverySettingValidatorTest extends EccubeTestCase
 
         $this->Product = $this->createProduct('テスト商品', 1);
         $this->ProductClass = $this->Product->getProductClasses()[0];
-        $this->validator = self::$container->get(DeliverySettingValidator::class);
+        $this->validator = static::getContainer()->get(DeliverySettingValidator::class);
         $this->cartItem = new CartItem();
         $this->cartItem->setProductClass($this->ProductClass);
     }

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/EmptyItemsValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/EmptyItemsValidatorTest.php
@@ -56,7 +56,7 @@ class EmptyItemsValidatorTest extends EccubeTestCase
     {
         parent::setUp();
 
-        $this->validator = self::$container->get(EmptyItemsValidator::class);
+        $this->validator = static::getContainer()->get(EmptyItemsValidator::class);
         $this->Product = $this->createProduct('テスト商品', 1);
         $this->ProductClass = $this->Product->getProductClasses()[0];
         $ItemType = new OrderItemType();

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PaymentChargeProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PaymentChargeProcessorTest.php
@@ -24,7 +24,7 @@ class PaymentChargePreprocessorTest extends EccubeTestCase
 {
     public function testProcess()
     {
-        $processor = self::$container->get(PaymentChargePreprocessor::class);
+        $processor = static::getContainer()->get(PaymentChargePreprocessor::class);
         $Order = $this->createOrder($this->createCustomer());
         /*
          * @var OrderItem
@@ -43,7 +43,7 @@ class PaymentChargePreprocessorTest extends EccubeTestCase
      */
     public function testProcessWithPaymentCharge()
     {
-        $processor = self::$container->get(PaymentChargePreProcessor::class);
+        $processor = static::getContainer()->get(PaymentChargePreProcessor::class);
         $Order = $this->createOrder($this->createCustomer());
         /*
          * @var OrderItem

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PaymentTotalLimitValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PaymentTotalLimitValidatorTest.php
@@ -74,7 +74,7 @@ class PaymentTotalLimitValidatorTest extends EccubeTestCase
      */
     private function newValidator($maxTotalFee)
     {
-        $result = self::$container->get(PaymentTotalLimitValidator::class);
+        $result = static::getContainer()->get(PaymentTotalLimitValidator::class);
         $rc = new \ReflectionClass(PaymentTotalLimitValidator::class);
         $prop = $rc->getProperty('maxTotalFee');
         $prop->setAccessible(true);

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PointDiffProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PointDiffProcessorTest.php
@@ -43,8 +43,8 @@ class PointDiffProcessorTest extends EccubeTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->processor = self::$container->get(PointDiffProcessor::class);
-        $this->pointProcessor = self::$container->get(PointProcessor::class);
+        $this->processor = static::getContainer()->get(PointDiffProcessor::class);
+        $this->pointProcessor = static::getContainer()->get(PointProcessor::class);
         $this->OrderStatusRepository = $this->entityManager->getRepository(\Eccube\Entity\Master\OrderStatus::class);
         $this->BaseInfo = $this->entityManager->find(BaseInfo::class, 1);
     }

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PointProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PointProcessorTest.php
@@ -41,8 +41,8 @@ class PointProcessorTest extends EccubeTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->processor = self::$container->get(PointProcessor::class);
-        $this->addPointProcessor = self::$container->get(AddPointProcessor::class);
+        $this->processor = static::getContainer()->get(PointProcessor::class);
+        $this->addPointProcessor = static::getContainer()->get(AddPointProcessor::class);
         $this->BaseInfo = $this->entityManager->find(BaseInfo::class, 1);
     }
 

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PriceChangeValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PriceChangeValidatorTest.php
@@ -51,7 +51,7 @@ class PriceChangeValidatorTest extends EccubeTestCase
 
         $this->Product = $this->createProduct('テスト商品', 1);
         $this->ProductClass = $this->Product->getProductClasses()[0];
-        $this->validator = self::$container->get(PriceChangeValidator::class);
+        $this->validator = static::getContainer()->get(PriceChangeValidator::class);
         $this->cartItem = new CartItem();
         $this->cartItem->setProductClass($this->ProductClass);
     }

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/ProductStatusValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/ProductStatusValidatorTest.php
@@ -49,7 +49,7 @@ class ProductStatusValidatorTest extends EccubeTestCase
 
         $this->Product = $this->createProduct('テスト商品', 1);
         $this->ProductClass = $this->Product->getProductClasses()[0];
-        $this->validator = self::$container->get(ProductStatusValidator::class);
+        $this->validator = static::getContainer()->get(ProductStatusValidator::class);
         $this->cartItem = new CartItem();
         $this->cartItem->setQuantity(10);
         $this->cartItem->setProductClass($this->ProductClass);

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/SaleLimitMultipleValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/SaleLimitMultipleValidatorTest.php
@@ -62,7 +62,7 @@ class SaleLimitMultipleValidatorTest extends EccubeTestCase
     {
         parent::setUp();
 
-        $this->validator = self::$container->get(SaleLimitMultipleValidator::class);
+        $this->validator = static::getContainer()->get(SaleLimitMultipleValidator::class);
         $this->Product = $this->createProduct('テスト商品', 1);
         $this->ProductClass = $this->Product->getProductClasses()[0];
         $ItemType = new OrderItemType();

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/StockDiffProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/StockDiffProcessorTest.php
@@ -44,7 +44,7 @@ class StockDiffProcessorTest extends EccubeTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->processor = self::$container->get(StockDiffProcessor::class);
+        $this->processor = static::getContainer()->get(StockDiffProcessor::class);
         $this->OrderStatusRepository = $this->entityManager->getRepository(\Eccube\Entity\Master\OrderStatus::class);
         $this->OrderItemTypeRepository = $this->entityManager->getRepository(\Eccube\Entity\Master\OrderItemType::class);
         $this->BaseInfo = $this->entityManager->find(BaseInfo::class, 1);

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/StockMultipleValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/StockMultipleValidatorTest.php
@@ -61,7 +61,7 @@ class StockMultipleValidatorTest extends EccubeTestCase
     {
         parent::setUp();
 
-        $this->validator = self::$container->get(StockMultipleValidator::class);
+        $this->validator = static::getContainer()->get(StockMultipleValidator::class);
         $this->Product = $this->createProduct('テスト商品', 1);
         $this->ProductClass = $this->Product->getProductClasses()->first();
         $this->Order = $this->createOrderWithProductClasses($this->createCustomer(),

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/StockReduceProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/StockReduceProcessorTest.php
@@ -25,7 +25,7 @@ class StockReduceProcessorTest extends EccubeTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->processor = self::$container->get(StockReduceProcessor::class);
+        $this->processor = static::getContainer()->get(StockReduceProcessor::class);
     }
 
     public function testPrepare()

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/StockValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/StockValidatorTest.php
@@ -52,7 +52,7 @@ class StockValidatorTest extends EccubeTestCase
 
         $this->Product = $this->createProduct('テスト商品', 1);
         $this->ProductClass = $this->Product->getProductClasses()[0];
-        $this->validator = self::$container->get(StockValidator::class);
+        $this->validator = static::getContainer()->get(StockValidator::class);
         $this->cartItem = new CartItem();
         $this->cartItem->setProductClass($this->ProductClass);
     }
@@ -82,7 +82,7 @@ class StockValidatorTest extends EccubeTestCase
     public function testValidStockOrder()
     {
         $Customer = $this->createCustomer();
-        $Order = self::$container->get(Generator::class)->createOrder($Customer, [$this->ProductClass]);
+        $Order = static::getContainer()->get(Generator::class)->createOrder($Customer, [$this->ProductClass]);
 
         self::assertEquals($Order->getOrderItems()[0]->getProductClass(), $this->ProductClass);
 

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/TaxProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/TaxProcessorTest.php
@@ -49,7 +49,7 @@ class TaxProcessorTest extends EccubeTestCase
     {
         parent::setUp();
 
-        $this->processor = self::$container->get(TaxProcessor::class);
+        $this->processor = static::getContainer()->get(TaxProcessor::class);
         $this->taxRuleRepository = $this->entityManager->getRepository(\Eccube\Entity\TaxRule::class);
 
         /** @var RoundingType $RoundingType */

--- a/tests/Eccube/Tests/Service/SystemServiceTest.php
+++ b/tests/Eccube/Tests/Service/SystemServiceTest.php
@@ -19,7 +19,7 @@ class SystemServiceTest extends AbstractServiceTestCase
 {
     public function testgetDbversion()
     {
-        $version = self::$container->get(SystemService::class)->getDbversion();
+        $version = static::getContainer()->get(SystemService::class)->getDbversion();
 
         $this->assertNotNull($version);
         $this->assertMatchesRegularExpression('/mysql|postgresql|sqlite/', strtolower($version));

--- a/tests/Eccube/Tests/Service/TaxRuleServiceTest.php
+++ b/tests/Eccube/Tests/Service/TaxRuleServiceTest.php
@@ -44,8 +44,8 @@ class TaxRuleServiceTest extends AbstractServiceTestCase
         $this->BaseInfo->setOptionProductTaxRule(0);
         $this->TaxRule1 = $this->entityManager->getRepository(\Eccube\Entity\TaxRule::class)->find(1);
         $this->TaxRule1->setApplyDate(new \DateTime('-1 day'));
-        self::$container->get('doctrine')->getManager()->flush();
-        $this->taxRuleService = self::$container->get(TaxRuleService::class);
+        static::getContainer()->get('doctrine')->getManager()->flush();
+        $this->taxRuleService = static::getContainer()->get(TaxRuleService::class);
     }
 
     public function testRoundByCalcRuleWithDefault()

--- a/tests/Eccube/Tests/Twig/Extension/EccubeExtensionTest.php
+++ b/tests/Eccube/Tests/Twig/Extension/EccubeExtensionTest.php
@@ -27,7 +27,7 @@ class EccubeExtensionTest extends EccubeTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $EccubeConfig = self::$container->get(EccubeConfig::class);
+        $EccubeConfig = static::getContainer()->get(EccubeConfig::class);
         $productRepository = $this->entityManager->getRepository(\Eccube\Entity\Product::class);
         $this->Extension = new EccubeExtension($EccubeConfig, $productRepository);
     }

--- a/tests/Eccube/Tests/Twig/Extension/TaxExtensionTest.php
+++ b/tests/Eccube/Tests/Twig/Extension/TaxExtensionTest.php
@@ -32,7 +32,7 @@ class TaxExtensionTest extends EccubeTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->taxExtension = self::$container->get(TaxExtension::class);
+        $this->taxExtension = static::getContainer()->get(TaxExtension::class);
         $this->taxRuleRepository = $this->entityManager->getRepository(\Eccube\Entity\TaxRule::class);
     }
 

--- a/tests/Eccube/Tests/Util/FormUtilTest.php
+++ b/tests/Eccube/Tests/Util/FormUtilTest.php
@@ -41,7 +41,7 @@ class FormUtilTest extends EccubeTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->formFactory = self::$container->get('form.factory');
+        $this->formFactory = static::getContainer()->get('form.factory');
         $this->form = $this->formFactory
             ->createBuilder(
                 FormType::class,

--- a/tests/Eccube/Tests/Web/Admin/Content/BlockControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/BlockControllerTest.php
@@ -56,8 +56,8 @@ class BlockControllerTest extends AbstractAdminWebTestCase
         ));
 
         $dir = sprintf('%s/app/template/%s/Block',
-            self::$container->getParameter('kernel.project_dir'),
-            self::$container->getParameter('eccube.theme'));
+            static::getContainer()->getParameter('kernel.project_dir'),
+            static::getContainer()->getParameter('eccube.theme'));
 
         $this->expected = '<p>test</p>';
         $this->actual = file_get_contents($dir.'/file_name.twig');

--- a/tests/Eccube/Tests/Web/Admin/Content/CacheControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/CacheControllerTest.php
@@ -35,7 +35,7 @@ class CacheControllerTest extends AbstractAdminWebTestCase
 
         $url = $this->generateUrl('admin_content_cache');
 
-        $cacheDir = self::$container->getParameter('kernel.cache_dir');
+        $cacheDir = static::getContainer()->getParameter('kernel.cache_dir');
         file_put_contents($cacheDir.'/twig/sample', 'test');
 
         $crawler = $client->request('POST', $url, [

--- a/tests/Eccube/Tests/Web/Admin/Content/CssControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/CssControllerTest.php
@@ -33,7 +33,7 @@ class CssControllerTest extends AbstractAdminWebTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->dir = self::$container->getParameter('eccube_html_dir').'/user_data/assets/css/';
+        $this->dir = static::getContainer()->getParameter('eccube_html_dir').'/user_data/assets/css/';
         $this->contents = file_get_contents($this->dir.self::CSS_FILE);
         $fs = new Filesystem();
         $fs->dumpFile($this->dir.self::CSS_FILE, '');

--- a/tests/Eccube/Tests/Web/Admin/Content/JsControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/JsControllerTest.php
@@ -33,7 +33,7 @@ class JsControllerTest extends AbstractAdminWebTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->dir = self::$container->getParameter('eccube_html_dir').'/user_data/assets/js/';
+        $this->dir = static::getContainer()->getParameter('eccube_html_dir').'/user_data/assets/js/';
         $this->contents = file_get_contents($this->dir.self::JS_FILE);
         $fs = new Filesystem();
         $fs->dumpFile($this->dir.self::JS_FILE, '');

--- a/tests/Eccube/Tests/Web/Admin/Content/MaintenanceControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/MaintenanceControllerTest.php
@@ -24,7 +24,7 @@ class MaintenanceControllerTest extends AbstractAdminWebTestCase
         parent::setUp();
 
         $this->maintenance_file_path
-            = self::$container->getParameter('eccube_content_maintenance_file_path');
+            = static::getContainer()->getParameter('eccube_content_maintenance_file_path');
 
         if (file_exists($this->maintenance_file_path)) {
             unlink($this->maintenance_file_path);

--- a/tests/Eccube/Tests/Web/Admin/Content/PageControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/PageControllerTest.php
@@ -76,10 +76,10 @@ class PageControllerTest extends AbstractAdminWebTestCase
 
         $editable = false;
 
-        $templatePath = self::$container->getParameter('eccube_theme_front_dir');
+        $templatePath = static::getContainer()->getParameter('eccube_theme_front_dir');
         $Page = $this->entityManager->getRepository(\Eccube\Entity\Page::class)->find(1);
 
-        $source = self::$container->get('twig')
+        $source = static::getContainer()->get('twig')
             ->getLoader()
             ->getSourceContext($Page->getFileName().'.twig')
             ->getCode();
@@ -118,7 +118,7 @@ class PageControllerTest extends AbstractAdminWebTestCase
         $client = $this->client;
         $faker = $this->getFaker();
 
-        $templatePath = self::$container->getParameter('eccube_theme_user_data_dir');
+        $templatePath = static::getContainer()->getParameter('eccube_theme_user_data_dir');
 
         $name = $faker->word;
         $source = $faker->realText();
@@ -155,10 +155,10 @@ class PageControllerTest extends AbstractAdminWebTestCase
     {
         $client = $this->client;
 
-        $templatePath = self::$container->getParameter('eccube_theme_front_dir');
+        $templatePath = static::getContainer()->getParameter('eccube_theme_front_dir');
         $Page = $this->entityManager->getRepository(\Eccube\Entity\Page::class)->find(42); // Shoppin/index
 
-        $source = self::$container->get('twig')
+        $source = static::getContainer()->get('twig')
             ->getLoader()
             ->getSourceContext($Page->getFileName().'.twig')
             ->getCode();
@@ -197,7 +197,7 @@ class PageControllerTest extends AbstractAdminWebTestCase
         $client = $this->client;
         $faker = $this->getFaker();
 
-        $templatePath = self::$container->getParameter('eccube_theme_user_data_dir');
+        $templatePath = static::getContainer()->getParameter('eccube_theme_user_data_dir');
 
         $name = $faker->word;
         $source = $faker->realText();
@@ -225,7 +225,7 @@ class PageControllerTest extends AbstractAdminWebTestCase
         $this->actual = $Page->getName();
         $this->verify('ページ新規作成');
 
-        $source = self::$container->get('twig')
+        $source = static::getContainer()->get('twig')
             ->getLoader()
             ->getSourceContext('@user_data/'.$Page->getFileName().'.twig')
             ->getCode();

--- a/tests/Eccube/Tests/Web/Admin/Customer/CustomerControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Customer/CustomerControllerTest.php
@@ -161,7 +161,7 @@ class CustomerControllerTest extends AbstractAdminWebTestCase
         $Order = $this->createOrder($Customer);
 
         /** @var OrderStatus $OrderStatus */
-        $OrderStatus = self::$container->get(OrderStatusRepository::class)->find($orderStatusId);
+        $OrderStatus = static::getContainer()->get(OrderStatusRepository::class)->find($orderStatusId);
         $Order->setOrderStatus($OrderStatus);
         $this->entityManager->flush();
 

--- a/tests/Eccube/Tests/Web/Admin/IndexControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/IndexControllerTest.php
@@ -154,7 +154,7 @@ class IndexControllerTest extends AbstractAdminWebTestCase
         $this->assertTrue($client->getResponse()->isRedirect($this->generateUrl('admin_change_password')));
 
         $Member = clone $this->Member;
-        $encoder = self::$container->get('security.encoder_factory')->getEncoder($this->Member);
+        $encoder = static::getContainer()->get('security.encoder_factory')->getEncoder($this->Member);
         $this->expected = $encoder->encodePassword($form['change_password']['first'], $this->Member->getSalt());
         $this->actual = $this->Member->getPassword();
 

--- a/tests/Eccube/Tests/Web/Admin/LoginControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/LoginControllerTest.php
@@ -40,10 +40,10 @@ class LoginControllerTest extends AbstractWebTestCase
             ]
         );
 
-        $this->assertNotNull(self::$container->get('security.token_storage')->getToken(), 'ログインしているかどうか');
+        $this->assertNotNull(static::getContainer()->get('security.token_storage')->getToken(), 'ログインしているかどうか');
     }
 
-    public function testRoutingAdminLoginÃ�グインしていない場合は302エラーがかえる()
+    public function testRoutingAdminLoginÃ�グインしていない場合は302エラーがかえる()
     {
         $this->client->request('GET', $this->generateUrl('admin_homepage'));
 

--- a/tests/Eccube/Tests/Web/Admin/Order/CsvImportControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/CsvImportControllerTest.php
@@ -130,7 +130,7 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         $csv = new CsvImportService(new \SplFileObject($tempFile));
         $csv->setHeaderRowNumber(0);
 
-        $controller = self::$container->get(CsvImportController::class);
+        $controller = static::getContainer()->get(CsvImportController::class);
         $rc = new \ReflectionClass(CsvImportController::class);
         $method = $rc->getMethod('loadCsv');
         $method->setAccessible(true);

--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -69,7 +69,7 @@ class EditControllerTest extends AbstractEditControllerTestCase
         $this->Product = $this->createProduct();
         $this->customerRepository = $this->entityManager->getRepository(\Eccube\Entity\Customer::class);
         $this->orderRepository = $this->entityManager->getRepository(\Eccube\Entity\Order::class);
-        $this->cartService = self::$container->get(CartService::class);
+        $this->cartService = static::getContainer()->get(CartService::class);
         $BaseInfo = $this->entityManager->find(BaseInfo::class, 1);
         $this->entityManager->flush($BaseInfo);
     }
@@ -463,7 +463,7 @@ class EditControllerTest extends AbstractEditControllerTestCase
         foreach ($formDataForEdit['OrderItems'] as $indx => $orderItem) {
             //商品数変更3個追加
             $formDataForEdit['OrderItems'][$indx]['quantity'] = $orderItem['quantity'] + 3;
-            $tax = self::$container->get(TaxRuleService::class)->getTax($orderItem['price']);
+            $tax = static::getContainer()->get(TaxRuleService::class)->getTax($orderItem['price']);
             $totalTax += $tax * $formDataForEdit['OrderItems'][$indx]['quantity'];
         }
 

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
@@ -390,7 +390,7 @@ class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $this->assertCount(1, $OrderPdfs, '1件保存されているはず');
 
         $OrderPdf = current($OrderPdfs);
-        $token = self::$container->get('security.token_storage')->getToken();
+        $token = static::getContainer()->get('security.token_storage')->getToken();
         $adminTest = $token->getUser();
         $this->assertEquals($adminTest->getId(), $OrderPdf->getMemberId(), '管理ユーザーのIDと一致するはず');
 

--- a/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
@@ -373,7 +373,7 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         // 一旦別の変数に代入しないと, config 以下の値を書きかえることができない
         $config = $this->eccubeConfig;
         $config['eccube_csv_export_encoding'] = 'UTF-8'; // SJIS だと比較できないので UTF-8 に変更しておく
-        self::$container->setParameter('eccube.constants', $config);
+        static::getContainer()->setParameter('eccube.constants', $config);
 
         $this->expectOutputString('商品ID,公開ステータス(ID),商品名,ショップ用メモ欄,商品説明(一覧),商品説明(詳細),検索ワード,フリーエリア,商品削除フラグ,商品画像,商品カテゴリ(ID),タグ(ID),販売種別(ID),規格分類1(ID),規格分類2(ID),発送日目安(ID),商品コード,在庫数,在庫数無制限フラグ,販売制限数,通常価格,販売価格,送料,税率'."\n");
 
@@ -597,7 +597,7 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         // 一旦別の変数に代入しないと, config 以下の値を書きかえることができない
         $config = $this->eccubeConfig;
         $config['eccube_csv_export_encoding'] = 'UTF-8'; // SJIS だと比較できないので UTF-8 に変更しておく
-        self::$container->setParameter('eccube.constants', $config);
+        static::getContainer()->setParameter('eccube.constants', $config);
 
         $this->expectOutputString('カテゴリID,カテゴリ名,親カテゴリID,カテゴリ削除フラグ'."\n");
 
@@ -948,7 +948,7 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
     public function testDeleteImage()
     {
         /** @var \Eccube\Tests\Fixture\Generator $generator */
-        $generator = self::$container->get(\Eccube\Tests\Fixture\Generator::class);
+        $generator = static::getContainer()->get(\Eccube\Tests\Fixture\Generator::class);
         $Product1 = $generator->createProduct(null, 0, 'abstract');
         $Product2 = $generator->createProduct(null, 0, 'abstract');
 

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
@@ -1015,7 +1015,7 @@ class ProductControllerTest extends AbstractAdminWebTestCase
     public function testDeleteImage()
     {
         /** @var Generator $generator */
-        $generator = self::$container->get(Generator::class);
+        $generator = static::getContainer()->get(Generator::class);
         $Product1 = $generator->createProduct(null, 0, 'abstract');
         $Product2 = $generator->createProduct(null, 0, 'abstract');
 
@@ -1054,7 +1054,7 @@ class ProductControllerTest extends AbstractAdminWebTestCase
     public function testDeleteAndDeleteProductImage()
     {
         /** @var Generator $generator */
-        $generator = self::$container->get(Generator::class);
+        $generator = static::getContainer()->get(Generator::class);
         $Product1 = $generator->createProduct(null, 0, 'abstract');
         $Product2 = $generator->createProduct(null, 0, 'abstract');
 

--- a/tests/Eccube/Tests/Web/Admin/Setting/Shop/MailControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/Shop/MailControllerTest.php
@@ -23,7 +23,7 @@ class MailControllerTest extends AbstractAdminWebTestCase
 {
     protected function tearDown(): void
     {
-        $themeDir = self::$container->getParameter('eccube_theme_front_dir');
+        $themeDir = static::getContainer()->getParameter('eccube_theme_front_dir');
         if (file_exists($themeDir.'/Mail/order.twig')) {
             unlink($themeDir.'/Mail/order.twig');
         }
@@ -142,7 +142,7 @@ class MailControllerTest extends AbstractAdminWebTestCase
         $redirectUrl = $this->generateUrl('admin_setting_shop_mail');
         $this->assertTrue($this->client->getResponse()->isRedirect($redirectUrl));
 
-        $outPut = self::$container->get('session')->getFlashBag()->get('eccube.admin.error');
+        $outPut = static::getContainer()->get('session')->getFlashBag()->get('eccube.admin.error');
         $this->actual = array_shift($outPut);
         $this->expected = 'admin.common.save_error';
         $this->verify();

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/LogControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/LogControllerTest.php
@@ -38,7 +38,7 @@ class LogControllerTest extends AbstractAdminWebTestCase
             'line_max' => '50',
         ];
 
-        $logDir = self::$container->getParameter('kernel.logs_dir');
+        $logDir = static::getContainer()->getParameter('kernel.logs_dir');
 
         $this->logTest = $logDir.'/'.$this->formData['files'];
 

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/MasterdataControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/MasterdataControllerTest.php
@@ -31,7 +31,7 @@ class MasterdataControllerTest extends AbstractAdminWebTestCase
     {
         parent::setUp();
 
-        $this->session = self::$container->get('session');
+        $this->session = static::getContainer()->get('session');
     }
 
     protected $entityTest = 'Eccube-Entity-Master-Sex';

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/SecurityControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/SecurityControllerTest.php
@@ -28,7 +28,7 @@ class SecurityControllerTest extends AbstractAdminWebTestCase
     {
         parent::setUp();
 
-        $this->envFile = self::$container->getParameter('kernel.project_dir').'/.env';
+        $this->envFile = static::getContainer()->getParameter('kernel.project_dir').'/.env';
         if (file_exists($this->envFile)) {
             $this->env = file_get_contents($this->envFile);
         }
@@ -72,7 +72,7 @@ class SecurityControllerTest extends AbstractAdminWebTestCase
         $this->assertTrue($this->client->getResponse()->isRedirection());
 
         // Message
-        $outPut = self::$container->get('session')->getFlashBag()->get('eccube.admin.success');
+        $outPut = static::getContainer()->get('session')->getFlashBag()->get('eccube.admin.success');
         $this->actual = array_shift($outPut);
         $this->expected = 'admin.setting.system.security.admin_url_changed';
         $this->verify();

--- a/tests/Eccube/Tests/Web/Admin/Store/TemplateControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Store/TemplateControllerTest.php
@@ -80,7 +80,7 @@ class TemplateControllerTest extends AbstractAdminWebTestCase
 
         $this->code = StringUtil::random(6);
 
-        $this->envFile = self::$container->getParameter('kernel.project_dir').'/.env';
+        $this->envFile = static::getContainer()->getParameter('kernel.project_dir').'/.env';
         if (file_exists($this->envFile)) {
             $this->env = file_get_contents($this->envFile);
         }
@@ -91,7 +91,7 @@ class TemplateControllerTest extends AbstractAdminWebTestCase
         $fs = new Filesystem();
         $fs->remove($this->dir);
 
-        $templatePath = self::$container->getParameter('kernel.project_dir').'/app/template/'.$this->code;
+        $templatePath = static::getContainer()->getParameter('kernel.project_dir').'/app/template/'.$this->code;
         if ($fs->exists($templatePath)) {
             $fs->remove($templatePath);
         }
@@ -207,7 +207,7 @@ class TemplateControllerTest extends AbstractAdminWebTestCase
 
         $Template = $this->templateRepository->find($id);
         self::assertNull($Template);
-        self::assertFalse(file_exists(self::$container->getParameter('kernel.project_dir').'/app/template/'.$code));
+        self::assertFalse(file_exists(static::getContainer()->getParameter('kernel.project_dir').'/app/template/'.$code));
     }
 
     protected function scenarioUpload($uppercase = false)

--- a/tests/Eccube/Tests/Web/CartValidationTest.php
+++ b/tests/Eccube/Tests/Web/CartValidationTest.php
@@ -42,7 +42,7 @@ class CartValidationTest extends AbstractWebTestCase
     {
         parent::setUp();
         $this->productStatusRepository = $this->entityManager->getRepository(\Eccube\Entity\Master\ProductStatus::class);
-        $this->cartService = self::$container->get(CartService::class);
+        $this->cartService = static::getContainer()->get(CartService::class);
         $this->BaseInfo = $this->entityManager->find(BaseInfo::class, 1);
     }
 

--- a/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
+++ b/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
@@ -58,20 +58,20 @@ class InstallControllerTest extends AbstractWebTestCase
     {
         parent::setUp();
 
-        $this->envFile = self::$container->getParameter('kernel.project_dir').'/.env';
+        $this->envFile = static::getContainer()->getParameter('kernel.project_dir').'/.env';
         $this->envFileBackup = $this->envFile.'.'.date('YmdHis');
         if (file_exists($this->envFile)) {
             rename($this->envFile, $this->envFileBackup);
         }
 
-        $favicon = self::$container->getParameter('eccube_html_dir').'/user_data/assets/img/common/favicon.ico';
+        $favicon = static::getContainer()->getParameter('eccube_html_dir').'/user_data/assets/img/common/favicon.ico';
         if (file_exists($favicon)) {
             unlink($favicon);
         }
 
-        $formFactory = self::$container->get('form.factory');
-        $encoder = self::$container->get(PasswordEncoder::class);
-        $cacheUtil = self::$container->get(CacheUtil::class);
+        $formFactory = static::getContainer()->get('form.factory');
+        $encoder = static::getContainer()->get(PasswordEncoder::class);
+        $cacheUtil = static::getContainer()->get(CacheUtil::class);
 
         $this->session = new Session(new MockArraySessionStorage());
         $this->controller = new InstallController($encoder, $cacheUtil);
@@ -111,8 +111,8 @@ class InstallControllerTest extends AbstractWebTestCase
         $this->actual = $this->controller->step2($this->request);
         $this->assertArrayHasKey('noWritePermissions', $this->actual);
 
-        $this->assertFileExists(self::$container->getParameter('eccube_html_dir').'/user_data/assets/img/common/favicon.ico');
-        $this->assertFileExists(self::$container->getParameter('eccube_html_dir').'/user_data/assets/pdf/logo.png');
+        $this->assertFileExists(static::getContainer()->getParameter('eccube_html_dir').'/user_data/assets/img/common/favicon.ico');
+        $this->assertFileExists(static::getContainer()->getParameter('eccube_html_dir').'/user_data/assets/pdf/logo.png');
     }
 
     public function testStep3()

--- a/tests/Eccube/Tests/Web/Mypage/DeliveryControllerTest.php
+++ b/tests/Eccube/Tests/Web/Mypage/DeliveryControllerTest.php
@@ -188,7 +188,7 @@ class DeliveryControllerTest extends AbstractWebTestCase
         $this->assertCount(0, $crawler->filter('span.ec-errorMessage'));
 
         // お届け先上限まで登録
-        $max = self::$container->getParameter('eccube_deliv_addr_max');
+        $max = static::getContainer()->getParameter('eccube_deliv_addr_max');
         for ($i = 0; $i < $max; $i++) {
             $this->createCustomerAddress($this->Customer);
         }

--- a/tests/Eccube/Tests/Web/Mypage/MypageControllerTest.php
+++ b/tests/Eccube/Tests/Web/Mypage/MypageControllerTest.php
@@ -111,7 +111,7 @@ class MypageControllerTest extends AbstractWebTestCase
         $Product = $this->createProduct();
         $ProductClasses = $Product->getProductClasses();
         // 後方互換のため最初の1つのみ渡す
-        $Order = self::$container->get(Generator::class)->createOrder($this->Customer, [$ProductClasses[0]], null,
+        $Order = static::getContainer()->get(Generator::class)->createOrder($this->Customer, [$ProductClasses[0]], null,
             0, 0, OrderStatus::NEW);
         $this->loginTo($this->Customer);
         $client = $this->client;
@@ -128,7 +128,7 @@ class MypageControllerTest extends AbstractWebTestCase
         $Product = $this->createProduct();
         $ProductClasses = $Product->getProductClasses();
         // 後方互換のため最初の1つのみ渡す
-        $Order = self::$container->get(Generator::class)->createOrder($this->Customer, [$ProductClasses[0]], null,
+        $Order = static::getContainer()->get(Generator::class)->createOrder($this->Customer, [$ProductClasses[0]], null,
             0, 0, OrderStatus::PROCESSING);
         $this->loginTo($this->Customer);
 

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -69,11 +69,11 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
     {
         $Customer = $this->createCustomer();
         $Order = $this->createOrder($Customer);
-        self::$container->get('session')->set('eccube.front.shopping.order.id', $Order->getId());
+        static::getContainer()->get('session')->set('eccube.front.shopping.order.id', $Order->getId());
         $this->client->request('GET', $this->generateUrl('shopping_complete'));
 
         $this->assertTrue($this->client->getResponse()->isSuccessful());
-        $this->assertNull(self::$container->get('session')->get('eccube.front.shopping.order.id'));
+        $this->assertNull(static::getContainer()->get('session')->get('eccube.front.shopping.order.id'));
     }
 
 
@@ -104,7 +104,7 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
 
         // 1つの新着情報を保存した後にホームページにアクセスする。
         // Request Homepage after saving a single news item
-        self::$container->get('session')->set('eccube.front.shopping.order.id', $Order->getId());
+        static::getContainer()->get('session')->set('eccube.front.shopping.order.id', $Order->getId());
         $crawler = $this->client->request('GET', $this->generateUrl('shopping_complete'));
 
         // <div>タグから危険なid属性が削除されていることを確認する。
@@ -561,7 +561,7 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
     {
         $Customer = $this->createCustomer();
         $SaleTypeNormal = $this->entityManager->find(SaleType::class, SaleType::SALE_TYPE_NORMAL);
-        $Delivery = self::$container->get(Generator::class)->createDelivery();
+        $Delivery = static::getContainer()->get(Generator::class)->createDelivery();
         $Delivery->setSaleType($SaleTypeNormal);
         $this->entityManager->flush($Delivery);
         $Payments = $this->paymentRepository->findAll();
@@ -1035,12 +1035,12 @@ class ShoppingControllerTest extends AbstractShoppingControllerTestCase
         $ProductClass->setPrice02($price);
         $this->entityManager->flush($ProductClass);
 
-        $Delivery = self::$container->get(Generator::class)->createDelivery();
+        $Delivery = static::getContainer()->get(Generator::class)->createDelivery();
         $Delivery->setSaleType($ProductClass->getSaleType());
         $this->entityManager->flush($Delivery);
 
-        $COD1 = self::$container->get(Generator::class)->createPayment($Delivery, 'COD1', 0, 0, 30000);
-        $COD2 = self::$container->get(Generator::class)->createPayment($Delivery, 'COD2', 0, 30001, 300000);
+        $COD1 = static::getContainer()->get(Generator::class)->createPayment($Delivery, 'COD1', 0, 0, 30000);
+        $COD2 = static::getContainer()->get(Generator::class)->createPayment($Delivery, 'COD2', 0, 30001, 300000);
 
         // カート画面
         $this->scenarioCartIn($Customer, 2);

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
@@ -982,7 +982,7 @@ class ShoppingControllerWithMultipleTest extends AbstractShoppingControllerTestC
             ],
         ];
 
-        $cartService = self::$container->get(CartService::class);
+        $cartService = static::getContainer()->get(CartService::class);
         $cartService->clear();
 
         $this->client->request(

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php
@@ -48,7 +48,7 @@ class ShoppingControllerWithNonmemberTest extends AbstractShoppingControllerTest
     public function testIndexWithCartNotFound()
     {
         // お客様情報を入力済の状態にするため, セッションにエンティティをセット.
-        $session = self::$container->get('session');
+        $session = static::getContainer()->get('session');
         $session->set(OrderHelper::SESSION_NON_MEMBER, new Customer());
 
         $this->client->request('GET', '/shopping');
@@ -141,9 +141,9 @@ class ShoppingControllerWithNonmemberTest extends AbstractShoppingControllerTest
         $formData = $this->createNonmemberFormData();
         $this->scenarioInput($formData);
 
-        $Nonmember = self::$container->get(OrderHelper::class)->getNonMember('eccube.front.shopping.nonmember');
+        $Nonmember = static::getContainer()->get(OrderHelper::class)->getNonMember('eccube.front.shopping.nonmember');
         $this->assertNotNull($Nonmember);
-        $this->assertNotNull(self::$container->get('session')->get('eccube.front.shopping.nonmember.customeraddress'));
+        $this->assertNotNull(static::getContainer()->get('session')->get('eccube.front.shopping.nonmember.customeraddress'));
 
         $this->expected = $formData['name']['name01'];
         $this->actual = $Nonmember->getName01();

--- a/tests/Eccube/Tests/Web/TemplateEventListenerTest.php
+++ b/tests/Eccube/Tests/Web/TemplateEventListenerTest.php
@@ -22,7 +22,7 @@ class TemplateEventListenerTest extends AbstractWebTestCase
     {
         $calledEvents = [];
         /** @var EventDispatcher $eventDispatcher */
-        $eventDispatcher = self::$container->get('event_dispatcher');
+        $eventDispatcher = static::getContainer()->get('event_dispatcher');
         $listener = function ($event) use (&$calledEvents) {
             /* @var TemplateEvent $event */
             $calledEvents[] = $event->getView();


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
self::$containerがSymfony5.3から非推奨なのでstatic::getContainer()に変更しました。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
