### PR TITLE
feat: パスワード要件を NIST SP 800-63B-4 に準拠させる (#6488)

### DIFF
--- a/.claude/skills/formtype/SKILL.md
+++ b/.claude/skills/formtype/SKILL.md
@@ -77,3 +77,4 @@ class ExampleType extends AbstractType
 - ❌ 既存フォームをコアで直接改変 → ✅ `FormTypeExtension`（app/Customize）で拡張
 - ❌ 管理画面検索フォームで CSRF 無効化 → ✅ CSRF 保護を保つ
 - ❌ 具象クラス依存 → ✅ コンストラクタ DI ＋ 必要なサービスの注入
+- ❌ 共通 FormType(RepeatedPasswordType 等)を子で使い `options.constraints` を渡す（親が定義した制約が全置換され消える） → ✅ 親の制約一式も再掲して付与する

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -33,6 +33,7 @@ jobs:
           - front-order
           - front-mypage
           - front-invoice
+          - front-password-nist
         include:
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db

--- a/app/config/eccube/packages/codeception/eccube.yaml
+++ b/app/config/eccube/packages/codeception/eccube.yaml
@@ -1,0 +1,5 @@
+parameters:
+    # E2E(Playwright/codeception 環境)では HaveIBeenPwned への外部通信を行わない.
+    # 外部 API の可用性・内容に E2E が依存しないようにするため(test 環境と同方針).
+    # 長さ・パターン・ブロックリストの各検証は引き続き有効.
+    eccube_password_compromised_check: false

--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -55,7 +55,7 @@ parameters:
     eccube_csv_size: 5                 # post_max_size, upload_max_filesize に任せればよい？
     eccube_csv_temp_realdir: '%kernel.cache_dir%/%kernel.environment%/eccube' # upload_tmp_dir に任せればよい？
     eccube_csv_split_lines: 100
-    eccube_default_password: 'abc********123'
+    eccube_default_password: 'abc*********123'
     eccube_deliv_addr_max: 20
     eccube_deliv_date_end_max: 21
     eccube_id_max_len: 50
@@ -113,10 +113,17 @@ parameters:
     eccube_price_max: 2147483647
     eccube_tel_len_max: 14
     eccube_postal_code: 8
-    eccube_password_min_len: 12
-    eccube_password_max_len: 50
-    # see https://github.com/EC-CUBE/ec-cube2/blob/87e269314f92ebb169ea212bf304c9371bb12fd2/data/class/SC_CheckError.php#L889
-    eccube_password_pattern: '/\A(?=.*?[a-z])(?=.*?\d)[!-~]+\z/i'
+    # NIST SP 800-63B-4 に準拠し, 単要素認証では15文字以上を推奨
+    eccube_password_min_len: 15
+    eccube_password_max_len: 128
+    # NIST SP 800-63B-4 に準拠し, 文字種の複雑さは要求しない.
+    # 全Unicode文字(\pL 文字, \pM 結合文字, \pN 数字, \pP 記号, \pS 記号, \pZ 空白)を許可し,
+    # 制御文字・不可視文字(\pC)のみを拒否する.
+    eccube_password_pattern: '/\A[\pL\pM\pN\pP\pS\pZ]+\z/u'
+    # 漏洩パスワードチェック(HaveIBeenPwned)を有効にするか. 閉域網等では false に設定する.
+    eccube_password_compromised_check: true
+    # 簡単に推測されるパスワードのブロックリストファイル
+    eccube_password_blocklist: '%kernel.project_dir%/src/Eccube/Resource/password_blocklist.txt'
     eccube_composer_memory_limit: 1536M
     eccube_order_mail_template_id: 1 #注文受付メール
     eccube_entry_confirm_mail_template_id: 2 #会員仮登録メール

--- a/app/config/eccube/packages/test/eccube.yaml
+++ b/app/config/eccube/packages/test/eccube.yaml
@@ -1,3 +1,5 @@
 parameters:
-    # テスト環境では HaveIBeenPwned への外部通信を行わない
+    # テスト環境では HaveIBeenPwned への外部通信を行わない(NotCompromisedPassword を無効化).
+    # このため各フォームテストで「有効」と判定するパスワードは, 長さ・パターン・ブロックリストの
+    # 各層を通過することのみを意味し, 本番では HIBP 漏洩チェックにより別途弾かれ得る点に注意.
     eccube_password_compromised_check: false

--- a/app/config/eccube/packages/test/eccube.yaml
+++ b/app/config/eccube/packages/test/eccube.yaml
@@ -1,0 +1,3 @@
+parameters:
+    # テスト環境では HaveIBeenPwned への外部通信を行わない
+    eccube_password_compromised_check: false

--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
         "symfony/flex": "^2.7",
         "symfony/form": "^7.4",
         "symfony/framework-bundle": "^7.4",
+        "symfony/http-client": "^7.4",
         "symfony/http-foundation": "^7.4",
         "symfony/http-kernel": "^7.4",
         "symfony/intl": "^7.4",

--- a/composer.lock
+++ b/composer.lock
@@ -15619,5 +15619,5 @@
     "platform-overrides": {
         "php": "8.2.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98f03b30b0f09f78545a7ae3f43316e9",
+    "content-hash": "e1647bfa3f3b5c8f5aa869fdcc3a6561",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -7543,6 +7543,189 @@
                 }
             ],
             "time": "2026-03-30T12:55:43+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "e8a112b8415707265a7e614278136a9d92989a6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/e8a112b8415707265a7e614278136a9d92989a6a",
