### PR TITLE
fix: rector.php を CLI 実行限定にする

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -33,6 +33,13 @@ use Rector\Symfony\Symfony61\Rector\Class_\CommandConfigureToAttributeRector;
 use Rector\Symfony\Symfony61\Rector\Class_\CommandPropertyToAttributeRector;
 use Rector\ValueObject\PhpVersion;
 
+// この設定ファイルは Rector の CLI 実行専用。
+// 公開ディレクトリに配置された場合に Web 経由で実行されないようガードする。
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    exit;
+}
+
 return RectorConfig::configure()
            // EC-CUBEのPHPバージョンに合わせて設定
            ->withPhpVersion(PhpVersion::PHP_83)


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

`rector.php` はリポジトリルートに配置されており、ルートの `.htaccess` の deny リスト（`vendor/`・特定拡張子のみ）にも該当しません。そのため、ドキュメントルートがプロジェクトルートになる構成（一部の共有ホスティング等）では `https://example.com/rector.php` が mod_php 等で Web 経由実行され得ます。

`PHP_SAPI` が `cli` 以外の場合は 403 を返して即終了するガードを追加し、公開ディレクトリ経由での実行を防ぎます。

## 方針(Policy)

- `.htaccess` への deny 追記のみだと Web サーバ設定依存（nginx・設定差し替えで無効化）になるため、ファイル自己完結で確実な `PHP_SAPI !== 'cli'` ガードを採用しました。
- Rector がこの設定ファイルを読み込むのは常に CLI コンテキスト（`PHP_SAPI === 'cli'`）のため、`return RectorConfig::configure()` 以降の処理はそのまま通過し、従来の Rector 動作には影響しません。

\`\`\`php
if (PHP_SAPI !== 'cli') {
    http_response_code(403);
    exit;
}
\`\`\`

## 実装に関する補足(Appendix)

- ガードは `use` 文の直後・`return` の直前に配置しています。
- `rector.php` は開発専用の設定ファイルで、本番デプロイ物に含めない運用が望ましいですが、リポジトリに同梱されている以上の多層防御として CLI 限定ガードを入れています。

## テスト（Test)

- `php -l rector.php` → 構文エラーなし
- `php rector.php`（CLI 実行）→ ガードを通過し `RectorConfig` 参照まで到達（CLI では従来通り処理が進むことを確認。autoloader 未読込による別エラーはガードと無関係）
- Rector バイナリでの dry-run は本 worktree に `vendor/bin/rector` 未インストールのため未実施

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [x] 外部へ公開されるファイルや機能の追加ではないか（本 PR は逆に公開実行を防ぐ修正）
  - [ ] テンプレートでのエスケープ漏れがないか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI 専用の設定が Web 経由で実行されないようになりました。
  * CLI 以外の環境では処理を即時終了し、アクセスを制限します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->