### PR TITLE
docs: システム要件を 4.4 (Symfony 7.4 / PHP 8.2-8.5) に更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-EC-CUBE is Japan's leading open-source e-commerce platform. This is the 4.3 branch, built on Symfony 6.4 and PHP 8.1+.
+EC-CUBE is Japan's leading open-source e-commerce platform. This is the 4.4 branch, built on Symfony 7.4 and PHP 8.2+.
 
 - **Repository**: https://github.com/EC-CUBE/ec-cube
 - **Documentation**: https://doc4.ec-cube.net/
@@ -10,13 +10,13 @@ EC-CUBE is Japan's leading open-source e-commerce platform. This is the 4.3 bran
 
 ## Technology Stack
 
-- **PHP**: 8.1 / 8.2 / 8.3
-- **Framework**: Symfony 6.4 (full-stack)
-- **ORM**: Doctrine ORM 2.x, DBAL 3.x
-- **Template**: Twig 3.8
-- **Database**: PostgreSQL 12+ or MySQL 8.4
-- **Frontend**: Sass (SCSS), webpack, jQuery
-- **Testing**: PHPUnit (via symfony/phpunit-bridge), Codeception (E2E)
+- **PHP**: 8.2 / 8.3 / 8.4 / 8.5
+- **Framework**: Symfony 7.4 (full-stack)
+- **ORM**: Doctrine ORM 3.x, DBAL 4.x
+- **Template**: Twig 3.x
+- **Database**: PostgreSQL 13–18 or MySQL 8.4 LTS
+- **Frontend**: Sass (SCSS), webpack, Bootstrap 5.3, jQuery 4.x
+- **Testing**: PHPUnit 11 (via symfony/phpunit-bridge), Codeception 5 (E2E)
 - **Static Analysis**: PHPStan
 - **Code Style**: PHP-CS-Fixer
 
@@ -73,7 +73,7 @@ tests/
 docker compose -f docker-compose.yml -f docker-compose.pgsql.yml up -d
 
 # Composer
-composer create-project ec-cube/ec-cube ec-cube "4.3.x-dev" --keep-vcs
+composer create-project ec-cube/ec-cube ec-cube "4.4.x-dev" --keep-vcs
 bin/console eccube:install
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# EC-CUBE 4.3
+# EC-CUBE 4.4
 
