### PR TITLE
refactor(bcmath): 浮動小数点演算をbcmath関数に置換

### DIFF
--- a/src/Eccube/Controller/Admin/AdminController.php
+++ b/src/Eccube/Controller/Admin/AdminController.php
@@ -511,12 +511,12 @@ class AdminController extends AbstractController
     {
         $raw = [];
         for ($date = $fromDate; $date <= $toDate; $date = $date->addDay()) {
-            $raw[$date->format($format)]['price'] = 0;
+            $raw[$date->format($format)]['price'] = '0';
             $raw[$date->format($format)]['count'] = 0;
         }
 
         foreach ($result as $Order) {
-            $raw[$Order->getOrderDate()->format($format)]['price'] += $Order->getPaymentTotal();
+            $raw[$Order->getOrderDate()->format($format)]['price'] = bcadd($raw[$Order->getOrderDate()->format($format)]['price'], $Order->getPaymentTotal(), 0);
             ++$raw[$Order->getOrderDate()->format($format)]['count'];
         }
 

--- a/src/Eccube/Controller/Admin/AdminController.php
+++ b/src/Eccube/Controller/Admin/AdminController.php
@@ -516,7 +516,7 @@ class AdminController extends AbstractController
         }
 
         foreach ($result as $Order) {
-            $raw[$Order->getOrderDate()->format($format)]['price'] = bcadd($raw[$Order->getOrderDate()->format($format)]['price'], $Order->getPaymentTotal(), 0);
+            $raw[$Order->getOrderDate()->format($format)]['price'] = bcadd($raw[$Order->getOrderDate()->format($format)]['price'], (string) $Order->getPaymentTotal(), 0);
             ++$raw[$Order->getOrderDate()->format($format)]['count'];
         }
 

--- a/src/Eccube/Controller/Admin/Setting/Shop/DeliveryController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/DeliveryController.php
@@ -361,8 +361,8 @@ class DeliveryController extends AbstractController
     {
         // 手数料抜きの利用条件の一覧を作成
         $rules = array_map(fn (Payment $Payment) => [
-            'min' => $Payment->getRuleMin() ? $Payment->getRuleMin() - $Payment->getCharge() : 0, // @phpstan-ignore-line TODO bcmath-polyfill を使用する
-            'max' => $Payment->getRuleMax() ? $Payment->getRuleMax() - $Payment->getCharge() + 1 : PHP_INT_MAX, // @phpstan-ignore-line TODO bcmath-polyfill を使用する
+            'min' => $Payment->getRuleMin() ? bcsub($Payment->getRuleMin(), $Payment->getCharge() ?? '0') : '0',
+            'max' => $Payment->getRuleMax() ? bcadd(bcsub($Payment->getRuleMax(), $Payment->getCharge() ?? '0'), '1') : (string) PHP_INT_MAX,
         ], $PaymentsData);
 
         /** @var array<int, array{min: int, max: int}> $mergeRules */

--- a/src/Eccube/Controller/Admin/Setting/Shop/DeliveryController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/DeliveryController.php
@@ -387,7 +387,6 @@ class DeliveryController extends AbstractController
             }
         }
 
-        // @phpstan-ignore-next-line
         usort($mergeRules, function (array $a, array $b): int {
             if ($a['min'] == $b['min']) {
                 return 0;

--- a/src/Eccube/Controller/CartController.php
+++ b/src/Eccube/Controller/CartController.php
@@ -67,7 +67,7 @@ class CartController extends AbstractController
         $quantity = [];
         $isDeliveryFree = [];
         $totalPrice = 0;
-        $totalQuantity = 0;
+        $totalQuantity = '0';
 
         foreach ($Carts as $Cart) {
             $quantity[$Cart->getCartKey()] = 0;
@@ -85,12 +85,12 @@ class CartController extends AbstractController
                 if (!$isDeliveryFree[$Cart->getCartKey()] && $this->baseInfo->getDeliveryFreeAmount() <= $Cart->getTotalPrice()) {
                     $isDeliveryFree[$Cart->getCartKey()] = true;
                 } else {
-                    $least[$Cart->getCartKey()] = $this->baseInfo->getDeliveryFreeAmount() - $Cart->getTotalPrice(); // @phpstan-ignore-line TODO bcmath-polyfill を使用する
+                    $least[$Cart->getCartKey()] = $this->baseInfo->getDeliveryFreeAmount() - $Cart->getTotalPrice();
                 }
             }
 
             $totalPrice += $Cart->getTotalPrice();
-            $totalQuantity += $Cart->getQuantity();
+            $totalQuantity = bcadd($totalQuantity, $Cart->getQuantity(), 0);
         }
 
         // カートが分割された時のセッション情報を削除

--- a/src/Eccube/Controller/CartController.php
+++ b/src/Eccube/Controller/CartController.php
@@ -85,11 +85,11 @@ class CartController extends AbstractController
                 if (!$isDeliveryFree[$Cart->getCartKey()] && $this->baseInfo->getDeliveryFreeAmount() <= $Cart->getTotalPrice()) {
                     $isDeliveryFree[$Cart->getCartKey()] = true;
                 } else {
-                    $least[$Cart->getCartKey()] = $this->baseInfo->getDeliveryFreeAmount() - $Cart->getTotalPrice();
+                    $least[$Cart->getCartKey()] = bcsub($this->baseInfo->getDeliveryFreeAmount(), (string) $Cart->getTotalPrice(), 0);
                 }
             }
 
-            $totalPrice += $Cart->getTotalPrice();
+            $totalPrice = bcadd((string) $totalPrice, (string) $Cart->getTotalPrice(), 0);
             $totalQuantity = bcadd($totalQuantity, $Cart->getQuantity(), 0);
         }
 

--- a/src/Eccube/Controller/EntryController.php
+++ b/src/Eccube/Controller/EntryController.php
@@ -225,7 +225,7 @@ class EntryController extends AbstractController
     /**
      * 会員登録処理を行う
      */
-    private function entryActivate(Request $request, string $secret_key): int
+    private function entryActivate(Request $request, string $secret_key): string
     {
         log_info('本会員登録開始');
         $Customer = $this->customerRepository->getProvisionalCustomerBySecretKey($secret_key);

--- a/src/Eccube/Controller/EntryController.php
+++ b/src/Eccube/Controller/EntryController.php
@@ -253,9 +253,9 @@ class EntryController extends AbstractController
 
         // Assign session carts into customer carts
         $Carts = $this->cartService->getCarts();
-        $qtyInCart = 0;
+        $qtyInCart = '0';
         foreach ($Carts as $Cart) {
-            $qtyInCart += $Cart->getTotalQuantity();
+            $qtyInCart = bcadd($qtyInCart, $Cart->getTotalQuantity(), 0);
         }
 
         if ($qtyInCart) {

--- a/src/Eccube/Controller/ShippingMultipleController.php
+++ b/src/Eccube/Controller/ShippingMultipleController.php
@@ -134,7 +134,7 @@ class ShippingMultipleController extends AbstractShoppingController
                         $quantity = $item['quantity']->getData();
 
                         if (isset($arrOrderItemTemp[$customerAddressName]) && array_key_exists($itemId, $arrOrderItemTemp[$customerAddressName])) {
-                            $arrOrderItemTemp[$customerAddressName][$itemId] = bcadd($arrOrderItemTemp[$customerAddressName][$itemId], $quantity, 0);
+                            $arrOrderItemTemp[$customerAddressName][$itemId] = bcadd((string) $arrOrderItemTemp[$customerAddressName][$itemId], (string) $quantity, 0);
                         } else {
                             $arrOrderItemTemp[$customerAddressName][$itemId] = $quantity;
                         }
@@ -147,7 +147,7 @@ class ShippingMultipleController extends AbstractShoppingController
             foreach ($arrOrderItemTemp as $FormItemByAddress) {
                 foreach ($FormItemByAddress as $itemId => $quantity) {
                     if (array_key_exists($itemId, $itemQuantities)) {
-                        $itemQuantities[$itemId] = bcadd($itemQuantities[$itemId], $quantity, 0);
+                        $itemQuantities[$itemId] = bcadd((string) $itemQuantities[$itemId], (string) $quantity, 0);
                     } else {
                         $itemQuantities[$itemId] = $quantity;
                     }

--- a/src/Eccube/Controller/ShippingMultipleController.php
+++ b/src/Eccube/Controller/ShippingMultipleController.php
@@ -76,7 +76,7 @@ class ShippingMultipleController extends AbstractShoppingController
             $itemId = $item->getProductClass()->getId();
             $quantity = $item->getQuantity();
             if (array_key_exists($itemId, $ItemQuantitiesByClassId)) {
-                $ItemQuantitiesByClassId[$itemId] += $quantity;
+                $ItemQuantitiesByClassId[$itemId] = bcadd($ItemQuantitiesByClassId[$itemId], $quantity, 0);
             } else {
                 $ItemQuantitiesByClassId[$itemId] = $quantity;
             }
@@ -134,7 +134,7 @@ class ShippingMultipleController extends AbstractShoppingController
                         $quantity = $item['quantity']->getData();
 
                         if (isset($arrOrderItemTemp[$customerAddressName]) && array_key_exists($itemId, $arrOrderItemTemp[$customerAddressName])) {
-                            $arrOrderItemTemp[$customerAddressName][$itemId] = $arrOrderItemTemp[$customerAddressName][$itemId] + $quantity;
+                            $arrOrderItemTemp[$customerAddressName][$itemId] = bcadd($arrOrderItemTemp[$customerAddressName][$itemId], $quantity, 0);
                         } else {
                             $arrOrderItemTemp[$customerAddressName][$itemId] = $quantity;
                         }
@@ -147,7 +147,7 @@ class ShippingMultipleController extends AbstractShoppingController
             foreach ($arrOrderItemTemp as $FormItemByAddress) {
                 foreach ($FormItemByAddress as $itemId => $quantity) {
                     if (array_key_exists($itemId, $itemQuantities)) {
-                        $itemQuantities[$itemId] = $itemQuantities[$itemId] + $quantity;
+                        $itemQuantities[$itemId] = bcadd($itemQuantities[$itemId], $quantity, 0);
                     } else {
                         $itemQuantities[$itemId] = $quantity;
                     }
@@ -285,7 +285,7 @@ class ShippingMultipleController extends AbstractShoppingController
             foreach ($Order->getProductOrderItems() as $Item) {
                 $id = $Item->getProductClass()->getId();
                 if (isset($quantityByProductClass[$id])) {
-                    $quantityByProductClass[$id] += $Item->getQuantity();
+                    $quantityByProductClass[$id] = bcadd($quantityByProductClass[$id], $Item->getQuantity(), 0);
                 } else {
                     $quantityByProductClass[$id] = $Item->getQuantity();
                 }

--- a/src/Eccube/Form/Type/ShippingMultipleItemType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleItemType.php
@@ -119,12 +119,12 @@ class ShippingMultipleItemType extends AbstractType
                     }
                 }
 
-                $quantity = 0;
+                $quantity = '0';
                 // Check all shipment items
                 foreach ($data->getProductOrderItems() as $OrderItem) {
                     // Check item distinct for each quantity
                     if ($data->getProductClassOfTemp()->getId() == $OrderItem->getProductClass()->getId()) {
-                        $quantity += $OrderItem->getQuantity();
+                        $quantity = bcadd($quantity, $OrderItem->getQuantity(), 0);
                     }
                 }
                 $form['quantity']->setData($quantity);

--- a/src/Eccube/Form/Type/Shopping/OrderType.php
+++ b/src/Eccube/Form/Type/Shopping/OrderType.php
@@ -264,11 +264,11 @@ class OrderType extends AbstractType
                 return true;
             }
 
-            if (null !== $min && bcadd($total, $charge) < $min) {
+            if (null !== $min && bccomp(bcadd($total, $charge ?? '0'), $min) < 0) {
                 return false;
             }
 
-            if (null !== $max && bcadd($total, $charge) > $max) {
+            if (null !== $max && bccomp(bcadd($total, $charge ?? '0'), $max) > 0) {
                 return false;
             }
 

--- a/src/Eccube/Service/OrderStateMachine.php
+++ b/src/Eccube/Service/OrderStateMachine.php
@@ -164,7 +164,7 @@ class OrderStateMachine implements EventSubscriberInterface
         $Order = $event->getSubject()->getOrder();
         $Customer = $Order->getCustomer();
         if ($Customer) {
-            $Customer->setPoint(intval($Customer->getPoint()) + intval($Order->getAddPoint()));
+            $Customer->setPoint(bcadd((string) $Customer->getPoint(), (string) $Order->getAddPoint()));
         }
     }
 
@@ -177,7 +177,7 @@ class OrderStateMachine implements EventSubscriberInterface
         $Order = $event->getSubject()->getOrder();
         $Customer = $Order->getCustomer();
         if ($Customer) {
-            $Customer->setPoint(intval($Customer->getPoint()) - intval($Order->getAddPoint()));
+            $Customer->setPoint(bcsub((string) $Customer->getPoint(), (string) $Order->getAddPoint()));
         }
     }
 

--- a/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeeFreeByShippingPreprocessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeeFreeByShippingPreprocessor.php
@@ -50,11 +50,11 @@ class DeliveryFeeFreeByShippingPreprocessor implements ItemHolderPreprocessor
             $Order = $itemHolder;
             foreach ($Order->getShippings() as $Shipping) {
                 $isFree = false;
-                $total = 0;
-                $quantity = 0;
+                $total = '0';
+                $quantity = '0';
                 foreach ($Shipping->getProductOrderItems() as $Item) {
-                    $total += $Item->getPriceIncTax() * $Item->getQuantity(); // @phpstan-ignore-line TODO bcmath-polyfill を使用する
-                    $quantity += $Item->getQuantity();
+                    $total = bcadd($total, bcmul($Item->getPriceIncTax(), $Item->getQuantity(), 0), 0);
+                    $quantity = bcadd($quantity, $Item->getQuantity(), 0);
                 }
                 // 送料無料（金額）を超えている
                 if ($this->BaseInfo->getDeliveryFreeAmount()) {

--- a/src/Eccube/Service/PurchaseFlow/Processor/PointProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PointProcessor.php
@@ -72,8 +72,8 @@ class PointProcessor implements DiscountProcessor, PurchaseProcessor
             // 購入フロー実行時
             if ($context->isShoppingFlow()) {
                 // 支払い金額 < 利用ポイントによる値引き額.
-                if (bccomp(bcadd((string) $itemHolder->getTotal(), $discount, 0), '0', 0) < 0) {
-                    $minus = bcadd((string) $itemHolder->getTotal(), $discount, 0);
+                if (bccomp(bcadd($itemHolder->getTotal(), $discount, 0), '0', 0) < 0) {
+                    $minus = bcadd($itemHolder->getTotal(), $discount, 0);
                     // 利用ポイントが支払い金額を上回っていた場合は支払い金額が0円以上となるようにポイントを調整
                     $overPoint = $this->pointHelper->priceToPoint($minus);
                     $usePoint = bcadd((string) $itemHolder->getUsePoint(), $overPoint);
@@ -92,7 +92,7 @@ class PointProcessor implements DiscountProcessor, PurchaseProcessor
             // 受注登録・編集実行時
             } else {
                 // 支払い金額 < 利用ポイントによる値引き額.
-                if (bccomp((string) $itemHolder->getTotal(), '0', 0) >= 0 && bccomp(bcadd((string) $itemHolder->getTotal(), $discount, 0), '0', 0) < 0) {
+                if (bccomp($itemHolder->getTotal(), '0', 0) >= 0 && bccomp(bcadd($itemHolder->getTotal(), $discount, 0), '0', 0) < 0) {
                     $result = ProcessResult::error(trans('purchase_flow.over_payment_total'), self::class);
                 }
             }

--- a/src/Eccube/Service/PurchaseFlow/Processor/PointProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/PointProcessor.php
@@ -66,15 +66,14 @@ class PointProcessor implements DiscountProcessor, PurchaseProcessor
         $discount = $this->pointHelper->pointToDiscount($usePoint);
 
         // 利用ポイントがある場合は割引明細を追加
-        if ($usePoint > 0) {
+        if (bccomp((string) $usePoint, '0', 0) > 0) {
             $result = null;
 
             // 購入フロー実行時
             if ($context->isShoppingFlow()) {
                 // 支払い金額 < 利用ポイントによる値引き額.
-                if ($itemHolder->getTotal() + $discount < 0) { // @phpstan-ignore-line TODO bcmath-polyfill を使用する
-                    /** @phpstan-ignore-next-line bcmathの実装次第、削除する */
-                    $minus = $itemHolder->getTotal() + $discount;
+                if (bccomp(bcadd((string) $itemHolder->getTotal(), $discount, 0), '0', 0) < 0) {
+                    $minus = bcadd((string) $itemHolder->getTotal(), $discount, 0);
                     // 利用ポイントが支払い金額を上回っていた場合は支払い金額が0円以上となるようにポイントを調整
                     $overPoint = $this->pointHelper->priceToPoint($minus);
                     $usePoint = bcadd((string) $itemHolder->getUsePoint(), $overPoint);
@@ -84,7 +83,7 @@ class PointProcessor implements DiscountProcessor, PurchaseProcessor
 
                 // 所有ポイント < 利用ポイント
                 $Customer = $itemHolder->getCustomer();
-                if ($Customer->getPoint() < $usePoint) {
+                if (bccomp((string) $Customer->getPoint(), (string) $usePoint, 0) < 0) {
                     // 利用ポイントが所有ポイントを上回っていた場合は所有ポイントで上書き
                     $usePoint = $Customer->getPoint();
                     $discount = $this->pointHelper->pointToDiscount($usePoint);
@@ -93,7 +92,7 @@ class PointProcessor implements DiscountProcessor, PurchaseProcessor
             // 受注登録・編集実行時
             } else {
                 // 支払い金額 < 利用ポイントによる値引き額.
-                if ($itemHolder->getTotal() >= 0 && $itemHolder->getTotal() + $discount < 0) { // @phpstan-ignore-line TODO bcmath-polyfill を使用する
+                if (bccomp((string) $itemHolder->getTotal(), '0', 0) >= 0 && bccomp(bcadd((string) $itemHolder->getTotal(), $discount, 0), '0', 0) < 0) {
                     $result = ProcessResult::error(trans('purchase_flow.over_payment_total'), self::class);
                 }
             }

--- a/src/Eccube/Service/PurchaseFlow/Processor/StockDiffProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/StockDiffProcessor.php
@@ -99,15 +99,15 @@ class StockDiffProcessor extends ItemHolderValidator implements PurchaseProcesso
             if (isset($FromItems[$id]) && isset($ToItems[$id])) {
                 // 2 -> 3 = +1
                 // 2 -> 1 = -1
-                $diff[$id] = (string) ($ToItems[$id] - $FromItems[$id]);
+                $diff[$id] = bcsub($ToItems[$id], $FromItems[$id], 0);
             } // 削除された明細
             elseif (isset($FromItems[$id]) && empty($ToItems[$id])) {
                 // 2 -> 0 = -2
-                $diff[$id] = (string) ($FromItems[$id] * -1);
+                $diff[$id] = bcmul($FromItems[$id], '-1', 0);
             } // 追加された明細
             elseif (!isset($FromItems[$id]) && isset($ToItems[$id])) {
                 // 0 -> 2 = +2
-                $diff[$id] = (string) $ToItems[$id];
+                $diff[$id] = $ToItems[$id];
             }
         }
 
@@ -117,7 +117,7 @@ class StockDiffProcessor extends ItemHolderValidator implements PurchaseProcesso
     /**
      * @param ItemHolderInterface $ItemHolder 受注 or カート
      *
-     * @return array<int, int> 商品クラスIDをキーとした商品の数量
+     * @return array<int, string> 商品クラスIDをキーとした商品の数量
      */
     protected function getQuantityByProductClass(ItemHolderInterface $ItemHolder): array
     {

--- a/src/Eccube/Service/PurchaseFlow/Processor/StockDiffProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/StockDiffProcessor.php
@@ -126,7 +126,7 @@ class StockDiffProcessor extends ItemHolderValidator implements PurchaseProcesso
             if ($Item->isProduct()) {
                 $id = $Item->getProductClass()->getId();
                 if (isset($ItemsByProductClass[$id])) {
-                    $ItemsByProductClass[$id] += $Item->getQuantity();
+                    $ItemsByProductClass[$id] = bcadd($ItemsByProductClass[$id], $Item->getQuantity(), 0);
                 } else {
                     $ItemsByProductClass[$id] = $Item->getQuantity();
                 }

--- a/src/Eccube/Service/PurchaseFlow/PurchaseFlow.php
+++ b/src/Eccube/Service/PurchaseFlow/PurchaseFlow.php
@@ -280,7 +280,7 @@ class PurchaseFlow implements \Stringable
     {
         $total = $itemHolder->getItems()
             ->getProductClasses()
-            ->reduce(fn ($sum, ItemInterface $item) => bcadd((string) $sum, bcmul($item->getPriceIncTax(), $item->getQuantity(), 2), 2), '0');
+            ->reduce(fn ($sum, ItemInterface $item) => bcadd($sum, bcmul($item->getPriceIncTax(), $item->getQuantity(), 2), 2), '0');
         // TODO
         if ($itemHolder instanceof Order) {
             // Order の場合は SubTotal をセットする
@@ -292,7 +292,7 @@ class PurchaseFlow implements \Stringable
     {
         $total = $itemHolder->getItems()
             ->getDeliveryFees()
-            ->reduce(fn ($sum, ItemInterface $item) => bcadd((string) $sum, bcmul($item->getPriceIncTax(), $item->getQuantity(), 2), 2), '0');
+            ->reduce(fn ($sum, ItemInterface $item) => bcadd($sum, bcmul($item->getPriceIncTax(), $item->getQuantity(), 2), 2), '0');
         $itemHolder->setDeliveryFeeTotal($total);
     }
 
@@ -300,7 +300,7 @@ class PurchaseFlow implements \Stringable
     {
         $total = $itemHolder->getItems()
             ->getDiscounts()
-            ->reduce(fn ($sum, ItemInterface $item) => bcadd((string) $sum, bcmul($item->getPriceIncTax(), $item->getQuantity(), 2), 2), '0');
+            ->reduce(fn ($sum, ItemInterface $item) => bcadd($sum, bcmul($item->getPriceIncTax(), $item->getQuantity(), 2), 2), '0');
         // TODO 後方互換のため discount には正の整数を代入する
         $itemHolder->setDiscount(bcmul((string) $total, '-1', 2));
     }
@@ -309,7 +309,7 @@ class PurchaseFlow implements \Stringable
     {
         $total = $itemHolder->getItems()
             ->getCharges()
-            ->reduce(fn ($sum, ItemInterface $item) => bcadd((string) $sum, bcmul($item->getPriceIncTax(), $item->getQuantity(), 2), 2), '0');
+            ->reduce(fn ($sum, ItemInterface $item) => bcadd($sum, bcmul($item->getPriceIncTax(), $item->getQuantity(), 2), 2), '0');
         $itemHolder->setCharge($total);
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
金額・ポイント・数量の計算処理において、浮動小数点演算の精度問題を回避するためbcmath関数を使用するよう修正しました。

対象ファイル:
- PointProcessor: ポイント比較・加算にbccomp/bcaddを使用
- OrderStateMachine: ポイント加算・減算にbcadd/bcsubを使用
- DeliveryController: 支払条件の計算にbcsub/bcaddを使用
- CartController: カート数量の合計にbcaddを使用、金額計算にbcsub/bcaddを使用
- OrderType: 支払金額の比較にbccompを使用
- ShippingMultipleController: 数量集計にbcaddを使用（4箇所）、引数に(string)キャスト追加
- AdminController: 売上集計にbcaddを使用、引数に(string)キャスト追加
- DeliveryFeeFreeByShippingPreprocessor: 送料無料判定にbcadd/bcmulを使用
- StockDiffProcessor: 在庫数量集計にbcaddを使用、getDiffOfQuantitiesにbcsub/bcmulを使用
- ShippingMultipleItemType: 数量集計にbcaddを使用
- EntryController: カート数量集計にbcaddを使用
- PurchaseFlow: reduce()内の冗長なキャストを削除

## 方針(Policy)
PHPの浮動小数点演算では精度の問題が発生する可能性があります。金額やポイントなど正確な計算が必要な箇所でbcmath関数を使用することで、この問題を回避します。

既存のコードで `// @phpstan-ignore-line TODO bcmath-polyfill を使用する` というコメントがあった箇所を中心に修正しています。

## 実装に関する補足(Appendix)
bcmath関数の使用方法:
- `bccomp($a, $b)`: 比較（戻り値: -1, 0, 1）
- `bcadd($a, $b)`: 加算
- `bcsub($a, $b)`: 減算
- `bcmul($a, $b)`: 乗算

### コミット履歴
1. `7b305b928a` - refactor(bcmath): 浮動小数点演算をbcmath関数に置換
2. `3fc19f2c10` - refactor(bcmath): 追加の浮動小数点演算をbcmath関数に置換
3. `4903f18a05` - refactor(bcmath): getDiffOfQuantities等の追加bcmath対応とphp-cs-fixer/rector適用

## テスト（Test)
- 既存のユニットテストで動作確認

## 相談（Discussion）
特になし

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)