### PR TITLE
chore(husky): pre-commit で rector / phpstan / cs-fixer を dry-run 実行

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,55 @@
-npx lint-staged -q || node -e ''
+#!/usr/bin/env sh
+# Pre-commit hook
+# stage に *.php があれば:
+#   1. rector --dry-run で project-wide チェック
+#   2. phpstan で静的解析
+#   3. lint-staged で php-cs-fixer を auto-fix (style 修正)
+# rector / phpstan が修正点・エラーを検出したらコミット中止.
+# cs-fixer は logic を変えない style 修正のみのため最後に auto-fix.
+#
+# 各ツールのコマンドは以下の workflow に準拠:
+#   - .github/workflows/rector.yml      (path: var/rector_cache)
+#   - .github/workflows/phpstan.yml     (path: /tmp/phpstan)
+#   - .github/workflows/php-cs-fixer.yml は lint-staged 側で対応
+
+# stage された .php ファイルを抽出
+STAGED_PHP=$(git diff --cached --name-only --diff-filter=ACMR | grep '\.php$' || true)
+
+if [ -z "$STAGED_PHP" ]; then
+  exit 0
+fi
+
+echo "Pre-commit: staged .php detected; running checks"
+echo ""
+
+# 1. Rector (dry-run)
+echo "[1/3] vendor/bin/rector process --dry-run --ansi --config=rector.php"
+rm -rf var/rector_cache
+if ! vendor/bin/rector process --dry-run --ansi --config=rector.php; then
+  echo ""
+  echo "FAIL: Rector で修正点が検出されました。修正する場合:"
+  echo "  vendor/bin/rector process --config=rector.php"
+  exit 1
+fi
+echo ""
+
+# 2. PHPStan
+echo "[2/3] vendor/bin/phpstan analyze src/"
+rm -rf /tmp/phpstan
+if ! vendor/bin/phpstan analyze src/; then
+  echo ""
+  echo "FAIL: PHPStan エラーが検出されました"
+  exit 1
+fi
+echo ""
+
+# 3. lint-staged (php-cs-fixer auto-fix)
+echo "[3/3] npx lint-staged (php-cs-fixer auto-fix)"
+if ! npx lint-staged; then
+  echo ""
+  echo "FAIL: lint-staged で失敗しました"
+  exit 1
+fi
+echo ""
+
+echo "Pre-commit: all checks passed"


### PR DESCRIPTION
   ## 概要

  `.husky/pre-commit` を強化し、stage に `.php` を含む commit 前に **rector → phpstan → php-cs-fixer の順で実行** するように変更する。

  - rector / phpstan: **dry-run** で検出、違反があればコミット中止
  - php-cs-fixer: `lint-staged` 経由で **staged file のみ auto-fix** (既存実装)

  ## 前提環境

  - `composer install` で `vendor/bin/{rector,phpstan,php-cs-fixer}` が揃っていること
  - 初回のみ `bin/console cache:warmup --env=dev` で `var/cache/dev/Eccube_KernelDevDebugContainer.xml` を生成 (rector が参照するため)

  ## 改善案

  - stage に `.php` が含まれる場合のみ実行 (それ以外は exit 0)
  - 実行順序:
    1. `vendor/bin/rector process --dry-run --ansi --config=rector.php`
    2. `vendor/bin/phpstan analyze src/`
    3. `npx lint-staged` (php-cs-fixer auto-fix)
  - rector / phpstan が非 0 → 修正手順をエラーメッセージで案内して `exit 1`
  - 全 pass → commit 続行

  ## 動作ロジック

  旧 hook では lint-staged (php-cs-fixer auto-fix) だけが走っていた。
  これは style 修正には十分だが、ロジック品質・静的解析違反は CI まで検出されなかった。
  本 PR で rector と phpstan を追加し、CI と同じ判定をローカル commit 段階で受けられるようにする。
  cs-fixer は logic を変えない style 修正のみなので **従来通り lint-staged で auto-fix のまま** 残す。

  加えて、旧 hook の `|| node -e ''` (lint-staged 失敗を握り潰す部分) を撤去した。
  lint-staged 自体が失敗する時点で何かおかしい状態なので、コミットを止める方針とする。

  ## Test plan

  - [ ] staged に `.php` を含まない commit はスキップされる
  - [ ] staged に `.php` を含む commit:
    - [ ] 3 ステップ全 pass → commit 成功
    - [ ] rector が修正点を検出 → commit 中止 + 修正コマンドの案内が出る
    - [ ] phpstan がエラーを検出 → commit 中止
    - [ ] cs-fixer の style 違反は auto-fix されて commit に取り込まれる
  - [ ] `HUSKY=0 git commit ...` で hook をスキップできる

  ## スキップ

  `HUSKY=0 git commit ...` で hook をスキップ可能 (husky 9 公式機能)。

