### PR TITLE
フロント画面へのIPアクセス制限の実装

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -2,6 +2,8 @@ parameters:
     # EC-CUBE default env parameters
     env(ECCUBE_ADMIN_ROUTE): 'admin'
     env(ECCUBE_USER_DATA_ROUTE): 'user_data'
+    env(ECCUBE_FRONT_ALLOW_HOSTS): '[]'
+    env(ECCUBE_FRONT_DENY_HOSTS): '[]'
     env(ECCUBE_ADMIN_ALLOW_HOSTS): '[]'
     env(ECCUBE_ADMIN_DENY_HOSTS): '[]'
     env(ECCUBE_FORCE_SSL): '0'
@@ -24,6 +26,8 @@ parameters:
     eccube_mailer_dsn: '%env(MAILER_DSN)%'
     eccube_admin_route: '%env(ECCUBE_ADMIN_ROUTE)%'
     eccube_user_data_route: '%env(ECCUBE_USER_DATA_ROUTE)%'
+    eccube_front_allow_hosts: '%env(json:ECCUBE_FRONT_ALLOW_HOSTS)%'
+    eccube_front_deny_hosts: '%env(json:ECCUBE_FRONT_DENY_HOSTS)%'
     eccube_admin_allow_hosts: '%env(json:ECCUBE_ADMIN_ALLOW_HOSTS)%'
     eccube_admin_deny_hosts: '%env(json:ECCUBE_ADMIN_DENY_HOSTS)%'
     eccube_force_ssl: '%env(bool:ECCUBE_FORCE_SSL)%'

--- a/codeception/_support/AcceptanceTester.php
+++ b/codeception/_support/AcceptanceTester.php
@@ -79,7 +79,7 @@ class AcceptanceTester extends \Codeception\Actor
         $I = $this;
         if ($dir == '') {
             $config = Fixtures::get('config');
-            $I->amOnPage('/'.$config['eccube_admin_route']);
+            $I->amOnPage('/'.$config['eccube_admin_route'].'/');
         } else {
             $I->amOnPage('/'.$dir);
         }

--- a/codeception/_support/Page/Admin/SystemSecurityPage.php
+++ b/codeception/_support/Page/Admin/SystemSecurityPage.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Page\Admin;
+
+class SystemSecurityPage extends AbstractAdminPageStyleGuide
+{
+    /**
+     * @param \AcceptanceTester $I
+     */
+    public static function go($I)
+    {
+        $page = new self($I);
+
+        return $page->goPage('/setting/system/security', 'セキュリティ管理システム設定');
+    }
+
+    /**
+     * @param \AcceptanceTester $I
+     */
+    public static function at($I)
+    {
+        $page = new self($I);
+        $page->atPage('セキュリティ管理システム設定');
+
+        return $page;
+    }
+
+    public function 入力_front許可リスト($ip)
+    {
+        $this->tester->fillField(['id' => 'admin_security_front_allow_hosts'], $ip);
+
+        return $this;
+    }
+
+    public function 入力_front拒否リスト($ip)
+    {
+        $this->tester->fillField(['id' => 'admin_security_front_deny_hosts'], $ip);
+
+        return $this;
+    }
+
+    public function 登録()
+    {
+        $this->tester->click('#page_admin_setting_system_security form div.c-contentsArea__cols > div.c-conversionArea > div > div > div:nth-child(2) > div > div > button');
+        $this->tester->see('保存しました');
+
+        return $this;
+    }
+}

--- a/codeception/_support/Page/Front/TopPage.php
+++ b/codeception/_support/Page/Front/TopPage.php
@@ -25,6 +25,14 @@ class TopPage extends AbstractFrontPage
         return $page->goPage('/');
     }
 
