### PR TITLE
上限を超えたお届け先の登録の修正

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -40,6 +40,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\RouterInterface;
@@ -666,6 +667,12 @@ class ShoppingController extends AbstractShoppingController
             return $this->redirectToRoute('shopping_error');
         }
 
+        $Customer = $this->getUser();
+        $addressCurrNum = count($Customer->getCustomerAddresses());
+        $addressMax = $this->eccubeConfig['eccube_deliv_addr_max'];
+        if ($addressCurrNum >= $addressMax) {
+            throw new NotFoundHttpException();
+        }
         $CustomerAddress = new CustomerAddress();
         if ($this->isGranted('IS_AUTHENTICATED_FULLY')) {
             // ログイン時は会員と紐付け


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

<!-- ****************************************************************************
脆弱性報告 (Vulnerability report)
脆弱性のご報告は弊社[問い合わせフォーム](https://www.ec-cube.net/contact/)からお願いします。
**************************************************************************** -->

## 概要(Overview・Refs Issue)
上限を超えたお届け先の登録ができてしまう
https://github.com/EC-CUBE/ec-cube/issues/6081

## 方針(Policy)
お届け先の上限を超えた場合、
/shopping/shipping_edit/{:受注に紐づくid}」に直接アクセスしても、
お届け先の登録ができなくなるようにする。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
以下の手順で動作確認しました。
1. マイページのお届け先一覧画面にアクセスし、お届け先を19件登録
2. 商品をカートに入れ、ショッピングカートに進み、「レジに進む」を押下
3. ご注文手続き画面にて、お届け先の「変更」を押下
4. お届け先の指定画面にて、「新規お届け先を追加する」を押下
5. お届け先の追加画面が表示されたら、必須項目を入力し、「登録する」を押下
6. マイページのお届け先一覧画面/お届け先の指定画面上で上限が20件となり、「新規お届け先を追加」ができないことを確認
7. "/shopping/shipping_edit/{:受注に紐づくid}” に直接アクセス
8. 404画面となることを確認

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
