### PR TITLE
chore: .claude/settings.json で .env の読み込みを deny する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Claude Code が `.env` を誤って読み取らないよう、プロジェクト共有設定 `.claude/settings.json` に Read 権限の deny ルールを追加します。

EC-CUBE では `.env` にデータベース接続情報・`APP_SECRET`・メール送信認証情報などの秘匿値が入ります。AI エージェントが `.env` を読むと、その内容が会話履歴・トランスクリプト・将来的なメモリやサマリへ転写される可能性があり、機密漏洩面が広がります。`.claude/settings.json` の `permissions.deny` に Read ルールを置くことで、ツール呼び出し段階で読み取りそのものをブロックします（プロンプトで「読まないで」と指示するより堅い）。

## 適用範囲（重要）

**本 PR の `.claude/settings.json` は Claude Code 専用の設定であり、Codex CLI / Gemini CLI / Google Antigravity / Cursor 等の他 AI ツールには適用されません。**

AGENTS.md にある通り、これらツール間で共有しているのは「規約・知識」（`AGENTS.md` と `.claude/skills/*` の Skill 群）のみで、「実行時パーミッション制御」は各ツール独自の機構です。Claude Code 以外のツールで同等の防御を入れたい場合は、各ツール側で個別に設定する必要があります（後述）。

## 変更内容

新規ファイル `.claude/settings.json`:

```json
{
  \"permissions\": {
    \"deny\": [
      \"Read(./.env)\",
      \"Read(./.env.*)\"
    ]
  }
}
```

- `Read(./.env)` — `.env` 本体
- `Read(./.env.*)` — `.env.local` / `.env.dev` / `.env.prod` など派生ファイル

EC-CUBE 4.4 の `.env` はプロジェクトルート直下にしか作られないため、`**/.env` のようなネストパターンは付けていません（実在しないパスに対するルールは無駄に冗長）。

## 設定ファイルの選択

`.claude/settings.json` はリポジトリにコミットしてチーム全体で共有される設定で、`.claude/settings.local.json`（個人用・gitignore 対象）とは性質が異なります。`.env` 漏洩防止はチーム全体に効かせるべきセキュリティ既定なので、共有側に置くのが妥当と判断しました。

Claude Code の権限ルールはツール × パターンで評価され、`deny` は `allow` より優先されます。個別開発者が `.claude/settings.local.json` で意図して上書きしない限り、`.env` への Read は確実にブロックされます。

## 他 AI ツールで同等の防御を入れる方法

本 PR の設定は Claude Code 以外には効きません。他ツールを併用する場合は各自で以下の設定を入れてください（リポジトリ共有設定としては今回追加しません — 各ツールの管理方針はユーザー側に委ねます）。

### Codex CLI

`~/.codex/config.toml` でサンドボックス／承認ポリシーを設定します。リポジトリ単位での deny パターン共有機構は提供されていないため、ユーザーごとに設定する必要があります。

```toml
# 例: ファイル書き込みは承認制、ネットワークは禁止
approval_policy = \"on-request\"
sandbox_mode = \"workspace-write\"

[sandbox_workspace_write]
network_access = false
```

機密ファイルの読み取りそのものをツール呼び出し段階でブロックする deny ルールは Codex CLI には現状ありません。**Read 前に毎回プロンプトで確認させる**運用（`approval_policy = \"on-request\"` または `\"untrusted\"`）が現実的な防御となります。

### Gemini CLI

Gemini CLI はパス単位の deny ルール機構を持ちません。実行ごとの承認（デフォルト）または YOLO モード（`--yolo`）の二択で、`.env` 読み取りをツール側でブロックする手段がありません。以下のいずれかで対処してください。

- デフォルトの承認モードのまま運用し、`.env` を読もうとしたら手動で拒否する
- `.gitignore` で確実にコミットを防ぎつつ、OS レベルの権限（`chmod 600 .env`）で実行ユーザー以外の読み取りを制限する

### Google Antigravity / Cursor

両ツールとも `.claude/skills/` を参照する仕組み（symlink 経由）はあるものの、Claude Code の `.claude/settings.json` のパーミッション設定は読まれません。各ツール側の設定機構に従ってください。

### 全ツール共通の最終防衛線

ツール非依存で効くのは以下です。AI ツール側の deny に頼り切らず、これらと併用するのが堅い構成です。

- `.gitignore` で `.env` を除外（リポジトリへの混入を防ぐ）— EC-CUBE は標準で対応済み
- OS レベルの権限制御（`chmod 600 .env`）
- 必要に応じてシークレットマネージャ（Vault, AWS Secrets Manager 等）に移行

## 想定する効果（Claude Code 利用時）

- AI エージェントが `.env` の中身をうっかり Read してしまうリスクを物理的に遮断
- 会話履歴 / トランスクリプト / 自動メモリへの秘匿情報の混入を抑止
- 「`.env` を読まないように」と毎回プロンプトで言わなくて済む

## 想定外（このPRでは対象外）

- `Bash(cat .env)` のようなシェル経由の読み取りまではブロックしていません。AI エージェントが `cat`/`grep` で `.env` を覗くケースまで塞ぐなら別途 `Bash(cat .env*:*)` 等の deny ルールが必要ですが、シェルパターンの取りこぼしリスクがあるためまずは Read ツールのみ対象としました（要望があれば別 PR で追加）。
- 既存プラグインや本体コードには影響しません。`.env` の読込は Symfony Dotenv が起動時にネイティブで行うため、Claude Code の Read 権限とは無関係です。
- Claude Code 以外の AI ツール（Codex CLI / Gemini CLI / Antigravity / Cursor 等）への適用は本 PR の対象外です（上記「他 AI ツールで同等の防御を入れる方法」参照）。

## Test plan

- [ ] `.claude/settings.json` が JSON として valid（`jq . .claude/settings.json` でパース可）
- [ ] Claude Code 起動後、`.env` を `Read` ツールで開こうとすると拒否される
- [ ] `.env.local` 等の `.env.*` 派生ファイルも同様に拒否される
- [ ] 既存の EC-CUBE 起動 / `bin/console` / テスト実行に影響がないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チア**
  * 開発環境の設定を更新しました。

---

**注記:** このリリースに含まれるのは内部設定の変更であり、エンドユーザーに対する機能追加やバグ修正はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
