### PR TITLE
プラグインテストのFlaky test対策としてwaitForElementVisibleを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+/Users/kurozumi/eccube-dev/main/CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-/Users/kurozumi/eccube-dev/main/CLAUDE.md

--- a/codeception/_support/Page/Admin/AbstractAdminPageStyleGuide.php
+++ b/codeception/_support/Page/Admin/AbstractAdminPageStyleGuide.php
@@ -24,7 +24,8 @@ abstract class AbstractAdminPageStyleGuide extends AbstractAdminPage
      */
     protected function atPage($pageTitle)
     {
-        $this->tester->waitForText($pageTitle, PluginManagePage::WAIT_TIMEOUT, '.c-pageTitle');
+        $this->tester->waitForElementVisible('.c-pageTitle', PluginManagePage::WAIT_TIMEOUT);
+        $this->tester->see($pageTitle, '.c-pageTitle');
 
         return $this;
     }

--- a/codeception/_support/Page/Admin/AbstractAdminPageStyleGuide.php
+++ b/codeception/_support/Page/Admin/AbstractAdminPageStyleGuide.php
@@ -24,8 +24,7 @@ abstract class AbstractAdminPageStyleGuide extends AbstractAdminPage
      */
     protected function atPage($pageTitle)
     {
-        $this->tester->waitForElementVisible('.c-pageTitle', PluginManagePage::WAIT_TIMEOUT);
-        $this->tester->see($pageTitle, '.c-pageTitle');
+        $this->tester->waitForText($pageTitle, PluginManagePage::WAIT_TIMEOUT, '.c-pageTitle');
 
         return $this;
     }

--- a/codeception/_support/Page/Admin/AbstractAdminPageStyleGuide.php
+++ b/codeception/_support/Page/Admin/AbstractAdminPageStyleGuide.php
@@ -24,7 +24,7 @@ abstract class AbstractAdminPageStyleGuide extends AbstractAdminPage
      */
     protected function atPage($pageTitle)
     {
-        $this->tester->waitForElementVisible('.c-pageTitle', 30);
+        $this->tester->waitForElementVisible('.c-pageTitle', PluginManagePage::WAIT_TIMEOUT);
         $this->tester->see($pageTitle, '.c-pageTitle');
 
         return $this;

--- a/codeception/_support/Page/Admin/AbstractAdminPageStyleGuide.php
+++ b/codeception/_support/Page/Admin/AbstractAdminPageStyleGuide.php
@@ -24,6 +24,7 @@ abstract class AbstractAdminPageStyleGuide extends AbstractAdminPage
      */
     protected function atPage($pageTitle)
     {
+        $this->tester->waitForElementVisible('.c-pageTitle', 30);
         $this->tester->see($pageTitle, '.c-pageTitle');
 
         return $this;

--- a/codeception/_support/Page/Admin/PluginLocalInstallPage.php
+++ b/codeception/_support/Page/Admin/PluginLocalInstallPage.php
@@ -32,6 +32,7 @@ class PluginLocalInstallPage extends AbstractAdminPageStyleGuide
         $this->tester->compressPlugin($pluginDirName, codecept_data_dir('plugins'));
         $this->tester->attachFile(['id' => 'plugin_local_install_plugin_archive'], 'plugins/'.$pluginDirName.'.tgz');
         $this->tester->click(['css' => '#upload-form > div > div > div > div > div.card-body > div > div > button']);
+        $this->tester->waitForText('プラグインをインストールしました。', PluginManagePage::WAIT_TIMEOUT, PluginManagePage::完了メッセージ);
 
         return PluginManagePage::at($this->tester);
     }

--- a/codeception/_support/Page/Admin/PluginLocalInstallPage.php
+++ b/codeception/_support/Page/Admin/PluginLocalInstallPage.php
@@ -32,6 +32,8 @@ class PluginLocalInstallPage extends AbstractAdminPageStyleGuide
         $this->tester->compressPlugin($pluginDirName, codecept_data_dir('plugins'));
         $this->tester->attachFile(['id' => 'plugin_local_install_plugin_archive'], 'plugins/'.$pluginDirName.'.tgz');
         $this->tester->click(['css' => '#upload-form > div > div > div > div > div.card-body > div > div > button']);
+        // ページ遷移を待ってからメッセージを確認
+        $this->tester->waitForElementVisible('#page_admin_store_plugin', PluginManagePage::WAIT_TIMEOUT);
         $this->tester->waitForText('プラグインをインストールしました。', PluginManagePage::WAIT_TIMEOUT, PluginManagePage::完了メッセージ);
 
         return PluginManagePage::at($this->tester);

--- a/codeception/_support/Page/Admin/PluginManagePage.php
+++ b/codeception/_support/Page/Admin/PluginManagePage.php
@@ -41,8 +41,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function ストアプラグイン_有効化($pluginCode, $message = '有効にしました。')
     {
         $this->ストアプラグイン_ボタンクリック($pluginCode, '有効化');
-        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], self::WAIT_TIMEOUT);
-        $this->tester->see($message, self::完了メッセージ);
+        $this->tester->waitForText($message, self::WAIT_TIMEOUT, self::完了メッセージ);
 
         return $this;
     }
