### PR TITLE
feat: フロントに管理画面ログイン用セッションの注意帯を追加

### DIFF
--- a/codeception/acceptance/EA06ContentsManagementCest.php
+++ b/codeception/acceptance/EA06ContentsManagementCest.php
@@ -524,7 +524,7 @@ class EA06ContentsManagementCest
 
         $I->expect('トップページを確認します');
         $I->amOnPage('/');
-        $I->waitForText('メンテナンスモードが有効になっています。', 10, '#page_homepage > div.ec-maintenanceAlert > div');
+        $I->waitForText('メンテナンスモードが有効になっています。', 10, '#page_homepage .ec-maintenanceAlert > div');
         $I->waitForText('全ての商品', 10, TopPage::$検索_カテゴリ選択);
 
         $I->expect('ログアウトします');
@@ -533,7 +533,7 @@ class EA06ContentsManagementCest
 
         $I->expect('トップページを確認します');
         $I->amOnPage('/');
-        $I->dontSee('メンテナンスモードが有効になっています。', '#page_homepage > div.ec-maintenanceAlert > div');
+        $I->dontSee('メンテナンスモードが有効になっています。', '#page_homepage .ec-maintenanceAlert > div');
         $I->waitForText('ただいまメンテナンス中です。', 10, 'body > div > div > div > div > p.ec-404Role__title.ec-reportHeading');
 
         // 画面遷移がスムーズにいかない場合があるため、ログイン画面に遷移させておく
@@ -552,7 +552,7 @@ class EA06ContentsManagementCest
 
         $I->expect('トップページを確認します');
         $I->amOnPage('/');
-        $I->dontSee('メンテナンスモードが有効になっています。', '#page_homepage > div.ec-maintenanceAlert > div');
+        $I->dontSee('メンテナンスモードが有効になっています。', '#page_homepage .ec-maintenanceAlert > div');
         $I->waitForText('全ての商品', 10, TopPage::$検索_カテゴリ選択);
     }
 

--- a/html/template/default/assets/css/style.css
+++ b/html/template/default/assets/css/style.css
@@ -10758,6 +10758,10 @@ Styleguide 11.2
 .ec-headerNaviRole .ec-headerNaviRole__cart a:hover {
   text-decoration: none;
 }
+.ec-headerNavSP,
+.ec-drawerRoleClose {
+  top: calc(var(--ec-mode-alert-strips, 0) * 50px + 10px);
+}
 .ec-headerNavSP {
   display: block;
   cursor: pointer;
@@ -10771,9 +10775,8 @@ Styleguide 11.2
   color: black;
   background: white;
   position: fixed;
-  top: 10px;
   left: 10px;
-  z-index: 1000;
+  z-index: 10001;
 }
 .ec-headerNavSP .fas {
   vertical-align: top;
@@ -11254,9 +11257,8 @@ Styleguide 11.2.6
   color: black;
   background: white;
   position: fixed;
-  top: 10px;
   left: 270px;
-  z-index: 1000;
+  z-index: 10001;
 }
 .ec-drawerRoleClose .fas {
   position: absolute;

--- a/html/template/default/assets/css/style.css
+++ b/html/template/default/assets/css/style.css
@@ -10582,6 +10582,7 @@ Styleguide 11.2
   min-height: 100dvh;
   transition: transform 0.3s;
   background: #fff;
+  padding-top: calc(var(--ec-mode-alert-strips, 0) * 50px);
 }
 .ec-layoutRole .ec-layoutRole__contentTop {
   padding: 0;
@@ -11313,14 +11314,21 @@ Styleguide 11.2.7
 .ec-itemNavAccordion {
   display: none;
 }
-.ec-maintenanceAlert {
-  background: steelblue;
-  height: 50px;
+.ec-modeAlertStack {
   position: fixed;
   top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+}
+.ec-maintenanceAlert {
+  background: steelblue;
+  flex-shrink: 0;
+  height: 50px;
   width: 100%;
   color: white;
-  z-index: 9999;
   display: flex;
   font-weight: bold;
 }
@@ -11336,18 +11344,12 @@ Styleguide 11.2.7
   fill: #fff;
   vertical-align: top;
 }
-.ec-maintenanceAlert + * {
-  margin-top: 50px;
-}
-/* devモードの追加 */
 .ec-debugModeAlert {
   background: red;
+  flex-shrink: 0;
   height: 50px;
-  position: fixed;
-  top: 0;
   width: 100%;
   color: white;
-  z-index: 9999;
   display: flex;
   font-weight: bold;
 }
@@ -11363,11 +11365,26 @@ Styleguide 11.2.7
   fill: #fff;
   vertical-align: top;
 }
