### PR TITLE
「自動的にログインする」の期限を1週間に変更

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -11,7 +11,7 @@ parameters:
     env(ECCUBE_AUTH_MAGIC): '<change.me>'
     env(ECCUBE_COOKIE_NAME): 'eccube'
     env(ECCUBE_COOKIE_PATH): '/'
-    env(ECCUBE_COOKIE_LIFETIME): '0'
+    env(ECCUBE_COOKIE_LIFETIME): '604800'
     env(ECCUBE_GC_MAXLIFETIME): '1440'
     env(ECCUBE_PACKAGE_API_URL): 'https://package-api-c2.ec-cube.net/v42'
     env(ECCUBE_OWNERS_STORE_URL): 'https://www.ec-cube.net'

--- a/app/config/eccube/packages/security.yaml
+++ b/app/config/eccube/packages/security.yaml
@@ -45,7 +45,7 @@ security:
             provider: customer_provider
             remember_me:
                 secret: '%kernel.secret%'
-                lifetime: 3600
+                lifetime: '%env(int:ECCUBE_COOKIE_LIFETIME)%'
                 name: eccube_remember_me
                 remember_me_parameter: 'login_memory'
                 secure: auto


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
「自動ログインが1時間で切れる」という、 #5975 の問題を解消

## 方針(Policy)
今回はYAMLの修正しか行っていません。

## 実装に関する補足(Appendix)
security.yaml のremember_meの時間が1時間になっていたので、そちらを修正。
参照する先を実数値ではなくeccube.yamlにある ECCUBE_COOKIE_LIFETIMEへ変更。
これにより、環境変数の値を使う（なければyamlの値を使う）という使い方が可能になる

## テスト（Test)
ログインした際のCookieの期限が変化しているかを目視確認で実施。問題ないことを確認。

## 相談（Discussion）
他にいい実装方法あればご指南ください

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
