### PR TITLE
fix: Shipping エンティティの nullable カラムと型定義の不整合を修正

### DIFF
--- a/src/Eccube/Entity/Shipping.php
+++ b/src/Eccube/Entity/Shipping.php
@@ -239,7 +239,7 @@ if (!class_exists(Shipping::class)) {
         /**
          * Set kana01.
          */
-        public function setKana01(string $kana01): Shipping
+        public function setKana01(?string $kana01): Shipping
         {
             $this->kana01 = $kana01;
 
@@ -249,7 +249,7 @@ if (!class_exists(Shipping::class)) {
         /**
          * Get kana01.
          */
-        public function getKana01(): string
+        public function getKana01(): ?string
         {
             return $this->kana01;
         }
@@ -257,7 +257,7 @@ if (!class_exists(Shipping::class)) {
         /**
          * Set kana02.
          */
-        public function setKana02(string $kana02): Shipping
+        public function setKana02(?string $kana02): Shipping
         {
             $this->kana02 = $kana02;
 
@@ -267,7 +267,7 @@ if (!class_exists(Shipping::class)) {
         /**
          * Get kana02.
          */
-        public function getKana02(): string
+        public function getKana02(): ?string
         {
             return $this->kana02;
         }
@@ -643,7 +643,7 @@ if (!class_exists(Shipping::class)) {
         /**
          * Set trackingNumber
          */
-        public function setTrackingNumber(string $trackingNumber): Shipping
+        public function setTrackingNumber(?string $trackingNumber): Shipping
         {
             $this->tracking_number = $trackingNumber;
 


### PR DESCRIPTION
## 概要

`dtb_shipping` のスキーマ定義(`#[ORM\Column]` の `nullable: true`)と、`Shipping` エンティティの getter / setter の型定義に不整合があったため修正します。

PR #6802 のレビュー指摘([pullrequestreview-4417047208](https://github.com/EC-CUBE/ec-cube/pull/6802#pullrequestreview-4417047208))で「別PRで Shipping 側を修正すべき」とされた内容に対応するものです。

## 不整合の内容

| カラム | スキーマ | 修正前 getter | 修正前 setter |
|---|---|---|---|
| `kana01` | `nullable: true` | `getKana01(): string` | `setKana01(string)` |
| `kana02` | `nullable: true` | `getKana02(): string` | `setKana02(string)` |
| `tracking_number` | `nullable: true` | `getTrackingNumber(): ?string`(整合済) | `setTrackingNumber(string)` |

`kana01` / `kana02` はカラムが nullable にもかかわらず getter 戻り型が非null (`string`) だったため、DB に `NULL` が格納されている `Shipping` を読み込んで getter を呼ぶと `TypeError` が発生する状態でした。

## 修正内容

`src/Eccube/Entity/Shipping.php`:

- `getKana01()` / `getKana02()` の戻り型を `?string` に変更
- `setKana01()` / `setKana02()` の引数型を `?string` に変更
- `setTrackingNumber()` の引数型を `?string` に変更

## 補足

- `Customer` / `CustomerAddress` の同名カラムは既に `?string` で定義されており、本変更で住所系エンティティ間の型定義が揃います。
- getter 戻り型・setter 引数を nullable に**広げる後方互換な変更**です。`CustomerAddress::setFromShipping()` 等の呼び出し側にも影響はありません。
- PHPStan(`Shipping.php` / `CustomerAddress.php`)は問題なく通過することを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 配送情報の個人情報系フィールド（フリガナ、追跡番号）について、空値の取り扱いに対応しました。これにより、これらのフィールドはより柔軟に処理されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->