### PR TITLE
ci: E2E の front-order / front-mypage / front-invoice を matrix に登録

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -30,6 +30,9 @@ jobs:
           - front-product
           - front-customer
           - front-other
+          - front-order
+          - front-mypage
+          - front-invoice
         include:
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db


### PR DESCRIPTION
## 概要

`e2e-test.yml` の matrix は**許可リスト**であり、列挙されていない spec は CI で一切実行されません。
以下の 3 spec はテストカバレッジ向上（6226f744f5）で 4.3 系に追加された当初から matrix 未登録のままで、**4.3 / 4.4 のいずれでも一度も CI で実行されていません**。本 PR で matrix に登録します。

| spec | テスト数 |
|---|---|
| `front-order.spec.ts` | 16 |
| `front-mypage.spec.ts` | 11（うち skip 1） |
| `front-invoice.spec.ts` | 2 |

## 背景・調査内容

- 実行コマンドは `npx playwright test --project=setup --project=front-tests <suite>.spec.ts` で、matrix の suite 名がそのまま spec ファイル名に対応する設計。
- `front-throttling` は `e2e-test-throttling.yml`、`deny` は `deny-test.yml`、`plugin-*` は `plugin-test.yml` で実行されており、配線漏れは本 3 件のみ。
- 参考: 同じ構造により、spec を追加しても matrix に登録しないと「CI がグリーンに見えるが実は実行されていない」状態になります（例: #6823 の `admin-order-display-setting.spec.ts` は `admin-order` ジョブのパターンにマッチせず未実行。ジョブログは `Running 18 tests` = admin-order 17 件 + setup 1 件）。

## 動作確認

- これらの spec は CI 実績がないため、**本 PR の CI が初めての実行**になります（`fail-fast: false` のため suite ごとに結果を確認できます）。
- ローカル（Docker dev 環境）では `front-mypage` 10 passed / `front-invoice` 1 passed を確認済み。各 1 件の失敗は dev 環境の Symfony デバッグツールバーが管理画面のクリックを横取りすることによるもので、CI の `APP_ENV=codeception`（ツールバー無効）では発生しません。

## 関連

- 追加元コミット: 6226f744f5「Increase test coverage: shopping flow, stock tests, EA07, layout, 2FA」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## テスト
* E2Eテストの実行範囲が拡大しました。注文、マイページ、請求書機能を対象とした新しいテストスイートが追加され、より包括的な品質確保が実現しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->