### PR TITLE
FilePond：【styleItemPanelAspectRatio】指定追加

### DIFF
--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -76,6 +76,7 @@ file that was distributed with this source code.
                 allowDrop: true,
                 allowReorder: true,
                 labelIdle: '<i class="fa fa-cloud-upload fa-3x text-ec-lightGray mx-3 align-middle" aria-hidden="true" style="font-size: 40px"></i>{{ 'admin.common.drag_and_drop_image_description'|trans }}<span class="filepond--label-action">{{ 'admin.common.file_select'|trans }}</span>',
+                styleItemPanelAspectRatio: 0.5625,
                 // 保存されている画像のロード
                 files: [
                     {% for image in form.images %}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
商品登録画面で縦サイズが600以下の画像を登録するとレイアウトが崩れる #5602

## 方針(Policy)
プラグイン【FilePond】→「先頭にある画像の高さを基準に親要素の高さが可変する」仕様と判明、
同じ様な不具合を経験されている方が数名いらっしゃいました。

▼参考
https://github.com/pqina/vue-filepond/issues/94

## 実装に関する補足(Appendix)
【styleItemPanelAspectRatio】の指定を加える事により解決。
アスペクト比は【16 : 9 = 1 : 0.5625】としています。

## テスト（Test)
【/admin/product/product/new】にて動作確認

```
▼開発環境（M1 Mac：Docker）

EC-CUBE：4.2.0-beta2
DB：MySQL 5.7.39
Apache/2.4.54 (Debian)
PHP：7.4.30
```

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか