### PR TITLE
user_dataアセットにキャッシュバスティング機能を追加

### DIFF
--- a/app/config/eccube/packages/framework.yaml
+++ b/app/config/eccube/packages/framework.yaml
@@ -37,6 +37,7 @@ framework:
           base_path: '/html/upload/temp_image'
         user_data:
           base_path: '/html/user_data'
+          version_strategy: 'eccube.asset.user_data_version_strategy'
         bundle:
           base_path: '/html/bundle'
         # json_manifest_path: '%kernel.project_dir%/public/build/manifest.json'

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -242,7 +242,10 @@ services:
         arguments:
             $container: !tagged_locator { tag: 'cache.pool.clearer' }
 
-    eccube.asset.user_data_version_strategy:
-        class: Eccube\Asset\FilemtimeVersionStrategy
+    Eccube\Asset\FilemtimeVersionStrategy:
         arguments:
             - '%eccube_html_dir%/user_data'
+
+    eccube.asset.user_data_version_strategy:
+        alias: Eccube\Asset\FilemtimeVersionStrategy
+        public: true

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -241,3 +241,8 @@ services:
     Eccube\Util\CacheUtil:
         arguments:
             $container: !tagged_locator { tag: 'cache.pool.clearer' }
+
+    eccube.asset.user_data_version_strategy:
+        class: Eccube\Asset\FilemtimeVersionStrategy
+        arguments:
+            - '%kernel.project_dir%/html/user_data'

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -245,4 +245,4 @@ services:
     eccube.asset.user_data_version_strategy:
         class: Eccube\Asset\FilemtimeVersionStrategy
         arguments:
-            - '%kernel.project_dir%/html/user_data'
+            - '%eccube_html_dir%/user_data'

