### PR TITLE
カテゴリ管理・ファイル管理 カテゴリ名やファイル名が長いと階層表示が崩れるのを修正

### DIFF
--- a/html/template/admin/assets/css/app.css
+++ b/html/template/admin/assets/css/app.css
@@ -816,6 +816,47 @@ include /assets/tmpl/components/directory.pug
 
 Styleguide 7.0
 */
+.c-directoryTree li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: start;
+  margin-bottom: 0;
+}
+.c-directoryTree li > a, .c-directoryTree li span {
+  flex: 1;
+  word-break: break-all;
+}
+.c-directoryTree ul {
+  width: 100%;
+}
+.c-directoryTree > ul {
+  margin-bottom: 0.5em;
+}
+.c-directoryTree ul > li > ul li > label {
+  margin-left: 10px;
+  position: relative;
+}
+.c-directoryTree ul > li > ul li:not(:last-of-type) > label::before {
+  margin-left: 2px;
+  margin-right: 0.5em;
+  content: "├";
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+}
+.c-directoryTree ul > li > ul li:last-of-type > label::before {
+  margin-right: 0.6em;
+  content: "└";
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+}
+.c-directoryTree ul > li ul > li ul li > label {
+  margin-left: 20px;
+}
+.c-directoryTree ul > li ul > li ul > li ul li > label {
+  margin-left: 30px;
+}
 .c-directoryTree label::before {
   content: "\f146";
   display: inline-block;
@@ -839,29 +880,6 @@ Styleguide 7.0
   font-family: "Font Awesome 5 Free";
   font-size: 16px;
   font-weight: 400;
-}
-.c-directoryTree ul > li > ul li > label {
-  margin-left: 10px;
-  position: relative;
-}
-.c-directoryTree ul > li > ul li > label span {
-  display: inline-block;
-  margin-left: 16px;
-}
-.c-directoryTree ul > li > ul li:not(:last-of-type) > label::before {
-  margin-left: 2px;
-  margin-right: 0.5em;
-  content: "├";
-  display: inline-block;
-  width: 1em;
-  height: 1em;
-}
-.c-directoryTree ul > li > ul li:last-of-type > label::before {
-  margin-right: 0.6em;
-  content: "└";
-  display: inline-block;
-  width: 1em;
-  height: 1em;
 }
 .c-directoryTree ul > li > ul label::after {
   content: "\f146";
@@ -893,11 +911,26 @@ Styleguide 7.0
   position: absolute;
   left: 20px;
 }
