### PR TITLE
受注テーブルのtaxに税率ごとの消費税額の合算を設定する

### DIFF
--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -141,6 +141,9 @@ if (!class_exists('\Eccube\Entity\Order')) {
             $roundingTypes = $this->getRoundingTypeByTaxRate();
             $tax = [];
             foreach ($this->getTaxableTotalByTaxRate() as $rate => $totalPrice) {
+                if (is_null($roundingTypes[$rate])) {
+                    continue;
+                }
                 $tax[$rate] = TaxRuleService::roundByRoundingType(
                     $this->getTaxableTotal() ?
                         ($totalPrice - abs($this->getTaxFreeDiscount()) * $totalPrice / $this->getTaxableTotal()) * ($rate / (100 + $rate)) : 0,

--- a/src/Eccube/Service/PurchaseFlow/PurchaseFlow.php
+++ b/src/Eccube/Service/PurchaseFlow/PurchaseFlow.php
@@ -353,12 +353,7 @@ class PurchaseFlow
         } else {
             $total = $itemHolder->getItems()
                 ->reduce(function ($sum, ItemInterface $item) {
-                    if ($item instanceof OrderItem) {
-                        $sum += $item->getTax() * $item->getQuantity();
-                    } else {
-                        $sum += ($item->getPriceIncTax() - $item->getPrice()) * $item->getQuantity();
-                    }
-
+                    $sum += ($item->getPriceIncTax() - $item->getPrice()) * $item->getQuantity();
                     return $sum;
                 }, 0);
         }

--- a/src/Eccube/Service/PurchaseFlow/PurchaseFlow.php
+++ b/src/Eccube/Service/PurchaseFlow/PurchaseFlow.php
@@ -17,7 +17,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Eccube\Entity\ItemHolderInterface;
 use Eccube\Entity\ItemInterface;
 use Eccube\Entity\Order;
-use Eccube\Entity\OrderItem;
 
 class PurchaseFlow
 {
@@ -354,6 +353,7 @@ class PurchaseFlow
             $total = $itemHolder->getItems()
                 ->reduce(function ($sum, ItemInterface $item) {
                     $sum += ($item->getPriceIncTax() - $item->getPrice()) * $item->getQuantity();
+
                     return $sum;
                 }, 0);
         }

--- a/src/Eccube/Service/PurchaseFlow/PurchaseFlow.php
+++ b/src/Eccube/Service/PurchaseFlow/PurchaseFlow.php
@@ -346,16 +346,22 @@ class PurchaseFlow
      */
     protected function calculateTax(ItemHolderInterface $itemHolder)
     {
-        $total = $itemHolder->getItems()
-            ->reduce(function ($sum, ItemInterface $item) {
-                if ($item instanceof OrderItem) {
-                    $sum += $item->getTax() * $item->getQuantity();
-                } else {
-                    $sum += ($item->getPriceIncTax() - $item->getPrice()) * $item->getQuantity();
-                }
-
-                return $sum;
+        if ($itemHolder instanceof Order) {
+            $total = array_reduce($itemHolder->getTaxByTaxRate(), function ($sum, $tax) {
+                return $sum + $tax;
             }, 0);
+        } else {
+            $total = $itemHolder->getItems()
+                ->reduce(function ($sum, ItemInterface $item) {
+                    if ($item instanceof OrderItem) {
+                        $sum += $item->getTax() * $item->getQuantity();
+                    } else {
+                        $sum += ($item->getPriceIncTax() - $item->getPrice()) * $item->getQuantity();
+                    }
+
+                    return $sum;
+                }, 0);
+        }
         $itemHolder->setTax($total);
     }
 

--- a/tests/Eccube/Tests/Entity/OrderTest.php
+++ b/tests/Eccube/Tests/Entity/OrderTest.php
@@ -251,27 +251,6 @@ class OrderTest extends EccubeTestCase
 
     protected function createTestOrder()
     {
-        $data = $this->getOrderItemData();
-        $Order = new Order();
-        foreach ($data as $row) {
-            $OrderItem = new OrderItem();
-            $OrderItem->setTaxType($row[0]);
-            $OrderItem->setTaxRate($row[1]);
-            $OrderItem->setPrice($row[2]);
-            $OrderItem->setTax($row[3]);
-            $OrderItem->setQuantity($row[4]);
-            $OrderItem->setOrderItemType($row[5]);
-            $OrderItem->setTaxDisplayType($row[6]);
-            $OrderItem->setRoundingType($row[7]);
-
-            $Order->addOrderItem($OrderItem);
-        }
-
-        return $Order;
-    }
-
-    protected function getOrderItemData()
-    {
         $Taxation = $this->entityManager->find(TaxType::class, TaxType::TAXATION);
         $NonTaxable = $this->entityManager->find(TaxType::class, TaxType::NON_TAXABLE);
         $TaxExempt = $this->entityManager->find(TaxType::class, TaxType::TAX_EXEMPT);
@@ -288,17 +267,32 @@ class OrderTest extends EccubeTestCase
 
         // 税率ごとに金額を集計する
         $data = [
-            [$Taxation, 10, 71141, round(71141 * (10 / 100)), 5, $ProductItem, $TaxExcluded, $RoundingType],    // 商品明細
-            [$Taxation, 10, 92778, round(92778 * (10 / 100)), 4, $ProductItem, $TaxExcluded, $RoundingType],    // 商品明細
-            [$Taxation, 8, 15221, round(15221 * (8 / 100)), 5, $ProductItem, $TaxExcluded, $RoundingType],      // 商品明細
-            [$Taxation, 10, -71141, round(-71141 * (10 / 100)), 1, $DiscountItem, $TaxExcluded, $RoundingType],  // 課税値引き
-            [$Taxation, 8, -15221, round(-15221 * (8 / 100)), 1, $DiscountItem, $TaxExcluded, $RoundingType],    // 課税値引き
-            [$Taxation, 10, 1000, round(1000 * (10 / 100)), 1, $DeliveryFee, $TaxIncluded, $RoundingType],    // 送料
-            [$Taxation, 10, 2187, round(1000 * (10 / 100)), 1, $Charge, $TaxIncluded, $RoundingType],    // 手数料
+            [$Taxation, 10, 71141, round(71141 * (10/100)), 5, $ProductItem, $TaxExcluded, $RoundingType],    // 商品明細
+            [$Taxation, 10, 92778, round(92778 * (10/100)), 4, $ProductItem, $TaxExcluded, $RoundingType],    // 商品明細
+            [$Taxation, 8, 15221, round(15221 * (8/100)), 5, $ProductItem, $TaxExcluded, $RoundingType],      // 商品明細
+            [$Taxation, 10, -71141, round(-71141 * (10/100)), 1, $DiscountItem, $TaxExcluded, $RoundingType],  // 課税値引き
+            [$Taxation, 8, -15221, round(-15221 * (8/100)), 1, $DiscountItem, $TaxExcluded, $RoundingType],    // 課税値引き
+            [$Taxation, 10, 1000, round(1000 * (10/100)), 1, $DeliveryFee, $TaxIncluded, $RoundingType],    // 送料
+            [$Taxation, 10, 2187, round(1000 * (10/100)), 1, $Charge, $TaxIncluded, $RoundingType],    // 手数料
             [$NonTaxable, 0, -7000, 0, 1, $DiscountItem, $TaxIncluded, $RoundingType],    // 不課税明細
             [$TaxExempt, 0, -159, 0, 1, $DiscountItem, $TaxIncluded, $RoundingType],     // 非課税明細
         ];
 
-        return $data;
+        $Order = new Order();
+        foreach ($data as $row) {
+            $OrderItem = new OrderItem();
+            $OrderItem->setTaxType($row[0]);
+            $OrderItem->setTaxRate($row[1]);
+            $OrderItem->setPrice($row[2]);
+            $OrderItem->setTax($row[3]);
+            $OrderItem->setQuantity($row[4]);
+            $OrderItem->setOrderItemType($row[5]);
+            $OrderItem->setTaxDisplayType($row[6]);
+            $OrderItem->setRoundingType($row[7]);
+
+            $Order->addOrderItem($OrderItem);
+        }
+
+        return $Order;
     }
 }

--- a/tests/Eccube/Tests/Entity/OrderTest.php
+++ b/tests/Eccube/Tests/Entity/OrderTest.php
@@ -237,7 +237,6 @@ class OrderTest extends EccubeTestCase
     {
         $Order = $this->createTestOrder();
 
-        self::assertSame(790187, $this->getTaxableTotal(), '課税合計');
         self::assertSame(65160.0, $Order->getTotalByTaxRate()[8], '8%対象値引き後合計');
         self::assertSame(717868.0, $Order->getTotalByTaxRate()[10], '10%対象値引き後合計');
     }
@@ -301,19 +300,5 @@ class OrderTest extends EccubeTestCase
         ];
 
         return $data;
-    }
-
-    protected function getTaxableTotal()
-    {
-        $data = $this->getOrderItemData();
-        $Taxation = $this->entityManager->find(TaxType::class, TaxType::TAXATION);
-        $TaxExcluded = $this->entityManager->find(TaxDisplayType::class, TaxDisplayType::EXCLUDED);
-        $taxableItem = array_filter($data, function ($item) use ($Taxation) {
-            return $item[0] === $Taxation;
-        });
-
-        return array_reduce($taxableItem, function ($sum, $item) use ($TaxExcluded) {
-            return $sum + ($item[2] + $item[6] !== $TaxExcluded ? $item[3] : 0) * $item[4];
-        });
     }
 }

