### PR TITLE
chore: Dependabot のスケジュールを月曜 07:00 JST に固定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Asia/Tokyo"
     cooldown:
       default-days: 5
     allow:
@@ -23,6 +26,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Asia/Tokyo"
     cooldown:
       default-days: 5
 
@@ -31,6 +37,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Asia/Tokyo"
     cooldown:
       default-days: 5
     allow:


### PR DESCRIPTION
## 概要

Dependabot の `weekly` スケジュールに曜日・時刻・タイムゾーンを明示し、**月曜 07:00 (Asia/Tokyo)** に一括生成するよう固定します。

## 背景

現状は 3 エコシステム (composer / github-actions / npm) すべてで `schedule.interval: "weekly"` のみ指定で、曜日・時刻・タイムゾーンが未指定です。この場合の既定は月曜 05:00 UTC ですが、Dependabot 側のジッター (数時間の遅延) と `cooldown.default-days: 5` が重なることで PR 生成が後続の実行回にずれ込み、**水曜 15:00 JST 前後に固まって出てくる**挙動になりがちでした。

この時間帯は Dependabot PR の定時マージ作業を行っており、作業中に新規 PR が割り込むと取りこぼしやレビューの混乱が起きやすい状況でした。

## 変更内容

```yaml
schedule:
  interval: "weekly"
  day: "monday"
  time: "07:00"
  timezone: "Asia/Tokyo"
```

- **月曜 07:00 JST に一括生成** → 水曜のマージ作業時点では PR がすべて出揃い、2 日間「枯れた」安定状態でレビュー・マージできる。
- **水曜の作業中に新規 PR が割り込まない** (ジッターを考慮しても月曜なら水曜午後には影響しない)。
- `cooldown` はそのまま維持 (スケジュール時刻にチェックし、5 日未満のものは次回に回る)。

composer / github-actions / npm の 3 エコシステムすべてに同一設定を適用しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存関係の自動更新スケジュールを設定しました。毎週月曜の午前7時（日本時間）に定期実行されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->