### PR TITLE
fix(ci): add least-privilege permissions to all workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,9 @@ name: Coverage
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   phpunit:
     name: PHPUnit

--- a/.github/workflows/deny-test.yml
+++ b/.github/workflows/deny-test.yml
@@ -3,6 +3,9 @@ name: Deny check for EC-CUBE
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deny check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,11 @@ name: Deploy for EC-CUBE
 on:
   release:
     types: [ published ]
+permissions: {}
 jobs:
   deploy:
+    permissions:
+      contents: write
     name: Deploy
     runs-on: ubuntu-24.04
     services:

--- a/.github/workflows/e2e-test-throttling.yml
+++ b/.github/workflows/e2e-test-throttling.yml
@@ -3,6 +3,9 @@ name: E2E test(Throttoling) for EC-CUBE
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   codeception:
     name: Codeception

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -3,6 +3,9 @@ name: E2E test for EC-CUBE
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   codeception:
     name: Codeception

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,9 @@ on:
       - '**'
       - '!*.md'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -3,6 +3,9 @@ name: PHP CS Fixer
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   php-cs-fixer:
     name: Run PHP CS Fixer

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -3,6 +3,9 @@ name: PHPStan
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   phpstan:
     name: PHPStan

--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -3,6 +3,9 @@ name: Plugin test for EC-CUBE
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   plugin-install:
     name: Plugin install

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -3,6 +3,9 @@ name: Rector
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   rector:
     name: Rector

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,6 +3,9 @@ name: Unit test for EC-CUBE
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   phpunit:
     name: PHPUnit

--- a/.github/workflows/vaddy-1.yml
+++ b/.github/workflows/vaddy-1.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '0 15 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   vaddy:
     name: VAddy

--- a/.github/workflows/vaddy-2.yml
+++ b/.github/workflows/vaddy-2.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '0 21 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   vaddy:
     name: VAddy

--- a/.github/workflows/vaddyscan.yml
+++ b/.github/workflows/vaddyscan.yml
@@ -1,5 +1,7 @@
 name: VAddy-test
 on: push
+permissions:
+  contents: read
 jobs:
   vaddy:
     name: VAddy

--- a/.github/workflows/zaproxy.yml
+++ b/.github/workflows/zaproxy.yml
@@ -9,6 +9,9 @@ name: OWASP ZAP
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   prune:
     name: Prune Docker images


### PR DESCRIPTION
## 概要
`permissions` 宣言が欠如している全ワークフローに最小権限の `permissions` ブロックを追加します。

## 背景
`permissions` が未宣言のワークフローでは、`GITHUB_TOKEN` がリポジトリのデフォルト設定に従います。パブリックリポジトリのレガシーデフォルトでは全スコープに write 権限が付与されるため、サプライチェーン攻撃が成立した場合の被害範囲が大幅に拡大します。

具体的には、侵害された Action が以下の操作を実行可能になります：
- リポジトリのコード改竄（`contents: write`）
- リリースアーティファクトの差し替え
- Issue/PR の操作
- パッケージの改竄

## 変更内容
- 全ワークフローに明示的な `permissions` ブロックを追加
- 各ワークフローの実際の要件に基づいた最小権限を設定
- テスト系ワークフロー: `contents: read` のみ
- デプロイワークフロー: `contents: write`（リリースアーティファクトアップロードに必要）

## テスト計画
- [ ] CI ワークフローが正常に実行されることを確認
- [ ] 権限不足によるエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)