### PR TITLE
テスト用Fixturesの生成でユニーク項目がユニークになるようにする

### DIFF
--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -201,6 +201,11 @@ class Generator
         $Member = new Member();
         if (is_null($username)) {
             $username = $faker->word;
+            do {
+                $loginId = $faker->word;
+            } while ($this->memberRepository->findBy(['login_id' => $loginId]));
+        } else {
+            $loginId = $username;
         }
         $Work = $this->entityManager->find(\Eccube\Entity\Master\Work::class, 1);
         $Authority = $this->entityManager->find(\Eccube\Entity\Master\Authority::class, 0);
@@ -211,7 +216,7 @@ class Generator
         $password = $this->passwordEncoder->encodePassword($password, $salt);
 
         $Member
-            ->setLoginId($username)
+            ->setLoginId($loginId)
             ->setName($username)
             ->setSalt($salt)
             ->setPassword($password)
@@ -236,7 +241,9 @@ class Generator
         $faker = $this->getFaker();
         $Customer = new Customer();
         if (is_null($email)) {
-            $email = $faker->safeEmail;
+            do {
+                $email = $faker->safeEmail;
+            } while ($this->customerRepository->findBy(['email' => $email]));
         }
         $phoneNumber = str_replace('-', '', $faker->phoneNumber);
         $Status = $this->entityManager->find(\Eccube\Entity\Master\CustomerStatus::class, CustomerStatus::ACTIVE);
@@ -332,7 +339,9 @@ class Generator
         $faker = $this->getFaker();
         $Customer = new Customer();
         if (is_null($email)) {
-            $email = $faker->safeEmail;
+            do {
+                $email = $faker->safeEmail;
+            } while ($this->customerRepository->findBy(['email' => $email]));
         }
         $Pref = $this->entityManager->find(\Eccube\Entity\Master\Pref::class, $faker->numberBetween(1, 47));
         $phoneNumber = str_replace('-', '', $faker->phoneNumber);
@@ -378,6 +387,7 @@ class Generator
         $ProductStatus = $this->entityManager->find(\Eccube\Entity\Master\ProductStatus::class, \Eccube\Entity\Master\ProductStatus::DISPLAY_SHOW);
         $SaleType = $this->entityManager->find(\Eccube\Entity\Master\SaleType::class, 1);
         $DeliveryDurations = $this->durationRepository->findAll();
+        $ProductCodesGenerated = [];
 
         $Product = new Product();
         if (is_null($product_name)) {
@@ -443,8 +453,12 @@ class Generator
             $this->entityManager->persist($ProductStock);
             $this->entityManager->flush();
             $ProductClass = new ProductClass();
+            do {
+                $ProductCode = $faker->word;
+            } while (in_array($ProductCode, $ProductCodesGenerated));
+            $ProductCodesGenerated[] = $ProductCode;
             $ProductClass
-                ->setCode($faker->word)
+                ->setCode($ProductCode)
                 ->setCreator($Member)
                 ->setStock($ProductStock->getStock())
                 ->setProductStock($ProductStock)
@@ -488,8 +502,12 @@ class Generator
         } else {
             $ProductClass->setVisible(true);
         }
+        do {
+            $ProductCode = $faker->word;
+        } while (in_array($ProductCode, $ProductCodesGenerated));
+        $ProductCodesGenerated[] = $ProductCode;
         $ProductClass
-            ->setCode($faker->word)
+            ->setCode($ProductCode)
             ->setCreator($Member)
             ->setStock($ProductStock->getStock())
             ->setProductStock($ProductStock)
@@ -823,10 +841,16 @@ class Generator
         $faker = $this->getFaker();
         /** @var Page $Page */
         $Page = $this->pageRepository->newPage();
+        do {
+            $url = $faker->word;
+        } while ($this->pageRepository->findBy(['url' => $url]));
+        do {
+            $filename = $faker->word;
+        } while ($this->pageRepository->findBy(['file_name' => $filename]));
         $Page
             ->setName($faker->word)
-            ->setUrl($faker->word)
-            ->setFileName($faker->word)
+            ->setUrl($url)
+            ->setFileName($filename)
             ->setAuthor($faker->word)
             ->setDescription($faker->word)
             ->setKeyword($faker->word)


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#5613
[4.2] ランダムで落ちるテストを修正したい
関連です。

Fixturesの生成時に、Customerのメールアドレスなど、本来ユニークな値が生成されなければならない項目があります。
これまではここがFakerのword生成頼りになっていたのですが、生成候補に限りがあるため、稀に重複する値が生成されておりました。

重複する値が生成されてしまった場合には値がユニークになるまで再生成するようにコードを修正しました。

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

NonMember のメールアドレスまでユニークにする必要性はなかったかもしれません。
が、NonMemberのメールアドレスの重複で問題が起きるようなら、それはそれで別のテストを作るべき項目と考えられますので、とりあえずユニークになるようにしました。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
