### PR TITLE
管理者ログイン画面のID, PWの長さ制限をeccube.yamlの設定値にそろえる

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -107,7 +107,7 @@ parameters:
     eccube_tel_len_max: 14
     eccube_postal_code: 8
     eccube_password_min_len: 12
-    eccube_password_max_len: 32
+    eccube_password_max_len: 50
     # see https://github.com/EC-CUBE/ec-cube2/blob/87e269314f92ebb169ea212bf304c9371bb12fd2/data/class/SC_CheckError.php#L889
     eccube_password_pattern: '/\A(?=.*?[a-z])(?=.*?\d)[!-~]+\z/i'
     eccube_composer_memory_limit: 1536M

--- a/src/Eccube/Form/Type/Admin/LoginType.php
+++ b/src/Eccube/Form/Type/Admin/LoginType.php
@@ -13,6 +13,7 @@
 
 namespace Eccube\Form\Type\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -24,12 +25,20 @@ use Symfony\Component\Validator\Constraints as Assert;
 class LoginType extends AbstractType
 {
     /**
+     * @var EccubeConfig
+     */
+    protected $eccubeConfig;
+
+    /**
      * @var SessionInterface
      */
     protected $session;
 
-    public function __construct(SessionInterface $session)
-    {
+    public function __construct(
+        EccubeConfig $eccubeConfig,
+        SessionInterface $session
+    ) {
+        $this->eccubeConfig = $eccubeConfig;
         $this->session = $session;
     }
 
@@ -40,7 +49,7 @@ class LoginType extends AbstractType
     {
         $builder->add('login_id', TextType::class, [
             'attr' => [
-                'maxlength' => 50,
+                'maxlength' => $this->eccubeConfig['eccube_id_max_len'],
             ],
             'constraints' => [
                 new Assert\NotBlank(),
@@ -49,7 +58,7 @@ class LoginType extends AbstractType
         ]);
         $builder->add('password', PasswordType::class, [
             'attr' => [
-                'maxlength' => 50,
+                'maxlength' => $this->eccubeConfig['eccube_password_max_len'],
             ],
             'constraints' => [
                 new Assert\NotBlank(),


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Form/Type/Admin/LoginType.php 内の login_id, password の長さ制限(maxlength)がハードコーディングされていました。
eccube.yaml 内でid, password の長さ制限値（eccube_id_max_len, eccube_password_max_len）を大きな値に変更した場合にログインできなくなる恐れがあるので、eccube.yaml の値をそのまま持ってくるように修正しました。

## テスト（Test)

もともと動作していた部分ですので、テストに手は加えていません

念のため、正しい id, password の組み合わせでログインできること、不正な id, password の組み合わせでログインできないことを目視確認してあります。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
