### PR TITLE
docs: AGENTS.md の E2E 記述を実態(Playwright)に修正

### DIFF
--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: e2e
+description: EC-CUBE 4.4 の E2E テスト（Playwright・`e2e/` 配下）を実装・修正するときの規約。「E2Eテストを書いて」「Playwrightテストを追加して」「E2Eが落ちる/flakyを直して」「spec を追加して」などと言われたとき、または `e2e/tests` `e2e/pages` `e2e/models` `e2e/helpers` `e2e/fixtures` 配下を作成・編集するときに使用する。
+---
+
+# E2E テスト規約（Playwright・EC-CUBE 4.4）
+
+**対象**: `e2e/tests/*.spec.ts`, `e2e/{pages,models,helpers,fixtures}/*.ts`
+**前提**: Playwright（TypeScript）。`cd e2e && npm ci` 済み。baseURL は環境変数 `BASE_URL`（既定 `http://127.0.0.1:8000`）。
+
+> EC-CUBE の E2E は `e2e/` 配下の Playwright が正。`codeception/` はレガシー残置で CI 無効（`AGENTS.md` 参照）。
+> 混同しないこと。
+
+## 基本ルール
+
+- **spec ファイル名の接頭辞 = プロジェクト = 認証状態**（`e2e/playwright.config.ts` の `testMatch`）。新規 spec はこの規則で命名する:
+  - `admin-*` / `plugin-*` … storageState=`.auth/admin.json` で**管理者ログイン済み** → spec 側でログイン不要。
+  - `front-*` / `deny*` … 空 state（`{ cookies: [], origins: [] }`）で**未認証** → 会員操作は spec 内でログインするか、admin 経由で会員を作成する。
+- **命名規約**: `test.describe('… (EFxx)')`（フロント）/ `(EAxx)`（管理）。test 名は `EF0401-UC01-T01 会員登録 …`（機能ID-ユースケース-テストID + 日本語説明）。既存 `front-customer.spec.ts` / `admin-customer.spec.ts` に倣う。
+- **状態を引き継ぐ一連のテスト**（create→search→edit→delete 等）は `test.describe.configure({ mode: 'serial' })` を付ける。`playwright.config.ts` は `workers: 1` / `fullyParallel: false`。
+- **テストデータは投入済み前提**: `global-setup.ts` が `setup-fixtures.php` を実行し、会員・商品・受注を投入する。固定会員 `playwright@test.test`（ACTIVE）などを再利用し、新規作成データはメール等を `nist_${Date.now()}@example.com` のように一意化して衝突を避ける。
+- **パスは baseURL 相対**（`page.goto('/entry')`）。ホスト/ポートの直書きは禁止（環境差・ローカル/CI 差を吸収するため）。
+
+## 実装パターン
+
+- **認証**: admin/plugin spec はログイン不要。認証フロー自体を検証するときだけ `test.use({ storageState: { cookies: [], origins: [] } })` で上書きして毎回ログインする（`admin-auth.spec.ts`）。
+- **POM（Page Object Model）**: `tsconfig.json` のパスエイリアスで import する。
+  - `@pages/*` … UI ページ単位の操作（例 `PluginManagePage`）。`static at(page)` でページ到達を検証して返す。
+  - `@models/*` … 操作チェーン＋DB/FS 検証（例 `StorePlugin.インストール()` が UI 操作後に `db.getPlugin()` で状態確認）。
+  - `@helpers/*` … 低レベル: `db-client`（テーブル/カラム/プラグイン状態）、`file-helper`（proxy への trait 注入確認）、`tar-helper`（プラグイン .tgz 圧縮）。
+- **plugin 系 spec** は拡張 fixture（`e2e/fixtures/plugin-test.ts`）の `{ page, db, config }` を test 引数で受け取る。
+- **待機は web-first assertion** を使う: `await expect(locator).toBeVisible()` / `toContainText()` / `page.waitForURL()`。`expect.timeout` / `actionTimeout` は 30s に設定済み。
+- **入力ページ残留の判定**は、確認画面でパスワードが hidden になる性質を使い、入力欄（例 `#entry_plain_password_first`）の `toBeVisible()` で行う。
+
+## よくある間違い
+
+- ❌ `waitForTimeout(固定ms)` で同期を取る → ✅ web-first assertion（`expect().toBeVisible()` / `waitForFunction()`）で「状態」を待つ。**例外**: yubinbango 郵便番号の自動入力など外部 JS 由来の待機のみ許容（理由をコメントで明記）。
+- ❌ `front-*` spec で管理者ログイン済みを前提にする → ✅ front は未認証 state。spec 内でログインするか admin 経由で会員作成する。
+- ❌ 固定件数で assert（`検索結果：1件が該当`）→ ✅ 正規表現（`/検索結果：\d+件が該当/`）。retry 時の重複データに強くする（`admin-product.spec.ts` 修正例）。
+- ❌ セレクタが複数要素にマッチ（strict mode violation）→ ✅ `.first()` か `data-*` 属性（例 `button[data-bs-target="#initializationConfirm"]`）で一意化する。
+- ❌ テスト境界で管理者セッションが切れて 401 → ✅ `ensureAdminLoggedIn()` 等で再ログインしてから操作（`admin-basicinfo.spec.ts` 修正例）。
+- ❌ retry でプラグイン/データが残留し「既にインストール済み」で再失敗 → ✅ `beforeEach`/`afterEach` で cleanup（無効化→削除→ディレクトリ削除。`plugin-misc.spec.ts` 修正例）。
+- ❌ パスワードを見た目の文字数で作る → ✅ NFKC 正規化後で 15 文字以上か数える（min15。`[...str.normalize('NFKC')].length` で確認。#6488）。
+- ❌ 新規 `admin-*`/`front-*` spec を作ったのに CI で実行されない → ✅ `.github/workflows/e2e-test.yml` の `suite:` 配列にファイル名（接尾辞 `.spec.ts` 抜き）を追加する。
+
+## 実行・確認方法
+
+```bash
+cd e2e && npm ci
+# project は接頭辞で決まる。setup（ログイン/データ投入の前段）を併せて指定する
+npx playwright test --project=setup --project=front-tests  front-product.spec.ts
+npx playwright test --project=setup --project=admin-tests  admin-customer.spec.ts
+npx playwright test --project=setup --project=plugin-tests plugin-install.spec.ts
+```
+
+CI 構造（spec 群ごとに担当ワークフローが分かれている）:
+
+- `e2e-test.yml` … `admin-*` / `front-*` を `matrix.suite` で 1 ファイル = 1 シャード実行。**新規 admin-/front- spec はここに追加**。
+- `plugin-test.yml` … plugin 系を `npx playwright test plugin-install --grep "${METHOD}"` 等で method 単位実行。
+- `e2e-test-throttling.yml` … `front-throttling.spec.ts` を `-g "${METHOD}"` で実行。
+- `deny-test.yml` … `deny.spec.ts` を実行。

