### PR TITLE
fix(ci): pcov を setup-php に統一して php8.5-pcov の apt 取得失敗を回避

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,11 +44,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: redis
-
-      - name: Setup pcov
-        run: |
-          sudo apt-get install -y php${{ matrix.php }}-pcov
-          sudo phpenmod -s cli pcov
+          coverage: pcov
 
       - name: Initialize Composer
         uses: ./.github/actions/composer


### PR DESCRIPTION
## 概要

`coverage / PHPUnit (8.5, pgsql)` ジョブが以下で失敗するようになったため修正します。

```
sudo apt-get install -y php8.5-pcov
E: Unable to locate package php8.5-pcov
##[error]Process completed with exit code 100
```

## 原因

- coverage.yml は pcov を **apt（Ondřej PPA）から OS パッケージとして導入**していた（2021年の導入時からの方式。apt-fast→apt-get と変遷）。
- `php8.5-pcov` が apt で取得できなくなり、`apt-get install` が "Unable to locate package" で失敗。
- 2026-06-11 時点では成功していたため、ワークフロー側の変更ではなく **apt/PPA 側の提供状況変化による外部要因の回帰**。

## 修正

pcov のインストールを apt から **`shivammathur/setup-php` の `coverage: pcov` 入力に統一**し、PPA の在庫状況に依存しないようにします。すぐ隣で同アクションを PHP 導入に使っているため、自然に寄せられます。

```diff
         with:
           php-version: ${{ matrix.php }}
           extensions: redis
-
-      - name: Setup pcov
-        run: |
-          sudo apt-get install -y php${{ matrix.php }}-pcov
-          sudo phpenmod -s cli pcov
+          coverage: pcov
```

## 備考

- codeception ジョブにも同様の apt 経由 pcov 導入（`php8.4-pcov`）がありますが、当該ジョブは `if: false` で無効化済みのため本PRの対象外としています。
- 動作確認: 本PRの CI で `coverage / PHPUnit (8.5, pgsql)` の `Setup PHP` ステップが成功し pcov が有効化されることを確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * テスト実行環境のセットアップを効率化しました。PCOV（コードカバレッジツール）の有効化プロセスが簡潔になり、テストの実行がより効率的になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->