### PR TITLE
fix: ゲスト購入時のスコープレート制限で発生する TypeErrorを修正

### DIFF
--- a/src/Eccube/EventListener/RateLimiterListener.php
+++ b/src/Eccube/EventListener/RateLimiterListener.php
@@ -74,8 +74,14 @@ class RateLimiterListener implements EventSubscriberInterface
             /** @var RateLimiterFactory $factory */
             $factory = $this->locator->get($limiterId);
             if (in_array('customer', $config['type']) || in_array('user', $config['type'])) {
-                /** @var Customer|Member $User */
+                /** @var Customer|Member|null $User */
                 $User = $this->requestContext->getCurrentUser();
+                // ゲスト購入時など未ログイン経路でも customer / user スコープのレート制限が
+                // 設定された route (例: shopping_shipping_multiple_edit) に到達することがある.
+                // その場合 $User は null となり, getId() で TypeError になるため早期 continue する.
+                if ($User === null) {
+                    continue;
+                }
                 $limiter = $factory->create((string) $User->getId());
                 if (!$limiter->consume()->isAccepted()) {
                     throw new TooManyRequestsHttpException();


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

<!-- ****************************************************************************
脆弱性報告 (Vulnerability report)
脆弱性のご報告は弊社[問い合わせフォーム](https://www.ec-cube.net/contact/)からお願いします。
**************************************************************************** -->

## 概要(Overview・Refs Issue)

  ゲスト購入時 (未ログイン状態) に user / customerスコープのレート制限が設定されたエンドポイント (例: /shopping/shipping_multiple_edit) に POST すると、prod環境で「システムエラーが発生しました。」になるバグの修正。

## 方針(Policy)

- RateLimiterListener::onController で$this->requestContext->getCurrentUser() が nullを返したケースを早期 continue でスキップ
- userスコープのレート制限は本来「ログインユーザ単位で計測」が目的なので、未ログイン経路では適用対象外と扱う

## 実装に関する補足(Appendix)

  - null ガード 1 行 + コメントの追加のみで挙動を維持
  - ip スコープのレート制限は従来どおり機能する
  - app/config/eccube/packages/prod/eccube_rate_limiter.yaml 側の
  shopping_shipping_multiple_edit_customer 等の設定はそのまま
  (type: user であってもゲスト到達時にエラーにしない)

##  テスト(Test)

###  再現手順

1. 未ログインのままカートに商品追加 → ご注文手続き
2. お届け先を複数指定 → お届け先追加(/shopping/shipping_multiple_edit への POST)

修正後: 正常に追加画面へ遷移、ゲスト購入完了まで通る
修正前: prod 環境で「システムエラーが発生しました。」


###  確認観点

  - 未ログインで shopping_shipping_multiple_edit / shopping_shipping_edit への POST
  が通ること
  - ログインユーザでは従来どおり user スコープのレート制限が機能すること (10 回/30
  分の制限を超えると TooManyRequestsHttpException)
  
  ## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
