### PR TITLE
fix(cs-fixer): setRiskyAllowed(true)を追加

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -52,4 +52,5 @@ $config = new \PhpCsFixer\Config();
 return $config
     ->setRules($rules)
     ->setFinder($finder)
+    ->setRiskyAllowed(true)
     ;


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

PHP CS Fixerの設定に `setRiskyAllowed(true)` を追加し、riskyフィクサーを `--allow-risky=yes` オプションなしで実行可能にします。

現在の設定では `phpdoc_to_param_type`, `phpdoc_to_return_type`, `phpdoc_to_property_type` などのriskyフィクサーが有効になっていますが、`setRiskyAllowed(true)` が設定されていないため、huskyを利用したpre-commitフック実行時に以下の警告が発生していました：

```
The rules contain risky fixers ("phpdoc_to_return_type", "phpdoc_to_param_type" and "phpdoc_to_property_type"), but they are not allowed to run. Perhaps you forget to use --allow-risky=yes option?
```

## 方針(Policy)

- PHP CS Fixer公式ドキュメントに従い、riskyフィクサーを使用する場合は `setRiskyAllowed(true)` を設定する必要があります
- コマンドラインオプションではなく設定ファイルに追加することで、毎回オプションを指定する手間を省きます

## 実装に関する補足(Appendix)

`.php-cs-fixer.dist.php` に `->setRiskyAllowed(true)` を1行追加しただけのシンプルな変更です。

## テスト（Test)

- `vendor/bin/php-cs-fixer fix --dry-run` でエラーなく実行できることを確認
- huskyのpre-commitフックでエラーが発生しないことを確認

## 相談（Discussion）

特にありません。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)