### PR TITLE
【Symfony6.3より非推奨になったエラー】@required アノテーションの修正

### DIFF
--- a/src/Eccube/Command/PluginCommandTrait.php
+++ b/src/Eccube/Command/PluginCommandTrait.php
@@ -18,6 +18,7 @@ use Eccube\Service\PluginService;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
+use Symfony\Contracts\Service\Attribute\Required;
 
 trait PluginCommandTrait
 {
@@ -33,8 +34,8 @@ trait PluginCommandTrait
 
     /**
      * @param PluginService $pluginService
-     * @required
      */
+    #[Required]
     public function setPluginService(PluginService $pluginService)
     {
         $this->pluginService = $pluginService;
@@ -42,8 +43,8 @@ trait PluginCommandTrait
 
     /**
      * @param PluginRepository $pluginRepository
-     * @required
      */
+    #[Required]
     public function setPluginRepository(PluginRepository $pluginRepository)
     {
         $this->pluginRepository = $pluginRepository;

--- a/src/Eccube/Controller/AbstractController.php
+++ b/src/Eccube/Controller/AbstractController.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AbstractController extends Controller
@@ -65,8 +66,8 @@ class AbstractController extends Controller
 
     /**
      * @param EccubeConfig $eccubeConfig
-     * @required
      */
+    #[Required]
     public function setEccubeConfig(EccubeConfig $eccubeConfig)
     {
         $this->eccubeConfig = $eccubeConfig;
@@ -74,8 +75,8 @@ class AbstractController extends Controller
 
     /**
      * @param EntityManagerInterface $entityManager
-     * @required
      */
+    #[Required]
     public function setEntityManager(EntityManagerInterface $entityManager)
     {
         $this->entityManager = $entityManager;
@@ -83,8 +84,8 @@ class AbstractController extends Controller
 
     /**
      * @param TranslatorInterface $translator
-     * @required
      */
+    #[Required]
     public function setTranslator(TranslatorInterface $translator)
     {
         $this->translator = $translator;
@@ -92,8 +93,8 @@ class AbstractController extends Controller
 
     /**
      * @param Session $session
-     * @required
      */
+    #[Required]
     public function setSession(Session $session)
     {
         $this->session = $session;
@@ -101,8 +102,8 @@ class AbstractController extends Controller
 
     /**
      * @param FormFactoryInterface $formFactory
-     * @required
      */
+    #[Required]
     public function setFormFactory(FormFactoryInterface $formFactory)
     {
         $this->formFactory = $formFactory;
@@ -110,8 +111,8 @@ class AbstractController extends Controller
 
     /**
      * @param EventDispatcherInterface $eventDispatcher
-     * @required
      */
+    #[Required]
     public function setEventDispatcher(EventDispatcherInterface $eventDispatcher)
     {
         $this->eventDispatcher = $eventDispatcher;
@@ -120,8 +121,8 @@ class AbstractController extends Controller
     /**
      * @param RouterInterface $router
      * @return void
-     * @required
      */
+    #[Required]
     public function setRouter(RouterInterface $router)
     {
         $this->router = $router;

--- a/src/Eccube/Controller/AbstractShoppingController.php
+++ b/src/Eccube/Controller/AbstractShoppingController.php
@@ -18,6 +18,7 @@ use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Eccube\Service\PurchaseFlow\PurchaseFlow;
 use Eccube\Service\PurchaseFlow\PurchaseFlowResult;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Contracts\Service\Attribute\Required;
 
 class AbstractShoppingController extends AbstractController
 {
@@ -28,8 +29,8 @@ class AbstractShoppingController extends AbstractController
 
     /**
      * @param PurchaseFlow $shoppingPurchaseFlow
-     * @required
      */
+    #[Required]
     public function setPurchaseFlow(PurchaseFlow $shoppingPurchaseFlow)
     {
         $this->purchaseFlow = $shoppingPurchaseFlow;


### PR DESCRIPTION
デバッグモードで検証したところ
Symfony6.3より非推奨になったエラーを検出したため、修正しました。

 `@required` アノテーションは、`#[Required]` と指定方法が変更になるようです。

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

以下、公式サイトに従って変更をしました。
https://symfony.com/doc/6.4/service_container/autowiring.html#autowiring-calls

```php
<?php
// src/Util/Rot13Transformer.php
namespace App\Util;

+ use Symfony\Contracts\Service\Attribute\Required;

class Rot13Transformer
{
    private LoggerInterface $logger;

+    #[Required]
    public function setLogger(LoggerInterface $logger): void
    {
        $this->logger = $logger;
    }

    public function transform($value): string
    {
        $this->logger->info('Transforming '.$value);
        // ...
    }
}
```

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

デバッグモードにてどのページでも、同じようなエラーがSymfony developer toolで検知されていました。
この修正で以下のメリットがあると思いますので、もし可能でしたら4.3へのマージのご検討のほどよろしくおねがいします。
- ログファイルの肥大化の抑止
- 軽微な改修でエラー検知しやすくなる

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->



## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

管理画面＞ダッシュボードページのログ

<img width="1217" alt="eccube43_管理画面_ダッシュボード" src="https://github.com/EC-CUBE/ec-cube/assets/121001891/267d3aa6-4ad4-4255-ab02-c072499b2165">


## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
