### PR TITLE
fix: ステートレスAPIリクエストでUnexpectedSessionUsageExceptionが発生する問題を修正

### DIFF
--- a/src/Eccube/EventListener/SecurityListener.php
+++ b/src/Eccube/EventListener/SecurityListener.php
@@ -58,6 +58,14 @@ class SecurityListener implements EventSubscriberInterface
     public function onAuthenticationFailure(LoginFailureEvent $event): void
     {
         $request = $this->requestStack->getCurrentRequest();
+
+        // login_memory はフロントのログインフォーム専用のため, ステートレスなファイアウォール(API 等)では
+        // セッションを使用しない. ステートレスなリクエストでセッションを使用すると
+        // UnexpectedSessionUsageException が発生し, 認証失敗時に 401 ではなく 500 を返してしまう.
+        if ($request->attributes->get('_stateless', false) || !$request->hasSession()) {
+            return;
+        }
+
         $request->getSession()->set('_security.login_memory', (bool) $request->request->get('login_memory', 0));
     }
 

--- a/tests/Eccube/Tests/EventListener/SecurityListenerTest.php
+++ b/tests/Eccube/Tests/EventListener/SecurityListenerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\EventListener;
+
+use Eccube\EventListener\SecurityListener;
+use Eccube\Tests\Web\AbstractWebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Event\LoginFailureEvent;
+
+final class SecurityListenerTest extends AbstractWebTestCase
+{
+    /**
+     * ステートフルなリクエスト(フロントのログインフォーム)では,
+     * login_memory の値がセッションに保存されること.
+     */
+    public function testOnAuthenticationFailureStoresLoginMemory(): void
+    {
+        $request = Request::create($this->generateUrl('mypage_login'), Request::METHOD_POST, ['login_memory' => '1']);
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        $this->dispatchLoginFailureEvent($request);
+
+        $this->assertTrue($session->get('_security.login_memory'));
+    }
+
+    /**
+     * ステートレスなファイアウォール(API 等)からの認証失敗では, セッションを使用しないこと.
+     *
+     * セッションを使用すると UnexpectedSessionUsageException が発生し,
+     * 401 を返すべきところが 500 になる.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/pull/6760
+     */
+    public function testOnAuthenticationFailureWithStatelessRequest(): void
+    {
+        $request = Request::create('/api', Request::METHOD_POST);
+        $request->attributes->set('_stateless', true);
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        $this->dispatchLoginFailureEvent($request);
+
+        $this->assertFalse($session->isStarted());
+        $this->assertNull($session->get('_security.login_memory'));
+    }
+
+    /**
+     * セッションを持たないリクエストでは, SessionNotFoundException を発生させないこと.
+     */
+    public function testOnAuthenticationFailureWithoutSession(): void
+    {
+        $request = Request::create('/api', Request::METHOD_POST);
+
+        $this->dispatchLoginFailureEvent($request);
+
+        $this->assertFalse($request->hasSession());
+    }
+
+    private function dispatchLoginFailureEvent(Request $request): void
+    {
+        $requestStack = static::getContainer()->get(RequestStack::class);
+        $requestStack->push($request);
+
+        $event = new LoginFailureEvent(
+            new AuthenticationException(),
+            $this->createStub(AuthenticatorInterface::class),
+            $request,
+            null,
+            'customer'
+        );
+
+        try {
+            static::getContainer()->get(SecurityListener::class)->onAuthenticationFailure($event);
+        } finally {
+            $requestStack->pop();
+        }
+    }
+}


### PR DESCRIPTION
## 概要

`stateless` なファイアウォール（`/api` 等）に対して認証失敗が発生した際、`SecurityListener::onAuthenticationFailure()` がセッションに書き込もうとするため `UnexpectedSessionUsageException` が発生し、本来 401 を返すべきところが 500 になる問題を修正します。

## 問題の詳細

EC-CUBE の Api42 プラグインは `/api` を `stateless` で設定しています。このため Bearer トークン認証に失敗した場合（例：トークン期限切れ）に 500 エラーになります。

