### PR TITLE
ECCUBE_PACKAGE_API_TYPE を追加

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -12,6 +12,7 @@ parameters:
     env(ECCUBE_COOKIE_LIFETIME): '0'
     env(ECCUBE_GC_MAXLIFETIME): '1440'
     env(ECCUBE_PACKAGE_API_URL): 'https://package-api-c2.ec-cube.net/v42'
+    env(ECCUBE_PACKAGE_API_TYPE): 'composer'
     env(ECCUBE_OWNERS_STORE_URL): 'https://www.ec-cube.net'
     env(ECCUBE_MAINTENANCE_FILE_PATH): '%kernel.project_dir%/.maintenance'
     env(ECCUBE_2FA_ENABLED): '1'
@@ -123,6 +124,7 @@ parameters:
     eccube_rfc_email_check: false
     eccube_email_len: 254
     eccube_package_api_url: '%env(ECCUBE_PACKAGE_API_URL)%'
+    eccube_package_api_type: '%env(ECCUBE_PACKAGE_API_TYPE)%'
     # 注文番号のフォーマット. 以下のフォーマットが利用可能です. フォーマットを空にした場合, dtb_order.idを出力します.
     # {yyyy} : 西暦(4桁)
     # {yy}: 西暦(2桁)

--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -386,7 +386,7 @@ class ComposerApiService implements ComposerServiceInterface
         $this->workingDir = $this->workingDir ? $this->workingDir : $this->eccubeConfig['kernel.project_dir'];
         $url = $this->eccubeConfig['eccube_package_api_url'];
         $json = json_encode([
-            'type' => 'composer',
+            'type' => $this->eccubeConfig['eccube_package_api_type'],
             'url' => $url,
             'options' => [
                 'http' => [


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
従来、オーナーズストアのプラグインをテストするには [mock-package-api](https://doc4.ec-cube.net/plugin_mock_package_api) を使う必要があり、インストールの度に tgz に固めないといけなかったり、設定が煩雑だったり、プラグインを削除したら .git まで消しとんで泣きそうになったりしていましたが、

以下のように `.env` に追加すると, `../Recommend-plugin` にあるプラグインをコマンドラインでインストールできるようになってプラグイン開発が捗るようになります。

```
ECCUBE_PACKAGE_API_TYPE=path
ECCUBE_PACKAGE_API_URL=../Recommend-plugin
```

app/Plugin から ECCUBE_PACKAGE_API_URL で指定したディレクトリにシンボリックリンクされるので、間違ってプラグインを消したりしても、元のプラグインが消えることはありません。

```
ls -al app/Plugin
合計 48
drwxr-sr-x 12 nanasess nanasess 4096 10月 17 16:08 .
drwxr-sr-x 10 nanasess nanasess 4096  7月  5 09:54 ..
lrwxrwxrwx  1 nanasess nanasess   26 10月 17 16:08 Recommend42 -> ../../../Recommend-plugin/
```

複数のプラグインを使用したい場合は、以下のように composer.json にリポジトリを追加すればよい
```json
"repositories": {
        "eccube": {
            "type": "path",
            "url": "../Recommend-plugin",
            "options": {
                "http": {
                    "header": ["X-ECCUBE-KEY: aaa"]
                }
            }
        },
        // 以下を追加
        "maker": {
            "type": "path",
            "url": "../maker-plugin"
        }
    }
```
## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
ECCUBE_PACKAGE_API_TYPE を追加し、package-api で使用するリポジトリの type を指定できるようにする

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
- Composer API でプラグイン一覧を返すことができないので、管理画面の **プラグインを探す** からはインストールできない(有効化/無効化/削除は可能)
- 開発用途なので、本番環境での使用は推奨しません
 
## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
1. .env に以下を追加
    ```
    ECCUBE_PACKAGE_API_TYPE=path
    ECCUBE_PACKAGE_API_URL=../Recommend-plugin
    ```
2. ec-cube と同じ階層におすすめ商品プラグインを clone
    ```
    cd ../
    git clone https://github.com/EC-CUBE/Recommend-plugin.git
    ``` 
3. 以下でおすすめ商品プラグインがインストールできることを確認
    ```
    bin/console eccube:plugin:require "ec-cube/recommend24"
    ```

インストール時に以下のようなエラーが出た場合は、
```
In PluginInstaller.php line 56:

  Undefined index: id
```
プラグインの composer.json に extra.id を追加してください。(id の値は重複しない数字であればOK)
```diff
diff --git a/composer.json b/composer.json
index 7e23bbd..2d1cf32 100644
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "ec-cube/plugin-installer": "^2.0"
   },
   "extra": {
-    "code": "Maker42"
+      "code": "Maker42",
+      "id": 2
   }
 }
```
## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