+    public function at($title)
+    {
+        $this->tester->see($title);
+
+        return $this;
+    }
+
+
     public function 新着情報選択($rowNum)
     {
         $this->tester->click(['css' => "div.ec-newsRole__news > div:nth-child($rowNum) > div.ec-newsRole__newsHeading"]);

--- a/codeception/acceptance/EA08SysteminfoCest.php
+++ b/codeception/acceptance/EA08SysteminfoCest.php
@@ -612,6 +612,8 @@ class EA08SysteminfoCest
 
     public function systeminfo_セキュリティ管理フロントIP制限_許可リスト(AcceptanceTester $I)
     {
+        $I->wantTo('EA0804-UC01-T06 セキュリティ管理 - フロントIP制限（許可リスト）');
+
         // 許可リストに該当するので、閲覧できるパターン
         SystemSecurityPage::go($I)->入力_front許可リスト('127.0.0.1')
         ->登録();
@@ -630,6 +632,8 @@ class EA08SysteminfoCest
 
     public function systeminfo_セキュリティ管理フロントIP制限_拒否リスト(AcceptanceTester $I)
     {
+        $I->wantTo('EA0804-UC01-T07 セキュリティ管理 - フロントIP制限（拒否リスト）');
+
         // 拒否リストに該当するため閲覧できないパターン
         SystemSecurityPage::go($I)->入力_front拒否リスト('127.0.0.1')
         ->登録();
@@ -650,7 +654,7 @@ class EA08SysteminfoCest
      */
     public function systeminfo_セキュリティ管理IP制限_許可リスト(AcceptanceTester $I)
     {
-        $I->wantTo('EA0804-UC01-T03 セキュリティ管理 - IP制限（許可リスト）');
+        $I->wantTo('EA0804-UC01-T03 セキュリティ管理 - 管理画面IP制限（許可リスト）');
 
         $findPlugins = Fixtures::get('findPlugins');
         $Plugins = $findPlugins();

--- a/codeception/acceptance/EA08SysteminfoCest.php
+++ b/codeception/acceptance/EA08SysteminfoCest.php
@@ -610,31 +610,6 @@ class EA08SysteminfoCest
         $I->see('この機能は管理者によって制限されています。');
     }
 
-    /**
-     * ATTENTION 後続のテストが失敗するため、最後に実行する必要がある
-     */
-    public function systeminfo_セキュリティ管理IP制限_許可リスト(AcceptanceTester $I)
-    {
-        $I->wantTo('EA0804-UC01-T03 セキュリティ管理 - IP制限（許可リスト）');
-
-        $findPlugins = Fixtures::get('findPlugins');
-        $Plugins = $findPlugins();
-        if (is_array($Plugins) && count($Plugins) > 0) {
-            $I->getScenario()->skip('プラグインのアンインストールが必要なため、テストをスキップします');
-        }
-
-        // 表示
-        $config = Fixtures::get('config');
-        $I->amOnPage('/'.$config['eccube_admin_route'].'/setting/system/security');
-        $I->see('セキュリティ管理システム設定', '#page_admin_setting_system_security .c-pageTitle__titles');
-
-        $I->fillField(['id' => 'admin_security_admin_allow_hosts'], '1.1.1.1');
-        $I->click('#page_admin_setting_system_security form div.c-contentsArea__cols > div.c-conversionArea > div > div > div:nth-child(2) > div > div > button');
-
-        $I->amOnPage('/'.$config['eccube_admin_route']);
-        $I->see('アクセスできません。', '//*[@id="error-page"]//h3');
-    }
-
     public function systeminfo_セキュリティ管理フロントIP制限_許可リスト(AcceptanceTester $I)
     {
         // 許可リストに該当するので、閲覧できるパターン
@@ -668,6 +643,31 @@ class EA08SysteminfoCest
         //後片付け（後続処理がエラーにならないため）
         SystemSecurityPage::go($I)->入力_front拒否リスト('')
         ->登録();
+    }
+
+    /**
+     * ATTENTION 後続のテストが失敗するため、最後に実行する必要がある
+     */
+    public function systeminfo_セキュリティ管理IP制限_許可リスト(AcceptanceTester $I)
+    {
+        $I->wantTo('EA0804-UC01-T03 セキュリティ管理 - IP制限（許可リスト）');
+
+        $findPlugins = Fixtures::get('findPlugins');
+        $Plugins = $findPlugins();
+        if (is_array($Plugins) && count($Plugins) > 0) {
+            $I->getScenario()->skip('プラグインのアンインストールが必要なため、テストをスキップします');
+        }
+
+        // 表示
+        $config = Fixtures::get('config');
+        $I->amOnPage('/'.$config['eccube_admin_route'].'/setting/system/security');
+        $I->see('セキュリティ管理システム設定', '#page_admin_setting_system_security .c-pageTitle__titles');
+
+        $I->fillField(['id' => 'admin_security_admin_allow_hosts'], '1.1.1.1');
+        $I->click('#page_admin_setting_system_security form div.c-contentsArea__cols > div.c-conversionArea > div > div > div:nth-child(2) > div > div > button');
+
+        $I->amOnPage('/'.$config['eccube_admin_route']);
+        $I->see('アクセスできません。', '//*[@id="error-page"]//h3');
     }
 
 }

--- a/codeception/acceptance/EA08SysteminfoCest.php
+++ b/codeception/acceptance/EA08SysteminfoCest.php
@@ -16,6 +16,8 @@ use Page\Admin\AuthorityManagePage;
 use Page\Admin\LoginHistoryPage;
 use Page\Admin\MasterDataManagePage;
 use Page\Admin\SystemMemberEditPage;
+use Page\Admin\SystemSecurityPage;
+use Page\Front\TopPage;
 
 /**
  * @group admin
@@ -632,4 +634,40 @@ class EA08SysteminfoCest
         $I->amOnPage('/'.$config['eccube_admin_route']);
         $I->see('アクセスできません。', '//*[@id="error-page"]//h3');
     }
+
+    public function systeminfo_セキュリティ管理フロントIP制限_許可リスト(AcceptanceTester $I)
+    {
+        // 許可リストに該当するので、閲覧できるパターン
+        SystemSecurityPage::go($I)->入力_front許可リスト('127.0.0.1')
+        ->登録();
+        TopPage::go($I)->at('彩のジェラート"CUBE"をご堪能ください');
+
+        // 許可リストに該当しないので、閲覧できないパターン
+        SystemSecurityPage::go($I)->入力_front許可リスト('192.168.100.1')
+        ->登録();
+        TopPage::go($I)->at('アクセスできません。');
+
+        //後片付け（後続処理がエラーにならないため）
+        SystemSecurityPage::go($I)->入力_front許可リスト('')
+        ->登録();
+
+    }
+
+    public function systeminfo_セキュリティ管理フロントIP制限_拒否リスト(AcceptanceTester $I)
+    {
+        // 拒否リストに該当するため閲覧できないパターン
+        SystemSecurityPage::go($I)->入力_front拒否リスト('127.0.0.1')
+        ->登録();
+        TopPage::go($I)->at('アクセスできません');
+
+        // 拒否リストに該当しないため閲覧可能なパターン
+        SystemSecurityPage::go($I)->入力_front拒否リスト('192.168.100.1')
+        ->登録();
+        TopPage::go($I)->at('彩のジェラート"CUBE"をご堪能ください');
+
+        //後片付け（後続処理がエラーにならないため）
+        SystemSecurityPage::go($I)->入力_front拒否リスト('')
+        ->登録();
+    }
+
 }

--- a/codeception/acceptance/EA08SysteminfoCest.php
+++ b/codeception/acceptance/EA08SysteminfoCest.php
@@ -290,7 +290,7 @@ class EA08SysteminfoCest
         $config = Fixtures::get('config');
         $I->amOnPage('/'.$config['eccube_admin_route'].'/setting/system/security');
         $I->see('セキュリティ管理システム設定', '#page_admin_setting_system_security .c-pageTitle__titles');
-        $I->see('セキュリティ設定', '#page_admin_setting_system_security > div.c-container > div.c-contentsArea > form > div > div.c-contentsArea__primaryCol > div > div > div.card-header > div > div.col-8 > span');
+        $I->see('管理画面URL設定', '#page_admin_setting_system_security > div.c-container > div.c-contentsArea > form > div > div.c-contentsArea__primaryCol > div > div > div.card-header > div > div.col-8 > span');
     }
 
     public function systeminfo_セキュリティ管理ディレクトリ名(AcceptanceTester $I)

--- a/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/SecurityController.php
@@ -61,6 +61,17 @@ class SecurityController extends AbstractController
             $envFile = $this->getParameter('kernel.project_dir').'/.env';
             $env = file_get_contents($envFile);
 
+            $frontAllowHosts = \json_encode(
+                array_filter(\explode("\n", StringUtil::convertLineFeed($data['front_allow_hosts'])), function ($str) {
+                    return StringUtil::isNotBlank($str);
+                })
+            );
+            $frontDenyHosts = \json_encode(
+                array_filter(\explode("\n", StringUtil::convertLineFeed($data['front_deny_hosts'])), function ($str) {
+                    return StringUtil::isNotBlank($str);
+                })
+            );
+
             $adminAllowHosts = \json_encode(
                 array_filter(\explode("\n", StringUtil::convertLineFeed($data['admin_allow_hosts'])), function ($str) {
                     return StringUtil::isNotBlank($str);
@@ -73,6 +84,8 @@ class SecurityController extends AbstractController
             );
 
             $env = StringUtil::replaceOrAddEnv($env, [
+                'ECCUBE_FRONT_ALLOW_HOSTS' => "'{$frontAllowHosts}'",
+                'ECCUBE_FRONT_DENY_HOSTS' => "'{$frontDenyHosts}'",
                 'ECCUBE_ADMIN_ALLOW_HOSTS' => "'{$adminAllowHosts}'",
                 'ECCUBE_ADMIN_DENY_HOSTS' => "'{$adminDenyHosts}'",
                 'ECCUBE_FORCE_SSL' => $data['force_ssl'] ? '1' : '0',

--- a/src/Eccube/Form/Type/Admin/SecurityType.php
+++ b/src/Eccube/Form/Type/Admin/SecurityType.php
@@ -135,7 +135,13 @@ class SecurityType extends AbstractType
 
                 foreach ($ips as $ip) {
                     // 適切なIPとビットマスクになっているか
-                    if ($this->hasErrorIpAddressAndBitMask($ip)) {
+                    $errors = $this->validator->validate($ip, new Assert\AtLeastOneOf([
+                        'constraints' => [
+                            new Assert\Ip(),
+                            new Assert\Cidr()
+                        ]
+                    ]));
+                    if ($errors->count() > 0) {
                         $form['front_allow_hosts']->addError(new FormError(trans('admin.setting.system.security.ip_limit_invalid_ip_and_submask', ['%ip%' => $ip])));
                     }
                 }
@@ -145,7 +151,13 @@ class SecurityType extends AbstractType
 
                 foreach ($ips as $ip) {
                     // 適切なIPとビットマスクになっているか
-                    if ($this->hasErrorIpAddressAndBitMask($ip)) {
+                    $errors = $this->validator->validate($ip, new Assert\AtLeastOneOf([
+                        'constraints' => [
+                            new Assert\Ip(),
+                            new Assert\Cidr()
+                        ]
+                    ]));
+                    if ($errors->count() > 0) {
                         $form['front_deny_hosts']->addError(new FormError(trans('admin.setting.system.security.ip_limit_invalid_ip_and_submask', ['%ip%' => $ip])));
                     }
                 }
@@ -154,10 +166,13 @@ class SecurityType extends AbstractType
                 $ips = preg_split("/\R/", $data['admin_allow_hosts'], null, PREG_SPLIT_NO_EMPTY);
 
                 foreach ($ips as $ip) {
-                    $errors = $this->validator->validate($ip, [
+                    // 適切なIPとビットマスクになっているか
+                    $errors = $this->validator->validate($ip, new Assert\AtLeastOneOf([
+                        'constraints' => [
                             new Assert\Ip(),
+                            new Assert\Cidr()
                         ]
-                    );
+                    ]));
                     if ($errors->count() != 0) {
                         $form['admin_allow_hosts']->addError(new FormError(trans('admin.setting.system.security.ip_limit_invalid_ipv4', ['%ip%' => $ip])));
                     }
@@ -167,10 +182,13 @@ class SecurityType extends AbstractType
                 $ips = preg_split("/\R/", $data['admin_deny_hosts'], null, PREG_SPLIT_NO_EMPTY);
 
                 foreach ($ips as $ip) {
-                    $errors = $this->validator->validate($ip, [
+                    // 適切なIPとビットマスクになっているか
+                    $errors = $this->validator->validate($ip, new Assert\AtLeastOneOf([
+                        'constraints' => [
                             new Assert\Ip(),
+                            new Assert\Cidr()
                         ]
-                    );
+                    ]));
                     if ($errors->count() != 0) {
                         $form['admin_deny_hosts']->addError(new FormError(trans('admin.setting.system.security.ip_limit_invalid_ipv4', ['%ip%' => $ip])));
                     }
@@ -182,17 +200,6 @@ class SecurityType extends AbstractType
                 }
             })
         ;
-    }
-
-    private function hasErrorIpAddressAndBitMask($ip)
-    {
-        $errors = $this->validator->validate($ip, [
-            new Assert\Regex([
-                'pattern' => '/^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\/(3[0-2]|[1-2]?[0-9]))?$/',
-            ])
-        ]);
-
-        return $errors->count() > 0;
     }
 
     /**

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -1322,14 +1322,14 @@ admin.setting.system.security.ip_limit_description_deny: |
   Please enter the URLs one by one which you deny the access to.
   The IP address corresponds to the subnet mask notation.
 admin.setting.system.security.front_ip_limit_description: |
-  This will restrict the access to the storefront to specified IP addresses.
+  This will restrict the access to the Front Screen to specified IP addresses.
   Please enter the URLs one by one which you allow the access to. If no URLs are entered, any URL can access your Front Screen.
   The IP address corresponds to the subnet mask notation.
 admin.setting.system.security.front_ip_limit_sample: |
   127.0.0.1/28
   192.0.2.1
 admin.setting.system.security.front_ip_limit_description_deny: |
-  This will deny the access to the storefront from specified IP addresses.
+  This will deny the access to the Front Screen from specified IP addresses.
   Please enter the URLs one by one which you deny the access to.
   The IP address corresponds to the subnet mask notation.
 admin.setting.system.security.force_ssl: SSL is mandatory
@@ -1639,8 +1639,8 @@ tooltip.product.sale_limit: This will limit the number of products shoppers can 
 tooltip.product.delivery_duration: You can register estimated shipping date per product.
 tooltip.product.product_class: You can review and manage the option(s) set to this product.
 tooltip.product.free_area: The entry will be displayed on the product page. The placement varies according to the design templates.
-tooltip.product.shop_memo: Notes for store use. This will not be displayed on the storefront.
-tooltip.product.backend_name: 'You can register an alias for administrator (e.g. Option Name: Size - Alias: Size (Clothing) or Size (Shoes) etc. It will not be displayed on the storefront.'
+tooltip.product.shop_memo: Notes for store use. This will not be displayed on the Front Screen.
+tooltip.product.backend_name: 'You can register an alias for administrator (e.g. Option Name: Size - Alias: Size (Clothing) or Size (Shoes) etc. It will not be displayed on the Front Screen.'
 tooltip.product.csv_upload: Bulk product registration is available with a CSV template.
 tooltip.product.csv_format: You can create a CSV data easily with templates available for downloads.
 tooltip.category.csv_upload: Bulk category registration is available with a CSV template.
@@ -1657,7 +1657,7 @@ tooltip.order.shipping_info.tracking_number: If you have a tracking number (deli
 tooltip.order.shipping_info.delivery_provider: You can change delivery companies or delivery methods here. Please note the shipping charge may be updated if you change any of them.
 tooltip.order.shipping_info.shop_memo: You can save a note for shipping operators or delivery companies. You can review it in Shipping CSV etc.
 tooltip.order.product_info: Here displayed the purchased product information and the total amount including shipping charge or any other charges. If you add a product(s) or change the amount, please update the total amount as well.
-tooltip.order.shop_memo: You can save notes for store use. They are not displayed on the storefront.
+tooltip.order.shop_memo: You can save notes for store use. They are not displayed on the Front Screen.
 tooltip.order.mail_history: You can review the emails sent and create a new email.
 tooltip.order.mail_destination_info: You can send emails to shoppers.
 tooltip.order.mail_template: You can select an email template.
@@ -1668,7 +1668,7 @@ tooltip.customer.multi_search_label: You can filter the list with keywords. To f
 tooltip.customer.customer_id: Auto-generated Customer IDs.
 tooltip.customer.customer_address: The delivery address registered by this customer. You can add a new address from this page as well.
 tooltip.customer.purchase_history: Order history of this customer is displayed here.
-tooltip.customer.shop_memo: Notes for store use. This will not be displayed on the storefront.
+tooltip.customer.shop_memo: Notes for store use. This will not be displayed on the Front Screen.
 tooltip.content.news.url: If there is a page which provides the details of this news, enter its URL. You can also enter external URLs.
 tooltip.content.news.body: You can use HTML tags.
 tooltip.content.file.upload_file: You can select multiple files and upload files.
@@ -1705,7 +1705,7 @@ tooltip.setting.shop.payment.logo_image: You can upload the payment option icons
 tooltip.setting.shop.delivery.tracking_number_url: Enter the URL of the shipping tracker of the delivery company.
 tooltip.setting.shop.delivery.sale_type: Specify the sales type(s) available for this delivery method.
 tooltip.setting.shop.delivery.apply_to_pref: The same shipping charge can be applied to all prefectures. You can later change the shipping rate for each prefecture one by one.
-tooltip.setting.shop.delivery.shop_memo: This is a note for store Owner''s. It is not displayed on the storefront.
+tooltip.setting.shop.delivery.shop_memo: This is a note for store Owner''s. It is not displayed on the Front Screen.
 tooltip.setting.shop.tax_setting: You can set the tax rates applicable to all products. The general tax rate can be overwritten if you enter a new rate.
 tooltip.setting.shop.mail.mail_template: Please select an existing email template. Contents are displayed in the text field below.
 tooltip.setting.shop.csv.csv_columns: You can output various data in CSV format. You can specify the items for CSV output.
@@ -1720,11 +1720,11 @@ tooltip.setting.system.member.work: You can set customers to inactive temporaril
 tooltip.setting.system.member.two_factor_auth_enabled: If enabled, you must log in using two-factor authentication. You will be able to login after setting up two-factor authentication.
 tooltip.setting.system.two_factor_auth.qr_code: Please read the QR code with the two-factor authentication app.
 tooltip.setting.system.security.admin_url: Set the URL to sign in to the Admin Console. Please specify a URL which is hardly guessed.
-tooltip.setting.system.security.front_ip_limit: Restricting IP addresses which are allowed to sign in to the Storefront.
-tooltip.setting.system.security.front_ip_limit_deny: IP addresses where access to the Storefront is denied.
+tooltip.setting.system.security.front_ip_limit: Restricting IP addresses which are allowed to sign in to the Front Screen.
+tooltip.setting.system.security.front_ip_limit_deny: IP addresses where access to the Front Screen is denied.
 tooltip.setting.system.security.ip_limit: Restricting IP addresses which are allowed to sign in to the Admin Console.
 tooltip.setting.system.security.ip_limit_deny: IP addresses where access to the Admin Console is denied.
-tooltip.setting.system.security.force_ssl: Restricting the access to the storefront and Admin Console to via SSL(https).
+tooltip.setting.system.security.force_ssl: Restricting the access to the Front Screen and Admin Console to via SSL(https).
 tooltip.setting.system.security.trusted_hosts: Deny access to non-trusted hosts.
 tooltip.setting.system.login_history.multi_search_label: You can filter the list with keywords. For more search options, open [Advanced Search].
 tooltip.setting.system.log_display: Here you can check logs such as access logs and error logs etc.

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -1301,31 +1301,35 @@ admin.setting.system.authority.deny_url_is_invalid: /(slash) is required.
 #------------------------------------------------------------------------------------
 
 admin.setting.system.security__card_title: Security Settings
+admin.setting.system.security_admin_url__card_title: Admin Console URL Setting
+admin.setting.system.security_admin_ip_limit__card_title: Admin Console IP Restrictions Setting
+admin.setting.system.security_front_ip_limit__card_title: Storefront IP Restrictions Setting
+admin.setting.system.security_connect_card_title: Connect Setting
 admin.setting.system.security.admin_url: Admin Console URL
 admin.setting.system.security.admin_url_description: It is recommended to set the URL which would NOT be easily guessed.
 admin.setting.system.security.admin_url_changed: The URL of Admin Console has been changed. Please sign in again.
-admin.setting.system.security.ip_limit: Admin Console IP Restrictions(Allow List)
+admin.setting.system.security.ip_limit: IP Restrictions(Allow List)
 admin.setting.system.security.ip_limit_description: |
  This will restrict the access to the Admin Console to specified IP addresses.
  Please enter the URLs one by one which you allow the access to. If no URLs are entered, any URL can access your Admin Console.
+  The IP address corresponds to the subnet mask notation.
 admin.setting.system.security.ip_limit_sample: |
  127.0.0.1
  192.0.2.1
-admin.setting.system.security.ip_limit_deny: Admin Console IP Restrictions(Deny List)
+admin.setting.system.security.ip_limit_deny: IP Restrictions(Deny List)
 admin.setting.system.security.ip_limit_description_deny: |
   This will deny the access to the Admin Console from specified IP addresses.
   Please enter the URLs one by one which you deny the access to.
-admin.setting.system.security.front_ip_limit: Front Screen IP Restrictions(Allow List)
+  The IP address corresponds to the subnet mask notation.
 admin.setting.system.security.front_ip_limit_description: |
-  This will restrict the access to the Front Screen to specified IP addresses.
+  This will restrict the access to the storefront to specified IP addresses.
   Please enter the URLs one by one which you allow the access to. If no URLs are entered, any URL can access your Front Screen.
   The IP address corresponds to the subnet mask notation.
 admin.setting.system.security.front_ip_limit_sample: |
   127.0.0.1/28
   192.0.2.1
-admin.setting.system.security.front_ip_limit_deny: Front Screen IP Restrictions(Deny List)
 admin.setting.system.security.front_ip_limit_description_deny: |
-  This will deny the access to the Front Screen from specified IP addresses.
+  This will deny the access to the storefront from specified IP addresses.
   Please enter the URLs one by one which you deny the access to.
   The IP address corresponds to the subnet mask notation.
 admin.setting.system.security.force_ssl: SSL is mandatory
@@ -1716,8 +1720,8 @@ tooltip.setting.system.member.work: You can set customers to inactive temporaril
 tooltip.setting.system.member.two_factor_auth_enabled: If enabled, you must log in using two-factor authentication. You will be able to login after setting up two-factor authentication.
 tooltip.setting.system.two_factor_auth.qr_code: Please read the QR code with the two-factor authentication app.
 tooltip.setting.system.security.admin_url: Set the URL to sign in to the Admin Console. Please specify a URL which is hardly guessed.
-tooltip.setting.system.security.front_ip_limit: Restricting IP addresses which are allowed to sign in to the Front Screen.
-tooltip.setting.system.security.front_ip_limit_deny: IP addresses where access to the Front Screen is denied.
+tooltip.setting.system.security.front_ip_limit: Restricting IP addresses which are allowed to sign in to the Storefront.
+tooltip.setting.system.security.front_ip_limit_deny: IP addresses where access to the Storefront is denied.
 tooltip.setting.system.security.ip_limit: Restricting IP addresses which are allowed to sign in to the Admin Console.
 tooltip.setting.system.security.ip_limit_deny: IP addresses where access to the Admin Console is denied.
 tooltip.setting.system.security.force_ssl: Restricting the access to the storefront and Admin Console to via SSL(https).

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -1314,7 +1314,7 @@ admin.setting.system.security.ip_limit_description: |
  Please enter the URLs one by one which you allow the access to. If no URLs are entered, any URL can access your Admin Console.
   The IP address corresponds to the subnet mask notation.
 admin.setting.system.security.ip_limit_sample: |
- 127.0.0.1
+ 127.0.0.1/28
  192.0.2.1
 admin.setting.system.security.ip_limit_deny: IP Restrictions(Deny List)
 admin.setting.system.security.ip_limit_description_deny: |
@@ -1325,9 +1325,6 @@ admin.setting.system.security.front_ip_limit_description: |
   This will restrict the access to the Front Screen to specified IP addresses.
   Please enter the URLs one by one which you allow the access to. If no URLs are entered, any URL can access your Front Screen.
   The IP address corresponds to the subnet mask notation.
-admin.setting.system.security.front_ip_limit_sample: |
-  127.0.0.1/28
-  192.0.2.1
 admin.setting.system.security.front_ip_limit_description_deny: |
   This will deny the access to the Front Screen from specified IP addresses.
   Please enter the URLs one by one which you deny the access to.

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -1304,17 +1304,30 @@ admin.setting.system.security__card_title: Security Settings
 admin.setting.system.security.admin_url: Admin Console URL
 admin.setting.system.security.admin_url_description: It is recommended to set the URL which would NOT be easily guessed.
 admin.setting.system.security.admin_url_changed: The URL of Admin Console has been changed. Please sign in again.
-admin.setting.system.security.ip_limit: IP Restrictions(Allow List)
+admin.setting.system.security.ip_limit: Admin Console IP Restrictions(Allow List)
 admin.setting.system.security.ip_limit_description: |
  This will restrict the access to the Admin Console to specified IP addresses.
  Please enter the URLs one by one which you allow the access to. If no URLs are entered, any URL can access your Admin Console.
 admin.setting.system.security.ip_limit_sample: |
  127.0.0.1
  192.0.2.1
-admin.setting.system.security.ip_limit_deny: IP Restrictions(Deny List)
+admin.setting.system.security.ip_limit_deny: Admin Console IP Restrictions(Deny List)
 admin.setting.system.security.ip_limit_description_deny: |
   This will deny the access to the Admin Console from specified IP addresses.
   Please enter the URLs one by one which you deny the access to.
+admin.setting.system.security.front_ip_limit: Front Screen IP Restrictions(Allow List)
+admin.setting.system.security.front_ip_limit_description: |
+  This will restrict the access to the Front Screen to specified IP addresses.
+  Please enter the URLs one by one which you allow the access to. If no URLs are entered, any URL can access your Front Screen.
+  The IP address corresponds to the subnet mask notation.
+admin.setting.system.security.front_ip_limit_sample: |
+  127.0.0.1/28
+  192.0.2.1
+admin.setting.system.security.front_ip_limit_deny: Front Screen IP Restrictions(Deny List)
+admin.setting.system.security.front_ip_limit_description_deny: |
+  This will deny the access to the Front Screen from specified IP addresses.
+  Please enter the URLs one by one which you deny the access to.
+  The IP address corresponds to the subnet mask notation.
 admin.setting.system.security.force_ssl: SSL is mandatory
 admin.setting.system.security.force_ssl_description: Only https access is allowed to set SSL restrictions.
 admin.setting.system.security.ip_limit_invalid_ipv4: '%ip% is not an IPv4 address.'
@@ -1703,6 +1716,8 @@ tooltip.setting.system.member.work: You can set customers to inactive temporaril
 tooltip.setting.system.member.two_factor_auth_enabled: If enabled, you must log in using two-factor authentication. You will be able to login after setting up two-factor authentication.
 tooltip.setting.system.two_factor_auth.qr_code: Please read the QR code with the two-factor authentication app.
 tooltip.setting.system.security.admin_url: Set the URL to sign in to the Admin Console. Please specify a URL which is hardly guessed.
+tooltip.setting.system.security.front_ip_limit: Restricting IP addresses which are allowed to sign in to the Front Screen.
+tooltip.setting.system.security.front_ip_limit_deny: IP addresses where access to the Front Screen is denied.
 tooltip.setting.system.security.ip_limit: Restricting IP addresses which are allowed to sign in to the Admin Console.
 tooltip.setting.system.security.ip_limit_deny: IP addresses where access to the Admin Console is denied.
 tooltip.setting.system.security.force_ssl: Restricting the access to the storefront and Admin Console to via SSL(https).

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -1304,20 +1304,34 @@ admin.setting.system.security__card_title: セキュリティ設定
 admin.setting.system.security.admin_url: 管理画面URL
 admin.setting.system.security.admin_url_description: 推測されにくいURLを設定することを推奨します。
 admin.setting.system.security.admin_url_changed: 管理画面のURLを変更しました。再度ログインを行ってください。
-admin.setting.system.security.ip_limit: IP制限(許可リスト)
+admin.setting.system.security.ip_limit: 管理機能 IP制限(許可リスト)
 admin.setting.system.security.ip_limit_description: |
   管理機能へのアクセスを特定のIPアドレスからの接続のみに制限します。
   アクセスを許可するIPアドレスを1行ずつ入力してください。何も入力しない場合は全てを許可します。
 admin.setting.system.security.ip_limit_sample: |
   127.0.0.1
   192.0.2.1
-admin.setting.system.security.ip_limit_deny: IP制限(拒否リスト)
+admin.setting.system.security.ip_limit_deny: 管理機能 IP制限(拒否リスト)
 admin.setting.system.security.ip_limit_description_deny: |
   特定のIPアドレスからの管理機能へのアクセスを拒否します。
   アクセスを拒否するIPアドレスを1行ずつ入力してください。
+admin.setting.system.security.front_ip_limit: ショップ画面 IP制限(許可リスト)
+admin.setting.system.security.front_ip_limit_description: |
+  ショップ画面へのアクセスを特定のIPアドレスからの接続のみに制限します。
+  アクセスを許可するIPアドレスを1行ずつ入力してください。何も入力しない場合は全てを許可します。
+  IPアドレスはサブネットマスク表記に対応してます。
+admin.setting.system.security.front_ip_limit_sample: |
+  127.0.0.1/28
+  192.0.2.1
+admin.setting.system.security.front_ip_limit_deny: ショップ画面 IP制限(拒否リスト)
+admin.setting.system.security.front_ip_limit_description_deny: |
+  特定のIPアドレスからのショップ画面へのアクセスを拒否します。
+  アクセスを拒否するIPアドレスを1行ずつ入力してください。
+  IPアドレスはサブネットマスク表記に対応してます。
 admin.setting.system.security.force_ssl: SSLを強制
 admin.setting.system.security.force_ssl_description: httpsからの接続でなければSSL制限を設定できません。
 admin.setting.system.security.ip_limit_invalid_ipv4: '%ip%はIPv4アドレスではありません。'
+admin.setting.system.security.ip_limit_invalid_ip_and_submask: '%ip%はIPv4/ビットマスクの形式ではありません。'
 admin.setting.system.security.ip_limit_invalid_https: 'httpの場合には設定できません。'
 admin.setting.system.security.admin_url_warning: 管理画面URLは、セキュリティのため推測されにくいものを設定してください。
 admin.setting.system.security.not_found_env_file: .envファイルが見つかりません。.envを利用していない場合はセキュリティ設定を管理画面から変更できません。
@@ -1703,6 +1717,8 @@ tooltip.setting.system.member.work: 一時的に非稼働にすることが可�
 tooltip.setting.system.member.two_factor_auth_enabled: 有効にすると2段階認証でのログインが必要になります。2段階認証のデバイス設定をしていない状態でログインした場合、設定後にログインできるようになります。
 tooltip.setting.system.two_factor_auth.qr_code: QRコードを2段階認証用スマートフォンアプリで読み込み、表示された6桁の数字を入力してください。
 tooltip.setting.system.security.admin_url: 管理画面にログインするためのURLを指定します。推測されにくいURLを指定して下さい。
+tooltip.setting.system.security.front_ip_limit: ショップ画面にアクセスできる接続元のIPアドレスを制限します。
+tooltip.setting.system.security.front_ip_limit_deny: ショップ画面へのアクセスを拒否する接続元のIPアドレスを指定します。
 tooltip.setting.system.security.ip_limit: 管理画面にログインできる接続元のIPアドレスを制限します。
 tooltip.setting.system.security.ip_limit_deny: 管理画面へのアクセスを拒否する接続元のIPアドレスを指定します。
 tooltip.setting.system.security.force_ssl: ショップサイトと管理画面への接続をSSL(https)での接続に制限します。

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -1303,7 +1303,7 @@ admin.setting.system.authority.deny_url_is_invalid: 「/」を必ず記入して
 admin.setting.system.security__card_title: セキュリティ設定
 admin.setting.system.security_admin_url__card_title: 管理画面URL設定
 admin.setting.system.security_admin_ip_limit__card_title: 管理画面IP制限設定
-admin.setting.system.security_front_ip_limit__card_title: ショップサイトIP制限設定
+admin.setting.system.security_front_ip_limit__card_title: フロント画面IP制限設定
 admin.setting.system.security_connect_card_title: 接続設定
 admin.setting.system.security.admin_url: 管理画面URL
 admin.setting.system.security.admin_url_description: 推測されにくいURLを設定することを推奨します。
@@ -1322,14 +1322,14 @@ admin.setting.system.security.ip_limit_description_deny: |
   アクセスを拒否するIPアドレスを1行ずつ入力してください。
   IPアドレスはサブネットマスク表記に対応しています。
 admin.setting.system.security.front_ip_limit_description: |
-  ショップサイトへのアクセスを特定のIPアドレスからの接続のみに制限します。
+  フロント画面へのアクセスを特定のIPアドレスからの接続のみに制限します。
   アクセスを許可するIPアドレスを1行ずつ入力してください。何も入力しない場合は全てを許可します。
   IPアドレスはサブネットマスク表記に対応してます。
 admin.setting.system.security.front_ip_limit_sample: |
   127.0.0.1/28
   192.0.2.1
 admin.setting.system.security.front_ip_limit_description_deny: |
-  特定のIPアドレスからのショップサイトへのアクセスを拒否します。
+  特定のIPアドレスからのフロント画面へのアクセスを拒否します。
   アクセスを拒否するIPアドレスを1行ずつ入力してください。
   IPアドレスはサブネットマスク表記に対応してます。
 admin.setting.system.security.force_ssl: SSLを強制
@@ -1721,11 +1721,11 @@ tooltip.setting.system.member.work: 一時的に非稼働にすることが可�
 tooltip.setting.system.member.two_factor_auth_enabled: 有効にすると2段階認証でのログインが必要になります。2段階認証のデバイス設定をしていない状態でログインした場合、設定後にログインできるようになります。
 tooltip.setting.system.two_factor_auth.qr_code: QRコードを2段階認証用スマートフォンアプリで読み込み、表示された6桁の数字を入力してください。
 tooltip.setting.system.security.admin_url: 管理画面にログインするためのURLを指定します。推測されにくいURLを指定して下さい。
-tooltip.setting.system.security.front_ip_limit: ショップサイトにアクセスできる接続元のIPアドレスを制限します。
-tooltip.setting.system.security.front_ip_limit_deny: ショップサイトへのアクセスを拒否する接続元のIPアドレスを指定します。
+tooltip.setting.system.security.front_ip_limit: フロント画面にアクセスできる接続元のIPアドレスを制限します。
+tooltip.setting.system.security.front_ip_limit_deny: フロント画面へのアクセスを拒否する接続元のIPアドレスを指定します。
 tooltip.setting.system.security.ip_limit: 管理画面にログインできる接続元のIPアドレスを制限します。
 tooltip.setting.system.security.ip_limit_deny: 管理画面へのアクセスを拒否する接続元のIPアドレスを指定します。
-tooltip.setting.system.security.force_ssl: ショップサイトと管理画面への接続をSSL(https)での接続に制限します。
+tooltip.setting.system.security.force_ssl: フロント画面と管理画面への接続をSSL(https)での接続に制限します。
 tooltip.setting.system.security.trusted_hosts: 設定されたホスト名以外でのアクセスを拒否します。
 tooltip.setting.system.login_history.multi_search_label: 情報を入力して一覧の絞り込み検索ができます。より詳細な条件を指定するには［詳細検索］を開いてください。
 tooltip.setting.system.log_display: アクセスやエラー状況などのログを確認できます。

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -1314,7 +1314,7 @@ admin.setting.system.security.ip_limit_description: |
   アクセスを許可するIPアドレスを1行ずつ入力してください。何も入力しない場合は全てを許可します。
   IPアドレスはサブネットマスク表記に対応しています。
 admin.setting.system.security.ip_limit_sample: |
-  127.0.0.1
+  127.0.0.1/28
   192.0.2.1
 admin.setting.system.security.ip_limit_deny: IP制限(拒否リスト)
 admin.setting.system.security.ip_limit_description_deny: |
@@ -1324,14 +1324,11 @@ admin.setting.system.security.ip_limit_description_deny: |
 admin.setting.system.security.front_ip_limit_description: |
   フロント画面へのアクセスを特定のIPアドレスからの接続のみに制限します。
   アクセスを許可するIPアドレスを1行ずつ入力してください。何も入力しない場合は全てを許可します。
-  IPアドレスはサブネットマスク表記に対応してます。
-admin.setting.system.security.front_ip_limit_sample: |
-  127.0.0.1/28
-  192.0.2.1
+  IPアドレスはサブネットマスク表記に対応しています。
 admin.setting.system.security.front_ip_limit_description_deny: |
   特定のIPアドレスからのフロント画面へのアクセスを拒否します。
   アクセスを拒否するIPアドレスを1行ずつ入力してください。
-  IPアドレスはサブネットマスク表記に対応してます。
+  IPアドレスはサブネットマスク表記に対応しています。
 admin.setting.system.security.force_ssl: SSLを強制
 admin.setting.system.security.force_ssl_description: httpsからの接続でなければSSL制限を設定できません。
 admin.setting.system.security.ip_limit_invalid_ipv4: '%ip%はIPv4アドレスではありません。'

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -1301,31 +1301,35 @@ admin.setting.system.authority.deny_url_is_invalid: 「/」を必ず記入して
 #------------------------------------------------------------------------------------
 
 admin.setting.system.security__card_title: セキュリティ設定
+admin.setting.system.security_admin_url__card_title: 管理画面URL設定
+admin.setting.system.security_admin_ip_limit__card_title: 管理画面IP制限設定
+admin.setting.system.security_front_ip_limit__card_title: ショップサイトIP制限設定
+admin.setting.system.security_connect_card_title: 接続設定
 admin.setting.system.security.admin_url: 管理画面URL
 admin.setting.system.security.admin_url_description: 推測されにくいURLを設定することを推奨します。
 admin.setting.system.security.admin_url_changed: 管理画面のURLを変更しました。再度ログインを行ってください。
-admin.setting.system.security.ip_limit: 管理機能 IP制限(許可リスト)
+admin.setting.system.security.ip_limit: IP制限(許可リスト)
 admin.setting.system.security.ip_limit_description: |
   管理機能へのアクセスを特定のIPアドレスからの接続のみに制限します。
   アクセスを許可するIPアドレスを1行ずつ入力してください。何も入力しない場合は全てを許可します。
+  IPアドレスはサブネットマスク表記に対応しています。
 admin.setting.system.security.ip_limit_sample: |
   127.0.0.1
   192.0.2.1
-admin.setting.system.security.ip_limit_deny: 管理機能 IP制限(拒否リスト)
+admin.setting.system.security.ip_limit_deny: IP制限(拒否リスト)
 admin.setting.system.security.ip_limit_description_deny: |
   特定のIPアドレスからの管理機能へのアクセスを拒否します。
   アクセスを拒否するIPアドレスを1行ずつ入力してください。
-admin.setting.system.security.front_ip_limit: ショップ画面 IP制限(許可リスト)
+  IPアドレスはサブネットマスク表記に対応しています。
 admin.setting.system.security.front_ip_limit_description: |
-  ショップ画面へのアクセスを特定のIPアドレスからの接続のみに制限します。
+  ショップサイトへのアクセスを特定のIPアドレスからの接続のみに制限します。
   アクセスを許可するIPアドレスを1行ずつ入力してください。何も入力しない場合は全てを許可します。
   IPアドレスはサブネットマスク表記に対応してます。
 admin.setting.system.security.front_ip_limit_sample: |
   127.0.0.1/28
   192.0.2.1
-admin.setting.system.security.front_ip_limit_deny: ショップ画面 IP制限(拒否リスト)
 admin.setting.system.security.front_ip_limit_description_deny: |
-  特定のIPアドレスからのショップ画面へのアクセスを拒否します。
+  特定のIPアドレスからのショップサイトへのアクセスを拒否します。
   アクセスを拒否するIPアドレスを1行ずつ入力してください。
   IPアドレスはサブネットマスク表記に対応してます。
 admin.setting.system.security.force_ssl: SSLを強制
@@ -1717,8 +1721,8 @@ tooltip.setting.system.member.work: 一時的に非稼働にすることが可�
 tooltip.setting.system.member.two_factor_auth_enabled: 有効にすると2段階認証でのログインが必要になります。2段階認証のデバイス設定をしていない状態でログインした場合、設定後にログインできるようになります。
 tooltip.setting.system.two_factor_auth.qr_code: QRコードを2段階認証用スマートフォンアプリで読み込み、表示された6桁の数字を入力してください。
 tooltip.setting.system.security.admin_url: 管理画面にログインするためのURLを指定します。推測されにくいURLを指定して下さい。
-tooltip.setting.system.security.front_ip_limit: ショップ画面にアクセスできる接続元のIPアドレスを制限します。
-tooltip.setting.system.security.front_ip_limit_deny: ショップ画面へのアクセスを拒否する接続元のIPアドレスを指定します。
+tooltip.setting.system.security.front_ip_limit: ショップサイトにアクセスできる接続元のIPアドレスを制限します。
+tooltip.setting.system.security.front_ip_limit_deny: ショップサイトへのアクセスを拒否する接続元のIPアドレスを指定します。
 tooltip.setting.system.security.ip_limit: 管理画面にログインできる接続元のIPアドレスを制限します。
 tooltip.setting.system.security.ip_limit_deny: 管理画面へのアクセスを拒否する接続元のIPアドレスを指定します。
 tooltip.setting.system.security.force_ssl: ショップサイトと管理画面への接続をSSL(https)での接続に制限します。

--- a/src/Eccube/Resource/template/admin/Setting/System/security.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/security.twig
@@ -35,18 +35,19 @@ file that was distributed with this source code.
         <div class="c-contentsArea__cols">
             <div class="c-contentsArea__primaryCol">
                 <div class="c-primaryCol">
+
                     <div class="card rounded border-0 mb-4">
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <span class="card-title">{{ 'admin.setting.system.security__card_title'|trans }}</span>
+                                    <span class="card-title">{{ 'admin.setting.system.security_admin_url__card_title'|trans }}</span>
                                 </div>
                                 <div class="col-4 text-end">
-                                    <a data-bs-toggle="collapse" href="#basicConfig" aria-expanded="false" aria-controls="basicConfig"><i class="fa fa-angle-up fa-lg"></i></a>
+                                    <a data-bs-toggle="collapse" href="#urlConfig" aria-expanded="false" aria-controls="basicConfig"><i class="fa fa-angle-up fa-lg"></i></a>
                                 </div>
                             </div>
                         </div>
-                        <div class="collapse show ec-cardCollapse" id="basicConfig">
+                        <div class="collapse show ec-cardCollapse" id="urlConfig">
                             <div class="card-body">
                                 <!-- ディレクトリ名 -->
                                 <div class="row mb-2">
@@ -60,6 +61,23 @@ file that was distributed with this source code.
                                         {{ form_errors(form.admin_route_dir) }}
                                     </div>
                                 </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card rounded border-0 mb-4">
+                        <div class="card-header">
+                            <div class="row">
+                                <div class="col-8">
+                                    <span class="card-title">{{ 'admin.setting.system.security_admin_ip_limit__card_title'|trans }}</span>
+                                </div>
+                                <div class="col-4 text-end">
+                                    <a data-bs-toggle="collapse" href="#adminIpConfig" aria-expanded="false" aria-controls="basicConfig"><i class="fa fa-angle-up fa-lg"></i></a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="collapse show ec-cardCollapse" id="adminIpConfig">
+                            <div class="card-body">
                                 <!-- 管理画面側 IP制限 許可リスト -->
                                 <div class="row mb-2">
                                     <div class="col-3">
@@ -86,11 +104,31 @@ file that was distributed with this source code.
                                         <p>{{ 'admin.setting.system.security.ip_limit_description_deny'|trans|nl2br }}</p>
                                     </div>
                                 </div>
+                            </div>
+                        </div>
+                    </div>
+
+
+
+
+                    <div class="card rounded border-0 mb-4">
+                        <div class="card-header">
+                            <div class="row">
+                                <div class="col-8">
+                                    <span class="card-title">{{ 'admin.setting.system.security_front_ip_limit__card_title'|trans }}</span>
+                                </div>
+                                <div class="col-4 text-end">
+                                    <a data-bs-toggle="collapse" href="#frontIpConfig" aria-expanded="false" aria-controls="basicConfig"><i class="fa fa-angle-up fa-lg"></i></a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="collapse show ec-cardCollapse" id="frontIpConfig">
+                            <div class="card-body">
                                 <!-- フロント側 IP制限 許可リスト -->
                                 <div class="row mb-2">
                                     <div class="col-3">
                                         <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'tooltip.setting.system.security.front_ip_limit'|trans }}">
-                                            <span>{{ 'admin.setting.system.security.front_ip_limit'|trans }}</span><i class="fa fa-question-circle fa-lg ms-1"></i>
+                                            <span>{{ 'admin.setting.system.security.ip_limit'|trans }}</span><i class="fa fa-question-circle fa-lg ms-1"></i>
                                         </div>
                                     </div>
                                     <div class="col">
@@ -103,7 +141,7 @@ file that was distributed with this source code.
                                 <div class="row mb-2">
                                     <div class="col-3">
                                         <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'tooltip.setting.system.security.front_ip_limit_deny'|trans }}">
-                                            <span>{{ 'admin.setting.system.security.front_ip_limit_deny'|trans }}</span><i class="fa fa-question-circle fa-lg ms-1"></i>
+                                            <span>{{ 'admin.setting.system.security.ip_limit_deny'|trans }}</span><i class="fa fa-question-circle fa-lg ms-1"></i>
                                         </div>
                                     </div>
                                     <div class="col">
@@ -112,6 +150,24 @@ file that was distributed with this source code.
                                         <p>{{ 'admin.setting.system.security.front_ip_limit_description_deny'|trans|nl2br }}</p>
                                     </div>
                                 </div>
+                            </div>
+                        </div>
+                    </div><!-- /.card -->
+
+
+                    <div class="card rounded border-0 mb-4">
+                        <div class="card-header">
+                            <div class="row">
+                                <div class="col-8">
+                                    <span class="card-title">{{ 'admin.setting.system.security_connect_card_title'|trans }}</span>
+                                </div>
+                                <div class="col-4 text-end">
+                                    <a data-bs-toggle="collapse" href="#networkConfig" aria-expanded="false" aria-controls="basicConfig"><i class="fa fa-angle-up fa-lg"></i></a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="collapse show ec-cardCollapse" id="networkConfig">
+                            <div class="card-body">
                                 <!-- 強制SSL -->
                                 <div class="row mb-2">
                                     <div class="col-3">
@@ -143,9 +199,12 @@ file that was distributed with this source code.
                                         <p>{{ 'admin.setting.system.security.trusted_hosts_description'|trans|nl2br }}</p>
                                     </div>
                                 </div>
+
                             </div>
                         </div>
                     </div><!-- /.card -->
+
+
                 </div>
             </div>
 

--- a/src/Eccube/Resource/template/admin/Setting/System/security.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/security.twig
@@ -132,7 +132,7 @@ file that was distributed with this source code.
                                         </div>
                                     </div>
                                     <div class="col">
-                                        {{ form_widget(form.front_allow_hosts, { 'attr': { 'rows': '8', 'placeholder': 'admin.setting.system.security.front_ip_limit_sample'|trans }}) }}
+                                        {{ form_widget(form.front_allow_hosts, { 'attr': { 'rows': '8', 'placeholder': 'admin.setting.system.security.ip_limit_sample'|trans }}) }}
                                         {{ form_errors(form.front_allow_hosts) }}
                                         <p>{{ 'admin.setting.system.security.front_ip_limit_description'|trans|nl2br }}</p>
                                     </div>
@@ -145,7 +145,7 @@ file that was distributed with this source code.
                                         </div>
                                     </div>
                                     <div class="col">
-                                        {{ form_widget(form.front_deny_hosts, { 'attr': { 'rows': '8', 'placeholder': 'admin.setting.system.security.front_ip_limit_sample'|trans }}) }}
+                                        {{ form_widget(form.front_deny_hosts, { 'attr': { 'rows': '8', 'placeholder': 'admin.setting.system.security.ip_limit_sample'|trans }}) }}
                                         {{ form_errors(form.front_deny_hosts) }}
                                         <p>{{ 'admin.setting.system.security.front_ip_limit_description_deny'|trans|nl2br }}</p>
                                     </div>

--- a/src/Eccube/Resource/template/admin/Setting/System/security.twig
+++ b/src/Eccube/Resource/template/admin/Setting/System/security.twig
@@ -60,7 +60,7 @@ file that was distributed with this source code.
                                         {{ form_errors(form.admin_route_dir) }}
                                     </div>
                                 </div>
-                                <!-- IP制限 許可リスト -->
+                                <!-- 管理画面側 IP制限 許可リスト -->
                                 <div class="row mb-2">
                                     <div class="col-3">
                                         <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'tooltip.setting.system.security.ip_limit'|trans }}">
@@ -73,7 +73,7 @@ file that was distributed with this source code.
                                         <p>{{ 'admin.setting.system.security.ip_limit_description'|trans|nl2br }}</p>
                                     </div>
                                 </div>
-                                <!-- IP制限 拒否リスト -->
+                                <!-- 管理画面側 IP制限 拒否リスト -->
                                 <div class="row mb-2">
                                     <div class="col-3">
                                         <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'tooltip.setting.system.security.ip_limit_deny'|trans }}">
@@ -84,6 +84,32 @@ file that was distributed with this source code.
                                         {{ form_widget(form.admin_deny_hosts, { 'attr': { 'rows': '8', 'placeholder': 'admin.setting.system.security.ip_limit_sample'|trans }}) }}
                                         {{ form_errors(form.admin_deny_hosts) }}
                                         <p>{{ 'admin.setting.system.security.ip_limit_description_deny'|trans|nl2br }}</p>
+                                    </div>
+                                </div>
+                                <!-- フロント側 IP制限 許可リスト -->
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'tooltip.setting.system.security.front_ip_limit'|trans }}">
+                                            <span>{{ 'admin.setting.system.security.front_ip_limit'|trans }}</span><i class="fa fa-question-circle fa-lg ms-1"></i>
+                                        </div>
+                                    </div>
+                                    <div class="col">
+                                        {{ form_widget(form.front_allow_hosts, { 'attr': { 'rows': '8', 'placeholder': 'admin.setting.system.security.front_ip_limit_sample'|trans }}) }}
+                                        {{ form_errors(form.front_allow_hosts) }}
+                                        <p>{{ 'admin.setting.system.security.front_ip_limit_description'|trans|nl2br }}</p>
+                                    </div>
+                                </div>
+                                <!-- フロント側 IP制限 禁止リスト -->
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'tooltip.setting.system.security.front_ip_limit_deny'|trans }}">
+                                            <span>{{ 'admin.setting.system.security.front_ip_limit_deny'|trans }}</span><i class="fa fa-question-circle fa-lg ms-1"></i>
+                                        </div>
+                                    </div>
+                                    <div class="col">
+                                        {{ form_widget(form.front_deny_hosts, { 'attr': { 'rows': '8', 'placeholder': 'admin.setting.system.security.front_ip_limit_sample'|trans }}) }}
+                                        {{ form_errors(form.front_deny_hosts) }}
+                                        <p>{{ 'admin.setting.system.security.front_ip_limit_description_deny'|trans|nl2br }}</p>
                                     </div>
                                 </div>
                                 <!-- 強制SSL -->

--- a/tests/Eccube/Tests/EventListener/IpAddrListenerTest.php
+++ b/tests/Eccube/Tests/EventListener/IpAddrListenerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\EventListener;
+
+use Eccube\Tests\Web\AbstractWebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Eccube\Common\EccubeConfig;
+use Eccube\Request\Context;
+use Eccube\EventListener\IpAddrListener;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class IpAddrListenerTest extends AbstractWebTestCase
+{
+
+    protected $clientIp = '192.168.56.1';
+
+    public function frontIpAddressParams()
+    {
+        return [
+            // allowチェック 許可パターン
+            [[], [], true], // 空
+            [['192.168.56.1'], [], true], // IPアドレスのみ
+            [['192.168.56.1/32'], [], true], // IPアドレスとビットマスク最大値
+            [['127.0.0.1', '192.168.56.1/32'], [],  false], // 複数行に渡る記述
+
+            // allowチェック 拒否パターン
+            [['192.168.56.2'], [], false], // IPアドレスのみ
+            [['192.168.56.2/32'], [], false], // IPアドレスとビットマスク最大値
+            [['127.0.0.1', '192.168.56.2/32'], [],  false], // 複数行に渡る記述
+
+            // denyチェック 拒否パターン
+            [[], ['192.168.56.1'], false], // IPアドレスのみ
+            [[], ['192.168.56.1/32'], false], // IPアドレスとビットマスク最大値
+            [[], ['127.0.0.1', '192.168.56.1/32'], false], // 複数行に渡る記述
+            [['192.168.56.1/32'], ['192.168.56.1/32'], false], // 許可リストで許可後、拒否リストに同様の記述があるため結果拒否される
+
+            // denyチェック 許可パターン
+            [[], ['192.168.56.2'], true], // IPアドレスのみ
+            [[], ['192.168.56.2/32'], true], // IPアドレスとビットマスク最大値
+            [[], ['127.0.0.1', '192.168.56.2/32'],  true], // 複数行に渡る記述
+
+        ];
+    }
+
+
+    /**
+     * @dataProvider frontIpAddressParams
+     */    
+    public function testOnKernelRequest($allowHost, $denyHost, $expected)
+    {
+        $event = $this->createStub(RequestEvent::class);
+        $event->method('isMainRequest')
+            ->willReturn(true);
+
+        $context = $this->createStub(Context::class);
+        $context->method('isAdmin')
+            ->willReturn(false);
+
+        $map = [
+            ['eccube_front_allow_hosts', $allowHost],
+            ['eccube_front_deny_hosts',  $denyHost],
+        ];
+        $eccubeConfig = $this->createStub(EccubeConfig::class);
+        $eccubeConfig->method('offsetGet')
+            ->will($this->returnValueMap($map));
+
+        $request = $this->createStub(Request::class);
+        $request->method('getClientIp')
+            ->willReturn($this->clientIp);
+
+        $event->method('getRequest')
+            ->willReturn($request);
+
+        $ipAddrListerner = new IpAddrListener($eccubeConfig, $context);
+
+        $actual = true;
+        try {
+            $ipAddrListerner->onKernelRequest($event);
+        } catch (AccessDeniedHttpException $e) {
+            $actual = false;
+        }
+
+        $this->assertSame($expected, $actual);
+    }
+
+}

--- a/tests/Eccube/Tests/Form/Type/Admin/SecurityTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SecurityTypeTest.php
@@ -136,7 +136,7 @@ class SecurityTypeTest extends AbstractTypeTestCase
         $this->assertTrue($this->form->isValid());
     }
 
