### PR TITLE
feat: スロットリングのデータストレージを DB に変更

### DIFF
--- a/app/config/eccube/packages/rate_limiter.yml
+++ b/app/config/eccube/packages/rate_limiter.yml
@@ -3,4 +3,9 @@ framework:
     cache:
         pools:
             rate_limiter.cache:
-                adapter: cache.adapter.filesystem
+                # スロットリングのデータストレージを DB で管理する.
+                # アダプタは services.yaml の eccube.rate_limiter.dbal_adapter
+                # (cache.adapter.doctrine_dbal を継承 / dtb_rate_limiter テーブル).
+                # provider で DBAL 接続(第1引数)を供給する.
+                adapter: eccube.rate_limiter.dbal_adapter
+                provider: doctrine.dbal.default_connection

--- a/app/config/eccube/packages/rate_limiter.yml
+++ b/app/config/eccube/packages/rate_limiter.yml
@@ -6,6 +6,6 @@ framework:
                 # スロットリングのデータストレージを DB で管理する.
                 # アダプタは services.yaml の eccube.rate_limiter.dbal_adapter
                 # (cache.adapter.doctrine_dbal を継承 / dtb_rate_limiter テーブル).
-                # provider で DBAL 接続(第1引数)を供給する.
+                # DBAL 接続はアダプタサービス側(index_0)で注入するため, ここで provider は
+                # 指定しない(provider を書くと test の filesystem プールにも漏れて壊れる).
                 adapter: eccube.rate_limiter.dbal_adapter
-                provider: doctrine.dbal.default_connection

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -215,6 +215,22 @@ services:
     Eccube\EventListener\RateLimiterListener:
         arguments: [ !tagged_locator { tag: 'eccube_rate_limiter' } ]
 
+    # スロットリング用キャッシュプール(rate_limiter.cache)のバックエンド.
+    # データストレージをファイルから DB へ変更するためのアダプタテンプレート.
+    # framework 標準の cache.adapter.doctrine_dbal(abstract)を継承し, 位置引数 index_3 の
+    # テーブルオプションだけを上書きする. カラム名は Eccube\Entity\RateLimiter
+    # (dtb_rate_limiter)のマッピングと厳密に一致させている.
+    eccube.rate_limiter.dbal_adapter:
+        parent: cache.adapter.doctrine_dbal
+        abstract: true
+        arguments:
+            index_3:
+                db_table: 'dtb_rate_limiter'
+                db_id_col: 'cache_key'
+                db_data_col: 'cache_data'
+                db_lifetime_col: 'cache_lifetime'
+                db_time_col: 'cache_time'
+
     Eccube\Security\PasswordHasher\PasswordHasher:
         arguments:
             - '%eccube_auth_magic%'

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -224,6 +224,10 @@ services:
         parent: cache.adapter.doctrine_dbal
         abstract: true
         arguments:
+            # index_0 に DBAL 接続を焼き込む. プール設定側で provider を指定すると
+            # test 環境の filesystem プールにも provider がマージで漏れて TypeError に
+            # なるため, ここで接続を渡す.
+            index_0: '@doctrine.dbal.default_connection'
             index_3:
                 db_table: 'dtb_rate_limiter'
                 db_id_col: 'cache_key'

