### PR TITLE
メンテナンス画面のHTTPヘッダーのバージョン表記を実際のプロトコルに合わせる

### DIFF
--- a/index.php
+++ b/index.php
@@ -72,7 +72,7 @@ if (file_exists($maintenanceFile)) {
             $templateCode = env('ECCUBE_TEMPLATE_CODE');
             $baseUrl = \htmlspecialchars(\rawurldecode($request->getBaseUrl()), ENT_QUOTES);
 
-            header('HTTP/1.1 503 Service Temporarily Unavailable');
+            http_response_code(503);
             require __DIR__.'/maintenance.php';
             return;
         }


### PR DESCRIPTION
## 概要

メンテナンス画面表示時のHTTPレスポンスヘッダーで、HTTPバージョンが`HTTP/1.1`にハードコードされていたため、実際のプロトコルバージョン（HTTP/2, HTTP/3等）を反映するように修正しました。

## 再現手順

1. HTTP/2またはHTTP/3環境でEC-CUBEを動作させる
2. メンテナンスモードを有効化（`.maintenance`ファイル作成）
3. フロント画面にアクセス
4. レスポンスヘッダーを確認すると`HTTP/1.1 503`となっている

## 原因

`index.php`の75行目で`header('HTTP/1.1 503 Service Temporarily Unavailable');`とHTTPバージョンがハードコードされていた。

## 修正内容

`http_response_code(503)`を使用することで、PHPが自動的に実際のHTTPプロトコルバージョンを使用するように変更。

## 検証方法

1. メンテナンスモードを有効化
2. フロント画面にアクセス
3. レスポンスヘッダーでHTTPステータスコード503が返却されることを確認
4. HTTPプロトコルバージョンが実際の接続に応じたものになっていることを確認

## 影響範囲

- `index.php`のメンテナンス画面表示処理のみ

## 互換性

破壊的変更なし。動作に影響はなく、レスポンスヘッダーのプロトコル表記が正確になるのみ。

fixes #6407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * メンテナンスモード中のHTTPステータス通知方法を改善しました。サーバーがメンテナンス状態をより正確にブラウザやプロキシに通知するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->