@@ -56,8 +55,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function ストアプラグイン_無効化($pluginCode, $message = '無効にしました。')
     {
         $this->ストアプラグイン_ボタンクリック($pluginCode, '無効化');
-        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], self::WAIT_TIMEOUT);
-        $this->tester->see($message, self::完了メッセージ);
+        $this->tester->waitForText($message, self::WAIT_TIMEOUT, self::完了メッセージ);
 
         return $this;
     }
@@ -116,8 +114,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function 独自プラグイン_有効化($pluginCode)
     {
         $this->独自プラグイン_ボタンクリック($pluginCode, '有効化');
-        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], self::WAIT_TIMEOUT);
-        $this->tester->see('有効にしました。', self::完了メッセージ);
+        $this->tester->waitForText('有効にしました。', self::WAIT_TIMEOUT, self::完了メッセージ);
 
         return $this;
     }
@@ -130,8 +127,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function 独自プラグイン_無効化($pluginCode)
     {
         $this->独自プラグイン_ボタンクリック($pluginCode, '無効化');
-        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], self::WAIT_TIMEOUT);
-        $this->tester->see('無効にしました。', self::完了メッセージ);
+        $this->tester->waitForText('無効にしました。', self::WAIT_TIMEOUT, self::完了メッセージ);
 
         return $this;
     }
@@ -161,8 +157,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
         $this->tester->compressPlugin($pluginDirName, codecept_data_dir('plugins'));
         $this->tester->attachFile(['xpath' => $this->独自プラグイン_セレクタ($pluginCode).'/../td[5]//input[@type="file"]'], 'plugins/'.$pluginDirName.'.tgz');
         $this->tester->click(['xpath' => $this->独自プラグイン_セレクタ($pluginCode).'/../td[5]//button']);
-        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], self::WAIT_TIMEOUT);
-        $this->tester->see('アップデートしました。', self::完了メッセージ);
+        $this->tester->waitForText('アップデートしました。', self::WAIT_TIMEOUT, self::完了メッセージ);
 
         return $this;
     }

--- a/codeception/_support/Page/Admin/PluginManagePage.php
+++ b/codeception/_support/Page/Admin/PluginManagePage.php
@@ -16,7 +16,7 @@ namespace Page\Admin;
 class PluginManagePage extends AbstractAdminPageStyleGuide
 {
     /** @var int 要素の表示待機時間（秒） */
-    public const WAIT_TIMEOUT = 30;
+    public const WAIT_TIMEOUT = 10;
 
     public const 完了メッセージ = '#page_admin_store_plugin > div.c-container > div.c-contentsArea > div.alert.alert-dismissible.fade.show.m-3 > span';
 

--- a/codeception/_support/Page/Admin/PluginManagePage.php
+++ b/codeception/_support/Page/Admin/PluginManagePage.php
@@ -105,6 +105,11 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
         return '//*[@id="page_admin_store_plugin"]//div/h5[contains(text(), "オーナーズストアのプラグイン")]/../..//table/tbody//td[3]/p[contains(text(), "'.$pluginCode.'")]';
     }
 
+    /**
+     * @param string $pluginCode
+     *
+     * @return PluginManagePage
+     */
     public function 独自プラグイン_有効化($pluginCode)
     {
         $this->独自プラグイン_ボタンクリック($pluginCode, '有効化');
@@ -114,6 +119,11 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
         return $this;
     }
 
+    /**
+     * @param string $pluginCode
+     *
+     * @return PluginManagePage
+     */
     public function 独自プラグイン_無効化($pluginCode)
     {
         $this->独自プラグイン_ボタンクリック($pluginCode, '無効化');
@@ -123,6 +133,11 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
         return $this;
     }
 
