### PR TITLE
購入エラー画面ではWarningレベルのメッセージを削除する.

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -774,6 +774,12 @@ class ShoppingController extends AbstractShoppingController
             $this->cartService->save();
         }
 
+        // 購入エラー画面についてはwarninメッセージを出力しない為、warningレベルのメッセージが存在する場合、削除する.
+        // (warningが残っている場合、購入エラー画面以降のタイミングで誤って表示されてしまう為.)
+        if ($this->session->getFlashBag()->has('eccube.front.warning')) {
+            $this->session->getFlashBag()->get('eccube.front.warning');
+        }
+
         $event = new EventArgs(
             [],
             $request


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#4031 の対応

## 方針(Policy)
#4031コメント内に記載の[購入エラー画面表示時に警告があれば消しておく]で対応

## 実装に関する補足(Appendix)
問題となっているメッセージだけでなく(在庫不足の為、削除)、PurchaseFlowでエラー＋警告が同時に発生した場合、
個別メッセージの内容を判定はせずに、警告レベルのメッセージが残らないように、Controller側で削除しています.

## テスト（Test)
### パターン①（購入エラー画面が表示されるパターン）
①カート内に[チェリーアイスサンド]を投入
②管理画面より[チェリーアイスサンド]を在庫=0に設定
③レジへ進む > 購入エラー画面が表示される
④商品在庫を追加し、再度カート投入しレジへ進む
⑤ご注文手続き画面が表示される。（この際、警告メッセージなし）

### パターン②（購入エラー画面が表示されないパターン）
①カート内に[チェリーアイスサンド] / [彩のジェラートCUBE]を投入
②管理画面より[チェリーアイスサンド]を在庫=0に設定
③レジへ進む 
④ご注文手続き画面が表示される。（この際、「チェリーアイスサンド」の在庫が不足しております。該当商品をカートから削除しました。が表示される。）

## 相談（Discussion）
なし

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [-] 既存機能の仕様変更はありません
- [-] フックポイントの呼び出しタイミングの変更はありません
- [-] フックポイントのパラメータの削除・データ型の変更はありません
- [-] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [-]] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [-] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
