### PR TITLE
test: 既知脆弱性クラスの回帰テストを補完（Host検証・トラバーサル経路・JS文脈エスケープ）

### DIFF
--- a/tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php
@@ -61,6 +61,80 @@ final class FileControllerTest extends AbstractAdminWebTestCase
         $this->assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
     }
 
+    /**
+     * download で select_file にディレクトリトラバーサル(`../`)を与えても弾かれることを確認する.
+     *
+     * checkDir() が `..` を含むパスを拒否するため 404 になる.
+     */
+    public function testDownloadWithTraversalFailure()
+    {
+        $filepath = $this->getUserDataDir().'/aaa.html';
+        $contents = '<html><body><h1>test</h1></body></html>';
+        file_put_contents($filepath, $contents);
+
+        $this->client->request(
+            Request::METHOD_GET,
+            $this->generateUrl('admin_content_file_download').'?select_file=/../user_data/aaa.html'
+        );
+        $this->assertFalse($this->client->getResponse()->isSuccessful());
+        $this->assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+    }
+
+    /**
+     * delete で select_file にディレクトリトラバーサル(`../`)を与えても
+     * user_data 外のファイルが削除されないことを確認する.
+     *
+     * checkDir() が `..` を含むパスを拒否するため, リダイレクトはするが remove は実行されない.
+     */
+    public function testDeleteWithTraversalDoesNotRemoveFile()
+    {
+        // user_data の外（親ディレクトリ）にファイルを作成する
+        $outsideFile = $this->getUserDataDir().'/../traversal_target.html';
+        file_put_contents($outsideFile, '<html><body><h1>target</h1></body></html>');
+
+        $this->client->request(
+            Request::METHOD_DELETE,
+            $this->generateUrl('admin_content_file_delete').'?select_file=/../traversal_target.html'
+        );
+
+        // checkDir で弾かれるため user_data 外のファイルは削除されない
+        $this->assertFileExists($outsideFile);
+
+        unlink($outsideFile);
+    }
+
+    /**
+     * create(mkdir) で now_dir にディレクトリトラバーサル(`../`)を与えても
+     * user_data 外にディレクトリが作成されないことを確認する.
+     *
+     * checkDir() が `..` を含む now_dir を拒否し, 作成先は user_data 直下にフォールバックする.
+     */
+    public function testIndexWithCreateTraversalStaysInUserDataDir()
+    {
+        $folder = 'traversal_folder';
+        $this->client->request(
+            Request::METHOD_POST,
+            $this->generateUrl('admin_content_file'),
+            [
+                'form' => [
+                    '_token' => 'dummy',
+                    'create_file' => $folder,
+                    'file' => '',
+                ],
+                'mode' => 'create',
+                'now_dir' => $this->getUserDataDir().'/../',
+            ]
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        // user_data 外（親ディレクトリ）には作成されない
+        $this->assertDirectoryDoesNotExist($this->getUserDataDir().'/../'.$folder);
+        // user_data 直下へフォールバックして作成される
+        $this->assertDirectoryExists($this->getUserDataDir().'/'.$folder);
+
+        rmdir($this->getUserDataDir().'/'.$folder);
+    }
+
     public function testDownload()
     {
         $filepath = $this->getUserDataDir().'/aaa.html';

--- a/tests/Eccube/Tests/Web/Admin/Store/AuthenticationSettingXssTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Store/AuthenticationSettingXssTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Web\Admin\Store;
+
+use Eccube\Entity\BaseInfo;
+use Eccube\Repository\BaseInfoRepository;
+use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Twig\Environment;
+use Twig\Runtime\EscaperRuntime;
+
+/**
+ * 認証設定画面(authentication_setting.twig)の JS コンテキスト XSS 回帰テスト.
+ *
+ * 店名(shop_name)は JavaScript 文字列リテラル内に出力されるため,
+ * `escape('js')` でエスケープされていないと JS 文字列を脱出して任意スクリプトを実行できる.
+ * テンプレートの `{{ eccubeShopName|escape('js') }}` が効いていることを検証する.
+ */
+final class AuthenticationSettingXssTest extends AbstractAdminWebTestCase
+{
+    private ?BaseInfoRepository $baseInfoRepository = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->baseInfoRepository = $this->entityManager->getRepository(BaseInfo::class);
+    }
+
+    public function testShopNameIsJsEscapedInAuthenticationSetting(): void
+    {
+        // JS 文字列リテラルを脱出しようとするペイロードを店名に設定する
+        $payload = '";alert(1)//';
+        $BaseInfo = $this->baseInfoRepository->get();
+        $BaseInfo->setShopName($payload);
+        $this->entityManager->persist($BaseInfo);
+        $this->entityManager->flush();
+
+        $this->client->request(
+            Request::METHOD_GET,
+            $this->generateUrl('admin_store_authentication_setting')
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $content = (string) $this->client->getResponse()->getContent();
+
+        // escape('js') が適用された期待値を Twig 環境から実際に算出する（エスケープ仕様変更にも追従させる）
+        /** @var Environment $twig */
+        $twig = static::getContainer()->get(Environment::class);
+        $expectedEscaped = $twig->getRuntime(EscaperRuntime::class)->escape($payload, 'js');
+
+        // ペイロードに二重引用符が含まれているため, JS エスケープすると元の並びとは変わるはず
+        $this->assertNotSame($payload, $expectedEscaped, '前提: ペイロードは escape(js) で変化するべき');
+
+        // 生のペイロード（JS 文字列を脱出する `";alert(1)` の並び）が出力されていないこと
+        $this->assertStringNotContainsString($payload, $content, 'JS 文字列を脱出する生ペイロードが出力されてはならない');
+        // escape('js') 適用後の文字列が出力されていること
+        $this->assertStringContainsString($expectedEscaped, $content, "escape('js') 適用後の文字列が出力されるべき");
+    }
+}

--- a/tests/Eccube/Tests/Web/TrustedHostsTest.php
+++ b/tests/Eccube/Tests/Web/TrustedHostsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Web;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * trusted_hosts による Host ヘッダインジェクション対策の回帰テスト.
+ *
+ * Symfony は trusted_hosts が設定されている場合, リクエストの Host ヘッダが
+ * 許可パターンに一致しないと SuspiciousOperationException を投げ, 400 を返す
+ * (ValidateRequestListener が毎リクエストで Request::getHost() を呼ぶ).
+ *
+ * trusted_hosts は static な Request::$trustedHostPatterns で管理されるため,
+ * テスト内で setTrustedHosts() を用いて設定状態を再現し, 元の値を tearDown で復元する.
+ */
+final class TrustedHostsTest extends AbstractWebTestCase
+{
+    /**
+     * @var string[]|null テスト前の trusted host パターン（復元用）
+     */
+    private ?array $originalTrustedHosts = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // 既存の trusted host パターンを退避する
+        $this->originalTrustedHosts = Request::getTrustedHosts();
+        // 許可ホストを設定する（管理画面の trusted_hosts 設定と同じ正規表現形式）
+        Request::setTrustedHosts(['^127\.0\.0\.1$', '^localhost$']);
+    }
+
+    protected function tearDown(): void
+    {
+        // static 状態を元に戻し, 他テストへ影響させない
+        // setTrustedHosts は `{...}i` 形式に包むため, 退避済みの値から元の生パターンへ戻す
+        $restored = array_map(
+            static fn (string $pattern): string => preg_replace('/^\{(.*)\}i$/', '$1', $pattern),
+            $this->originalTrustedHosts ?? []
+        );
+        Request::setTrustedHosts($restored);
+
+        parent::tearDown();
+    }
+
+    /**
+     * 許可されたホスト(localhost)からのアクセスは正常に処理される.
+     */
+    public function testTrustedHostIsAllowed(): void
+    {
+        $this->client->request(
+            Request::METHOD_GET,
+            $this->generateUrl('homepage'),
+            [],
+            [],
+            ['HTTP_HOST' => 'localhost']
+        );
+
+        $this->assertTrue(
+            $this->client->getResponse()->isSuccessful(),
+            '許可ホスト localhost からのアクセスは成功するべき. Status='.$this->client->getResponse()->getStatusCode()
+        );
+    }
+
+    /**
+     * 許可されていないホスト(evil.com)からのアクセスは 400 で拒否される.
+     */
+    public function testUntrustedHostIsRejected(): void
+    {
+        $this->client->request(
+            Request::METHOD_GET,
+            $this->generateUrl('homepage'),
+            [],
+            [],
+            ['HTTP_HOST' => 'evil.com']
+        );
+
+        $this->assertSame(
+            Response::HTTP_BAD_REQUEST,
+            $this->client->getResponse()->getStatusCode(),
+            '信頼できない Host ヘッダ(evil.com)は 400 で拒否されるべき'
+        );
+    }
+}


### PR DESCRIPTION
## 概要

EC-CUBE 公式の脆弱性履歴（4系）に対し**既存の回帰テストカバレッジを監査**し、**未カバーだった穴だけを補完**するセキュリティ回帰テストです。テスト追加のみで、`src/` の挙動は変更していません。

監査の結果、XSS（コンテンツ除去）・認可（Voter）・SSTI（Twig サンドボックス）・MFA・プラグイン install 検証などは**既に回帰テスト済み**でした。本 PR は残った 3 つの穴を埋めます。

## 追加するテスト

| テスト | 守る対象 | 内容 |
|---|---|---|
| `tests/Eccube/Tests/Web/TrustedHostsTest.php`（新規） | Host ヘッダ / trusted_hosts | trusted_hosts 設定下で不正 Host（`evil.com`）が 400 で拒否され、正規ホスト（`localhost`）は通ることを検証。`Request::setTrustedHosts()` で設定状態を再現し tearDown で復元（static 状態のリーク防止） |
| `tests/Eccube/Tests/Web/Admin/Content/FileControllerTest.php`（+3メソッド） | ディレクトリトラバーサル | download / delete / create（mkdir）で `select_file`・`now_dir` に `../` を与えても `html/user_data` の jail 外に出られないことを検証。既存の view ケース（`checkDir()`）に倣う |
| `tests/Eccube/Tests/Web/Admin/Store/AuthenticationSettingXssTest.php`（新規） | 管理画面 JS 文脈 XSS | `BaseInfo` の shop_name に `";alert(1)//` を入れても `escape('js')` で JS 文字列を脱出できないことを検証。期待値は `EscaperRuntime::escape()` で実行時算出（仕様変更に追従） |

## 回帰検知性（mutation テストで確認済み）

各テストは「防御を壊すと FAIL する」ことを確認しています:

- `checkDir()` の `..` 拒否＋jail を無効化 → トラバーサル 3 件が FAIL
- テンプレートの `|escape('js')` を除去 → XSS テストが FAIL
- trusted_hosts を未設定相当にする → 拒否テストが FAIL（`evil.com` が 200 になる）

## 確認

- 新規/変更テストは全 PASS（6 tests）。
- php-cs-fixer / Rector ともに clean。新規ファイルはライセンスヘッダ付き。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 管理画面のファイル操作で、`../` を含む入力によるディレクトリ移動が防がれることを確認する回帰テストを追加しました。
  * 認証設定画面で、ショップ名が JavaScript 文脈で適切にエスケープされることを確認するテストを追加しました。
  * Host ヘッダーの許可・拒否が正しく動作することを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->