### PR TITLE
既存のjsの仕組みを流用しつつプラグインで商品/会員/受注管理の一覧のソートを追加したい #6520 の修正

### DIFF
--- a/src/Eccube/Controller/Admin/Customer/CustomerController.php
+++ b/src/Eccube/Controller/Admin/Customer/CustomerController.php
@@ -157,19 +157,23 @@ class CustomerController extends AbstractController
         /** @var QueryBuilder $qb */
         $qb = $this->customerRepository->getQueryBuilderBySearchData($searchData);
 
+        $paginate_options = [];
         $event = new EventArgs(
             [
                 'form' => $searchForm,
                 'qb' => $qb,
+                'paginate_options' => $paginate_options,
             ],
             $request
         );
         $this->eventDispatcher->dispatch($event, EccubeEvents::ADMIN_CUSTOMER_INDEX_SEARCH);
+        $paginate_options = $event->getArgument('paginate_options');
 
         $pagination = $paginator->paginate(
             $qb,
             $page_no,
-            $pageCount
+            $pageCount,
+            $paginate_options
         );
 
         return [

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -292,31 +292,30 @@ class OrderController extends AbstractController
 
         $qb = $this->orderRepository->getQueryBuilderBySearchDataForAdmin($searchData);
 
+        $sortKey = $searchData['sortkey'];
+        $paginate_options = ['wrap-queries' => true];
+        if (empty($this->orderRepository::COLUMNS[$sortKey]) || $sortKey == 'order_status') {
+            $paginate_options = [];
+        }
+
         $event = new EventArgs(
             [
                 'qb' => $qb,
                 'searchData' => $searchData,
+                'paginate_options' => $paginate_options,
             ],
             $request
         );
 
         $this->eventDispatcher->dispatch($event, EccubeEvents::ADMIN_ORDER_INDEX_SEARCH);
-        $sortKey = $searchData['sortkey'];
+        $paginate_options = $event->getArgument('paginate_options');
 
-        if (empty($this->orderRepository::COLUMNS[$sortKey]) || $sortKey == 'order_status') {
-            $pagination = $paginator->paginate(
-                $qb,
-                $page_no,
-                $page_count
-            );
-        } else {
-            $pagination = $paginator->paginate(
-                $qb,
-                $page_no,
-                $page_count,
-                ['wrap-queries' => true]
-            );
-        }
+        $pagination = $paginator->paginate(
+            $qb,
+            $page_no,
+            $page_count,
+            $paginate_options
+        );
 
         return [
             'searchForm' => $searchForm->createView(),

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -247,32 +247,30 @@ class ProductController extends AbstractController
 
         $qb = $this->productRepository->getQueryBuilderBySearchDataForAdmin($searchData);
 
+        $sortKey = $searchData['sortkey'];
+        $paginate_options = ['wrap-queries' => true];
+        if (empty($this->productRepository::COLUMNS[$sortKey]) || $sortKey == 'code' || $sortKey == 'status') {
+            $paginate_options = [];
+        }
+
         $event = new EventArgs(
             [
                 'qb' => $qb,
                 'searchData' => $searchData,
+                'paginate_options' => $paginate_options,
             ],
             $request
         );
 
         $this->eventDispatcher->dispatch($event, EccubeEvents::ADMIN_PRODUCT_INDEX_SEARCH);
+        $paginate_options = $event->getArgument('paginate_options');
 
-        $sortKey = $searchData['sortkey'];
-
-        if (empty($this->productRepository::COLUMNS[$sortKey]) || $sortKey == 'code' || $sortKey == 'status') {
-            $pagination = $paginator->paginate(
-                $qb,
-                $page_no,
-                $page_count
-            );
-        } else {
-            $pagination = $paginator->paginate(
-                $qb,
-                $page_no,
-                $page_count,
-                ['wrap-queries' => true]
-            );
-        }
+        $pagination = $paginator->paginate(
+            $qb,
+            $page_no,
+            $page_count,
+            $paginate_options
+        );
 
         return [
             'searchForm' => $searchForm->createView(),

--- a/src/Eccube/Repository/AbstractRepository.php
+++ b/src/Eccube/Repository/AbstractRepository.php
@@ -85,9 +85,10 @@ abstract class AbstractRepository extends ServiceEntityRepository
      * @param string $alias
      * @param array $sortColumns
      * @param array $searchData
+     *
      * @return void
      */
-    protected function setQueryBuilderAdminSearchDataOrderBy($qb, $alias='p', $sortColumns=[], $searchData=[])
+    protected function setQueryBuilderAdminSearchDataOrderBy($qb, $alias = 'p', $sortColumns = [], $searchData = [])
     {
         if (isset($searchData['sortkey']) && !empty($searchData['sortkey'])) {
             $sortOrder = (isset($searchData['sorttype']) && $searchData['sorttype'] == 'a') ? 'ASC' : 'DESC';

--- a/src/Eccube/Repository/AbstractRepository.php
+++ b/src/Eccube/Repository/AbstractRepository.php
@@ -76,4 +76,29 @@ abstract class AbstractRepository extends ServiceEntityRepository
     {
         return 'mysql' == $this->getEntityManager()->getConnection()->getDatabasePlatform()->getName();
     }
+
+    /**
+     * 管理画面の検索時のソートの設定の際にソートキーが存在しない場合にWarningになるのでその対処
+     * プラグインやカスタマイズでソートキーを追加し、QueryCustomizerで制御できるようにするための措置
+     *
+     * @param \Doctrine\ORM\QueryBuilder $qb
+     * @param string $alias
+     * @param array $sortColumns
+     * @param array $searchData
+     * @return void
+     */
+    protected function setQueryBuilderAdminSearchDataOrderBy($qb, $alias='p', $sortColumns=[], $searchData=[])
+    {
+        if (isset($searchData['sortkey']) && !empty($searchData['sortkey'])) {
+            $sortOrder = (isset($searchData['sorttype']) && $searchData['sorttype'] == 'a') ? 'ASC' : 'DESC';
+
+            $addOrderBy = $sortColumns[$searchData['sortkey']] ?? "{$alias}.update_date";
+            $qb->orderBy($addOrderBy, $sortOrder);
+            $qb->addOrderBy("{$alias}.update_date", 'DESC');
+            $qb->addOrderBy("{$alias}.id", 'DESC');
+        } else {
+            $qb->orderBy("{$alias}.update_date", 'DESC');
+            $qb->addOrderBy("{$alias}.id", 'DESC');
+        }
+    }
 }

--- a/src/Eccube/Repository/CustomerRepository.php
+++ b/src/Eccube/Repository/CustomerRepository.php
@@ -313,15 +313,7 @@ class CustomerRepository extends AbstractRepository
         }
 
         // Order By
-        if (isset($searchData['sortkey']) && !empty($searchData['sortkey'])) {
-            $sortOrder = (isset($searchData['sorttype']) && $searchData['sorttype'] == 'a') ? 'ASC' : 'DESC';
-            $qb->orderBy(self::COLUMNS[$searchData['sortkey']], $sortOrder);
-            $qb->addOrderBy('c.update_date', 'DESC');
-            $qb->addOrderBy('c.id', 'DESC');
-        } else {
-            $qb->orderBy('c.update_date', 'DESC');
-            $qb->addOrderBy('c.id', 'DESC');
-        }
+        $this->setQueryBuilderAdminSearchDataOrderBy($qb, 'c', self::COLUMNS, $searchData);
 
         return $this->queries->customize(QueryKey::CUSTOMER_SEARCH, $qb, $searchData);
     }

--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -395,16 +395,7 @@ class OrderRepository extends AbstractRepository
         }
 
         // Order By
-        if (isset($searchData['sortkey']) && !empty($searchData['sortkey'])) {
-            $sortOrder = (isset($searchData['sorttype']) && $searchData['sorttype'] == 'a') ? 'ASC' : 'DESC';
-
-            $qb->orderBy(self::COLUMNS[$searchData['sortkey']], $sortOrder);
-            $qb->addOrderBy('o.update_date', 'DESC');
-            $qb->addOrderBy('o.id', 'DESC');
-        } else {
-            $qb->orderBy('o.update_date', 'DESC');
-            $qb->addorderBy('o.id', 'DESC');
-        }
+        $this->setQueryBuilderAdminSearchDataOrderBy($qb, 'o', self::COLUMNS, $searchData);
 
         return $this->queries->customize(QueryKey::ORDER_SEARCH_ADMIN, $qb, $searchData);
     }

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -399,16 +399,7 @@ class ProductRepository extends AbstractRepository
         }
 
         // Order By
