### PR TITLE
fix: E2Eテスト商品一覧ソートのページング起因テスト失敗を修正

### DIFF
--- a/codeception/acceptance/EF02ProductCest.php
+++ b/codeception/acceptance/EF02ProductCest.php
@@ -49,6 +49,7 @@ class EF02ProductCest
 
         // TOPページ>商品一覧（ヘッダーのいずれかのカテゴリを選択）へ遷移
         $topPage->カテゴリ選択(['新入荷']);
+        $I->waitForElement(['css' => '.ec-shelfGrid__item']);
 
         // 各商品のサムネイルが表示される デフォルトは価格順
         $products = $I->grabMultiple(['xpath' => "//*[@class='ec-shelfGrid__item']/a/p[2]"]);
@@ -91,7 +92,7 @@ class EF02ProductCest
 
         // TOPページ>商品一覧（ヘッダーのいずれかのカテゴリを選択）へ遷移
         $topPage->カテゴリ選択(['新入荷']);
-        $listPage = new ProductListPage($I);
+        $listPage = ProductListPage::at($I);
 
         // 各商品のサムネイルが表示される
         $config = Fixtures::get('test_config');
@@ -114,6 +115,7 @@ class EF02ProductCest
 
         // TOPページ>商品一覧（ヘッダーのいずれかのカテゴリを選択）へ遷移
         $topPage->カテゴリ選択(['新入荷']);
+        $I->waitForElement(['css' => '.ec-shelfGrid__item']);
 
         // 絞込検索条件では、検索数が多い場合、「次へ」「前へ」「ページ番号」が表示される
         $I->scrollTo(['css' => 'li.ec-pager__item--active']);

--- a/codeception/acceptance/EF02ProductCest.php
+++ b/codeception/acceptance/EF02ProductCest.php
@@ -51,6 +51,9 @@ class EF02ProductCest
         $topPage->カテゴリ選択(['新入荷']);
         $I->waitForElement(['css' => '.ec-shelfGrid__item']);
 
+        // 全商品を1ページに表示（フィクスチャ商品数によりページングされるため）
+        $listPage = ProductListPage::at($I)->表示件数設定(40);
+
         // 各商品のサムネイルが表示される デフォルトは価格順
         $products = $I->grabMultiple(['xpath' => "//*[@class='ec-shelfGrid__item']/a/p[2]"]);
         $pPos = 0;
@@ -66,9 +69,7 @@ class EF02ProductCest
         $I->assertTrue($pPos < $fPos);
 
         // ソート条件の選択リストを変更する
-        ProductListPage::at($I)
-            ->表示件数設定(40)
-            ->表示順設定('価格が高い順');
+        $listPage->表示順設定('価格が高い順');
 
         // 変更されたソート条件に従い、商品がソートされる
         $products = $I->grabMultiple(['xpath' => "//*[@class='ec-shelfGrid__item']/a/p[2]"]);


### PR DESCRIPTION
## Summary
- `EF02ProductCest::product_商品一覧ソート` でフィクスチャの商品数がデフォルト表示件数を超えるとページングされ、1ページ目の商品だけでソート順を検証するためテストが不安定になる問題を修正
- カテゴリ選択直後に `表示件数設定(40)` を実行し、全商品を1ページに表示させてからソート順を検証するように変更

## 原因
フィクスチャで登録される商品数によっては、デフォルトの表示件数でページングが発生する。ソート順の検証対象商品が1ページ目にすべて含まれるとは限らず、アサーションが不安定になっていた。

## Test plan
- [x] `e2e-test / Codeception (8.3, pgsql, front-a)` が pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)