### PR TITLE
受注一覧、商品一覧、会員一覧の検索結果の件数が桁区切りされていないため見づらい #6508 の修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Customer/index.twig
+++ b/src/Eccube/Resource/template/admin/Customer/index.twig
@@ -224,7 +224,7 @@ file that was distributed with this source code.
         <div class="c-outsideBlock__contents mb-5">
             <button type="submit" class="btn btn-ec-conversion px-5">{{ 'admin.common.search'|trans }}</button>
             {% if pagination %}
-                <span class="fw-bold ms-2">{{ 'admin.common.search_result'|trans({'%count%':pagination.totalItemCount}) }}</span>
+                <span class="fw-bold ms-2">{{ 'admin.common.search_result'|trans({'%count%':pagination.totalItemCount|number_format}) }}</span>
             {% endif %}
         </div>
         <div class="c-outsideBlock__contents mb-5">

--- a/src/Eccube/Resource/template/admin/Order/index.twig
+++ b/src/Eccube/Resource/template/admin/Order/index.twig
@@ -371,7 +371,7 @@ file that was distributed with this source code.
                         <div class="col-12">
                             <button class="btn btn-ec-conversion px-5" type="submit" id="search_submit">{{ 'admin.common.search'|trans }}</button>
                             {% if pagination %}
-                                <span class="fw-bold ms-2" id="search_total_count">{{ 'admin.common.search_result'|trans({"%count%":pagination.totalItemCount})|raw }}</span>
+                                <span class="fw-bold ms-2" id="search_total_count">{{ 'admin.common.search_result'|trans({"%count%":pagination.totalItemCount|number_format})|raw }}</span>
                             {% endif %}
                         </div>
                     </div>

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -253,7 +253,7 @@ file that was distributed with this source code.
             <div class="c-outsideBlock__contents mb-5">
                 <button class="btn btn-ec-conversion px-5" type="submit">{{ 'admin.common.search'|trans }}</button>
                 {% if pagination %}
-                    <span class="fw-bold ms-2">{{ 'admin.common.search_result'|trans({"%count%":pagination.totalItemCount})|raw }}</span>
+                    <span class="fw-bold ms-2">{{ 'admin.common.search_result'|trans({"%count%":pagination.totalItemCount|number_format})|raw }}</span>
                 {% endif %}
             </div>
             <div class="c-outsideBlock__contents mb-5">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#6508 への対応

## 方針(Policy)


## 実装に関する補足(Appendix)


## テスト（Test)

検索結果を1000にするためにデータを作るのは手がかかりますので
Controllerでのパラメータ渡しの前に、pagination.totalItemCountに1000を代入し
表示された検索結果の表示が3桁区切りになっていることを確認しました。

検索結果が0件の場合も1000件未満の場合もエラーなく表示されることを確認しました。


## 相談（Discussion）


## マイナーバージョン互換性保持のための制限事項チェックリスト


- [ ✓] 既存機能の仕様変更はありません
- [ ✓] フックポイントの呼び出しタイミングの変更はありません
- [ ✓] フックポイントのパラメータの削除・データ型の変更はありません
- [ ✓] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ✓] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ✓] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