-.ec-debugModeAlert + * {
-  margin-top: 50px;
+.ec-adminLoginAlert {
+  background: #fd7e14;
+  flex-shrink: 0;
+  height: 50px;
+  width: 100%;
+  color: white;
+  display: flex;
+  font-weight: bold;
 }
-.ec-twoModeAlert + * {
-  margin-top: 100px;
+.ec-adminLoginAlert > * {
+  margin: auto;
+}
+.ec-adminLoginAlert .ec-adminLoginAlert__icon {
+  display: inline-block;
+  margin-right: 1rem;
+  width: 20px;
+  height: 20px;
+  color: #fff;
+  fill: #fff;
+  vertical-align: top;
 }
 /**
 メディアクエリ

--- a/html/template/default/assets/scss/project/_11.2.header.scss
+++ b/html/template/default/assets/scss/project/_11.2.header.scss
@@ -30,6 +30,8 @@ Styleguide 11.2
   min-height: 100dvh;
   transition: transform 0.3s;
   background: #fff;
+  /* default_frame が --ec-mode-alert-strips（0〜3）をセット。帯1本あたり 50px */
+  padding-top: calc(var(--ec-mode-alert-strips, 0) * 50px);
   & &__contentTop {
     padding: 0;
   }
@@ -831,14 +833,23 @@ Styleguide 11.2.7
   display: none;
 }
 
-.ec-maintenanceAlert {
-  background: steelblue;
-  height: 50px;
+/* メンテ／デバッグ／管理セッション帯: 1 か所に固定し縦積み（本文は .ec-layoutRole の padding-top で確保） */
+.ec-modeAlertStack {
   position: fixed;
   top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+}
+
+.ec-maintenanceAlert {
+  background: steelblue;
+  flex-shrink: 0;
+  height: 50px;
   width: 100%;
   color: white;
-  z-index: 9999;
   display: flex;
   font-weight: bold;
   & > * {
@@ -853,39 +864,49 @@ Styleguide 11.2.7
     fill: #fff;
     vertical-align: top;
   }
-  & +* {
-    margin-top: 50px;
-  }
 }
 
-/* devモードの追加 */
 .ec-debugModeAlert {
   background: red;
+  flex-shrink: 0;
   height: 50px;
-  position: fixed;
-  top: 0;
   width: 100%;
   color: white;
-  z-index: 9999;
   display: flex;
   font-weight: bold;
   & > * {
-  margin: auto;
+    margin: auto;
   }
   & &__icon {
-  display: inline-block;
-  margin-right: 1rem;
-  width: 20px;
-  height: 20px;
-  color: #fff;
-  fill: #fff;
-  vertical-align: top;
-  }
-  & +* {
-    margin-top: 50px;
+    display: inline-block;
+    margin-right: 1rem;
+    width: 20px;
+    height: 20px;
+    color: #fff;
+    fill: #fff;
+    vertical-align: top;
   }
 }
 
-.ec-twoModeAlert + * {
-  margin-top: 100px;
+/* フロントで管理セッションが残っている場合（色は mixins/_variables.scss の $orange） */
+.ec-adminLoginAlert {
+  background: $orange;
+  flex-shrink: 0;
+  height: 50px;
+  width: 100%;
+  color: white;
+  display: flex;
+  font-weight: bold;
+  & > * {
+    margin: auto;
+  }
+  & &__icon {
+    display: inline-block;
+    margin-right: 1rem;
+    width: 20px;
+    height: 20px;
+    color: #fff;
+    fill: #fff;
+    vertical-align: top;
+  }
 }

--- a/html/template/default/assets/scss/project/_11.2.header.scss
+++ b/html/template/default/assets/scss/project/_11.2.header.scss
@@ -30,7 +30,7 @@ Styleguide 11.2
   min-height: 100dvh;
   transition: transform 0.3s;
   background: #fff;
-  /* default_frame が --ec-mode-alert-strips（0〜3）をセット。帯1本あたり 50px */
+  /* body が --ec-mode-alert-strips（0〜3）をセット。帯1本あたり 50px */
   padding-top: calc(var(--ec-mode-alert-strips, 0) * 50px);
   & &__contentTop {
     padding: 0;
@@ -164,6 +164,12 @@ Styleguide 11.2
   }
 }
 
+/* SP 固定ナビ: モード帯の高さ分だけ viewport 上端から下げる（--ec-mode-alert-strips は body） */
+.ec-headerNavSP,
+.ec-drawerRoleClose {
+  top: calc(var(--ec-mode-alert-strips, 0) * 50px + 10px);
+}
+
 .ec-headerNavSP {
   display: block;
   cursor: pointer;
@@ -178,9 +184,8 @@ Styleguide 11.2
   color: black;
   background: white;
   position: fixed;
-  top: 10px;
   left: 10px;
-  z-index: 1000;
+  z-index: 10001;
 
   .fas {
     vertical-align: top;
@@ -746,9 +751,8 @@ Styleguide 11.2.6
   color: black;
   background: white;
   position: fixed;
-  top: 10px;
   left: 270px;
-  z-index: 1000;
+  z-index: 10001;
 
   .fas {
     position: absolute;

--- a/src/Eccube/EventListener/TwigInitializeListener.php
+++ b/src/Eccube/EventListener/TwigInitializeListener.php
@@ -78,7 +78,7 @@ class TwigInitializeListener implements EventSubscriberInterface
      * セッションストレージが読み込まれた後に、フロント表示用 Twig グローバルをセットする.
      * （onKernelRequest priority 6 より後に実行するため -20 で登録）
      */
-    public function setIsAdminLoggedInOnFrontGlobal(RequestEvent $event)
+    public function setIsAdminLoggedInOnFrontGlobal(RequestEvent $event): void
     {
         if (!$event->isMainRequest()) {
             return;
@@ -89,15 +89,15 @@ class TwigInitializeListener implements EventSubscriberInterface
         }
 
         $request = $event->getRequest();
-        if (!$request->hasSession()) {
+        // セッション Cookie が無いリクエストでは触れない（Session::has() がセッション開始を引き起こすのを避ける）
+        if (!$request->hasPreviousSession()) {
             $this->twig->addGlobal('isAdminLoggedInOnFront', false);
 
             return;
         }
 
         $session = $request->getSession();
-        // セッション Cookie があるのに未開始のとき、ストレージから属性を読み込む
-        if (!$session->isStarted() && $request->cookies->has($session->getName())) {
+        if (!$session->isStarted()) {
             $session->start();
         }
 

--- a/src/Eccube/EventListener/TwigInitializeListener.php
+++ b/src/Eccube/EventListener/TwigInitializeListener.php
@@ -75,6 +75,36 @@ class TwigInitializeListener implements EventSubscriberInterface
     }
 
     /**
+     * セッションストレージが読み込まれた後に、フロント表示用 Twig グローバルをセットする.
+     * （onKernelRequest priority 6 より後に実行するため -20 で登録）
+     */
+    public function setIsAdminLoggedInOnFrontGlobal(RequestEvent $event)
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if ($this->requestContext->isAdmin()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        if (!$request->hasSession()) {
+            $this->twig->addGlobal('isAdminLoggedInOnFront', false);
+
+            return;
+        }
+
+        $session = $request->getSession();
+        // セッション Cookie があるのに未開始のとき、ストレージから属性を読み込む
+        if (!$session->isStarted() && $request->cookies->has($session->getName())) {
+            $session->start();
+        }
+
+        $this->twig->addGlobal('isAdminLoggedInOnFront', $session->has('_security_admin'));
+    }
+
+    /**
      * @throws NonUniqueResultException
      */
     public function setFrontVariables(RequestEvent $event): void
@@ -222,6 +252,8 @@ class TwigInitializeListener implements EventSubscriberInterface
             KernelEvents::REQUEST => [
                 // SecurityServiceProviderで、認証処理が完了した後に実行.
                 ['onKernelRequest', 6],
+                // Security / Session より後（高い priority が先に実行される）
+                ['setIsAdminLoggedInOnFrontGlobal', -20],
             ],
         ];
     }

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -397,7 +397,7 @@ front.shopping.not_available_payment_method: The payment method you have selecte
 front.shopping.payment_method_not_fount: Sorry, you have no payment options. If you have selected multiple delivery methods, you can only select the same payment option for them all.
 front.under_maintenance: The site is currently under maintenance.
 front.under_debug_mode: The site is currently under debug mode.
-front.admin_login_active: You are logged in to the administration panel.
+front.admin_login_active: You are logged in to the Admin Console.
 
 #====================================================================================
 # Admin Console

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -397,6 +397,7 @@ front.shopping.not_available_payment_method: The payment method you have selecte
 front.shopping.payment_method_not_fount: Sorry, you have no payment options. If you have selected multiple delivery methods, you can only select the same payment option for them all.
 front.under_maintenance: The site is currently under maintenance.
 front.under_debug_mode: The site is currently under debug mode.
+front.admin_login_active: You are logged in to the administration panel.
 
 #====================================================================================
 # Admin Console

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -396,6 +396,7 @@ front.shopping.not_available_payment_method: 選択したお支払い方法は�
 front.shopping.payment_method_not_fount: 選択できるお支払い方法がありません。配送方法が異なる場合は同じ配送方法を選んでください。
 front.under_maintenance: メンテナンスモードが有効になっています。
 front.under_debug_mode: デバッグモードが有効になっています。
+front.admin_login_active: 管理画面にログイン中です。
 
 #====================================================================================
 # 管理画面

--- a/src/Eccube/Resource/template/default/_front_mode_alert_row.twig
+++ b/src/Eccube/Resource/template/default/_front_mode_alert_row.twig
@@ -1,0 +1,7 @@
+{# フロント固定バー1行分（メンテ / デバッグ / 管理セッション） #}
+<div class="{{ alert_class }}">
+    <div>
+        <div class="{{ alert_class }}__icon"><img src="{{ asset('assets/icon/exclamation-white.svg') }}" alt="" width="20" height="20"></div>
+        {{ message_key|trans }}
+    </div>
+</div>

--- a/src/Eccube/Resource/template/default/default_frame.twig
+++ b/src/Eccube/Resource/template/default/default_frame.twig
@@ -60,42 +60,26 @@ file that was distributed with this source code.
     {{ include('block.twig', {'Blocks': Layout.BodyAfter}) }}
 {% endif %}
 
-
-{%  if (isMaintenance is defined and isMaintenance) and (isDebugMode is defined and isDebugMode) %}
-    <dev class="ec-twoModeAlert">
-        <div class="ec-maintenanceAlert">
-            <div>
-                <div class="ec-maintenanceAlert__icon"><img src="{{ asset('assets/icon/exclamation-white.svg') }}"/></div>
-                {{ 'front.under_maintenance'|trans }}
-            </div>
-        </div>
-        <div class="ec-debugModeAlert bg-danger">
-            <div>
-                <div class="ec-debugModeAlert__icon"><img src="{{ asset('assets/icon/exclamation-white.svg') }}"/></div>
-                {{ 'front.under_debug_mode'|trans }}
-            </div>
-        </div>
-    </dev>
-{%  else %}
-    {% if (isMaintenance is defined and isMaintenance) %}
-        <div class="ec-maintenanceAlert">
-            <div>
-                <div class="ec-maintenanceAlert__icon"><img src="{{ asset('assets/icon/exclamation-white.svg') }}"/></div>
-                {{ 'front.under_maintenance'|trans }}
-            </div>
-        </div>
-    {% endif %}
-    {% if (isDebugMode is defined and isDebugMode) %}
-        <div class="ec-debugModeAlert bg-danger">
-            <div>
-                <div class="ec-debugModeAlert__icon"><img src="{{ asset('assets/icon/exclamation-white.svg') }}"/></div>
-                {{ 'front.under_debug_mode'|trans }}
-            </div>
-        </div>
-    {% endif %}
+{# メンテ / デバッグ / 管理セッション: 本数に応じて .ec-layoutRole に --ec-mode-alert-strips を渡し padding-top で本文を下げる #}
+{% set show_maintenance = isMaintenance is defined and isMaintenance %}
+{% set show_debug = isDebugMode is defined and isDebugMode %}
+{% set show_admin_on_front = isAdminLoggedInOnFront is defined and isAdminLoggedInOnFront %}
+{% set mode_alert_count = (show_maintenance ? 1 : 0) + (show_debug ? 1 : 0) + (show_admin_on_front ? 1 : 0) %}
+{% if mode_alert_count > 0 %}
+    <div class="ec-modeAlertStack" aria-live="polite">
+        {% if show_maintenance %}
+            {{ include('_front_mode_alert_row.twig', { alert_class: 'ec-maintenanceAlert', message_key: 'front.under_maintenance' }) }}
+        {% endif %}
+        {% if show_debug %}
+            {{ include('_front_mode_alert_row.twig', { alert_class: 'ec-debugModeAlert', message_key: 'front.under_debug_mode' }) }}
+        {% endif %}
+        {% if show_admin_on_front %}
+            {{ include('_front_mode_alert_row.twig', { alert_class: 'ec-adminLoginAlert', message_key: 'front.admin_login_active' }) }}
+        {% endif %}
+    </div>
 {% endif %}
 
-<div class="ec-layoutRole">
+<div class="ec-layoutRole" style="--ec-mode-alert-strips: {{ mode_alert_count }}">
     {# Layout: HEADER #}
     {% if Layout.Header %}
         <header class="ec-layoutRole__header">

--- a/src/Eccube/Resource/template/default/default_frame.twig
+++ b/src/Eccube/Resource/template/default/default_frame.twig
@@ -54,17 +54,17 @@ file that was distributed with this source code.
     {% if plugin_assets is defined %}{{ include('@admin/snippet.twig', { snippets: plugin_assets }) }}{% endif %}
     <link rel="stylesheet" href="{{ asset('assets/css/customize.css', 'user_data') }}">
 </head>
-<body id="page_{{ app.request.get('_route') }}" class="{{ body_class|default('other_page') }}">
+{# メンテ / デバッグ / 管理セッション: body に --ec-mode-alert-strips（0〜3）を渡し、本文 padding と SP 固定ナビの top で帯分を確保 #}
+{% set show_maintenance = isMaintenance is defined and isMaintenance %}
+{% set show_debug = isDebugMode is defined and isDebugMode %}
+{% set show_admin_on_front = isAdminLoggedInOnFront is defined and isAdminLoggedInOnFront %}
+{% set mode_alert_count = (show_maintenance ? 1 : 0) + (show_debug ? 1 : 0) + (show_admin_on_front ? 1 : 0) %}
+<body id="page_{{ app.request.get('_route') }}" class="{{ body_class|default('other_page') }}" style="--ec-mode-alert-strips: {{ mode_alert_count }}">
 {# Layout: BODY_AFTER #}
 {% if Layout.BodyAfter %}
     {{ include('block.twig', {'Blocks': Layout.BodyAfter}) }}
 {% endif %}
 
-{# メンテ / デバッグ / 管理セッション: 本数に応じて .ec-layoutRole に --ec-mode-alert-strips を渡し padding-top で本文を下げる #}
-{% set show_maintenance = isMaintenance is defined and isMaintenance %}
-{% set show_debug = isDebugMode is defined and isDebugMode %}
-{% set show_admin_on_front = isAdminLoggedInOnFront is defined and isAdminLoggedInOnFront %}
-{% set mode_alert_count = (show_maintenance ? 1 : 0) + (show_debug ? 1 : 0) + (show_admin_on_front ? 1 : 0) %}
 {% if mode_alert_count > 0 %}
     <div class="ec-modeAlertStack" aria-live="polite">
         {% if show_maintenance %}
@@ -79,7 +79,7 @@ file that was distributed with this source code.
     </div>
 {% endif %}
 
-<div class="ec-layoutRole" style="--ec-mode-alert-strips: {{ mode_alert_count }}">
+<div class="ec-layoutRole">
     {# Layout: HEADER #}
     {% if Layout.Header %}
         <header class="ec-layoutRole__header">


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

<!-- ****************************************************************************
脆弱性報告 (Vulnerability report)
脆弱性のご報告は弊社[問い合わせフォーム](https://www.ec-cube.net/contact/)からお願いします。
**************************************************************************** -->

## 概要(Overview・Refs Issue)

店舗フロント表示時に、同一ブラウザに管理画面ログイン用セッション（`_security_admin`）が残っている場合に、画面上部へ注意帯を表示するようにしました。
また既存のメンテナンス／デバッグモードのレイアウトを一本化しています。

既存機能の、メンテナンスモードなどは従来どおり表示されます。マークアップとスタイルの当て方（固定スタック＋本文の padding-top）のみ変更し、見た目は維持しています。

画像：
<img width="1379" height="398" alt="スクリーンショット 2026-03-25 16 09 02" src="https://github.com/user-attachments/assets/bf4940d7-0ca4-413d-af8c-2c6a42493a2c" />


## 方針(Policy)

- 管理セッションの有無は、セッション読み込み後に判定する必要があるため、`TwigInitializeListener` に `KernelEvents::REQUEST` priority `-20` のハンドラを追加し、Twig グローバル `isAdminLoggedInOnFront` を付与する形にしました（既存の priority `6` の初期化処理とは分離）。
- 帯の見た目・重なり対策は、帯ごとに `position: fixed` と兄弟セレクタでマージンを積む方式から、**1 つの固定スタック＋本文側の余白**に変更し、メンテ有無の組み合わせでのずれを抑えます。
- デフォルトテンプレートの差分は `default_frame.twig` と行パーツ `_front_mode_alert_row.twig`、および `html/template/default` の SCSS／`style.css` に限定。
- Codeception の EA06 は、フロントの DOM が `ec-modeAlertStack` 配下になったことに合わせ、セレクタのみ追随（管理画面の操作フロー自体は変更なし）。

## 実装に関する補足(Appendix)

## テスト（Test)

- `codeception/acceptance/EA06ContentsManagementCest.php` の、メンテ有効化後のフロント確認用セレクタを `#page_homepage .ec-maintenanceAlert` 系に変更済み。
- （任意）`tests/Eccube/Tests/Web/FrontModeAlertTest.php` はローカル用／別コミット想定であれば本 PR には含めない想定可。

## 相談（Discussion）

- 文言・帯の色（管理セッション用の `$orange`）はデザイン調整の余地あり。
- default_frame.twigの変更があるため、カスタムテンプレートなどへの影響があるかもしれません。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません。
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません。
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません。*追加あり
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません。
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません。

## レビュワー確認項目

- [ ] 動作確認（メンテ ON/OFF、APP_DEBUG、管理ログイン有無の組み合わせで帯の本数と本文のずれ）
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認（EA06 の変更含む／必要なら CI 実行）
- [ ] 互換性が保持されているか（カスタム `default_frame` 利用者への影響説明で足りるか）
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか（表示のみ・セッションキー参照のみ）
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか（文言は `trans`、アイコンは固定パス）

Closes #5006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 管理画面にログイン中の場合、ストアフロント上に「管理画面にログイン中です。」という新しい警告アラートが表示されるようになりました。

* **改善**
  * 複数のアラート（メンテナンス、デバッグモード、管理ログイン）を同時に表示する際のレイアウトを統一し、ヘッダーや操作ボタンの位置もアラート表示に合わせて調整されます。

* **テスト**
  * メンテナンスモードに関する受け入れテストを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->