+    /**
+     * @param string $pluginCode
+     *
+     * @return PluginManagePage
+     */
     public function 独自プラグイン_削除($pluginCode)
     {
         $this->独自プラグイン_ボタンクリック($pluginCode, '削除');
@@ -132,6 +147,12 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
         return $this;
     }
 
+    /**
+     * @param string $pluginCode
+     * @param string $pluginDirName
+     *
+     * @return PluginManagePage
+     */
     public function 独自プラグイン_アップデート($pluginCode, $pluginDirName)
     {
         $this->tester->compressPlugin($pluginDirName, codecept_data_dir('plugins'));

--- a/codeception/_support/Page/Admin/PluginManagePage.php
+++ b/codeception/_support/Page/Admin/PluginManagePage.php
@@ -15,6 +15,9 @@ namespace Page\Admin;
 
 class PluginManagePage extends AbstractAdminPageStyleGuide
 {
+    /** @var int 要素の表示待機時間（秒） */
+    public const WAIT_TIMEOUT = 30;
+
     public const 完了メッセージ = '#page_admin_store_plugin > div.c-container > div.c-contentsArea > div.alert.alert-dismissible.fade.show.m-3 > span';
 
     public function __construct(\AcceptanceTester $I)
@@ -38,7 +41,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function ストアプラグイン_有効化($pluginCode, $message = '有効にしました。')
     {
         $this->ストアプラグイン_ボタンクリック($pluginCode, '有効化');
-        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], 30);
+        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], self::WAIT_TIMEOUT);
         $this->tester->see($message, self::完了メッセージ);
 
         return $this;
@@ -53,7 +56,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function ストアプラグイン_無効化($pluginCode, $message = '無効にしました。')
     {
         $this->ストアプラグイン_ボタンクリック($pluginCode, '無効化');
-        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], 30);
+        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], self::WAIT_TIMEOUT);
         $this->tester->see($message, self::完了メッセージ);
 
         return $this;
@@ -72,7 +75,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
         $this->ストアプラグイン_ボタンクリック($pluginCode, '削除');
         $this->tester->waitForElementVisible(['id' => 'officialPluginDeleteButton'], 60);
         $this->tester->click(['id' => 'officialPluginDeleteButton']);
-        $this->tester->waitForElementVisible(['css' => '#officialPluginDeleteModal > div > div > div.modal-footer > button:nth-child(3)'], 30);
+        $this->tester->waitForElementVisible(['css' => '#officialPluginDeleteModal > div > div > div.modal-footer > button:nth-child(3)'], self::WAIT_TIMEOUT);
         $this->tester->see($message, ['css' => '#officialPluginDeleteModal > div > div > div.modal-body.text-start > p']);
         $this->tester->click(['css' => '#officialPluginDeleteModal > div > div > div.modal-footer > button:nth-child(3)']);
 
@@ -113,7 +116,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function 独自プラグイン_有効化($pluginCode)
     {
         $this->独自プラグイン_ボタンクリック($pluginCode, '有効化');
-        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], 30);
+        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], self::WAIT_TIMEOUT);
         $this->tester->see('有効にしました。', self::完了メッセージ);
 
         return $this;
@@ -127,7 +130,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function 独自プラグイン_無効化($pluginCode)
     {
         $this->独自プラグイン_ボタンクリック($pluginCode, '無効化');
-        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], 30);
+        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], self::WAIT_TIMEOUT);
         $this->tester->see('無効にしました。', self::完了メッセージ);
 
         return $this;
@@ -141,7 +144,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function 独自プラグイン_削除($pluginCode)
     {
         $this->独自プラグイン_ボタンクリック($pluginCode, '削除');
-        $this->tester->waitForElementVisible(['css' => '#localPluginDeleteModal .modal-footer a']);
+        $this->tester->waitForElementVisible(['css' => '#localPluginDeleteModal .modal-footer a'], self::WAIT_TIMEOUT);
         $this->tester->click(['css' => '#localPluginDeleteModal .modal-footer a']);
 
         return $this;
@@ -158,7 +161,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
         $this->tester->compressPlugin($pluginDirName, codecept_data_dir('plugins'));
         $this->tester->attachFile(['xpath' => $this->独自プラグイン_セレクタ($pluginCode).'/../td[5]//input[@type="file"]'], 'plugins/'.$pluginDirName.'.tgz');
         $this->tester->click(['xpath' => $this->独自プラグイン_セレクタ($pluginCode).'/../td[5]//button']);
-        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], 30);
+        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], self::WAIT_TIMEOUT);
         $this->tester->see('アップデートしました。', self::完了メッセージ);
 
         return $this;

