### PR TITLE
fix(ci): dockerbuild ワークフローの起動失敗を解消し PR でも実行可能にする

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -1,9 +1,6 @@
 name: Testing dockerbuild
 on:
-  push:
-    paths:
-      - '**'
-      - '!*.md'
+  workflow_call:
   release:
     types: [ published ]
 env:
@@ -20,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-24.04 ]
-        php: [ '8.4', '8.5' ]
+        php: [ '8.3', '8.4', '8.5' ]
         db: [ pgsql ]
         include:
           - db: pgsql
@@ -45,22 +42,8 @@ jobs:
       # - name: Set up Docker Buildx
       #   uses: docker/setup-buildx-action@v2
 
-      - name: Setup PHP
-        uses: nanasess/setup-php@bc11abbf4dd060b7bfd20d03edeeb43417ebe245  # master
-        with:
-          php-version: ${{ matrix.php }}
-
-      - name: Install ext-redis 6.1+
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y php${{ matrix.php }}-redis
-          sudo phpenmod -s cli redis
-          php -m | grep -i redis
-
-      - name: Initialize Composer
-        uses: ./.github/actions/composer
-
       - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4
         with:
           registry: ghcr.io
@@ -104,8 +87,8 @@ jobs:
       ## see https://docs.github.com/ja/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action
 
       - name: Push Docker image
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7
-        if: success()
         with:
           context: .
           push: true

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -25,10 +25,14 @@ jobs:
             database_server_version: 14
           - php: '8.3'
             tag: '8.3-apache'
+            ext_install_args: 'zip gd mysqli pdo_mysql opcache intl'
           - php: '8.4'
             tag: '8.4-apache'
+            ext_install_args: 'zip gd mysqli pdo_mysql opcache intl'
+          # PHP 8.5 以降は opcache がコア組み込みのため install 対象から除外する
           - php: '8.5'
             tag: '8.5-apache'
+            ext_install_args: 'zip gd mysqli pdo_mysql intl'
 
     steps:
       - name: downcase REPO
@@ -69,7 +73,9 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: TAG=${{ matrix.tag }}
+          build-args: |
+            TAG=${{ matrix.tag }}
+            EXT_INSTALL_ARGS=${{ matrix.ext_install_args }}
 
       - name: Setup to EC-CUBE
         env:
@@ -95,4 +101,6 @@ jobs:
           # platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: TAG=${{ matrix.tag }}
