### PR TITLE
str_starts_withが使えるのはPHP8からなので修正

### DIFF
--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -144,7 +144,7 @@ class InstallerCommand extends Command
         $this->envFileUpdater->serverVersion = $this->getDatabaseServerVersion($databaseUrl);
 
         // DATABASE_CHARSET
-        $this->envFileUpdater->databaseCharset = \str_starts_with($databaseUrl, 'mysql') ? 'utf8mb4' : 'utf8';
+        $this->envFileUpdater->databaseCharset = 'mysql' === substr($databaseUrl, 0, 5) ? 'utf8mb4' : 'utf8';
 
         // MAILER_DSN
         $mailerDsn = $this->container->getParameter('eccube_mailer_dsn');

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -384,7 +384,7 @@ class ProductController extends AbstractController
             $image = \realpath($dir.'/'.$request->query->get('source'));
             $dir = \realpath($dir);
 
-            if (\is_file($image) && \str_starts_with($image, $dir)) {
+            if (\is_file($image) && preg_match('/^' . $dir . '/', $image)) {
                 $file = new \SplFileObject($image);
 
                 return $this->file($file, $file->getBasename());

--- a/src/Eccube/Controller/Admin/Setting/Shop/PaymentController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/PaymentController.php
@@ -123,10 +123,10 @@ class PaymentController extends AbstractController
             // ファイルアップロード
             $file = $form['payment_image']->getData();
             $fs = new Filesystem();
-            if ($file && $fs->exists($this->getParameter('eccube_temp_image_dir').'/'.$file)) {
+            if ($file && $fs->exists($this->getParameter('eccube_temp_image_dir') . '/' . $file)) {
                 $fs->rename(
-                    $this->getParameter('eccube_temp_image_dir').'/'.$file,
-                    $this->getParameter('eccube_save_image_dir').'/'.$file
+                    $this->getParameter('eccube_temp_image_dir') . '/' . $file,
+                    $this->getParameter('eccube_save_image_dir') . '/' . $file
                 );
             }
 
@@ -191,7 +191,7 @@ class PaymentController extends AbstractController
                 throw new UnsupportedMediaTypeHttpException();
             }
 
-            $filename = date('mdHis').uniqid('_').'.'.$extension;
+            $filename = date('mdHis') . uniqid('_') . '.' . $extension;
             $image->move($this->getParameter('eccube_temp_image_dir'), $filename);
         }
         $event = new EventArgs(
@@ -225,10 +225,10 @@ class PaymentController extends AbstractController
         ];
 
         foreach ($dirs as $dir) {
-            $image = \realpath($dir.'/'.$request->query->get('source'));
+            $image = \realpath($dir . '/' . $request->query->get('source'));
             $dir = \realpath($dir);
 
-            if (\is_file($image) && \str_starts_with($image, $dir)) {
+            if (\is_file($image) && preg_match('/^' . $dir . '/', $image)) {
                 $file = new \SplFileObject($image);
 
                 return $this->file($file, $file->getBasename());
@@ -250,7 +250,7 @@ class PaymentController extends AbstractController
             throw new BadRequestHttpException();
         }
 
-        $tempFile = $this->eccubeConfig['eccube_temp_image_dir'].'/'.$request->getContent();
+        $tempFile = $this->eccubeConfig['eccube_temp_image_dir'] . '/' . $request->getContent();
         if (is_file($tempFile) && stripos(realpath($tempFile), $this->eccubeConfig['eccube_temp_image_dir']) === 0) {
             $fs = new Filesystem();
             $fs->remove($tempFile);

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -479,7 +479,7 @@ class InstallController extends AbstractController
             'ECCUBE_TEMPLATE_CODE' => 'default',
             'ECCUBE_LOCALE' => 'ja',
             'TRUSTED_HOSTS' => '^'.str_replace('.', '\\.', $request->getHost()).'$',
-            'DATABASE_CHARSET' => \str_starts_with($databaseUrl, 'mysql') ? 'utf8mb4' : 'utf8',
+            'DATABASE_CHARSET' => substr($databaseUrl, 0, 5) === 'mysql' ? 'utf8mb4' : 'utf8',
         ];
 
         $env = StringUtil::replaceOrAddEnv($env, $replacement);

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -479,7 +479,7 @@ class InstallController extends AbstractController
             'ECCUBE_TEMPLATE_CODE' => 'default',
             'ECCUBE_LOCALE' => 'ja',
             'TRUSTED_HOSTS' => '^'.str_replace('.', '\\.', $request->getHost()).'$',
-            'DATABASE_CHARSET' => substr($databaseUrl, 0, 5) === 'mysql' ? 'utf8mb4' : 'utf8',
+            'DATABASE_CHARSET' => 'mysql' === substr($databaseUrl, 0, 5) ? 'utf8mb4' : 'utf8',
         ];
 
         $env = StringUtil::replaceOrAddEnv($env, $replacement);


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
str_starts_withが使えるのはPHP8からなので修正しました。

https://www.php.net/manual/ja/function.str-starts-with.php

なんでテストが失敗しないのか不思議です。
インストーラーのテストを修正したいけどよくわかりませんでした。


## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