--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -648,6 +648,7 @@ class Generator
         $ItemDeliveryFee = $this->entityManager->find(OrderItemType::class, OrderItemType::DELIVERY_FEE);
         $ItemCharge = $this->entityManager->find(OrderItemType::class, OrderItemType::CHARGE);
         $ItemDiscount = $this->entityManager->find(OrderItemType::class, OrderItemType::DISCOUNT);
+        $ItemPoint = $this->entityManager->find(OrderItemType::class, OrderItemType::POINT);
         $BaseInfo = $this->entityManager->getRepository(BaseInfo::class)->get();
 
         /** @var ProductClass $ProductClass */
@@ -726,6 +727,19 @@ class Generator
             ->setOrderItemType($ItemDiscount); // 値引き明細
         // $Shipping->addOrderItem($OrderItemDiscount); // Shipping には登録しない
         $Order->addOrderItem($OrderItemDiscount);
+
+        if (($point = mt_rand(0, min($Customer->getPoint(), $Order->getPaymentTotal()))) > 0) {
+            $OrderItemPoint = new OrderItem();
+            $OrderItemPoint
+                ->setOrder($Order)
+                ->setProductName('ポイント')
+                ->setPrice($point * -1)
+                ->setQuantity(1)
+                ->setTaxType($NonTaxable)
+                ->setTaxDisplayType($TaxInclude)
+                ->setOrderItemType($ItemPoint);
+            $Order->addOrderItem($OrderItemPoint);
+        }
 
         $this->orderPurchaseFlow->validate($Order, new PurchaseContext($Order));
 
