### PR TITLE
商品画像・支払方法設定画面の画像アップロードでWebPがアップロードできない #6497 の修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -330,7 +330,7 @@ class ProductController extends AbstractController
 
         $images = $request->files->get('admin_product');
 
-        $allowExtensions = ['gif', 'jpg', 'jpeg', 'png'];
+        $allowExtensions = ['gif', 'jpg', 'jpeg', 'png', 'webp'];
         $files = [];
         if (count($images) > 0) {
             foreach ($images as $img) {

--- a/src/Eccube/Controller/Admin/Setting/Shop/PaymentController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/PaymentController.php
@@ -176,7 +176,7 @@ class PaymentController extends AbstractController
 
         $images = $request->files->get('payment_register');
 
-        $allowExtensions = ['gif', 'jpg', 'jpeg', 'png'];
+        $allowExtensions = ['gif', 'jpg', 'jpeg', 'png', 'webp'];
 
         $filename = null;
         if (isset($images['payment_image_file'])) {

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -74,7 +74,8 @@ file that was distributed with this source code.
                 acceptedFileTypes: [
                     'image/gif',
                     'image/png',
-                    'image/jpeg'
+                    'image/jpeg',
+                    'image/webp',
                 ],
                 allowFileSizeValidation: true,
                 maxFileSize: 10000000,

--- a/src/Eccube/Resource/template/admin/Setting/Shop/payment_edit.twig
+++ b/src/Eccube/Resource/template/admin/Setting/Shop/payment_edit.twig
@@ -59,7 +59,8 @@ file that was distributed with this source code.
                 acceptedFileTypes: [
                     'image/gif',
                     'image/png',
-                    'image/jpeg'
+                    'image/jpeg',
+                    'image/webp',
                 ],
                 allowFileSizeValidation: true,
                 maxFileSize: 10000000,


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#6497 の修正を行いました。

## 方針(Policy)

webpをアップロードし登録できること

## 実装に関する補足(Appendix)

補足はありません。

## テスト（Test)

商品登録画面、支払い方法設定画面のどちらでもwebpがアップロードし登録できることを確認しました。

## 相談（Discussion）

特にありません。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ✓] 既存機能の仕様変更はありません
- [ ✓] フックポイントの呼び出しタイミングの変更はありません
- [ ✓] フックポイントのパラメータの削除・データ型の変更はありません
- [ ✓] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ✓] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ✓] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
