### PR TITLE
エラーページでのトップへ戻るリンクがlocalhostになる不具合を修正

### DIFF
--- a/src/Eccube/Resource/template/default/error.twig
+++ b/src/Eccube/Resource/template/default/error.twig
@@ -29,7 +29,7 @@ file that was distributed with this source code.
                 </div>
                 <p class="ec-404Role__title ec-reportHeading">{{ error_title }}</p>
                 <p class="ec-404Role__description ec-reportDescription">{{ error_message }}</p>
-                <a class="ec-blockBtn--cancel" href="{{ app.request.base_path ?? '/' }}">{{ 'common.go_to_top'|trans }}</a>
+                <a class="ec-blockBtn--cancel" href="{{ app.request.basePath ~ '/' }}">{{ 'common.go_to_top'|trans }}</a>
             </div>
         </div>
     </div>

--- a/src/Eccube/Resource/template/default/error.twig
+++ b/src/Eccube/Resource/template/default/error.twig
@@ -29,7 +29,7 @@ file that was distributed with this source code.
                 </div>
                 <p class="ec-404Role__title ec-reportHeading">{{ error_title }}</p>
                 <p class="ec-404Role__description ec-reportDescription">{{ error_message }}</p>
-                <a class="ec-blockBtn--cancel" href="{{ url('homepage') }}">{{ 'common.go_to_top'|trans }}</a>
+                <a class="ec-blockBtn--cancel" href="{{ app.request.base_path ?? '/' }}">{{ 'common.go_to_top'|trans }}</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#5747 の対応。Untrustedhost時のトップページリンク生成ロジックを変更。
localhostにならないよう自ドメインのトップページへ遷移させる

## 方針(Policy)
url関数を使わずtwigの関数である、app.request.basePathへ変更

## 実装に関する補足(Appendix)
`app.request.basePath ~ '/'` のやり方を採用しているのは、
urlやpath関数ではルーティング前の値を取得してしまいうまく動作しないため。
（サブディレクトリが切られて居ない時はbasePathの中身はbrankになる）

## テスト（Test)
UIの簡単な確認で済むため、UTの追加等はしていません。

## 相談（Discussion）
「こういうサイトのURLパターンだとうまく機能しない」というような
考慮漏れがないかどうかを気にしているので見ていただきたい。
→ルートディレクトリ・サブディレクトリはそれぞれ確認済み

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