-    public function frontIpAddressParams()
+    public function ipAddressParams()
     {
         return [
             // 正常系（適切なIPアドレス表記として認める）
@@ -158,7 +158,7 @@ class SecurityTypeTest extends AbstractTypeTestCase
     }
 
     /**
-     * @dataProvider frontIpAddressParams
+     * @dataProvider ipAddressParams
      */
     public function testFrontAllowHost($ip, $valid)
     {
@@ -168,7 +168,7 @@ class SecurityTypeTest extends AbstractTypeTestCase
     }
 
     /**
-     * @dataProvider frontIpAddressParams
+     * @dataProvider ipAddressParams
      */
     public function testFrontDenyHost($ip, $valid)
     {
@@ -178,4 +178,23 @@ class SecurityTypeTest extends AbstractTypeTestCase
     }
 
 
+    /**
+     * @dataProvider ipAddressParams
+     */
+    public function testAdminAllowHost($ip, $valid)
+    {
+        $this->formData['admin_allow_hosts'] = $ip;
+        $this->form->submit($this->formData);
+        $this->assertSame($valid, $this->form['admin_allow_hosts']->isValid());
+    }
+
+    /**
+     * @dataProvider ipAddressParams
+     */
+    public function testAdminDenyHost($ip, $valid)
+    {
+        $this->formData['admin_deny_hosts'] = $ip;
+        $this->form->submit($this->formData);
+        $this->assertSame($valid, $this->form['admin_deny_hosts']->isValid());
+    }
 }

