### PR TITLE
注文完了ページの所有者検証と配送先削除の IDOR 修正

### DIFF
--- a/src/Eccube/Controller/Mypage/DeliveryController.php
+++ b/src/Eccube/Controller/Mypage/DeliveryController.php
@@ -177,17 +177,24 @@ class DeliveryController extends AbstractController
      *
      * @Route("/mypage/delivery/{id}/delete", name="mypage_delivery_delete", methods={"DELETE"})
      */
-    public function delete(Request $request, CustomerAddress $CustomerAddress)
+    public function delete(Request $request, $id)
     {
         $this->isTokenValid();
 
-        log_info('お届け先削除開始', [$CustomerAddress->getId()]);
-
         $Customer = $this->getUser();
 
-        if ($Customer->getId() != $CustomerAddress->getCustomer()->getId()) {
-            throw new BadRequestHttpException();
+        $CustomerAddress = $this->customerAddressRepository->findOneBy(
+            [
+                'id' => $id,
+                'Customer' => $Customer,
+            ]
+        );
+
+        if (!$CustomerAddress) {
+            throw new NotFoundHttpException();
         }
+
+        log_info('お届け先削除開始', [$CustomerAddress->getId()]);
 
         $this->customerAddressRepository->delete($CustomerAddress);
 

--- a/src/Eccube/Controller/Mypage/DeliveryController.php
+++ b/src/Eccube/Controller/Mypage/DeliveryController.php
@@ -24,7 +24,6 @@ use Eccube\Repository\CustomerAddressRepository;
 use Eccube\Service\MailService;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -545,6 +545,22 @@ class ShoppingController extends AbstractShoppingController
 
         $Order = $this->orderRepository->find($orderId);
 
+        if (!$Order) {
+            log_info('[注文完了] 受注が存在しないため, トップページへ遷移します.', [$orderId]);
+
+            return $this->redirectToRoute('homepage');
+        }
+
+        // 受注の所有者チェック
+        $Customer = $this->getUser();
+        if ($Customer instanceof Customer) {
+            if ($Order->getCustomer() && $Order->getCustomer()->getId() !== $Customer->getId()) {
+                log_info('[注文完了] 受注の所有者が一致しないため, トップページへ遷移します.', [$orderId]);
+
+                return $this->redirectToRoute('homepage');
+            }
+        }
+
         $event = new EventArgs(
             [
                 'Order' => $Order,


### PR DESCRIPTION
## Summary
- `ShoppingController::complete()` に受注の所有者チェックを追加し、セッション内の受注IDが現在のログインユーザーに紐づくか検証するようにしました
- `DeliveryController::delete()` を ParamConverter から `findOneBy` に変更し、`edit()` と同じ所有者検証パターンに統一しました

## 変更内容

### 1. 注文完了ページの所有者検証追加
セッションの `SESSION_ORDER_ID` で受注を取得した後、ログインユーザーの受注であることを確認します。不一致の場合はトップページにリダイレクトします。

### 2. 配送先削除の IDOR 修正
`delete()` メソッドで Symfony の ParamConverter（IDのみでエンティティをロード）を使用していたのを、`edit()` と同じ `findOneBy(['id' => $id, 'Customer' => $Customer])` パターンに変更し、所有者検証をクエリレベルで行うようにしました。

## Test plan
- [x] 注文完了後に `/shopping/complete` にアクセスし、正常に表示されること
- [x] ログイン中に他ユーザーの受注IDがセッションにあった場合、トップページにリダイレクトされること
- [x] 配送先の削除が正常に動作すること
- [x] 他ユーザーの配送先IDを指定した場合、404エラーになること

fix #6624

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

配送先管理とご注文確定機能のセキュリティを向上させました。

* **バグ修正**
  * 配送先削除時の所有権確認を改善し、IDベースで確実に住所を検証して不正削除を防止しました。
  * ご注文確定時に注文の存在確認と所有者検証を追加し、該当しない注文は処理を中断してリダイレクトするようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->