--- a/codeception/_support/Page/Admin/PluginManagePage.php
+++ b/codeception/_support/Page/Admin/PluginManagePage.php
@@ -16,7 +16,7 @@ namespace Page\Admin;
 class PluginManagePage extends AbstractAdminPageStyleGuide
 {
     /** @var int 要素の表示待機時間（秒） */
-    public const WAIT_TIMEOUT = 10;
+    public const WAIT_TIMEOUT = 60;
 
     public const 完了メッセージ = '#page_admin_store_plugin > div.c-container > div.c-contentsArea > div.alert.alert-dismissible.fade.show.m-3 > span';
 

--- a/codeception/_support/Page/Admin/PluginManagePage.php
+++ b/codeception/_support/Page/Admin/PluginManagePage.php
@@ -73,8 +73,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
         $this->ストアプラグイン_ボタンクリック($pluginCode, '削除');
         $this->tester->waitForElementVisible(['id' => 'officialPluginDeleteButton'], 60);
         $this->tester->click(['id' => 'officialPluginDeleteButton']);
-        $this->tester->waitForElementVisible(['css' => '#officialPluginDeleteModal > div > div > div.modal-footer > button:nth-child(3)'], self::WAIT_TIMEOUT);
-        $this->tester->see($message, ['css' => '#officialPluginDeleteModal > div > div > div.modal-body.text-start > p']);
+        $this->tester->waitForText($message, self::WAIT_TIMEOUT, ['css' => '#officialPluginDeleteModal > div > div > div.modal-body.text-start > p']);
         $this->tester->click(['css' => '#officialPluginDeleteModal > div > div > div.modal-footer > button:nth-child(3)']);
 
         return $this;

--- a/codeception/_support/Page/Admin/PluginManagePage.php
+++ b/codeception/_support/Page/Admin/PluginManagePage.php
@@ -15,7 +15,7 @@ namespace Page\Admin;
 
 class PluginManagePage extends AbstractAdminPageStyleGuide
 {
-    public const 完了メーッセージ = '#page_admin_store_plugin > div.c-container > div.c-contentsArea > div.alert.alert-dismissible.fade.show.m-3 > span';
+    public const 完了メッセージ = '#page_admin_store_plugin > div.c-container > div.c-contentsArea > div.alert.alert-dismissible.fade.show.m-3 > span';
 
     public function __construct(\AcceptanceTester $I)
     {
@@ -38,8 +38,8 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function ストアプラグイン_有効化($pluginCode, $message = '有効にしました。')
     {
         $this->ストアプラグイン_ボタンクリック($pluginCode, '有効化');
-        $this->tester->waitForElementVisible(['css' => self::完了メーッセージ], 30);
-        $this->tester->see($message, self::完了メーッセージ);
+        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], 30);
+        $this->tester->see($message, self::完了メッセージ);
 
         return $this;
     }
@@ -53,8 +53,8 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function ストアプラグイン_無効化($pluginCode, $message = '無効にしました。')
     {
         $this->ストアプラグイン_ボタンクリック($pluginCode, '無効化');
-        $this->tester->waitForElementVisible(['css' => self::完了メーッセージ], 30);
-        $this->tester->see($message, self::完了メーッセージ);
+        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], 30);
+        $this->tester->see($message, self::完了メッセージ);
 
         return $this;
     }
@@ -108,8 +108,8 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function 独自プラグイン_有効化($pluginCode)
     {
         $this->独自プラグイン_ボタンクリック($pluginCode, '有効化');
-        $this->tester->waitForElementVisible(['css' => self::完了メーッセージ], 30);
-        $this->tester->see('有効にしました。', self::完了メーッセージ);
+        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], 30);
+        $this->tester->see('有効にしました。', self::完了メッセージ);
 
         return $this;
     }
@@ -117,8 +117,8 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function 独自プラグイン_無効化($pluginCode)
     {
         $this->独自プラグイン_ボタンクリック($pluginCode, '無効化');
-        $this->tester->waitForElementVisible(['css' => self::完了メーッセージ], 30);
-        $this->tester->see('無効にしました。', self::完了メーッセージ);
+        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], 30);
+        $this->tester->see('無効にしました。', self::完了メッセージ);
 
         return $this;
     }
