### PR TITLE
PHP Deprecated Using ${var} in strings is deprecated, use {$var} instead

### DIFF
--- a/app/DoctrineMigrations/Version20210412073123.php
+++ b/app/DoctrineMigrations/Version20210412073123.php
@@ -42,7 +42,7 @@ final class Version20210412073123 extends AbstractMigration
             $env = file_get_contents($envFile);
 
             $env = StringUtil::replaceOrAddEnv($env, [
-                'ECCUBE_ADMIN_DENY_HOSTS' => "'${denyHosts}'",
+                'ECCUBE_ADMIN_DENY_HOSTS' => "'{$denyHosts}'",
             ]);
 
             file_put_contents($envFile, $env);

--- a/codeception/_support/AcceptanceTester.php
+++ b/codeception/_support/AcceptanceTester.php
@@ -218,7 +218,7 @@ class AcceptanceTester extends \Codeception\Actor
         $result = array_filter($arrayOfSelector, function ($element) use ($self) {
             $id = $element['id'];
 
-            return $self->executeJS("return document.getElementById('${id}') != null;");
+            return $self->executeJS("return document.getElementById('{$id}') != null;");
         });
         $this->assertTrue(empty($result));
     }

--- a/codeception/_support/Page/AbstractPage.php
+++ b/codeception/_support/Page/AbstractPage.php
@@ -36,7 +36,7 @@ abstract class AbstractPage
     protected function goPage($url, $pageTitle = '')
     {
         $this->tester->amOnPage($url);
-        $this->tester->waitForJS("return location.pathname + location.search == '${url}'", 30);
+        $this->tester->waitForJS("return location.pathname + location.search == '{$url}'", 30);
 
         return $this;
     }

--- a/codeception/_support/Page/Admin/ApiOauthPage.php
+++ b/codeception/_support/Page/Admin/ApiOauthPage.php
@@ -29,9 +29,9 @@ class ApiOauthPage extends AbstractAdminPageStyleGuide
 
     public function 削除($i)
     {
-        $this->tester->click(['xpath' => "//*[@id=\"page_admin_api_oauth\"]/div[1]//table/tbody/tr[${i}]/td[6]/div/div/div[1]/a"]);
-        $this->tester->waitForElementVisible(['xpath' => "//*[@id=\"page_admin_api_oauth\"]/div[1]//table/tbody/tr[${i}]/td[6]//a[contains(@class, 'btn-ec-delete')]"]);
-        $this->tester->click(['xpath' => "//*[@id=\"page_admin_api_oauth\"]/div[1]//table/tbody/tr[${i}]/td[6]//a[contains(@class, 'btn-ec-delete')]"]);
+        $this->tester->click(['xpath' => "//*[@id=\"page_admin_api_oauth\"]/div[1]//table/tbody/tr[{$i}]/td[6]/div/div/div[1]/a"]);
+        $this->tester->waitForElementVisible(['xpath' => "//*[@id=\"page_admin_api_oauth\"]/div[1]//table/tbody/tr[{$i}]/td[6]//a[contains(@class, 'btn-ec-delete')]"]);
+        $this->tester->click(['xpath' => "//*[@id=\"page_admin_api_oauth\"]/div[1]//table/tbody/tr[{$i}]/td[6]//a[contains(@class, 'btn-ec-delete')]"]);
         return $this;
     }
 

--- a/codeception/_support/Page/Admin/ApiWebHookPage.php
+++ b/codeception/_support/Page/Admin/ApiWebHookPage.php
@@ -29,14 +29,14 @@ class ApiWebHookPage extends AbstractAdminPageStyleGuide
 
     public function 編集($i)
     {
-        $this->tester->click(['xpath' => "//*[@id=\"page_admin_api_webhook\"]/div[1]/div[3]/div[2]/div/div/div[2]/div/table/tbody/tr[${i}]/td[3]//a[1]"]);
+        $this->tester->click(['xpath' => "//*[@id=\"page_admin_api_webhook\"]/div[1]/div[3]/div[2]/div/div/div[2]/div/table/tbody/tr[{$i}]/td[3]//a[1]"]);
         return $this;
     }
 
     public function 削除($i)
     {
-        $this->tester->click(['xpath' => "//*[@id=\"page_admin_api_webhook\"]/div[1]/div[3]/div[2]/div/div/div[2]/div/table/tbody/tr[${i}]/td[3]/div/div[2]//a[contains(@class, 'action-delete')]"]);
-        $this->tester->waitForElementVisible(['xpath' => "//*[@id=\"page_admin_api_webhook\"]/div[1]/div[3]/div[2]/div/div/div[2]/div/table/tbody/tr[${i}]/td[3]/div/div[2]//a[contains(@class, 'btn-ec-delete')]"]);
+        $this->tester->click(['xpath' => "//*[@id=\"page_admin_api_webhook\"]/div[1]/div[3]/div[2]/div/div/div[2]/div/table/tbody/tr[{$i}]/td[3]/div/div[2]//a[contains(@class, 'action-delete')]"]);
+        $this->tester->waitForElementVisible(['xpath' => "//*[@id=\"page_admin_api_webhook\"]/div[1]/div[3]/div[2]/div/div/div[2]/div/table/tbody/tr[{$i}]/td[3]/div/div[2]//a[contains(@class, 'btn-ec-delete')]"]);
         $this->tester->click(['xpath' => "//*[@id=\"page_admin_api_webhook\"]/div[1]/div[3]/div[2]/div/div/div[2]/div/table/tbody/tr[${i}]/td[3]/div/div[2]//a[contains(@class, 'btn-ec-delete')]"]);
         return $this;
     }

