### PR TITLE
出荷通知メール、会員情報変更通知メールにフックポイントを追加

### DIFF
--- a/src/Eccube/Event/EccubeEvents.php
+++ b/src/Eccube/Event/EccubeEvents.php
@@ -589,4 +589,6 @@ final class EccubeEvents
     public const MAIL_ADMIN_ORDER = 'mail.admin.order';
     public const MAIL_PASSWORD_RESET = 'mail.password.reset';
     public const MAIL_PASSWORD_RESET_COMPLETE = 'mail.password.reset.complete';
+    public const MAIL_SHIPPING_NOTIFY = 'mail.shipping.notify';
+    public const MAIL_CUSTOMER_CHANGE_NOTIFY = 'mail.customer.change.notify';
 }

--- a/src/Eccube/Service/MailService.php
+++ b/src/Eccube/Service/MailService.php
@@ -683,6 +683,18 @@ class MailService
             $message->text($body);
         }
 
+        $event = new EventArgs(
+            [
+                'message' => $message,
+                'Shipping' => $Shipping,
+                'Order' => $Order,
+                'MailTemplate' => $MailTemplate,
+                'BaseInfo' => $this->BaseInfo,
+            ],
+            null
+        );
+        $this->eventDispatcher->dispatch($event, EccubeEvents::MAIL_SHIPPING_NOTIFY);
+
         try {
             $this->mailer->send($message);
         } catch (TransportExceptionInterface $e) {
@@ -805,6 +817,19 @@ class MailService
         } else {
             $message->text($body);
         }
+
+        $event = new EventArgs(
+            [
+                'message' => $message,
+                'Customer' => $Customer,
+                'BaseInfo' => $this->BaseInfo,
+                'MailTemplate' => $MailTemplate,
+                'userData' => $userData,
+                'eventName' => $eventName,
+            ],
+            null
+        );
+        $this->eventDispatcher->dispatch($event, EccubeEvents::MAIL_CUSTOMER_CHANGE_NOTIFY);
 
         try {
             $this->mailer->send($message);

--- a/tests/Eccube/Tests/Service/MailServiceTest.php
+++ b/tests/Eccube/Tests/Service/MailServiceTest.php
@@ -16,6 +16,7 @@ namespace Eccube\Tests\Service;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Customer;
 use Eccube\Entity\Master\Pref;
+use Eccube\Event\EccubeEvents;
 use Eccube\Service\MailService;
 use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
 use Symfony\Component\HttpFoundation\Request;
@@ -452,5 +453,84 @@ class MailServiceTest extends AbstractServiceTestCase
 
         $this->assertEmailTextBodyContains($Message, $userData['ipAddress']);
         $this->assertEmailHtmlBodyContains($Message, $userData['ipAddress']);
+    }
+
+    public function testSendShippingNotifyMail()
+    {
+        $Order = $this->Order;
+        $Shipping = $Order->getShippings()->first();
+
+        $this->mailService->sendShippingNotifyMail($Shipping);
+
+        $this->assertEmailCount(1);
+        /** @var Email $Message */
+        $Message = $this->getMailerMessage(0);
+
+        $this->expected = '['.$this->BaseInfo->getShopName().'] 商品出荷のお知らせ';
+        $this->actual = $Message->getSubject();
+        $this->verify();
+
+        $this->expected = $Order->getEmail();
+        $this->actual = $Message->getTo()[0]->getAddress();
+        $this->verify();
+
+        $this->expected = $this->BaseInfo->getEmail03();
+        $this->actual = $Message->getReplyTo()[0]->getAddress();
+        $this->verify();
+
+        $this->expected = $this->BaseInfo->getEmail01();
+        $this->actual = $Message->getBcc()[0]->getAddress();
+        $this->verify();
+    }
+
+    public function testSendShippingNotifyMailHookPoint()
+    {
+        $Order = $this->Order;
+        $Shipping = $Order->getShippings()->first();
+
+        $hookEmail = 'hook-test@example.com';
+        $eventDispatcher = static::getContainer()->get('event_dispatcher');
+        $eventDispatcher->addListener(EccubeEvents::MAIL_SHIPPING_NOTIFY, function ($event) use ($hookEmail) {
+            /** @var Email $message */
+            $message = $event->getArgument('message');
+            $message->addBcc($hookEmail);
+        });
+
+        $this->mailService->sendShippingNotifyMail($Shipping);
+
+        $this->assertEmailCount(1);
+        /** @var Email $Message */
+        $Message = $this->getMailerMessage(0);
+
+        // フックポイントで追加したBccが含まれていることを確認
+        $bccAddresses = array_map(fn (Address $a) => $a->getAddress(), $Message->getBcc());
+        $this->assertContains($hookEmail, $bccAddresses);
+    }
+
+    public function testSendCustomerChangeNotifyMailHookPoint()
+    {
+        $userData = [
+            'userAgent' => 'Test User Agent',
+            'ipAddress' => '192.168.0.1',
+        ];
+        $eventName = 'テスト';
+
+        $hookEmail = 'hook-test@example.com';
+        $eventDispatcher = static::getContainer()->get('event_dispatcher');
+        $eventDispatcher->addListener(EccubeEvents::MAIL_CUSTOMER_CHANGE_NOTIFY, function ($event) use ($hookEmail) {
+            /** @var Email $message */
+            $message = $event->getArgument('message');
+            $message->addBcc($hookEmail);
+        });
+
+        $this->mailService->sendCustomerChangeNotifyMail($this->Customer, $userData, $eventName);
+
+        $this->assertEmailCount(1);
+        /** @var Email $Message */
+        $Message = $this->getMailerMessage(0);
+
+        // フックポイントで追加したBccが含まれていることを確認
+        $bccAddresses = array_map(fn (Address $a) => $a->getAddress(), $Message->getBcc());
+        $this->assertContains($hookEmail, $bccAddresses);
     }
 }


