### PR TITLE
商品CSVダウンロードボタンを「商品CSV」と「商品CSV(非表示の商品規格を含む)」に分ける

### DIFF
--- a/codeception/_support/Page/Admin/ProductManagePage.php
+++ b/codeception/_support/Page/Admin/ProductManagePage.php
@@ -262,9 +262,11 @@ class ProductManagePage extends AbstractAdminPageStyleGuide
         return $this;
     }
 
-    public function CSVダウンロード()
+    public function CSVダウンロード($selector = ['id' => 'productCsvDownload'])
     {
-        $this->tester->click('.c-contentsArea__cols .row div:nth-child(2) div:nth-child(2) a:nth-child(1)');
+        $this->tester->click(['id' => 'csvDownloadDropDown']);
+        $this->tester->waitForElementVisible($selector);
+        $this->tester->click($selector);
 
         return $this;
     }

--- a/codeception/_support/Page/Admin/ProductManagePage.php
+++ b/codeception/_support/Page/Admin/ProductManagePage.php
@@ -273,7 +273,7 @@ class ProductManagePage extends AbstractAdminPageStyleGuide
 
     public function CSV出力項目設定()
     {
-        $this->tester->click('.c-contentsArea__cols .row div:nth-child(2) div:nth-child(2) a:nth-child(2)');
+        $this->tester->click('#form_bulk > div > div.col-5.text-end > div:nth-child(2) > div > div > a');
 
         return $this;
     }

--- a/codeception/acceptance/EA03ProductCest.php
+++ b/codeception/acceptance/EA03ProductCest.php
@@ -139,7 +139,28 @@ class EA03ProductCest
         $Products = $findProducts();
         ProductManagePage::go($I)
             ->検索()
