### PR TITLE
アップロードファイル名の拡張子が複数ある場合に最後のものだけを残す

### DIFF
--- a/src/Eccube/Controller/Admin/Content/FileController.php
+++ b/src/Eccube/Controller/Admin/Content/FileController.php
@@ -299,6 +299,11 @@ class FileController extends AbstractController
         /** @var UploadedFile $file */
         foreach ($data['file'] as $file) {
             $filename = $this->convertStrToServer($file->getClientOriginalName());
+            // 拡張子が複数ある場合は最後のものだけを残す
+            $filename_parts = explode('.', $filename);
+            if (count($filename_parts) > 2) {
+                $filename = $filename_parts[0] . '.' . $filename_parts[array_key_last($filename_parts)];
+            }
             try {
                 // フォルダの存在チェック
                 if (is_dir(rtrim($nowDir, '/\\').\DIRECTORY_SEPARATOR.$filename)) {

--- a/tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php
@@ -156,6 +156,10 @@ class FileControllerTest extends AbstractAdminWebTestCase
         $contents2 = '<html><body><h1>test2</h1></body></html>';
         file_put_contents($filepath2, $contents2);
 
+        $filepath4 = $this->getUserDataDir().'/../ddd.php.html';
+        $contents4 = '<html><body><h1>test4</h1></body></html>';
+        file_put_contents($filepath4, $contents4);
+
         $file1 = new UploadedFile(
             realpath($filepath1),          // file path
             'aaa.html',         // original name
@@ -170,6 +174,13 @@ class FileControllerTest extends AbstractAdminWebTestCase
             null,               // error
             true                // test mode
         );
+        $file4 = new UploadedFile(
+            realpath($filepath4),          // file path
+            'ddd.php.html',         // original name
+            'text/html',        // mimeType
+            null,               // error
+            true                // test mode
+        );
         $crawler = $this->client->request(
             'POST',
             $this->generateUrl('admin_content_file'),
@@ -177,17 +188,18 @@ class FileControllerTest extends AbstractAdminWebTestCase
                 'form' => [
                     '_token' => 'dummy',
                     'create_file' => '',
-                    'file' => [$file1, $file2],
+                    'file' => [$file1, $file2, $file4],
                 ],
                 'mode' => 'upload',
                 'now_dir' => '/',
             ],
-            ['form' => ['file' => [$file1, $file2]]]
+            ['form' => ['file' => [$file1, $file2, $file4]]]
         );
 
         $this->assertTrue($this->client->getResponse()->isSuccessful());
         $this->assertTrue(file_exists($this->getUserDataDir().'/aaa.html'));
         $this->assertTrue(file_exists($this->getUserDataDir().'/bbb.html'));
+        $this->assertTrue(file_exists($this->getUserDataDir().'/ddd.html'));
     }
 
     public function testUploadIgnoreFiles()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
アップロードファイル名の拡張子が複数ある場合（例：hoge.fuga.txt）に、最後のものだけを残して他の途中の拡張子を削除する（例：hoge.txt）

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