--- a/.claude/skills/twig-template/SKILL.md
+++ b/.claude/skills/twig-template/SKILL.md
@@ -97,6 +97,7 @@ public function onTemplateCart(TemplateEvent $event): void
 - ❌ 上書きを `app/template/` 直下に置く / `@admin` 名前空間を付け忘れる → ✅ 正しいサブディレクトリ・名前空間に置く
 - ❌ **管理画面テンプレートだから安全**と油断して `|raw` する → ✅ admin 配下も XSS シンク（過去の XSS 修正は管理画面テンプレートに多い）。DB/入力由来の値は admin でも必ずエスケープする
 - ❌ テンプレートイベントにエンティティ永続化など業務処理を書く → ✅ 見た目調整のみ。業務は対応するコントローライベントへ
+- ❌ inline `<script>`（JSON-LD `application/ld+json` 等）に動的値を文字列直書き／素の `json_encode` で埋める → ✅ 商品名・説明中の `</script>` や `"` で XSS・JSON 破壊になる。`json_encode($data, JSON_UNESCAPED_SLASHES｜JSON_HEX_TAG｜JSON_HEX_AMP｜JSON_HEX_APOS｜JSON_HEX_QUOT)` で `<`/`>`/`&` をエスケープする
 
 ## 実行・確認方法
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,7 @@ frontmatter の `description` がトリガ条件で、該当レイヤを触る�
 | レイヤ / 観点 | 規約 Skill（本文） | Skill 名 |
 |--------|------------------|----------|
 | PHPUnit テスト | [`.claude/skills/phpunit/SKILL.md`](./.claude/skills/phpunit/SKILL.md) | `phpunit` |
