### PR TITLE
仮会員メール認証後に、再ログインを必要とするよう変更

### DIFF
--- a/codeception/acceptance/EA07BasicinfoCest.php
+++ b/codeception/acceptance/EA07BasicinfoCest.php
@@ -126,7 +126,6 @@ class EA07BasicinfoCest
         $I->logoutAsMember();
 
         // 会員ステータスのチェック
-        $I->loginAsAdmin();
         $page = CustomerManagePage::go($I);
         $I->fillField('#admin_search_customer_multi', $email);
         $page->詳細検索_仮会員();

--- a/codeception/acceptance/EF04CustomerCest.php
+++ b/codeception/acceptance/EF04CustomerCest.php
@@ -12,6 +12,8 @@
  */
 
 use Codeception\Util\Fixtures;
+use Page\Front\CartPage;
+use Page\Front\ProductDetailPage;
 
 /**
  * @group front
@@ -210,6 +212,177 @@ class EF04CustomerCest
 
         $I->click('.ec-registerRole form button.ec-blockBtn--cancel');
         $I->see('新規会員登録', '.ec-pageHeader h1');
+    }
+
+    public function customer_会員登録正常_ログイン(AcceptanceTester $I)
+    {
+        $I->wantTo('EF0401-UC01-T06 会員登録 ログイン');
+        $I->amOnPage('/entry');
+        $faker = Fixtures::get('faker');
+        $BaseInfo = Fixtures::get('baseinfo');
+        $new_email = microtime(true).'.'.$faker->safeEmail;
+        // 会員情報入力フォームに、会員情報を入力する
+        // 「同意する」ボタンを押下する
+        $form = [
+            'entry[name][name01]' => '姓',
+            'entry[name][name02]' => '名',
+            'entry[kana][kana01]' => 'セイ',
+            'entry[kana][kana02]' => 'メイ',
+            'entry[postal_code]' => '530-0001',
+            'entry[address][pref]' => ['value' => '27'],
+            'entry[address][addr01]' => '大阪市北区',
+            'entry[address][addr02]' => '梅田2-4-9 ブリーゼタワー13F',
+            'entry[phone_number]' => '111-111-111',
+            'entry[email][first]' => $new_email,
+            'entry[email][second]' => $new_email,
+            'entry[plain_password][first]' => 'password1234',
+            'entry[plain_password][second]' => 'password1234',
+            'entry[job]' => ['value' => '1'],
+            'entry[user_policy_check]' => '1',
+        ];
+        $findPluginByCode = Fixtures::get('findPluginByCode');
+        $Plugin = $findPluginByCode('MailMagazine42');
+        if ($Plugin) {
+            $I->amGoingTo('メルマガプラグインを発見したため、メルマガを購読します');
+            $form['entry[mailmaga_flg]'] = '1';
+        }
+        $I->submitForm(['css' => '.ec-layoutRole__main form'], $form, ['css' => 'button.ec-blockBtn--action']);
+
+        // 入力した会員情報を確認する。
+        $I->see('姓 名', '.ec-registerRole form .ec-borderedDefs dl:nth-child(1) dd');
+        $I->see('111111111', '.ec-registerRole form .ec-borderedDefs dl:nth-child(5) dd');
+        $I->see($new_email, '.ec-registerRole form .ec-borderedDefs dl:nth-child(6) dd');
+
+        $I->resetEmails();
+        // 「会員登録をする」ボタンを押下する
+        $I->click('.ec-registerRole form button.ec-blockBtn--action');
+
+        $message = $I->lastMessage();
+        $I->assertCount(2, $message->getRecipients(), 'Bcc で管理者にも送信するので宛先アドレスは2つ');
+        $I->seeEmailCount(1);
+        foreach ([$new_email, $BaseInfo->getEmail01()] as $email) {
+            $I->seeInLastEmailSubjectTo($email, '会員登録のご確認');
+            $I->seeInLastEmailTo($email, '姓 名 様');
+            $I->seeInLastEmailTo($email, 'この度は会員登録依頼をいただきまして、有り難うございます。');
+        }
+
+        // 「トップページへ」ボタンを押下する
+        $I->click('a.ec-blockBtn--cancel');
+        $I->see('新着情報', '.ec-secHeading__ja');
+
+        // アクティベートURL取得
+        $activateUrl = $I->grabFromLastEmailTo($new_email, '@/entry/activate/(.*)@');
+        $I->resetEmails();
+
+        // アクティベートURLからトップページへ
+        $I->amOnPage($activateUrl);
+        $I->see('新規会員登録(完了)', 'div.ec-pageHeader h1');
+
+        $message = $I->lastMessage();
+        $I->assertCount(2, $message->getRecipients(), 'Bcc で管理者にも送信するので宛先アドレスは2つ');
+        $I->seeEmailCount(1);
+        foreach ([$new_email, $BaseInfo->getEmail01()] as $email) {
+            $I->seeInLastEmailSubjectTo($email, '会員登録が完了しました。');
+            $I->seeInLastEmailTo($email, '姓 名 様');
+            $I->seeInLastEmailTo($email, '本会員登録が完了いたしました。');
+        }
+        $I->click('div.ec-headerNaviRole__right > div.ec-headerNaviRole__nav > div > div:nth-child(3) > a'); // ヘッダーナビ ログインボタン
+
+        $I->submitForm('#login_mypage', [
+            'login_email' => $new_email,
+            'login_pass' => 'password1234',
+        ]);
+        $I->seeInCurrentUrl('/mypage');
+    }
+
+    public function customer_会員登録正常_カート(AcceptanceTester $I)
+    {
+        $I->wantTo('EF0401-UC01-T07 会員登録 カート');
+
+        // 商品詳細パーコレータ カートへ
+        ProductDetailPage::go($I, 2)
+            ->カートに入れる(1)
+            ->カートへ進む();
+        $I->click(['css' => 'div.ec-cartRole__actions a.ec-blockBtn--action']); // レジに進む
+        $I->click('#shopping_login > div > div.ec-grid2 > div:nth-child(2) > div:nth-child(2) > a'); // 新規会員登録
+
+        $faker = Fixtures::get('faker');
+        $BaseInfo = Fixtures::get('baseinfo');
+        $new_email = microtime(true).'.'.$faker->safeEmail;
+        // 会員情報入力フォームに、会員情報を入力する
+        // 「同意する」ボタンを押下する
+        $form = [
+            'entry[name][name01]' => '姓',
+            'entry[name][name02]' => '名',
+            'entry[kana][kana01]' => 'セイ',
+            'entry[kana][kana02]' => 'メイ',
+            'entry[postal_code]' => '530-0001',
+            'entry[address][pref]' => ['value' => '27'],
+            'entry[address][addr01]' => '大阪市北区',
+            'entry[address][addr02]' => '梅田2-4-9 ブリーゼタワー13F',
+            'entry[phone_number]' => '111-111-111',
+            'entry[email][first]' => $new_email,
+            'entry[email][second]' => $new_email,
+            'entry[plain_password][first]' => 'password1234',
+            'entry[plain_password][second]' => 'password1234',
+            'entry[job]' => ['value' => '1'],
+            'entry[user_policy_check]' => '1',
+        ];
+        $findPluginByCode = Fixtures::get('findPluginByCode');
+        $Plugin = $findPluginByCode('MailMagazine42');
+        if ($Plugin) {
+            $I->amGoingTo('メルマガプラグインを発見したため、メルマガを購読します');
+            $form['entry[mailmaga_flg]'] = '1';
+        }
+        $I->submitForm(['css' => '.ec-layoutRole__main form'], $form, ['css' => 'button.ec-blockBtn--action']);
+
+        // 入力した会員情報を確認する。
+        $I->see('姓 名', '.ec-registerRole form .ec-borderedDefs dl:nth-child(1) dd');
+        $I->see('111111111', '.ec-registerRole form .ec-borderedDefs dl:nth-child(5) dd');
+        $I->see($new_email, '.ec-registerRole form .ec-borderedDefs dl:nth-child(6) dd');
+
+        $I->resetEmails();
+        // 「会員登録をする」ボタンを押下する
+        $I->click('.ec-registerRole form button.ec-blockBtn--action');
+
+        $message = $I->lastMessage();
+        $I->assertCount(2, $message->getRecipients(), 'Bcc で管理者にも送信するので宛先アドレスは2つ');
+        $I->seeEmailCount(1);
+        foreach ([$new_email, $BaseInfo->getEmail01()] as $email) {
+            $I->seeInLastEmailSubjectTo($email, '会員登録のご確認');
+            $I->seeInLastEmailTo($email, '姓 名 様');
+            $I->seeInLastEmailTo($email, 'この度は会員登録依頼をいただきまして、有り難うございます。');
+        }
+
+        // 「トップページへ」ボタンを押下する
+        $I->click('a.ec-blockBtn--cancel');
+        $I->see('新着情報', '.ec-secHeading__ja');
+
+        // アクティベートURL取得
+        $activateUrl = $I->grabFromLastEmailTo($new_email, '@/entry/activate/(.*)@');
+        $I->resetEmails();
+
+        // アクティベートURLからトップページへ
+        $I->amOnPage($activateUrl);
+        $I->see('新規会員登録(完了)', 'div.ec-pageHeader h1');
+
+        $message = $I->lastMessage();
+        $I->assertCount(2, $message->getRecipients(), 'Bcc で管理者にも送信するので宛先アドレスは2つ');
+        $I->seeEmailCount(1);
+        foreach ([$new_email, $BaseInfo->getEmail01()] as $email) {
+            $I->seeInLastEmailSubjectTo($email, '会員登録が完了しました。');
+            $I->seeInLastEmailTo($email, '姓 名 様');
+            $I->seeInLastEmailTo($email, '本会員登録が完了いたしました。');
+        }
+        $I->click('div.ec-registerCompleteRole a.ec-blockBtn--action'); // カートへ進む
+        CartPage::go($I)
+            ->レジに進む();
+
+        $I->submitForm('#shopping_login', [
+            'login_email' => $new_email,
+            'login_pass' => 'password1234',
+        ]);
+        $I->seeInCurrentUrl('/shopping');
     }
 
     /**

--- a/src/Eccube/Controller/EntryController.php
+++ b/src/Eccube/Controller/EntryController.php
@@ -258,6 +258,10 @@ class EntryController extends AbstractController
             ]
         );
 
+        if (!$this->session->has('eccube.login.target.path')) {
+            $this->setLoginTargetPath($this->generateUrl('mypage'));
+        }
+
         if (!is_null($qtyInCart)) {
             return [
                 'qtyInCart' => $qtyInCart,

--- a/src/Eccube/Controller/EntryController.php
+++ b/src/Eccube/Controller/EntryController.php
@@ -315,16 +315,9 @@ class EntryController extends AbstractController
             $qtyInCart += $Cart->getTotalQuantity();
         }
 
-        // 本会員登録してログイン状態にする
-        $token = new UsernamePasswordToken($Customer, 'customer', ['ROLE_USER']);
-        $this->tokenStorage->setToken($token);
-        $request->getSession()->migrate(true);
-
         if ($qtyInCart) {
             $this->cartService->save();
         }
-
-        log_info('ログイン済に変更', [$this->getUser()->getId()]);
 
         return $qtyInCart;
     }

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -255,7 +255,7 @@ front.mypage.reorder_message: '*Please note that the price has been changed when
 front.mypage.mail_not_found: No email found.
 front.mypage.mail_list: Email History
 front.mypage.customer_complete_message__title: Customer information has been updated
-front.mypage.customer_complete_message__body: Please continue your shopping!
+front.mypage.customer_complete_message__body: Please login with your email address and password and enjoy shopping!
 front.mypage.favorite_count: '%count% item(s) found in Favorites'
 front.mypage.favorite_not_found: No item found in Favorites.
 front.mypage.customer_address_count: '%count% items are registered in Delivery Addresses'

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -255,7 +255,7 @@ front.mypage.reorder_message: ※金額が変更されている商品がある�
 front.mypage.mail_not_found: メール履歴はありません。
 front.mypage.mail_list: メール配信履歴一覧
 front.mypage.customer_complete_message__title: 会員登録内容の変更が完了いたしました
-front.mypage.customer_complete_message__body: それでは、引き続きショッピングをお楽しみください。
+front.mypage.customer_complete_message__body: メールアドレスとパスワードでログイン後、ショッピングをお楽しみください。
 front.mypage.favorite_count: '%count%件のお気に入りがあります'
 front.mypage.favorite_not_found: お気に入りは登録されていません。
 front.mypage.customer_address_count: '%count%件のお届け先があります'

--- a/src/Eccube/Resource/template/default/Mail/entry_complete.html.twig
+++ b/src/Eccube/Resource/template/default/Mail/entry_complete.html.twig
@@ -32,7 +32,7 @@ file that was distributed with this source code.
                             <br>
                             {{ BaseInfo.shop_name }}でございます。<br/>
                             この度は会員登録依頼をいただきましてまことに有り難うございます。<br/>
-                            ショッピングをお楽しみくださいませ。<br/>
+                            メールアドレスとパスワードでログイン後、ショッピングをお楽しみくださいませ。<br/>
                             <br/>
                             今後ともどうぞ{{ BaseInfo.shop_name }}をよろしくお願い申し上げます。<br/>
                             <br/>

--- a/src/Eccube/Resource/template/default/Mail/entry_complete.twig
+++ b/src/Eccube/Resource/template/default/Mail/entry_complete.twig
@@ -27,7 +27,7 @@ file that was distributed with this source code.
 この度は会員登録依頼をいただきましてまことに有り難うございます。
 
 本会員登録が完了いたしました。
-ショッピングをお楽しみくださいませ。
+メールアドレスとパスワードでログイン後、ショッピングをお楽しみくださいませ。
 
 今後ともどうぞ{{ BaseInfo.shop_name }}をよろしくお願い申し上げます。
 {% endautoescape %}


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
- Fixes #5664
- 仮会員メール認証後は自動でログイン状態としない

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
- 本会員登録時、自動ログインしていた処理を削除
- 本会員登録メールの文言を変更

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
- #5664 では、 **ログインに認証しない限りはメール認証成功とはしない** という提案がありましたが、これを実現するためには、仮会員状態でログイン可能な画面を作成する必要があり、実装が複雑になるため別途対応とします
- 現代は多くのWebサービスでは自動ログインしないため、 ON/OFF 機能は実装せず、必要であれば別途対応とします。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
E2Eテストを追加

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
