### PR TITLE
商品CSVアップロードで visible = false から visible = true に更新できるようにする

### DIFF
--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -1405,6 +1405,13 @@ class CsvImportController extends AbstractCsvImportController
             $ProductStock->setStock(null);
         }
 
+        if (isset($row[$headerByKey['product_class_invisible_flg']])) {
+            if (StringUtil::isNotBlank($row[$headerByKey['product_class_invisible_flg']])
+                && $row[$headerByKey['product_class_invisible_flg']] == (string) Constant::ENABLED) {
+                $ProductClass->setVisible(false);
+            }
+        }
+
         return $ProductClass;
     }
 
@@ -1558,6 +1565,11 @@ class CsvImportController extends AbstractCsvImportController
             trans('admin.product.product_csv.tax_rate_col') => [
                 'id' => 'tax_rate',
                 'description' => 'admin.product.product_csv.tax_rate_description',
+                'required' => false,
+            ],
+            trans('admin.product.product_csv.product_class_invisible_flag_col') => [
+                'id' => 'product_class_invisible_flg',
+                'description' => 'admin.product.product_csv.product_class_invisible_flag_description',
                 'required' => false,
             ],
         ];

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -1405,6 +1405,10 @@ class CsvImportController extends AbstractCsvImportController
             $ProductStock->setStock(null);
         }
 
+        if ($ProductClass->isVisible() === false && $ProductClass->getClassCategory1() !== null) {
+            $ProductClass->setVisible(true);
+        }
+
         if (isset($row[$headerByKey['product_class_invisible_flg']])) {
             if (StringUtil::isNotBlank($row[$headerByKey['product_class_invisible_flg']])
                 && $row[$headerByKey['product_class_invisible_flg']] == (string) Constant::ENABLED) {

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -757,6 +757,8 @@ admin.product.product_csv.delivery_fee_col: Shipping Charge
 admin.product.product_csv.delivery_fee_description: If the shipping charge is set per product, set the value more than 0
 admin.product.product_csv.tax_rate_col: Tax Rate
 admin.product.product_csv.tax_rate_description: If the Tax Rate is set per product, set the value more than 0
+admin.product.product_csv.product_class_invisible_flag_col: Product options invisible flag
+admin.product.product_csv.product_class_invisible_flag_description: 0:Not change 1:Invisible. If unspecified, it will be set to 0.
 
 # Category CSV Templates
 admin.product.category_csv.category_id_col: Category ID

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -757,6 +757,8 @@ admin.product.product_csv.delivery_fee_col: 送料
 admin.product.product_csv.delivery_fee_description: 商品ごとの送料設定が有効の場合、0以上の数値を設定
 admin.product.product_csv.tax_rate_col: 税率
 admin.product.product_csv.tax_rate_description: 商品別税率機能設定が有効の場合、0以上の数値を設定
+admin.product.product_csv.product_class_invisible_flag_col: 商品規格非表示フラグ
+admin.product.product_csv.product_class_invisible_flag_description: 0:変更しない 1:非表示を指定します。未指定の場合、0として扱います。
 
 # カテゴリCSV雛形
 admin.product.category_csv.category_id_col: カテゴリID

--- a/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
@@ -942,6 +942,66 @@ class CsvImportControllerTest extends AbstractAdminWebTestCase
         ];
     }
 
+    public function testImportProductWithProductClassInvisible()
+    {
+        $Product = $this->createProduct('商品規格が1つの商品を生成', 1);
+        /** @var ProductClass $ProductClass */
+        $ProductClass = $Product->getProductClasses()->filter(
+            function (ProductClass $ProductClass) {
+                return $ProductClass->getClassCategory1() !== null;
+            })[0];
+        /** @var Generator $faker */
+        $faker = $this->getFaker();
+        $csv[] = ['商品ID', '公開ステータス(ID)', '商品名', '販売種別(ID)', '在庫数無制限フラグ', '販売価格', '規格分類1(ID)', '規格分類2(ID)', '商品規格非表示フラグ'];
+        $csv[] = [$Product->getId(),
+                  1, '商品名'.$faker->word.'商品名', 1, 1, $faker->randomNumber(5),
+                  $ProductClass->getClassCategory1()->getId(),
+                  $ProductClass->getClassCategory2() ? $ProductClass->getClassCategory2()->getId() : null, 1];
+        $this->filepath = $this->createCsvFromArray($csv);
+        $crawler = $this->scenario();
+
+        $this->assertMatchesRegularExpression('/CSVファイルをアップロードしました/u', $crawler->filter('div.alert-success')->text());
+
+        /** @var Product $Product */
+        $Product = $this->productRepo->find($Product->getId());
+
+        foreach ($Product->getProductClasses() as $ProductClass) {
+            if ($ProductClass->getClassCategory1() !== null) {
+                $this->assertFalse($ProductClass->isVisible());
+            }
+        }
+    }
+
+    public function testImportProductWithProductClassInvisibleOff()
+    {
+        $Product = $this->createProduct('商品規格が1つの商品を生成', 1);
+        /** @var ProductClass $ProductClass */
+        $ProductClass = $Product->getProductClasses()->filter(
+            function (ProductClass $ProductClass) {
+                return $ProductClass->getClassCategory1() !== null;
+            })[0];
+        /** @var Generator $faker */
+        $faker = $this->getFaker();
+        $csv[] = ['商品ID', '公開ステータス(ID)', '商品名', '販売種別(ID)', '在庫数無制限フラグ', '販売価格', '規格分類1(ID)', '規格分類2(ID)', '商品規格非表示フラグ'];
+        $csv[] = [$Product->getId(),
+                  1, '商品名'.$faker->word.'商品名', 1, 1, $faker->randomNumber(5),
+                  $ProductClass->getClassCategory1()->getId(),
+                  $ProductClass->getClassCategory2() ? $ProductClass->getClassCategory2()->getId() : null, 0];
+        $this->filepath = $this->createCsvFromArray($csv);
+        $crawler = $this->scenario();
+
+        $this->assertMatchesRegularExpression('/CSVファイルをアップロードしました/u', $crawler->filter('div.alert-success')->text());
+
+        /** @var Product $Product */
+        $Product = $this->productRepo->find($Product->getId());
+
+        foreach ($Product->getProductClasses() as $ProductClass) {
+            if ($ProductClass->getClassCategory1() !== null) {
+                $this->assertTrue($ProductClass->isVisible());
+            }
+        }
+    }
+
     /**
      * 商品を削除する際に、他の商品画像が参照しているファイルは削除せず、それ以外は削除することをテスト
      */


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
- refs #5856 
- Fixes #4282
- 商品CSVアップロードで visible = false から visible = true に更新できるようにする
- #5864 のあとにマージお願いします
 
## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- 商品規格が visible = false かつ、 ClassCategory1 が存在する場合は visible = true に更新する

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
明示的に商品規格非表示フラグでの ON/OFF を検討したが、以下の理由から **CSVに  visible = false の行が含まれていれば visible = true に更新する** 仕様とした
- 商品規格非表示フラグを必須項目にするとマイナーバージョンアップが難しい
-  visible = false のレコードは、管理画面上は **削除されているように見える** ため、商品規格非表示フラグの ON/OFF は直感的ではない

もし、 visible = false  のレコードを visible = false を維持したまま CSV で更新したい場合は、 商品規格非表示フラグ を 1 に設定する必要があります

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
ユニットテストを追加

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