--- a/tests/Eccube/Tests/Form/Type/Admin/SecurityTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/SecurityTypeTest.php
@@ -30,6 +30,8 @@ class SecurityTypeTest extends AbstractTypeTestCase
         'admin_route_dir' => 'admin',
         'admin_allow_hosts' => '',
         'admin_deny_hosts' => '',
+        'front_allow_hosts' => '',
+        'front_deny_hosts' => '',
         'trusted_hosts' => 'localhost',
     ];
 
@@ -133,4 +135,47 @@ class SecurityTypeTest extends AbstractTypeTestCase
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());
     }
+
+    public function frontIpAddressParams()
+    {
+        return [
+            // 正常系（適切なIPアドレス表記として認める）
+            ['', true], // 空パターン
+            ['127.0.0.1', true], // IPアドレスのみ
+            ['192.168.56.1/0', true], // IPアドレスとビットマスク最小値
+            ['192.168.56.1/32', true], // IPアドレスとビットマスク最大値
+            ["127.0.0.1\n192.168.56.1/32", true], // 複数行に渡る記述
+            [str_repeat("127.0.0.1\n", 300), true], // 300回リピート（3000byte以内チェック）
+
+            // 異常系（IPアドレス表記として認めないパターン）
+            ['a', false], // 表記に従わない記述
+            ['192.168.56.1/33', false], // ビットマスク最大値を超えた値
+            ['192.168.56.1/a', false], // ビットマスクが不正な値
+            ["127.0.0.1\n192.168.56.1/33", false], // 複数行に渡る記述で2行目が不正な値
+            ['999.168.56.1/32', false], // IPアドレスの範囲外
+            [str_repeat("127.0.0.1\n", 301), false], // 301回リピート（3000byteオーバーチェック）
+        ];
+    }
+
+    /**
+     * @dataProvider frontIpAddressParams
+     */
+    public function testFrontAllowHost($ip, $valid)
+    {
+        $this->formData['front_allow_hosts'] = $ip;
+        $this->form->submit($this->formData);
+        $this->assertSame($valid, $this->form['front_allow_hosts']->isValid());
+    }
+
+    /**
+     * @dataProvider frontIpAddressParams
+     */
+    public function testFrontDenyHost($ip, $valid)
+    {
+        $this->formData['front_deny_hosts'] = $ip;
+        $this->form->submit($this->formData);
+        $this->assertSame($valid, $this->form['front_deny_hosts']->isValid());
+    }
+
+
 }

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/SecurityControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/SecurityControllerTest.php
@@ -89,6 +89,8 @@ class SecurityControllerTest extends AbstractAdminWebTestCase
         $formData['admin_route_dir'] = null;
         $formData['admin_allow_hosts'] = null;
         $formData['admin_deny_hosts'] = null;