--- a/src/Eccube/Asset/FilemtimeVersionStrategy.php
+++ b/src/Eccube/Asset/FilemtimeVersionStrategy.php
@@ -40,8 +40,11 @@ class FilemtimeVersionStrategy implements VersionStrategyInterface
     {
         $fullPath = $this->basePath.'/'.$path;
 
-        if (file_exists($fullPath)) {
-            return (string) filemtime($fullPath);
+        if (file_exists($fullPath) && is_readable($fullPath)) {
+            $mtime = @filemtime($fullPath);
+            if ($mtime !== false) {
+                return (string) $mtime;
+            }
         }
 
         return '';

--- a/src/Eccube/Asset/FilemtimeVersionStrategy.php
+++ b/src/Eccube/Asset/FilemtimeVersionStrategy.php
@@ -20,12 +20,15 @@ use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
  */
 class FilemtimeVersionStrategy implements VersionStrategyInterface
 {
+    /**
+     * @var string
+     */
     private $basePath;
 
     /**
      * @param string $basePath アセットファイルのベースパス
      */
-    public function __construct($basePath)
+    public function __construct(string $basePath)
     {
         $this->basePath = rtrim($basePath, '/');
     }
@@ -33,7 +36,7 @@ class FilemtimeVersionStrategy implements VersionStrategyInterface
     /**
      * {@inheritdoc}
      */
-    public function getVersion($path)
+    public function getVersion(string $path): string
     {
         $fullPath = $this->basePath.'/'.$path;
 
@@ -47,7 +50,7 @@ class FilemtimeVersionStrategy implements VersionStrategyInterface
     /**
      * {@inheritdoc}
      */
-    public function applyVersion($path)
+    public function applyVersion(string $path): string
     {
         $version = $this->getVersion($path);
 

--- a/src/Eccube/Asset/FilemtimeVersionStrategy.php
+++ b/src/Eccube/Asset/FilemtimeVersionStrategy.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Asset;
+
+use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
+
+/**
+ * ファイルの最終更新時刻をバージョンとして使用するバージョン戦略
+ */
+class FilemtimeVersionStrategy implements VersionStrategyInterface
+{
+    private $basePath;
+
+    /**
+     * @param string $basePath アセットファイルのベースパス
+     */
+    public function __construct($basePath)
+    {
+        $this->basePath = rtrim($basePath, '/');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVersion($path)
+    {
+        $fullPath = $this->basePath.'/'.$path;
+
+        if (file_exists($fullPath)) {
+            return (string) filemtime($fullPath);
+        }
+
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function applyVersion($path)
+    {
+        $version = $this->getVersion($path);
+
+        if ('' === $version) {
+            return $path;
+        }
+
+        return sprintf('%s?v=%s', $path, $version);
+    }
+}

--- a/src/Eccube/Asset/FilemtimeVersionStrategy.php
+++ b/src/Eccube/Asset/FilemtimeVersionStrategy.php
@@ -38,11 +38,14 @@ class FilemtimeVersionStrategy implements VersionStrategyInterface
      */
     public function getVersion(string $path): string
     {
+        // パスの先頭のスラッシュを削除
+        $path = ltrim($path, '/');
         $fullPath = $this->basePath.'/'.$path;
 
-        if (file_exists($fullPath) && is_readable($fullPath)) {
+        // ファイルが存在する場合のみバージョンを返す
+        if (@is_file($fullPath)) {
             $mtime = @filemtime($fullPath);
-            if ($mtime !== false) {
+            if (false !== $mtime) {
                 return (string) $mtime;
             }
         }

--- a/tests/Eccube/Tests/Web/TopControllerTest.php
+++ b/tests/Eccube/Tests/Web/TopControllerTest.php
@@ -30,7 +30,14 @@ class TopControllerTest extends AbstractWebTestCase
     {
         $crawler = $this->client->request('GET', $this->generateUrl('homepage'));
         $node = $crawler->filter('link[rel=icon]');
-        $this->assertSame('/html/user_data/assets/img/common/favicon.ico', $node->attr('href'));
+        $href = $node->attr('href');
+
+        // バージョンパラメータ付きのURLを期待（キャッシュバスティング）
+        $this->assertMatchesRegularExpression(
+            '#^/html/user_data/assets/img/common/favicon\.ico(\?v=\d+)?$#',
+            $href,
+            'Favicon URL should be /html/user_data/assets/img/common/favicon.ico with optional version parameter'
+        );
     }
 
     public function testGAスクリプト表示確認()


### PR DESCRIPTION
## 概要
管理画面で更新される `customize.css` などの `user_data` アセットに対して、ファイルの最終更新時刻をクエリパラメーターとして自動付与し、ブラウザキャッシュを適切に制御できるようにしました。

## 変更内容
- `Eccube\Asset\FilemtimeVersionStrategy` クラスを新規作成
  - SymfonyのVersionStrategyInterfaceを実装
  - ファイルの最終更新時刻（filemtime）をバージョンとして返す
  - `applyVersion()` メソッドで `?v={timestamp}` 形式のクエリパラメーターを付与
- `services.yaml` に `eccube.asset.user_data_version_strategy` サービスを追加
- `framework.yaml` の `user_data` パッケージに `version_strategy` を設定

## 技術的詳細
- Symfonyの標準的なアセットバージョニング機能を活用
- テンプレート側の変更は不要（既存の `asset()` 関数がそのまま動作）
- CSSファイルが更新されると、自動的にタイムスタンプが更新され、ブラウザキャッシュが無効化される

## 影響範囲
- `html/user_data` 配下の全アセットファイルに影響
- 主な対象: `customize.css`, `customize.js` など

## テスト方法
1. 管理画面で「コンテンツ管理」→「CSS管理」からCSSを編集・保存
2. フロント画面でソースコードを表示し、`customize.css` のURLに `?v={timestamp}` が付与されていることを確認
3. 再度CSSを編集・保存し、タイムスタンプが更新されることを確認
4. 古いタイムスタンプのURLではキャッシュされ、新しいタイムスタンプでは更新されたCSSが読み込まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)