### PR TITLE
仮会員に登録用メールを再送した際に用いる認証URLは送信毎に再生成するように修正

### DIFF
--- a/src/Eccube/Controller/Admin/Customer/CustomerController.php
+++ b/src/Eccube/Controller/Admin/Customer/CustomerController.php
@@ -194,6 +194,10 @@ class CustomerController extends AbstractController
         if (is_null($Customer)) {
             throw new NotFoundHttpException();
         }
+        $secretKey = $this->customerRepository->getUniqueSecretKey();
+        $Customer->setSecretKey($secretKey);
+        $this->entityManager->persist($Customer);
+        $this->entityManager->flush();
 
         $activateUrl = $this->generateUrl(
             'entry_activate',

--- a/tests/Eccube/Tests/Web/Admin/Customer/CustomerControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Customer/CustomerControllerTest.php
@@ -223,6 +223,34 @@ class CustomerControllerTest extends AbstractAdminWebTestCase
     }
 
     /**
+     * testResend run multiple times
+     */
+    public function testResendWithMultipleTimes()
+    {
+        $Customer = $this->createCustomer();
+        $this->client->request(
+            'GET',
+            $this->generateUrl('admin_customer_resend', ['id' => $Customer->getId()])
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('admin_customer')));
+        $MessageFistTime = $this->getMailerMessage(0);
+
+        $this->client->request(
+            'GET',
+            $this->generateUrl('admin_customer_resend', ['id' => $Customer->getId()])
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('admin_customer')));
+        $MessageSecondTime = $this->getMailerMessage(0);
+
+        //test mail resend to 仮会員. (シークレットキーが毎回変わることを確認)
+        $FirstTimeMail       = $MessageFistTime->toString();
+        $SecondTimeMail      = $MessageSecondTime->toString();
+        $secretKeyFirstTime  = mb_substr($FirstTimeMail, mb_strrpos($FirstTimeMail, '/activate/') + 10, 32);
+        $secretKeySecondTime = mb_substr($SecondTimeMail, mb_strrpos($SecondTimeMail, '/activate/') + 10, 32);
+        $this->assertNotEquals($secretKeyFirstTime, $secretKeySecondTime);
+    }
+
+    /**
      * testDelete
      */
     public function testDelete()


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
#5667 に対応しました。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 仮メールを再送する際にeccubedb.dtb_customer.secret_keyを更新してから再送する。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
一度目のメール
<img width="718" alt="image" src="https://user-images.githubusercontent.com/49148169/194105700-e29ae5da-6074-48fd-a1da-1e7051184372.png">

二度目のメール
<img width="691" alt="image" src="https://user-images.githubusercontent.com/49148169/194105903-c1523949-db28-48fc-9ff7-645da23a431d.png">

登録完了画面
<img width="1079" alt="image" src="https://user-images.githubusercontent.com/49148169/194106323-f69af9a7-618a-465f-b35d-2c356c74dd4a.png">


## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
