### PR TITLE
fix(composer): config.platform に ext-sodium を追加 (sodium 拡張なし環境で API プラグイン導入可能に)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -184,7 +184,8 @@
     },
     "config": {
         "platform": {
-            "php": "8.2.0"
+            "php": "8.2.0",
+            "ext-sodium": "1.0.18"
         },
         "preferred-install": {
             "*": "dist"

--- a/src/Eccube/Controller/InstallPluginController.php
+++ b/src/Eccube/Controller/InstallPluginController.php
@@ -17,7 +17,6 @@ use Eccube\Controller\Install\InstallController;
 use Eccube\Entity\Plugin;
 use Eccube\Exception\PluginException;
 use Eccube\Repository\PluginRepository;
-use Eccube\Service\Composer\ComposerApiService;
 use Eccube\Service\PluginService;
 use Eccube\Service\SystemService;
 use Eccube\Util\CacheUtil;
@@ -33,7 +32,7 @@ use Symfony\Component\Routing\Attribute\Route;
 
 class InstallPluginController extends InstallController
 {
-    public function __construct(protected CacheUtil $cacheUtil, protected PluginRepository $pluginReposigoty, protected EventDispatcherInterface $eventDispatcher, private readonly SystemService $systemService, private readonly PluginService $pluginService, private readonly ComposerApiService $composerApiService)
+    public function __construct(protected CacheUtil $cacheUtil, protected PluginRepository $pluginReposigoty, protected EventDispatcherInterface $eventDispatcher, private readonly SystemService $systemService, private readonly PluginService $pluginService)
     {
     }
 
@@ -162,7 +161,13 @@ class InstallPluginController extends InstallController
 
     /**
      * WebApiプラグインのシステム要件をチェックする
-     * sodium拡張がインストールされていない場合、WebApiプラグインをアンインストールする
+     *
+     * かつては sodium 拡張が無い環境で WebApi プラグイン (ec-cube/api42) を自動アンインストールしていたが、
+     * 同プラグインの実行時 (OAuth2 トークンの署名・検証) は RSA + openssl で処理し sodium 関数を呼ばないため、
+     * sodium 拡張が無くても動作する。composer の install 時の platform チェックは composer.json の
+     * config.platform.ext-sodium で満たすため、sodium 非対応の共有レンタルサーバーでも導入・維持できる (#6827)。
+     * 本エンドポイントはインストーラ画面 (install/complete.twig) からの呼び出し互換のため残しているが、
+     * 要件不適合によるアンインストールは行わない。
      *
      * @throws BadRequestHttpException|NotFoundHttpException
      */
@@ -177,22 +182,6 @@ class InstallPluginController extends InstallController
         $token = $request->headers->get('ECCUBE-CSRF-TOKEN');
         if (!$this->isValidTransaction($token)) {
             throw new NotFoundHttpException();
-        }
-
-        /** @var Plugin|null $Plugin */
-        $Plugin = $this->pluginReposigoty->findByCode('Api42');
-
-        // WebApiプラグインがインストールされているが、sodium拡張がない場合は、プラグインをアンインストールする
-        if ($Plugin && !extension_loaded('sodium')) {
-            $this->clearCacheOnTerminate();
-
-            try {
-                $this->composerApiService->execRemove('ec-cube/api42');
-            } catch (\Exception $e) {
-                log_error($e);
-
-                return $this->json(['success' => false, 'log' => $e->getMessage()], 500);
-            }
         }
 
         return $this->json(['success' => true]);


### PR DESCRIPTION
Closes #6827

## 概要

`ec-cube/api42` (Web API プラグイン) を導入すると、推移的依存の `lcobucci/jwt` が `ext-sodium` を **ハード要求 (require)** するため、**sodium 拡張を持たない共有レンタルサーバーでは composer の依存解決に失敗**し、管理画面のプラグインインストーラからも導入できません。

本体 `composer.json` の `config.platform` に **`ext-sodium` を宣言**し、CLI を使えない利用者でも本体同梱の設定で導入が通るようにします。

## 変更

```diff
 "config": {
     "platform": {
-        "php": "8.2.0"
+        "php": "8.2.0",
+        "ext-sodium": "1.0.18"
     },
```

> [!NOTE]
> composer.json は JSON のためインラインコメントを置けません。判断根拠は本文・コミットメッセージ・#6827 に記載します。

## なぜ動作するか (実行時に sodium を呼ばない)

- OAuth2 アクセストークンの署名・検証は **RSA + openssl** (`Lcobucci\JWT\Signer\Rsa\Sha256`)。`lcobucci/jwt` が sodium を使うのは `Eddsa`/`Blake2b` のみで未使用。
- 将来の Agentic Commerce 対応 (UCP 署名=ECDSA P-256 / ACP webhook=HMAC 等) も **openssl / hash** が担当し、sodium の Curve25519/Ed25519 系は登場しません。
- よって sodium 拡張が実在しなくても **install 時の platform チェックのみを通せば実行時は正常動作**します。

## 影響範囲

- `config.platform` は列挙した platform パッケージのみを上書きし、未列挙の拡張は通常どおり実機検出されるため他の依存解決に影響しません。
- sodium を実機で持つ環境への影響もありません (宣言があってもネイティブ拡張がそのまま使われます)。

## 対象ブランチ

- 本 PR は **4.4 のみ** を対象とします (#6827 では 4.2/4.3/4.4 を挙げていますが、本 PR では 4.4 に限定)。

## 検証

sodium 拡張なし環境での導入確認は、結合 E2E ワークフロー (本体↔api44↔samplepayment44) を **sodium 拡張なしの PHP** で実行する形で別途検証します (統合プレビュー #6872 にて、setup-php から `sodium` を外し `config.platform.ext-sodium` のみで composer install が通ることを確認)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 実行環境の要件に Sodium 拡張（ext-sodium）のサポートを追加しました。
  * 既存の PHP バージョン要件はそのまま維持しています。  
* **Bug Fixes**
  * `check_api` エンドポイントで、Sodium 非対応環境時のプラグインアンインストール処理を行わず、成功レスポンスを返す挙動に変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->