-[![Unit test for EC-CUBE](https://github.com/EC-CUBE/ec-cube/actions/workflows/unit-test.yml/badge.svg?branch=4.3)](https://github.com/EC-CUBE/ec-cube/actions/workflows/unit-test.yml)
-[![E2E test for EC-CUBE](https://github.com/EC-CUBE/ec-cube/actions/workflows/e2e-test.yml/badge.svg?branch=4.3)](https://github.com/EC-CUBE/ec-cube/actions/workflows/e2e-test.yml)
-[![Plugin test for EC-CUBE](https://github.com/EC-CUBE/ec-cube/actions/workflows/plugin-test.yml/badge.svg?branch=4.3)](https://github.com/EC-CUBE/ec-cube/actions/workflows/plugin-test.yml)
-[![PHPStan](https://github.com/EC-CUBE/ec-cube/actions/workflows/phpstan.yml/badge.svg?branch=4.3)](https://github.com/EC-CUBE/ec-cube/actions/workflows/phpstan.yml)
-[![codecov](https://codecov.io/gh/EC-CUBE/ec-cube/branch/4.3/graph/badge.svg?token=BhnPjjvfwd)](https://codecov.io/gh/EC-CUBE/ec-cube)
+[![Unit test for EC-CUBE](https://github.com/EC-CUBE/ec-cube/actions/workflows/unit-test.yml/badge.svg?branch=4.4)](https://github.com/EC-CUBE/ec-cube/actions/workflows/unit-test.yml)
+[![E2E test for EC-CUBE](https://github.com/EC-CUBE/ec-cube/actions/workflows/e2e-test.yml/badge.svg?branch=4.4)](https://github.com/EC-CUBE/ec-cube/actions/workflows/e2e-test.yml)
+[![Plugin test for EC-CUBE](https://github.com/EC-CUBE/ec-cube/actions/workflows/plugin-test.yml/badge.svg?branch=4.4)](https://github.com/EC-CUBE/ec-cube/actions/workflows/plugin-test.yml)
+[![PHPStan](https://github.com/EC-CUBE/ec-cube/actions/workflows/phpstan.yml/badge.svg?branch=4.4)](https://github.com/EC-CUBE/ec-cube/actions/workflows/phpstan.yml)
+[![codecov](https://codecov.io/gh/EC-CUBE/ec-cube/branch/4.4/graph/badge.svg?token=BhnPjjvfwd)](https://codecov.io/gh/EC-CUBE/ec-cube)
 
 [![Slack](https://img.shields.io/badge/slack-join%5fchat-brightgreen.svg?style=flat)](https://join.slack.com/t/ec-cube/shared_invite/enQtNDA1MDYzNDQxMTIzLTY5MTRhOGQ2MmZhMjQxYTAwMmVlMDc5MDU2NjJlZmFiM2E3M2Q0M2Y3OTRlMGY4NTQzN2JiZDBkNmQwNTUzYzc)
 
-**4.2からの更新内容は[リリースノート](https://github.com/EC-CUBE/ec-cube/releases/tag/4.3.0)をご確認ください。**
+**4.4のリリース内容・計画は[ロードマップ](https://github.com/EC-CUBE/ec-cube/issues/6762)をご確認ください。**
 
 + 本ドキュメントはEC-CUBEの開発者を主要な対象者としております。
 + パッケージ版は[EC-CUBEオフィシャルサイト](https://www.ec-cube.net)で配布しています。
@@ -19,7 +19,7 @@
 
 ## インストール
 
-### EC-CUBE 4.3のインストール方法
+### EC-CUBE 4.4のインストール方法
 
 開発ドキュメントの [インストール方法](https://doc4.ec-cube.net/quickstart/install) の手順に従ってインストールしてください。
 
@@ -80,8 +80,8 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose
 ### 動作確認環境
 
 * Apache 2.4.x (mod_rewrite / mod_ssl 必須)
-* PHP 8.1.x / 8.2.x / 8.3.x
-* PostgreSQL 12.x or higher / MySQL 8.4.x
+* PHP 8.2.x / 8.3.x / 8.4.x / 8.5.x
+* PostgreSQL 13.x 〜 18.x / MySQL 8.4.x (LTS)
 * ブラウザー：Google Chrome
 
 詳しくは開発ドキュメントの [システム要件](https://doc4.ec-cube.net/quickstart/requirement) をご確認ください。
@@ -97,7 +97,7 @@ EC-CUBE 4.x 系の仕様や手順、開発Tipsに関するドキュメントを�
 
 ## 開発への参加
 
-EC-CUBE 4.3の不具合の修正、機能のブラッシュアップを目的として、継続的に開発を行っております。  
+EC-CUBE 4.4の不具合の修正、機能のブラッシュアップを目的として、継続的に開発を行っております。  
 コードのリファクタリング、不具合修正以外のPullRequestを送る際は、Pull Requestのコメントなどに意図を明確に記載してください。  
 
 Pull Requestの送信前に、Issueにて提議いただく事も可能です。
@@ -130,12 +130,12 @@ Key differentiators:
 
 | Component | Technology |
 |-----------|-----------|
-| Language | PHP 8.1 / 8.2 / 8.3 |
-| Framework | Symfony 6.4 |
-| ORM | Doctrine ORM 2.x |
-| Template | Twig 3.8 |
-| Database | PostgreSQL 12+ / MySQL 8.4 |
-| Frontend | Sass, webpack, jQuery |
+| Language | PHP 8.2 / 8.3 / 8.4 / 8.5 |
+| Framework | Symfony 7.4 |
+| ORM | Doctrine ORM 3.x, DBAL 4.x |
+| Template | Twig 3.x |
+| Database | PostgreSQL 13–18 / MySQL 8.4 LTS |
+| Frontend | Sass, webpack, Bootstrap 5.3, jQuery 4.x |
 
 ### Quick Start
 
@@ -151,7 +151,7 @@ docker compose -f docker-compose.yml -f docker-compose.pgsql.yml up -d
 #### Composer
 
 ```bash
-composer create-project ec-cube/ec-cube ec-cube "4.3.x-dev" --keep-vcs
+composer create-project ec-cube/ec-cube ec-cube "4.4.x-dev" --keep-vcs
 cd ec-cube
 bin/console eccube:install
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # EC-CUBE
 
-> EC-CUBE is Japan's leading open-source e-commerce platform, powering over 35,000 online stores. Built on Symfony 6.4 and PHP 8.1+, it provides a full-featured, highly customizable solution designed for the Japanese market — including reduced tax rates, point systems, multiple shipping addresses, and a robust plugin architecture.
+> EC-CUBE is Japan's leading open-source e-commerce platform, powering over 35,000 online stores. Built on Symfony 7.4 and PHP 8.2+, it provides a full-featured, highly customizable solution designed for the Japanese market — including reduced tax rates, point systems, multiple shipping addresses, and a robust plugin architecture.
 
 ## Quick Start
 
@@ -20,19 +20,19 @@ docker compose -f docker-compose.yml -f docker-compose.pgsql.yml up -d
 ### Composer
 
 ```bash
-composer create-project ec-cube/ec-cube ec-cube "4.3.x-dev" --keep-vcs
+composer create-project ec-cube/ec-cube ec-cube "4.4.x-dev" --keep-vcs
 cd ec-cube
 bin/console eccube:install
 ```
 
 ## Architecture
 
-- **Framework**: Symfony 6.4 (full-stack)
-- **Language**: PHP 8.1 / 8.2 / 8.3
-- **ORM**: Doctrine ORM 2.x with Doctrine DBAL 3.x
-- **Template Engine**: Twig 3.8
-- **Database**: PostgreSQL 12+ or MySQL 8.4
-- **Frontend**: Sass (SCSS), webpack, jQuery
+- **Framework**: Symfony 7.4 (full-stack)
+- **Language**: PHP 8.2 / 8.3 / 8.4 / 8.5
+- **ORM**: Doctrine ORM 3.x with Doctrine DBAL 4.x
+- **Template Engine**: Twig 3.x
+- **Database**: PostgreSQL 13–18 or MySQL 8.4 LTS
+- **Frontend**: Sass (SCSS), webpack, Bootstrap 5.3, jQuery 4.x
 - **License**: GPL-2.0 / proprietary dual license
 
 ### Directory Structure


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

デフォルトブランチが 4.4 (Symfony 7.4) になりましたが、`README.md` / `CLAUDE.md` / `llms.txt` のシステム要件が 4.3 (Symfony 6.4 / PHP 8.1) のままだったため、4.4 系へ更新します。

要件値は 4.4 Roadmap (#6762) のシステム要件表に準拠しています。

Refs #6762

## 方針(Policy)

- ドキュメント記載値は Issue #6762 のシステム要件・フレームワーク表に合わせました。
- `composer.json` / `package.json` / CI matrix (`unit-test.yml`) と突き合わせて検証済みの項目:
  - PHP `^8.2`(CI: 8.2/8.3/8.4/8.5)、Symfony `^7.4`、Doctrine ORM `^3.0`、PHPUnit `^11.0`、Codeception `^5.0`、Bootstrap `^5.3.8`

## 実装に関する補足(Appendix)

主な変更点:

- バージョン表記・CI バッジ・リリースノートリンク・インストール例を `4.3` → `4.4`
- 動作確認環境 / Technology Stack:
  - PHP 8.2〜8.5 / Symfony 7.4 / Doctrine ORM 3.x・DBAL 4.x / Twig 3.x
  - PostgreSQL 13〜18 / MySQL 8.4 LTS / Bootstrap 5.3 / jQuery 4.x / PHPUnit 11 / Codeception 5

補足(レビュー時の判断材料):

- **Doctrine DBAL / jQuery** は Roadmap (#6762) の 4.x 表記に合わせていますが、現状コードはそれぞれ `doctrine/dbal ^3.8` / `jquery ^3.7.1` で **まだ 3.x** です。実装の追従後に整合します。
- 以下はドキュメントではなくインフラ/コードのため本 PR には**含めていません**(別途対応を想定):
  - `docker-compose.yml` のデフォルト `TAG:-8.1-apache`(PHP 8.1 は EOL)
  - `docker-compose.pgsql.yml` の `postgres:14`(CI は `postgres:16`)
  - `src/Eccube/Common/Constant.php` の `VERSION = '4.3.1-p1'`

## テスト（Test)

ドキュメントのみの変更のため、ビルド・テストへの影響はありません。

## 相談（Discussion）

DBAL / jQuery を Roadmap 準拠の 4.x 表記としていますが、実装が 3.x のままのため「現状の実体に合わせる(3.x)」方が適切であればご指摘ください。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * EC-CUBE 4.4 対応のドキュメントに更新しました
  * インストール手順を 4.4.x-dev に対応させました
  * PHP 8.2～8.5、PostgreSQL 13～18、MySQL 8.4 LTS の動作要件を更新しました
  * 技術スタック情報（Symfony 7.4、PHP 8.2+ など）を最新化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->