### PR TITLE
feat: 商品詳細の構造化データ(JSON-LD)を Google 商品仕様に拡充 (Closes #6149)

### DIFF
--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -26,6 +26,7 @@ use Eccube\Repository\CustomerFavoriteProductRepository;
 use Eccube\Repository\Master\ProductListMaxRepository;
 use Eccube\Repository\ProductRepository;
 use Eccube\Service\CartService;
+use Eccube\Service\ProductStructuredDataService;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Eccube\Service\PurchaseFlow\PurchaseFlow;
 use Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination;
@@ -62,6 +63,7 @@ class ProductController extends AbstractController
         protected AuthenticationUtils $helper,
         protected ProductListMaxRepository $productListMaxRepository,
         private readonly PaginatorInterface $paginator,
+        private readonly ProductStructuredDataService $productStructuredDataService,
     ) {
         $this->purchaseFlow = $cartPurchaseFlow;
         $this->BaseInfo = $baseInfoRepository->get();
@@ -207,12 +209,20 @@ class ProductController extends AbstractController
             $is_favorite = $this->customerFavoriteProductRepository->isFavorite($Customer, $Product);
         }
 
+        $productJsonLd = $this->productStructuredDataService->createProductJsonLd(
+            $Product,
+            $request->getSchemeAndHttpHost(),
+            $this->generateUrl('product_detail', ['id' => $Product->getId()], UrlGeneratorInterface::ABSOLUTE_URL),
+            $this->eccubeConfig['currency'],
+        );
+
         return [
             'title' => $this->title,
             'subtitle' => $Product->getName(),
             'form' => $builder->getForm()->createView(),
             'Product' => $Product,
             'is_favorite' => $is_favorite,
+            'product_json_ld' => $productJsonLd,
         ];
     }
 

--- a/src/Eccube/Event/EccubeEvents.php
+++ b/src/Eccube/Event/EccubeEvents.php
@@ -506,6 +506,14 @@ final class EccubeEvents
     public const FRONT_PRODUCT_DETAIL_FAVORITE = 'front.product.detail.favorite';
     public const FRONT_PRODUCT_DETAIL_COMPLETE = 'front.product.detail.complete';
 
+    /**
+     * 商品詳細ページの構造化データ（JSON-LD）を組み立てる際に発火.
+     *
+     * EventArgs の 'json_ld' に注入対象の連想配列、'Product' に対象商品を渡す。
+     * プラグインは 'json_ld' を読み取り aggregateRating / review 等を追加して setArgument できる。
+     */
+    public const FRONT_PRODUCT_DETAIL_JSON_LD = 'front.product.detail.json_ld';
+
     public const FRONT_PRODUCT_CART_ADD_INITIALIZE = 'front.product.cart.add.initialize';
     public const FRONT_PRODUCT_CART_ADD_COMPLETE = 'front.product.cart.add.complete';
 

--- a/src/Eccube/Resource/template/default/Product/detail.twig
+++ b/src/Eccube/Resource/template/default/Product/detail.twig
@@ -248,32 +248,9 @@ file that was distributed with this source code.
             $('.ec-modal').hide()
         });
     </script>
-    <script type="application/ld+json">
-    {
-        "@context": "https://schema.org/",
-        "@type": "Product",
-        "name": "{{ Product.name }}",
-        "image": [
-            {% for img in Product.ProductImage %}
-                "{{ app.request.schemeAndHttpHost }}{{ asset(img, 'save_image') }}"{% if not loop.last %},{% endif %}
-
-            {% else %}
-                "{{ app.request.schemeAndHttpHost }}{{ asset(''|no_image_product, 'save_image') }}"
-            {% endfor %}
-        ],
-        "description": "{{ Product.description_list | default(Product.description_detail) | replace({'\n': '', '\r': ''}) | slice(0,300) }}",
-        {% if Product.code_min %}
-        "sku": "{{ Product.code_min }}",
-        {% endif %}
-        "offers": {
-            "@type": "Offer",
-            "url": "{{ url('product_detail', {'id': Product.id}) }}",
-            "priceCurrency": "{{ eccube_config.currency }}",
-            "price": {{ Product.getPrice02IncTaxMin ? Product.getPrice02IncTaxMin : 0}},
-            "availability": "{{ Product.stock_find ? "InStock" : "OutOfStock" }}"
-        }
-    }
-    </script>
+    {% if product_json_ld is defined and product_json_ld %}
+    <script type="application/ld+json">{{ product_json_ld|json_ld }}</script>
+    {% endif %}
 {% endblock %}
 
 {% block main %}

