### PR TITLE
MySQL 8.0 EOL対応のため、MySQL 8.4にバージョンを固定

### DIFF
--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -34,7 +34,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.4
         env:
           MYSQL_ROOT_PASSWORD: password
         ports:
@@ -172,7 +172,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.4
         env:
           MYSQL_ROOT_PASSWORD: password
         ports:
@@ -319,7 +319,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.4
         env:
           MYSQL_ROOT_PASSWORD: password
         ports:
@@ -469,7 +469,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.4
         env:
           MYSQL_ROOT_PASSWORD: password
         ports:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -29,7 +29,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:8
+        image: mysql:8.4
         env:
           MYSQL_ROOT_PASSWORD: password
         ports:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose
 
 * Apache 2.4.x (mod_rewrite / mod_ssl 必須)
 * PHP 8.1.x / 8.2.x / 8.3.x
-* PostgreSQL 12.x or higher / MySQL 8.0.x
+* PostgreSQL 12.x or higher / MySQL 8.4.x
 * ブラウザー：Google Chrome
 
 詳しくは開発ドキュメントの [システム要件](https://doc4.ec-cube.net/quickstart/requirement) をご確認ください。

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -15,7 +15,7 @@ services:
       DATABASE_CHARSET: 'utf8mb4'
 
   mysql:
-    image: mysql:8.0
+    image: mysql:8.4
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_USER: dbuser


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

MySQL 8.0のサポート終了（EOL）に伴い、CI/CD環境およびDocker開発環境のMySQLバージョンを8.4に固定します。

## 方針(Policy)

- MySQL 8.0は2026年4月にEOLを迎えるため、後継バージョンのMySQL 8.4に移行
- GitHub Actions（unit-test、plugin-test）とdocker-compose.mysql.ymlで使用するMySQLイメージを8.4に統一
- 既存のテストが問題なく動作することを確認

## 実装に関する補足(Appendix)

### 変更ファイル
- `.github/workflows/plugin-test.yml`: MySQL 5.7/8.0 → 8.4 に更新
- `.github/workflows/unit-test.yml`: MySQL 8 → 8.4 に更新
- `docker-compose.mysql.yml`: MySQL 8.0 → 8.4 に更新

### 影響範囲
- CI/CDパイプラインで使用するMySQLバージョンの変更のみ
- アプリケーションコードの変更なし
- 設定ファイルの変更のみのため、機能への影響なし

## テスト（Test)

- 既存のGitHub Actionsワークフロー（unit-test、plugin-test）が正常に動作することを確認
- ローカル開発環境でdocker-compose.mysql.ymlを使用した動作確認

## 相談（Discussion）

特にありません。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)