### PR TITLE
受注管理：受注一覧の対応状況変更の変更できませんのメッセージの番号が画面上にない #6506 の修正

### DIFF
--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -494,7 +494,7 @@ class OrderController extends AbstractController
         try {
             if ($Order->getOrderStatus()->getId() == $OrderStatus->getId()) {
                 log_info('対応状況一括変更スキップ');
-                $result = ['message' => trans('admin.order.skip_change_status', ['%name%' => $Shipping->getId()])];
+                $result = ['message' => trans('admin.order.skip_change_status', ['%name%' => $Order->getOrderNo()])];
             } else {
                 if ($this->orderStateMachine->can($Order, $OrderStatus)) {
                     if ($OrderStatus->getId() == OrderStatus::DELIVERED) {
@@ -549,7 +549,7 @@ class OrderController extends AbstractController
                     $from = $Order->getOrderStatus()->getName();
                     $to = $OrderStatus->getName();
                     $result = ['message' => trans('admin.order.failed_to_change_status', [
-                        '%name%' => $Shipping->getId(),
+                        '%name%' => $Order->getOrderNo(),
                         '%from%' => $from,
                         '%to%' => $to,
                     ])];


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#6506 の修正です。

## 方針(Policy)

画面上に表示されていない番号でしたので、ひとまず画面上に表示されている番号に切り替える

## 実装に関する補足(Appendix)

受注ステータスの更新時のエラーメッセージで、画面上にない出荷IDが表示されていましたので
受注Noに変更しました。

## テスト（Test)

出荷IDと受注Noが異なる受注を対応中に変更し
1. 対応中に一括変更し、スキップのメッセージに受注Noが表示されること
2. 新規受付に一括変更し、ステータス変更できませんのメッセージに受注Noが表示されること

購入処理中の受注でも同様に、受注と同じ対応状況のステータスと移動できないステータスを指定して確認しました。


## 相談（Discussion）

今回、受注Noに変更しましたが、
受注一覧が出荷データの一覧になっていますので
表示する受注Noが表示されている部分に出荷IDに関係するデータも表示し
エラーメッセージで該当行を示せるようにしたほうが良いかもしれません。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ✓] 既存機能の仕様変更はありません
- [ ✓] フックポイントの呼び出しタイミングの変更はありません
- [ ✓] フックポイントのパラメータの削除・データ型の変更はありません
- [ ✓] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ✓] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ✓] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
