### PR TITLE
各FormType に ::getBlockPrefix() の戻り値の型宣言（:string）を追加

### DIFF
--- a/src/Eccube/Form/Type/AddCartType.php
+++ b/src/Eccube/Form/Type/AddCartType.php
@@ -184,7 +184,8 @@ class AddCartType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'add_cart';
     }

--- a/src/Eccube/Form/Type/AddressType.php
+++ b/src/Eccube/Form/Type/AddressType.php
@@ -127,7 +127,8 @@ class AddressType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'address';
     }

--- a/src/Eccube/Form/Type/Admin/AuthenticationType.php
+++ b/src/Eccube/Form/Type/Admin/AuthenticationType.php
@@ -77,7 +77,8 @@ class AuthenticationType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_authentication';
     }

--- a/src/Eccube/Form/Type/Admin/AuthorityRoleType.php
+++ b/src/Eccube/Form/Type/Admin/AuthorityRoleType.php
@@ -79,7 +79,8 @@ class AuthorityRoleType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_authority_role';
     }

--- a/src/Eccube/Form/Type/Admin/BlockType.php
+++ b/src/Eccube/Form/Type/Admin/BlockType.php
@@ -136,7 +136,8 @@ class BlockType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'block';
     }

--- a/src/Eccube/Form/Type/Admin/CalendarType.php
+++ b/src/Eccube/Form/Type/Admin/CalendarType.php
@@ -143,7 +143,8 @@ class CalendarType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'calendar';
     }

--- a/src/Eccube/Form/Type/Admin/CategoryType.php
+++ b/src/Eccube/Form/Type/Admin/CategoryType.php
@@ -67,7 +67,8 @@ class CategoryType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_category';
     }

--- a/src/Eccube/Form/Type/Admin/ChangePasswordType.php
+++ b/src/Eccube/Form/Type/Admin/ChangePasswordType.php
@@ -84,7 +84,8 @@ class ChangePasswordType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_change_password';
     }

--- a/src/Eccube/Form/Type/Admin/ClassCategoryType.php
+++ b/src/Eccube/Form/Type/Admin/ClassCategoryType.php
@@ -78,7 +78,8 @@ class ClassCategoryType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_class_category';
     }

--- a/src/Eccube/Form/Type/Admin/ClassNameType.php
+++ b/src/Eccube/Form/Type/Admin/ClassNameType.php
@@ -77,7 +77,8 @@ class ClassNameType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_class_name';
     }

--- a/src/Eccube/Form/Type/Admin/CsvImportType.php
+++ b/src/Eccube/Form/Type/Admin/CsvImportType.php
@@ -70,7 +70,8 @@ class CsvImportType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_csv_import';
     }

--- a/src/Eccube/Form/Type/Admin/CustomerType.php
+++ b/src/Eccube/Form/Type/Admin/CustomerType.php
@@ -181,7 +181,8 @@ class CustomerType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_customer';
     }

--- a/src/Eccube/Form/Type/Admin/DeliveryFeeType.php
+++ b/src/Eccube/Form/Type/Admin/DeliveryFeeType.php
@@ -45,7 +45,8 @@ class DeliveryFeeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'delivery_fee';
     }

--- a/src/Eccube/Form/Type/Admin/DeliveryTimeType.php
+++ b/src/Eccube/Form/Type/Admin/DeliveryTimeType.php
@@ -82,7 +82,8 @@ class DeliveryTimeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'delivery_time';
     }

--- a/src/Eccube/Form/Type/Admin/DeliveryType.php
+++ b/src/Eccube/Form/Type/Admin/DeliveryType.php
@@ -122,7 +122,8 @@ class DeliveryType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'delivery';
     }

--- a/src/Eccube/Form/Type/Admin/LayoutType.php
+++ b/src/Eccube/Form/Type/Admin/LayoutType.php
@@ -84,7 +84,8 @@ class LayoutType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_layout';
     }

--- a/src/Eccube/Form/Type/Admin/LogType.php
+++ b/src/Eccube/Form/Type/Admin/LogType.php
@@ -92,7 +92,8 @@ class LogType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_system_log';
     }

--- a/src/Eccube/Form/Type/Admin/LoginType.php
+++ b/src/Eccube/Form/Type/Admin/LoginType.php
@@ -79,7 +79,8 @@ class LoginType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_login';
     }

--- a/src/Eccube/Form/Type/Admin/MailType.php
+++ b/src/Eccube/Form/Type/Admin/MailType.php
@@ -64,7 +64,8 @@ class MailType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'mail';
     }