--- a/src/Eccube/Entity/RateLimiter.php
+++ b/src/Eccube/Entity/RateLimiter.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+if (!class_exists(RateLimiter::class)) {
+    /**
+     * RateLimiter.
+     *
+     * スロットリング(レートリミッター)のデータストレージ用テーブル.
+     *
+     * 実体は Symfony\Component\Cache\Adapter\DoctrineDbalAdapter が読み書きするキャッシュテーブルで,
+     * カラム名は services.yaml で定義した DoctrineDbalAdapter の options
+     * (db_id_col / db_data_col / db_lifetime_col / db_time_col) と厳密に一致させている.
+     * これによりテーブルを ORM のメタデータ管理下に置き, プラグイン削除やスキーマ再構築で
+     * 削除されないようにするとともに, symfony/cache・DBAL のバージョンアップで既定カラム名が
+     * 変わってもサイレントに壊れないようにする.
+     *
+     * NOTE: dtb_* テーブルは通常 integer の id を主キーに持つが, 本テーブルは adapter が
+     * キャッシュキー(文字列)を主キーとして SELECT/DELETE するため, 文字列カラムを主キーにしている.
+     */
+    #[ORM\Table(name: 'dtb_rate_limiter')]
+    #[ORM\Entity]
+    class RateLimiter extends AbstractEntity
+    {
+        #[ORM\Id]
+        #[ORM\Column(name: 'cache_key', type: Types::STRING, length: 255)]
+        private string $cacheKey;
+
+        /**
+         * @var resource|string|null
+         */
+        #[ORM\Column(name: 'cache_data', type: Types::BLOB)]
+        private $cacheData;
+
+        #[ORM\Column(name: 'cache_lifetime', type: Types::INTEGER, nullable: true, options: ['unsigned' => true])]
+        private ?int $cacheLifetime = null;
+
+        #[ORM\Column(name: 'cache_time', type: Types::INTEGER, options: ['unsigned' => true])]
+        private int $cacheTime;
+
+        /**
+         * Get cacheKey.
+         */
+        public function getCacheKey(): string
+        {
+            return $this->cacheKey;
+        }
+
+        /**
+         * Set cacheKey.
+         */
+        public function setCacheKey(string $cacheKey): RateLimiter
+        {
+            $this->cacheKey = $cacheKey;
+
+            return $this;
+        }
+
+        /**
+         * Get cacheData.
+         *
+         * @return resource|string|null
+         */
+        public function getCacheData()
+        {
+            return $this->cacheData;
+        }
+
+        /**
+         * Set cacheData.
+         *
+         * @param resource|string|null $cacheData
+         */
+        public function setCacheData($cacheData): RateLimiter
+        {
+            $this->cacheData = $cacheData;
+
+            return $this;
+        }
+
+        /**
+         * Get cacheLifetime.
+         */
+        public function getCacheLifetime(): ?int
+        {
+            return $this->cacheLifetime;
+        }
+
+        /**
+         * Set cacheLifetime.
+         */
+        public function setCacheLifetime(?int $cacheLifetime = null): RateLimiter
+        {
+            $this->cacheLifetime = $cacheLifetime;
+
+            return $this;
+        }
+
+        /**
+         * Get cacheTime.
+         */
+        public function getCacheTime(): int
+        {
+            return $this->cacheTime;
+        }
+
+        /**
+         * Set cacheTime.
+         */
+        public function setCacheTime(int $cacheTime): RateLimiter
+        {
+            $this->cacheTime = $cacheTime;
+
+            return $this;
+        }
+    }
+}

