### PR TITLE
`eccube:plugin:install` コマンドに `--if-not-exists` オプションを追加

### DIFF
--- a/src/Eccube/Command/PluginInstallCommand.php
+++ b/src/Eccube/Command/PluginInstallCommand.php
@@ -29,6 +29,7 @@ class PluginInstallCommand extends Command
         $this
             ->addOption('path', null, InputOption::VALUE_OPTIONAL, 'path of tar or zip')
             ->addOption('code', null, InputOption::VALUE_OPTIONAL, 'plugin code')
+            ->addOption('if-not-exists', null, InputOption::VALUE_NONE, 'If plugin is already installed, skip install.')
             ->setDescription('Install plugin from local.');
     }
 
@@ -38,10 +39,11 @@ class PluginInstallCommand extends Command
 
         $path = $input->getOption('path');
         $code = $input->getOption('code');
+        $ifNotExists = $input->getOption('if-not-exists');
 
         // アーカイブからインストール
         if ($path) {
-            if ($this->pluginService->install($path)) {
+            if ($this->pluginService->install($path, $ifNotExists)) {
                 $io->success('Installed.');
 
                 return 0;
@@ -50,7 +52,7 @@ class PluginInstallCommand extends Command
 
         // 設置済ファイルからインストール
         if ($code) {
-            $this->pluginService->installWithCode($code);
+            $this->pluginService->installWithCode($code, $ifNotExists);
             $this->clearCache($io);
             $io->success('Installed.');
 

--- a/tests/Eccube/Tests/Service/PluginServiceTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceTest.php
@@ -134,6 +134,13 @@ class PluginServiceTest extends AbstractServiceTestCase
         }
         // 同じプラグインの二重インストールが蹴られるか
 
+        // --if-not-exists オプションの検証
+        try {
+            $this->service->install($tmpfile, 0, true);
+        } catch (\Eccube\Exception\PluginException $e) {
+            $this->fail('--if-not-exists オプションを指定した場合は例外が発生しない: '.$e->getMessage());
+        }
+
         // アンインストールできるか
         $this->assertTrue((bool) $plugin = $this->pluginRepository->findOneBy(['code' => $tmpname]));
         $this->assertEquals(Constant::DISABLED, $plugin->isEnabled());


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
`eccube:plugin:install` コマンドに `--if-not-exists` オプションを追加する。
CI/CD で自動デプロイをする際、プラグインも自動でインストールしたい場合がある。具体的には以下のような shell スクリプトを使用してインストールする

```shell
## declare an plugins variable
declare -a plugins=("plugin01" "plugin02")
# get length of an array
arraylength=${#plugins[@]}

# use for loop to read all values and indexes
for (( i=0; i<${arraylength}; i++ ));
do
    # check exist plugin
    count=$( bin/console doctrine:query:sql "select count(*) as cnt from dtb_plugin where code='${plugins[$i]}'" )
    # Ex: count="----- cnt ----- 1 -----"
    # Creating an array from a string separated by spaces
    str2array=($(echo $count | tr ' ' "\n"))
    # Get value count installed plugin
    cnt=${str2array[3]}

    # Check exist
    if [ ${cnt} != 0 ] ; then
        echo "${plugins[$i]} plugin already exist. Nothing to do."
    else
        echo "-----START: Install ${plugins[$i]} plugin -----";

        bin/console eccube:composer:require ec-cube/${plugins[$i],,}
        bin/console eccube:plugin:install --code=${plugins[$i]}
        bin/console eccube:plugin:enable --code=${plugins[$i]}

        echo "-----END: Install ${plugins[$i]} plugin -----";
    fi
done
```

`bin/console eccube:plugin:install` を実行する際、既にインストール済みのプラグインが存在していると `plugin already installed.` のエラーが発生してしまうため、 shell で事前にプラグインの存在チェックをしている

`bin/console eccube:plugin:install`  コマンドに `--if-not-exists` オプションを追加することで、以下のように簡素化できる

```shell
## declare an plugins variable
declare -a plugins=("plugin01" "plugin02")
# get length of an array
arraylength=${#plugins[@]}

# use for loop to read all values and indexes
for (( i=0; i<${arraylength}; i++ ));
do
    echo "-----START: Install ${plugins[$i]} plugin -----";
    bin/console eccube:composer:require ec-cube/${plugins[$i],,}
    bin/console eccube:plugin:install --code=${plugins[$i]} --if-not-exists
    bin/console eccube:plugin:enable --code=${plugins[$i]}
    echo "-----END: Install ${plugins[$i]} plugin -----";
done
```

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
 `bin/console doctrine:database:create` と同様に  `--if-not-exists` オプションを追加する

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
TODO

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
もっと良いアイディアがあればご教授ください

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