@@ -137,8 +137,8 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
         $this->tester->compressPlugin($pluginDirName, codecept_data_dir('plugins'));
         $this->tester->attachFile(['xpath' => $this->独自プラグイン_セレクタ($pluginCode).'/../td[5]//input[@type="file"]'], 'plugins/'.$pluginDirName.'.tgz');
         $this->tester->click(['xpath' => $this->独自プラグイン_セレクタ($pluginCode).'/../td[5]//button']);
-        $this->tester->waitForElementVisible(['css' => self::完了メーッセージ], 30);
-        $this->tester->see('アップデートしました。', self::完了メーッセージ);
+        $this->tester->waitForElementVisible(['css' => self::完了メッセージ], 30);
+        $this->tester->see('アップデートしました。', self::完了メッセージ);
 
         return $this;
     }

--- a/codeception/_support/Page/Admin/PluginManagePage.php
+++ b/codeception/_support/Page/Admin/PluginManagePage.php
@@ -38,6 +38,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function ストアプラグイン_有効化($pluginCode, $message = '有効にしました。')
     {
         $this->ストアプラグイン_ボタンクリック($pluginCode, '有効化');
+        $this->tester->waitForElementVisible(['css' => self::完了メーッセージ], 30);
         $this->tester->see($message, self::完了メーッセージ);
 
         return $this;
@@ -52,6 +53,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function ストアプラグイン_無効化($pluginCode, $message = '無効にしました。')
     {
         $this->ストアプラグイン_ボタンクリック($pluginCode, '無効化');
+        $this->tester->waitForElementVisible(['css' => self::完了メーッセージ], 30);
         $this->tester->see($message, self::完了メーッセージ);
 
         return $this;
@@ -106,6 +108,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function 独自プラグイン_有効化($pluginCode)
     {
         $this->独自プラグイン_ボタンクリック($pluginCode, '有効化');
+        $this->tester->waitForElementVisible(['css' => self::完了メーッセージ], 30);
         $this->tester->see('有効にしました。', self::完了メーッセージ);
 
         return $this;
@@ -114,6 +117,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     public function 独自プラグイン_無効化($pluginCode)
     {
         $this->独自プラグイン_ボタンクリック($pluginCode, '無効化');
+        $this->tester->waitForElementVisible(['css' => self::完了メーッセージ], 30);
         $this->tester->see('無効にしました。', self::完了メーッセージ);
 
         return $this;
@@ -133,6 +137,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
         $this->tester->compressPlugin($pluginDirName, codecept_data_dir('plugins'));
         $this->tester->attachFile(['xpath' => $this->独自プラグイン_セレクタ($pluginCode).'/../td[5]//input[@type="file"]'], 'plugins/'.$pluginDirName.'.tgz');
         $this->tester->click(['xpath' => $this->独自プラグイン_セレクタ($pluginCode).'/../td[5]//button']);
+        $this->tester->waitForElementVisible(['css' => self::完了メーッセージ], 30);
         $this->tester->see('アップデートしました。', self::完了メーッセージ);
 
         return $this;

--- a/codeception/acceptance/EA10PluginCest.php
+++ b/codeception/acceptance/EA10PluginCest.php
@@ -783,8 +783,6 @@ class Local_Plugin extends Abstract_Plugin
 
         $this->initialized = true;
 
-        $this->I->waitForText('プラグインをインストールしました。', PluginManagePage::WAIT_TIMEOUT, PluginManagePage::完了メッセージ);
-
         $this->検証();
 
         $this->Plugin = $this->pluginRepository->findByCode($this->code);

--- a/codeception/acceptance/EA10PluginCest.php
+++ b/codeception/acceptance/EA10PluginCest.php
@@ -783,6 +783,7 @@ class Local_Plugin extends Abstract_Plugin
 
         $this->initialized = true;
 
+        $this->I->waitForElementVisible(PluginManagePage::完了メッセージ, PluginManagePage::WAIT_TIMEOUT);
         $this->I->see('プラグインをインストールしました。', PluginManagePage::完了メッセージ);
 
         $this->検証();
@@ -831,6 +832,7 @@ class Local_Plugin extends Abstract_Plugin
         $this->initialized = false;
         $this->enabled = false;
 
+        $this->I->waitForElementVisible(PluginManagePage::完了メッセージ, PluginManagePage::WAIT_TIMEOUT);
         $this->I->see('プラグインを削除しました。', PluginManagePage::完了メッセージ);
 
         $this->検証();

--- a/codeception/acceptance/EA10PluginCest.php
+++ b/codeception/acceptance/EA10PluginCest.php
@@ -783,8 +783,7 @@ class Local_Plugin extends Abstract_Plugin
 
         $this->initialized = true;
 
-        $this->I->waitForElementVisible(PluginManagePage::完了メッセージ, PluginManagePage::WAIT_TIMEOUT);
-        $this->I->see('プラグインをインストールしました。', PluginManagePage::完了メッセージ);
+        $this->I->waitForText('プラグインをインストールしました。', PluginManagePage::WAIT_TIMEOUT, PluginManagePage::完了メッセージ);
 
         $this->検証();
 
@@ -832,8 +831,7 @@ class Local_Plugin extends Abstract_Plugin
         $this->initialized = false;
         $this->enabled = false;
 
-        $this->I->waitForElementVisible(PluginManagePage::完了メッセージ, PluginManagePage::WAIT_TIMEOUT);
-        $this->I->see('プラグインを削除しました。', PluginManagePage::完了メッセージ);
+        $this->I->waitForText('プラグインを削除しました。', PluginManagePage::WAIT_TIMEOUT, PluginManagePage::完了メッセージ);
 
         $this->検証();
 

--- a/codeception/acceptance/EA10PluginCest.php
+++ b/codeception/acceptance/EA10PluginCest.php
@@ -783,7 +783,7 @@ class Local_Plugin extends Abstract_Plugin
 
         $this->initialized = true;
 
-        $this->I->see('プラグインをインストールしました。', PluginManagePage::完了メーッセージ);
+        $this->I->see('プラグインをインストールしました。', PluginManagePage::完了メッセージ);
 
         $this->検証();
 
@@ -831,7 +831,7 @@ class Local_Plugin extends Abstract_Plugin
         $this->initialized = false;
         $this->enabled = false;
 
-        $this->I->see('プラグインを削除しました。', PluginManagePage::完了メーッセージ);
+        $this->I->see('プラグインを削除しました。', PluginManagePage::完了メッセージ);
 
         $this->検証();
 


### PR DESCRIPTION
## 概要

プラグインテスト（EA10PluginCest）でFlaky testが発生していたため、待機処理を改善して安定化しました。

## 原因

- プラグインの有効化・無効化後、アラートメッセージ（`.alert.fade.show`）の確認で失敗
- Bootstrapのフェードインアニメーション完了前に`see()`が実行される
- CI環境の負荷によりタイミングが不安定

## 修正内容

### `waitForText()`の採用

`waitForElementVisible()` + `see()` の2段階パターンを `waitForText()` に統一しました。

```php
// Before: 要素表示とテキスト確認が分離（タイミング問題が残る）
$this->tester->waitForElementVisible(['css' => self::完了メッセージ], self::WAIT_TIMEOUT);
$this->tester->see($message, self::完了メッセージ);

// After: 待機とアサーションを1回で実行（より堅牢）
$this->tester->waitForText($message, self::WAIT_TIMEOUT, self::完了メッセージ);
```

このアプローチは他のEC-CUBEテスト（EA07BasicinfoCest、PL06SecurityCheckCest）で既に使用されており、実績があります。

### 変更ファイル

#### PluginLocalInstallPage.php
- `アップロード()`: インストール完了メッセージを待機してからページ遷移

#### PluginManagePage.php
- `WAIT_TIMEOUT`定数を追加（待機時間を一括変更可能に）
- `ストアプラグイン_有効化()`: `waitForText()`に変更
- `ストアプラグイン_無効化()`: `waitForText()`に変更
- `ストアプラグイン_削除()`: `waitForText()`に変更
- `独自プラグイン_有効化()`: `waitForText()`に変更
- `独自プラグイン_無効化()`: `waitForText()`に変更
- `独自プラグイン_削除()`: モーダルの待機時間を追加
- `独自プラグイン_アップデート()`: `waitForText()`に変更

#### EA10PluginCest.php
- `Local_Plugin::削除()`: `waitForText()`に変更
- 定数名typo修正（`完了メーッセージ` → `完了メッセージ`）

## 検証方法

- GitHub ActionsのCIでplugin-testが安定して通ることを確認

## 影響範囲

- Codeceptionテストコードのみ
- 本体のPHPコードへの影響なし

## 互換性

破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)