### PR TITLE
unserialize() に allowed_classes オプションを追加

### DIFF
--- a/src/Eccube/Controller/ShippingMultipleController.php
+++ b/src/Eccube/Controller/ShippingMultipleController.php
@@ -451,7 +451,7 @@ class ShippingMultipleController extends AbstractShoppingController
             } else {
                 // 非会員用のセッションに追加
                 $CustomerAddresses = $this->session->get(OrderHelper::SESSION_NON_MEMBER_ADDRESSES);
-                $CustomerAddresses = unserialize($CustomerAddresses);
+                $CustomerAddresses = unserialize($CustomerAddresses, ['allowed_classes' => [CustomerAddress::class, Customer::class, \Eccube\Entity\Master\Pref::class, \Eccube\Entity\Master\Country::class]]);
                 $CustomerAddresses[] = $CustomerAddress;
                 $this->session->set(OrderHelper::SESSION_NON_MEMBER_ADDRESSES, serialize($CustomerAddresses));
             }

--- a/src/Eccube/Form/Type/ShippingMultipleItemType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleItemType.php
@@ -130,7 +130,7 @@ class ShippingMultipleItemType extends AbstractType
                         $CustomerAddress->setFromCustomer($NonMember);
 
                         if ($CustomerAddresses = $this->session->get('eccube.front.shopping.nonmember.customeraddress')) {
-                            $CustomerAddresses = unserialize($CustomerAddresses);
+                            $CustomerAddresses = unserialize($CustomerAddresses, ['allowed_classes' => [CustomerAddress::class, Customer::class, \Eccube\Entity\Master\Pref::class, \Eccube\Entity\Master\Country::class]]);
                             $CustomerAddresses = array_merge([$CustomerAddress], $CustomerAddresses);
                             foreach ($CustomerAddresses as $Address) {
                                 $Pref = $this->prefRepository->find($Address->getPref()->getId());

--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -324,7 +324,7 @@ class Generator
             $Customer->addCustomerAddress($CustomerAddress);
             // TODO 外部でやった方がいい？
             $sessionCustomerAddressKey = 'eccube.front.shopping.nonmember.customeraddress';
-            $customerAddresses = unserialize($this->requestStack->getSession()->get($sessionCustomerAddressKey));
+            $customerAddresses = unserialize($this->requestStack->getSession()->get($sessionCustomerAddressKey), ['allowed_classes' => [CustomerAddress::class, Customer::class, Pref::class, \Eccube\Entity\Master\Country::class]]);
             if (!is_array($customerAddresses)) {
                 $customerAddresses = [];
             }


### PR DESCRIPTION
## Summary
- セキュリティ診断で指摘された `unserialize()` の `allowed_classes` 未指定の問題を修正
- 非会員フローでセッションに保存される `CustomerAddress` のデシリアライズ時に、許可するクラスを明示的に指定
- オブジェクトインジェクション攻撃のリスクを軽減

## 修正内容
- `ShippingMultipleController.php`: 非会員のお届け先追加時の `unserialize()` に `allowed_classes` を追加
- `ShippingMultipleItemType.php`: 非会員の配送先リスト構築時の `unserialize()` に `allowed_classes` を追加
- `Generator.php`（テストフィクスチャ）: 同様の修正を適用

### allowed_classes に含めるクラス
- `CustomerAddress` — メインのエンティティ
- `Customer` — 顧客エンティティ
- `Pref` — 都道府県マスタ
- `Country` — 国マスタ

fix #6620

## Test plan
- [x] `bin/phpunit tests/Eccube/Tests/Web/ShoppingControllerWithMultipleNonmemberTest.php` で非会員複数配送テスト実行
- [x] `bin/phpunit tests/Eccube/Tests/Web/ShoppingControllerWithNonmemberTest.php` で非会員テスト実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 複数配送時の非会員アドレス処理において、セッションデータからのオブジェクト復元時のセキュリティを強化しました。これにより、意図しないクラスのインスタンス化を防止し、より安全なデータ処理を実現します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->