### PR TITLE
[4.2] Docker ホストのユーザーの UID と GID を www-data にマッピングする

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,5 +2,8 @@ version: '3'
 
 services:
   ec-cube:
+    environment:
+      USER_ID: ${UID:-}
+      GROUP_ID: ${GID:-}
     volumes:
       - ".:/var/www/html:cached"

--- a/dockerbuild/docker-php-entrypoint
+++ b/dockerbuild/docker-php-entrypoint
@@ -1,6 +1,13 @@
 #!/bin/sh
 set -e
 
+if [ -n "${USER_ID}" ]; then
+    usermod -u ${USER_ID} -o www-data
+fi
+if [ -n "${GROUP_ID}" ]; then
+    groupmod -g ${GROUP_ID} www-data
+fi
+
 if [ ! -d /var/www/html/vendor/bin ]; then
     composer install \
         --no-scripts \


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
#5369 の影響で、 Linux 及び Windows(WSL2) の Docker においてホストのディレクトリをマウントした場合、 www-data の UID/GID に強制的に変更されてしまうようになった。
そのままではファイルの編集ができなくなってしまい、開発用途では大変使いづらいため、ホストのUID/GID を www-data ユーザーにマッピングする。
macOS の場合は影響ありません。

以下のように docker-compose コマンドを実行することで、ホストのユーザー
の UID 及び GID を www-data ユーザーにマッピングできる

```
UID=${UID} GID=${GID} docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
```

.bashrc などに設定しておけば、毎回指定しなくてもよい

```
echo "export UID=${UID} GID=${GID}" >> .bashrc
```

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
1. docker-compose.dev.yml にて UID/GID の値を環境変数へ渡す
2. dockerbuild/docker-php-entrypoint にて、 www-data の UID/GID を環境変数の値に変更

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
Docker for Windows(WSL2) にて、ホスト側ファイルの UID/GID が変更されないことを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
