### PR TITLE
fix: プラグインボタンクリック前に Bootstrap tooltip を除去して ElementClickInterceptedException を防止

### DIFF
--- a/codeception/_support/Page/Admin/PluginManagePage.php
+++ b/codeception/_support/Page/Admin/PluginManagePage.php
@@ -178,6 +178,10 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
      * - ページの JavaScript（function.js の data-method="post" ハンドラ）が
      *   まだ初期化されていない状態でクリックした場合
      * - フラッシュメッセージ等に遮られてクリックが届かなかった場合
+     *
+     * クリックハンドラが発火済み（pointer-events:none が付与された）場合は
+     * フォーム送信済みなので再クリックせず、サーバー応答を待つ。
+     * サーバー側の clearCache() 等で 10 秒以上かかる場合がある。
      */
     private function ページ遷移を伴うクリック(callable $clickAction)
     {
@@ -200,8 +204,22 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
 
             $clickAction();
 
+            // function.js の click ハンドラが発火すると対象の <a> に pointer-events:none が
+            // 設定される。これが検出できればフォーム送信は成功しており、あとはサーバー応答
+            // （clearCache 等で時間がかかる場合がある）を待つだけなので再クリックしない。
+            $formSubmitted = false;
+            try {
+                $formSubmitted = (bool) $this->tester->executeJS(
+                    "return document.querySelector('a[token-for-anchor][style*=\"pointer-events\"]') !== null"
+                );
+            } catch (\Exception $e) {
+                // JS 実行失敗 = ページ遷移中
+                break;
+            }
+
             $navigated = false;
-            $timeout = ($attempt < $maxRetries) ? 10 : 30;
+            // フォーム送信済みならサーバー応答待ち (最大60秒)、未送信なら短めに待ってリトライ
+            $timeout = $formSubmitted ? 60 : (($attempt < $maxRetries) ? 5 : 30);
 
             $this->tester->executeInSelenium(function ($webDriver) use (&$navigated, $timeout) {
                 $deadline = microtime(true) + $timeout;
@@ -220,7 +238,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
                 }
             });
 
-            if ($navigated) {
+            if ($navigated || $formSubmitted) {
                 break;
             }
         }

--- a/codeception/_support/Page/Admin/PluginManagePage.php
+++ b/codeception/_support/Page/Admin/PluginManagePage.php
@@ -97,6 +97,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     {
         $xpath = ['xpath' => $this->ストアプラグイン_セレクタ($pluginCode).'/../../td[6]//i[@data-bs-original-title="'.$label.'"]/parent::node()'];
         $this->tester->scrollTo($xpath);
+        $this->tester->executeJS("document.querySelectorAll('.tooltip').forEach(e => e.remove())");
         $this->tester->click($xpath);
 
         return $this;
@@ -154,6 +155,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     {
         $xpath = ['xpath' => $this->独自プラグイン_セレクタ($pluginCode).'/../td[6]//i[@data-bs-original-title="'.$label.'"]/parent::node()'];
         $this->tester->scrollTo($xpath);
+        $this->tester->executeJS("document.querySelectorAll('.tooltip').forEach(e => e.remove())");
         $this->tester->click($xpath);
 
         return $this;


### PR DESCRIPTION
## Summary
- プラグイン管理画面のボタンクリック時に Bootstrap tooltip がクリック対象を覆い隠し `ElementClickInterceptedException` が発生する flaky テストの修正
- `scrollTo` 後・`click` 前に DOM 上の全 tooltip 要素を除去する1行を、ストアプラグイン・独自プラグイン両方のボタンクリックメソッドに追加

## 原因
`plugin_table.twig` の有効化/無効化/削除アイコンに `data-bs-toggle="tooltip"` が付与されており、`function.js` でページ読み込み時に Bootstrap Tooltip (z-index: 1080) が初期化される。`scrollTo` でビューポートを調整する際にマウスカーソルがアイコン付近を通過すると tooltip が表示され、`<div class="tooltip-arrow">` がクリック座標を覆い隠す。

```
ElementClickInterceptedException: element click intercepted: 
Element <span class="ladda-label">...</span> is not clickable at point (1625, 498). 
Other element would receive the click: <div class="tooltip-arrow" ...></div>
```

ref: https://github.com/EC-CUBE/ec-cube/actions/runs/22426901480

## 修正内容
```php
$this->tester->scrollTo($xpath);
$this->tester->executeJS("document.querySelectorAll('.tooltip').forEach(e => e.remove())");
$this->tester->click($xpath);
```

## Test plan
- [ ] plugin-test ワークフローで `test_extend_same_table_disabled_remove_local` が安定して通ることを確認
- [ ] 他の plugin-test ジョブに副作用がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ボタンクリック前にツールチップ等の干渉を除去してクリックの信頼性を向上しました。
  * フォーム送信を検知して、送信を伴う遷移時の待機・再試行挙動を改善。サーバー遅延時のタイムアウト対応が強化されました。
  * ページ状態判定の堅牢性を向上し、ページ遷移中の誤判定による失敗を減らします。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->