### PR TITLE
[4.3-symfony7] feat(rector): Doctrine EventSubscriberInterfaceToAttributeRector を追加

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -25,6 +25,7 @@ use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector;
+use Rector\Doctrine\Bundle210\Rector\Class_\EventSubscriberInterfaceToAttributeRector;
 use Rector\Doctrine\Set\DoctrineSetList;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
@@ -76,6 +77,7 @@ return RectorConfig::configure()
                CommandConfigureToAttributeRector::class, // Symfonyコマンドのconfigureメソッドをアトリビュートに変換する
                CommandPropertyToAttributeRector::class, // Symfonyコマンドのプロパティをアトリビュートに変換する,
                StaticDataProviderClassMethodRector::class, // PHPUnitのデータプロバイダを静的メソッドに変換する
+               EventSubscriberInterfaceToAttributeRector::class, // Doctrine EventSubscriberをAsDoctrineListenerアトリビュートに変換する
                AttributeArgumentsOrderRector::class, // すべての Attribute の引数をコンストラクタ引数順序に統一する
                NormalizePhpDocArrayGenericSpacingRector::class, // PHPDoc の配列ジェネリクス表記のカンマ後のスペースを統一する
            ])


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Doctrine EventSubscriber を AsDoctrineListener アトリビュートに変換する Rector ルール `EventSubscriberInterfaceToAttributeRector` を rector.php の `withRules` に追加しました。

## 方針(Policy)

- Doctrine EventSubscriber はカスタマイズで多く使用されている機能のため、明示的に Rector ルールとして有効化

## 実装に関する補足(Appendix)

- `use` 文と `withRules` 配列の両方に `EventSubscriberInterfaceToAttributeRector` を追加
- コメントで変換内容を説明（「Doctrine EventSubscriberをAsDoctrineListenerアトリビュートに変換する」）

## テスト（Test)

- rector.php の構文エラーがないことを確認

## 相談（Discussion）

特になし

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)