@@ -900,7 +914,6 @@ class Generator
      * Faker を生成する.
      *
      * @return \Faker\Generator
-     *
      */
     protected function getFaker()
     {

--- a/tests/Eccube/Tests/Service/PurchaseFlow/ItemCollectionTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/ItemCollectionTest.php
@@ -122,12 +122,16 @@ class ItemCollectionTest extends EccubeTestCase
     {
         shuffle($this->Items);
 
-        $this->expected = [1 => '商品', 2 => '送料', 3 => '手数料', 4 => '割引'];
+        $this->expected = [1 => '商品', 2 => '送料', 3 => '手数料'];
         $this->actual = [];
         $Items = (new ItemCollection($this->Items))->sort();
         foreach ($Items as $Item) {
             $this->actual[$Item->getOrderItemType()->getId()] = $Item->getOrderItemType()->getName();
         }
+        if (array_key_exists(6, $this->actual)) {
+            $this->expected[6] = 'ポイント';
+        }
+        $this->expected[4] = '割引';
 
         $this->verify();
     }

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PaymentTotalNegativeValidatorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PaymentTotalNegativeValidatorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Service\PurchaseFlow\Processor;
+
+use Eccube\Entity\Cart;
+use Eccube\Service\PurchaseFlow\Processor\PaymentTotalNegativeValidator;
+use Eccube\Service\PurchaseFlow\PurchaseContext;
+use Eccube\Tests\EccubeTestCase;
+
+class PaymentTotalNegativeValidatorTest extends EccubeTestCase
+{
+    public function testPositiveValidate()
+    {
+        $validator = $this->newValidator();
+
+        $cart = new Cart();
+        $cart->setTotal(100);
+
+        $result = $validator->execute($cart, new PurchaseContext());
+        self::assertTrue($result->isSuccess());
+    }
+
+    public function testNegativeValidate()
+    {
+        $validator = $this->newValidator();
+
+        $cart = new Cart();
+        $cart->setTotal(-100);
+
+        $result = $validator->execute($cart, new PurchaseContext());
+        self::assertTrue($result->isError());
+    }
+
+    /**
+     * @return PaymentTotalNegativeValidator
+     */
+    private function newValidator()
+    {
+        return static::getContainer()->get(PaymentTotalNegativeValidator::class);
+    }
+}


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

<!-- ****************************************************************************
脆弱性報告 (Vulnerability report)
脆弱性のご報告は弊社[問い合わせフォーム](https://www.ec-cube.net/contact/)からお願いします。
**************************************************************************** -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
dtb_orderのtaxカラムは非奨励ではあるようですが、適格請求書に記載する消費税を設定しておきたいです。

![image](https://user-images.githubusercontent.com/8424850/231455199-32bf21da-0582-4fbf-b8c9-fbdbaa32eb6f.png)


## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
現在は、各商品の消費税分×数量の合算を設定していますが、このプルリクでは消費税率ごとの消費税の合算としています。




## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [X] フックポイントの呼び出しタイミングの変更はありません
- [X] フックポイントのパラメータの削除・データ型の変更はありません
- [X] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [X] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [X] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
