### PR TITLE
#6614 認証キー設定画面のモーダル内メッセージを多言語対応

### DIFF
--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -1472,6 +1472,7 @@ admin.store.setting.api_key: API Authentication Key
 admin.store.setting.api_key_tooltip: This key is required for installing purchased plug-ins, etc.
 admin.store.setting.get_api_key: Obtain an API authentication key
 admin.store.setting.get_api_key_info: Issue a new authentication key
+admin.store.setting.get_api_key_modal_info: A new authentication key will be issued. If you already have an authentication key, please set the existing key without issuing a new one.
 admin.store.setting.captcha_message: Please enter the letters displayed.
 admin.store.setting.php_path_setting: Set PHP Path
 admin.store.setting.php_path: PHP Path

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -1473,6 +1473,7 @@ admin.store.setting.api_key: 認証キー
 admin.store.setting.api_key_tooltip: 購入したプラグイン等のインストールに必要となるキーです。
 admin.store.setting.get_api_key: 認証キー新規発行
 admin.store.setting.get_api_key_info: 認証キーの新規発行と登録を行います。
+admin.store.setting.get_api_key_modal_info: 新しい認証キーを発行します。既に認証キーがある場合は、発行せずに既存のキーを設定してください。
 admin.store.setting.captcha_message: 画像に表示されている文字を入力してください。
 admin.store.setting.php_path_setting: PHPパスの設定
 admin.store.setting.php_path: PHPパス

--- a/src/Eccube/Resource/template/admin/Store/authentication_setting.twig
+++ b/src/Eccube/Resource/template/admin/Store/authentication_setting.twig
@@ -185,7 +185,7 @@ file that was distributed with this source code.
                         <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body text-start">
-                        <p>新しい認証キーを発行します。既に認証キーがある場合は、発行せずに既存のキーを設定してください。</p>
+                        <p>{{ 'admin.store.setting.get_api_key_modal_info'|trans }}</p>
                         <img id="captcha_image" class="mb-2" src="#">
                         <button id="captcha-refresh" type="button" class="btn btn-default"><i class="fa fa-refresh" aria-hidden="true"></i></button>
                         <input type="text" id="captcha_text" value="" class="form-control" placeholder="{{ 'admin.store.setting.captcha_message'|trans }}"/>


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

<!-- ****************************************************************************
脆弱性報告 (Vulnerability report)
脆弱性のご報告は弊社[問い合わせフォーム](https://www.ec-cube.net/contact/)からお願いします。
**************************************************************************** -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
認証キー設定画面（authentication_setting.twig）のモーダル内に日本語がハードコードされていたメッセージを多言語対応。

Closes #6614

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
同テンプレート内の多言語対応済みメッセージと統一。
既存の `admin.store.setting.get_api_key_info` に準拠し、`admin.store.setting.get_api_key_modal_info` とした。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->
- 変更対象は3ファイルのみ（テンプレート1、翻訳ファイル2）
- 翻訳キーは既存キー get_api_key_info の直後に配置

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
- 管理画面で [オーナーズストア] > [認証キー設定] を開き、「認証キーを取得する」ボタンをクリックしてモーダル内のメッセージが正しく表示されることを確認
- 言語を英語に切り替え、英語メッセージが表示されることを確認

[ECCUBE_LOCALE: "ja"]
<img width="533" height="311" alt="スクリーンショット 2026-02-06 094038" src="https://github.com/user-attachments/assets/257fb2b3-792f-46a5-92fa-2a7e0899f5af" />

[ECCUBE_LOCALE: "en"]
<img width="569" height="332" alt="スクリーンショット 2026-02-06 092225" src="https://github.com/user-attachments/assets/3741c5fd-7a7d-4474-b94b-b4b4efda2568" />


## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメンテーション**
  * API キー認証設定画面のモーダルメッセージを多言語対応に更新しました。新規キー発行に関するガイダンステキストの英語および日本語翻訳を追加。既存キーを保有するユーザーに対し「発行せずに既存キーを設定してください」という指示が、各言語で正確に伝わるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->