### PR TITLE
#6591 「同時購入できない商品がカートに含まれています。」というメッセージを変更

### DIFF
--- a/codeception/acceptance/EF03OrderCest.php
+++ b/codeception/acceptance/EF03OrderCest.php
@@ -609,7 +609,7 @@ class EF03OrderCest
         // ログイン
         ShoppingLoginPage::at($I)->ログイン($customer->getEmail());
 
-        $I->see('同時購入できない商品がカートに含まれています', '.ec-alert-warning__text');
+        $I->see('同時購入できない商品のカートを分けました。お手数ですが別々で注文してください。', '.ec-alert-warning__text');
     }
 
     /**

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -314,7 +314,8 @@ front.cart.nav__order: Checkout
 front.cart.nav__confirm: Review
 front.cart.nav__complete: Order Placed
 front.cart.total_price: "Total: <strong>%price%</strong>"
-front.cart.divide_cart: Some item(s) in the cart can not be purchased in this order.
+front.cart.divide_cart: We've separated items that cannot be purchased together. Please
+    complete each order separately.
 front.cart.delete: ""
 front.cart.delete__confirm: Are you sure to delete this item from the cart?
 front.cart.product: Items

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -314,8 +314,7 @@ front.cart.nav__order: ご注文手続き
 front.cart.nav__confirm: ご注文内容確認
 front.cart.nav__complete: 完了
 front.cart.total_price: "商品の合計金額は「<strong>%price%</strong>」です。"
-front.cart.divide_cart: 同時購入できない商品のカートを分けました。お手数ですが別々で注文して
-  ください。
+front.cart.divide_cart: 同時購入できない商品のカートを分けました。お手数ですが別々で注文してください。
 front.cart.delete: 削除
 front.cart.delete__confirm: カートから商品を削除してよろしいですか？
 front.cart.product: 商品内容

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -314,7 +314,8 @@ front.cart.nav__order: ご注文手続き
 front.cart.nav__confirm: ご注文内容確認
 front.cart.nav__complete: 完了
 front.cart.total_price: "商品の合計金額は「<strong>%price%</strong>」です。"
-front.cart.divide_cart: 同時購入できない商品がカートに含まれています。
+front.cart.divide_cart: 同時購入できない商品のカートを分けました。お手数ですが別々で注文して
+  ください。
 front.cart.delete: 削除
 front.cart.delete__confirm: カートから商品を削除してよろしいですか？
 front.cart.product: 商品内容


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
#6591 issueの対応

## 方針(Policy)
- 日本語、英語のyamlファイルをそれぞれ変更しました。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **その他の改善**
  * カート内で同時購入できない商品が分割された旨の案内文を日本語・英語でより詳しく（英語は複数行表現）更新し、別々に注文を完了するよう明確に案内します。
* **テスト**
  * 表示される警告文に合わせて受け入れテストの期待値を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->