### PR TITLE
税率設定時に商品別税率を考慮していないのを修正

### DIFF
--- a/src/Eccube/Form/Type/Admin/TaxRuleType.php
+++ b/src/Eccube/Form/Type/Admin/TaxRuleType.php
@@ -77,6 +77,7 @@ class TaxRuleType extends AbstractType
             $qb
                 ->select('count(t.id)')
                 ->where('t.apply_date = :apply_date')
+                ->andWhere('t.ProductClass IS NULL')
                 ->setParameter('apply_date', $TaxRule->getApplyDate());
 
             if ($TaxRule->getId()) {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
Issue
商品別税率が設定されている場合に、基本税率を編集しようとするとエラーになる #6090

## 方針(Policy)
商品別税率が設定されている場合に、基本税率を編集しようとすると、
「同時刻の適用日時を設定できません。」というエラーが表示されてしまいます。
基本税率での適用日時と同じapply_dateで商品別税率が設定されている商品が存在する場合に発生していたため、修正を行いました。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [x] 動作確認
- [x] コードレビュー
- [x] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [x] 互換性が保持されているか
- [x] セキュリティ上の問題がないか
  - [x] 権限を超えた操作が可能にならないか
  - [x] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか
  - [x] テンプレートでのエスケープ漏れがないか