--- a/src/Eccube/Form/Type/Admin/MainEditType.php
+++ b/src/Eccube/Form/Type/Admin/MainEditType.php
@@ -293,7 +293,8 @@ class MainEditType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'main_edit';
     }

--- a/src/Eccube/Form/Type/Admin/MasterdataDataType.php
+++ b/src/Eccube/Form/Type/Admin/MasterdataDataType.php
@@ -75,7 +75,8 @@ class MasterdataDataType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_system_masterdata_data';
     }

--- a/src/Eccube/Form/Type/Admin/MasterdataEditType.php
+++ b/src/Eccube/Form/Type/Admin/MasterdataEditType.php
@@ -68,7 +68,8 @@ class MasterdataEditType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_system_masterdata_edit';
     }

--- a/src/Eccube/Form/Type/Admin/MasterdataType.php
+++ b/src/Eccube/Form/Type/Admin/MasterdataType.php
@@ -97,7 +97,8 @@ class MasterdataType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_system_masterdata';
     }

--- a/src/Eccube/Form/Type/Admin/MemberType.php
+++ b/src/Eccube/Form/Type/Admin/MemberType.php
@@ -181,7 +181,8 @@ class MemberType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_member';
     }

--- a/src/Eccube/Form/Type/Admin/NewsType.php
+++ b/src/Eccube/Form/Type/Admin/NewsType.php
@@ -106,7 +106,8 @@ class NewsType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_news';
     }

--- a/src/Eccube/Form/Type/Admin/OrderItemType.php
+++ b/src/Eccube/Form/Type/Admin/OrderItemType.php
@@ -310,7 +310,8 @@ class OrderItemType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'order_item';
     }

--- a/src/Eccube/Form/Type/Admin/OrderMailType.php
+++ b/src/Eccube/Form/Type/Admin/OrderMailType.php
@@ -77,7 +77,8 @@ class OrderMailType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_order_mail';
     }

--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -263,7 +263,8 @@ class OrderType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'order';
     }

--- a/src/Eccube/Form/Type/Admin/PageType.php
+++ b/src/Eccube/Form/Type/Admin/PageType.php
@@ -42,7 +42,8 @@ class PageType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_page';
     }

--- a/src/Eccube/Form/Type/Admin/PaymentRegisterType.php
+++ b/src/Eccube/Form/Type/Admin/PaymentRegisterType.php
@@ -116,7 +116,8 @@ class PaymentRegisterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'payment_register';
     }

--- a/src/Eccube/Form/Type/Admin/PluginLocalInstallType.php
+++ b/src/Eccube/Form/Type/Admin/PluginLocalInstallType.php
@@ -43,7 +43,8 @@ class PluginLocalInstallType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'plugin_local_install';
     }

--- a/src/Eccube/Form/Type/Admin/PluginManagementType.php
+++ b/src/Eccube/Form/Type/Admin/PluginManagementType.php
@@ -57,7 +57,8 @@ class PluginManagementType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'plugin_management';
     }

--- a/src/Eccube/Form/Type/Admin/ProductClassType.php
+++ b/src/Eccube/Form/Type/Admin/ProductClassType.php
@@ -160,7 +160,8 @@ class ProductClassType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_product_class';
     }

--- a/src/Eccube/Form/Type/Admin/ProductTag.php
+++ b/src/Eccube/Form/Type/Admin/ProductTag.php
@@ -55,7 +55,8 @@ class ProductTag extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_product_tag';
     }

--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -229,7 +229,8 @@ class ProductType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_product';
     }

--- a/src/Eccube/Form/Type/Admin/SearchCustomerType.php
+++ b/src/Eccube/Form/Type/Admin/SearchCustomerType.php
@@ -407,7 +407,8 @@ class SearchCustomerType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_search_customer';
     }

--- a/src/Eccube/Form/Type/Admin/SearchLoginHistoryType.php
+++ b/src/Eccube/Form/Type/Admin/SearchLoginHistoryType.php
@@ -111,7 +111,8 @@ class SearchLoginHistoryType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_search_login_history';
     }

--- a/src/Eccube/Form/Type/Admin/SearchOrderType.php
+++ b/src/Eccube/Form/Type/Admin/SearchOrderType.php
@@ -423,7 +423,8 @@ class SearchOrderType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_search_order';
     }

--- a/src/Eccube/Form/Type/Admin/SearchPluginApiType.php
+++ b/src/Eccube/Form/Type/Admin/SearchPluginApiType.php
@@ -89,7 +89,8 @@ class SearchPluginApiType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'search_plugin';
     }