-        if (isset($searchData['sortkey']) && !empty($searchData['sortkey'])) {
-            $sortOrder = (isset($searchData['sorttype']) && $searchData['sorttype'] == 'a') ? 'ASC' : 'DESC';
-
-            $qb->orderBy(self::COLUMNS[$searchData['sortkey']], $sortOrder);
-            $qb->addOrderBy('p.update_date', 'DESC');
-            $qb->addOrderBy('p.id', 'DESC');
-        } else {
-            $qb->orderBy('p.update_date', 'DESC');
-            $qb->addOrderBy('p.id', 'DESC');
-        }
+        $this->setQueryBuilderAdminSearchDataOrderBy($qb, 'p', self::COLUMNS, $searchData);
 
         return $this->queries->customize(QueryKey::PRODUCT_SEARCH_ADMIN, $qb, $searchData);
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#6520 の修正を行いました。

## 方針(Policy)

修正部分がほぼ同じ部分は共通化しました。

## 実装に関する補足(Appendix)

以下のコメントとほぼ同じですが、paginateの第4引数のoptionsを制御できるようにしております。
それは、ソートの項目によって `['wrap-queries' => true]` を入れないと動かないパターンがあったためです。
https://github.com/EC-CUBE/ec-cube/issues/6520#issuecomment-3580396329

そうなる状況を見つけたProductController以外にも入れたのは
改修その他で追加テーブルなどあった場合に同様の状況が発生する可能性を考慮したためです。

## テスト（Test)

ソートの追加項目によってシステムエラーが出ないことを以下確かめました
・商品一覧：販売価格、検索ワード
・受注一覧：お問い合わせ
・会員一覧：電話番号

optionsが設定できることについては
eventから取り出した箇所にてdumpで設定されていることを確かめました
商品一覧では販売価格のソートを入れるとシステムエラーになりますので、
 `['wrap-queries' => true]` をイベントにて追加することでシステムエラーが起きないことを確かめました。

## 相談（Discussion）

競合を極力防ぐために
paginateの第4引数に `['wrap-queries' => true]` を入れるか入れないかだけの制御を
eventの引数にする方法もあります。

今回、細かく調査していませんが、
他にエラーが発生し他のoptionsの設定内容で制御できるならそれも良しかと
第4引数のoptionsを全て制御できるようにしております。

どちらがよりふさわしいかはご相談かと思っております。

## マイナーバージョン互換性保持のための制限事項チェックリスト

下位互換はありますが、フックポイントのパラメータ追加があるため仕様変更となるかと思います。

- [ ] 既存機能の仕様変更はありません
- [ ✓] フックポイントの呼び出しタイミングの変更はありません
- [ ✓] フックポイントのパラメータの削除・データ型の変更はありません
- [ ✓] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ✓] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ✓] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
