### PR TITLE
下層ディレクトリにec-cubeを設置した場合、カート→レジに進むにてログインした場合にエラーになる #5863

### DIFF
--- a/src/Eccube/Resource/template/default/Shopping/login.twig
+++ b/src/Eccube/Resource/template/default/Shopping/login.twig
@@ -25,8 +25,8 @@ file that was distributed with this source code.
 
             <div class="ec-grid3__cell2">
                 <form name="shopping_login" id="shopping_login" method="post" action="{{ url('mypage_login') }}">
-                    <input type="hidden" name="_target_path" value="{{ path('shopping') }}" />
-                    <input type="hidden" name="_failure_path" value="{{ path('shopping_login') }}" />
+                    <input type="hidden" name="_target_path" value="{{ url('shopping') }}" />
+                    <input type="hidden" name="_failure_path" value="{{ url('shopping_login') }}" />
                     <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
                     <div class="ec-login">
                         <div class="ec-login__icon">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
下層ディレクトリにec-cubeを設置した場合、カート→レジに進むにてログインした場合にエラーになる #5863

## 方針(Policy)
https://example.com/ec-cube のように下層ディレクトリにec-cubeを設置した場合も、
「ページがみつかりません。」の表示ではなく通常通りログインでき、
「ご注文手続き」画面が表示される。

## 実装に関する補足(Appendix)
path関数で実装されていた箇所をurl関数に修正しました。

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト
- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