--- a/src/Eccube/Form/Type/Admin/SearchProductType.php
+++ b/src/Eccube/Form/Type/Admin/SearchProductType.php
@@ -271,7 +271,8 @@ class SearchProductType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_search_product';
     }

--- a/src/Eccube/Form/Type/Admin/SecurityType.php
+++ b/src/Eccube/Form/Type/Admin/SecurityType.php
@@ -145,7 +145,8 @@ class SecurityType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_security';
     }

--- a/src/Eccube/Form/Type/Admin/ShippingType.php
+++ b/src/Eccube/Form/Type/Admin/ShippingType.php
@@ -345,7 +345,8 @@ class ShippingType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'shipping';
     }

--- a/src/Eccube/Form/Type/Admin/ShopMasterType.php
+++ b/src/Eccube/Form/Type/Admin/ShopMasterType.php
@@ -258,7 +258,8 @@ class ShopMasterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'shop_master';
     }

--- a/src/Eccube/Form/Type/Admin/TagType.php
+++ b/src/Eccube/Form/Type/Admin/TagType.php
@@ -60,7 +60,8 @@ class TagType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_tag';
     }

--- a/src/Eccube/Form/Type/Admin/TaxRuleType.php
+++ b/src/Eccube/Form/Type/Admin/TaxRuleType.php
@@ -106,7 +106,8 @@ class TaxRuleType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'tax_rule';
     }

--- a/src/Eccube/Form/Type/Admin/TemplateType.php
+++ b/src/Eccube/Form/Type/Admin/TemplateType.php
@@ -86,7 +86,8 @@ class TemplateType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_template';
     }

--- a/src/Eccube/Form/Type/Admin/TwoFactorAuthType.php
+++ b/src/Eccube/Form/Type/Admin/TwoFactorAuthType.php
@@ -55,7 +55,8 @@ class TwoFactorAuthType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'admin_two_factor_auth';
     }

--- a/src/Eccube/Form/Type/Front/ContactType.php
+++ b/src/Eccube/Form/Type/Front/ContactType.php
@@ -83,7 +83,8 @@ class ContactType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'contact';
     }

--- a/src/Eccube/Form/Type/Front/CustomerAddressType.php
+++ b/src/Eccube/Form/Type/Front/CustomerAddressType.php
@@ -80,7 +80,8 @@ class CustomerAddressType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'customer_address';
     }

--- a/src/Eccube/Form/Type/Front/CustomerLoginType.php
+++ b/src/Eccube/Form/Type/Front/CustomerLoginType.php
@@ -72,7 +72,8 @@ class CustomerLoginType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'customer_login';
     }

--- a/src/Eccube/Form/Type/Front/EntryType.php
+++ b/src/Eccube/Form/Type/Front/EntryType.php
@@ -137,7 +137,8 @@ class EntryType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         // todo entry,mypageで共有されているので名前を変更する
         return 'entry';

--- a/src/Eccube/Form/Type/Front/ForgotType.php
+++ b/src/Eccube/Form/Type/Front/ForgotType.php
@@ -59,7 +59,8 @@ class ForgotType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'forgot';
     }

--- a/src/Eccube/Form/Type/Front/NonMemberType.php
+++ b/src/Eccube/Form/Type/Front/NonMemberType.php
@@ -77,7 +77,8 @@ class NonMemberType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'nonmember';
     }

--- a/src/Eccube/Form/Type/Front/PasswordResetType.php
+++ b/src/Eccube/Form/Type/Front/PasswordResetType.php
@@ -67,7 +67,8 @@ class PasswordResetType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'forgot_reset';
     }

--- a/src/Eccube/Form/Type/Front/ShoppingShippingType.php
+++ b/src/Eccube/Form/Type/Front/ShoppingShippingType.php
@@ -47,7 +47,8 @@ class ShoppingShippingType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'shopping_shipping';
     }

--- a/src/Eccube/Form/Type/Install/Step1Type.php
+++ b/src/Eccube/Form/Type/Install/Step1Type.php
@@ -34,7 +34,8 @@ class Step1Type extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'install_step1';
     }

--- a/src/Eccube/Form/Type/Install/Step3Type.php
+++ b/src/Eccube/Form/Type/Install/Step3Type.php
@@ -162,7 +162,8 @@ class Step3Type extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'install_step3';
     }

--- a/src/Eccube/Form/Type/Install/Step4Type.php
+++ b/src/Eccube/Form/Type/Install/Step4Type.php
@@ -125,7 +125,8 @@ class Step4Type extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'install_step4';
     }

