### PR TITLE
[4.2] 商品規格の初期化時は物理削除する

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductClassController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductClassController.php
@@ -13,6 +13,7 @@
 
 namespace Eccube\Controller\Admin\Product;
 
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\ORM\NoResultException;
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\ClassName;
@@ -206,22 +207,34 @@ class ProductClassController extends AbstractController
                 'Product' => $Product,
             ]);
 
-            // デフォルト規格のみ有効にする
-            foreach ($ProductClasses as $ProductClass) {
-                $ProductClass->setVisible(false);
-            }
-            foreach ($ProductClasses as $ProductClass) {
-                if (null === $ProductClass->getClassCategory1() && null === $ProductClass->getClassCategory2()) {
-                    $ProductClass->setVisible(true);
-                    break;
+            try {
+                // デフォルト規格のみ有効にし、他は削除する
+                foreach ($ProductClasses as $ProductClass) {
+                    $ProductClass->setVisible(false);
                 }
+                foreach ($ProductClasses as $ProductClass) {
+                    if (null === $ProductClass->getClassCategory1() && null === $ProductClass->getClassCategory2()) {
+                        $ProductClass->setVisible(true);
+                        break;
+                    }
+                }
+                foreach ($ProductClasses as $ProductClass) {
+                    if (!$ProductClass->isVisible()) {
+                        $this->entityManager->remove($ProductClass);
+                    }
+                }
+
+                $this->entityManager->flush();
+
+                $this->addSuccess('admin.product.reset_complete', 'admin');
+
+                $cacheUtil->clearDoctrineCache();
+            } catch (ForeignKeyConstraintViolationException $e) {
+                log_error('商品規格の初期化失敗', [$e]);
+
+                $message = trans('admin.common.delete_error_foreign_key', ['%name%' => trans('admin.product.product_class')]);
+                $this->addError($message, 'admin');
             }
-
-            $this->entityManager->flush();
-
-            $this->addSuccess('admin.product.reset_complete', 'admin');
-
-            $cacheUtil->clearDoctrineCache();
         }
 
         if ($request->get('return_product_list')) {


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
商品規格を初期化した際、論理削除だと無駄なデータが残り続ける
- Fixes https://github.com/EC-CUBE/ec-cube/issues/5766
- Fixes #5698 

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- 商品規格初期化時は物理削除する
- 外部参照制約エラーになった場合は、エラーメッセージを表示する
  - 従来の仕様では、既に受注の入った商品規格を初期化しても非表示となるだけなのでエラーとならなかった。
  - 既に受注の入った商品規格を初期化するとデータの不整合を許すことになるため、エラーとなるよう変更しました

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
ユニットテストを追加

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
