### PR TITLE
`eccube:composer:require` コマンドに `--from` オプションを追加

### DIFF
--- a/src/Eccube/Command/ComposerRequireCommand.php
+++ b/src/Eccube/Command/ComposerRequireCommand.php
@@ -17,6 +17,7 @@ use Eccube\Service\Composer\ComposerApiService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ComposerRequireCommand extends Command
@@ -37,7 +38,8 @@ class ComposerRequireCommand extends Command
     protected function configure()
     {
         $this->addArgument('package', InputArgument::REQUIRED)
-            ->addArgument('version', InputArgument::OPTIONAL);
+            ->addArgument('version', InputArgument::OPTIONAL)
+            ->addOption('from', null, InputOption::VALUE_OPTIONAL, 'Path of composer repository');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -46,7 +48,8 @@ class ComposerRequireCommand extends Command
         if ($input->getArgument('version')) {
             $packageName .= ':'.$input->getArgument('version');
         }
-        $this->composerService->execRequire($packageName, $output);
+
+        $this->composerService->execRequire($packageName, $output, $input->getOption('from'));
 
         return 0;
     }

--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -94,6 +94,7 @@ class ComposerApiService implements ComposerServiceInterface
      *
      * @param string $packageName format "foo/bar foo/bar:1.0.0"
      * @param OutputInterface|null $output
+     * @param string|null $from
      *
      * @return string
      *
@@ -101,11 +102,11 @@ class ComposerApiService implements ComposerServiceInterface
      * @throws \Doctrine\ORM\NoResultException
      * @throws \Doctrine\ORM\NonUniqueResultException
      */
