### PR TITLE
refactor(ItemCollection): reduce() メソッドの型安全性を向上

### DIFF
--- a/src/Eccube/Service/PurchaseFlow/ItemCollection.php
+++ b/src/Eccube/Service/PurchaseFlow/ItemCollection.php
@@ -33,7 +33,7 @@ class ItemCollection extends ArrayCollection
      */
     public function __construct(array|Collection|null $Items = null, ?string $type = null)
     {
-        $this->type = is_null($type) ? Order::class : $type;
+        $this->type = $type ?? Order::class;
 
         if ($Items instanceof Collection) {
             $Items = $Items->toArray();
@@ -42,9 +42,12 @@ class ItemCollection extends ArrayCollection
     }
 
     /**
-     * @param mixed|null $initial
+     * @template TReturn
      *
-     * @return mixed|null
+     * @param \Closure(TReturn, ItemInterface): TReturn $func
+     * @param TReturn|null $initial
+     *
+     * @return TReturn|null
      */
     #[\Override]
     public function reduce(\Closure $func, mixed $initial = null): mixed
@@ -59,7 +62,8 @@ class ItemCollection extends ArrayCollection
     public function getProductClasses(): ItemCollection
     {
         return $this->filter(
-            fn (ItemInterface $OrderItem) => $OrderItem->isProduct());
+            fn (ItemInterface $OrderItem) => $OrderItem->isProduct()
+        );
     }
 
     /**
@@ -68,7 +72,8 @@ class ItemCollection extends ArrayCollection
     public function getDeliveryFees(): ItemCollection
     {
         return $this->filter(
-            fn (ItemInterface $OrderItem) => $OrderItem->isDeliveryFee());
+            fn (ItemInterface $OrderItem) => $OrderItem->isDeliveryFee()
+        );
     }
 
     /**
@@ -77,7 +82,8 @@ class ItemCollection extends ArrayCollection
     public function getCharges(): ItemCollection
     {
         return $this->filter(
-            fn (ItemInterface $OrderItem) => $OrderItem->isCharge());
+            fn (ItemInterface $OrderItem) => $OrderItem->isCharge()
+        );
     }
 
     /**
@@ -86,7 +92,8 @@ class ItemCollection extends ArrayCollection
     public function getDiscounts(): ItemCollection
     {
         return $this->filter(
-            fn (ItemInterface $OrderItem) => $OrderItem->isDiscount() || $OrderItem->isPoint());
+            fn (ItemInterface $OrderItem) => $OrderItem->isDiscount() || $OrderItem->isPoint()
+        );
     }
 
     /**
@@ -107,14 +114,13 @@ class ItemCollection extends ArrayCollection
 
     /**
      * 指定した受注明細区分の明細が存在するかどうか.
-     *
-     * @param OrderItemType $OrderItemType 受注区分
      */
     public function hasItemByOrderItemType(OrderItemType $OrderItemType): bool
     {
-        $filteredItems = $this->filter(fn (ItemInterface $OrderItem) =>
-            /* @var OrderItem $OrderItem */
-            $OrderItem->getOrderItemType() && $OrderItem->getOrderItemType()->getId() == $OrderItemType->getId());
+        $filteredItems = $this->filter(
+            fn (ItemInterface $OrderItem) => $OrderItem->getOrderItemType()
+                && $OrderItem->getOrderItemType()->getId() == $OrderItemType->getId()
+        );
 
         return !$filteredItems->isEmpty();
     }

--- a/src/Eccube/Service/PurchaseFlow/ItemCollection.php
+++ b/src/Eccube/Service/PurchaseFlow/ItemCollection.php
@@ -52,7 +52,7 @@ class ItemCollection extends ArrayCollection
     #[\Override]
     public function reduce(\Closure $func, mixed $initial = null): mixed
     {
-        return array_reduce($this->toArray(), $func, $initial);
+        return parent::reduce($func, $initial);
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

ItemCollection クラスの `reduce()` メソッドの型安全性を向上させるリファクタリングです。
Doctrine Collections 2.1 で追加された `reduce()` メソッドに対応し、PHPDoc のテンプレート型定義を改善しました。

## 方針(Policy)

- `reduce()` メソッドの PHPDoc を `@template TReturn` 形式に変更し、ジェネリクスによる型安全性を向上
- `reduce()` の実装を `parent::reduce()` に委譲し、DRY原則に従ったシンプルな実装に変更
- コンストラクタの null チェックを null 合体演算子（`??`）に簡略化
- フィルターメソッドのフォーマットを複数行形式に統一し、可読性を向上
- 不要な PHPDoc コメントを削除

## 実装に関する補足(Appendix)

### 変更内容

| 項目 | 変更前 | 変更後 |
|-----|--------|--------|
| コンストラクタ | `is_null($type) ? Order::class : $type` | `$type ?? Order::class` |
| reduce() PHPDoc | `@param mixed\|null` | `@template TReturn` 形式 |
| reduce() 実装 | `array_reduce($this->toArray(), ...)` | `parent::reduce(...)` |
| フィルターメソッド | 1行形式 | 複数行形式 |

### 使用例

```php
$total = $itemHolder->getItems()
    ->getProductClasses()
    ->reduce(
        fn (string $sum, ItemInterface $item) => bcadd(
            $sum,
            bcmul($item->getPriceIncTax(), $item->getQuantity(), 2),
            2
        ),
        '0'
    );
```

## テスト（Test)

- [x] PHPStan Level 6 で `src/Eccube/` 全体がエラーなしで通過

## 相談（Discussion）

特になし

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)