-.c-directoryTree ul > li ul > li ul li > label {
-  margin-left: 20px;
+.c-directoryTree ul > li > ul li:not(:last-of-type) > label:before, .c-directoryTree ul > li > ul li:last-of-type > label:before {
+  margin-right: 1.6em;
 }
-.c-directoryTree ul > li ul > li ul > li ul li > label {
-  margin-left: 30px;
+.c-directoryTree label::before {
+  content: "\f146";
+}
+.c-directoryTree label[data-toggle=collapse]::before {
+  content: "\f146";
+}
+.c-directoryTree label.collapsed::before {
+  content: "\f0fe";
+}
+.c-directoryTree ul > li > ul label::after {
+  content: "\f146";
+}
+.c-directoryTree ul > li > ul label[data-toggle=collapse]::after {
+  content: "\f146";
+}
+.c-directoryTree ul > li > ul label.collapsed::after {
+  content: "\f0fe";
 }
 /*
 ディレクトリツリー（カテゴリ登録）
@@ -920,8 +953,25 @@ Styleguide 7.1
   max-height: 300px;
   overflow: scroll;
 }
+.c-directoryTree--register li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: start;
+  margin-bottom: 0;
+}
+.c-directoryTree--register li > a, .c-directoryTree--register li span {
+  flex: 1;
+  word-break: break-all;
+}
+.c-directoryTree--register ul {
+  width: 100%;
+}
+.c-directoryTree--register > ul {
+  margin-bottom: 0.5em;
+}
 .c-directoryTree--register ul > li > ul li > label {
   margin-left: 10px;
+  position: relative;
 }
 .c-directoryTree--register ul > li > ul li:not(:last-of-type) > label::before {
   margin-left: 2px;
@@ -944,6 +994,14 @@ Styleguide 7.1
 .c-directoryTree--register ul > li ul > li ul > li ul li > label {
   margin-left: 30px;
 }
+.c-directoryTree--register input {
+  display: block;
+  margin-right: 10px;
+}
+.c-directoryTree--register label {
+  flex: 1;
+  word-break: break-all;
+}
 /*
 ディレクトリツリー（フォルダー）
 
@@ -956,37 +1014,25 @@ include /assets/tmpl/components/directory.pug
 
 Styleguide 7.2
 */
-.c-directoryTree--folder label::before {
-  content: "\f07b";
-  display: inline-block;
-  margin-right: 0.5em;
-  font-family: "Font Awesome 5 Free";
-  font-size: 16px;
-  font-weight: 400;
+.c-directoryTree--folder li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: start;
+  margin-bottom: 0;
 }
-.c-directoryTree--folder label[data-toggle=collapse]::before {
-  content: "\f07c";
-  display: inline-block;
-  margin-right: 0.5em;
-  font-family: "Font Awesome 5 Free";
-  font-size: 16px;
-  font-weight: 400;
+.c-directoryTree--folder li > a, .c-directoryTree--folder li span {
+  flex: 1;
+  word-break: break-all;
 }
-.c-directoryTree--folder label.collapsed::before {
-  content: "\f07b";
-  display: inline-block;
-  margin-right: 0.5em;
-  font-family: "Font Awesome 5 Free";
-  font-size: 16px;
-  font-weight: 400;
+.c-directoryTree--folder ul {
+  width: 100%;
+}
+.c-directoryTree--folder > ul {
+  margin-bottom: 0.5em;
 }
 .c-directoryTree--folder ul > li > ul li > label {
   margin-left: 10px;
   position: relative;
-}
-.c-directoryTree--folder ul > li > ul li > label span, .c-directoryTree--folder ul > li > ul li > label a {
-  display: inline-block;
-  margin-left: 1.5rem;
 }
 .c-directoryTree--folder ul > li > ul li:not(:last-of-type) > label::before {
   margin-left: 2px;
@@ -1003,8 +1049,38 @@ Styleguide 7.2
   width: 1em;
   height: 1em;
 }
+.c-directoryTree--folder ul > li ul > li ul li > label {
+  margin-left: 20px;
+}
+.c-directoryTree--folder ul > li ul > li ul > li ul li > label {
+  margin-left: 30px;
+}
+.c-directoryTree--folder label::before {
+  content: "\f146";
+  display: inline-block;
+  margin-right: 0.5em;
+  font-family: "Font Awesome 5 Free";
+  font-size: 16px;
+  font-weight: 400;
+}
+.c-directoryTree--folder label[data-toggle=collapse]::before {
+  content: "\f146";
+  display: inline-block;
+  margin-right: 0.5em;
+  font-family: "Font Awesome 5 Free";
+  font-size: 16px;
+  font-weight: 400;
+}
+.c-directoryTree--folder label.collapsed::before {
+  content: "\f0fe";
+  display: inline-block;
+  margin-right: 0.5em;
+  font-family: "Font Awesome 5 Free";
+  font-size: 16px;
+  font-weight: 400;
+}
 .c-directoryTree--folder ul > li > ul label::after {
-  content: "\f07b";
+  content: "\f146";
   display: inline-block;
   margin-right: 0.5em;
   font-family: "Font Awesome 5 Free";
@@ -1014,7 +1090,7 @@ Styleguide 7.2
   left: 20px;
 }
 .c-directoryTree--folder ul > li > ul label[data-toggle=collapse]::after {
-  content: "\f07c";
+  content: "\f146";
   display: inline-block;
   margin-right: 0.5em;
   font-family: "Font Awesome 5 Free";
@@ -1024,7 +1100,7 @@ Styleguide 7.2
   left: 20px;
 }
 .c-directoryTree--folder ul > li > ul label.collapsed::after {
-  content: "\f07b";
+  content: "\f0fe";
   display: inline-block;
   margin-right: 0.5em;
   font-family: "Font Awesome 5 Free";
@@ -1033,11 +1109,26 @@ Styleguide 7.2
   position: absolute;
   left: 20px;
 }
-.c-directoryTree--folder ul > li ul > li ul li > label {
-  margin-left: 20px;
+.c-directoryTree--folder ul > li > ul li:not(:last-of-type) > label:before, .c-directoryTree--folder ul > li > ul li:last-of-type > label:before {
+  margin-right: 1.6em;
 }
-.c-directoryTree--folder ul > li ul > li ul > li ul li > label {
-  margin-left: 30px;
+.c-directoryTree--folder label::before {
+  content: "\f07b";
+}
+.c-directoryTree--folder label[data-toggle=collapse]::before {
+  content: "\f07c";
+}
+.c-directoryTree--folder label.collapsed::before {
+  content: "\f07b";
+}
+.c-directoryTree--folder ul > li > ul label::after {
+  content: "\f07b";
+}
+.c-directoryTree--folder ul > li > ul label[data-toggle=collapse]::after {
+  content: "\f07c";
+}
+.c-directoryTree--folder ul > li > ul label.collapsed::after {
+  content: "\f07b";
 }
 /*
 トグルスイッチ

--- a/html/template/admin/assets/js/file_manager.js
+++ b/html/template/admin/assets/js/file_manager.js
@@ -332,14 +332,13 @@
             eccube.fileManager.openFolder(path);
             return e.preventDefault();
         });
-        a.appendTo(label);
 
         label.attr('data-toggle', 'collapse');
         label.attr('href', '#' + path.replace('/', '_'));
         label.attr('aria-expanded', false);
         label.attr('aria-control', '');
         label.appendTo(li);
-
+        a.appendTo(li);
         if (currentPath.indexOf(path) !== 0) {
             label.addClass('collapsed')
         }

--- a/html/template/admin/assets/scss/component/_directory.scss
+++ b/html/template/admin/assets/scss/component/_directory.scss
@@ -1,17 +1,62 @@
 @import "../library/_variable";
 @import "../mixin/_media";
-/*
-ディレクトリツリー
 
-ディレクトリ構造をツリー形式で表示します。
+@mixin directoryTree{
+  li {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: start;
+    margin-bottom: 0;
+    > a, span {
+      flex: 1;
+      word-break: break-all;
+    }
+  }
+  ul {
+    width: 100%;
+  }
+  > ul {
+    margin-bottom: 0.5em;
+  }
+  //2層目以降
+  ul >li > ul {
+    li > label {
+      margin-left: 10px;
+      position: relative;
+    }
+    li:not(:last-of-type) > label::before {
+      margin-left: 2px;
+      margin-right: .5em;
+      content: "├";
+      display: inline-block;
+      width: 1em;
+      height: 1em;
+    }
+    li:last-of-type > label::before  {
+      margin-right: .6em;
+      content: "└";
+      display: inline-block;
+      width: 1em;
+      height: 1em;
+    }
+  }
 
-Markup:
-include /assets/tmpl/components/directory.pug
-+c-directoryTree
+  //3層目
+  ul >li ul >li ul  {
+    li > label {
+      margin-left: 20px;
+    }
+  }
+  //4層目
+  ul >li ul >li ul > li ul  {
+    li > label {
+      margin-left: 30px;
+    }
+  }
+}
 
-Styleguide 7.0
-*/
-.c-directoryTree {
+
+@mixin directoryLabelIcon{
   //1層目
   label {
     &::before {
@@ -46,31 +91,6 @@ Styleguide 7.0
   }
   //2層目以降
   ul >li > ul {
-    li > label {
-      margin-left: 10px;
-      position: relative;
-      span {
-        display: inline-block;
-        margin-left: 16px;
-      }
-
-    }
-    li:not(:last-of-type) > label::before {
-      margin-left: 2px;
-      margin-right: .5em;
-      content: "├";
-      display: inline-block;
-      width: 1em;
-      height: 1em;
-    }
-
-    li:last-of-type > label::before  {
-      margin-right: .6em;
-      content: "└";
-      display: inline-block;
-      width: 1em;
-      height: 1em;
-    }
     label {
       &::after {
         content: "\f146";
@@ -107,17 +127,62 @@ Styleguide 7.0
         left: 20px;
       }
     }
-  }
-  //3層目
-  ul >li ul >li ul  {
-    li > label {
-      margin-left: 20px;
+    li {
+      &:not(:last-of-type), &:last-of-type {
+        > label:before {
+          margin-right: 1.6em;
+        }
+      }
     }
   }
-  //4層目
-  ul >li ul >li ul > li ul  {
-    li > label {
-      margin-left: 30px;
+
+}
+/*
+ディレクトリツリー
+
+ディレクトリ構造をツリー形式で表示します。
+
+Markup:
+include /assets/tmpl/components/directory.pug
++c-directoryTree
+
+Styleguide 7.0
+*/
+.c-directoryTree {
+  @include directoryTree();
+  @include directoryLabelIcon();
+  //1層目
+  label {
+    &::before {
+      content: "\f146";
+    }
+  }
+  label[data-toggle="collapse"] {
+    &::before {
+      content: "\f146";
+    }
+  }
+  label.collapsed {
+    &::before {
+      content: "\f0fe";
+    }
+  }
+  //2層目以降
+  ul >li > ul {
+    label {
+      &::after {
+        content: "\f146";
+      }
+    }
+    label[data-toggle="collapse"] {
+      &::after {
+        content: "\f146";
+      }
+    }
+    label.collapsed {
+      &::after {
+        content: "\f0fe";
+      }
     }
   }
 }
@@ -141,42 +206,16 @@ include /assets/tmpl/components/directory.pug
 Styleguide 7.1
 */
 .c-directoryTree--register {
+  @include directoryTree();
   max-height: 300px;
   overflow: scroll;
-
-  //2層目以降
-  ul >li > ul {
-    li > label {
-      margin-left: 10px;
-    }
-    li:not(:last-of-type) > label::before {
-      margin-left: 2px;
-      margin-right: .5em;
-      content: "├";
-      display: inline-block;
-      width: 1em;
-      height: 1em;
-    }
-
-    li:last-of-type > label::before  {
-      margin-right: .6em;
-      content: "└";
-      display: inline-block;
-      width: 1em;
-      height: 1em;
-    }
+  input {
+    display: block;
+    margin-right: 10px;
   }
-  //3層目
-  ul >li ul >li ul  {
-    li > label {
-      margin-left: 20px;
-    }
-  }
-  //4層目
-  ul >li ul >li ul > li ul  {
-    li > label {
-      margin-left: 30px;
-    }
+  label {
+    flex: 1;
+    word-break: break-all;
   }
 }
 
@@ -194,110 +233,41 @@ Styleguide 7.2
 */
 
 .c-directoryTree--folder {
+  @include directoryTree();
+  @include directoryLabelIcon();
   //1層目
   label {
     &::before {
       content: "\f07b";
-      display: inline-block;
-      margin-right: .5em;
-      font-family: 'Font Awesome 5 Free';
-      font-size: 16px;
-      font-weight: 400;
     }
   }
   label[data-toggle="collapse"] {
     &::before {
       content: "\f07c";
-      display: inline-block;
-      margin-right: .5em;
-      font-family: 'Font Awesome 5 Free';
-      font-size: 16px;
-      font-weight: 400;
     }
   }
   label.collapsed {
     &::before {
       content: "\f07b";
-      display: inline-block;
-      margin-right: .5em;
-      font-family: 'Font Awesome 5 Free';
-      font-size: 16px;
-      font-weight: 400;
     }
   }
+
   //2層目以降
   ul >li > ul {
-    li > label {
-      margin-left: 10px;
-      position: relative;
-      span,a {
-        display: inline-block;
-        margin-left: 1.5rem;
-      }
-    }
-    li:not(:last-of-type) > label::before {
-      margin-left: 2px;
-      margin-right: .5em;
-      content: "├";
-      display: inline-block;
-      width: 1em;
-      height: 1em;
-    }
-
-    li:last-of-type > label::before  {
-      margin-right: .6em;
-      content: "└";
-      display: inline-block;
-      width: 1em;
-      height: 1em;
-    }
     label {
       &::after {
         content: "\f07b";
-        display: inline-block;
-        margin-right: .5em;
-        font-family: 'Font Awesome 5 Free';
-        font-size: 16px;
-        font-weight: 400;
-        position: absolute;
-        left: 20px;
       }
     }
     label[data-toggle="collapse"] {
       &::after {
         content: "\f07c";
-        display: inline-block;
-        margin-right: .5em;
-        font-family: 'Font Awesome 5 Free';
-        font-size: 16px;
-        font-weight: 400;
-        position: absolute;
-        left: 20px;
       }
     }
     label.collapsed {
       &::after {
         content: "\f07b";
-        display: inline-block;
-        margin-right: .5em;
-        font-family: 'Font Awesome 5 Free';
-        font-size: 16px;
-        font-weight: 400;
-        position: absolute;
-        left: 20px;
       }
-    }
-  }
-  //3層目
-  ul >li ul >li ul  {
-    li > label {
-      margin-left: 20px;
-    }
-  }
-  //4層目
-  ul >li ul >li ul > li ul  {
-    li > label {
-      margin-left: 30px;
     }
   }
 }

--- a/src/Eccube/Resource/template/admin/Product/category.twig
+++ b/src/Eccube/Resource/template/admin/Product/category.twig
@@ -117,16 +117,6 @@ file that was distributed with this source code.
     </script>
 {% endblock %}
 
-{% block stylesheet %}
-    {#TODO: Move to css file#}
-    <style>
-        .c-directoryTree ul > li > ul li:not(:last-of-type) > label:before,
-        .c-directoryTree ul > li > ul li:last-of-type > label:before {
-            margin-right: 1.6em;
-        }
-    </style>
-{% endblock %}
-
 {% block main %}
     <div class="c-outsideBlock">
         <div class="c-outsideBlock__contents mb-2">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
Issue
商品登録画面 カテゴリ名が長い場合、カテゴリ選択フォームが崩れて表示されてしまう #6089

## 方針(Policy)
カテゴリ名が長い場合、カテゴリ選択フォームが崩れて表示されます
全角15文字以上で崩れることを確認しました
現象はissueの通りです　#6089

以下3箇所が同様のスタイルを適用していたため、スタイルを統一できるよう調整しました。
・商品登録画面　カテゴリ選択フォーム
・カテゴリ登録画面　カテゴリ階層表示
・ファイル管理　ファイル階層表示

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
