### PR TITLE
fix(CI/CD): Dockerbuild が失敗していたため修正

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,6 +4,8 @@ use Eccube\Kernel;
 use Eccube\Service\SystemService;
 use Symfony\Component\ErrorHandler\Debug;
 use Dotenv\Dotenv;
+use Dotenv\Repository\Adapter\PutenvAdapter;
+use Dotenv\Repository\RepositoryBuilder;
 use Symfony\Component\HttpFoundation\Request;
 
 // システム要件チェック
@@ -37,7 +39,17 @@ if (!isset($_SERVER['APP_ENV'])) {
     // APP_ENV が環境変数として設定されている場合（Docker など）でも .env を読み込む。
     // ただし既存の環境変数（Docker で設定済みのもの）は上書きしない。
     // これにより管理画面からのテンプレート切り替えが .env への書き込みで反映される。
-    (Dotenv::createImmutable(__DIR__))->safeLoad();
+    //
+    // 既定の createImmutable は $_ENV / $_SERVER / Apache CGI でのみ既存値を判定し、
+    // putenv 経由の値は見ない。Apache の PassEnv で渡されない変数 (DATABASE_URL 等) や
+    // PHP の variables_order に E が含まれない構成では、本来 Docker から渡された env が
+    // 「未設定」と誤判定され、.env の値で $_SERVER 等を上書きしてしまう。
+    // PutenvAdapter を明示的に追加することで getenv 側の既存値も尊重する。
+    $repository = RepositoryBuilder::createWithDefaultAdapters()
+        ->addAdapter(PutenvAdapter::class)
+        ->immutable()
+        ->make();
+    Dotenv::create($repository, __DIR__)->safeLoad();
 }
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
 


### PR DESCRIPTION


<!-- 以下を参考にコメントを作成してください。 -->

<!-- ****************************************************************************
脆弱性報告 (Vulnerability report)
脆弱性のご報告は弊社[問い合わせフォーム](https://www.ec-cube.net/contact/)からお願いします。
**************************************************************************** -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

PR #6712 の `Dotenv::createImmutable($dir)->safeLoad()` 追加後, CI の dockerbuild (admin01) が全 PHP バージョンで一貫して 500 になっていた. 原因は vlucas/phpdotenv の `createImmutable` のデフォルト adapter が `ApacheAdapter / EnvConstAdapter / ServerConstAdapter` のみで `PutenvAdapter` を含まないこと.

失敗経路 (CI Apache 環境):

- Apache の `PassEnv` は `APP_ENV APP_DEBUG TRUSTED_PROXIES TRUSTED_HOSTS` のみで `DATABASE_URL` を渡していない → `$_SERVER['DATABASE_URL']` 未設定
- PHP の `variables_order` 既定値 (`GPCS`) は スーパーグローバル`$_ENV`( E ) を含まない → `$_ENV['DATABASE_URL']` 未設定
- `getenv('DATABASE_URL')` だけが Docker 由来の postgres URL を保持

この状態で `createImmutable` の immutability check は「既存値なし」と判定し `.env` の `DATABASE_URL=sqlite:///var/eccube.db` を `$_SERVER` / `$_ENV` に 書き込んでしまう. 

Symfony の `EnvVarProcessor` は `$_SERVER` を最優先で読むため 本来の postgres ではなく SQLite に接続し, `no such table: dtb_base_info` で 500 を引き起こしていた.

- vlucas/phpdotenv v5.6.3 の挙動で確認
- 最小再現スクリプトで OLD/NEW の差分検証済み

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

`RepositoryBuilder::createWithDefaultAdapters()->addAdapter(PutenvAdapter::class)` で putenv 由来の値も既存値として尊重するように修正する.


## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 環境変数を介して設定される場合の環境設定の読み込み処理を改善し、既存の環境変数が正しく尊重されるようになりました。Docker などのコンテナ環境でのより安定した動作を実現します。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EC-CUBE/ec-cube/pull/6752)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->