--- a/codeception/_support/Page/Admin/FileManagePage.php
+++ b/codeception/_support/Page/Admin/FileManagePage.php
@@ -60,26 +60,26 @@ class FileManagePage extends AbstractAdminPageStyleGuide
 
     public function ファイル名($rowNum)
     {
-        return "#fileList table > tbody > tr:nth-child(${rowNum}) > td:nth-child(2)";
+        return "#fileList table > tbody > tr:nth-child({$rowNum}) > td:nth-child(2)";
     }
 
     public function 一覧_ダウンロード($rowNum)
     {
-        $this->tester->click("#fileList table > tbody > tr:nth-child(${rowNum}) > td:nth-child(5) a.action-download");
+        $this->tester->click("#fileList table > tbody > tr:nth-child({$rowNum}) > td:nth-child(5) a.action-download");
 
         return $this;
     }
 
     public function 一覧_表示($rowNum)
     {
-        $this->tester->click("#fileList table > tbody > tr:nth-child(${rowNum}) > td:nth-child(5) a.action-view");
+        $this->tester->click("#fileList table > tbody > tr:nth-child({$rowNum}) > td:nth-child(5) a.action-view");
 
         return $this;
     }
 
     public function 一覧_パスをコピー($rowNum)
     {
-        $this->tester->click("#fileList table > tbody > tr:nth-child(${rowNum}) > td:nth-child(5) a.action-copy");
+        $this->tester->click("#fileList table > tbody > tr:nth-child({$rowNum}) > td:nth-child(5) a.action-copy");
 
         return $this;
     }