+        $formData['front_allow_hosts'] = null;
+        $formData['front_deny_hosts'] = null;
         $formData['force_ssl'] = null;
 
         $this->client->request(
@@ -117,6 +119,8 @@ class SecurityControllerTest extends AbstractAdminWebTestCase
             'admin_route_dir' => 'admintest',
             'admin_allow_hosts' => '127.0.0.1',
             'admin_deny_hosts' => '127.0.0.1',
+            'front_allow_hosts' => '127.0.0.1/32',
+            'front_deny_hosts' => '127.0.0.1/32',
             'trusted_hosts' => '^127\.0\.0\.1$,^localhost$',
         ];
 

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/SecurityControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/SecurityControllerTest.php
@@ -117,8 +117,8 @@ class SecurityControllerTest extends AbstractAdminWebTestCase
         $formData = [
             '_token' => 'dummy',
             'admin_route_dir' => 'admintest',
-            'admin_allow_hosts' => '127.0.0.1',
-            'admin_deny_hosts' => '127.0.0.1',
+            'admin_allow_hosts' => '127.0.0.1/32',
+            'admin_deny_hosts' => '127.0.0.1/32',
             'front_allow_hosts' => '127.0.0.1/32',
             'front_deny_hosts' => '127.0.0.1/32',
             'trusted_hosts' => '^127\.0\.0\.1$,^localhost$',


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

下記のIssueで取り上げられていた、フロント画面へのIPアクセス制御を実装。
https://github.com/EC-CUBE/ec-cube/issues/5779



## 方針(Policy)

従来から実装されていた、管理画面へのアクセス制限を踏襲し実装。

## 実装に関する補足(Appendix)

管理画面へのアクセス制限を踏襲したものの、
複数の範囲の制限が需要として考えられることから
サブネットマスクでの管理を可能としている点が少し実装ロジックが異なります。
（管理画面ではビットマスクによる指定ができる）

例: 192.168.56.1/32

## テスト（Test)

Unitテスト、E2Eテスト共に更新済みです

## 相談（Discussion）

EC-CUBEの仕様に乗っ取れているか。
実装箇所が間違っていないか。

## マイナーバージョン互換性保持のための制限事項チェックリスト

※以下、確認中です
- [ ] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
