### PR TITLE
出荷削除ボタンの重複data-bs-toggle属性を修正

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/shipping.twig
+++ b/src/Eccube/Resource/template/admin/Order/shipping.twig
@@ -244,7 +244,7 @@ file that was distributed with this source code.
                                     <div class="col-4 text-end">
                                         {% if form.shippings|length > 1 %}
                                             <!-- 出荷が2つ以上ある場合は, 出荷の削除ボタンを表示する -->
-                                            <a class="btn btn-ec-regular me-2" data-bs-toggle="modal" data-bs-target="#delete_shipping_{{ shippingForm.vars.id }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
+                                            <a class="btn btn-ec-regular me-2" data-bs-toggle="modal" data-bs-target="#delete_shipping_{{ shippingForm.vars.id }}" title="{{ 'admin.common.delete'|trans }}">
                                                 <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
                                                 {{ 'admin.order.delete_shipping'|trans }}
                                             </a>


### PR DESCRIPTION
data-bs-toggleが二重に指定されていた問題を修正

- 修正前: data-bs-toggle="modal" data-bs-target="..." data-bs-toggle="tooltip" data-bs-placement="top" title="..."
- 修正後: data-bs-toggle="modal" data-bs-target="..." title="..."

Bootstrap 5では1つの要素に複数のdata-bs-toggleを指定できないため、
もともと動作してないtooltip用のdata-bs-toggle属性とdata-bs-placement属性を削除。
title属性は残してあるため、ブラウザ標準のツールチップは表示される。

Fixes #6582


## テスト（Test)
・挙動が変わっていないことを画面で確認
・削除モーダルは正常に開く


## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
