### PR TITLE
fix: PHP 8.2/8.3 の unit-test で polyfill-php84 の bcround が未定義になる問題を修正

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,8 +12,16 @@
  */
 
 use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Polyfill\Php84\Php84;
 
 require dirname(__DIR__).'/vendor/autoload.php';
+
+// symfony/polyfill-php84 の Php84 クラスをテスト実行前に確実にロードしておく。
+// テスト env では Symfony の DebugClassLoader が有効で、kernel 起動後に
+// グローバル関数 bcround() から Php84 を遅延 autoload すると
+// Php84::bcround() が解決できず、PHP 8.2/8.3 で税計算(bcround)を通す
+// 全テストが「Call to undefined method」で失敗する。事前ロードで回避する。
+class_exists(Php84::class);
 
 if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
     require dirname(__DIR__).'/config/bootstrap.php';


### PR DESCRIPTION
## 概要(Overview)

PHP 8.2 / 8.3 の unit-test で、`symfony/polyfill-php84` の `Symfony\Polyfill\Php84\Php84::bcround()` が
実行時に「Call to undefined method」となり、税計算（`TaxRuleService::roundByRoundingType()` の `bcround()`）を
通す**全テストが 600 件超エラー**になる問題を修正します。

## 症状

- 発生条件: **PHP 8.2 / 8.3**（8.4 以降はネイティブ `bcround` のため無関係）。
- 現象: 新規に `composer install` した環境（＝新規 PR）の unit-test で以下が多発。
  ```
  Error: Call to undefined method Symfony\Polyfill\Php84\Php84::bcround()
  vendor/symfony/polyfill-php84/bootstrap80.php:47
  src/Eccube/Service/TaxRuleService.php:130
  ```
- `4.4` ブランチの push CI が緑なのは、化石化した working な `vendor/` キャッシュを
  `Nothing to install` で復元しているためで、fresh install する新規 PR は本問題を踏みます。

## 原因

テスト環境（`APP_ENV=test`）では Symfony の **`DebugClassLoader` が有効**です。この状態で、
グローバル関数 `bcround()`（`polyfill-php84` の `bootstrap80.php` が定義）から
`Symfony\Polyfill\Php84\Php84` クラスを **kernel 起動後に遅延 autoload** すると、
`Php84::bcround()` が解決できなくなります。

- bootstrap 時点や standalone（`php -r`）では `Php84::bcround` は正しく存在し `bcround()` も動作する。
- kernel 起動後（DebugClassLoader 有効）に初めて `Php84` を autoload するケースだけ失敗する。

切り分けの結果、**composer キャッシュ・opcache・polyfill のバージョン（1.37 / 1.38 とも）は無関係**で、
「遅延 autoload のタイミング」が要因であることを確認しています。

## 修正

`tests/bootstrap.php` で kernel 起動前に `Php84` クラスを `class_exists()` で事前ロードします（8 行）。
これにより PHP 8.2 / 8.3 の unit-test が安定して通ります。本番（`APP_ENV=prod`, debug 無効）は
`DebugClassLoader` が非活性のため影響を受けません。

## 検証

- 修正前: fresh install（キャッシュ完全無効）・opcache 無効いずれの条件でも 8.2/8.3 が失敗。
- 修正後: 8.2 / 8.3 を含む unit-test マトリクスが全て success。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * テスト実行時に一部の環境で発生していた失敗を防ぎ、より安定してテストを実行できるようにしました。
  * 依存ライブラリの読み込み順による不具合を回避し、既存のテストが正しく開始されるように改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->