**エラーログ:**

```
request.CRITICAL: Uncaught PHP Exception
Symfony\Component\HttpKernel\Exception\UnexpectedSessionUsageException:
"Session was used while the request was declared stateless."
at AbstractSessionListener.php line 224
[POST, /api, ...]
```

**原因:**

`SecurityListener::onAuthenticationFailure()` は、フロントのログインフォームの「ログイン状態を保持する」チェックボックスの値をセッションに保存するために書かれたコードです。しかしこのリスナーは API からの認証失敗でも呼ばれるため、ステートレスなリクエストでセッションに書き込もうとして例外が発生します。

## 修正方針

`login_memory` はフロントのログインフォーム専用の値のため、次の場合は何もせず早期リターンします。

- リクエストがステートレスな場合（`_stateless` 属性）
- リクエストがセッションを持たない場合

```php
public function onAuthenticationFailure(LoginFailureEvent $event): void
{
    $request = $this->requestStack->getCurrentRequest();

    // login_memory はフロントのログインフォーム専用のため, ステートレスなファイアウォール(API 等)では
    // セッションを使用しない. ステートレスなリクエストでセッションを使用すると
    // UnexpectedSessionUsageException が発生し, 認証失敗時に 401 ではなく 500 を返してしまう.
    if ($request->attributes->get('_stateless', false) || !$request->hasSession()) {
        return;
    }

    $request->getSession()->set('_security.login_memory', (bool) $request->request->get('login_memory', 0));
}
```

### `_stateless` を判定に使う理由

`UnexpectedSessionUsageException` を送出する `Symfony\Component\HttpKernel\EventListener\AbstractSessionListener` は、2 つの経路のいずれも `_stateless` 属性でゲートしています（symfony/http-kernel v7.4.13）。

- `onKernelResponse()`: `if (!$event->getRequest()->attributes->get('_stateless', false)) { return; }` の後に throw
- `onSessionUsage()`: リクエストスタックを走査して `_stateless` が真の場合のみ throw

つまり `_stateless` は Symfony が例外を投げる条件そのものであり、過不足のない判定になります。

なお「セッションが未開始か」（`$session->isStarted()`）で判定する方法もありますが、ステートフルなリクエストでセッションがまだ開始されていない場合に `login_memory` を保存できなくなるため、`_stateless` での判定としました。

## 影響範囲

- フロントのログイン機能には影響なし（ステートフルなリクエストでは従来通り `login_memory` を保存）
- Api42 プラグイン使用時の Bearer トークン認証で、認証失敗時に正しく 401 が返るようになる

## テスト

`tests/Eccube/Tests/EventListener/SecurityListenerTest.php` を追加しました。

| テスト | 内容 |
|---|---|
| `testOnAuthenticationFailureStoresLoginMemory` | ステートフルなリクエストでは `_security.login_memory` が保存されること |
| `testOnAuthenticationFailureWithStatelessRequest` | ステートレスなリクエストではセッションを一切使用しないこと（`isStarted()` が false のまま） |
| `testOnAuthenticationFailureWithoutSession` | セッションを持たないリクエストで `SessionNotFoundException` が発生しないこと |

修正を取り消すと後者 2 件が失敗することを確認済みです。

**ローカルでの確認結果:**

- `vendor/bin/phpunit tests/Eccube/Tests/EventListener/SecurityListenerTest.php` → OK (3 tests, 4 assertions)
- `vendor/bin/phpunit tests/Eccube/Tests/Web/Mypage/MypageControllerTest.php tests/Eccube/Tests/Web/PasswordNormalizationLoginTest.php` → OK (20 tests, 34 assertions)
- `vendor/bin/phpstan analyse src`（level 6）→ エラーなし
- `vendor/bin/php-cs-fixer fix --dry-run --diff` → 差分なし
- `vendor/bin/rector process --dry-run --config=rector.php` → 差分なし

## 互換性

- 既存の public メソッドのシグネチャ変更なし
- フックポイント・パラメータの削除／型変更なし
- 入出力フォーマットの変更なし
