### PR TITLE
refactor(doctrine): setResultCacheLifetimeをenableResultCacheに置換

### DIFF
--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -120,7 +120,7 @@ class ProductController extends AbstractController
         $searchData = $event->getArgument('searchData');
 
         $query = $qb->getQuery()
-            ->setResultCacheLifetime($this->eccubeConfig['eccube_result_cache_lifetime_short']);
+            ->enableResultCache($this->eccubeConfig['eccube_result_cache_lifetime_short']);
 
         /** @var SlidingPagination<int, Product> $pagination */
         $pagination = $paginator->paginate(

--- a/src/Eccube/Repository/CategoryRepository.php
+++ b/src/Eccube/Repository/CategoryRepository.php
@@ -85,7 +85,7 @@ class CategoryRepository extends AbstractRepository
             $qb->where('c1.Parent IS NULL');
         }
         $Categories = $qb->getQuery()
-            ->setResultCacheLifetime($this->getCacheLifetime())
+            ->enableResultCache($this->getCacheLifetime())
             ->getResult();
 
         if ($flat) {

--- a/src/Eccube/Repository/LayoutRepository.php
+++ b/src/Eccube/Repository/LayoutRepository.php
@@ -47,7 +47,7 @@ class LayoutRepository extends AbstractRepository
                 ->orderBy('bp.block_row', 'ASC')
                 ->setParameter('id', $id)
                 ->getQuery()
-                ->setResultCacheLifetime($this->getCacheLifetime())
+                ->enableResultCache($this->getCacheLifetime())
                 ->getSingleResult();
         } catch (NoResultException) {
             return null;

--- a/src/Eccube/Repository/PageRepository.php
+++ b/src/Eccube/Repository/PageRepository.php
@@ -67,7 +67,7 @@ class PageRepository extends AbstractRepository
                 ->where('p.url = :url')
                 ->setParameter('url', $route)
                 ->getQuery()
-                ->setResultCacheLifetime($this->getCacheLifetime())
+                ->enableResultCache($this->getCacheLifetime())
                 ->getSingleResult();
         } catch (\Exception) {
             return $this->newPage();
@@ -88,7 +88,7 @@ class PageRepository extends AbstractRepository
             ->where('p.url = :route')
             ->setParameter('route', $url)
             ->getQuery()
-            ->setResultCacheLifetime($this->getCacheLifetime())
+            ->enableResultCache($this->getCacheLifetime())
             ->getSingleResult();
     }
 

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -107,7 +107,7 @@ class ProductRepository extends AbstractRepository
 
         return $qb
             ->getQuery()
-            ->setResultCacheLifetime($this->eccubeConfig['eccube_result_cache_lifetime_short'])
+            ->enableResultCache($this->eccubeConfig['eccube_result_cache_lifetime_short'])
             ->getResult();
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Doctrine ORM 3.xで`setResultCacheLifetime()`の使用は非推奨となり、`enableResultCache()`の使用が推奨されています。

このPRでは、以下のファイルで`setResultCacheLifetime()`を`enableResultCache()`に置換しています：

- `src/Eccube/Controller/ProductController.php`
- `src/Eccube/Repository/CategoryRepository.php`
- `src/Eccube/Repository/LayoutRepository.php`
- `src/Eccube/Repository/PageRepository.php` (2箇所)
- `src/Eccube/Repository/ProductRepository.php`

## 方針(Policy)

Doctrine ORM 3.x の API変更に対応するためのリファクタリングです。

## 実装に関する補足(Appendix)

`setResultCacheLifetime()` は内部的にキャッシュを有効にする処理を行いますが、`enableResultCache()` を明示的に使用することで、意図が明確になります。

## テスト（Test)

- [x] PHPUnit テスト
- [x] PHPStan

## 相談（Discussion）

特になし

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)