--- a/src/Eccube/Form/Type/Install/Step5Type.php
+++ b/src/Eccube/Form/Type/Install/Step5Type.php
@@ -35,7 +35,8 @@ class Step5Type extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'install_step5';
     }

--- a/src/Eccube/Form/Type/KanaType.php
+++ b/src/Eccube/Form/Type/KanaType.php
@@ -94,7 +94,8 @@ class KanaType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'kana';
     }

--- a/src/Eccube/Form/Type/Master/CategoryType.php
+++ b/src/Eccube/Form/Type/Master/CategoryType.php
@@ -41,7 +41,8 @@ class CategoryType extends AbstractType
         return MasterType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'category';
     }

--- a/src/Eccube/Form/Type/Master/CsvType.php
+++ b/src/Eccube/Form/Type/Master/CsvType.php
@@ -35,7 +35,8 @@ class CsvType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'csv_type';
     }

--- a/src/Eccube/Form/Type/Master/CustomerStatusType.php
+++ b/src/Eccube/Form/Type/Master/CustomerStatusType.php
@@ -42,7 +42,8 @@ class CustomerStatusType extends AbstractType
         return MasterType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'customer_status';
     }

--- a/src/Eccube/Form/Type/Master/DeliveryDurationType.php
+++ b/src/Eccube/Form/Type/Master/DeliveryDurationType.php
@@ -36,7 +36,8 @@ class DeliveryDurationType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'delivery_duration';
     }

--- a/src/Eccube/Form/Type/Master/DeviceTypeType.php
+++ b/src/Eccube/Form/Type/Master/DeviceTypeType.php
@@ -43,7 +43,8 @@ class DeviceTypeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'device_type';
     }

--- a/src/Eccube/Form/Type/Master/JobType.php
+++ b/src/Eccube/Form/Type/Master/JobType.php
@@ -33,7 +33,8 @@ class JobType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'job';
     }

--- a/src/Eccube/Form/Type/Master/LoginHistoryStatusType.php
+++ b/src/Eccube/Form/Type/Master/LoginHistoryStatusType.php
@@ -41,7 +41,8 @@ class LoginHistoryStatusType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'login_history_status';
     }

--- a/src/Eccube/Form/Type/Master/MailTemplateType.php
+++ b/src/Eccube/Form/Type/Master/MailTemplateType.php
@@ -42,7 +42,8 @@ class MailTemplateType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'mail_template';
     }

--- a/src/Eccube/Form/Type/Master/OrderStatusType.php
+++ b/src/Eccube/Form/Type/Master/OrderStatusType.php
@@ -71,7 +71,8 @@ class OrderStatusType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'order_status';
     }

--- a/src/Eccube/Form/Type/Master/PageMaxType.php
+++ b/src/Eccube/Form/Type/Master/PageMaxType.php
@@ -67,7 +67,8 @@ class PageMaxType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'page_max';
     }

--- a/src/Eccube/Form/Type/Master/PaymentType.php
+++ b/src/Eccube/Form/Type/Master/PaymentType.php
@@ -40,7 +40,8 @@ class PaymentType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'payment';
     }

--- a/src/Eccube/Form/Type/Master/PrefType.php
+++ b/src/Eccube/Form/Type/Master/PrefType.php
@@ -36,7 +36,8 @@ class PrefType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'pref';
     }

--- a/src/Eccube/Form/Type/Master/ProductListMaxType.php
+++ b/src/Eccube/Form/Type/Master/ProductListMaxType.php
@@ -49,7 +49,8 @@ class ProductListMaxType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'product_list_max';
     }

--- a/src/Eccube/Form/Type/Master/ProductListOrderByType.php
+++ b/src/Eccube/Form/Type/Master/ProductListOrderByType.php
@@ -49,7 +49,8 @@ class ProductListOrderByType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'product_list_order_by';
     }

--- a/src/Eccube/Form/Type/Master/ProductStatusType.php
+++ b/src/Eccube/Form/Type/Master/ProductStatusType.php
@@ -41,7 +41,8 @@ class ProductStatusType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'product_status';
     }

--- a/src/Eccube/Form/Type/Master/RoundingTypeType.php
+++ b/src/Eccube/Form/Type/Master/RoundingTypeType.php
@@ -32,7 +32,8 @@ class RoundingTypeType extends AbstractType
         return MasterType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'rounding_type';
     }

--- a/src/Eccube/Form/Type/Master/SaleTypeType.php
+++ b/src/Eccube/Form/Type/Master/SaleTypeType.php
@@ -36,7 +36,8 @@ class SaleTypeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'sale_type';
     }

