### PR TITLE
fix: 利用条件外のデフォルト支払方法の手数料が加算される問題を修正 (#6200)

### DIFF
--- a/.claude/skills/controller/SKILL.md
+++ b/.claude/skills/controller/SKILL.md
@@ -134,6 +134,7 @@ vendor/bin/php-cs-fixer fix                     # PSR-12 整形・ライセン�
 - ❌ `$this->isTokenValid();`（戻り値を捨てた bare 呼び出し）を「CSRF 未検証」と誤読 → ✅ 無効時は `AccessDeniedHttpException` を投げ戻り値は常に true。bare 呼び出しで検証は成立し、`if (!isTokenValid())` の false 分岐はデッドコード
 - ❌ `#[Template]` 付きアクションの「エラー時に再描画される」を前提にレビュー判断 → ✅ `#[Template]` は配列を返したときのみ engage。Response/Redirect を返すパス（例: フォーム失敗で `redirectToRoute`）では描画されない
 - ❌ 管理アクションを `%eccube_admin_route%` 配下以外に置く → ✅ admin ファイアウォール配下に置く
+- ❌ 同一アクションで `executePurchaseFlow()` を複数回呼ぶとき 2 回目以降の `FlowResult` を無視する → ✅ 毎回 `hasError()`/`hasWarning()` の分岐を 1 回目と同じに揃える（共通化可）
 
 ---
 

--- a/.claude/skills/phpunit/SKILL.md
+++ b/.claude/skills/phpunit/SKILL.md
@@ -108,6 +108,7 @@ public static function provideStatuses(): array
 - ❌ `new Client()` など HTTP クライアントの自前生成 → ✅ 親クラスの `$this->client`。
 - ❌ URL の文字列直書き（`'/products/list'`）→ ✅ `$this->generateUrl('product_list')`。
 - ❌ Entity の手組み → ✅ `createXxx()` フィクスチャヘルパ。
+- ❌ 支払方法のデフォルト/再選択テストで `find(1)` 等の ID 前提 → ✅ `Generator::createPayment()` で sort_no・利用条件を明示し `assertSame()` で再選択先を固定（フィクスチャ並び変更で偽陽性になり得る）。
 - ❌ ステータス値のハードコーディング（`if ($status == 1)`）→ ✅ 定数（例: `OrderStatus::NEW`）を使う。
 - ❌ 型宣言の省略 → ✅ 引数・戻り値に型を付け、PHPStan level 6 を通す。
 

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -16,6 +16,7 @@ namespace Eccube\Controller;
 use Eccube\Entity\Customer;
 use Eccube\Entity\CustomerAddress;
 use Eccube\Entity\Order;
+use Eccube\Entity\Payment;
 use Eccube\Entity\Shipping;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
@@ -117,12 +118,55 @@ class ShoppingController extends AbstractShoppingController
         $activeTradeLaws = $this->tradeLawRepository->findBy(['displayOrderScreen' => true], ['sortNo' => 'ASC']);
         $form = $this->createForm(OrderType::class, $Order);
 
+        // 初期選択された支払方法が利用条件に合致せず選択肢に含まれない場合は,
+        // 選択可能な支払方法の先頭に再設定し, 手数料を再集計する.
+        // @see https://github.com/EC-CUBE/ec-cube/issues/6200
+        if ($this->reselectUnavailablePayment($Order, $form)) {
+            $this->executePurchaseFlow($Order, false);
+            $this->entityManager->flush();
+            $form = $this->createForm(OrderType::class, $Order);
+        }
+
         return [
             'form' => $form->createView(),
             'Order' => $Order,
             'activeTradeLaws' => $activeTradeLaws,
             'Prefs' => $this->prefRepository->findAll(),
         ];
+    }
+
+    /**
+     * 受注に設定された支払方法が, フォームで選択可能な支払方法に含まれているかを判定する.
+     *
+     * 利用条件(利用可能金額の範囲)に合致しない支払方法が初期選択されている場合,
+     * 選択可能な支払方法の先頭に再設定する. 再設定を行った場合は true を返す.
+     */
+    private function reselectUnavailablePayment(Order $Order, FormInterface $form): bool
+    {
+        if (!$form->has('Payment')) {
+            return false;
+        }
+
+        /** @var Payment[] $Payments */
+        $Payments = $form->get('Payment')->getConfig()->getOption('choices');
+        $Payment = $Order->getPayment();
+
+        // 選択中の支払方法が選択肢に含まれていれば補正不要.
+        $selectableIds = array_map(static fn (Payment $p) => $p->getId(), $Payments);
+        if ($Payment && in_array($Payment->getId(), $selectableIds, true)) {
+            return false;
+        }
+
+        $NewPayment = $Payments ? reset($Payments) : null;
+        // 既に同じ状態(共にnull)であれば補正不要.
+        if ($Payment === $NewPayment) {
+            return false;
+        }
+
+        $Order->setPayment($NewPayment ?: null);
+        $Order->setPaymentMethod($NewPayment ? $NewPayment->getMethod() : null);
+
+        return true;
     }
 
     /**

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -122,8 +122,23 @@ class ShoppingController extends AbstractShoppingController
         // 選択可能な支払方法の先頭に再設定し, 手数料を再集計する.
         // @see https://github.com/EC-CUBE/ec-cube/issues/6200
         if ($this->reselectUnavailablePayment($Order, $form)) {
-            $this->executePurchaseFlow($Order, false);
+            $flowResult = $this->executePurchaseFlow($Order, false);
             $this->entityManager->flush();
+            if ($flowResult->hasError()) {
+                log_info('[注文手続] Errorが発生したため購入エラー画面へ遷移します.', [$flowResult->getErrors()]);
+
+                return $this->redirectToRoute('shopping_error');
+            }
+            if ($flowResult->hasWarning()) {
+                log_info('[注文手続] Warningが発生しました.', [$flowResult->getWarning()]);
+
+                // 受注明細と同期をとるため, CartPurchaseFlowを実行する
+                $this->cartPurchaseFlow->validate($Cart, new PurchaseContext($Cart, $this->getUser()));
+
+                // 注文フローで取得されるカートの入れ替わりを防止する
+                // @see https://github.com/EC-CUBE/ec-cube/issues/4293
+                $this->cartService->setPrimary($Cart->getCartKey());
+            }
             $form = $this->createForm(OrderType::class, $Order);
         }
 

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -1089,6 +1089,48 @@ final class ShoppingControllerTest extends AbstractShoppingControllerTestCase
     }
 
     /**
+     * 利用条件(利用可能金額)に合致しないデフォルト支払方法の手数料が,
+     * 注文手続き画面の初期表示で加算されないことを確認する.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6200
+     */
+    public function testDefaultPaymentChargeNotAppliedWhenConditionUnmet()
+    {
+        $Customer = $this->createCustomer();
+
+        // 商品価格を上げ, デフォルト支払方法の利用上限を超えるようにする.
+        /** @var ProductClass $ProductClass */
+        $ProductClass = $this->entityManager->getRepository(ProductClass::class)->find(2);
+        $ProductClass->setPrice02('3000');
+        $this->entityManager->flush($ProductClass);
+
+        // 先頭(デフォルト)の支払方法に手数料と低い利用上限を設定する (#6200 再現条件).
+        /** @var Payment $DefaultPayment */
+        $DefaultPayment = $this->paymentRepository->find(1);
+        $DefaultPayment->setCharge('500')->setRuleMin('0')->setRuleMax('1000');
+        $this->entityManager->flush($DefaultPayment);
+
+        // カート投入 → 注文手続き画面.
+        $this->scenarioCartIn($Customer, 2);
+        $crawler = $this->scenarioConfirm($Customer);
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        /** @var Order $Order */
+        $Order = $this->entityManager->getRepository(Order::class)->findOneBy([
+            'Customer' => $Customer,
+            'OrderStatus' => OrderStatus::PROCESSING,
+        ]);
+
+        // 利用条件外のデフォルト支払方法が選択されず, 手数料(¥500)が加算されていないこと.
+        $this->assertInstanceOf(Payment::class, $Order->getPayment());
+        $this->assertNotSame($DefaultPayment->getId(), $Order->getPayment()->getId());
+        $this->assertEquals(0, $Order->getCharge());
+
+        // 利用条件外の支払方法は選択肢に表示されないこと.
+        $this->assertStringNotContainsString($DefaultPayment->getMethod(), (string) $crawler->filter('body')->html());
+    }
+
+    /**
      * @param Payment[] $Payments
      */
     private function setUpPayments(Delivery $Delivery, array $Payments)

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -1136,7 +1136,7 @@ final class ShoppingControllerTest extends AbstractShoppingControllerTestCase
         ]);
 
         // 利用条件外のデフォルト支払方法が選択されず, 手数料(¥500)が加算されていないこと.