--- a/codeception/_support/Page/Admin/LayoutEditPage.php
+++ b/codeception/_support/Page/Admin/LayoutEditPage.php
@@ -43,7 +43,7 @@ class LayoutEditPage extends AbstractAdminPageStyleGuide
 
     public function ブロックを移動($blockName, $dest, $timeout = 10)
     {
-        $this->tester->waitForElementVisible(['xpath' => "//div[contains(@id, 'detail_box__layout_item')][div[div[1][span[text()='${blockName}']]]]"], $timeout);
+        $this->tester->waitForElementVisible(['xpath' => "//div[contains(@id, 'detail_box__layout_item')][div[div[1][span[text()='{$blockName}']]]]"], $timeout);
         $this->tester->dragAndDrop(['xpath' => "//div[contains(@id, 'detail_box__layout_item')][div[div[1][span[text()='${blockName}']]]]"], $dest);
 
         return $this;

--- a/codeception/_support/Page/Admin/NewsManagePage.php
+++ b/codeception/_support/Page/Admin/NewsManagePage.php
@@ -46,7 +46,7 @@ class NewsManagePage extends AbstractAdminPage
 
     public function 一覧_編集($rowNum)
     {
-        $this->tester->click(".c-contentsArea .list-group > li:nth-child(${rowNum}) a[data-bs-original-title=編集]");
+        $this->tester->click(".c-contentsArea .list-group > li:nth-child({$rowNum}) a[data-bs-original-title=編集]");
 
         return $this;
     }

--- a/codeception/_support/Page/Admin/OrderEditPage.php
+++ b/codeception/_support/Page/Admin/OrderEditPage.php
@@ -167,7 +167,7 @@ class OrderEditPage extends AbstractAdminPageStyleGuide
     public function 商品検索結果_選択($rowNum)
     {
         $rowNum = $rowNum * 2;
-        $this->tester->click(['css' => "#searchProductModalList > table > tbody > tr:nth-child(${rowNum}) > td.text-end > button"]);
+        $this->tester->click(['css' => "#searchProductModalList > table > tbody > tr:nth-child({$rowNum}) > td.text-end > button"]);
         $this->tester->waitForElementNotVisible(['id' => 'searchProductModalList']);
 
         return $this;

--- a/codeception/_support/Page/Admin/TaxManagePage.php
+++ b/codeception/_support/Page/Admin/TaxManagePage.php
@@ -59,14 +59,14 @@ class TaxManagePage extends AbstractAdminPageStyleGuide
 
     public function 一覧_編集($rowNum)
     {
-        $this->tester->click("table tbody tr:nth-child(${rowNum}) .edit-button");
+        $this->tester->click("table tbody tr:nth-child({$rowNum}) .edit-button");
 
         return $this;
     }
 
     public function 一覧_削除($rowNum)
     {
-        $this->tester->click("table tbody tr:nth-child(${rowNum}) > td.align-middle.action > div > div > div:nth-child(2) > div.d-inline-block.me-3 > a");
+        $this->tester->click("table tbody tr:nth-child({$rowNum}) > td.align-middle.action > div > div > div:nth-child(2) > div.d-inline-block.me-3 > a");
 
         // accept modal
         $this->tester->waitForElementVisible("table tbody tr:nth-child(${rowNum}) > td.align-middle.action > div > div > div:nth-child(2) > div.modal");

--- a/codeception/acceptance/EA03ProductCest.php
+++ b/codeception/acceptance/EA03ProductCest.php
@@ -509,7 +509,7 @@ class EA03ProductCest
 
         $createProduct = Fixtures::get('createProduct');
         foreach (range(1, 5) as $i) {
-            $createProduct("一括削除用_${i}");
+            $createProduct("一括削除用_{$i}");
         }
         $ProductManagePage = ProductManagePage::go($I)
             ->検索('一括削除用')
@@ -534,35 +534,35 @@ class EA03ProductCest
         $timestamp = time();
         // 受注に紐付いていない商品と紐付いている商品を作成
         foreach (range(1, 5) as $i) {
-            $createProduct("一括削除用_${timestamp}_受注なし_${i}");
+            $createProduct("一括削除用_{$timestamp}_受注なし_{$i}");
         }
         $Customer = (Fixtures::get('createCustomer'))();
         foreach (range(1, 5) as $i) {
-            $Product = $createProduct("一括削除用_${timestamp}_受注あり_${i}");
+            $Product = $createProduct("一括削除用_{$timestamp}_受注あり_{$i}");
             $createOrders($Customer, 1, $Product->getProductClasses()->toArray());
         }
 
         $ProductManagePage = ProductManagePage::go($I)
-            ->検索("一括削除用_${timestamp}")
+            ->検索("一括削除用_{$timestamp}")
             ->すべて選択();
 
         $I->see('検索結果：10件が該当しました', ProductManagePage::$検索結果_メッセージ);
-        $I->see("一括削除用_${timestamp}_受注あり", ProductManagePage::$検索結果_一覧);
-        $I->see("一括削除用_${timestamp}_受注なし", ProductManagePage::$検索結果_一覧);
+        $I->see("一括削除用_{$timestamp}_受注あり", ProductManagePage::$検索結果_一覧);
+        $I->see("一括削除用_{$timestamp}_受注なし", ProductManagePage::$検索結果_一覧);
 
         $ProductManagePage->完全に削除();
 
-        $I->see("一括削除用_${timestamp}_受注あり_1", ProductManagePage::$一括削除エラー);
-        $I->see("一括削除用_${timestamp}_受注あり_2", ProductManagePage::$一括削除エラー);
-        $I->see("一括削除用_${timestamp}_受注あり_3", ProductManagePage::$一括削除エラー);
-        $I->see("一括削除用_${timestamp}_受注あり_4", ProductManagePage::$一括削除エラー);
-        $I->see("一括削除用_${timestamp}_受注あり_5", ProductManagePage::$一括削除エラー);
+        $I->see("一括削除用_{$timestamp}_受注あり_1", ProductManagePage::$一括削除エラー);
+        $I->see("一括削除用_{$timestamp}_受注あり_2", ProductManagePage::$一括削除エラー);
+        $I->see("一括削除用_{$timestamp}_受注あり_3", ProductManagePage::$一括削除エラー);
+        $I->see("一括削除用_{$timestamp}_受注あり_4", ProductManagePage::$一括削除エラー);
+        $I->see("一括削除用_{$timestamp}_受注あり_5", ProductManagePage::$一括削除エラー);
 
         $ProductManagePage->一括削除完了();
 
         $I->see('検索結果：5件が該当しました', ProductManagePage::$検索結果_メッセージ);
-        $I->see("一括削除用_${timestamp}_受注あり", ProductManagePage::$検索結果_一覧);
-        $I->dontSee("一括削除用_${timestamp}_受注なし", ProductManagePage::$検索結果_一覧);
+        $I->see("一括削除用_{$timestamp}_受注あり", ProductManagePage::$検索結果_一覧);
+        $I->dontSee("一括削除用_{$timestamp}_受注なし", ProductManagePage::$検索結果_一覧);
     }
 
     public function product_規格登録_(AcceptanceTester $I)

--- a/codeception/acceptance/EA08SysteminfoCest.php
+++ b/codeception/acceptance/EA08SysteminfoCest.php
@@ -58,7 +58,7 @@ class EA08SysteminfoCest
         if ($config['eccube_phpinfo_enabled'] == 1) {
             $I->see('PHP情報', '#php_info_box__header > div > span');
         }
-        
+
         $I->expect('session.save_path をチェックします');
         $I->amOnPage('/'.$config['eccube_admin_route'].'/setting/system/system/phpinfo');
         $I->scrollTo('a[name=module_session]');
@@ -392,7 +392,7 @@ class EA08SysteminfoCest
 
         // URL直でもアクセスできないことを確認
         $config = Fixtures::get('config');
-        $I->amOnPage("/${config['eccube_admin_route']}/setting/system/member");
+        $I->amOnPage("/{$config['eccube_admin_route']}/setting/system/member");
         $I->seeInTitle('アクセスできません');
 
         // 設定を削除
@@ -412,7 +412,7 @@ class EA08SysteminfoCest
         $I->wait(1);
         $I->see('システム設定', '#nav-setting');
 
-        $I->amOnPage("/${config['eccube_admin_route']}/setting/system/member");
+        $I->amOnPage("/{$config['eccube_admin_route']}/setting/system/member");
         $I->seeInTitle('メンバー管理');
     }
 
@@ -435,7 +435,7 @@ class EA08SysteminfoCest
 
         // アクセスして確認
         $config = Fixtures::get('config');
-        $I->amOnPage("/${config['eccube_admin_route']}/content/news");
+        $I->amOnPage("/{$config['eccube_admin_route']}/content/news");
         $I->seeInTitle('アクセスできません');
     }
 