--- a/src/Eccube/Service/ProductStructuredDataService.php
+++ b/src/Eccube/Service/ProductStructuredDataService.php
@@ -1,0 +1,235 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service;
+
+use Eccube\Entity\Category;
+use Eccube\Entity\Product;
+use Eccube\Event\EccubeEvents;
+use Eccube\Event\EventArgs;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * 商品詳細ページの構造化データ（JSON-LD / schema.org Product）を組み立てる Service.
+ *
+ * 価格分岐・カテゴリパス整形・StrikethroughPrice 判定などの業務ロジックをここに集約し、
+ * 戻り値の連想配列を単体テストで直接アサートできるようにする。
+ * リクエスト依存値（絶対URL・通貨コード）は引数で受け取り HTTP 非依存に保つ。
+ */
+class ProductStructuredDataService
+{
+    /**
+     * 画像が無い場合のフォールバック画像ファイル名.
+     */
+    private const NO_IMAGE_FILE = 'no_image_product.png';
+
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly Packages $packages,
+    ) {
+    }
+
+    /**
+     * 商品詳細ページの JSON-LD 構造（連想配列）を組み立てて返す.
+     *
+     * @param string $baseUrl    スキーム込みホスト（例: https://example.com）
+     * @param string $productUrl 商品詳細ページの絶対URL
+     * @param string $currency   通貨コード（例: JPY）
+     *
+     * @return array<string, mixed>
+     */
+    public function createProductJsonLd(Product $Product, string $baseUrl, string $productUrl, string $currency): array
+    {
+        // 価格の min/max を算出しておく
+        $Product->_calc();
+
+        $data = [
+            '@context' => 'https://schema.org/',
+            '@type' => 'Product',
+            'name' => $Product->getName(),
+            'image' => $this->buildImages($Product, $baseUrl),
+        ];
+
+        $description = $this->buildDescription($Product);
+        if ($description !== '') {
+            $data['description'] = $description;
+        }
+
+        $sku = $Product->getCodeMin();
+        if ($sku !== null && $sku !== '') {
+            $data['sku'] = $sku;
+        }
+
+        $category = $this->buildCategory($Product);
+        if ($category !== null) {
+            $data['category'] = $category;
+        }
+
+        $offers = $this->buildOffers($Product, $productUrl, $currency);
+        if ($offers !== null) {
+            $data['offers'] = $offers;
+        }
+
+        // プラグイン等が aggregateRating / review 等を配列へ注入するための拡張点.
+        $event = new EventArgs(
+            [
+                'json_ld' => $data,
+                'Product' => $Product,
+            ]
+        );
+        $this->eventDispatcher->dispatch($event, EccubeEvents::FRONT_PRODUCT_DETAIL_JSON_LD);
+
+        /** @var array<string, mixed> $data */
+        $data = $event->getArgument('json_ld');
+
+        return $data;
+    }
+
+    /**
+     * 商品画像の絶対URL配列を組み立てる（画像が無ければ no_image を返す）.
+     *
+     * @return list<string>
+     */
+    private function buildImages(Product $Product, string $baseUrl): array
+    {
+        $images = [];
+        foreach ($Product->getProductImage() as $ProductImage) {
+            $images[] = $baseUrl.$this->packages->getUrl((string) $ProductImage, 'save_image');
+        }
+
+        if ($images === []) {
+            $images[] = $baseUrl.$this->packages->getUrl(self::NO_IMAGE_FILE, 'save_image');
+        }
+
+        return $images;
+    }
+
+    /**
+     * 説明文を HTML 除去・空白正規化して 300 文字に丸める.
+     */
+    private function buildDescription(Product $Product): string
+    {
+        $description = $Product->getDescriptionList();
+        if ($description === null || $description === '') {
+            $description = $Product->getDescriptionDetail();
+        }
+        if ($description === null || $description === '') {
+            return '';
+        }
+
+        $description = strip_tags($description);
+        $description = preg_replace('/\s+/u', ' ', $description) ?? $description;
+        $description = trim($description);
+
+        return mb_substr($description, 0, 300);
+    }
+
+    /**
+     * 店舗カテゴリのパス（親カテゴリを ">" 連結）を返す.
+     * カテゴリが1件なら文字列、複数なら文字列配列、無ければ null.
+     *
+     * @return string|list<string>|null
+     */
+    private function buildCategory(Product $Product): string|array|null
+    {
+        $paths = [];
+        foreach ($Product->getProductCategories() as $ProductCategory) {
+            $Category = $ProductCategory->getCategory();
+            if ($Category === null) {
+                continue;
+            }
+            $names = [];
+            foreach ($Category->getPath() as $ancestor) {
+                /* @var Category $ancestor */
+                $names[] = $ancestor->getName();
+            }
+            $path = implode(' > ', $names);
+            if ($path !== '') {
+                $paths[] = $path;
+            }
+        }
+
+        $paths = array_values(array_unique($paths));
+        if ($paths === []) {
+            return null;
+        }
+
+        return count($paths) === 1 ? $paths[0] : $paths;
+    }
+
+    /**
+     * offers 構造を組み立てる.
+     * 単一価格 → Offer（条件付きで StrikethroughPrice）／価格帯 → AggregateOffer.
+     * 価格が取得できない場合は null（offers を出力しない）.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function buildOffers(Product $Product, string $productUrl, string $currency): ?array
+    {
+        $priceMin = $Product->getPrice02IncTaxMin();
+        if ($priceMin === null) {
+            return null;
+        }
+        $priceMax = $Product->getPrice02IncTaxMax();
+        $availability = $Product->getStockFind() ? 'InStock' : 'OutOfStock';
+
+        // 価格帯（規格で価格が異なる）商品は AggregateOffer
+        if ($priceMax !== null && (float) $priceMin !== (float) $priceMax) {
+            return [
+                '@type' => 'AggregateOffer',
+                'url' => $productUrl,
+                'priceCurrency' => $currency,
+                'lowPrice' => $priceMin,
+                'highPrice' => $priceMax,
+                'offerCount' => $this->countVisibleProductClasses($Product),
+                'availability' => $availability,
+                'itemCondition' => 'NewCondition',
+            ];
+        }
+
+        $offers = [
+            '@type' => 'Offer',
+            'url' => $productUrl,
+            'priceCurrency' => $currency,
+            'price' => $priceMin,
+            'availability' => $availability,
+            'itemCondition' => 'NewCondition',
+        ];
+
+        // 通常価格(price01) > 販売価格(price02) のときのみ取消線価格を付与（税込同士で比較）
+        $listPrice = $Product->getPrice01IncTaxMin();
+        if ($listPrice !== null && (float) $listPrice > 0 && (float) $listPrice > (float) $priceMin) {
+            $offers['priceSpecification'] = [
+                '@type' => 'UnitPriceSpecification',
+                'priceType' => 'StrikethroughPrice',
+                'price' => $listPrice,
+                'priceCurrency' => $currency,
+            ];
+        }
+
+        return $offers;
+    }
+
+    private function countVisibleProductClasses(Product $Product): int
+    {
+        $count = 0;
+        foreach ($Product->getProductClasses() as $ProductClass) {
+            if ($ProductClass->isVisible()) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+}

--- a/src/Eccube/Service/ProductStructuredDataService.php
+++ b/src/Eccube/Service/ProductStructuredDataService.php
@@ -221,13 +221,29 @@ class ProductStructuredDataService
         return $offers;
     }
 
+    /**
+     * offerCount 算出用に有効な規格数を数える.
+     *
+     * lowPrice/highPrice の元になる Product::_calc() と同一条件で絞り込む
+     * （ProductClass 本体に加えて ClassCategory1/2 の表示状態も判定）ことで、
+     * 非表示のクラスカテゴリを持つ規格が offerCount に混入しないようにする.
+     */
     private function countVisibleProductClasses(Product $Product): int
     {
         $count = 0;
         foreach ($Product->getProductClasses() as $ProductClass) {
-            if ($ProductClass->isVisible()) {
-                ++$count;
+            if (!$ProductClass->isVisible()) {
+                continue;
             }
+            $ClassCategory1 = $ProductClass->getClassCategory1();
+            if ($ClassCategory1 && !$ClassCategory1->isVisible()) {
+                continue;
+            }
+            $ClassCategory2 = $ProductClass->getClassCategory2();
+            if ($ClassCategory2 && !$ClassCategory2->isVisible()) {
+                continue;
+            }
+            ++$count;
         }
 
         return $count;

--- a/src/Eccube/Twig/Extension/EccubeExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeExtension.php
@@ -265,10 +265,20 @@ class EccubeExtension extends AbstractExtension
      */
     public function encodeJsonLd(array $data): string
     {
-        return json_encode(
+        $json = json_encode(
             $data,
             JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
         );
+
+        // 不正な UTF-8 等でエンコードに失敗した場合、空の <script> を黙って出さず
+        // ログに残したうえで妥当な JSON（空オブジェクト）を返す.
+        if ($json === false) {
+            log_error('JSON-LD のエンコードに失敗しました: '.json_last_error_msg());
+
+            return '{}';
+        }
+
+        return $json;
     }
 
     /**

--- a/src/Eccube/Twig/Extension/EccubeExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeExtension.php
@@ -67,6 +67,7 @@ class EccubeExtension extends AbstractExtension
             new TwigFilter('ellipsis', $this->getEllipsis(...)),
             new TwigFilter('time_ago', $this->getTimeAgo(...)),
             new TwigFilter('file_ext_icon', $this->getExtensionIcon(...), ['is_safe' => ['html']]),
+            new TwigFilter('json_ld', $this->encodeJsonLd(...), ['is_safe' => ['html']]),
         ];
     }
 
@@ -252,6 +253,22 @@ class EccubeExtension extends AbstractExtension
         }
 
         return json_encode($class_categories);
+    }
+
+    /**
+     * JSON-LD 連想配列を `<script type="application/ld+json">` 埋め込み用に安全にエンコードする.
+     *
+     * JSON_HEX_TAG 等により `< > & ' "` をエスケープし、`</script>` 混入による
+     * スクリプト破壊・蓄積型 XSS を機械的に防ぐ.
+     *
+     * @param array<string, mixed> $data
+     */
+    public function encodeJsonLd(array $data): string
+    {
+        return json_encode(
+            $data,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+        );
     }
 
     /**

--- a/tests/Eccube/Tests/Service/ProductStructuredDataServiceTest.php
+++ b/tests/Eccube/Tests/Service/ProductStructuredDataServiceTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Service;
+
+use Eccube\Entity\Product;
+use Eccube\Event\EccubeEvents;
+use Eccube\Event\EventArgs;
+use Eccube\Service\ProductStructuredDataService;
+use Eccube\Twig\Extension\EccubeExtension;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+final class ProductStructuredDataServiceTest extends AbstractServiceTestCase
+{
+    private ?ProductStructuredDataService $service = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = static::getContainer()->get(ProductStructuredDataService::class);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function build(Product $Product): array
+    {
+        return $this->service->createProductJsonLd(
+            $Product,
+            'https://example.com',
+            'https://example.com/products/detail/'.$Product->getId(),
+            'JPY'
+        );
+    }
+
+    public function testBaseStructure(): void
+    {
+        $Product = $this->createProduct('構造化データ商品', 0);
+
+        $data = $this->build($Product);
+
+        $this->assertSame('https://schema.org/', $data['@context']);
+        $this->assertSame('Product', $data['@type']);
+        $this->assertSame('構造化データ商品', $data['name']);
+        $this->assertNotEmpty($data['image']);
+        $this->assertStringStartsWith('https://example.com', $data['image'][0]);
+    }
+
+    public function testSinglePriceOfferWithoutStrikethrough(): void
+    {
+        $Product = $this->createProduct('単一価格商品', 0);
+        $ProductClass = $Product->getProductClasses()->first();
+        $ProductClass->setPrice01(null);
+        $ProductClass->setPrice02('1000')->setPrice02IncTax('1100');
+
+        $data = $this->build($Product);
+
+        $this->assertSame('Offer', $data['offers']['@type']);
+        $this->assertSame('JPY', $data['offers']['priceCurrency']);
+        $this->assertSame('https://example.com/products/detail/'.$Product->getId(), $data['offers']['url']);
+        $this->assertSame('NewCondition', $data['offers']['itemCondition']);
+        $this->assertArrayNotHasKey('priceSpecification', $data['offers']);
+    }
+
+    public function testStrikethroughPriceWhenListPriceIsHigher(): void
+    {
+        $Product = $this->createProduct('セール商品', 0);
+        $ProductClass = $Product->getProductClasses()->first();
+        $ProductClass->setPrice01('2000')->setPrice01IncTax('2200'); // 通常価格
+        $ProductClass->setPrice02('1000')->setPrice02IncTax('1100'); // 販売価格
+
+        $data = $this->build($Product);
+
+        $this->assertSame('Offer', $data['offers']['@type']);
+        $this->assertArrayHasKey('priceSpecification', $data['offers']);
+        $this->assertSame('UnitPriceSpecification', $data['offers']['priceSpecification']['@type']);
+        $this->assertSame('StrikethroughPrice', $data['offers']['priceSpecification']['priceType']);
+        // 販売価格 < 通常価格（いずれも税込）
+        $this->assertLessThan((float) $data['offers']['priceSpecification']['price'], (float) $data['offers']['price']);
+    }
+
+    public function testNoStrikethroughWhenListPriceIsNotHigher(): void
+    {
+        $Product = $this->createProduct('通常商品', 0);
+        $ProductClass = $Product->getProductClasses()->first();
+        $ProductClass->setPrice01('500')->setPrice01IncTax('550'); // 通常価格 <= 販売価格
+        $ProductClass->setPrice02('1000')->setPrice02IncTax('1100');
+
+        $data = $this->build($Product);
+
+        $this->assertArrayNotHasKey('priceSpecification', $data['offers']);
+    }
+
+    public function testAggregateOfferForPriceRange(): void
+    {
+        $Product = $this->createProduct('価格帯商品', 2);
+        $visibleClasses = [];
+        foreach ($Product->getProductClasses() as $ProductClass) {
+            if ($ProductClass->isVisible()) {
+                $visibleClasses[] = $ProductClass;
+            }
+        }
+        $this->assertCount(2, $visibleClasses);
+        $visibleClasses[0]->setPrice02('1000')->setPrice02IncTax('1100');
+        $visibleClasses[1]->setPrice02('2000')->setPrice02IncTax('2200');
+
+        $data = $this->build($Product);
+
+        $this->assertSame('AggregateOffer', $data['offers']['@type']);
+        $this->assertSame(2, $data['offers']['offerCount']);
+        $this->assertLessThan((float) $data['offers']['highPrice'], (float) $data['offers']['lowPrice']);
+        $this->assertArrayNotHasKey('price', $data['offers']);
+    }
+
+    public function testNoOffersWhenPriceIsUnavailable(): void
+    {
+        $Product = $this->createProduct('価格なし商品', 0);
+        // 有効な規格を無くすと価格が算出できずに offers を出さない
+        foreach ($Product->getProductClasses() as $ProductClass) {
+            $ProductClass->setVisible(false);
+        }
+
+        $data = $this->build($Product);
+
+        $this->assertArrayNotHasKey('offers', $data);
+    }
+
+    public function testJsonLdEventCanInjectAggregateRating(): void
+    {
+        $Product = $this->createProduct('レビュー注入商品', 0);
+
+        // プラグインが JSON-LD 配列へ review 等を注入する拡張点を検証する
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(EccubeEvents::FRONT_PRODUCT_DETAIL_JSON_LD, function (EventArgs $event): void {
+            $data = $event->getArgument('json_ld');
+            $data['aggregateRating'] = [
+                '@type' => 'AggregateRating',
+                'ratingValue' => '4.5',
+                'reviewCount' => '10',
+            ];
+            $event->setArgument('json_ld', $data);
+        });
+        $service = new ProductStructuredDataService($dispatcher, static::getContainer()->get(Packages::class));
+
+        $data = $service->createProductJsonLd($Product, 'https://example.com', 'https://example.com/products/detail/1', 'JPY');
+
+        $this->assertArrayHasKey('aggregateRating', $data);
+        $this->assertSame('4.5', $data['aggregateRating']['ratingValue']);
+    }
+
+    public function testEncodeJsonLdEscapesClosingScriptTag(): void
+    {
+        /** @var EccubeExtension $extension */
+        $extension = static::getContainer()->get(EccubeExtension::class);
+
+        $json = $extension->encodeJsonLd([
+            '@type' => 'Product',
+            'name' => 'evil</script><script>alert(1)</script>',
+        ]);
+
+        // </script> がそのまま出力されず、< > は < > にエスケープされる
+        $this->assertStringNotContainsString('</script>', $json);
+        $this->assertStringNotContainsString('<script>', $json);
+        $this->assertStringContainsString('\u003C', $json);
+        // JSON として妥当で、デコードすれば元の文字列に戻る
+        $decoded = json_decode($json, true);
+        $this->assertSame('evil</script><script>alert(1)</script>', $decoded['name']);
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Closes #6149

商品詳細ページの構造化データ（JSON-LD / schema.org `Product`）を Google の商品向け仕様（merchant listing）に沿って拡充します。本 PR は **新フィールドを増やさず今あるデータで出せる範囲（Issue の 🟢 スコープ）** に責務を絞っています。

## 方針(Policy)

- JSON-LD の組み立てを **`ProductStructuredDataService`（連想配列を返すビルダ）に集約**し、`ProductController::detail` はビルダを呼んで結果を渡すだけ、Twig は `json_ld` フィルタで `json_encode` するだけの薄いアダプタに留めました（Fat コントローラ回避・単体テスト可能化）。
- 絶対URL・通貨コードなどリクエスト依存値は **引数で受け取り HTTP 非依存**に保ち、戻り値の配列を PHPUnit で直接アサートできるようにしています。
- 拡張点として **ビルダ内の「配列段階」で新設イベント `front.product.detail.json_ld` を発行**し、プラグイン（レビュー等）が `aggregateRating`/`review` を配列へ注入できるようにしました。

### 実装した項目（🟢）

| 項目 | 内容 |
|---|---|
| ビルダ集約 | 現状のテンプレ文字列直書きを Service ＋ `json_ld` フィルタに置き換え |
| `category` | 店舗カテゴリの親パスを `>` 連結で出力（例: `アイスサンド > フルーツ`）。複数カテゴリは配列 |
| 価格分岐 | 単一価格 → `Offer`／規格で価格が異なる → `AggregateOffer`(`lowPrice`/`highPrice`/`offerCount`) |
| セール表現 | `price01`(通常) > `price02`(販売) を **税込同士で比較**し、そのときのみ `priceSpecification`(`UnitPriceSpecification` + `StrikethroughPrice`) を付与。`price01` が null/0 または `≦ price02` なら付与しない |
| `itemCondition` | `NewCondition` を既定出力 |
| `description` | `striptags` → 空白正規化 → 300字に整形 |
| 価格ガード | 価格が取得できない商品は `price:0` を出さず `offers` 自体を出力しない |
| 拡張点 | `aggregateRating`/`review` 注入用の新設イベント `front.product.detail.json_ld` をビルダ内で発行 |

## 実装に関する補足(Appendix)

- **セキュリティ**: `json_ld` フィルタは `json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT)` でエンコードします。`JSON_HEX_TAG` により `</script>` が無害化され、蓄積型 XSS / JSON 破壊を機械的に防ぎます（従来の文字列直書きにあった `"` 混入で JSON が壊れるバグも解消）。
- `availability` は既存挙動どおり `InStock`/`OutOfStock` の2値を維持（段階表現は #7 の範囲のため対象外）。
- 価格・取消線価格は文字列で出力します（Google 推奨、小数の精度問題回避）。既存 `ProductControllerTest` の数値アサーションは delta 比較のため回帰しません。

### 本 PR では扱わない（派生 Issue へ分割）

`Brand`(#14) / `JAN・GTIN`(#15) / 返品ポリシー `hasMerchantReturnPolicy`(#13) / セール期間 `priceValidUntil`(#11) / `shippingDetails`(#12) / `color`/`size`/`material` の型付け(#17) / `availability` 段階表現(#7) / レビュー機能本体（プラグイン側）/ Google 公式商品タクソノミへのマッピング。

## テスト（Test)

- 新規 `ProductStructuredDataServiceTest`（ビルダの戻り連想配列を直接アサート、8ケース）:
  基本構造 / 単一 `Offer`（取消線なし）/ `StrikethroughPrice` 付与 / 通常価格が販売価格以下なら非付与 / `AggregateOffer`(価格帯) / 価格なしで `offers` 非出力 / イベントによる `aggregateRating` 注入 / `</script>` 混入時のエスケープ。
- 既存 `ProductControllerTest`（構造化データ含む 16 テスト）が回帰なしでパス。
- 実機（`/products/detail/2`）で `category` パス・`StrikethroughPrice`・`itemCondition`・HTML 除去済み `description`・絶対画像URL を確認。
- ローカル CI ゲート通過済み: php-cs-fixer / phpstan(level 6, src 全体) / rector(dry-run) / phpunit。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません（既存の `name`/`image`/`sku`/`offers` の構造は維持。`description` の HTML 除去と価格0商品の `offers` 抑止は意図した改善）
- [x] フックポイントの呼び出しタイミングの変更はありません（イベントは新設のみ）
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません（`product_json_ld` を追加）
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません（新設 Service）
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 商品詳細ページに schema.org 準拠の JSON-LD（商品情報）を追加（条件付き出力）。
  * 商品詳細向けに JSON-LD を拡張できるイベントを追加。
  * JSON-LD を安全に埋め込むための Twig フィルタを追加。
* **改善**
  * 価格・在庫・オファー/価格帯・カテゴリ・説明などを条件に応じてより正確に反映。
* **テスト**
  * JSON-LD 生成、イベント注入、エスケープ/エンコード挙動のテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->