### PR TITLE
fix: プラグインボタンクリック前にフラッシュメッセージのアラートを除去

### DIFF
--- a/codeception/_support/Page/Admin/PluginManagePage.php
+++ b/codeception/_support/Page/Admin/PluginManagePage.php
@@ -95,10 +95,15 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
 
     private function ストアプラグイン_ボタンクリック($pluginCode, $label)
     {
-        $xpath = ['xpath' => $this->ストアプラグイン_セレクタ($pluginCode).'/../../td[6]//i[@data-bs-original-title="'.$label.'"]/parent::node()'];
-        $this->tester->scrollTo($xpath);
-        $this->tester->executeJS("document.querySelectorAll('.tooltip, .alert-dismissible').forEach(e => e.remove())");
-        $this->tester->click($xpath);
+        $xpathStr = $this->ストアプラグイン_セレクタ($pluginCode).'/../../td[6]//i[@data-bs-original-title="'.$label.'"]/parent::node()';
+        $this->tester->scrollTo(['xpath' => $xpathStr]);
+        // tooltip やアラートを除去した上で JS クリックすることで、
+        // WebDriver のマウス移動による tooltip 再出現を回避する
+        $this->tester->executeJS(
+            "document.querySelectorAll('.tooltip, .alert-dismissible').forEach(e => e.remove());"
+            ."document.evaluate(arguments[0], document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.click()",
+            [$xpathStr]
+        );
 
         return $this;
     }
@@ -153,10 +158,13 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
 
     private function 独自プラグイン_ボタンクリック($pluginCode, $label)
     {
-        $xpath = ['xpath' => $this->独自プラグイン_セレクタ($pluginCode).'/../td[6]//i[@data-bs-original-title="'.$label.'"]/parent::node()'];
-        $this->tester->scrollTo($xpath);
-        $this->tester->executeJS("document.querySelectorAll('.tooltip, .alert-dismissible').forEach(e => e.remove())");
-        $this->tester->click($xpath);
+        $xpathStr = $this->独自プラグイン_セレクタ($pluginCode).'/../td[6]//i[@data-bs-original-title="'.$label.'"]/parent::node()';
+        $this->tester->scrollTo(['xpath' => $xpathStr]);
+        $this->tester->executeJS(
+            "document.querySelectorAll('.tooltip, .alert-dismissible').forEach(e => e.remove());"
+            ."document.evaluate(arguments[0], document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.click()",
+            [$xpathStr]
+        );
 
         return $this;
     }

--- a/codeception/_support/Page/Admin/PluginManagePage.php
+++ b/codeception/_support/Page/Admin/PluginManagePage.php
@@ -97,7 +97,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     {
         $xpath = ['xpath' => $this->ストアプラグイン_セレクタ($pluginCode).'/../../td[6]//i[@data-bs-original-title="'.$label.'"]/parent::node()'];
         $this->tester->scrollTo($xpath);
-        $this->tester->executeJS("document.querySelectorAll('.tooltip').forEach(e => e.remove())");
+        $this->tester->executeJS("document.querySelectorAll('.tooltip, .alert-dismissible').forEach(e => e.remove())");
         $this->tester->click($xpath);
 
         return $this;
@@ -155,7 +155,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
     {
         $xpath = ['xpath' => $this->独自プラグイン_セレクタ($pluginCode).'/../td[6]//i[@data-bs-original-title="'.$label.'"]/parent::node()'];
         $this->tester->scrollTo($xpath);
-        $this->tester->executeJS("document.querySelectorAll('.tooltip').forEach(e => e.remove())");
+        $this->tester->executeJS("document.querySelectorAll('.tooltip, .alert-dismissible').forEach(e => e.remove())");
         $this->tester->click($xpath);
 
         return $this;

--- a/codeception/_support/Page/Admin/PluginManagePage.php
+++ b/codeception/_support/Page/Admin/PluginManagePage.php
@@ -101,7 +101,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
         // WebDriver のマウス移動による tooltip 再出現を回避する
         $this->tester->executeJS(
             "document.querySelectorAll('.tooltip, .alert-dismissible').forEach(e => e.remove());"
-            ."document.evaluate(arguments[0], document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.click()",
+            .'document.evaluate(arguments[0], document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.click()',
             [$xpathStr]
         );
 
@@ -162,7 +162,7 @@ class PluginManagePage extends AbstractAdminPageStyleGuide
         $this->tester->scrollTo(['xpath' => $xpathStr]);
         $this->tester->executeJS(
             "document.querySelectorAll('.tooltip, .alert-dismissible').forEach(e => e.remove());"
-            ."document.evaluate(arguments[0], document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.click()",
+            .'document.evaluate(arguments[0], document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.click()',
             [$xpathStr]
         );
 


### PR DESCRIPTION
## Summary
- プラグイン有効化/無効化の連続操作時に、前操作の完了アラート（`.alert-dismissible`）がボタン領域を遮り、クリックが届かずタイムアウトする問題を修正
- 既存の tooltip 除去（PR #6638）に加え、フラッシュメッセージのアラートバナーも DOM から除去するように変更

## 原因
プラグインの有効化後に表示される「有効にしました。」のフラッシュメッセージ（Bootstrap alert）が、次の無効化ボタンの上に重なりクリックを遮る。`ページ遷移を伴うクリック` のリトライ機構でも、アラートが残り続けるためクリックが届かない。

## Test plan
- [ ] `plugin-test / Plugin extend` が安定して pass することを確認
- [ ] `plugin-test / Plugin depend` が安定して pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * プラグイン管理ページのUI操作で、操作前にツールチップやアラート要素を確実に除去する処理を強化しました。これによりツールチップの再表示やクリックの失敗が抑えられ、プラグイン操作に関する自動テストや手動操作の安定性と信頼性が向上します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->