### PR TITLE
fix: PHPサポートバージョン (8.2〜8.5) の設定不整合とcomposer.json repositoriesの修正

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -17,12 +17,15 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-24.04 ]
-        php: [ '8.3', '8.4', '8.5' ]
+        php: [ '8.2', '8.3', '8.4', '8.5' ]
         db: [ pgsql ]
         include:
           - db: pgsql
             database_url: postgres://dbuser:secret@127.0.0.1:15432/eccubedb
             database_server_version: 14
+          - php: '8.2'
+            tag: '8.2-apache'
+            ext_install_args: 'zip gd mysqli pdo_mysql opcache intl'
           - php: '8.3'
             tag: '8.3-apache'
             ext_install_args: 'zip gd mysqli pdo_mysql opcache intl'

--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-24.04 ]
-        php: [ '8.2', '8.3', '8.4' ]
+        php: [ '8.2', '8.3', '8.4', '8.5' ]
         db: [ pgsql, mysql ]
         method:
           - test_install_enable_disable_remove_store
@@ -168,7 +168,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-24.04 ]
-        php: [ '8.2', '8.3', '8.4' ]
+        php: [ '8.2', '8.3', '8.4', '8.5' ]
         db: [ pgsql, mysql ]
         method:
           - test_install_update_remove_store
@@ -318,7 +318,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-24.04 ]
-        php: [ '8.2', '8.3', '8.4' ]
+        php: [ '8.2', '8.3', '8.4', '8.5' ]
         db: [ pgsql, mysql ]
         method:
           - test_extend_same_table_store
@@ -468,7 +468,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-24.04 ]
-        php: [ '8.2', '8.3', '8.4' ]
+        php: [ '8.2', '8.3', '8.4', '8.5' ]
         db: [ pgsql, mysql ]
         method:
           - test_dependency_each_install_plugin

--- a/.github/workflows/zaproxy.yml
+++ b/.github/workflows/zaproxy.yml
@@ -179,7 +179,7 @@ jobs:
       - name: Load image
         run: |
           docker load --input /tmp/ec-cube.tar
-          docker tag ec-cube ghcr.io/ec-cube/ec-cube-php:8.1-apache
+          docker tag ec-cube ghcr.io/ec-cube/ec-cube-php:8.2-apache
 
       - name: Run containers
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TAG=8.1-apache-bullseye
+ARG TAG=8.2-apache
 FROM php:${TAG}
 
 ENV APACHE_DOCUMENT_ROOT /var/www/html

--- a/composer.json
+++ b/composer.json
@@ -184,7 +184,7 @@
     },
     "config": {
         "platform": {
-            "php": "8.3.24"
+            "php": "8.2.0"
         },
         "preferred-install": {
             "*": "dist"
@@ -198,17 +198,5 @@
             "phpstan/extension-installer": true,
             "symfony/flex": true
         }
-    },
-    "repositories": [
-        {
-            "name": "eccube",
-            "type": "composer",
-            "url": "https://package-api-c2.ec-cube.net/v43",
-            "options": {
-                "http": {
-                    "header": ["X-ECCUBE-KEY: abcxyzABCXYZ123098"]
-                }
-            }
-        }
-        ]
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa5a33881c14453ea071a6d0c574e9f2",
+    "content-hash": "98f03b30b0f09f78545a7ae3f43316e9",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -15429,7 +15429,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.3.24"
+        "php": "8.2.0"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,9 @@ services:
   ### ECCube4 ##################################
   ec-cube:
     ### ローカルでビルドする場合は以下のコマンドを使用します
-    ## docker build -t ec-cube --no-cache --pull --build-arg TAG=8.1-apache .
-    ## docker tag ec-cube ghcr.io/ec-cube/ec-cube-php:8.1-apache
-    image: ${REGISTRY:-ghcr.io}/${IMAGE_NAME:-ec-cube/ec-cube-php}:${TAG:-8.1-apache}
+    ## docker build -t ec-cube --no-cache --pull --build-arg TAG=8.2-apache .
+    ## docker tag ec-cube ghcr.io/ec-cube/ec-cube-php:8.2-apache
+    image: ${REGISTRY:-ghcr.io}/${IMAGE_NAME:-ec-cube/ec-cube-php}:${TAG:-8.2-apache}
     ports:
       - 8080:80
       - 4430:443


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

4.4 のサポート対象 PHP バージョン (8.2.x / 8.3.x / 8.4.x / 8.5.x) と、Docker・CI・composer 設定の各所が一致していなかったため修正します。あわせて `composer.json` の `repositories` にハードコードされていたプレースホルダ設定を除去し、4.3 ブランチ同様の動的設定方式へ揃えます。

主な不整合:
- `docker-compose.yml` / `Dockerfile` の既定タグがサポート外の `8.1-apache`
- `dockerbuild.yml` のマトリクスが `8.3`〜`8.5` で `8.2` が抜け
- `plugin-test.yml` の主要ジョブが `8.2`〜`8.4` で `8.5` が抜け
- `zaproxy.yml` のイメージタグが `8.1-apache`
- `composer.json` の `repositories` にプレースホルダ URL (`v43`) と仮キーがハードコード

## 方針(Policy)

- **PHP バージョン**: サポート対象 (8.2〜8.5) に各設定を統一。単一バージョンで十分な静的解析 (phpstan/php-cs-fixer/rector/deny-test) やデプロイ系 (deploy/vaddy) は変更せず、補助ジョブ (plugin-assets/plugin-misc) も単一バージョン維持。`coverage.yml` は計測コスト観点から現状維持。
- **repositories**: 4.3 ブランチには `composer.json` に `repositories` キーが存在せず、プラグイン操作時に `ComposerApiService::init()` が `composer config repositories.eccube` で動的設定する仕組み。4.4 でもこの動的ロジックは健在のため、ハードコードを除去して 4.3 と同じ挙動に揃えました。
- **platform.php**: 最小サポートの `8.2.0` に変更 (従来 `8.3.24`)。8.2 環境で動作しない依存の混入を防ぐ目的。

## 実装に関する補足(Appendix)

- `composer.lock` は `repositories` 削除 (Composer 2 では content-hash の対象) と `platform-overrides` 同期のため `composer update --lock` を実行。依存パッケージのバージョン変更はありません (「Nothing to modify in lock file」)。
- コミットは指示により composer.* とそれ以外で分割しています。

## テスト（Test)

- `composer validate --no-check-publish` → valid
- `git grep` でサポート外の `8.1` 参照が残っていないことを確認 (zap のテストフィクスチャを除く)

## 相談（Discussion）

- `coverage.yml` のマトリクス (現状 8.4/8.5) を 8.2〜8.5 へ拡張すべきか、CI 時間とのトレードオフでご相談させてください。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * PHP 8.5 対応のテストマトリクスを追加

* **改善**
  * 基盤となる PHP イメージを 8.2 へアップグレード
  * ビルドおよびテストワークフローを PHP 8.2〜8.5 対応に更新
  * Docker ベースイメージを PHP 8.2-apache に統一

<!-- end of auto-generated comment: release notes by coderabbit.ai -->