### PR TITLE
ci: コードカバレッジのアップロード先を Codecov から GitHub Code Quality に移行

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  code-quality: write
 
 jobs:
   phpunit:
@@ -13,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.4', '8.5' ]
+        php: [ '8.5' ]
         db: [ pgsql ]
         include:
           - db: pgsql
@@ -42,7 +43,7 @@ jobs:
 
       - name: Setup pcov
         run: |
-          sudo apt-get install -y php8.4-pcov
+          sudo apt-get install -y php${{ matrix.php }}-pcov
           sudo phpenmod -s cli pcov
 
       - name: Initialize Composer
@@ -63,6 +64,7 @@ jobs:
           bin/console eccube:fixtures:load
 
       - name: PHPUnit
+        id: phpunit
         env:
           APP_ENV: 'test'
           DATABASE_URL: ${{ matrix.database_url }}
@@ -72,7 +74,19 @@ jobs:
         run: |
           echo "session.save_path=$PWD/var/sessions/test" > php.ini
           echo "memory_limit=1012M" >> php.ini
-          php -c php.ini -dpcov.enabled=1 vendor/bin/phpunit --exclude-group cache-clear --exclude-group cache-clear-install --exclude-group update-schema-doctrine --coverage-clover=coverage1.xml --testdox
+          php -c php.ini -dpcov.enabled=1 vendor/bin/phpunit --exclude-group cache-clear --exclude-group cache-clear-install --exclude-group update-schema-doctrine --coverage-cobertura=coverage1.xml --testdox
+      # GitHub のコードカバレッジ (Code Quality) にアップロードする。
+      # - PHPUnit ステップの outcome でガードする: 上記の continue-on-error により
+      #   テストがクラッシュしてもジョブは成功扱いのままになり、coverage1.xml が
+      #   欠損・不完全な状態でアップロードされる恐れがあるため。
+      # - fork からの PR ではアクション内部でスキップされる (GITHUB_TOKEN が read-only のため)。
+      - name: Upload coverage to GitHub
+        if: steps.phpunit.outcome == 'success'
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3  # v1.3.0
+        with:
+          file: coverage1.xml
+          language: PHP
+          label: Unit
       - name: Upload report
         if: success()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,4 +57,8 @@ jobs:
   coverage:
     needs: [ unit-test ]  # PHPUnit coverage only, no need to wait for e2e-test
     if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      code-quality: write
+    secrets: inherit  # Codecov アップロードに CODECOV_TOKEN が必要
     uses: ./.github/workflows/coverage.yml


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

コードカバレッジを GitHub Code Qualityにも送信し、PR上でカバレッジ差分をネイティブ表示できるようにします。`Codecovとは共存`させます。

  ## 方針(Policy)
  - [公式ドキュメント](https://docs.github.com/en/code-security/how-tos/maintain-quality-code/set-up-code-coverage)に従い `actions/upload-code-coverage`(SHAピン留め)でアップロード
  
  - fork PR では GitHub ネイティブ表示が動作しないため Codecov と共存(fork PR はCodecov が担当)。`secrets: inherit` を追加しトークン未着も修正
  - カバレッジ形式を Clover → Cobertura に変更(GitHub の対応形式。Codecov も読める)
  - coverage の matrix を PHP 8.5 のみに縮小(合否判定は unit-test.yml が8.2〜8.5×3DB で実施済み)

  ## 実装に関する補足(Appendix)

  - fork PR では GITHUB_TOKEN が read-only のため、アクションが自動スキップ(これが Codecov を残す理由)
  - pcov のパッケージ名ハードコードを `php${{ matrix.php }}-pcov`に変更
  - 前提: リポジトリの Code Quality 有効化(済)

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

### Codecov(fork PR の表示担当)
- 本 PR(fork)の CI で Codecov へのアップロードが成功し、PRにカバレッジが表示されること
- マージ後の 4.4 push で、ベースライン送信が成功すること(`secrets: inherit`修正の確認)

### GitHub Code Quality(同一リポジトリ PR の表示担当)
- 本 PR では「Upload coverage to GitHub」がスキップされること(forkのため)
- マージ後の 4.4 push で、アップロードが成功しベースラインが記録されること
- その後、本体リポジトリのブランチから PR を作成し、PR上にカバレッジが表示されること

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更はありません
- [ ] フックポイントの呼び出しタイミングの変更はありません
- [ ] フックポイントのパラメータの削除・データ型の変更はありません
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [ ] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストには、エンドユーザーに対する表面的な変更はありません。内部の継続的インテグレーション基盤の改善のみが含まれています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->