### PR TITLE
大文字小文字を区別するファイルシステムで eccube:composer:remove が失敗するのを修正

### DIFF
--- a/src/Eccube/Service/Composer/ComposerApiService.php
+++ b/src/Eccube/Service/Composer/ComposerApiService.php
@@ -424,8 +424,21 @@ class ComposerApiService implements ComposerServiceInterface
 
     private function dropTableToExtra($packageNames)
     {
+        $projectRoot = $this->eccubeConfig->get('kernel.project_dir');
+
         foreach (explode(' ', trim($packageNames)) as $packageName) {
-            $pluginCode = basename($packageName);
+            $pluginCode = null;
+            // 大文字小文字を区別するファイルシステムを考慮して, ディレクトリ名からプラグインコードを取得する
+            foreach (glob($projectRoot.'/app/Plugin/*', GLOB_ONLYDIR) as $dir) {
+                if (strtolower(basename($dir)) === strtolower(basename($packageName))) {
+                    $pluginCode = basename($dir);
+                    break;
+                }
+            }
+            if ($pluginCode === null) {
+                throw new PluginException($packageName.' not found');
+            }
+
             $this->pluginContext->setCode($pluginCode);
             $this->pluginContext->setUninstall();
 


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
大文字小文字を区別するファイルシステムの環境で、 `eccube:composer:remove` が失敗する。
Composer v2 から、パッケージ名はすべて小文字が強制されるようになったが、大文字小文字を区別するファイルシステムでは `ec-cube/<プラグインコード>` としないと `eccube:composer:remove`  が失敗し、削除できない。

```shell
## Composer v2 では正しいパッケージ名だが、大文字小文字を区別するファイルシステムでは削除に失敗する
bin/console eccube:composer:remove "ec-cube/sitekit42"

In PluginContext.php line 74:
  /home/nanasess/git-repos/ec-cube/app/Plugin/sitekit42/composer.json not found.

eccube:composer:remove <package>

## ec-cube/<Plugin Code> を指定すれば削除可能だが、 Composer v2 の仕様とは異なる
bin/console eccube:composer:remove "ec-cube/SiteKit42"

[51.7MiB/0.00s] ./composer.json has been updated
[54.4MiB/0.04s] Running composer update ec-cube/sitekit42
[55.6MiB/0.05s] Loading composer repositories with package information
[56.6MiB/0.06s] Updating dependencies
[58.2MiB/0.08s] Lock file operations: 0 installs, 0 updates, 8 removals
[58.2MiB/0.08s]   - Removing ec-cube/sitekit42 (4.2.2)
...snip
```

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
`ec-cube/SiteKit42` または `ec-cube/sitekit42` のどちらでも削除できるよう修正

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
`ComposerApiService::execRemove` をコールした段階ではプラグインコードを取得できないため、 `app/Plugin` 以下のディレクトリ名からプラグインコードを取得しています

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
`ec-cube/SiteKit42` または `ec-cube/sitekit42` のどちらでも削除できることを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