@@ -457,7 +457,7 @@ class EA08SysteminfoCest
 
         // アクセスして確認
         $config = Fixtures::get('config');
-        $I->amOnPage("/${config['eccube_admin_route']}/content/news");
+        $I->amOnPage("/{$config['eccube_admin_route']}/content/news");
         $I->seeInTitle('コンテンツ管理');
     }
 

--- a/codeception/acceptance/EA10PluginCest.php
+++ b/codeception/acceptance/EA10PluginCest.php
@@ -550,7 +550,7 @@ abstract class Abstract_Plugin
     {
         foreach ($this->columns as $column) {
             list($tableName, $columnName) = explode('.', $column);
-            $exists = $this->conn->executeQuery("SELECT count(*) AS count FROM information_schema.columns WHERE table_name = '${tableName}' AND column_name = '${columnName}';")->fetch()['count'] == 1;
+            $exists = $this->conn->executeQuery("SELECT count(*) AS count FROM information_schema.columns WHERE table_name = '{$tableName}' AND column_name = '{$columnName}';")->fetch()['count'] == 1;
             $this->I->assertTrue($exists, 'カラムがあるはず '.$column);
         }
     }
@@ -559,7 +559,7 @@ abstract class Abstract_Plugin
     {
         foreach ($this->columns as $column) {
             list($tableName, $columnName) = explode('.', $column);
-            $exists = $this->conn->executeQuery("SELECT count(*) AS count FROM information_schema.columns WHERE table_name = '${tableName}' AND column_name = '${columnName}';")->fetch()['count'] == 1;
+            $exists = $this->conn->executeQuery("SELECT count(*) AS count FROM information_schema.columns WHERE table_name = '{$tableName}' AND column_name = '{$columnName}';")->fetch()['count'] == 1;
             $this->I->assertFalse($exists, 'カラムがないはず '.$column);
         }
     }
@@ -767,7 +767,7 @@ class Store_Plugin extends Abstract_Plugin
     protected function publishPlugin($fileName)
     {
         $dirname = str_replace('.tgz', '', $fileName);
-        $this->I->assertTrue(!!$this->I->compressPlugin($dirname, codecept_root_dir().'repos'), "公開できた ${fileName}");
+        $this->I->assertTrue(!!$this->I->compressPlugin($dirname, codecept_root_dir().'repos'), "公開できた {$fileName}");
     }
 }
 

