### PR TITLE
EC-CUBEの基本設定内にあるメールの設定を修正したい

### DIFF
--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -1125,9 +1125,9 @@ admin.setting.shop.shop.shop_name_kana: 店名(カナ)
 admin.setting.shop.shop.shop_name_en: 店名(英語表記)
 admin.setting.shop.shop.business_hour: 店舗営業時間
 admin.setting.shop.shop.email_from: 送信元メールアドレス(From)
-admin.setting.shop.shop.email_for_inquiries: 問い合わせ受付メールアドレス(From, ReplyTo)
-admin.setting.shop.shop.email_reply_to: 返信受付メールアドレス(ReplyTo)
-admin.setting.shop.shop.email_return_path: 送信エラー受付メールアドレス(ReturnPath)
+admin.setting.shop.shop.email_for_inquiries: 問い合わせ専用メールアドレス(From, ReplyTo)
+admin.setting.shop.shop.email_reply_to: 返信先メールアドレス(ReplyTo)
+admin.setting.shop.shop.email_return_path: 送信エラー通知メールアドレス(ReturnPath)
 admin.setting.shop.shop.good_traded: 取り扱い商品説明文
 admin.setting.shop.shop.message: 店舗からのメッセージ
 admin.setting.shop.shop.option_delivery_fee: 送料設定

--- a/src/Eccube/Resource/template/admin/Setting/Shop/shop_master.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/shop_master.twig
@@ -124,17 +124,7 @@ file that was distributed with this source code.
                             </div>
                             <div class="row mb-3">
                                 <div class="col-3">
-                                    <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'tooltip.setting.shop.shop.email_for_inquiries'|trans }}"><span>{{ 'admin.setting.shop.shop.email_for_inquiries'|trans }}</span><i class="fa fa-question-circle fa-lg ms-1"></i></div>
-                                    <span class="badge bg-primary ms-1">{{ 'admin.common.required'|trans }}</span>
-                                </div>
-                                <div class="col mb-2">
-                                    {{ form_widget(form.email02) }}
-                                    {{ form_errors(form.email02) }}
-                                </div>
-                            </div>
-                            <div class="row mb-3">
-                                <div class="col-3">
-                                    <div class="d-inline-block" class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'tooltip.setting.shop.shop.email_reply_to'|trans }}"><span>{{ 'admin.setting.shop.shop.email_reply_to'|trans }}</span><i class="fa fa-question-circle fa-lg ms-1"></i></div>
+                                    <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'tooltip.setting.shop.shop.email_reply_to'|trans }}"><span>{{ 'admin.setting.shop.shop.email_reply_to'|trans }}</span><i class="fa fa-question-circle fa-lg ms-1"></i></div>
                                     <span class="badge bg-primary ms-1">{{ 'admin.common.required'|trans }}</span>
                                 </div>
                                 <div class="col mb-2">
@@ -150,6 +140,16 @@ file that was distributed with this source code.
                                 <div class="col mb-2">
                                     {{ form_widget(form.email04) }}
                                     {{ form_errors(form.email04) }}
+                                </div>
+                            </div>
+                            <div class="row mb-3">
+                                <div class="col-3">
+                                    <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'tooltip.setting.shop.shop.email_for_inquiries'|trans }}"><span>{{ 'admin.setting.shop.shop.email_for_inquiries'|trans }}</span><i class="fa fa-question-circle fa-lg ms-1"></i></div>
+                                    <span class="badge bg-primary ms-1">{{ 'admin.common.required'|trans }}</span>
+                                </div>
+                                <div class="col mb-2">
+                                    {{ form_widget(form.email02) }}
+                                    {{ form_errors(form.email02) }}
                                 </div>
                             </div>
                             <div class="row">

--- a/src/Eccube/Service/MailService.php
+++ b/src/Eccube/Service/MailService.php
@@ -439,7 +439,7 @@ class MailService
 
         $message = (new Email())
             ->subject('['.$this->BaseInfo->getShopName().'] '.$MailTemplate->getMailSubject())
-            ->from(new Address($this->BaseInfo->getEmail03(), $this->BaseInfo->getShopName()))
+            ->from(new Address($this->BaseInfo->getEmail01(), $this->BaseInfo->getShopName()))
             ->to($this->convertRFCViolatingEmail($Customer->getEmail()))
             ->bcc($this->BaseInfo->getEmail01())
             ->replyTo($this->BaseInfo->getEmail03())
@@ -551,6 +551,7 @@ class MailService
             ->subject('['.$this->BaseInfo->getShopName().'] '.$MailTemplate->getMailSubject())
             ->from(new Address($this->BaseInfo->getEmail01(), $this->BaseInfo->getShopName()))
             ->to($this->convertRFCViolatingEmail($Customer->getEmail()))
+            ->bcc($this->BaseInfo->getEmail01())
             ->replyTo($this->BaseInfo->getEmail03())
             ->returnPath($this->BaseInfo->getEmail04());
 


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

EC-CUBEの基本設定内にあるメールの設定を修正したい #5937
の対応です。

仮会員登録再送メールのfromを Email03からEmail01に変更
パスワード再発行メールのbccに Email01 を設定

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
