### PR TITLE
fix:インストール時のDBパスワード入力フォームからpurifyを外す

### DIFF
--- a/src/Eccube/Form/Type/Install/Step4Type.php
+++ b/src/Eccube/Form/Type/Install/Step4Type.php
@@ -91,6 +91,7 @@ class Step4Type extends AbstractType
             ->add('database_password', PasswordType::class, [
                 'label' => trans('install.database_password'),
                 'required' => false,
+                'purify_html' => false,
             ])
             ->addEventListener(FormEvents::POST_SUBMIT, function ($event) {
                 $form = $event->getForm();


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

<!-- ****************************************************************************
脆弱性報告 (Vulnerability report)
脆弱性のご報告は弊社[問い合わせフォーム](https://www.ec-cube.net/contact/)からお願いします。
**************************************************************************** -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
インストール時のDBパスワードに、記号が入っていた場合は変換されてしまうため、DBへの接続が出来ない。
https://github.com/EC-CUBE/ec-cube/issues/6025

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
 DBの設定には`  ! # % & ( ) * + , - . / ; < = > ? @ [ ] ^ _ { | } ~ `の記号が使えるとの事なので、記号があった場合でも接続できるようにする。
https://faq.zenlogic.jp/faqs/FAQ01272

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->


## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
- パスワードに「! # % & ( ) * + , - . / ; < = > ? @ [ ] ^ _ { | } ~ 」を入れた状態で、フロントに出力
した結果、全て半角になっていた。
```
string(52) "! # % & ( ) * + , - . / ; < = > ? @ [ ] ^ _ { | } ~ "
```

- 実際にパスワードに`&`が含まれるユーザで、動作確認を行なって、問題なく動作した。

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
- このパスワードフォームを用いて、攻撃が可能になってしまっていないか？
フロントに表示や、DBに保存などしていなく、.envはテキストベースなので、攻撃は出来ないと考えています。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
