### PR TITLE
chore: docker compose build で PHP バージョンを TAG で切り替え可能にする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,17 @@ volumes:
 services:
   ### ECCube4 ##################################
   ec-cube:
-    ### ローカルでビルドする場合は以下のコマンドを使用します
-    ## docker build -t ec-cube --no-cache --pull --build-arg TAG=8.1-apache .
-    ## docker tag ec-cube ghcr.io/ec-cube/ec-cube-php:8.1-apache
+    ### 別バージョンの PHP でローカルビルドする場合は環境変数 TAG を指定します
+    ## TAG=8.3-apache docker compose build
+    ## TAG=8.3-apache docker compose build --no-cache
+    ## TAG=8.3-apache docker compose up -d --build
     image: ${REGISTRY:-ghcr.io}/${IMAGE_NAME:-ec-cube/ec-cube-php}:${TAG:-8.1-apache}
+    build:
+      context: .
+      args:
+        TAG: ${TAG:-8.1-apache}
+      pull: true
+    pull_policy: missing
     ports:
       - 8080:80
       - 4430:443


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

ec-cube2 の EC-CUBE/ec-cube2#1405 と同様に、`docker compose build` で環境変数 `TAG` を指定するだけで任意の PHP バージョンのイメージをローカルビルドできるようにします。これまで必要だった手動の `docker build` + `docker tag` の手順を不要にします。

## 方針(Policy)

- EC-CUBE/ec-cube2#1405 にならい、`ec-cube` サービスに `build` セクションと `pull_policy: missing` を追加
- `build.args.TAG` を `image` のタグと同じ環境変数 `${TAG:-8.1-apache}` で共有し、ビルドするタグと付与されるイメージ名を常に一致させる
- `pull_policy: missing` により、通常の `docker compose up` は従来どおり registry (ghcr.io) からイメージを取得する挙動を維持

## 実装に関する補足(Appendix)

変更は `docker-compose.yml` のみです。

```yaml
    build:
      context: .
      args:
        TAG: ${TAG:-8.1-apache}
      pull: true
    pull_policy: missing
```

手動ビルド用のコメントも環境変数ベースの手順に置き換えています。

```
TAG=8.3-apache docker compose build
TAG=8.3-apache docker compose build --no-cache
TAG=8.3-apache docker compose up -d --build
```

DB バックエンドを指定する場合は `COMPOSE_FILE` と併用します。

```
COMPOSE_FILE=docker-compose.yml:docker-compose.pgsql.yml TAG=8.3-apache docker compose build
```

## テスト（Test)

`docker compose config` で構成が正しく解決されることを確認済みです。

- デフォルト: `args.TAG: 8.1-apache` / `image: ghcr.io/ec-cube/ec-cube-php:8.1-apache`
- `TAG=8.3-apache` 指定時: `args.TAG` と `image` のタグが連動して `8.3-apache` に切り替わる

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **その他（Chores）**
  * Docker環境構成を見直し、イメージのタグ切替に対応する設定を明確化しました。  
  * ビルド／取得の挙動やキャッシュ・プルに関する設定を整理し、ローカルでの複数バージョン対応手順の注釈を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->