-    public function execRequire($packageName, $output = null)
+    public function execRequire($packageName, $output = null, $from = null)
     {
         $packageName = explode(' ', trim($packageName));
 
-        $this->init();
+        $this->init(null, $packageName, $from);
         $this->execConfig('allow-plugins.symfony/flex', ['false']);
 
         try {
@@ -366,12 +367,14 @@ class ComposerApiService implements ComposerServiceInterface
      * Init composer console application
      *
      * @param BaseInfo|null $BaseInfo
+     * @param string[] $packageName
+     * @param string|null $from
      *
      * @throws PluginException
      * @throws \Doctrine\ORM\NoResultException
      * @throws \Doctrine\ORM\NonUniqueResultException
      */
-    private function init($BaseInfo = null)
+    private function init($BaseInfo = null, $packageName = [], $from = null)
     {
         $BaseInfo = $BaseInfo ?: $this->baseInfoRepository->get();
 
@@ -385,7 +388,8 @@ class ComposerApiService implements ComposerServiceInterface
         $this->initConsole();
         $this->workingDir = $this->workingDir ? $this->workingDir : $this->eccubeConfig['kernel.project_dir'];
         $url = $this->eccubeConfig['eccube_package_api_url'];
-        $json = json_encode([
+        $config = $this->getConfig();
+        $eccube_repository = [
             'type' => 'composer',
             'url' => $url,
             'options' => [
@@ -393,9 +397,33 @@ class ComposerApiService implements ComposerServiceInterface
                     'header' => ['X-ECCUBE-KEY: '.$BaseInfo->getAuthenticationKey()],
                 ],
             ],
-        ]);
+        ];
+        $exclude = [];
+        if (array_key_exists('eccube', $config['repositories'])
+            && array_key_exists('exclude', $config['repositories']['eccube'])) {
+            $exclude = array_map(
+                function ($package) {
+                    return trim($package);
+                },
+                explode(',', str_replace(['[', ']'], '', $config['repositories']['eccube']['exclude']))
+            );
+        }
+
+        if ($from !== null) {
+            $exclude = array_unique(array_merge($exclude, [trim(current($packageName))]));
+            $this->execConfig('repositories.'.str_replace(['.', '/'], '', strtolower($from)), [json_encode([
+                'type' => 'path',
+                'url' => $from,
+            ])]);
+        }
+
+        if (!empty($exclude)) {
+            $eccube_repository['exclude'] = $exclude;
+        }
+
         $this->execConfig('platform.php', [PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION]);
-        $this->execConfig('repositories.eccube', [$json]);
+        $this->execConfig('repositories.eccube', [json_encode($eccube_repository)]);
+
         if (strpos($url, 'http://') === 0) {
             $this->execConfig('secure-http', ['false']);
         }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
従来、オーナーズストアのプラグインをテストするには [mock-package-api](https://doc4.ec-cube.net/plugin_mock_package_api) を使う必要があり、インストールの度に tgz に固めないといけなかったり、設定が煩雑だったり、プラグインを削除したら .git まで消しとんで泣きそうになったりしていましたが、

以下のように `eccube:composer:require` を実行すると, `../Recommend-plugin` にあるプラグインをコマンドラインでインストールできるようになってプラグイン開発が捗ります。

```
bin/console eccube:composer:require ec-cube/recommend42 --from=../Recommend-plugin
```

app/Plugin から `--from`  で指定したディレクトリにシンボリックリンクされるので、間違ってプラグインを消したりしても、元のプラグインが消えることはありません。

```
ls -al app/Plugin
合計 48
drwxr-sr-x 12 nanasess nanasess 4096 10月 17 16:08 .
drwxr-sr-x 10 nanasess nanasess 4096  7月  5 09:54 ..
lrwxrwxrwx  1 nanasess nanasess   26 10月 17 16:08 Recommend42 -> ../../../Recommend-plugin/
```

`--from` で追加したパッケージは、 package-api のリポジトリから取得されなくなり、 require/update/remove は `--from` で指定したパスを対象に実行されます

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- `eccube:composer:require`  に `--from=<repository path>` オプションを追加する
- `--from` で指定したパスを composer.json の repository に追加し、 対象のパッケージを package-api の exclude へ追加する
- `bin/console eccube:composer:require ec-cube/recommend42 --from=../Recommend-plugin` を実行すると、composer.json の repositories は以下のように変更されます
```json
    "repositories": {
        "recommend-plugin": {
            "type": "path",
            "url": "../Recommend-plugin"
        },
        "eccube": {
            "type": "composer",
            "url": "https://package-api-c2.ec-cube.net/v42",
            "options": {
                "http": {
                    "header": ["X-ECCUBE-KEY: aaa"]
                }
            },
            "exclude": ["ec-cube/recommend42"]
        }
    }
```
- `--from` で追加したリポジトリを削除したり、再び package-api から取得したい場合は、 composer.json の repositories を初期状態に戻します

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
- Composer API でプラグイン一覧を返すことができないので、管理画面の **プラグインを探す** からはインストールできない(有効化/無効化/削除は可能)
- 開発用途なので、本番環境での使用は推奨しません
- 追加されたリポジトリや `exclude` を削除する場合は、 composer.json を修正します

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
1. ec-cube と同じ階層におすすめ商品プラグインを clone
    ```
    cd ../
    git clone https://github.com/EC-CUBE/Recommend-plugin.git
    ``` 
2. 以下でおすすめ商品プラグインがインストールできることを確認
    ```
    bin/console eccube:plugin:require "ec-cube/recommend24" --from=../Recommend-plugin
    ```
3. シンボリックリンクでプラグインが追加されているのを確認
    ```
    ls -al app/Plugin
    drwxr-sr-x 12 nanasess nanasess 4096 10月 17 16:08 .
    drwxr-sr-x 10 nanasess nanasess 4096  7月  5 09:54 ..
    lrwxrwxrwx  1 nanasess nanasess   26 10月 17 16:08 Recommend42 -> ../../../Recommend-plugin/
    ```
インストール時に以下のようなエラーが出た場合は、
```
In PluginInstaller.php line 56:

  Undefined index: id
```
プラグインの composer.json に extra.id を追加してください。(id の値は重複しない数字であればOK)
```diff
diff --git a/composer.json b/composer.json
index 7e23bbd..2d1cf32 100644
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "ec-cube/plugin-installer": "^2.0"
   },
   "extra": {
-    "code": "Maker42"
+      "code": "Maker42",
+      "id": 2
   }
 }
```
## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
