### PR TITLE
fix: Rector の Attribute 引数順序で非推奨 Sensio クラスのパラメータ名を使わない (#6540)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -82,7 +82,10 @@ jobs:
         run: |
           echo "session.save_path=$PWD/var/sessions/test" > php.ini
           echo "memory_limit=1012M" >> php.ini
-          php -c php.ini -dpcov.enabled=1 vendor/bin/phpunit --exclude-group cache-clear --exclude-group cache-clear-install --exclude-group update-schema-doctrine --coverage-cobertura=coverage1.xml --testdox
+          # rector グループ (AttributeArgumentsOrderRectorTest) は rector 同梱の
+          # nikic/php-parser を読み込み、pcov 有効時に本体の nikic/php-parser と衝突して
+          # fatal (Cannot redeclare PhpParser\Node\Scalar\Float_) になるため除外する。
+          php -c php.ini -dpcov.enabled=1 vendor/bin/phpunit --exclude-group cache-clear --exclude-group cache-clear-install --exclude-group update-schema-doctrine --exclude-group rector --coverage-cobertura=coverage1.xml --testdox
       # GitHub のコードカバレッジ (Code Quality) にアップロードする。
       # - PHPUnit ステップの outcome でガードする: 上記の continue-on-error により
       #   テストがクラッシュしてもジョブは成功扱いのままになり、coverage1.xml が

--- a/src/Eccube/Rector/CodingStyle/AttributeArgumentsOrderRector.php
+++ b/src/Eccube/Rector/CodingStyle/AttributeArgumentsOrderRector.php
@@ -51,7 +51,7 @@ final class AttributeArgumentsOrderRector extends AbstractRector
      * 差し替え、置換後のクラスの正しいパラメータ順序（例: Template の $template）を使う。
      * 差し替えるのはリフレクション対象のみで、出力される Attribute 名ノードには手を加えない。
      *
-     * @var array<class-string, class-string>
+     * @var array<string, class-string>
      *
      * @see https://github.com/EC-CUBE/ec-cube/issues/6540
      */

--- a/src/Eccube/Rector/CodingStyle/AttributeArgumentsOrderRector.php
+++ b/src/Eccube/Rector/CodingStyle/AttributeArgumentsOrderRector.php
@@ -39,6 +39,30 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class AttributeArgumentsOrderRector extends AbstractRector
 {
     /**
+     * 非推奨アノテーションクラス → 新しい Attribute クラスのマッピング
+     *
+     * AnnotationToAttributeRector が Sensio FrameworkExtraBundle のアノテーションを
+     * Attribute に変換した直後、まだ use 文が Sensio クラスを指している段階で本ルールが走ると、
+     * リフレクションで Sensio 側のコンストラクタ第一パラメータ（例: Template の $data）を
+     * 読み取ってしまい、後段の RenameClassRector がクラスだけ置換しても誤った名前付き引数
+     * （例: #[Template(data: '...')]）が残る。
+     *
+     * これを避けるため、リフレクション対象のクラス名を「新しい Attribute クラス」へ事前に
+     * 差し替え、置換後のクラスの正しいパラメータ順序（例: Template の $template）を使う。
+     * 差し替えるのはリフレクション対象のみで、出力される Attribute 名ノードには手を加えない。
+     *
+     * @var array<class-string, class-string>
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6540
+     */
+    private const DEPRECATED_CLASS_MAPPING = [
+        'Sensio\Bundle\FrameworkExtraBundle\Configuration\Template' => \Symfony\Bridge\Twig\Attribute\Template::class,
+        'Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache' => \Symfony\Component\HttpKernel\Attribute\Cache::class,
+        'Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted' => \Symfony\Component\Security\Http\Attribute\IsGranted::class,
+        'Sensio\Bundle\FrameworkExtraBundle\Configuration\Security' => \Symfony\Component\Security\Http\Attribute\IsGranted::class,
+    ];
+
+    /**
      * コンストラクタパラメータ順序のキャッシュ
      *
      * @var array<string, array<string, int>>
@@ -195,6 +219,10 @@ CODE_SAMPLE
      */
     private function getConstructorParameterOrder(string $className): array
     {
+        // 非推奨アノテーションクラスは新しい Attribute クラスへ差し替えてからリフレクションする
+        // (#6540: Sensio クラスの第一パラメータ名が残ってしまう問題への対策)
+        $className = self::DEPRECATED_CLASS_MAPPING[$className] ?? $className;
+
         // キャッシュをチェック
         if (isset($this->constructorParameterOrderCache[$className])) {
             return $this->constructorParameterOrderCache[$className];

--- a/tests/Eccube/Tests/Rector/CodingStyle/AttributeArgumentsOrderRectorTest.php
+++ b/tests/Eccube/Tests/Rector/CodingStyle/AttributeArgumentsOrderRectorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Rector\CodingStyle;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AttributeArgumentsOrderRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/Eccube/Tests/Rector/CodingStyle/AttributeArgumentsOrderRectorTest.php
+++ b/tests/Eccube/Tests/Rector/CodingStyle/AttributeArgumentsOrderRectorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of EC-CUBE
  *
@@ -13,13 +15,12 @@
 
 namespace Eccube\Tests\Rector\CodingStyle;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class AttributeArgumentsOrderRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData
-     */
+    #[DataProvider(methodName: 'provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/Eccube/Tests/Rector/CodingStyle/AttributeArgumentsOrderRectorTest.php
+++ b/tests/Eccube/Tests/Rector/CodingStyle/AttributeArgumentsOrderRectorTest.php
@@ -16,8 +16,17 @@ declare(strict_types=1);
 namespace Eccube\Tests\Rector\CodingStyle;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
+/**
+ * Rector を実行するため rector 同梱の nikic/php-parser を読み込む。
+ * pcov 有効のカバレッジ実行では本体の nikic/php-parser と衝突して
+ * "Cannot redeclare class PhpParser\Node\Scalar\Float_" で fatal になるため、
+ * カバレッジ実行から除外できるよう rector グループを付与する
+ * (coverage.yml で --exclude-group rector)。
+ */
+#[Group('rector')]
 final class AttributeArgumentsOrderRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider(methodName: 'provideData')]

--- a/tests/Eccube/Tests/Rector/CodingStyle/Fixture/deprecated_template_attribute.php.inc
+++ b/tests/Eccube/Tests/Rector/CodingStyle/Fixture/deprecated_template_attribute.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Eccube\Tests\Rector\CodingStyle\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+class DeprecatedTemplateAttribute
+{
+    #[Template('@admin/Content/cache.twig')]
+    public function index()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Eccube\Tests\Rector\CodingStyle\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+class DeprecatedTemplateAttribute
+{
+    #[Template(template: '@admin/Content/cache.twig')]
+    public function index()
+    {
+    }
+}
+
+?>

--- a/tests/Eccube/Tests/Rector/CodingStyle/Fixture/route_attribute_order.php.inc
+++ b/tests/Eccube/Tests/Rector/CodingStyle/Fixture/route_attribute_order.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Eccube\Tests\Rector\CodingStyle\Fixture;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+class RouteAttributeOrder
+{
+    #[Route('/contact', requirements: ['id' => '\d+'], name: 'contact', methods: ['GET', 'POST'])]
+    public function contact()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Eccube\Tests\Rector\CodingStyle\Fixture;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+class RouteAttributeOrder
+{
+    #[Route(path: '/contact', name: 'contact', requirements: ['id' => '\d+'], methods: ['GET', 'POST'])]
+    public function contact()
+    {
+    }
+}
+
+?>

--- a/tests/Eccube/Tests/Rector/CodingStyle/config/configured_rule.php
+++ b/tests/Eccube/Tests/Rector/CodingStyle/config/configured_rule.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Eccube\Rector\CodingStyle\AttributeArgumentsOrderRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([
+        AttributeArgumentsOrderRector::class,
+    ]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,8 +12,16 @@
  */
 
 use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Polyfill\Php84\Php84;
 
 require dirname(__DIR__).'/vendor/autoload.php';
+
+// symfony/polyfill-php84 の Php84 クラスをテスト実行前に確実にロードしておく。
+// テスト env では Symfony の DebugClassLoader が有効で、kernel 起動後に
+// グローバル関数 bcround() から Php84 を遅延 autoload すると
+// Php84::bcround() が解決できず、PHP 8.2/8.3 で税計算(bcround)を通す
+// 全テストが「Call to undefined method」で失敗する。事前ロードで回避する。
+class_exists(Php84::class);
 
 if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
     require dirname(__DIR__).'/config/bootstrap.php';


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Closes #6540

カスタム Rector ルール `AttributeArgumentsOrderRector` が、`@Template("...")` を
`#[Template(data: '...')]` と**誤った名前付き引数**へ変換してしまう問題を修正します。

### 原因

1. `AnnotationToAttributeRector` がアノテーションを Attribute へ変換した時点では、まだ
   use 文が `Sensio\Bundle\FrameworkExtraBundle\Configuration\Template`（非推奨）を指している。
2. `AttributeArgumentsOrderRector` がリフレクションで Sensio の `Template` を調べ、第一パラメータ
   `$data` を読み取って `data:` を付与する。
3. その後 `RenameClassRector` が use 文を `Symfony\Bridge\Twig\Attribute\Template` へ rename するが、
   名前付き引数 `data:` はそのまま残る。

`Symfony\Bridge\Twig\Attribute\Template` の第一パラメータは `$template` で `$data` は存在しないため、
`#[Template(data: '...')]` は実行時に **Unknown named parameter $data** となる実害があります。

## 方針(Policy)

`AttributeArgumentsOrderRector` に「非推奨クラス → 新しい Attribute クラス」のマッピング
（`DEPRECATED_CLASS_MAPPING`）を追加し、**リフレクション対象のクラス名を新クラスへ事前差し替え**します。
これにより置換後クラスの正しいパラメータ順序（`Template` の `$template` 等）が使われます。
差し替えるのはリフレクション対象のみで、出力される Attribute 名ノードには手を加えません。

対象マッピング（#6540 の提案に準拠）:

| 非推奨（Sensio） | 新クラス |
|---|---|
| `...\Configuration\Template` | `Symfony\Bridge\Twig\Attribute\Template` |
| `...\Configuration\Cache` | `Symfony\Component\HttpKernel\Attribute\Cache` |
| `...\Configuration\IsGranted` | `Symfony\Component\Security\Http\Attribute\IsGranted` |
| `...\Configuration\Security` | `Symfony\Component\Security\Http\Attribute\IsGranted` |

> 新クラスがオートロードできない場合は従来どおり `ReflectionException` で空配列を返してスキップするため、安全側にフォールバックします。

## 実装に関する補足(Appendix)

- `src/Eccube/Rector/CodingStyle/AttributeArgumentsOrderRector.php`: `DEPRECATED_CLASS_MAPPING` 定数を追加し、`getConstructorParameterOrder()` のリフレクション前にクラス名を差し替え。
- `tests/Eccube/Tests/Rector/CodingStyle/AttributeArgumentsOrderRectorTest.php`（＋ config / Fixture）を追加。

## テスト（Test)

`AbstractRectorTestCase` ベースのルール単体テストを追加し、ローカルで確認済み:

- `use Sensio\...\Template;` 配下の `#[Template('@admin/Content/cache.twig')]` が
  `#[Template(template: '@admin/Content/cache.twig')]` へ変換される（修正の本丸）
- 通常の `#[Route(...)]` 引数並べ替えが従来どおり動作する（リグレッションガード）
- マッピングを無効化すると本テストが赤くなり、有効化で緑になることを確認（修正がテストで守られている）

```
vendor/bin/phpunit tests/Eccube/Tests/Rector/CodingStyle/AttributeArgumentsOrderRectorTest.php
OK (2 tests)
```

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません（開発時のみ使う Rector ルールの修正）
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 属性引数の並び替えで、非推奨表記が混在するケースでも正しい形式として判定されるよう改善し、結果の安定性を高めました。
* **Tests**
  * 属性引数の順序を検証するテストを追加しました。
  * テスト用フィクスチャ（Template/Routeの属性記法）を更新しました。
  * 環境差によるテスト失敗を防ぐための事前読み込みや、カバレッジ対象の調整を行いました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

> 本 PR は #6877 を最新の `4.4` から作り直したものです（#6877 はクローズ）。
