### PR TITLE
管理画面内の日付絞り込み時、１度目だけ 今日の日付+T00:00 が設定される

### DIFF
--- a/html/template/admin/assets/js/function.js
+++ b/html/template/admin/assets/js/function.js
@@ -239,3 +239,17 @@ $(function() {
         }
     });
 });
+
+// input[type="datetime-local"]、初期クリック時に当日の0時0分を設定
+$(function() {
+    if( $('[type="datetime-local"]').length ){
+        $('[type="datetime-local"]').on('click',function(){
+            if( $(this).val() === '' && !$(this).hasClass('is_adjusted') ){
+                $(this).addClass('is_adjusted');
+                let date = new Date();
+                let adjusted_date = date.toLocaleDateString().split('/').map((e)=>{ return ( String(e).length < 2 )? "0"+e : e ; }).join('-');
+                $(this).val( adjusted_date + 'T00:00');
+            }
+        });
+    }
+});


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
管理画面内の日付絞り込み時に、現在時刻を00:00など一意の値に制御したい #5920

JavaScriptで、input[type="datetime-local"]をクリックされた時に、１度目だけ、 現在日T00:00 が設定されるようにしました。

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

Mac OSのChrome, Firefox, Safariの各最新版と、Windowsの Edge, Chromeでは動作確認しました。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