### PR DESCRIPTION
## 概要

出荷通知メール（`sendShippingNotifyMail`）と会員情報変更通知メール（`sendCustomerChangeNotifyMail`）にフックポイントを追加しました。

refs #6501

## 再現手順

現状、`MailService`の他のメール送信メソッド（`sendOrderMail`、`sendCustomerConfirmMail`等）にはフックポイントが存在し、プラグインからBccやreplyToを変更できますが、以下の2つのメソッドにはフックポイントがありませんでした。

- `sendShippingNotifyMail`（出荷通知メール）
- `sendCustomerChangeNotifyMail`（会員情報変更通知メール）

## 原因

これらのメソッドにイベントディスパッチの処理が実装されていなかったため。

## 修正内容

1. `EccubeEvents`に以下の定数を追加
   - `MAIL_SHIPPING_NOTIFY` = `'mail.shipping.notify'`
   - `MAIL_CUSTOMER_CHANGE_NOTIFY` = `'mail.customer.change.notify'`

2. `MailService`の該当メソッドで、`$this->mailer->send($message)` の前にイベントをディスパッチするように修正

### イベント引数

**MAIL_SHIPPING_NOTIFY**:
| 引数 | 内容 |
|------|------|
| message | Email オブジェクト |
| Shipping | 出荷情報 |
| Order | 受注情報 |
| MailTemplate | メールテンプレート |
| BaseInfo | 基本情報 |

**MAIL_CUSTOMER_CHANGE_NOTIFY**:
| 引数 | 内容 |
|------|------|
| message | Email オブジェクト |
| Customer | 会員情報 |
| BaseInfo | 基本情報 |
| MailTemplate | メールテンプレート |
| userData | ユーザーデータ |
| eventName | イベント名 |

## 検証方法

```php
// プラグインでのフックポイント利用例
use Eccube\Event\EccubeEvents;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;

class MailEventSubscriber implements EventSubscriberInterface
{
    public static function getSubscribedEvents()
    {
        return [
            EccubeEvents::MAIL_SHIPPING_NOTIFY => 'onShippingNotifyMail',
            EccubeEvents::MAIL_CUSTOMER_CHANGE_NOTIFY => 'onCustomerChangeNotifyMail',
        ];
    }

    public function onShippingNotifyMail($event)
    {
        $message = $event->getArgument('message');
        $message->addBcc('admin@example.com');
    }

    public function onCustomerChangeNotifyMail($event)
    {
        $message = $event->getArgument('message');
        $message->replyTo('support@example.com');
    }
}
```

### 自動テスト

```bash
./vendor/bin/phpunit tests/Eccube/Tests/Service/MailServiceTest.php
```

## 影響範囲

- `src/Eccube/Event/EccubeEvents.php`
- `src/Eccube/Service/MailService.php`

## 互換性

- 破壊的変更なし
- 既存の動作に影響なし（フックポイントを利用しない場合、従来通りの動作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メール送信前にカスタム処理を実行するための配送通知と顧客変更通知のイベント機能を追加

* **テスト**
  * 新しいメールイベント機能のホックポイント動作検証テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->