### PR TITLE
fix: LoginFailureEvent の passport が null で 500 エラーになる問題を修正

### DIFF
--- a/src/Eccube/EventListener/LoginHistoryListener.php
+++ b/src/Eccube/EventListener/LoginHistoryListener.php
@@ -85,14 +85,15 @@ class LoginHistoryListener implements EventSubscriberInterface
             return;
         }
 
-        $Member = null;
-        $userName = null;
+        // Bearer/AccessToken 系認証で passport 生成前に失敗した場合は null になる.
+        // UserBadge を持たない場合もユーザーを特定できないため、ログイン履歴の記録対象外とする.
         $passport = $event->getPassport();
-        if ($passport->hasBadge(UserBadge::class) && $passport->getBadge(UserBadge::class) instanceof UserBadge) {
-            $userName = $passport->getBadge(UserBadge::class)
-                ->getUserIdentifier();
-            $Member = $this->memberRepository->findOneBy(['login_id' => $userName]);
+        if ($passport === null || !$passport->hasBadge(UserBadge::class)) {
+            return;
         }
+
+        $userName = $passport->getBadge(UserBadge::class)->getUserIdentifier();
+        $Member = $this->memberRepository->findOneBy(['login_id' => $userName]);
 
         $LoginHistory = new LoginHistory();
         $LoginHistory

--- a/tests/Eccube/Tests/EventListener/LoginHistoryListenerTest.php
+++ b/tests/Eccube/Tests/EventListener/LoginHistoryListenerTest.php
@@ -15,10 +15,17 @@ declare(strict_types=1);
 
 namespace Eccube\Tests\EventListener;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\LoginHistory;
 use Eccube\Entity\Master\LoginHistoryStatus;
+use Eccube\EventListener\LoginHistoryListener;
 use Eccube\Tests\Web\AbstractWebTestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Event\LoginFailureEvent;
 
 final class LoginHistoryListenerTest extends AbstractWebTestCase
 {
@@ -62,5 +69,63 @@ final class LoginHistoryListenerTest extends AbstractWebTestCase
             ]);
 
         $this->assertInstanceOf(LoginHistory::class, $LoginHistory);
+    }
+
+    /**
+     * passport が null の場合（Bearer/AccessToken 系認証でトークン抽出前に失敗した場合など）、
+     * 例外を発生させず、ログイン履歴も記録しないこと.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6783
+     */
+    public function testOnAuthenticationFailureWithNullPassport()
+    {
+        $countBefore = $this->countFailureHistories();
+
+        $this->dispatchLoginFailureEvent(null);
+
+        $this->assertSame($countBefore, $this->countFailureHistories());
+    }
+
+    /**
+     * passport が UserBadge を持たない場合、ユーザーを特定できないため、
+     * 例外を発生させず、ログイン履歴も記録しないこと.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6783
+     */
+    public function testOnAuthenticationFailureWithoutUserBadge()
+    {
+        $countBefore = $this->countFailureHistories();
+
+        $passport = $this->createMock(Passport::class);
+        $passport->method('hasBadge')->willReturn(false);
+
+        $this->dispatchLoginFailureEvent($passport);
+
+        $this->assertSame($countBefore, $this->countFailureHistories());
+    }
+
+    private function dispatchLoginFailureEvent(?Passport $passport): void
+    {
+        $adminRoute = static::getContainer()->get(EccubeConfig::class)->get('eccube_admin_route');
+        $request = Request::create(sprintf('/%s/login', $adminRoute));
+
+        static::getContainer()->get(RequestStack::class)->push($request);
+
+        $event = new LoginFailureEvent(
+            new AuthenticationException(),
+            $this->createStub(AuthenticatorInterface::class),
+            $request,
+            null,
+            'admin',
+            $passport
+        );
+
+        static::getContainer()->get(LoginHistoryListener::class)->onAuthenticationFailure($event);
+    }
+
+    private function countFailureHistories(): int
+    {
+        return count($this->entityManager->getRepository(LoginHistory::class)
+            ->findBy(['Status' => LoginHistoryStatus::FAILURE]));
     }
 }


### PR DESCRIPTION

<!-- 以下を参考にコメントを作成してください。 -->

<!-- ****************************************************************************
脆弱性報告 (Vulnerability report)
脆弱性のご報告は弊社[問い合わせフォーム](https://www.ec-cube.net/contact/)からお願いします。
**************************************************************************** -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

Closes #6783

管理画面ログイン失敗時に発火するLoginHistoryListener::onAuthenticationFailure()が、LoginFailureEvent::getPassport()(戻り値は nullable な?Passport)を null チェックせずに hasBadge()を呼んでいたため、passport が生成される前に認証が失敗するケースでFatal Error → 500 になっていた。


## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->
早期 returnする(Issue 記載の修正方針案を採用)。
これにより passport null と UserBadge なしの両経路を同時に解消できる。

これらの失敗は dtb_login_historyには記録されない。
現在、ログイン失敗などは記録されていないため、現行実装に沿った形にした。

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 認証失敗時に一部の状況（認証情報が存在しない、または期待する識別情報がない場合）でも例外を発生させず、ログイン履歴記録の安定性を向上しました。

* **Tests**
  * 上記のケースを検証する自動テストを追加し、回帰防止を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->