### PR TITLE
monologにてdeprecatedログを出力しないよう設定

### DIFF
--- a/app/config/eccube/packages/prod/monolog.yml
+++ b/app/config/eccube/packages/prod/monolog.yml
@@ -1,5 +1,11 @@
 monolog:
     handlers:
+        e_user_deprecated_filter:
+            type: filter
+            accepted_levels: ['info']
+            channels: ['php']
+            handler: blackhole
+            bubble: false
         main:
             type: fingers_crossed
             action_level: error
@@ -39,3 +45,6 @@ monolog:
             type: console
             process_psr_3_messages: false
             channels: ['!event', '!doctrine']
+        # keep this last
+        blackhole:
+            type: "null"


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
co4.0環境で発生したdeprecatedログの肥大化への対応

## 方針(Policy)
monologにてdeprecatedログを出力しないよう設定
（暫定対応と同様）

## テスト（Test)
PRマージ後イメージ作成しテストします。

## 相談（Discussion）
特になし

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更はありません
→ログの出力仕様が変わります。
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
