### PR TITLE
Dependabotにcooldown設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
     allow:
       - dependency-type: "all"
     ignore:
@@ -21,12 +23,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
 
   # npm の依存関係を維持する
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
     allow:
       - dependency-type: "all"
     ignore:


### PR DESCRIPTION
## Summary
- Dependabotの全ecosystem（composer, github-actions, npm）に `cooldown: default-days: 5` を追加
- 公開から5日経過したバージョンのみを更新対象とすることで、サプライチェーン攻撃のリスクを軽減
- セキュリティアップデートはcooldownの対象外のため、即座にPRが作成される

## Reference
- https://zenn.dev/yamachu/articles/7e59341013fd10
- https://docs.github.com/en/code-security/dependabot/configuration-options-for-the-dependabot.yml-file/configuration-options-for-the-dependabot.yml-file#cooldown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

本リリースには、エンドユーザーに影響する変更はありません。

* **チア（Chores）**
  * 依存関係管理の設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->