--- a/src/Eccube/Entity/RateLimiter.php
+++ b/src/Eccube/Entity/RateLimiter.php
@@ -75,7 +75,7 @@ if (!class_exists(RateLimiter::class)) {
          *
          * @return resource|string|null
          */
-        public function getCacheData()
+        public function getCacheData(): mixed
         {
             return $this->cacheData;
         }
@@ -85,7 +85,7 @@ if (!class_exists(RateLimiter::class)) {
          *
          * @param resource|string|null $cacheData
          */
-        public function setCacheData($cacheData): RateLimiter
+        public function setCacheData(mixed $cacheData): RateLimiter
         {
             $this->cacheData = $cacheData;
 

--- a/tests/Eccube/Tests/EventListener/RateLimiterStorageTest.php
+++ b/tests/Eccube/Tests/EventListener/RateLimiterStorageTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\EventListener;
+
+use Eccube\Tests\EccubeTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\CacheStorage;
+
+/**
+ * スロットリングのデータストレージ(DB)に関するテスト.
+ *
+ * services.yaml の eccube.rate_limiter.dbal_adapter と同じ設定で
+ * DoctrineDbalAdapter を組み立て, dtb_rate_limiter テーブル
+ * (Eccube\Entity\RateLimiter) に読み書きできることを確認する.
+ */
+#[Group('rate-limiter-storage')]
+final class RateLimiterStorageTest extends EccubeTestCase
+{
+    private const TABLE = 'dtb_rate_limiter';
+
+    private function createAdapter(): DoctrineDbalAdapter
+    {
+        return new DoctrineDbalAdapter(
+            $this->entityManager->getConnection(),
+            '',
+            0,
+            [
+                'db_table' => self::TABLE,
+                'db_id_col' => 'cache_key',
+                'db_data_col' => 'cache_data',
+                'db_lifetime_col' => 'cache_lifetime',
+                'db_time_col' => 'cache_time',
+            ]
+        );
+    }
+
+    private function countRows(): int
+    {
+        return (int) $this->entityManager->getConnection()
+            ->fetchOne('SELECT COUNT(*) FROM '.self::TABLE);
+    }
+
+    /**
+     * dtb_rate_limiter テーブルが Entity のメタデータから生成され存在すること.
+     */
+    public function testTableExists(): void
+    {
+        $schemaManager = $this->entityManager->getConnection()->createSchemaManager();
+
+        $this->assertTrue($schemaManager->tablesExist([self::TABLE]), self::TABLE.' テーブルが存在しません');
+    }
+
+    /**
+     * Entity の列名が adapter の options と一致し, カラムが揃っていること.
+     */
+    public function testColumnsMatchAdapterOptions(): void
+    {
+        $schemaManager = $this->entityManager->getConnection()->createSchemaManager();
+        $columns = array_map(
+            fn ($column) => $column->getName(),
+            $schemaManager->listTableColumns(self::TABLE)
+        );
+
+        foreach (['cache_key', 'cache_data', 'cache_lifetime', 'cache_time'] as $expected) {
+            $this->assertContains($expected, $columns, "列 {$expected} がありません");
+        }
+    }
+
+    /**
+     * DoctrineDbalAdapter 経由で DB に読み書きできること.
+     */
+    public function testReadWriteThroughAdapter(): void
+    {
+        $adapter = $this->createAdapter();
+        $adapter->deleteItem('throttle_test');
+
+        $item = $adapter->getItem('throttle_test');
+        $this->assertFalse($item->isHit());
+
+        $item->set('stored-value');
+        $this->assertTrue($adapter->save($item));
+
+        // DB にレコードが書き込まれていること
+        $this->assertGreaterThan(0, $this->countRows());
+
+        // 別インスタンスからでも取り出せる(＝ファイルではなく DB に永続化されている)こと
+        $fetched = $this->createAdapter()->getItem('throttle_test');
+        $this->assertTrue($fetched->isHit());
+        $this->assertSame('stored-value', $fetched->get());
+
+        $adapter->deleteItem('throttle_test');
+    }
+
+    /**
+     * RateLimiter コンポーネントが DB ストレージ上でスロットリングを行えること.
+     */
+    public function testRateLimiterConsumesOnDbStorage(): void
+    {
+        $storage = new CacheStorage($this->createAdapter());
+        $factory = new RateLimiterFactory(
+            [
+                'id' => 'test_throttle',
+                'policy' => 'fixed_window',
+                'limit' => 2,
+                'interval' => '30 minutes',
+            ],
+            $storage
+        );
+
+        $limiter = $factory->create('192.0.2.1');
+
+        $this->assertTrue($limiter->consume()->isAccepted());
+        $this->assertTrue($limiter->consume()->isAccepted());
+        // limit を超えたら拒否される
+        $this->assertFalse($limiter->consume()->isAccepted());
+
+        // 状態が DB に保存されていること
+        $this->assertGreaterThan(0, $this->countRows());
+
+        $limiter->reset();
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

スロットリング(レートリミッター)のデータを、ファイル(filesystem キャッシュ)ではなく **DB で管理する**ように変更します。

- Refs #6285 — スロットリングのデータストレージを DB に変更（本 PR の主目的）
- Refs #5957 — プラグイン削除でスロットリングが機能しなくなる問題も構造的に解消

### 解決する課題

1. **キャッシュクリアでデータが消える(#6285)**: filesystem キャッシュのため、`cache:clear` 実行時にスロットリングのデータも消えてしまう。
2. **プラグイン削除でテーブルが消える(#5957)**: `cache_items` テーブルは Symfony の `DoctrineDbalAdapter` が自動生成し ORM メタデータ管理外のため、`SchemaService`(メタデータ直組み)から見ると削除対象になり、プラグイン削除でテーブルごと消えてスロットリングが機能しなくなる。

## 方針(Policy)

- **テーブルを ORM 管理下に置く**: `Eccube\Entity\RateLimiter` を追加し `dtb_rate_limiter` にマップ。メタデータに乗るため `schema:update` で正規に作られ、プラグイン削除やスキーマ再構築で削除されなくなる(#5957 を構造的に解消)。
- **DB ストレージ化**: `rate_limiter.cache` プールのアダプタを Symfony 標準の `cache.adapter.doctrine_dbal`(abstract)を `parent` 継承した定義に差し替え。`provider` で DBAL 接続を供給する。
- **列名を options で明示**: `db_table` / `db_id_col` / `db_data_col` / `db_lifetime_col` / `db_time_col`(位置引数 index_3)を指定し、Entity のカラム定義と厳密に一致させる。列名を固定することで symfony/cache・DBAL のバージョンアップで既定値が変わってもサイレントに壊れないようにする(レビュー指摘を想定した堅牢化)。

## 実装に関する補足(Appendix)

- `DoctrineDbalAdapter` はテーブルが存在すればレイジー生成(`createTable()`)を実行しないため、スキーマの源泉は Entity 一本に集約される。仮にテーブル未作成のままスロットリング経路へ到達しても、adapter が同じ列名でフォールバック生成する。
- `dtb_rate_limiter` は adapter がキャッシュキー(文字列)を主キーとして SELECT/DELETE する都合上、`dtb_*` 慣習の integer id ではなく **文字列カラム(`cache_key`)を主キー**にしている(理由は Entity にコメント記載)。
- 単純な新規テーブル追加のため、Entity 属性＋`schema:update` で反映され、ALTER マイグレーションは不要。
- **互換性への影響**: 既存は filesystem プールのため DB キャッシュテーブルは元々存在せず、移行データはなし(スロットリングデータは揮発性)。

## テスト（Test)

- `tests/Eccube/Tests/EventListener/RateLimiterStorageTest.php` を追加(4 tests)。
  - `dtb_rate_limiter` テーブルの存在確認
  - Entity のカラム名が adapter の options と一致すること
  - `DoctrineDbalAdapter` 経由での DB read/write ラウンドトリップ
  - `RateLimiter` コンポーネントが DB ストレージ上で throttle すること
- test 環境のプールは filesystem のまま据え置き(既存スイートへの影響を避けるため)。DB ストレージ経路は上記専用テストで担保。
- ローカル検証済み(SQLite): 新規4 + 既存 `RateLimiterListenerTest` 4 = 8/8 green、`doctrine:schema:validate`(mapping OK)、`doctrine:schema:update --dump-sql` で `dtb_rate_limiter` が期待どおり生成・重複なし、PHPStan(level 6)/php-cs-fixer/rector クリーン。
- PostgreSQL / MySQL 実機での差分ゼロ確認と E2E(`EF09ThrottlingCest`)は CI マトリクスに委ねる。

## 相談（Discussion）

- テーブル名 `dtb_rate_limiter` / カラム名(`cache_key` 等)の命名について、より適切な案があればご指摘ください。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * レート制限をデータベースで管理し、再起動後も抑止状態が継続しやすくなりました。
* **バグ修正**
  * レート制御の保存先設定を調整し、読み書きの整合性が向上しました。
* **テスト**
  * テーブル存在・列の整合性・DB経由の読み書き・消費判定を確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->