### PR TITLE
注文時に会員ポイントの使用をオフにしても、購入を完了することができますくなる 不具合の修正 

### DIFF
--- a/app/config/eccube/packages/purchaseflow.yaml
+++ b/app/config/eccube/packages/purchaseflow.yaml
@@ -100,6 +100,7 @@ services:
                 - '@Eccube\Service\PurchaseFlow\Processor\PaymentChargeChangeValidator' # 手数料の変更検知
                 - '@Eccube\Service\PurchaseFlow\Processor\DeliveryFeeChangeValidator' # 送料の変更検知
                 - '@Eccube\Service\PurchaseFlow\Processor\TaxRateChangeValidator' # 税率の変更検知
+                - '@Eccube\Service\PurchaseFlow\Processor\PointSettingChangeValidator'
 
     eccube.purchase.flow.shopping.purchase:
         class: Doctrine\Common\Collections\ArrayCollection

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -390,6 +390,7 @@ front.shopping.payment_method_unselected: Please select the payment method.
 front.shopping.not_available_payment_method: The payment method you have selected is not available.
 front.shopping.payment_method_not_fount: Sorry, you have no payment options. If you have selected multiple delivery methods, you can only select the same payment option for them all.
 front.under_maintenance: The site is currently under maintenance.
+front.shopping.point_setting_change: Sorry, the points cannot be used. Please check the total amount.
 
 #====================================================================================
 # Admin Console

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -390,6 +390,7 @@ front.shopping.payment_method_unselected: お支払い方法を選択してく�
 front.shopping.not_available_payment_method: 選択したお支払い方法はご利用できません。
 front.shopping.payment_method_not_fount: 選択できるお支払い方法がありません。配送方法が異なる場合は同じ配送方法を選んでください。
 front.under_maintenance: メンテナンスモードが有効になっています。
+front.shopping.point_setting_change: 申し訳ありませんが、ポイントは使用できません。合計金額をご確認ください。
 
 #====================================================================================
 # 管理画面

--- a/src/Eccube/Service/PurchaseFlow/Processor/PointSettingChangeValidator.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PointSettingChangeValidator.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\PurchaseFlow\Processor;
+
+use Eccube\Entity\ItemHolderInterface;
+use Eccube\Entity\Order;
+use Eccube\Service\PurchaseFlow\InvalidItemException;
+use Eccube\Service\PurchaseFlow\ItemHolderValidator;
+use Eccube\Service\PurchaseFlow\PurchaseContext;
+use Eccube\Service\PointHelper;
+
+/**
+ * ポイント利用状況やポイント利用設定の確認
+ */
+class PointSettingChangeValidator extends ItemHolderValidator
+{
+    /**
+     * @param ItemHolderInterface $itemHolder
+     * @param PurchaseContext $context
+     *
+     * @throws InvalidItemException
+     */
+
+    /**
+     * @var PointHelper
+     */
+    protected $pointHelper;
+
+    /**
+     * PointSettingChangeValidator constructor.
+     *
+     * @param PointHelper $pointHelper
+     */
+    public function __construct(PointHelper $pointHelper)
+    {
+        $this->pointHelper = $pointHelper;
+    }
+
+    protected function validate(ItemHolderInterface $itemHolder, PurchaseContext $context)
+    {
+        if (!$itemHolder instanceof Order) {
+            return;
+        }
+
+        /** @var Order $originHolder */
+        $originHolder = $context->getOriginHolder();
+
+        // 受注の生成直後はチェックしない
+        if (!$originHolder->getOrderNo()) {
+            return;
+        }
+
+        //「ポイント機能」の設定と使用中のポイントを確認する
+        if (!$this->pointHelper->isPointEnabled() && $itemHolder->getUsePoint() > 0) {
+            $this->throwInvalidItemException('front.shopping.point_setting_change');
+        }
+    }
+}

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PointSettingChangeValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PointSettingChangeValidatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Service\PurchaseFlow\Processor;
+
+use Eccube\Entity\BaseInfo;
+use Eccube\Service\PurchaseFlow\Processor\PointSettingChangeValidator;
+use Eccube\Service\PurchaseFlow\PurchaseContext;
+use Eccube\Tests\EccubeTestCase;
+
+class PointSettingChangeValidatorTest extends EccubeTestCase
+{
+    /** @var BaseInfo */
+    private $BaseInfo;
+
+    /**
+     * @var PointSettingChangeValidator
+     */
+    private $validator;
+
+    /**
+     * @var $Order
+     */
+    private $Order;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = static::getContainer()->get(PointSettingChangeValidator::class);
+        $Customer = $this->createCustomer();
+        $this->Order = $this->createOrder($Customer);
+        $this->BaseInfo = $this->entityManager->find(BaseInfo::class, 1);
+        $this->BaseInfo->setOptionPoint(true);
+        $this->Order->setUsePoint(100);
+    }
+
+    public function testInstance()
+    {
+        self::assertInstanceOf(PointSettingChangeValidator::class, $this->validator);
+    }
+
+    public function testValidatePointSettingDisable()
+    {
+        $CloneOrder = clone $this->Order;
+        $this->BaseInfo->setOptionPoint(false);
+        $result = $this->validator->execute($this->Order, new PurchaseContext($CloneOrder));
+        self::assertTrue($result->isError());
+    }
+}


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
以下のissueの対応です。
[https://github.com/EC-CUBE/ec-cube/issues/5713](https://github.com/EC-CUBE/ec-cube/issues/5713) 注文時に会員ポイントの使用をオフにしても、購入を完了することができます

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

この問題を修正し、次のような機能テストを行いました。


- ポイントを使用してからポイント機能をオフにする
1. 顧客がポイントを使用してもエラーを表示し、管理者がポイント使用機能を無効にする
![image](https://user-images.githubusercontent.com/105194449/189859626-ccfb9b0a-78da-4149-b1d8-92fae75b2bb6.png)

2. その後、顧客はショッピング カート ページにリダイレクトされ、ショッピングを続行します。
![image](https://user-images.githubusercontent.com/105194449/189859946-61d811cc-54df-49ae-835e-281e8b3e9812.png)


- Unit Test
![image](https://user-images.githubusercontent.com/105194449/189859047-36363656-8fb1-4114-89e5-218e8c153d5a.png)



## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