+          build-args: |
+            TAG=${{ matrix.tag }}
+            EXT_INSTALL_ARGS=${{ matrix.ext_install_args }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,11 @@ jobs:
   e2e-test:
     needs: [ rector, phpstan, php-cs-fixer ]
     uses: ./.github/workflows/e2e-test.yml
+  dockerbuild:
+    uses: ./.github/workflows/dockerbuild.yml
+    permissions:
+      contents: read
+      packages: write
   plugin-test:
     needs: [ unit-test, e2e-test ]
     uses: ./.github/workflows/plugin-test.yml
@@ -44,7 +49,7 @@ jobs:
 #    needs: [ plugin-test ]
 #    uses: ./.github/workflows/deny-test.yml
   success:
-    needs: [ e2e-test-throttling ]
+    needs: [ e2e-test-throttling, dockerbuild ]
     runs-on: ubuntu-latest
     steps:
       - name: success

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,14 @@ RUN apt update \
   && locale-gen \
   ;
 
-RUN docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
-  && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
-  && docker-php-ext-install -j$(nproc) zip gd mysqli pdo_mysql opcache intl pgsql pdo_pgsql \
+# PHP 8.5 以降は opcache がコアに静的組み込みされ共有モジュール (.so) を生成しないため、
+# EXT_INSTALL_ARGS から opcache を外す。インストール対象はワークフロー側でバージョン別に制御する。
+ARG GD_OPTIONS="--with-freetype --with-jpeg --with-webp"
+ARG EXT_INSTALL_ARGS="zip gd mysqli pdo_mysql opcache intl"
+
+RUN docker-php-ext-install -j$(nproc) pgsql pdo_pgsql \
+  && docker-php-ext-configure gd ${GD_OPTIONS} \
+  && docker-php-ext-install -j$(nproc) ${EXT_INSTALL_ARGS} \
   ;
 
 RUN pecl install apcu && echo "extension=apcu.so" > /usr/local/etc/php/conf.d/apc.ini


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

`Testing dockerbuild` ワークフロー (`.github/workflows/dockerbuild.yml`) が 2026-05-13 以降、`4.4` ブランチで連続失敗していた問題を修正する。

失敗 run の例: https://github.com/EC-CUBE/ec-cube/actions/runs/26124921377

GitHub UI には「This run likely failed because of a workflow file issue」と表示され、`gh api /repos/EC-CUBE/ec-cube/actions/runs/<id>/jobs` の結果が `{"total_count":0,"jobs":[]}` となっており、ステップ実行前の workflow ファイル検証段階で失敗していた。

合わせて以下を整理する。

- `main.yml` 経由で PR でも dockerbuild の失敗を検知できるようにする
- Codeception 削除 (#6778) で不要になったホスト側 PHP/Composer セットアップを削除

## 方針(Policy)

### 起動失敗の根本原因

`dockerbuild.yml` の matrix 定義で `include` 内に **orphan な `{php: '8.3', tag: '8.3-apache'}` エントリ** が残存していた。

base matrix は `php: ['8.4', '8.5']` (8.3 が外れている) のため、GitHub Actions の [matrix include 仕様](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations) により `{php: '8.3', tag: '8.3-apache'}` は既存 combination にマージできず新規 combination として作成されるが、この新規 combination には `operating-system` が含まれず `runs-on: \${{ matrix.operating-system }}` が空となり workflow 検証エラーで起動失敗していた。

直接の起点は 2025-11-25 の commit `42a0cec799` (`ci: GitHub ActionsでPHP 8.4と8.5のサポートを追加`) で base を `php: ['8.4'] → ['8.4', '8.5']` に変更しつつ include の 8.3 エントリを残置したこと。2026-05-13 以降は `4.4` (旧 `4.3-symfony7`) ブランチが現役 CI 対象となり、毎 push で workflow 起動失敗が顕在化していた。

### 修正内容

base matrix に `'8.3'` を再加入し、include の 8.3 エントリと整合させる。`unit-test.yml` / `plugin-test.yml` / `e2e-test.yml` も 8.3 をテスト対象としている点とも揃う。

### PR 時の失敗検知

`dockerbuild.yml` を `on.workflow_call:` に変更し `main.yml` から呼び出す。`success` ジョブの `needs` に `dockerbuild` を追加し、PR の dockerbuild が失敗すれば `success` に到達しない構成にした。

PR では ghcr.io への push は行わず、ビルドと `docker compose up --wait` での EC-CUBE 起動確認までを実施する。

### 不要ステップの削除

#6778 で Codeception が削除されたため、ホスト側で動かしていた以下のステップは不要となり削除する。

- `Setup PHP`
- `Install ext-redis 6.1+`
- `Initialize Composer`

`.dockerignore` で `vendor/` を除外しているため、ホスト側 `composer install` の結果は Docker イメージに反映されず、これらは Codeception 実行のためだけに存在していた。

## 実装に関する補足(Appendix)

- `on.release` は維持。タグ公開時は従来通り `dockerbuild.yml` が直接トリガーされ ghcr.io にイメージを push する。
- `main.yml` の `dockerbuild` ジョブには `needs:` を指定しておらず、`rector` / `phpstan` / `php-cs-fixer` と並列で実行される (DX 上、Docker ビルドは早期に結果が出る方が便利なため)。
- `Login to GitHub Container Registry` / `Push Docker image` は `if: github.event_name != 'pull_request'` でガード。PR 由来の `GITHUB_TOKEN` が `packages: write` を持たないケースで失敗するのを避けるため。

## テスト（Test)

- [x] YAML 構文チェック: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dockerbuild.yml'))"` で OK
- [x] matrix 展開: 3 ジョブ (8.3 / 8.4 / 8.5) になることを確認
- [ ] このブランチ向け PR で `main.yml` 経由の `dockerbuild` ジョブが実際に起動し、各 PHP バージョンで Docker ビルド + EC-CUBE 起動確認まで通ることを確認
- [ ] マージ後、`4.4` への push で `Testing dockerbuild` ワークフローが起動し ghcr.io への push まで完了することを確認

## 相談（Discussion）

- 現状 dockerbuild は `4.4` で 8.3 / 8.4 / 8.5 の 3 並列。CI 時間が気になるようなら PR 時のみ 1 バージョンに絞る等の制限を検討する余地がある。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CIワークフロー間の呼び出しを許可し、パイプラインの柔軟性を向上
  * ビルドマトリクスに PHP 8.3 を追加
  * E2E 前にイメージビルドを組み込み、ビルドジョブにコンテナ書き込み権限を付与
  * Docker イメージビルド処理を見直し、拡張インストールの振る舞いや条件実行を最適化

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EC-CUBE/ec-cube/pull/6784?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->