### PR TITLE
CSVを出力するとシステムエラーになる不具合の修正

### DIFF
--- a/src/Eccube/Controller/Admin/Customer/CustomerController.php
+++ b/src/Eccube/Controller/Admin/Customer/CustomerController.php
@@ -292,12 +292,12 @@ class CustomerController extends AbstractController
             // CSV種別を元に初期化.
             $this->csvExportService->initCsvType(CsvType::CSV_TYPE_CUSTOMER);
 
-            // ヘッダ行の出力.
-            $this->csvExportService->exportHeader();
-
             // 会員データ検索用のクエリビルダを取得.
             $qb = $this->csvExportService
                 ->getCustomerQueryBuilder($request);
+
+            // ヘッダ行の出力.
+            $this->csvExportService->exportHeader();
 
             // データ行の出力.
             $this->csvExportService->setExportQueryBuilder($qb);

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -408,12 +408,12 @@ class OrderController extends AbstractController
             // CSV種別を元に初期化.
             $this->csvExportService->initCsvType($csvTypeId);
 
-            // ヘッダ行の出力.
-            $this->csvExportService->exportHeader();
-
             // 受注データ検索用のクエリビルダを取得.
             $qb = $this->csvExportService
                 ->getOrderQueryBuilder($request);
+
+            // ヘッダ行の出力.
+            $this->csvExportService->exportHeader();
 
             // データ行の出力.
             $this->csvExportService->setExportQueryBuilder($qb);

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -967,12 +967,12 @@ class ProductController extends AbstractController
             // CSV種別を元に初期化.
             $this->csvExportService->initCsvType(CsvType::CSV_TYPE_PRODUCT);
 
-            // ヘッダ行の出力.
-            $this->csvExportService->exportHeader();
-
             // 商品データ検索用のクエリビルダを取得.
             $qb = $this->csvExportService
                 ->getProductQueryBuilder($request);
+
+            // ヘッダ行の出力.
+            $this->csvExportService->exportHeader();
 
             // Get stock status
             $isOutOfStock = 0;


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

#5754 の修正

クエリビルダ構築時に[セッションから検索条件を取得している](https://github.com/EC-CUBE/ec-cube/blob/4.2/src/Eccube/Service/CsvExportService.php#L416)が、すでにCSVヘッダが出力されているため、`Failed to start the session because headers have already been sent`のエラーが発生していた。

クエリビルダの構築とヘッダ出力の順序を逆にすることで修正しています。

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

CSVが正常に出力されることを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