-            ->CSVダウンロード();
+            ->CSVダウンロード(['id' => 'productCsvDownloadVisibleOnly']);
+
+        $I->see('検索結果：'.count($Products).'件が該当しました', ProductManagePage::$検索結果_メッセージ);
+
+        $ProductCSV = $I->getLastDownloadFile('/^product_\d{14}\.csv$/');
+        $I->assertGreaterOrEquals(count($Products), count(file($ProductCSV)), '検索結果以上の行数があるはず');
+    }
+
+    /**
+     * @env firefox
+     * @env chrome
+     * @group vaddy
+     */
+    public function product_CSV出力_非表示の商品規格(AcceptanceTester $I)
+    {
+        $I->wantTo('EA0301-UC02-T01 CSV出力');
+
+        $findProducts = Fixtures::get('findProducts');
+        $Products = $findProducts();
+        ProductManagePage::go($I)
+            ->検索()
+            ->CSVダウンロード(['id' => 'productCsvDownload']);
 
         $I->see('検索結果：'.count($Products).'件が該当しました', ProductManagePage::$検索結果_メッセージ);
 

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Eccube\Common\Constant;
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\BaseInfo;
+use Eccube\Entity\Csv;
 use Eccube\Entity\ExportCsvRow;
 use Eccube\Entity\Master\CsvType;
 use Eccube\Entity\Master\ProductStatus;
@@ -1010,7 +1011,7 @@ class ProductController extends AbstractController
                 $ProductClasses = $Product->getProductClasses();
 
                 foreach ($ProductClasses as $ProductClass) {
-                    if ($ProductClass->isVisible() == false) {
+                    if ($request->get('product_class') === Csv::PRODUCT_CLASS_VISIBLE_ONLY && $ProductClass->isVisible() === false) {
                         // 非表示の商品規格は除外
                         continue;
                     }

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -1010,6 +1010,11 @@ class ProductController extends AbstractController
                 $ProductClasses = $Product->getProductClasses();
 
                 foreach ($ProductClasses as $ProductClass) {
+                    if ($ProductClass->isVisible() == false) {
+                        // 非表示の商品規格は除外
+                        continue;
+                    }
+
                     $ExportCsvRow = new ExportCsvRow();
 
                     // CSV出力項目と合致するデータを取得.

--- a/src/Eccube/Entity/Csv.php
+++ b/src/Eccube/Entity/Csv.php
@@ -27,6 +27,9 @@ if (!class_exists('\Eccube\Entity\Csv')) {
      */
     class Csv extends \Eccube\Entity\AbstractEntity
     {
+        /** @var string */
+        public const PRODUCT_CLASS_VISIBLE_ONLY = 'visible_only';
+
         /**
          * @var int
          *

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -707,6 +707,8 @@ admin.product.select__class1: Select option 1
 admin.product.select__class2: Select option 2
 admin.product.select__can_not_select_same_class: You are not allowed to select the same option as Option 1
 admin.product.unselected_class: Not selected
+admin.product.csv: Product CSV
+admin.product.csv.include_hidden_productclass: (Include hidden product classes)
 
 # Product CSV Templates
 admin.product.product_csv.product_id_col: Product ID

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -707,6 +707,8 @@ admin.product.select__class1: 規格1を選択してください
 admin.product.select__class2: 規格2を選択してください
 admin.product.select__can_not_select_same_class: 規格1と同じ規格は選択できません
 admin.product.unselected_class: 選択されていません
+admin.product.csv: 商品CSV
+admin.product.csv.include_hidden_productclass: (非表示の商品規格を含む)
 
 # 商品CSV雛形
 admin.product.product_csv.product_id_col: 商品ID

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -311,6 +311,9 @@ file that was distributed with this source code.
                                                     {{ 'admin.product.csv'|trans }}{{ 'admin.product.csv.include_hidden_productclass'|trans }}
                                                 </a>
                                             </div>
+                                            <a class="btn btn-ec-regular" href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_PRODUCT') }) }}">
+                                                <i class="fa fa-cog me-1 text-secondary"></i><span>{{ 'admin.setting.shop.csv_setting'|trans }}</span>
+                                            </a>
                                         </div>
                                     </div>
                                 </div>

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -298,12 +298,20 @@ file that was distributed with this source code.
                                 </div>
                                 <div class="d-inline-block">
                                     <div class="btn-group" role="group">
-                                        <a class="btn btn-ec-regular" href="{{ url('admin_product_export') }}">
-                                            <i class="fa fa-cloud-download me-1 text-secondary"></i><span>{{ 'admin.common.csv_download'|trans }}</span>
-                                        </a>
-                                        <a class="btn btn-ec-regular" href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_PRODUCT') }) }}">
-                                            <i class="fa fa-cog me-1 text-secondary"></i><span>{{ 'admin.setting.shop.csv_setting'|trans }}</span>
-                                        </a>
+                                        <div class="btn-group" role="group">
+                                            <button type="button" class="btn btn-ec-regular" data-bs-toggle="dropdown" id="csvDownloadDropDown">
+                                                <i class="fa fa-cloud-download me-1 text-secondary"></i>
+                                                <span>{{ 'admin.common.csv_download'|trans }}</span>
+                                            </button>
+                                            <div class="dropdown-menu">
+                                                <a class="dropdown-item" href="{{ url('admin_product_export', {'product_class': constant('Eccube\\Entity\\Csv::PRODUCT_CLASS_VISIBLE_ONLY') }) }}" id="productCsvDownloadVisibleOnly">
+                                                    {{ 'admin.product.csv'|trans }}
+                                                </a>
+                                                <a class="dropdown-item" href="{{ url('admin_product_export') }}" id="productCsvDownload">
+                                                    {{ 'admin.product.csv'|trans }}{{ 'admin.product.csv.include_hidden_productclass'|trans }}
+                                                </a>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
@@ -20,6 +20,7 @@ use Eccube\Entity\Master\RoundingType;
 use Eccube\Entity\Product;
 use Eccube\Entity\ProductClass;
 use Eccube\Entity\ProductImage;
+use Eccube\Entity\ProductStock;
 use Eccube\Entity\ProductTag;
 use Eccube\Entity\Tag;
 use Eccube\Entity\TaxRule;
@@ -549,17 +550,20 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $this->actual = $crawler->filter('div.c-outsideBlock__contents.mb-5 > span')->text();
         $this->verify('検索結果件数の確認テスト');
 
-        // TODO
-        $this->markTestIncomplete('検索項目(公開・非公開・在庫内)の実装完了後に実施');
+        // No stock
+        $searchForm['id'] = 'Product with stock';
+        $searchForm['stock'] = [ProductStock::OUT_OF_STOCK];
 
-        // No stock click button
-        $noStockUrl = $crawler->selectLink('在庫なし')->link()->getUri();
-        $crawler = $this->client->request('GET', $noStockUrl);
-        $this->expected = '検索結果 1 件 が該当しました';
+        $crawler = $this->client->request(
+            'POST',
+            $this->generateUrl('admin_product'),
+            ['admin_search_product' => $searchForm]
+        );
+        $this->expected = '検索結果：1件が該当しました';
         $this->actual = $crawler->filter('div.c-outsideBlock__contents.mb-5 > span')->text();
         $this->verify();
 
-        $csvExportUrl = $crawler->filter('ul.dropdown-menu')->selectLink('CSVダウンロード')->link()->getUri();
+        $csvExportUrl = $crawler->filter('.dropdown-menu')->selectLink('商品CSV(非表示の商品規格を含む)')->link()->getUri();
         $this->client->request('GET', $csvExportUrl);
     }
 
@@ -588,17 +592,18 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $this->actual = $crawler->filter('div.c-outsideBlock__contents.mb-5 > span')->text();
         $this->verify('検索結果件数の確認テスト');
 
-        // TODO
-        $this->markTestIncomplete('検索項目(公開・非公開・在庫内)の実装完了後に実施');
+        $searchForm['status'] = [ProductStatus::DISPLAY_HIDE];
 
-        // private click button
-        $privateUrl = $crawler->selectLink('非公開')->link()->getUri();
-        $crawler = $this->client->request('GET', $privateUrl);
-        $this->expected = '検索結果 1 件 が該当しました';
+        $crawler = $this->client->request(
+            'POST',
+            $this->generateUrl('admin_product'),
+            ['admin_search_product' => $searchForm]
+        );
+        $this->expected = '検索結果：1件が該当しました';
         $this->actual = $crawler->filter('div.c-outsideBlock__contents.mb-5 > span')->text();
         $this->verify();
 
-        $csvExportUrl = $crawler->filter('ul.dropdown-menu')->selectLink('CSVダウンロード')->link()->getUri();
+        $csvExportUrl = $crawler->filter('.dropdown-menu')->selectLink('商品CSV(非表示の商品規格を含む)')->link()->getUri();
         $this->client->request('GET', $csvExportUrl);
     }
 
@@ -627,17 +632,19 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $this->actual = $crawler->filter('div.c-outsideBlock__contents.mb-5 > span')->text();
         $this->verify('検索結果件数の確認テスト');
 
-        // TODO
-        $this->markTestIncomplete('検索項目(公開・非公開・在庫内)の実装完了後に実施');
+        $searchForm['status'] = [ProductStatus::DISPLAY_SHOW];
 
-        // public click button
-        $privateUrl = $crawler->selectLink('公開')->link()->getUri();
-        $crawler = $this->client->request('GET', $privateUrl);
-        $this->expected = '検索結果 1 件 が該当しました';
+        $crawler = $this->client->request(
+            'POST',
+            $this->generateUrl('admin_product'),
+            ['admin_search_product' => $searchForm]
+        );
+
+        $this->expected = '検索結果：1件が該当しました';
         $this->actual = $crawler->filter('div.c-outsideBlock__contents.mb-5 > span')->text();
         $this->verify();
 
-        $csvExportUrl = $crawler->filter('ul.dropdown-menu')->selectLink('CSVダウンロード')->link()->getUri();
+        $csvExportUrl = $crawler->filter('.dropdown-menu')->selectLink('商品CSV(非表示の商品規格を含む)')->link()->getUri();
         $this->client->request('GET', $csvExportUrl);
     }
 
@@ -646,7 +653,6 @@ class ProductControllerTest extends AbstractAdminWebTestCase
      */
     public function testExportWithAll()
     {
-        $this->markTestIncomplete('FIXME expectOutputRegex');
         $this->expectOutputRegex('/[Product with status]{1}[Product with status 02]{2}/');
         $this->createProduct('Product with status 01', 0);
         $testProduct02 = $this->createProduct('Product with status 02', 1);
@@ -667,17 +673,19 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $this->actual = $crawler->filter('div.c-outsideBlock__contents.mb-5 > span')->text();
         $this->verify('検索結果件数の確認テスト');
 
-        // TODO
-        $this->markTestIncomplete('検索項目(公開・非公開・在庫内)の実装完了後に実施');
+        $searchForm['status'] = [ProductStatus::DISPLAY_HIDE];
 
-        // private click button
-        $privateUrl = $crawler->selectLink('非公開')->link()->getUri();
-        $crawler = $this->client->request('GET', $privateUrl);
-        $this->expected = '検索結果 1 件 が該当しました';
+        $crawler = $this->client->request(
+            'POST',
+            $this->generateUrl('admin_product'),
+            ['admin_search_product' => $searchForm]
+        );
+
+        $this->expected = '検索結果：1件が該当しました';
         $this->actual = $crawler->filter('div.c-outsideBlock__contents.mb-5 > span')->text();
         $this->verify();
 
-        $csvExportUrl = $crawler->filter('ul.dropdown-menu')->selectLink('CSVダウンロード')->link()->getUri();
+        $csvExportUrl = $crawler->filter('.dropdown-menu')->selectLink('商品CSV')->link()->getUri();
         $this->client->request('GET', $csvExportUrl);
     }
 
@@ -719,7 +727,7 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         $this->verify('検索結果件数の確認テスト');
 
         $this->expectOutputRegex('/Product name [10-1]/');
-        $csvExportUrl = $crawler->filter('.btn-ec-regular')->selectLink('CSVダウンロード')->link()->getUri();
+        $csvExportUrl = $crawler->filter('#productCsvDownload')->selectLink('商品CSV(非表示の商品規格を含む)')->link()->getUri();
         $this->client->request('GET', $csvExportUrl);
 
         // get list product after call admin_product_export function
@@ -880,7 +888,6 @@ class ProductControllerTest extends AbstractAdminWebTestCase
      */
     public function testProductExport()
     {
-        $this->markTestIncomplete('FIXME expectOutputRegex');
         $productName = 'test01';
         $this->expectOutputRegex("/$productName/");
         $this->createProduct($productName);


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
- Fixes #4190 
  - Closes #4199
- Refs #5856 

規格有り商品をコピー→規格無し商品を登録した場合に visible = false の商品規格が残ってしまい、意図しない商品規格が商品CSVに含まれてしまう。
商品CSVダウンロードボタンを「商品CSV」と「商品CSV(非表示の商品規格を含む)」に分けることで、後方互換を維持する

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

### 商品CSV 
`visible = true` のみの商品規格を含んだCSVをダウンロードする。
`/%eccube_admin_route%/product/export` にクエリストリング `product_class=visible_only` を付与するとダウンロードできる

### 商品CSV(非表示の商品規格を含む)
従来通り、`visible = false` を含む、すべての商品規格をCSVをダウンロードする

### 商品一覧画面
受注一覧画面のCSVダウンロードと同様、ドロップダウンで選択できるようにする
![image](https://user-images.githubusercontent.com/815715/200777106-3a087753-812d-47e7-84ac-9d9aed4f9828.png)


## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
ユニットテストを追加

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