--- a/src/Eccube/Form/Type/Master/SexType.php
+++ b/src/Eccube/Form/Type/Master/SexType.php
@@ -42,7 +42,8 @@ class SexType extends AbstractType
         return MasterType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'sex';
     }

--- a/src/Eccube/Form/Type/MasterType.php
+++ b/src/Eccube/Form/Type/MasterType.php
@@ -40,7 +40,8 @@ class MasterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'master';
     }

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -135,7 +135,8 @@ class NameType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'name';
     }

--- a/src/Eccube/Form/Type/PhoneNumberType.php
+++ b/src/Eccube/Form/Type/PhoneNumberType.php
@@ -93,7 +93,8 @@ class PhoneNumberType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'phone_number';
     }

--- a/src/Eccube/Form/Type/PostalType.php
+++ b/src/Eccube/Form/Type/PostalType.php
@@ -94,7 +94,8 @@ class PostalType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'postal';
     }

--- a/src/Eccube/Form/Type/PriceType.php
+++ b/src/Eccube/Form/Type/PriceType.php
@@ -97,7 +97,8 @@ class PriceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'price';
     }

--- a/src/Eccube/Form/Type/RepeatedEmailType.php
+++ b/src/Eccube/Form/Type/RepeatedEmailType.php
@@ -86,7 +86,8 @@ class RepeatedEmailType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'repeated_email';
     }

--- a/src/Eccube/Form/Type/RepeatedPasswordType.php
+++ b/src/Eccube/Form/Type/RepeatedPasswordType.php
@@ -93,7 +93,8 @@ class RepeatedPasswordType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'repeated_password';
     }

--- a/src/Eccube/Form/Type/SearchProductBlockType.php
+++ b/src/Eccube/Form/Type/SearchProductBlockType.php
@@ -70,7 +70,8 @@ class SearchProductBlockType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'search_product_block';
     }

--- a/src/Eccube/Form/Type/SearchProductType.php
+++ b/src/Eccube/Form/Type/SearchProductType.php
@@ -98,7 +98,8 @@ class SearchProductType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'search_product';
     }

--- a/src/Eccube/Form/Type/ShippingMultipleItemType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleItemType.php
@@ -183,7 +183,8 @@ class ShippingMultipleItemType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'shipping_multiple_item';
     }

--- a/src/Eccube/Form/Type/ShippingMultipleType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleType.php
@@ -72,7 +72,8 @@ class ShippingMultipleType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'shipping_multiple';
     }

--- a/src/Eccube/Form/Type/Shopping/OrderItemType.php
+++ b/src/Eccube/Form/Type/Shopping/OrderItemType.php
@@ -39,7 +39,8 @@ class OrderItemType extends AbstractType
         );
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return '_shopping_order_item';
     }

--- a/src/Eccube/Form/Type/Shopping/OrderType.php
+++ b/src/Eccube/Form/Type/Shopping/OrderType.php
@@ -189,7 +189,8 @@ class OrderType extends AbstractType
         );
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return '_shopping_order';
     }

--- a/src/Eccube/Form/Type/Shopping/ShippingType.php
+++ b/src/Eccube/Form/Type/Shopping/ShippingType.php
@@ -278,7 +278,8 @@ class ShippingType extends AbstractType
         );
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return '_shopping_shipping';
     }

--- a/src/Eccube/Form/Type/ShoppingMultipleType.php
+++ b/src/Eccube/Form/Type/ShoppingMultipleType.php
@@ -63,7 +63,8 @@ class ShoppingMultipleType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix():string
+
     {
         return 'shopping_multiple';
     }


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
Symfony Profiler>Logsで発生しているdeprecation(非推奨)の対応です。
::getBlockPrefix() の戻り値の型宣言（:string）を追加しました。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->


## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

Symfony Profilerのログにて以下のようなログが90件ほど発生していました。
```
Method "Symfony\Component\Form\FormTypeInterface::getBlockPrefix()" might add "string" as a native return type declaration in the future. Do the same in implementation "Eccube\Form\Type\Shopping\OrderItemType" now to avoid errors or add an explicit @return annotation to suppress this message.

メソッド "SymfonyComponent FilterFormTypeInterface::getBlockPrefix()" は、将来的にネイティブの戻り値の型宣言として "string" を追加する可能性があります。エラーを回避するために、今すぐ実装 "Eccube FilterFormType" で同じことをするか、このメッセージを抑制するために明示的な @return アノテーションを追加してください。
```

ログ上では、`@return string` のアノテーション追加を推奨されているようなのですが、Deprecationが解消されなかったので、戻り値の型宣言を行ったところ解消されました。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