-        $this->assertNotNull($Order->getPayment());
+        $this->assertInstanceOf(Payment::class, $Order->getPayment());
         $this->assertSame($ValidAlternative->getId(), $Order->getPayment()->getId());
         $this->assertEquals(0, $Order->getCharge());
 

--- a/tests/Eccube/Tests/Web/ShoppingControllerTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerTest.php
@@ -1094,9 +1094,10 @@ final class ShoppingControllerTest extends AbstractShoppingControllerTestCase
      *
      * @see https://github.com/EC-CUBE/ec-cube/issues/6200
      */
-    public function testDefaultPaymentChargeNotAppliedWhenConditionUnmet()
+    public function testDefaultPaymentChargeNotAppliedWhenConditionUnmet(): void
     {
         $Customer = $this->createCustomer();
+        $Generator = static::getContainer()->get(Generator::class);
 
         // 商品価格を上げ, デフォルト支払方法の利用上限を超えるようにする.
         /** @var ProductClass $ProductClass */
@@ -1104,11 +1105,24 @@ final class ShoppingControllerTest extends AbstractShoppingControllerTestCase
         $ProductClass->setPrice02('3000');
         $this->entityManager->flush($ProductClass);
 
-        // 先頭(デフォルト)の支払方法に手数料と低い利用上限を設定する (#6200 再現条件).
-        /** @var Payment $DefaultPayment */
-        $DefaultPayment = $this->paymentRepository->find(1);
-        $DefaultPayment->setCharge('500')->setRuleMin('0')->setRuleMax('1000');
-        $this->entityManager->flush($DefaultPayment);
+        // フィクスチャ配送を除外し, このテスト専用の配送・支払方法だけを使う.
+        /** @var Delivery $FixtureDelivery */
+        $FixtureDelivery = $this->entityManager->find(Delivery::class, 1);
+        $FixtureDelivery->setVisible(false);
+        $this->entityManager->flush($FixtureDelivery);
+
+        $Delivery = $Generator->createDelivery();
+        $Delivery->setSaleType($ProductClass->getSaleType());
+        $Delivery->setSortNo(999);
+        $this->entityManager->flush($Delivery);
+
+        // 先頭(デフォルト)候補: 手数料あり・利用上限 ¥1,000（#6200 再現条件）.
+        $InvalidDefault = $Generator->createPayment($Delivery, 'INVALID6200', 500, 0, 1000);
+        $InvalidDefault->setSortNo(10);
+        // 再選択先: 手数料 ¥0・利用条件内.
+        $ValidAlternative = $Generator->createPayment($Delivery, 'VALID6200', 0, 0, 999999999);
+        $ValidAlternative->setSortNo(5);
+        $this->entityManager->flush();
 
         // カート投入 → 注文手続き画面.
         $this->scenarioCartIn($Customer, 2);
@@ -1122,12 +1136,14 @@ final class ShoppingControllerTest extends AbstractShoppingControllerTestCase
         ]);
 
         // 利用条件外のデフォルト支払方法が選択されず, 手数料(¥500)が加算されていないこと.