+                "reference": "e8a112b8415707265a7e614278136a9d92989a6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-client-contracts": "~3.4.4|^3.5.2",
+                "symfony/polyfill-php83": "^1.29",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "amphp/amp": "<2.5",
+                "amphp/socket": "<1.1",
+                "php-http/discovery": "<1.15",
+                "symfony/http-foundation": "<6.4"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "3.0"
+            },
+            "require-dev": {
+                "amphp/http-client": "^4.2.1|^5.0",
+                "amphp/http-tunnel": "^1.0|^2.0",
+                "guzzlehttp/promises": "^1.4|^2.0",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/amphp-http-client-meta": "^1.0|^2.0",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v7.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-24T09:57:54+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-06T13:17:50+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -15436,5 +15619,5 @@
     "platform-overrides": {
         "php": "8.2.0"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/e2e/tests/admin-auth.spec.ts
+++ b/e2e/tests/admin-auth.spec.ts
@@ -48,7 +48,7 @@ test.describe('Admin Authentication (EA02)', () => {
   test('authentication_非稼働_削除', async ({ page }) => {
     const loginId = 'not_active_test';
     const memberName = '非稼働テストメンバー';
-    const memberPassword = 'memberPass1234';
+    const memberPassword = 'EccubeMemberPass01';
 
     await loginAsAdmin(page);
 

--- a/e2e/tests/admin-basicinfo.spec.ts
+++ b/e2e/tests/admin-basicinfo.spec.ts
@@ -714,8 +714,8 @@ test.describe('Admin Basic Info (EA07)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(email1);
     await page.locator('#entry_email_second').fill(email1);
-    await page.locator('#entry_plain_password_first').fill('password1234');
-    await page.locator('#entry_plain_password_second').fill('password1234');
+    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
     await page.locator('#entry_user_policy_check').check();
     await page.locator('button.ec-blockBtn--action[type="submit"]').click();
     await page.waitForLoadState('load');
@@ -776,8 +776,8 @@ test.describe('Admin Basic Info (EA07)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(email2);
     await page.locator('#entry_email_second').fill(email2);
-    await page.locator('#entry_plain_password_first').fill('password1234');
-    await page.locator('#entry_plain_password_second').fill('password1234');
+    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
     await page.locator('#entry_user_policy_check').check();
     await page.locator('button.ec-blockBtn--action[type="submit"]').click();
     await page.waitForLoadState('load');

--- a/e2e/tests/admin-customer.spec.ts
+++ b/e2e/tests/admin-customer.spec.ts
@@ -49,8 +49,8 @@ test.describe('Admin Customer (EA05)', () => {
     await page.locator('#admin_customer_address_addr02').fill('ブリーゼタワー13F');
     await page.locator('#admin_customer_email').fill(createdCustomerEmail);
     await page.locator('#admin_customer_phone_number').fill('111111111');
-    await page.locator('#admin_customer_plain_password_first').fill('password1234');
-    await page.locator('#admin_customer_plain_password_second').fill('password1234');
+    await page.locator('#admin_customer_plain_password_first').fill('EccubeE2ePassword1');
+    await page.locator('#admin_customer_plain_password_second').fill('EccubeE2ePassword1');
 
     // Submit
     await page.locator('#customer_form .c-conversionArea button[type="submit"]').click();
@@ -234,8 +234,8 @@ test.describe('Admin Customer (EA05)', () => {
     await page.locator('#admin_customer_address_addr02').fill('梅田');
     await page.locator('#admin_customer_email').fill(cancelTestEmail);
     await page.locator('#admin_customer_phone_number').fill('111111111');
-    await page.locator('#admin_customer_plain_password_first').fill('password1234');
-    await page.locator('#admin_customer_plain_password_second').fill('password1234');
+    await page.locator('#admin_customer_plain_password_first').fill('EccubeE2ePassword1');
+    await page.locator('#admin_customer_plain_password_second').fill('EccubeE2ePassword1');
     await page.locator('#customer_form .c-conversionArea button[type="submit"]').click();
     await page.waitForLoadState('load');
     await expect(page.locator(successAlert)).toContainText('保存しました');
@@ -297,8 +297,8 @@ test.describe('Admin Customer (EA05)', () => {
     await page.locator('#admin_customer_address_addr02').fill('梅田');
     await page.locator('#admin_customer_email').fill(editTestEmail);
     await page.locator('#admin_customer_phone_number').fill('111111111');
-    await page.locator('#admin_customer_plain_password_first').fill('password1234');
-    await page.locator('#admin_customer_plain_password_second').fill('password1234');
+    await page.locator('#admin_customer_plain_password_first').fill('EccubeE2ePassword1');
+    await page.locator('#admin_customer_plain_password_second').fill('EccubeE2ePassword1');
     await page.locator('#customer_form .c-conversionArea button[type="submit"]').click();
     await page.waitForLoadState('load');
     await expect(page.locator(successAlert)).toContainText('保存しました');

--- a/e2e/tests/admin-system.spec.ts
+++ b/e2e/tests/admin-system.spec.ts
@@ -44,8 +44,8 @@ test.describe('Admin System Info (EA08)', () => {
     await page.locator('#admin_member_name').fill('admintest');
     await page.locator('#admin_member_department').fill('admintest department');
     await page.locator('#admin_member_login_id').fill('admintest');
-    await page.locator('#admin_member_plain_password_first').fill('password1234');
-    await page.locator('#admin_member_plain_password_second').fill('password1234');
+    await page.locator('#admin_member_plain_password_first').fill('EccubeE2ePassword1');
+    await page.locator('#admin_member_plain_password_second').fill('EccubeE2ePassword1');
     await page.locator('#admin_member_Authority').selectOption({ label: 'システム管理者' });
     await page.locator('#admin_member_Work_1').check();
 
@@ -73,8 +73,8 @@ test.describe('Admin System Info (EA08)', () => {
     await page.locator('#admin_member_name').fill('admintest2');
     await page.locator('#admin_member_department').fill('admintest department');
     await page.locator('#admin_member_login_id').fill('admintest');
-    await page.locator('#admin_member_plain_password_first').fill('password1234');
-    await page.locator('#admin_member_plain_password_second').fill('password1234');
+    await page.locator('#admin_member_plain_password_first').fill('EccubeE2ePassword1');
+    await page.locator('#admin_member_plain_password_second').fill('EccubeE2ePassword1');
     await page.locator('#admin_member_Authority').selectOption({ label: 'システム管理者' });
     await page.locator('#admin_member_Work_1').check();
 

--- a/e2e/tests/front-customer.spec.ts
+++ b/e2e/tests/front-customer.spec.ts
@@ -21,8 +21,8 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(email);
     await page.locator('#entry_email_second').fill(email);
-    await page.locator('#entry_plain_password_first').fill('password1234');
-    await page.locator('#entry_plain_password_second').fill('password1234');
+    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
     await page.locator('#entry_job').selectOption({ value: '1' });
     await page.locator('#entry_user_policy_check').check();
 
@@ -59,8 +59,8 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(email);
     await page.locator('#entry_email_second').fill(email);
-    await page.locator('#entry_plain_password_first').fill('password1234');
-    await page.locator('#entry_plain_password_second').fill('password1234');
+    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
 
     // 「同意する」ボタンを押下
     await page.locator('button.ec-blockBtn--action[type="submit"]').click();
@@ -106,8 +106,8 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(email);
     await page.locator('#entry_email_second').fill(email);
-    await page.locator('#entry_plain_password_first').fill('password1234');
-    await page.locator('#entry_plain_password_second').fill('password1234');
+    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
     await page.locator('#entry_job').selectOption({ value: '1' });
     await page.locator('#entry_user_policy_check').check();
 
@@ -145,8 +145,8 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(existingEmail);
     await page.locator('#entry_email_second').fill(existingEmail);
-    await page.locator('#entry_plain_password_first').fill('password1234');
-    await page.locator('#entry_plain_password_second').fill('password1234');
+    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
 
     // 「同意する」ボタンを押下
     await page.locator('button.ec-blockBtn--action[type="submit"]').click();
@@ -175,8 +175,8 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(newEmail);
     await page.locator('#entry_email_second').fill(newEmail);
-    await page.locator('#entry_plain_password_first').fill('password1234');
-    await page.locator('#entry_plain_password_second').fill('password1234');
+    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
     await page.locator('#entry_job').selectOption({ value: '1' });
     await page.locator('#entry_user_policy_check').check();
 
@@ -232,7 +232,7 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.goto('/mypage/login');
     await page.waitForLoadState('load');
     await page.locator('input[name="login_email"]').fill(newEmail);
-    await page.locator('input[name="login_pass"]').fill('password1234');
+    await page.locator('input[name="login_pass"]').fill('EccubeE2ePassword1');
     await page.locator('#login_mypage button[type="submit"]').click();
     await page.waitForLoadState('load');
 
@@ -285,8 +285,8 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(newEmail);
     await page.locator('#entry_email_second').fill(newEmail);
-    await page.locator('#entry_plain_password_first').fill('password1234');
-    await page.locator('#entry_plain_password_second').fill('password1234');
+    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
     await page.locator('#entry_job').selectOption({ value: '1' });
     await page.locator('#entry_user_policy_check').check();
 
@@ -339,7 +339,7 @@ test.describe('Front Customer Registration (EF04)', () => {
 
     // ログイン
     await page.locator('input[name="login_email"]').fill(newEmail);
-    await page.locator('input[name="login_pass"]').fill('password1234');
+    await page.locator('input[name="login_pass"]').fill('EccubeE2ePassword1');
     await page.getByRole('button', { name: 'ログイン' }).click();
     await page.waitForLoadState('load');
 

--- a/e2e/tests/front-mypage.spec.ts
+++ b/e2e/tests/front-mypage.spec.ts
@@ -20,7 +20,7 @@ async function loginAsTestCustomer(page: Page) {
 async function createCustomerViaAdmin(page: Page): Promise<{ email: string; password: string }> {
   const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
   const email = `test_withdraw_${Date.now()}@example.com`;
-  const password = 'password1234';
+  const password = 'EccubeE2ePassword1';
 
   const adminPage = await page.context().newPage();
   await adminPage.goto(`/${adminRoute}/`);

--- a/e2e/tests/front-other.spec.ts
+++ b/e2e/tests/front-other.spec.ts
@@ -82,8 +82,8 @@ test.describe('Front Other Pages (EF06)', () => {
     await adminPage.locator('#admin_customer_address_addr02').fill('梅田');
     await adminPage.locator('#admin_customer_phone_number').fill('111111111');
     await adminPage.locator('#admin_customer_email').fill(tempEmail);
-    await adminPage.locator('#admin_customer_plain_password_first').fill('password');
-    await adminPage.locator('#admin_customer_plain_password_second').fill('password');
+    await adminPage.locator('#admin_customer_plain_password_first').fill('EccubeE2ePassword1');
+    await adminPage.locator('#admin_customer_plain_password_second').fill('EccubeE2ePassword1');
     // ステータスを仮会員(1)に設定
     await adminPage.locator('#admin_customer_status').selectOption({ value: '1' });
     await adminPage.locator('button.btn-ec-conversion').click();
@@ -95,7 +95,7 @@ test.describe('Front Other Pages (EF06)', () => {
     await page.goto('/mypage/login');
     await page.waitForLoadState('load');
     await page.locator('input[name="login_email"]').fill(tempEmail);
-    await page.locator('input[name="login_pass"]').fill('password');
+    await page.locator('input[name="login_pass"]').fill('EccubeE2ePassword1');
     await page.locator('#login_mypage button[type="submit"]').click();
     await page.waitForLoadState('load');
 

--- a/e2e/tests/front-password-nist.spec.ts
+++ b/e2e/tests/front-password-nist.spec.ts
@@ -13,10 +13,10 @@ import { test, expect, Page } from '@playwright/test';
 
 const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
 
-// 半角カナ + 数字(NFKC で全角へ正規化される)
-const RAW_PASSWORD = 'ﾊﾟｽﾜｰﾄﾞﾃｽﾄ123456';
-// 上記を NFKC 正規化した文字列(全角)
-const NORMALIZED_PASSWORD = 'パスワードテスト123456';
+// 半角カナ + 数字(NFKC で全角へ正規化される)。正規化後 15 文字以上(min15 要件)。
+const RAW_PASSWORD = 'ﾊﾟｽﾜｰﾄﾞﾃｽﾄ1234567';
+// 上記を NFKC 正規化した文字列(全角)。15 文字。
+const NORMALIZED_PASSWORD = 'パスワードテスト1234567';
 
 /**
  * 管理画面から本会員を作成し, メールアドレスを返す。

--- a/e2e/tests/front-password-nist.spec.ts
+++ b/e2e/tests/front-password-nist.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * NIST SP 800-63B-4 対応(#6488)の E2E。
+ * - NFKC 正規化の往復: 半角カナで登録した会員が, 半角(非正規化)/全角(正規化済み)
+ *   どちらの入力でもフロントログインできること。
+ * - 入力検証: 15文字未満・ブロックリスト掲載パスワードが会員登録で拒否されること。
+ *
+ * 登録は管理画面から行う(フロント登録のメール確認フローを避けるため)。
+ * 管理会員登録フォームもフロント登録と同じ RepeatedPasswordType を経由し,
+ * PRE_SUBMIT で NFKC 正規化されるため, 保存値は正規化後の文字列になる。
+ */
+
+const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+
+// 半角カナ + 数字(NFKC で全角へ正規化される)
+const RAW_PASSWORD = 'ﾊﾟｽﾜｰﾄﾞﾃｽﾄ123456';
+// 上記を NFKC 正規化した文字列(全角)
+const NORMALIZED_PASSWORD = 'パスワードテスト123456';
+
+/**
+ * 管理画面から本会員を作成し, メールアドレスを返す。
+ */
+async function createActiveCustomerViaAdmin(page: Page, password: string): Promise<string> {
+  const email = `nist_${Date.now()}@example.com`;
+
+  const adminPage = await page.context().newPage();
+  await adminPage.goto(`/${adminRoute}/`);
+  await adminPage.waitForLoadState('load');
+  await adminPage.locator('#login_id').fill(process.env.ADMIN_USER || 'admin');
+  await adminPage.locator('#password').fill(process.env.ADMIN_PASSWORD || 'password');
+  await adminPage.getByRole('button', { name: 'ログイン' }).click();
+  await adminPage.waitForLoadState('load');
+
+  await adminPage.goto(`/${adminRoute}/customer/new`);
+  await adminPage.waitForLoadState('load');
+
+  await adminPage.locator('#admin_customer_name_name01').fill('正規化');
+  await adminPage.locator('#admin_customer_name_name02').fill('会員');
+  await adminPage.locator('#admin_customer_kana_kana01').fill('セイキカ');
+  await adminPage.locator('#admin_customer_kana_kana02').fill('カイイン');
+  await adminPage.locator('#admin_customer_postal_code').fill('530-0001');
+  await adminPage.locator('#admin_customer_address_pref').selectOption({ value: '27' });
+  await adminPage.locator('#admin_customer_address_addr01').fill('大阪市北区');
+  await adminPage.locator('#admin_customer_address_addr02').fill('梅田2-4-9');
+  await adminPage.locator('#admin_customer_phone_number').fill('111111111');
+  await adminPage.locator('#admin_customer_email').fill(email);
+  await adminPage.locator('#admin_customer_plain_password_first').fill(password);
+  await adminPage.locator('#admin_customer_plain_password_second').fill(password);
+  await adminPage.locator('#admin_customer_status').selectOption({ value: '2' }); // 本会員
+  await adminPage.locator('#admin_customer_point').fill('0');
+
+  await adminPage.locator('.c-conversionArea button[type="submit"]').first().click();
+  await adminPage.waitForLoadState('load');
+  await expect(adminPage.locator('.alert-success')).toBeVisible();
+  await adminPage.close();
+
+  return email;
+}
+
+/**
+ * フロントの会員ログインを試行する。
+ */
+async function loginAtFront(page: Page, email: string, password: string) {
+  await page.goto('/mypage/login');
+  await page.waitForLoadState('load');
+  await page.locator('input[name="login_email"]').fill(email);
+  await page.locator('input[name="login_pass"]').fill(password);
+  await page.getByRole('button', { name: 'ログイン' }).click();
+  await page.waitForLoadState('load');
+}
+
+/**
+ * /mypage にアクセスし, 認証済み(ログインへリダイレクトされない)であることを確認する。
+ */
+async function assertLoggedIn(page: Page) {
+  await page.goto('/mypage');
+  await page.waitForLoadState('load');
+  await expect(page).toHaveURL(/\/mypage\/?$/);
+}
+
+async function logoutFront(page: Page) {
+  await page.goto('/logout');
+  await page.waitForLoadState('load');
+}
+
+/**
+ * /entry の会員登録フォームを, パスワード以外を有効値で埋めて送信する。
+ */
+async function submitEntryForm(page: Page, password: string) {
+  await page.goto('/entry');
+  await page.waitForLoadState('load');
+
+  const email = `nist_entry_${Date.now()}@example.com`;
+  await page.locator('#entry_name_name01').fill('姓');
+  await page.locator('#entry_name_name02').fill('名');
+  await page.locator('#entry_kana_kana01').fill('セイ');
+  await page.locator('#entry_kana_kana02').fill('メイ');
+  await page.locator('#entry_postal_code').fill('530-0001');
+  await page.locator('#entry_address_pref').selectOption({ value: '27' });
+  await page.waitForTimeout(1000);
+  await page.locator('#entry_address_addr01').fill('大阪市北区');
+  await page.locator('#entry_address_addr02').fill('梅田2-4-9');
+  await page.locator('#entry_phone_number').fill('111-111-111');
+  await page.locator('#entry_email_first').fill(email);
+  await page.locator('#entry_email_second').fill(email);
+  await page.locator('#entry_plain_password_first').fill(password);
+  await page.locator('#entry_plain_password_second').fill(password);
+  await page.locator('#entry_job').selectOption({ value: '1' });
+  await page.locator('#entry_user_policy_check').check();
+
+  await page.locator('button.ec-blockBtn--action[type="submit"]').click();
+  await page.waitForLoadState('load');
+}
+
+test.describe('Front Password NIST (EF04 #6488)', () => {
+  test('NFKC 正規化: 半角カナで登録した会員が半角でも全角でもログインできる', async ({ page }) => {
+    // 前提: 半角カナと全角は別表記だが NFKC で同一になる
+    expect(RAW_PASSWORD).not.toBe(NORMALIZED_PASSWORD);
+
+    // 半角カナのパスワードで会員作成(保存時に NFKC 正規化される)
+    const email = await createActiveCustomerViaAdmin(page, RAW_PASSWORD);
+
+    // 半角カナ(非正規化)のままでログイン成功
+    await loginAtFront(page, email, RAW_PASSWORD);
+    await assertLoggedIn(page);
+
+    await logoutFront(page);
+
+    // 全角(正規化済み)でもログイン成功
+    await loginAtFront(page, email, NORMALIZED_PASSWORD);
+    await assertLoggedIn(page);
+  });
+
+  test('入力検証: 15文字未満のパスワードは会員登録で拒否される', async ({ page }) => {
+    await submitEntryForm(page, 'Short12345'); // 10文字
+
+    // 確認画面へ進まず入力ページに留まる(確認画面では password は hidden になる),
+    // かつ長さエラーが表示される
+    await expect(page.locator('#entry_plain_password_first')).toBeVisible();
+    await expect(page.locator('body')).toContainText('15文字以上');
+  });
+
+  test('入力検証: ブロックリスト掲載パスワードは会員登録で拒否される', async ({ page }) => {
+    await submitEntryForm(page, 'passwordpassword'); // 16文字・ブロックリスト掲載
+
+    await expect(page.locator('#entry_plain_password_first')).toBeVisible();
+    await expect(page.locator('body')).toContainText('推測されやすいパスワード');
+  });
+});

--- a/e2e/tests/front-throttling.spec.ts
+++ b/e2e/tests/front-throttling.spec.ts
@@ -93,8 +93,8 @@ async function submitEntryFormWithConfirm(page: import('@playwright/test').Page)
   await page.locator('#entry_phone_number').fill('111-111-111');
   await page.locator('#entry_email_first').fill(email);
   await page.locator('#entry_email_second').fill(email);
-  await page.locator('#entry_plain_password_first').fill('password1234');
-  await page.locator('#entry_plain_password_second').fill('password1234');
+  await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
+  await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
   await page.locator('#entry_user_policy_check').check();
 
   // Click agree/submit button
@@ -128,8 +128,8 @@ async function submitEntryFormWithoutConfirm(page: import('@playwright/test').Pa
   await page.locator('#entry_phone_number').fill('111-111-111');
   await page.locator('#entry_email_first').fill(email);
   await page.locator('#entry_email_second').fill(email);
-  await page.locator('#entry_plain_password_first').fill('password1234');
-  await page.locator('#entry_plain_password_second').fill('password1234');
+  await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
+  await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
 
   // Submit without checking user_policy_check (goes to confirm without mode=complete)
   await page.locator('button.ec-blockBtn--action[type="submit"]').click();
@@ -934,7 +934,7 @@ test.describe('Throttling (EF09)', () => {
 
     // Create a new member with 2FA enabled
     const loginId = 'admin_2fa_' + Date.now().toString(36);
-    const memberPassword = 'password1234';
+    const memberPassword = 'EccubeE2ePassword1';
 
     await adminPage.goto(`/${adminRoute}/setting/system/member/new`);
     await adminPage.waitForLoadState('load');

--- a/src/Eccube/Controller/Admin/AdminController.php
+++ b/src/Eccube/Controller/Admin/AdminController.php
@@ -36,6 +36,7 @@ use Eccube\Repository\MemberRepository;
 use Eccube\Repository\OrderRepository;
 use Eccube\Repository\ProductRepository;
 use Eccube\Service\PluginApiService;
+use Eccube\Util\PasswordNormalizer;
 use Symfony\Bridge\Twig\Attribute\Template;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -266,7 +267,7 @@ class AdminController extends AbstractController
             /** @var Member $Member */
             $Member = $this->getUser();
             $salt = $Member->getSalt();
-            $password = $form->get('change_password')->getData();
+            $password = PasswordNormalizer::normalize($form->get('change_password')->getData());
             $password = $this->passwordHasher->hashPassword($Member, $password);
 
             $Member

--- a/src/Eccube/Controller/Admin/AdminController.php
+++ b/src/Eccube/Controller/Admin/AdminController.php
@@ -36,7 +36,6 @@ use Eccube\Repository\MemberRepository;
 use Eccube\Repository\OrderRepository;
 use Eccube\Repository\ProductRepository;
 use Eccube\Service\PluginApiService;
-use Eccube\Util\PasswordNormalizer;
 use Symfony\Bridge\Twig\Attribute\Template;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -267,7 +266,7 @@ class AdminController extends AbstractController
             /** @var Member $Member */
             $Member = $this->getUser();
             $salt = $Member->getSalt();
-            $password = PasswordNormalizer::normalize($form->get('change_password')->getData());
+            $password = $form->get('change_password')->getData();
             $password = $this->passwordHasher->hashPassword($Member, $password);
 
             $Member

--- a/src/Eccube/Controller/ForgotController.php
+++ b/src/Eccube/Controller/ForgotController.php
@@ -19,6 +19,7 @@ use Eccube\Form\Type\Front\ForgotType;
 use Eccube\Form\Type\Front\PasswordResetType;
 use Eccube\Repository\CustomerRepository;
 use Eccube\Service\MailService;
+use Eccube\Util\PasswordNormalizer;
 use Symfony\Bridge\Twig\Attribute\Template;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -184,7 +185,7 @@ class ForgotController extends AbstractController
                 ->getRegularCustomerByResetKey($reset_key, $form->get('login_email')->getData());
             if ($Customer) {
                 // パスワードの発行・更新
-                $password = $this->passwordHasher->hashPassword($Customer, $form->get('password')->getData());
+                $password = $this->passwordHasher->hashPassword($Customer, PasswordNormalizer::normalize($form->get('password')->getData()));
                 $Customer->setPassword($password);
 
                 // リセットキーをクリア

--- a/src/Eccube/Controller/ForgotController.php
+++ b/src/Eccube/Controller/ForgotController.php
@@ -19,7 +19,6 @@ use Eccube\Form\Type\Front\ForgotType;
 use Eccube\Form\Type\Front\PasswordResetType;
 use Eccube\Repository\CustomerRepository;
 use Eccube\Service\MailService;
-use Eccube\Util\PasswordNormalizer;
 use Symfony\Bridge\Twig\Attribute\Template;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -185,7 +184,7 @@ class ForgotController extends AbstractController
                 ->getRegularCustomerByResetKey($reset_key, $form->get('login_email')->getData());
             if ($Customer) {
                 // パスワードの発行・更新
-                $password = $this->passwordHasher->hashPassword($Customer, PasswordNormalizer::normalize($form->get('password')->getData()));
+                $password = $this->passwordHasher->hashPassword($Customer, $form->get('password')->getData());
                 $Customer->setPassword($password);
 
                 // リセットキーをクリア

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -38,7 +38,6 @@ use Eccube\Form\Type\Install\Step3Type;
 use Eccube\Form\Type\Install\Step4Type;
 use Eccube\Form\Type\Install\Step5Type;
 use Eccube\Util\CacheUtil;
-use Eccube\Util\PasswordNormalizer;
 use Eccube\Util\StringUtil;
 use Symfony\Bridge\Twig\Attribute\Template;
 use Symfony\Component\Filesystem\Filesystem;
@@ -839,7 +838,7 @@ class InstallController extends AbstractController
     {
         $conn->beginTransaction();
         try {
-            $password = $this->passwordHasher->hashPassword(new Customer(), PasswordNormalizer::normalize($data['login_pass']));
+            $password = $this->passwordHasher->hashPassword(new Customer(), $data['login_pass']);
 
             $id = ('postgresql' === $conn->getDatabasePlatform()->getName())
                 ? $conn->fetchOne("select nextval('dtb_base_info_id_seq')")
@@ -901,7 +900,7 @@ class InstallController extends AbstractController
             $stmt->bindParam(':login_id', $data['login_id']);
             /** @var Result $row */
             $row = $stmt->executeQuery();
-            $password = $this->passwordHasher->hashPassword(new Customer(), PasswordNormalizer::normalize($data['login_pass']));
+            $password = $this->passwordHasher->hashPassword(new Customer(), $data['login_pass']);
             if ($row->fetchOne() !== false) {
                 // 同一の管理者IDであればパスワードのみ更新
                 $sth = $conn->prepare('UPDATE dtb_member set password = :password, update_date = current_timestamp WHERE login_id = :login_id;');

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -38,6 +38,7 @@ use Eccube\Form\Type\Install\Step3Type;
 use Eccube\Form\Type\Install\Step4Type;
 use Eccube\Form\Type\Install\Step5Type;
 use Eccube\Util\CacheUtil;
+use Eccube\Util\PasswordNormalizer;
 use Eccube\Util\StringUtil;
 use Symfony\Bridge\Twig\Attribute\Template;
 use Symfony\Component\Filesystem\Filesystem;
@@ -838,7 +839,7 @@ class InstallController extends AbstractController
     {
         $conn->beginTransaction();
         try {
-            $password = $this->passwordHasher->hashPassword(new Customer(), $data['login_pass']);
+            $password = $this->passwordHasher->hashPassword(new Customer(), PasswordNormalizer::normalize($data['login_pass']));
 
             $id = ('postgresql' === $conn->getDatabasePlatform()->getName())
                 ? $conn->fetchOne("select nextval('dtb_base_info_id_seq')")
@@ -900,7 +901,7 @@ class InstallController extends AbstractController
             $stmt->bindParam(':login_id', $data['login_id']);
             /** @var Result $row */
             $row = $stmt->executeQuery();
-            $password = $this->passwordHasher->hashPassword(new Customer(), $data['login_pass']);
+            $password = $this->passwordHasher->hashPassword(new Customer(), PasswordNormalizer::normalize($data['login_pass']));
             if ($row->fetchOne() !== false) {
                 // 同一の管理者IDであればパスワードのみ更新
                 $sth = $conn->prepare('UPDATE dtb_member set password = :password, update_date = current_timestamp WHERE login_id = :login_id;');

--- a/src/Eccube/Entity/Customer.php
+++ b/src/Eccube/Entity/Customer.php
@@ -23,6 +23,7 @@ use Eccube\Entity\Master\Job;
 use Eccube\Entity\Master\Pref;
 use Eccube\Entity\Master\Sex;
 use Eccube\Repository\CustomerRepository;
+use Eccube\Util\PasswordNormalizer;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\LegacyPasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
@@ -441,7 +442,8 @@ if (!class_exists(Customer::class)) {
          */
         public function setPlainPassword(?string $password): static
         {
-            $this->plain_password = $password;
+            // NIST SP 800-63B-4 に従い, 保存時とログイン照合時で表記ゆれを統一するため NFKC 正規化する.
+            $this->plain_password = PasswordNormalizer::normalize($password);
 
             return $this;
         }

--- a/src/Eccube/Entity/Member.php
+++ b/src/Eccube/Entity/Member.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Eccube\Entity\Master\Authority;
 use Eccube\Entity\Master\Work;
 use Eccube\Repository\MemberRepository;
+use Eccube\Util\PasswordNormalizer;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\LegacyPasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
@@ -205,7 +206,8 @@ if (!class_exists(Member::class)) {
          */
         public function setPlainPassword(?string $password): static
         {
-            $this->plainPassword = $password;
+            // NIST SP 800-63B-4 に従い, 保存時とログイン照合時で表記ゆれを統一するため NFKC 正規化する.
+            $this->plainPassword = PasswordNormalizer::normalize($password);
 
             return $this;
         }

--- a/src/Eccube/EventListener/PasswordNormalizationListener.php
+++ b/src/Eccube/EventListener/PasswordNormalizationListener.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\EventListener;
+
+use Eccube\Util\PasswordNormalizer;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * ログイン照合時に送信パスワードを NFKC 正規化するリスナ.
+ *
+ * NIST SP 800-63B-4 対応で, パスワード設定時に NFKC 正規化して保存している(PasswordNormalizer 参照).
+ * ログイン時にも同じ正規化を施さないと, Unicode パスワードの表記ゆれで照合に失敗するため,
+ * firewall(form_login)がパラメータを読む前に request 上の値を正規化しておく.
+ *
+ * 既存の ASCII パスワードは正規化しても不変(no-op)のため影響しない.
+ */
+class PasswordNormalizationListener implements EventSubscriberInterface
+{
+    /**
+     * ログインの check_path ルート名 => password_parameter のマッピング.
+     * security.yaml の firewalls.*.form_login と対応する.
+     */
+    private const LOGIN_PASSWORD_PARAMETERS = [
+        'admin_login' => 'password',
+        'mypage_login' => 'login_pass',
+    ];
+
+    #[\Override]
+    public static function getSubscribedEvents(): array
+    {
+        // RouterListener(priority 32)の後, firewall(priority 8)の前に実行する.
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 16],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!$request->isMethod('POST')) {
+            return;
+        }
+
+        $route = $request->attributes->get('_route');
+        if (!isset(self::LOGIN_PASSWORD_PARAMETERS[$route])) {
+            return;
+        }
+
+        $parameter = self::LOGIN_PASSWORD_PARAMETERS[$route];
+        $password = $request->request->get($parameter);
+
+        if (is_string($password) && $password !== '') {
+            $request->request->set($parameter, PasswordNormalizer::normalize($password));
+        }
+    }
+}

--- a/src/Eccube/Form/Type/Admin/ChangePasswordType.php
+++ b/src/Eccube/Form/Type/Admin/ChangePasswordType.php
@@ -14,6 +14,7 @@
 namespace Eccube\Form\Type\Admin;
 
 use Eccube\Common\EccubeConfig;
+use Eccube\Form\Validator\PasswordBlocklist;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
@@ -39,6 +40,23 @@ class ChangePasswordType extends AbstractType
     #[\Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $changePasswordConstraints = [
+            new Assert\NotBlank(),
+            new Assert\Length([
+                'min' => $this->eccubeConfig['eccube_password_min_len'],
+                'max' => $this->eccubeConfig['eccube_password_max_len'],
+            ]),
+            new Assert\Regex([
+                'pattern' => $this->eccubeConfig['eccube_password_pattern'],
+                'message' => 'form_error.password_pattern_invalid',
+            ]),
+            new PasswordBlocklist(),
+        ];
+        // NIST SP 800-63B-4 対応の漏洩パスワードチェック. 閉域網等では config で無効化できる.
+        if ($this->eccubeConfig['eccube_password_compromised_check']) {
+            $changePasswordConstraints[] = new Assert\NotCompromisedPassword(['skipOnError' => true]);
+        }
+
         $builder
             ->add('current_password', PasswordType::class, [
                 'label' => 'changepassword.label.current_pass',
@@ -54,17 +72,7 @@ class ChangePasswordType extends AbstractType
                 'second_options' => [
                     'label' => 'changepassword.label.verify_pass',
                 ],
-                'constraints' => [
-                    new Assert\NotBlank(),
-                    new Assert\Length([
-                        'min' => $this->eccubeConfig['eccube_password_min_len'],
-                        'max' => $this->eccubeConfig['eccube_password_max_len'],
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => $this->eccubeConfig['eccube_password_pattern'],
-                        'message' => 'form_error.password_pattern_invalid',
-                    ]),
-                ],
+                'constraints' => $changePasswordConstraints,
             ])
         ;
     }

--- a/src/Eccube/Form/Type/Admin/ChangePasswordType.php
+++ b/src/Eccube/Form/Type/Admin/ChangePasswordType.php
@@ -15,10 +15,13 @@ namespace Eccube\Form\Type\Admin;
 
 use Eccube\Common\EccubeConfig;
 use Eccube\Form\Validator\PasswordBlocklist;
+use Eccube\Util\PasswordNormalizer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -56,6 +59,20 @@ class ChangePasswordType extends AbstractType
         if ($this->eccubeConfig['eccube_password_compromised_check']) {
             $changePasswordConstraints[] = new Assert\NotCompromisedPassword(['skipOnError' => true]);
         }
+
+        // 検証と保存を同一の正規化済み値で行うため, 検証前(PRE_SUBMIT)に新パスワードを NFKC 正規化する.
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
+            $data = $event->getData();
+            if (!is_array($data) || !isset($data['change_password']) || !is_array($data['change_password'])) {
+                return;
+            }
+            foreach (['first', 'second'] as $key) {
+                if (isset($data['change_password'][$key]) && is_string($data['change_password'][$key])) {
+                    $data['change_password'][$key] = PasswordNormalizer::normalize($data['change_password'][$key]);
+                }
+            }
+            $event->setData($data);
+        });
 
         $builder
             ->add('current_password', PasswordType::class, [

--- a/src/Eccube/Form/Type/Admin/MemberType.php
+++ b/src/Eccube/Form/Type/Admin/MemberType.php
@@ -51,6 +51,7 @@ class MemberType extends AbstractType
         // RepeatedPasswordType の options.constraints を上書きするため,
         // 長さ・パターンに加えてブロックリスト・漏洩チェックもここで明示的に付与する.
         $passwordConstraints = [
+            new Assert\NotBlank(),
             new Assert\Length([
                 'min' => $this->eccubeConfig['eccube_password_min_len'],
                 'max' => $this->eccubeConfig['eccube_password_max_len'],
@@ -60,7 +61,6 @@ class MemberType extends AbstractType
                 'message' => 'form_error.password_pattern_invalid',
             ]),
             new PasswordBlocklist(),
-            new Assert\NotBlank(),
         ];
         // NIST SP 800-63B-4 対応の漏洩パスワードチェック. 閉域網等では config で無効化できる.
         if ($this->eccubeConfig['eccube_password_compromised_check']) {

--- a/src/Eccube/Form/Type/Admin/MemberType.php
+++ b/src/Eccube/Form/Type/Admin/MemberType.php
@@ -19,6 +19,7 @@ use Eccube\Entity\Master\Work;
 use Eccube\Entity\Member;
 use Eccube\Form\Type\RepeatedPasswordType;
 use Eccube\Form\Type\ToggleSwitchType;
+use Eccube\Form\Validator\PasswordBlocklist;
 use Eccube\Repository\MemberRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
@@ -47,6 +48,25 @@ class MemberType extends AbstractType
     #[\Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        // RepeatedPasswordType の options.constraints を上書きするため,
+        // 長さ・パターンに加えてブロックリスト・漏洩チェックもここで明示的に付与する.
+        $passwordConstraints = [
+            new Assert\Length([
+                'min' => $this->eccubeConfig['eccube_password_min_len'],
+                'max' => $this->eccubeConfig['eccube_password_max_len'],
+            ]),
+            new Assert\Regex([
+                'pattern' => $this->eccubeConfig['eccube_password_pattern'],
+                'message' => 'form_error.password_pattern_invalid',
+            ]),
+            new PasswordBlocklist(),
+            new Assert\NotBlank(),
+        ];
+        // NIST SP 800-63B-4 対応の漏洩パスワードチェック. 閉域網等では config で無効化できる.
+        if ($this->eccubeConfig['eccube_password_compromised_check']) {
+            $passwordConstraints[] = new Assert\NotCompromisedPassword(['skipOnError' => true]);
+        }
+
         $builder
             ->add('name', TextType::class, [
                 'constraints' => [
@@ -63,17 +83,7 @@ class MemberType extends AbstractType
             ])
             ->add('plain_password', RepeatedPasswordType::class, [
                 'options' => [
-                    'constraints' => [
-                        new Assert\Length([
-                            'min' => $this->eccubeConfig['eccube_password_min_len'],
-                            'max' => $this->eccubeConfig['eccube_password_max_len'],
-                        ]),
-                        new Assert\Regex([
-                            'pattern' => $this->eccubeConfig['eccube_password_pattern'],
-                            'message' => 'form_error.password_pattern_invalid',
-                        ]),
-                        new Assert\NotBlank(),
-                    ],
+                    'constraints' => $passwordConstraints,
                 ],
             ])
             ->add('Authority', EntityType::class, [

--- a/src/Eccube/Form/Type/Install/Step3Type.php
+++ b/src/Eccube/Form/Type/Install/Step3Type.php
@@ -16,6 +16,7 @@ namespace Eccube\Form\Type\Install;
 use Eccube\Common\EccubeConfig;
 use Eccube\Form\Validator\Email;
 use Eccube\Form\Validator\PasswordBlocklist;
+use Eccube\Util\PasswordNormalizer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
@@ -24,6 +25,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -60,6 +62,15 @@ class Step3Type extends AbstractType
         if ($this->eccubeConfig['eccube_password_compromised_check']) {
             $loginPassConstraints[] = new Assert\NotCompromisedPassword(['skipOnError' => true]);
         }
+
+        // 検証と保存を同一の正規化済み値で行うため, 検証前(PRE_SUBMIT)に login_pass を NFKC 正規化する.
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
+            $data = $event->getData();
+            if (is_array($data) && isset($data['login_pass']) && is_string($data['login_pass'])) {
+                $data['login_pass'] = PasswordNormalizer::normalize($data['login_pass']);
+                $event->setData($data);
+            }
+        });
 
         $builder
             ->add('shop_name', TextType::class, [

--- a/src/Eccube/Form/Type/Install/Step3Type.php
+++ b/src/Eccube/Form/Type/Install/Step3Type.php
@@ -15,6 +15,7 @@ namespace Eccube\Form\Type\Install;
 
 use Eccube\Common\EccubeConfig;
 use Eccube\Form\Validator\Email;
+use Eccube\Form\Validator\PasswordBlocklist;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
@@ -43,6 +44,23 @@ class Step3Type extends AbstractType
     #[\Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $loginPassConstraints = [
+            new Assert\NotBlank(),
+            new Assert\Length([
+                'min' => $this->eccubeConfig['eccube_password_min_len'],
+                'max' => $this->eccubeConfig['eccube_password_max_len'],
+            ]),
+            new Assert\Regex([
+                'pattern' => $this->eccubeConfig['eccube_password_pattern'],
+                'message' => 'form_error.password_pattern_invalid',
+            ]),
+            new PasswordBlocklist(),
+        ];
+        // NIST SP 800-63B-4 対応の漏洩パスワードチェック. 閉域網等では config で無効化できる.
+        if ($this->eccubeConfig['eccube_password_compromised_check']) {
+            $loginPassConstraints[] = new Assert\NotCompromisedPassword(['skipOnError' => true]);
+        }
+
         $builder
             ->add('shop_name', TextType::class, [
                 'label' => trans('install.shop_name'),
@@ -82,17 +100,7 @@ class Step3Type extends AbstractType
                     '%min%' => $this->eccubeConfig['eccube_password_min_len'],
                     '%max%' => $this->eccubeConfig['eccube_password_max_len'],
                 ]),
-                'constraints' => [
-                    new Assert\NotBlank(),
-                    new Assert\Length([
-                        'min' => $this->eccubeConfig['eccube_password_min_len'],
-                        'max' => $this->eccubeConfig['eccube_password_max_len'],
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => $this->eccubeConfig['eccube_password_pattern'],
-                        'message' => 'form_error.password_pattern_invalid',
-                    ]),
-                ],
+                'constraints' => $loginPassConstraints,
             ])
             ->add('admin_dir', TextType::class, [
                 'label' => trans('install.directory_name', [

--- a/src/Eccube/Form/Type/RepeatedPasswordType.php
+++ b/src/Eccube/Form/Type/RepeatedPasswordType.php
@@ -14,6 +14,7 @@
 namespace Eccube\Form\Type;
 
 use Eccube\Common\EccubeConfig;
+use Eccube\Form\Validator\PasswordBlocklist;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -38,22 +39,29 @@ class RepeatedPasswordType extends AbstractType
     #[\Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
+        $constraints = [
+            new Assert\Length([
+                'min' => $this->eccubeConfig['eccube_password_min_len'],
+                'max' => $this->eccubeConfig['eccube_password_max_len'],
+            ]),
+            new Assert\Regex([
+                'pattern' => $this->eccubeConfig['eccube_password_pattern'],
+                'message' => 'form_error.password_pattern_invalid',
+            ]),
+            new PasswordBlocklist(),
+        ];
+        // NIST SP 800-63B-4 対応の漏洩パスワードチェック. 閉域網等では config で無効化できる.
+        if ($this->eccubeConfig['eccube_password_compromised_check']) {
+            $constraints[] = new Assert\NotCompromisedPassword(['skipOnError' => true]);
+        }
+
         $resolver->setDefaults([
             'type' => TextType::class, // type password だと入力欄を空にされてしまうので、widgetで対応
             'invalid_message' => 'form_error.same_password',
             'required' => true,
             'error_bubbling' => false,
             'options' => [
-                'constraints' => [
-                    new Assert\Length([
-                        'min' => $this->eccubeConfig['eccube_password_min_len'],
-                        'max' => $this->eccubeConfig['eccube_password_max_len'],
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => $this->eccubeConfig['eccube_password_pattern'],
-                        'message' => 'form_error.password_pattern_invalid',
-                    ]),
-                ],
+                'constraints' => $constraints,
             ],
             'first_options' => [
                 'attr' => [

--- a/src/Eccube/Form/Type/RepeatedPasswordType.php
+++ b/src/Eccube/Form/Type/RepeatedPasswordType.php
@@ -15,9 +15,13 @@ namespace Eccube\Form\Type;
 
 use Eccube\Common\EccubeConfig;
 use Eccube\Form\Validator\PasswordBlocklist;
+use Eccube\Util\PasswordNormalizer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -31,6 +35,31 @@ class RepeatedPasswordType extends AbstractType
      */
     public function __construct(protected EccubeConfig $eccubeConfig)
     {
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array<string, mixed> $options
+     */
+    #[\Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        // 検証と保存を同一の正規化済み値で行うため, 検証前(PRE_SUBMIT)に NFKC 正規化する.
+        // これにより, 互換文字で長さ・ブロックリスト・漏洩チェックをすり抜けて
+        // 正規化後に別の値が保存される, という不整合を防ぐ.
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
+            $data = $event->getData();
+            if (!is_array($data)) {
+                return;
+            }
+            foreach (['first', 'second'] as $key) {
+                if (isset($data[$key]) && is_string($data[$key])) {
+                    $data[$key] = PasswordNormalizer::normalize($data[$key]);
+                }
+            }
+            $event->setData($data);
+        });
     }
 
     /**

--- a/src/Eccube/Form/Validator/PasswordBlocklist.php
+++ b/src/Eccube/Form/Validator/PasswordBlocklist.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Form\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * NIST SP 800-63B-4 に基づき, 推測されやすいパスワード(ブロックリスト)を拒否する制約.
+ *
+ * 照合対象のリストは eccube_password_blocklist で指定したファイルから読み込む.
+ */
+#[\Attribute]
+class PasswordBlocklist extends Constraint
+{
+    public string $message = 'form_error.password_blocklisted';
+}

--- a/src/Eccube/Form/Validator/PasswordBlocklistValidator.php
+++ b/src/Eccube/Form/Validator/PasswordBlocklistValidator.php
@@ -15,6 +15,7 @@ namespace Eccube\Form\Validator;
 
 use Eccube\Common\EccubeConfig;
 use Eccube\Util\PasswordNormalizer;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -32,7 +33,7 @@ class PasswordBlocklistValidator extends ConstraintValidator
      */
     private ?array $blocklist = null;
 
-    public function __construct(private readonly EccubeConfig $eccubeConfig)
+    public function __construct(private readonly EccubeConfig $eccubeConfig, private readonly LoggerInterface $logger)
     {
     }
 
@@ -87,11 +88,17 @@ class PasswordBlocklistValidator extends ConstraintValidator
 
         $file = $this->eccubeConfig['eccube_password_blocklist'] ?? null;
         if (!$file || !is_file($file) || !is_readable($file)) {
+            // 設定ミス等でブロックリストが読めない場合, 無言で無効化(fail-open)せず警告を残す.
+            // 漏洩チェック(NotCompromisedPassword)が主防御のため登録自体は継続する.
+            $this->logger->warning('パスワードブロックリストを読み込めませんでした。', ['file' => $file]);
+
             return $this->blocklist;
         }
 
         $lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
         if ($lines === false) {
+            $this->logger->warning('パスワードブロックリストの読み込みに失敗しました。', ['file' => $file]);
+
             return $this->blocklist;
         }
 

--- a/src/Eccube/Form/Validator/PasswordBlocklistValidator.php
+++ b/src/Eccube/Form/Validator/PasswordBlocklistValidator.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Form\Validator;
+
+use Eccube\Common\EccubeConfig;
+use Eccube\Util\PasswordNormalizer;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * PasswordBlocklist 制約のバリデータ.
+ *
+ * 入力値を NFKC 正規化し, 大文字小文字を無視してブロックリストと照合する.
+ * 一致した場合は違反を登録する.
+ */
+class PasswordBlocklistValidator extends ConstraintValidator
+{
+    /**
+     * @var array<string>|null 正規化済みブロックリスト(初回読込時にキャッシュ)
+     */
+    private ?array $blocklist = null;
+
+    public function __construct(private readonly EccubeConfig $eccubeConfig)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param mixed $value
+     */
+    #[\Override]
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof PasswordBlocklist) {
+            throw new UnexpectedTypeException($constraint, PasswordBlocklist::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        $normalized = $this->normalizeForComparison((string) $value);
+
+        if (in_array($normalized, $this->getBlocklist(), true)) {
+            $this->context->buildViolation($constraint->message)
+                ->addViolation();
+        }
+    }
+
+    /**
+     * 比較用に NFKC 正規化し小文字化する.
+     */
+    private function normalizeForComparison(string $value): string
+    {
+        return mb_strtolower((string) PasswordNormalizer::normalize($value));
+    }
+
+    /**
+     * ブロックリストを読み込む(初回のみファイルアクセスし以降はキャッシュ).
+     *
+     * @return array<string>
+     */
+    private function getBlocklist(): array
+    {
+        if ($this->blocklist !== null) {
+            return $this->blocklist;
+        }
+
+        $this->blocklist = [];
+
+        $file = $this->eccubeConfig['eccube_password_blocklist'] ?? null;
+        if (!$file || !is_file($file) || !is_readable($file)) {
+            return $this->blocklist;
+        }
+
+        $lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if ($lines === false) {
+            return $this->blocklist;
+        }
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '' || str_starts_with($line, '#')) {
+                continue;
+            }
+            $this->blocklist[] = $this->normalizeForComparison($line);
+        }
+
+        return $this->blocklist;
+    }
+}

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -45,7 +45,7 @@ common.mail_address: Email
 common.mail_address_sample: e.g. ec-cube@example.com
 common.repeated_confirm: Please re-enter
 common.password: Password
-common.password_sample: "Alphabets, numbers and symbols %min% - %max%chars"
+common.password_sample: "%min% - %max% chars"
 common.password_eq_email: Password cannot be set to the same value as email address.
 common.password_for_confirmation: Password (Re-enter)
 common.gender: Gender

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -45,7 +45,7 @@ common.mail_address: メールアドレス
 common.mail_address_sample: 例：ec-cube@example.com
 common.repeated_confirm: 確認のためもう一度入力してください
 common.password: パスワード
-common.password_sample: "半角英数記号%min%〜%max%文字"
+common.password_sample: "%min%〜%max%文字"
 common.password_eq_email: パスワードはメールアドレスと同じ値を設定できません。
 common.password_for_confirmation: パスワード(確認)
 common.gender: 性別

--- a/src/Eccube/Resource/locale/validators.en.yaml
+++ b/src/Eccube/Resource/locale/validators.en.yaml
@@ -22,6 +22,7 @@ Invalid credentials.: |
 Invalid CSRF token.: |
   Failed to sign in.
   Please make sure if the credentials are correct.
+This password has been leaked in a data breach, it must not be used. Please use another password.: This password has been found in a known data breach. Please use another password.
 
 #------------------------------------------------------------------------------------
 # EC-CUBE error message
@@ -42,7 +43,8 @@ form_error.same_email: Please enter the same email address.
 form_error.admin_is_not_available: Do not use "admin" as the directory name.
 form_error.member_already_exists: This ID is already registered.
 form_error.customer_already_exists:  This email address can not be used.
-form_error.password_pattern_invalid: Please use one alphanumeric character each.
+form_error.password_pattern_invalid: It contains characters that cannot be used (such as control characters).
+form_error.password_blocklisted: This password is too easy to guess. Please use another password.
 form_error.out_of_range: Invalid DateTime.
 
 #------------------------------------------------------------------------------------

--- a/src/Eccube/Resource/locale/validators.ja.yaml
+++ b/src/Eccube/Resource/locale/validators.ja.yaml
@@ -25,6 +25,7 @@ Invalid CSRF token.: |
 Too many failed login attempts, please try again later.: ログイン試行回数を超えました。しばらくして再度お試しください。
 Too many failed login attempts, please try again in %minutes% minute.: ログイン試行回数が多すぎます。%minutes%分後に再度お試しください。
 Too many failed login attempts, please try again in %minutes% minutes.: ログイン試行回数が多すぎます。%minutes%分後に再度お試しください。
+This password has been leaked in a data breach, it must not be used. Please use another password.: このパスワードは過去に漏洩が確認されています。別のパスワードを設定してください。
 
 #------------------------------------------------------------------------------------
 # EC-CUBE error message
@@ -45,7 +46,8 @@ form_error.same_email: 同じメールアドレスを入力してください。
 form_error.admin_is_not_available: ディレクトリ名に「admin」を使用することはできません。
 form_error.member_already_exists: 既に利用されているログインIDです。
 form_error.customer_already_exists:  このメールアドレスは利用できません。
-form_error.password_pattern_invalid: 英数字をそれぞれ1種類使用してください。
+form_error.password_pattern_invalid: 使用できない文字（制御文字など）が含まれています。
+form_error.password_blocklisted: 推測されやすいパスワードです。別のパスワードを設定してください。
 form_error.out_of_range: 不正な日付です。
 
 #------------------------------------------------------------------------------------

--- a/src/Eccube/Resource/password_blocklist.txt
+++ b/src/Eccube/Resource/password_blocklist.txt
@@ -1,0 +1,29 @@
+# EC-CUBE パスワードブロックリスト
+#
+# NIST SP 800-63B-4 に基づき, 推測されやすいパスワードを拒否するためのリストです.
+# eccube_password_min_len(既定15)以上の長さがあっても弱いパターンに絞って収録しています.
+# 網羅的な漏洩チェックは HaveIBeenPwned(NotCompromisedPassword)に委ねます.
+#
+# - 1行に1エントリを記載します.
+# - 大文字小文字は区別せず, NFKC 正規化した上で照合します.
+# - 行頭が # の行と空行は無視されます.
+# - 設置先は eccube_password_blocklist で差し替え可能です.
+#
+passwordpassword
+password12345678
+passwordpassword1
+123456789012345
+1234567890123456
+1234567890abcdef
+abcdefghijklmnop
+qwertyuiopasdfgh
+qwertyuiopasdfghjkl
+aaaaaaaaaaaaaaaa
+000000000000000
+111111111111111
+admin1234567890
+administrator123
+welcome123456789
+letmein123456789
+iloveyou12345678
+ec-cubeec-cube12

--- a/src/Eccube/Resource/password_blocklist.txt
+++ b/src/Eccube/Resource/password_blocklist.txt
@@ -27,3 +27,41 @@ welcome123456789
 letmein123456789
 iloveyou12345678
 ec-cubeec-cube12
+# キーボード配列・walk
+qwertyuiop123456
+1qaz2wsx3edc4rfv
+zaq12wsxcde34rfv
+1q2w3e4r5t6y7u8i
+asdfghjkl1234567
+qwertyqwerty1234
+# 連番・連続
+12345678901234567
+01234567890123456
+0123456789abcdef
+abcdef1234567890
+abcdefghijklmnopq
+# 同一文字の反復
+1111111111111111
+0000000000000000
+2222222222222222
+zzzzzzzzzzzzzzzz
+# 定番語＋パディング
+passwordpassword2
+password111111111
+passw0rdpassw0rd1
+welcomewelcome12
+iloveyouiloveyou
+letmeinletmein12
+adminadminadmin1
+monkeymonkey1234
+dragondragon1234
+trustno1trustno1
+sunshinesunshine
+princessprincess
+football12345678
+baseball12345678
+superman1234567
+michael123456789
+# サービス名由来
+eccubeeccube1234
+ec-cube123456789

--- a/src/Eccube/Util/PasswordNormalizer.php
+++ b/src/Eccube/Util/PasswordNormalizer.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Util;
+
+/**
+ * パスワードの Unicode 正規化を行うユーティリティ.
+ *
+ * NIST SP 800-63B-4 に従い, パスワード設定時とログイン照合時で表記ゆれを統一するため,
+ * NFKC 正規化を適用する. ext-intl(\Normalizer) が利用できない環境では入力値をそのまま返す.
+ */
+class PasswordNormalizer
+{
+    /**
+     * パスワードを NFKC 正規化する.
+     *
+     * @param string|null $password 正規化対象のパスワード
+     *
+     * @return string|null 正規化後のパスワード(\Normalizer 未導入時や正規化失敗時は入力値のまま)
+     */
+    public static function normalize(?string $password): ?string
+    {
+        if ($password === null || $password === '') {
+            return $password;
+        }
+
+        if (!class_exists(\Normalizer::class)) {
+            return $password;
+        }
+
+        $normalized = \Normalizer::normalize($password, \Normalizer::FORM_KC);
+
+        return $normalized === false ? $password : $normalized;
+    }
+}

--- a/tests/Eccube/Tests/Form/Type/Admin/CustomerTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/CustomerTypeTest.php
@@ -46,8 +46,8 @@ final class CustomerTypeTest extends AbstractTypeTestCase
         'job' => 1,
         'birth' => '1983-2-14',
         'plain_password' => [
-            'first' => 'password1234',
-            'second' => 'password1234',
+            'first' => 'password1234abc',
+            'second' => 'password1234abc',
         ],
         'status' => 1,
         'note' => 'note',
@@ -249,9 +249,40 @@ final class CustomerTypeTest extends AbstractTypeTestCase
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidPasswordAlphabetOnly()
+    /**
+     * NIST SP 800-63B-4 では文字種の複雑さを求めないため, 英字のみでも有効.
+     */
+    public function testValidPasswordAlphabetOnly()
     {
-        $password = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
+        $password = str_repeat('a', $this->eccubeConfig['eccube_password_min_len']);
+
+        $this->formData['plain_password']['first'] = $password;
+        $this->formData['plain_password']['second'] = $password;
+        $this->form->submit($this->formData);
+
+        $this->assertTrue($this->form->isValid());
+    }
+
+    /**
+     * 数字のみでも有効.
+     */
+    public function testValidPasswordNumericOnly()
+    {
+        $password = '987654321098765';
+
+        $this->formData['plain_password']['first'] = $password;
+        $this->formData['plain_password']['second'] = $password;
+        $this->form->submit($this->formData);
+
+        $this->assertTrue($this->form->isValid());
+    }
+
+    /**
+     * ブロックリストに掲載されたパスワードは不可.
+     */
+    public function testInvalidPasswordBlocklisted()
+    {
+        $password = 'passwordpassword';
 
         $this->formData['plain_password']['first'] = $password;
         $this->formData['plain_password']['second'] = $password;
@@ -260,9 +291,12 @@ final class CustomerTypeTest extends AbstractTypeTestCase
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidPasswordNumericOnly()
+    /**
+     * 制御文字(改行)を含む場合は不可.
+     */
+    public function testInvalidPasswordControlCharacter()
     {
-        $password = str_repeat('1', $this->eccubeConfig['eccube_password_max_len']);
+        $password = "abcdefghijklmno\nabc";
 
         $this->formData['plain_password']['first'] = $password;
         $this->formData['plain_password']['second'] = $password;

--- a/tests/Eccube/Tests/Form/Type/Admin/MemberTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/MemberTypeTest.php
@@ -148,6 +148,19 @@ final class MemberTypeTest extends AbstractTypeTestCase
         $this->assertFalse($this->form->isValid());
     }
 
+    /**
+     * MemberType は RepeatedPasswordType の制約を上書きするため,
+     * ブロックリスト制約が引き継がれていることを検証する(退行防止).
+     */
+    public function testInvalidPasswordBlocklisted()
+    {
+        $this->formData['plain_password']['first'] = 'passwordpassword';
+        $this->formData['plain_password']['second'] = 'passwordpassword';
+        $this->form->submit($this->formData);
+
+        $this->assertFalse($this->form->isValid());
+    }
+
     public function testInvalidAuthorityNotBlank()
     {
         $this->formData['Authority'] = null;

--- a/tests/Eccube/Tests/Form/Type/Admin/MemberTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/MemberTypeTest.php
@@ -32,8 +32,8 @@ final class MemberTypeTest extends AbstractTypeTestCase
         'department' => 'EC-CUBE事業部',
         'login_id' => 'takahashi',
         'plain_password' => [
-            'first' => 'password1234',
-            'second' => 'password1234',
+            'first' => 'password1234abc',
+            'second' => 'password1234abc',
         ],
         'Authority' => 1,
         'Work' => 1,

--- a/tests/Eccube/Tests/Form/Type/Admin/MemberTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/MemberTypeTest.php
@@ -152,7 +152,7 @@ final class MemberTypeTest extends AbstractTypeTestCase
      * MemberType は RepeatedPasswordType の制約を上書きするため,
      * ブロックリスト制約が引き継がれていることを検証する(退行防止).
      */
-    public function testInvalidPasswordBlocklisted()
+    public function testInvalidPasswordBlocklisted(): void
     {
         $this->formData['plain_password']['first'] = 'passwordpassword';
         $this->formData['plain_password']['second'] = 'passwordpassword';

--- a/tests/Eccube/Tests/Form/Type/Front/EntryTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Front/EntryTypeTest.php
@@ -46,8 +46,8 @@ final class EntryTypeTest extends AbstractTypeTestCase
             'second' => 'eccube1@example.com',
         ],
         'plain_password' => [
-            'first' => '1234567890ab',
-            'second' => '1234567890ab',
+            'first' => '1234567890abcde',
+            'second' => '1234567890abcde',
         ],
         'birth' => [
             'year' => '1980',

--- a/tests/Eccube/Tests/Form/Type/Front/PasswordResetTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Front/PasswordResetTypeTest.php
@@ -26,8 +26,8 @@ final class PasswordResetTypeTest extends AbstractTypeTestCase
     protected ?array $formData = [
         'login_email' => 'hideki_okajima@ec-cube.co.jp',
         'password' => [
-            'first' => 'password1234',
-            'second' => 'password1234',
+            'first' => 'password1234abc',
+            'second' => 'password1234abc',
         ],
     ];
 

--- a/tests/Eccube/Tests/Form/Type/Install/Step3TypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Install/Step3TypeTest.php
@@ -224,7 +224,7 @@ final class Step3TypeTest extends AbstractTypeTestCase
 
     public function testInvalidAdminDirBlank()
     {
-        $this->formData['login_pass'] = '';
+        $this->formData['admin_dir'] = '';
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
@@ -232,7 +232,7 @@ final class Step3TypeTest extends AbstractTypeTestCase
 
     public function testInvalidAdminDirMin()
     {
-        $this->formData['login_pass'] = str_repeat('a', $this->eccubeConfig['eccube_id_min_len'] - 1);
+        $this->formData['admin_dir'] = str_repeat('a', $this->eccubeConfig['eccube_id_min_len'] - 1);
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());

--- a/tests/Eccube/Tests/Form/Type/Install/Step3TypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Install/Step3TypeTest.php
@@ -30,7 +30,7 @@ final class Step3TypeTest extends AbstractTypeTestCase
         'shop_name' => '店舗名',
         'email' => 'eccube@example.com',
         'login_id' => 'administrator',
-        'login_pass' => 'administrator1',
+        'login_pass' => 'administrator1234',
         'admin_dir' => 'administrator',
         'admin_force_ssl' => true,
         'admin_allow_hosts' => '1.1.1.1',
@@ -163,29 +163,60 @@ final class Step3TypeTest extends AbstractTypeTestCase
         $this->assertTrue($this->form->isValid());
     }
 
-    public function testInvalidLoginPassHiragana()
+    /**
+     * NIST SP 800-63B-4 では文字種の複雑さを求めないため, ひらがなのみでも有効.
+     */
+    public function testValidLoginPassHiragana()
     {
-        $this->formData['login_pass'] = str_repeat('あ', $this->eccubeConfig['eccube_password_max_len']);
+        $this->formData['login_pass'] = str_repeat('あ', $this->eccubeConfig['eccube_password_min_len']);
 
         $this->form->submit($this->formData);
-        $this->assertFalse($this->form->isValid());
+        $this->assertTrue($this->form->isValid());
     }
 
-    public function testInvalidAlphabetOnly()
+    /**
+     * 英字のみ(数字なし)でも有効.
+     */
+    public function testValidAlphabetOnly()
     {
-        $password = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
+        $password = str_repeat('a', $this->eccubeConfig['eccube_password_min_len']);
 
         $this->formData['login_pass'] = $password;
         $this->form->submit($this->formData);
 
+        $this->assertTrue($this->form->isValid());
+    }
+
+    /**
+     * 数字のみでも有効.
+     */
+    public function testValidNumericOnly()
+    {
+        $password = '987654321098765';
+
+        $this->formData['login_pass'] = $password;
+        $this->form->submit($this->formData);
+
+        $this->assertTrue($this->form->isValid());
+    }
+
+    /**
+     * ブロックリストに掲載されたパスワードは不可.
+     */
+    public function testInvalidBlocklisted()
+    {
+        $this->formData['login_pass'] = 'passwordpassword';
+        $this->form->submit($this->formData);
+
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidNumericOnly()
+    /**
+     * 制御文字(改行)を含む場合は不可.
+     */
+    public function testInvalidControlCharacter()
     {
-        $password = str_repeat('1', $this->eccubeConfig['eccube_password_max_len']);
-
-        $this->formData['login_pass'] = $password;
+        $this->formData['login_pass'] = "abcdefghijklmno\nabc";
         $this->form->submit($this->formData);
 
         $this->assertFalse($this->form->isValid());
@@ -209,7 +240,7 @@ final class Step3TypeTest extends AbstractTypeTestCase
 
     public function testInvalidAdminDirMax()
     {
-        $this->formData['login_pass'] = str_repeat('a', $this->eccubeConfig['eccube_id_max_len'] + 1);
+        $this->formData['admin_dir'] = str_repeat('a', $this->eccubeConfig['eccube_id_max_len'] + 1);
 
         $this->form->submit($this->formData);
         $this->assertFalse($this->form->isValid());
@@ -217,7 +248,7 @@ final class Step3TypeTest extends AbstractTypeTestCase
 
     public function testVallidAdminDirMin()
     {
-        $this->formData['admin_dir'] = str_repeat('a', $this->eccubeConfig['eccube_password_min_len']);
+        $this->formData['admin_dir'] = str_repeat('a', $this->eccubeConfig['eccube_id_min_len']);
 
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());
@@ -225,7 +256,7 @@ final class Step3TypeTest extends AbstractTypeTestCase
 
     public function testValidAdminDirMax()
     {
-        $this->formData['admin_dir'] = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
+        $this->formData['admin_dir'] = str_repeat('a', $this->eccubeConfig['eccube_id_max_len']);
 
         $this->form->submit($this->formData);
         $this->assertTrue($this->form->isValid());

--- a/tests/Eccube/Tests/Form/Type/RepeatedPasswordTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/RepeatedPasswordTypeTest.php
@@ -46,6 +46,16 @@ final class RepeatedPasswordTypeTest extends AbstractTypeTestCase
         $this->form = null;
     }
 
+    /**
+     * 同じパスワードを両欄に設定して送信するヘルパ.
+     */
+    private function submitPassword(string $password): void
+    {
+        $this->formData['password']['first'] = $password;
+        $this->formData['password']['second'] = $password;
+        $this->form->submit($this->formData);
+    }
+
     public function testValidData()
     {
         $this->form->submit($this->formData);
@@ -62,100 +72,97 @@ final class RepeatedPasswordTypeTest extends AbstractTypeTestCase
 
     public function testInvalidNotBlank()
     {
-        $this->formData['password']['first'] = '';
-        $this->formData['password']['second'] = '';
-        $this->form->submit($this->formData);
+        $this->submitPassword('');
 
         $this->assertFalse($this->form->isValid());
     }
 
     public function testInvalidLengthMin()
     {
-        $password = str_repeat('1', $this->eccubeConfig['eccube_password_min_len'] - 1);
-
-        $this->formData['password']['first'] = $password;
-        $this->formData['password']['second'] = $password;
-        $this->form->submit($this->formData);
+        // NIST SP 800-63B-4 対応で min は 15. min-1 文字は不可.
+        $password = str_repeat('a', $this->eccubeConfig['eccube_password_min_len'] - 1);
+        $this->submitPassword($password);
 
         $this->assertFalse($this->form->isValid());
+    }
+
+    public function testValidLengthMin()
+    {
+        $password = str_repeat('a', $this->eccubeConfig['eccube_password_min_len']);
+        $this->submitPassword($password);
+
+        $this->assertTrue($this->form->isValid());
     }
 
     public function testInvalidLengthMax()
     {
-        $password = str_repeat('1', $this->eccubeConfig['eccube_password_max_len'] + 1);
-
-        $this->formData['password']['first'] = $password;
-        $this->formData['password']['second'] = $password;
-        $this->form->submit($this->formData);
+        $password = str_repeat('a', $this->eccubeConfig['eccube_password_max_len'] + 1);
+        $this->submitPassword($password);
 
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidHiragana()
+    /**
+     * NIST SP 800-63B-4 では文字種の複雑さを求めないため, ひらがなのみでも有効.
+     */
+    public function testValidHiragana()
     {
-        $password = str_repeat('あ', $this->eccubeConfig['eccube_password_max_len']);
-
-        $this->formData['password']['first'] = $password;
-        $this->formData['password']['second'] = $password;
-        $this->form->submit($this->formData);
-
-        $this->assertFalse($this->form->isValid());
-    }
-
-    /* 環境依存で通るっぽい
-    public function testValid_ZenkakuAlpha()
-    {
-        // これ通っていいのかな?
-        $password = str_repeat('Ａ', $this->eccubeConfig['eccube_password_max_len']);
-
-        $this->formData['password']['first'] = $password;
-        $this->formData['password']['second'] = $password;
-        $this->form->submit($this->formData);
+        $password = str_repeat('あ', $this->eccubeConfig['eccube_password_min_len']);
+        $this->submitPassword($password);
 
         $this->assertTrue($this->form->isValid());
     }
+
+    /**
+     * 英字のみ(数字・記号なし)でも有効.
      */
-
-    public function testInvalidSpaceOnly()
+    public function testValidAlphabetOnly()
     {
-        $password = str_repeat(' ', $this->eccubeConfig['eccube_password_max_len']);
+        $password = str_repeat('a', $this->eccubeConfig['eccube_password_min_len']);
+        $this->submitPassword($password);
 
-        $this->formData['password']['first'] = $password;
-        $this->formData['password']['second'] = $password;
-        $this->form->submit($this->formData);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    /**
+     * 数字のみでも有効.
+     */
+    public function testValidNumericOnly()
+    {
+        $password = '987654321098765';
+        $this->submitPassword($password);
+
+        $this->assertTrue($this->form->isValid());
+    }
+
+    /**
+     * パスワード中のスペースは許可される.
+     */
+    public function testValidContainsSpace()
+    {
+        $password = 'correct horse battery staple';
+        $this->submitPassword($password);
+
+        $this->assertTrue($this->form->isValid());
+    }
+
+    /**
+     * 制御文字(改行・タブ)を含む場合は不可.
+     */
+    public function testInvalidControlCharacter()
+    {
+        $password = "abcdefghijklmno\nabc";
+        $this->submitPassword($password);
 
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testInvalidSpace()
+    /**
+     * ブロックリストに掲載されたパスワードは不可.
+     */
+    public function testInvalidBlocklisted()
     {
-        $password = "1234 \n\s\t78a";
-
-        $this->formData['password']['first'] = $password;
-        $this->formData['password']['second'] = $password;
-        $this->form->submit($this->formData);
-
-        $this->assertFalse($this->form->isValid());
-    }
-
-    public function testInvalidAlphabetOnly()
-    {
-        $password = str_repeat('a', $this->eccubeConfig['eccube_password_max_len']);
-
-        $this->formData['password']['first'] = $password;
-        $this->formData['password']['second'] = $password;
-        $this->form->submit($this->formData);
-
-        $this->assertFalse($this->form->isValid());
-    }
-
-    public function testInvalidNumericOnly()
-    {
-        $password = str_repeat('1', $this->eccubeConfig['eccube_password_max_len']);
-
-        $this->formData['password']['first'] = $password;
-        $this->formData['password']['second'] = $password;
-        $this->form->submit($this->formData);
+        $this->submitPassword('passwordpassword');
 
         $this->assertFalse($this->form->isValid());
     }

--- a/tests/Eccube/Tests/Form/Type/RepeatedPasswordTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/RepeatedPasswordTypeTest.php
@@ -147,6 +147,18 @@ final class RepeatedPasswordTypeTest extends AbstractTypeTestCase
     }
 
     /**
+     * 検証は NFKC 正規化後の値で行われる(CodeRabbit 指摘の回避経路対策).
+     * 結合文字で見かけ上16文字でも, 正規化後は8文字となり min15 未満として拒否される.
+     */
+    public function testInvalidLengthAfterNormalization()
+    {
+        $password = str_repeat("e\u{0301}", 8); // 16コードポイント → NFKC で "é"×8 = 8文字
+        $this->submitPassword($password);
+
+        $this->assertFalse($this->form->isValid());
+    }
+
+    /**
      * 制御文字(改行・タブ)を含む場合は不可.
      */
     public function testInvalidControlCharacter()

--- a/tests/Eccube/Tests/Form/Validator/PasswordBlocklistValidatorTest.php
+++ b/tests/Eccube/Tests/Form/Validator/PasswordBlocklistValidatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Form\Validator;
+
+use Eccube\Form\Validator\PasswordBlocklist;
+use Eccube\Tests\Form\Type\AbstractTypeTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class PasswordBlocklistValidatorTest extends AbstractTypeTestCase
+{
+    protected ?ValidatorInterface $validator = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = static::getContainer()->get(ValidatorInterface::class);
+    }
+
+    /**
+     * @param mixed $password
+     * @param mixed $expectedValid
+     */
+    #[DataProvider(methodName: 'passwordProvider')]
+    public function testValidate($password, $expectedValid)
+    {
+        $errors = $this->validator->validate($password, new PasswordBlocklist());
+
+        $this->assertSame($expectedValid, count($errors) === 0);
+    }
+
+    /**
+     * @return array<array{0: string|null, 1: bool}>
+     */
+    public static function passwordProvider(): \Iterator
+    {
+        // ブロックリストに掲載された値は不可
+        yield ['passwordpassword', false];
+        // 大文字小文字を無視して照合する
+        yield ['PASSWORDPASSWORD', false];
+        // NFKC 正規化して照合する(全角は半角に正規化されて一致)
+        yield ['ｐａｓｓｗｏｒｄｐａｓｓｗｏｒｄ', false];
+        // 掲載されていない値は許可
+        yield ['correct horse battery staple', true];
+        // 空文字・null は対象外(他の制約で扱う)
+        yield ['', true];
+        yield [null, true];
+    }
+}

--- a/tests/Eccube/Tests/Form/Validator/PasswordBlocklistValidatorTest.php
+++ b/tests/Eccube/Tests/Form/Validator/PasswordBlocklistValidatorTest.php
@@ -45,6 +45,8 @@ final class PasswordBlocklistValidatorTest extends AbstractTypeTestCase
     {
         // ブロックリストに掲載された値は不可
         yield ['passwordpassword', false];
+        // 拡充エントリ(キーボード配列 walk)も不可
+        yield ['qwertyuiop123456', false];
         // 大文字小文字を無視して照合する
         yield ['PASSWORDPASSWORD', false];
         // NFKC 正規化して照合する(全角は半角に正規化されて一致)

--- a/tests/Eccube/Tests/Form/Validator/PasswordBlocklistValidatorTest.php
+++ b/tests/Eccube/Tests/Form/Validator/PasswordBlocklistValidatorTest.php
@@ -30,12 +30,8 @@ final class PasswordBlocklistValidatorTest extends AbstractTypeTestCase
         $this->validator = static::getContainer()->get(ValidatorInterface::class);
     }
 
-    /**
-     * @param mixed $password
-     * @param mixed $expectedValid
-     */
     #[DataProvider(methodName: 'passwordProvider')]
-    public function testValidate($password, $expectedValid)
+    public function testValidate(?string $password, bool $expectedValid): void
     {
         $errors = $this->validator->validate($password, new PasswordBlocklist());
 

--- a/tests/Eccube/Tests/Util/PasswordNormalizerTest.php
+++ b/tests/Eccube/Tests/Util/PasswordNormalizerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Util;
+
+use Eccube\Util\PasswordNormalizer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PasswordNormalizerTest extends TestCase
+{
+    /**
+     * @param string|null $input
+     * @param string|null $expected
+     */
+    #[DataProvider(methodName: 'normalizeProvider')]
+    public function testNormalize($input, $expected)
+    {
+        $this->assertSame($expected, PasswordNormalizer::normalize($input));
+    }
+
+    /**
+     * @return array<array{0: string|null, 1: string|null}>
+     */
+    public static function normalizeProvider(): \Iterator
+    {
+        // null・空文字はそのまま返す
+        yield [null, null];
+        yield ['', ''];
+        // ASCII は不変(既存パスワードに影響しない)
+        yield ['Password12345678', 'Password12345678'];
+        // 半角カナは全角へ正規化される
+        yield ['ﾊﾟｽﾜｰﾄﾞ', 'パスワード'];
+        // 全角英数字は半角へ正規化される
+        yield ['ＡＢＣ１２３', 'ABC123'];
+    }
+}

--- a/tests/Eccube/Tests/Util/PasswordNormalizerTest.php
+++ b/tests/Eccube/Tests/Util/PasswordNormalizerTest.php
@@ -21,12 +21,8 @@ use PHPUnit\Framework\TestCase;
 
 final class PasswordNormalizerTest extends TestCase
 {
-    /**
-     * @param string|null $input
-     * @param string|null $expected
-     */
     #[DataProvider(methodName: 'normalizeProvider')]
-    public function testNormalize($input, $expected)
+    public function testNormalize(?string $input, ?string $expected): void
     {
         $this->assertSame($expected, PasswordNormalizer::normalize($input));
     }

--- a/tests/Eccube/Tests/Web/Admin/Customer/CustomerEditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Customer/CustomerEditControllerTest.php
@@ -43,7 +43,7 @@ final class CustomerEditControllerTest extends AbstractAdminWebTestCase
     {
         $faker = $this->getFaker();
         $email = $faker->safeEmail;
-        $password = $faker->lexify('????????????').'a1';
+        $password = $faker->lexify('?????????????').'a1';
         $birth = $faker->dateTimeBetween;
 
         return [

--- a/tests/Eccube/Tests/Web/Admin/IndexControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/IndexControllerTest.php
@@ -178,7 +178,7 @@ final class IndexControllerTest extends AbstractAdminWebTestCase
     {
         $faker = $this->getFaker();
 
-        $password = $faker->lexify('????????????').'a1';
+        $password = $faker->lexify('?????????????').'a1';
 
         return [
             'current_password' => 'password',

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/MemberControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/MemberControllerTest.php
@@ -376,8 +376,8 @@ final class MemberControllerTest extends AbstractAdminWebTestCase
             'department' => $faker->word(),
             'login_id' => 'logintest',
             'plain_password' => [
-                'first' => 'password1234',
-                'second' => 'password1234',
+                'first' => 'password1234abc',
+                'second' => 'password1234abc',
             ],
             'Authority' => random_int(0, 1),
             'Work' => random_int(0, 1),

--- a/tests/Eccube/Tests/Web/EntryControllerTest.php
+++ b/tests/Eccube/Tests/Web/EntryControllerTest.php
@@ -35,7 +35,7 @@ final class EntryControllerTest extends AbstractWebTestCase
     {
         $faker = $this->getFaker();
         $email = $faker->safeEmail;
-        $password = $faker->lexify('????????????').'a1';
+        $password = $faker->lexify('?????????????').'a1';
         $birth = $faker->dateTimeBetween;
 
         return [

--- a/tests/Eccube/Tests/Web/Mypage/ChangeControllerTest.php
+++ b/tests/Eccube/Tests/Web/Mypage/ChangeControllerTest.php
@@ -33,7 +33,7 @@ final class ChangeControllerTest extends AbstractWebTestCase
     {
         $faker = $this->getFaker();
         $email = $faker->safeEmail;
-        $password = $faker->lexify('????????????').'a1';
+        $password = $faker->lexify('?????????????').'a1';
         $birth = $faker->dateTimeBetween;
 
         return [

--- a/tests/Eccube/Tests/Web/PasswordNormalizationLoginTest.php
+++ b/tests/Eccube/Tests/Web/PasswordNormalizationLoginTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Web;
+
+use Eccube\Entity\Customer;
+use Eccube\Util\PasswordNormalizer;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * NIST SP 800-63B-4 対応の NFKC 正規化が, パスワード設定時とログイン照合時で
+ * 一貫して適用され, Unicode パスワードの表記ゆれを吸収してログインできることを確認する.
+ */
+final class PasswordNormalizationLoginTest extends AbstractWebTestCase
+{
+    /** 半角カナを含む生パスワード(NFKC で全角へ正規化される) */
+    private const RAW_PASSWORD = 'ﾊﾟｽﾜｰﾄﾞﾃｽﾄ123456';
+
+    private ?Customer $Customer = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->Customer = $this->createCustomer();
+
+        // 設定時の正規化(setPlainPassword)を通して保存する.
+        $this->Customer->setPlainPassword(self::RAW_PASSWORD);
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $this->Customer->setPassword($hasher->hashPassword($this->Customer, $this->Customer->getPlainPassword()));
+        $this->entityManager->flush();
+    }
+
+    public function testRawPasswordIsNormalizedOnStore()
+    {
+        // 半角カナは NFKC で正規化され, 生の入力とは異なる文字列で保存される(前提条件の確認).
+        $this->assertNotSame(self::RAW_PASSWORD, PasswordNormalizer::normalize(self::RAW_PASSWORD));
+
+        // 保存済みハッシュは正規化後のパスワードで検証できる(生のままでは検証できない).
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $this->assertTrue($hasher->isPasswordValid($this->Customer, PasswordNormalizer::normalize(self::RAW_PASSWORD)));
+    }
+
+    public function testLoginWithNonNormalizedPasswordSucceeds()
+    {
+        // 保存は正規化済み. ログイン入力は生(非正規化)でも, リスナで正規化され照合に成功する.
+        $this->client->request(Request::METHOD_POST, $this->generateUrl('mypage_login'), [
+            '_csrf_token' => 'dummy',
+            '_target_path' => $this->generateUrl('mypage'),
+            'login_email' => $this->Customer->getEmail(),
+            'login_pass' => self::RAW_PASSWORD,
+        ]);
+
+        $this->assertTrue(
+            $this->client->getResponse()->isRedirect($this->generateUrl('mypage', [], UrlGeneratorInterface::ABSOLUTE_PATH)),
+            '非正規化のパスワードでログインできること'
+        );
+    }
+
+    public function testLoginWithNormalizedPasswordSucceeds()
+    {
+        // 正規化済みの表記でもログインできる.
+        $this->client->request(Request::METHOD_POST, $this->generateUrl('mypage_login'), [
+            '_csrf_token' => 'dummy',
+            '_target_path' => $this->generateUrl('mypage'),
+            'login_email' => $this->Customer->getEmail(),
+            'login_pass' => PasswordNormalizer::normalize(self::RAW_PASSWORD),
+        ]);
+
+        $this->assertTrue(
+            $this->client->getResponse()->isRedirect($this->generateUrl('mypage', [], UrlGeneratorInterface::ABSOLUTE_PATH)),
+            '正規化済みのパスワードでログインできること'
+        );
+    }
+}


### PR DESCRIPTION
## 概要

NIST SP 800-63B-4 のパスワード要件に準拠するため、パスワードバリデーションを見直します。
Issue #6488 にまとめた方針（バリデーション層のみで対応・ハッシャー `auto` は変更しない）に沿った実装です。

closes #6488

## 変更内容

### 設定値（`eccube.yaml`）
| 項目 | 変更前 | 変更後 |
|---|---|---|
| `eccube_password_min_len` | 12 | **15**（単要素認証は15文字以上） |
| `eccube_password_max_len` | 50 | **128** |
| `eccube_password_pattern` | `/\A(?=.*?[a-z])(?=.*?\d)[!-~]+\z/i` | **`/\A[\pL\pM\pN\pP\pS\pZ]+\z/u`**（複雑さ撤廃・全Unicode許可、制御/不可視文字 `\pC` のみ拒否） |

追加パラメータ:
- `eccube_password_compromised_check`（既定 `true`）— 漏洩チェックの有効/無効
- `eccube_password_blocklist` — 同梱ブロックリストのパス（差し替え可）

### 漏洩チェック（HaveIBeenPwned）
- Symfony 標準 `NotCompromisedPassword` を**既定ON**で全パスワードフォームに適用。
- `skipOnError: true` により API 到達不可（閉域網・障害）でも登録は継続。閉域網では `eccube_password_compromised_check: false` で無効化可能。
- `symfony/http-client` を依存に追加。

### ブロックリスト
- 「15文字以上だが弱い」古典的パターンに絞った小さな同梱リスト（`src/Eccube/Resource/password_blocklist.txt`、差し替え可）。
- カスタム制約 `PasswordBlocklist` + `PasswordBlocklistValidator` を新設（NFKC 正規化・大文字小文字無視で照合）。網羅照合は HIBP に委譲。

### NFKC 正規化（設定時・ログイン照合時の双方）
- 設定時: エンティティの `setPlainPassword()`（Customer/Member）、およびフォーム直読みフロー（パスワードリセット・管理者自身のパスワード変更・インストーラ）で正規化してから保存。
- ログイン照合時: `PasswordNormalizationListener`（`kernel.request`）が送信パスワードを正規化してから firewall に渡す。
- `Eccube\Util\PasswordNormalizer`（`ext-intl` 未導入時は no-op）に集約。既存の ASCII パスワードは正規化しても不変のため、既存ユーザーのログインに影響しません。

### 適用フォーム
`RepeatedPasswordType`（会員登録・パスワードリセット・会員管理が経由）/ `Admin/ChangePasswordType` / `Install/Step3Type` に一貫適用。
`Admin/MemberType` は `options.constraints` を上書きしており親の制約が引き継がれないため、ブロックリスト/漏洩チェックを明示的に再付与（管理ユーザー登録の取りこぼし防止）。翻訳メッセージ（ja/en）も更新。

### NIST 準拠済み（変更不要）
- **定期的なパスワード変更の強制**: 仕組みが無く既に準拠。
- **秘密の質問**: 機能が存在せず既に準拠。
- **ハッシャー**: `auto`（Argon2id/bcrypt）のため変更不要。

## テスト

- 既存フォームテストを新仕様へ刷新（英字のみ/数字のみ/ひらがなは**有効**化、制御文字・ブロックリストは無効を確認）。
- 新規: `PasswordNormalizerTest` / `PasswordBlocklistValidatorTest` / `PasswordNormalizationLoginTest`（NFKC 保存＋ログイン往復）。
- テスト環境では `eccube_password_compromised_check: false` で外部通信を回避。
- 12文字前提のフィクスチャを15文字以上へ更新。`eccube_default_password` も15文字へ（編集画面の未変更送信が新ルールを通るため）。

## 動作確認（手動 / Playwright・MailCatcher）

ローカル環境で、フロント・管理・メール経路を一通り確認しました。

**バリデーション（フロント会員登録 `/entry` と 管理ユーザー登録の両方で確認）**
- 14文字 → 「短すぎます。この値は15文字以上で入力してください。」で拒否（min15）。
- 漏洩既知パスワード（例 `password1234567`）→ HIBP が実際に外部APIを呼び「このパスワードは過去に漏洩が確認されています。…」で拒否（既定ON・日本語訳）。
- ブロックリスト掲載値 → 「推測されやすいパスワードです。…」で拒否。
- ひらがなのみ / 英字のみ等で15文字以上 → 受理（複雑さ要件の撤廃を確認。旧仕様では弾かれていたケース）。

**NFKC 正規化の往復（登録時＆ログイン時 / 両 firewall で確認）**
- **一般会員（`mypage_login`）**: `/entry` で半角カナ `ﾊﾟｽﾜｰﾄﾞﾃｽﾄ123456` を入力して仮登録 → MailCatcher の「会員登録のご確認」メールの URL で本登録 → `/mypage/login` に **半角カナ（非正規化）でも 全角（正規化済み）でも** ログイン成功。
- **管理ユーザー（`admin_login`）**: 半角カナで登録 → 同様に半角・全角どちらでもログイン成功。
- 既存 ASCII パスワード（`admin` / `password`）も従来どおりログイン可（正規化が no-op のため既存ユーザーに影響なし）。

> 「保存時に NFKC 正規化して格納」「ログイン時に入力を正規化して照合」が一致し、Unicode の表記ゆれを吸収できることを実フローで確認。

## QA

- PHPStan (level 6): No errors
- PHP-CS-Fixer / Rector: クリーン
- PHPUnit: 関連テスト・Form テスト全件 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * パスワード入力の表記ゆれ（NFKC）を正規化して、保存・ログイン照合での整合性を強化しました。
  * 推測されやすいパスワードのブロックリスト判定に対応し、設定により漏えい確認も有効化されます。
* **改善**
  * パスワードポリシー（長さ・文字種・正規表現）と表示文言を見直し、各画面で同等の入力チェックになります。
* **テスト**
  * 正規化・ブロックリスト・漏えい確認の挙動を含むテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