+| E2E（Playwright・spec 作成 / flaky 対策） | [`.claude/skills/e2e/SKILL.md`](./.claude/skills/e2e/SKILL.md) | `e2e` |
 | コントローラ（責務分離・Fat化防止） | [`.claude/skills/controller/SKILL.md`](./.claude/skills/controller/SKILL.md) | `controller` |
 | サービス（責務分離・単一責任） | [`.claude/skills/service/SKILL.md`](./.claude/skills/service/SKILL.md) | `service` |
 | マイグレーション（スキーマ変更） | [`.claude/skills/migration/SKILL.md`](./.claude/skills/migration/SKILL.md) | `migration` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,8 @@ EC-CUBE は日本で広く使われる OSS の EC プラットフォームです
 - **テンプレート**: Twig 3.x
 - **データベース**: PostgreSQL 13–18 または MySQL 8.4 LTS
 - **フロントエンド**: Sass (SCSS) / webpack / Bootstrap 5.3 / jQuery 4.x
-- **テスト**: PHPUnit 11（`symfony/phpunit-bridge` 経由）/ Codeception 5（E2E）
+- **テスト**: PHPUnit 11（`symfony/phpunit-bridge` 経由）/ Playwright（E2E、`e2e/`）
+  - ※ `codeception/` は残置（レガシー）。CI の Codeception ジョブは無効化（`if: false`）されており、E2E は Playwright が正。
 - **静的解析**: PHPStan（`phpstan.neon.dist` で level 6）
 - **コードスタイル**: PHP-CS-Fixer（PSR-12）
 
@@ -65,6 +66,10 @@ html/                 # 公開ドキュメントルート
 
 tests/
   Eccube/Tests/       # PHPUnit テスト
+
+e2e/                  # Playwright E2E（spec / Page Object / fixtures）
+  tests/              # *.spec.ts（CI は e2e-test.yml のマトリクスで 1 ファイル = 1 シャード）
+  pages/  models/  helpers/  fixtures/
 ```
 
 ## 開発コマンド
@@ -86,6 +91,14 @@ bin/console eccube:install
 bin/phpunit                                                      # 全テスト
 bin/phpunit tests/Eccube/Tests/Web/ShoppingControllerTest.php    # 単一ファイル
 bin/phpunit --filter testCompleteWithLogin                       # フィルタ
+```
+
+E2E（Playwright、`e2e/` 配下で実行）:
+
+```bash
+cd e2e && npm ci
+# project は front-tests / admin-tests。spec ファイル名でフィルタ
+npx playwright test --project=setup --project=front-tests front-product.spec.ts
 ```
 
 ### 静的解析

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ E2E（Playwright、`e2e/` 配下で実行）:
 
 ```bash
 cd e2e && npm ci
-# project は front-tests / admin-tests。spec ファイル名でフィルタ
+# project は front-tests / admin-tests / plugin-tests。spec ファイル名でフィルタ
 npx playwright test --project=setup --project=front-tests front-product.spec.ts
 ```
 


### PR DESCRIPTION
## 概要

`AGENTS.md`（AI コーディングエージェント向けの正典）が、E2E テストフレームワークを **「Codeception 5（E2E）」** と記載していましたが、実態とズレていたため修正します。

## 実態

- **E2E は `e2e/` 配下の Playwright** で実装されており、CI（`.github/workflows/e2e-test.yml`）もこちらをマトリクス実行している（1 spec ファイル = 1 シャード）。
- `codeception/` はリポジトリに残置されているものの、`coverage.yml` の Codeception ジョブは **`if: false`（Disabled until remote coverage collection is fixed）** で無効化されており、**CI では動作していない**。

正典が誤った情報を指していると、エージェントが Playwright E2E の存在に気づけず（または Codeception を前提に動いてしまう）ため修正します。

## 変更内容

- 技術スタックの「テスト」行を Playwright（E2E）へ修正し、Codeception が残置レガシー／CI 無効である旨を注記
- ディレクトリ構成に `e2e/`（spec / Page Object / fixtures）を追記
- 開発コマンドに E2E（Playwright）の実行例を追記

ドキュメントのみの変更で、コード・CI 設定への影響はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * 技術スタックのテスト記載を、Codeception（レガシー残置・CI無効）から PHPUnit（Symfony PHPUnit Bridge 経由）＋ Playwright E2E へ更新。
  * Playwright E2E の構成（e2e配下）と、CIでの分割実行方針（1ファイル＝1シャード）を追記。
  * Playwright E2E の実行手順、spec／命名規約、POM・fixture運用、待機方針などの規約を整理。
  * Twig テンプレートのよくある間違い（JSON-LD等への動的埋め込み時の XSS/JSON破壊対策）を追記。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->