### PR TITLE
納品書の郵便番号が出力されていない不具合を修正

### DIFF
--- a/src/Eccube/Service/OrderPdfService.php
+++ b/src/Eccube/Service/OrderPdfService.php
@@ -299,11 +299,15 @@ class OrderPdfService extends Fpdi
         $this->setBasePosition();
 
         // ショップ名
-        $this->lfText(125, 60, $this->baseInfoRepository->getShopName(), 8, 'B');
+        $this->lfText(125, 58, $this->baseInfoRepository->getShopName(), 8, 'B');
+
+        //郵便番号
+        $this->lfText(121, 63, "\u{3012}". ' ' . mb_substr($this->baseInfoRepository->getPostalCode(), 0, 3) . ' - ' . mb_substr($this->baseInfoRepository->getPostalCode(), 3, 4), 8);
+
 
         // 都道府県+所在地
         $text = $this->baseInfoRepository->getPref().$this->baseInfoRepository->getAddr01();
-        $this->lfText(125, 65, $text, 8);
+        $this->lfText(125, 66, $text, 8);
         $this->lfText(125, 69, $this->baseInfoRepository->getAddr02(), 8);
 
         // 電話番号
@@ -415,6 +419,10 @@ class OrderPdfService extends Fpdi
         // =========================================
 
         $Order = $Shipping->getOrder();
+
+        // 購入者郵便番号(3012は郵便マークのUTFコード)
+        $text = "\u{3012}" . ' ' . mb_substr($Shipping->getPostalCode(), 0, 3) . ' - ' . mb_substr($Shipping->getPostalCode(), 3, 4);
+        $this->lfText(22, 43, $text, 10);
 
         // 購入者都道府県+住所1
         // $text = $Order->getPref().$Order->getAddr01();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#4792 を受けて、納品書（PDF）への郵便番号出力がされるように対応。

## 方針(Policy)
すでに納品書出力のfunctionは実装されており、郵便番号の部分だけがgetされていないだけであったため、
`getPostalcode` と、それに伴うテキストの反映 `lfTerxt` を追加。

## 実装に関する補足(Appendix)
郵便番号のマークである「〒」をUTF-8のコードで表記。
そのままの文字で表記しても問題ないとは思うが、念の為。

## テスト（Test)
納品書への出力を何パターンか試し、問題ないことを確認。

## 相談（Discussion）
間のハイフンが要・不要によってコードの書き方が若干変わる。
不要な方がシンプルではあるが、馴染みのある表記かつ2系に則る形にしたため、ハイフンがある

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