--- a/codeception/acceptance/EF01TopCest.php
+++ b/codeception/acceptance/EF01TopCest.php
@@ -35,7 +35,7 @@ class EF01TopCest
         // キャッシュを削除して表示できるようにする
         $fs = new Symfony\Component\Filesystem\Filesystem();
         foreach (['prod', 'codeception'] as $env) {
-            $cacheDir = __DIR__."/../../var/cache/${env}/pools";
+            $cacheDir = __DIR__."/../../var/cache/{$env}/pools";
             if ($fs->exists($cacheDir)) {
                 $fs->remove($cacheDir);
             }

--- a/codeception/acceptance/Plugin/PL08ApiCest.php
+++ b/codeception/acceptance/Plugin/PL08ApiCest.php
@@ -40,10 +40,10 @@ class PL08ApiCest
             ->入力_クライアントID('testclient')
             ->入力_クライアントシークレット('testsecret')
             ->入力_スコープread()
-            ->入力_リダイレクトURI("${baseUrl}/callback")
+            ->入力_リダイレクトURI("{$baseUrl}/callback")
             ->登録();
 
-        $I->amOnPage("/admin/authorize?response_type=code&client_id=testclient&redirect_uri=${baseUrl}/callback&scope=read&state=test");
+        $I->amOnPage("/admin/authorize?response_type=code&client_id=testclient&redirect_uri={$baseUrl}/callback&scope=read&state=test");
         $I->click(['id' => 'oauth_authorization_approve']);
 
         $redirectUrl = $I->grabFromCurrentUrl();
@@ -59,17 +59,17 @@ class PL08ApiCest
                     'grant_type=authorization_code' +
                     '&client_id=testclient' +
                     '&client_secret=testsecret' +
-                    '&redirect_uri=${baseUrl}/callback' +
-                    '&code=${code}'
+                    '&redirect_uri={$baseUrl}/callback' +
+                    '&code={$code}'
             });
             return await res.json();
         ");
 
         $url = '/api?query={ product(id: 1) { id, name } }';
         $data = $I->executeJS("
-            res = await fetch('${url}', {
+            res = await fetch('{$url}', {
                 headers: {
-                    'Authorization': 'Bearer ${tokens['access_token']}'
+                    'Authorization': 'Bearer {$tokens['access_token']}'
                 }
             });
             return await res.json();

--- a/src/Eccube/Command/DeleteCartsCommand.php
+++ b/src/Eccube/Command/DeleteCartsCommand.php
@@ -138,7 +138,7 @@ class DeleteCartsCommand extends Command
             $this->entityManager->flush();
             $this->entityManager->commit();
 
-            $this->io->comment("Deleted ${deleteRows} carts.");
+            $this->io->comment("Deleted {$deleteRows} carts.");
         } catch (\Exception $e) {
             $this->io->error('Failed delete carts. Rollbacked.');
             $this->entityManager->rollback();

--- a/src/Eccube/Command/PluginGenerateCommand.php
+++ b/src/Eccube/Command/PluginGenerateCommand.php
@@ -252,7 +252,7 @@ jobs:
         $source = <<<EOL
 <?php
 
-namespace Plugin\\${code};
+namespace Plugin\\{$code};
 
 use Eccube\\Common\\EccubeTwigBlock;
 
@@ -279,7 +279,7 @@ EOL;
         $source = <<<EOL
 <?php
 
-namespace Plugin\\${code};
+namespace Plugin\\{$code};
 
 use Eccube\\Common\\EccubeNav;
 
@@ -306,7 +306,7 @@ EOL;
         $source = <<<EOL
 <?php
 
-namespace Plugin\\${code};
+namespace Plugin\\{$code};
 
 use Symfony\\Component\\EventDispatcher\\EventSubscriberInterface;
 
@@ -335,11 +335,11 @@ EOL;
         $source = <<<EOL
 <?php
 
-namespace Plugin\\${code}\\Controller\\Admin;
+namespace Plugin\\{$code}\\Controller\\Admin;
 
 use Eccube\\Controller\\AbstractController;
-use Plugin\\${code}\\Form\\Type\\Admin\\ConfigType;
-use Plugin\\${code}\\Repository\\ConfigRepository;
+use Plugin\\{$code}\\Form\\Type\\Admin\\ConfigType;
+use Plugin\\{$code}\\Repository\\ConfigRepository;
 use Sensio\\Bundle\\FrameworkExtraBundle\\Configuration\\Template;
 use Symfony\\Component\\HttpFoundation\\Request;
 use Symfony\\Component\\Routing\\Annotation\\Route;
@@ -362,8 +362,8 @@ class ConfigController extends AbstractController
     }
 
     /**
-     * @Route("/%eccube_admin_route%/${snakecased}/config", name="${snakecased}_admin_config")
-     * @Template("@${code}/admin/config.twig")
+     * @Route("/%eccube_admin_route%/{$snakecased}/config", name="{$snakecased}_admin_config")
+     * @Template("@{$code}/admin/config.twig")
      */
     public function index(Request \$request)
     {
@@ -377,7 +377,7 @@ class ConfigController extends AbstractController
             \$this->entityManager->flush();
             \$this->addSuccess('登録しました。', 'admin');
 
-            return \$this->redirectToRoute('${snakecased}_admin_config');
+            return \$this->redirectToRoute('{$snakecased}_admin_config');
         }
 
         return [
@@ -393,16 +393,16 @@ EOL;
         $source = <<<EOL
 <?php
 
-namespace Plugin\\${code}\\Entity;
+namespace Plugin\\{$code}\\Entity;
 
 use Doctrine\\ORM\\Mapping as ORM;
 
-if (!class_exists('\\Plugin\\${code}\\Entity\\Config', false)) {
+if (!class_exists('\\Plugin\\{$code}\\Entity\\Config', false)) {
     /**
      * Config
      *
-     * @ORM\Table(name="plg_${snakecased}_config")
-     * @ORM\Entity(repositoryClass="Plugin\\${code}\\Repository\\ConfigRepository")
+     * @ORM\Table(name="plg_{$snakecased}_config")
+     * @ORM\Entity(repositoryClass="Plugin\\{$code}\\Repository\\ConfigRepository")
      */
     class Config
     {
@@ -459,11 +459,11 @@ EOL;
         $source = <<<EOL
 <?php
 
-namespace Plugin\\${code}\\Repository;
+namespace Plugin\\{$code}\\Repository;
 
 use Doctrine\Persistence\ManagerRegistry;
 use Eccube\\Repository\\AbstractRepository;
-use Plugin\\${code}\\Entity\\Config;
+use Plugin\\{$code}\\Entity\\Config;
 
 /**
  * ConfigRepository
@@ -509,9 +509,9 @@ EOL;
         $source = <<<EOL
 <?php
 
-namespace Plugin\\${code}\\Form\\Type\\Admin;
+namespace Plugin\\{$code}\\Form\\Type\\Admin;
 
-use Plugin\\${code}\\Entity\\Config;
+use Plugin\\{$code}\\Entity\\Config;
 use Symfony\\Component\\Form\\AbstractType;
 use Symfony\\Component\\Form\\Extension\\Core\\Type\\TextType;
 use Symfony\\Component\\Form\\FormBuilderInterface;
@@ -554,7 +554,7 @@ EOL;
 
 {% set menus = ['store', 'plugin', 'plugin_list'] %}
 
-{% block title %}${code}{% endblock %}
+{% block title %}{$code}{% endblock %}
 {% block sub_title %}プラグイン一覧{% endblock %}
 
 {% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}

--- a/src/Eccube/Command/PluginSchemaUpdateCommand.php
+++ b/src/Eccube/Command/PluginSchemaUpdateCommand.php
@@ -42,7 +42,7 @@ class PluginSchemaUpdateCommand extends Command
         /** @var Plugin $Plugin */
         $Plugin = $this->pluginRepository->findByCode($code);
         if (!$Plugin) {
-            $io->error("No such plugin `${code}`.");
+            $io->error("No such plugin `{$code}`.");
 
             return 1;
         }

--- a/src/Eccube/Command/PluginUpdateCommand.php
+++ b/src/Eccube/Command/PluginUpdateCommand.php
@@ -42,7 +42,7 @@ class PluginUpdateCommand extends Command
         $Plugin = $this->pluginRepository->findByCode($code);
 
         if (!$Plugin) {
-            $io->error("No such plugin `${code}`.");
+            $io->error("No such plugin `{$code}`.");
 
             return 1;
         }

--- a/src/Eccube/Controller/CartController.php
+++ b/src/Eccube/Controller/CartController.php
@@ -163,7 +163,7 @@ class CartController extends AbstractController
             foreach ($result->getWarning() as $warning) {
                 if ($Carts[$index]->getItems()->count() > 0) {
                     $cart_key = $Carts[$index]->getCartKey();
-                    $this->addRequestError($warning->getMessage(), "front.cart.${cart_key}");
+                    $this->addRequestError($warning->getMessage(), "front.cart.{$cart_key}");
                 } else {
                     // キーが存在しない場合はグローバルにエラーを表示する
                     $this->addRequestError($warning->getMessage());

--- a/src/Eccube/Service/PluginContext.php
+++ b/src/Eccube/Service/PluginContext.php
@@ -71,11 +71,11 @@ class PluginContext
         $projectRoot = $this->eccubeConfig->get('kernel.project_dir');
         $composerJsonPath = $projectRoot.'/app/Plugin/'.$this->code.'/composer.json';
         if (file_exists($composerJsonPath) === false) {
-            throw new PluginException("${composerJsonPath} not found.");
+            throw new PluginException("{$composerJsonPath} not found.");
         }
         $this->composerJson = json_decode(file_get_contents($composerJsonPath), true);
         if ($this->composerJson === null) {
-            throw new PluginException("Invalid json format. [${composerJsonPath}]");
+            throw new PluginException("Invalid json format. [{$composerJsonPath}]");
         }
 
         return $this->composerJson;

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -470,20 +470,20 @@ class PluginService
     {
         $composerJsonPath = $pluginDir.DIRECTORY_SEPARATOR.'composer.json';
         if (file_exists($composerJsonPath) === false) {
-            throw new PluginException("${composerJsonPath} not found.");
+            throw new PluginException("{$composerJsonPath} not found.");
         }
 
         $json = json_decode(file_get_contents($composerJsonPath), true);
         if ($json === null) {
-            throw new PluginException("Invalid json format. [${composerJsonPath}]");
+            throw new PluginException("Invalid json format. [{$composerJsonPath}]");
         }
 
         if (!isset($json['version'])) {
-            throw new PluginException("`version` is not defined in ${composerJsonPath}");
+            throw new PluginException("`version` is not defined in {$composerJsonPath}");
         }
 
         if (!isset($json['extra']['code'])) {
-            throw new PluginException("`extra.code` is not defined in ${composerJsonPath}");
+            throw new PluginException("`extra.code` is not defined in {$composerJsonPath}");
         }
 
         return [
@@ -678,7 +678,7 @@ class PluginService
         }
 
         $enabledPluginEntityDirs = array_map(function ($code) {
-            return $this->projectRoot."/app/Plugin/${code}/Entity";
+            return $this->projectRoot."/app/Plugin/{$code}/Entity";
         }, $enabledPluginCodes);
 
         return $this->entityProxyService->generate(

--- a/src/Eccube/Util/StringUtil.php
+++ b/src/Eccube/Util/StringUtil.php
@@ -329,7 +329,7 @@ class StringUtil
                     $env = self::convertLineFeed($env, "\r\n");
                 }
             } else {
-                $env .= PHP_EOL."${key}=${value}";
+                $env .= PHP_EOL."{$key}={$value}";
             }
         }
 

--- a/tests/Eccube/Tests/Command/UpdateSchemaDoctrineCommandTest.php
+++ b/tests/Eccube/Tests/Command/UpdateSchemaDoctrineCommandTest.php
@@ -421,7 +421,7 @@ class UpdateSchemaDoctrineCommandTest extends EccubeTestCase
         $tar->addFromString('Entity/HogeTrait.php', <<< EOT
 <?php
 
-namespace Plugin\\${tmpname}\\Entity;
+namespace Plugin\\{$tmpname}\\Entity;
 
 use Eccube\Annotation\EntityExtension;
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Eccube/Tests/Service/PluginServiceWithEntityExtensionTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceWithEntityExtensionTest.php
@@ -129,7 +129,7 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
         // Traitは有効
         self::assertContainsTrait(
             static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
-            "Plugin\\${configA['code']}\\Entity\\HogeTrait");
+            "Plugin\\{$configA['code']}\\Entity\\HogeTrait");
     }
 
     /**
@@ -154,7 +154,7 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
         // Traitは無効
         self::assertNotContainsTrait(
             static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
-            "Plugin\\${configA['code']}\\Entity\\HogeTrait");
+            "Plugin\\{$configA['code']}\\Entity\\HogeTrait");
     }
 
     /**
@@ -185,7 +185,7 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
         // Traitは無効
         self::assertNotContainsTrait(
             static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
-            "Plugin\\${configA['code']}\\Entity\\HogeTrait");
+            "Plugin\\{$configA['code']}\\Entity\\HogeTrait");
     }
 
     /**
@@ -213,7 +213,7 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
         // Traitは無効
         self::assertNotContainsTrait(
             static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
-            "Plugin\\${configA['code']}\\Entity\\HogeTrait");
+            "Plugin\\{$configA['code']}\\Entity\\HogeTrait");
     }
 
     /**
@@ -242,12 +242,12 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
         $this->service->enable($pluginEnabled);
 
         self::assertNotContainsTrait(static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
-            "Plugin\\${configDisabled['code']}\\Entity\\HogeTrait",
+            "Plugin\\{$configDisabled['code']}\\Entity\\HogeTrait",
             '無効状態プラグインのTraitは利用されないはず');
 
         // 無効化状態のTraitは利用されないはず
         self::assertContainsTrait(static::getContainer()->getParameter('kernel.project_dir').'/app/proxy/entity/Customer.php',
-            "Plugin\\${configEnabled['code']}\\Entity\\HogeTrait",
+            "Plugin\\{$configEnabled['code']}\\Entity\\HogeTrait",
             '有効状態のプラグインは利用されるはず');
     }
 
@@ -308,7 +308,7 @@ class PluginServiceWithEntityExtensionTest extends AbstractServiceTestCase
         $tar->addFromString('Entity/HogeTrait.php', <<< EOT
 <?php
 
-namespace Plugin\\${tmpname}\\Entity;
+namespace Plugin\\{$tmpname}\\Entity;
 
 use Eccube\Annotation\EntityExtension;
 

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleNonmemberTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleNonmemberTest.php
@@ -1250,7 +1250,7 @@ class ShoppingControllerWithMultipleNonmemberTest extends AbstractShoppingContro
 
         // shipping number on the screen
         $lastShipping = $crawler->filter('#shopping-form > div > div.ec-orderRole__detail > div.ec-orderDelivery div.ec-orderDelivery__title')->last()->text();
-        $this->assertStringContainsString("(${addressNumber})", $lastShipping);
+        $this->assertStringContainsString("({$addressNumber})", $lastShipping);
     }
 
     /**
@@ -1278,7 +1278,7 @@ class ShoppingControllerWithMultipleNonmemberTest extends AbstractShoppingContro
         unset($formData['email']);
 
         for ($i = 0; $i < $maxAddress; $i++) {
-            $formData['address']['addr02'] = "addr02_${i}";
+            $formData['address']['addr02'] = "addr02_{$i}";
             $crawler = $this->client->request(
                 'POST',
                 $this->generateUrl('shopping_shipping_multiple_edit'),


### PR DESCRIPTION
PHP8.2、PHP8.3 を対象に `bin/console cache:clear --no-warmup` を実行したところ
PHP8.2より非推奨になったエラーを検出したため、修正しました。

```
root@c588aed4dd3e:/var/www/html/ec-cube-4.3# bin/console cache:clear --no-warmup && bin/console cache:warmup

 // Clearing the cache for the prod environment with debug false


 [OK] Cache for the "prod" environment (debug=false) was successfully cleared.



Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/DeleteCartsCommand.php on line 141

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 253

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 280

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 307

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 336

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 338

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 341

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 342

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 365

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 365

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 366

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 394

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 396

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 400

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 404

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 460

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 462

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 510

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 512

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginGenerateCommand.php on line 553

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginSchemaUpdateCommand.php on line 45

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Command/PluginUpdateCommand.php on line 45

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Controller/Admin/Store/PluginController.php on line 305

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Controller/CartController.php on line 166

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Doctrine/ORM/Mapping/Driver/ReloadSafeAnnotationDriver.php on line 142

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Doctrine/ORM/Mapping/Driver/ReloadSafeAnnotationDriver.php on line 145

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Doctrine/ORM/Query/Extract.php on line 104

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Service/PluginContext.php on line 74

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Service/PluginContext.php on line 78

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Service/PluginService.php on line 473

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Service/PluginService.php on line 478

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Service/PluginService.php on line 482

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Service/PluginService.php on line 486

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Service/PluginService.php on line 681

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Util/StringUtil.php on line 332

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/ec-cube-4.3/src/Eccube/Util/StringUtil.php on line 332

Deprecated: Eccube\Entity\Customer implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in /var/www/html/ec-cube-4.3/src/Eccube/Entity/Customer.php on line 34

Deprecated: Eccube\Entity\Member implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in /var/www/html/ec-cube-4.3/src/Eccube/Entity/Member.php on line 34

 // Warming up the cache for the prod environment with debug false


 [OK] Cache for the "prod" environment (debug=false) was successfully warmed.


root@c588aed4dd3e:/var/www/html/ec-cube-4.3#
```

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

引用元：https://www.php.net/manual/ja/migration82.deprecated.php#migration82.deprecated.core.dollar-brace-interpolation

```
"${var}" / "${expr}" 形式の、文字列への値の埋め込み

"${var}" と "${expr}" 形式の文字列への値の埋め込みは、推奨されなくなりました。
 "$var"/"{$var}" や "{${expr}}" 形式をそれぞれ使ってください。
```

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

### 考慮したもの
- EC-CUBE上に使われているコードを参考に、プログラムの動作を確認できるツールを用いて検証に加えPHP8.1環境でも動作が可能か確認しました。 https://3v4l.org/
- 対象ファイルを「.php」としました。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

### サンプルコード

(非推奨の場合) 結果：

```
<?php
        $code = 'code';
        var_dump("No such plugin `${code}`.");
```

結果 https://3v4l.org/b0Mmr

```
Output for 8.2.0 - 8.2.21, 8.3.0 - 8.3.9
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /in/b0Mmr on line 4
string(22) "No such plugin `code`."

Output for 4.3.0 - 4.3.11, 4.4.0 - 4.4.9, 5.0.0 - 5.0.5, 5.1.0 - 5.1.6, 5.2.0 - 5.2.17, 5.3.0 - 5.3.29, 5.4.0 - 5.4.45, 5.5.0 - 5.5.38, 5.6.0 - 5.6.40, 7.0.0 - 7.0.33, 7.1.0 - 7.1.33, 7.2.0 - 7.2.34, 7.3.0 - 7.3.33, 7.4.0 - 7.4.33, 8.0.0 - 8.0.30, 8.1.0 - 8.1.29
string(22) "No such plugin `code`."
```

（fix）

```
<?php
        $code = 'code';
        var_dump("No such plugin `{$code}`.");
```

結果 https://3v4l.org/nVM9p

```
Output for 4.3.0 - 4.3.11, 4.4.0 - 4.4.9, 5.0.0 - 5.0.5, 5.1.0 - 5.1.6, 5.2.0 - 5.2.17, 5.3.0 - 5.3.29, 5.4.0 - 5.4.45, 5.5.0 - 5.5.38, 5.6.0 - 5.6.40, 7.0.0 - 7.0.33, 7.1.0 - 7.1.33, 7.2.0 - 7.2.34, 7.3.0 - 7.3.33, 7.4.0 - 7.4.33, 8.0.0 - 8.0.30, 8.1.0 - 8.1.29, 8.2.0 - 8.2.21, 8.3.0 - 8.3.9
string(22) "No such plugin `code`."
```

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