-        $this->assertInstanceOf(Payment::class, $Order->getPayment());
-        $this->assertNotSame($DefaultPayment->getId(), $Order->getPayment()->getId());
+        $this->assertNotNull($Order->getPayment());
+        $this->assertSame($ValidAlternative->getId(), $Order->getPayment()->getId());
         $this->assertEquals(0, $Order->getCharge());
 
+        $html = (string) $crawler->filter('body')->html();
         // 利用条件外の支払方法は選択肢に表示されないこと.
-        $this->assertStringNotContainsString($DefaultPayment->getMethod(), (string) $crawler->filter('body')->html());
+        $this->assertStringNotContainsString($InvalidDefault->getMethod(), $html);
+        $this->assertStringContainsString($ValidAlternative->getMethod(), $html);
     }
 
     /**


### PR DESCRIPTION
## 概要

Fixes #6200

手数料あり・金額の利用条件付きの支払方法を先頭（デフォルト）に設定すると、利用条件に合致しない金額の注文でも、その**選択肢に表示されないデフォルト支払方法の手数料**が注文手続き画面で加算される不具合を修正します。

## 原因

- `OrderHelper::setDefaultPayment()` は支払総額が確定する前（PurchaseFlow 集計前）に呼ばれるため、利用条件（`rule_min` / `rule_max`）でフィルタせず、先頭の支払方法をそのまま初期選択していました。
- 一方、注文手続き画面の支払方法の選択肢は `OrderType::filterPayments()` が利用条件＋手数料で正しく絞り込みます。
- この結果、**「初期 Order に設定される支払方法（＝手数料の出どころ）」と「ユーザーが実際に選べる選択肢」のフィルタ条件が不一致**となり、選べないはずの支払方法の手数料だけが残っていました。

## 修正内容

`ShoppingController::index()` で集計後に、選択中の支払方法がフォームの選択肢（`filterPayments()` 済み＝税・送料込みの正統な判定）に含まれない場合、選択可能な支払方法の先頭へ再設定し、手数料を再集計するようにしました。これにより選べない支払方法の手数料は加算されなくなります。

- 選択可能な支払方法が存在しない場合は支払方法を未選択（`null`）に戻し、誤った手数料が残らないようにします。

## 再現手順（修正前）

1. 先頭の支払方法（例: 郵便振替）に手数料 ¥500 / 利用条件 ¥0〜¥1,000 を設定
2. ¥1,000 を超える商品（例: ¥3,080）をカートに追加
3. レジ → 注文手続き画面へ

**修正前**: 郵便振替は選択肢に表示されないのに手数料 ¥500 が加算され、合計に上乗せされる。
**修正後**: 選択可能な支払方法（手数料 ¥0）が初期選択され、手数料は加算されない。

## テスト

`tests/Eccube/Tests/Web/ShoppingControllerTest.php::testDefaultPaymentChargeNotAppliedWhenConditionUnmet` を追加。再現条件下で、初期選択がデフォルト支払方法ではなく利用条件を満たす支払方法に切り替わり、手数料が加算されないことを検証します。

- PHP-CS-Fixer / Rector / PHPStan(level 6) / PHPUnit（ShoppingController 系）すべてパス済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 注文手続き画面で、注文に合わない支払方法が初期選択されないよう改善しました。
  * 利用条件を満たさないデフォルト支払方法の手数料が、初期表示で誤って加算・表示されないよう修正しました。
  * 支払方法の再選択時も、画面・注文内容の反映が正しく行われるようになりました。
* **Tests**
  * 利用条件未達時のデフォルト支払手数料不適用を検証するテストを追加しました。
* **Documentation**
  * 関連ドキュメントに、フロー再実行時の注意点とテスト方針を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->