### PR TITLE
fix: マスタEntityをtraitで拡張するとマスタデータ管理から消える問題を修正 (#5400 #6273)

### DIFF
--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -367,6 +367,7 @@ jobs:
           - test_extend_same_table_disabled_remove_local
           - test_extend_same_table_crossed_store
           - test_extend_same_table_crossed_local
+          - test_master_entity_extension
         include:
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db

--- a/codeception/_data/plugins/MasterEntityExtension-1.0.0/Entity/DeviceTypeTrait.php
+++ b/codeception/_data/plugins/MasterEntityExtension-1.0.0/Entity/DeviceTypeTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\MasterEntityExtension\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Eccube\Attribute\EntityExtension;
+use Eccube\Entity\Master\DeviceType;
+
+/**
+ * マスタデータのEntity(Entity/Master配下)をtraitで拡張するサンプル.
+ * Issue #5400 / #6273 の回帰テスト用.
+ */
+#[EntityExtension(DeviceType::class)]
+trait DeviceTypeTrait
+{
+    #[ORM\Column(name: 'notes', type: Types::STRING, nullable: true)]
+    public ?string $notes = null;
+}

--- a/codeception/_data/plugins/MasterEntityExtension-1.0.0/composer.json
+++ b/codeception/_data/plugins/MasterEntityExtension-1.0.0/composer.json
@@ -1,0 +1,1 @@
+{"name":"ec-cube/masterentityextension","description":"エンティティ拡張機能(Master)のサンプル","version":"1.0.0","type":"eccube-plugin","require":{"ec-cube/plugin-installer":"^2.0@dev"},"extra":{"code":"MasterEntityExtension","id":10000}}

--- a/e2e/models/plugins/master-entity-extension-local.ts
+++ b/e2e/models/plugins/master-entity-extension-local.ts
@@ -1,0 +1,22 @@
+import { type Page } from '@playwright/test';
+import { type DbClient } from '../../helpers/db-client';
+import { type PluginTestConfig } from '../../fixtures/plugin-test';
+import { LocalPlugin } from '../local-plugin';
+
+/**
+ * マスタデータのEntity(Entity/Master配下)をtraitで拡張するローカルプラグイン。
+ * Issue #5400 / #6273 の回帰テスト用。
+ * Codeception の MasterEntityExtension_Local に相当。
+ */
+export class MasterEntityExtensionLocal extends LocalPlugin {
+  constructor(page: Page, db: DbClient, config: PluginTestConfig) {
+    super(page, db, config, 'MasterEntityExtension');
+    // Entity/Master 配下のEntityを拡張するtrait。
+    // 有効化でこのtraitがproxyに注入され、mtb_device_type がプルダウンに残ることを検証する。
+    this.traits.set('Plugin\\MasterEntityExtension\\Entity\\DeviceTypeTrait', 'src/Eccube/Entity/Master/DeviceType');
+  }
+
+  static async start(page: Page, db: DbClient, config: PluginTestConfig): Promise<MasterEntityExtensionLocal> {
+    return new MasterEntityExtensionLocal(page, db, config);
+  }
+}

--- a/e2e/pages/master-data-manage.page.ts
+++ b/e2e/pages/master-data-manage.page.ts
@@ -1,0 +1,67 @@
+import { type Page, expect } from '@playwright/test';
+
+/**
+ * マスタデータ管理ページ
+ * Codeception の Page\Admin\MasterDataManagePage に相当。
+ * Issue #5400 / #6273: Entity/Master 配下のマスタEntityをtraitで拡張しても
+ * プルダウンから消えないことを検証する。
+ */
+export class MasterDataManagePage {
+  /** マスタデータ選択プルダウン (form1) */
+  static readonly SELECT_SELECTOR = '#admin_system_masterdata_masterdata';
+  /** 更新完了フラッシュ */
+  static readonly ALERT_SUCCESS_SELECTOR = '.c-contentsArea .alert-success';
+
+  constructor(private readonly page: Page) {}
+
+  static async go(page: Page, adminRoute = 'admin'): Promise<MasterDataManagePage> {
+    await page.goto(`/${adminRoute}/setting/system/masterdata`);
+    await expect(page.locator(MasterDataManagePage.SELECT_SELECTOR)).toBeVisible({ timeout: 30_000 });
+    return new MasterDataManagePage(page);
+  }
+
+  /**
+   * プルダウンに指定ラベル(テーブル名)の選択肢が存在するか。
+   * バグがある場合は拡張したマスタのテーブル名が選択肢から消えるため false になる。
+   */
+  async 選択肢が存在する(label: string): Promise<boolean> {
+    const count = await this.page
+      .locator(MasterDataManagePage.SELECT_SELECTOR)
+      .locator('option', { hasText: label })
+      .count();
+    return count > 0;
+  }
+
+  /**
+   * マスタデータを選択して form1 を submit し、編集フォーム(form2)を表示する。
+   * 選択肢が存在しない場合は selectOption がタイムアウトして回帰を検知する。
+   */
+  async 選択(label: string): Promise<this> {
+    await expect(
+      this.page.locator(MasterDataManagePage.SELECT_SELECTOR).locator('option', { hasText: label }),
+      `マスタデータのプルダウンに ${label} が存在する`,
+    ).toHaveCount(1);
+
+    await this.page.locator(MasterDataManagePage.SELECT_SELECTOR).selectOption({ label });
+    await this.page.locator('#form1 button[type="submit"]').click();
+    await this.page.waitForLoadState('load');
+
+    // 選択後は編集フォーム(form2)が表示される
+    await expect(this.page.locator('#form2')).toBeVisible({ timeout: 30_000 });
+
+    return this;
+  }
+
+  /**
+   * 編集フォーム(form2)を保存し、更新完了メッセージを確認する。
+   */
+  async 保存(): Promise<this> {
+    await this.page.locator('#form2 .c-conversionArea button[type="submit"]').click();
+    await this.page.waitForLoadState('load');
+    await expect(this.page.locator(MasterDataManagePage.ALERT_SUCCESS_SELECTOR)).toContainText('保存しました', {
+      timeout: 30_000,
+    });
+
+    return this;
+  }
+}

--- a/e2e/tests/plugin-extend.spec.ts
+++ b/e2e/tests/plugin-extend.spec.ts
@@ -128,6 +128,8 @@ test.describe('Plugin Extend', () => {
     await masterPage.選択('mtb_device_type');
     await masterPage.保存();
 
+    // 後片付け(無効化・削除)はプラグイン管理画面上で行うため、マスタデータ画面から戻る
+    await page.goto(`/${config.adminRoute}/store/plugin`);
     await plugin.無効化();
     await plugin.削除();
   });

--- a/e2e/tests/plugin-extend.spec.ts
+++ b/e2e/tests/plugin-extend.spec.ts
@@ -3,6 +3,8 @@ import { HorizonStore } from '../models/plugins/horizon-store';
 import { HorizonLocal } from '../models/plugins/horizon-local';
 import { BoomerangStore } from '../models/plugins/boomerang-store';
 import { BoomerangLocal } from '../models/plugins/boomerang-local';
+import { MasterEntityExtensionLocal } from '../models/plugins/master-entity-extension-local';
+import { MasterDataManagePage } from '../pages/master-data-manage.page';
 import { emptyDir } from '../helpers/tar-helper';
 
 test.describe('Plugin Extend', () => {
@@ -110,5 +112,23 @@ test.describe('Plugin Extend', () => {
     await boomerang.検証();
     await boomerang.無効化();
     await boomerang.削除();
+  });
+
+  // Issue #5400 / #6273: Entity/Master 配下のマスタEntityをtraitで拡張すると、
+  // マスタデータ管理ページのプルダウンから拡張したテーブルが消えてしまう回帰の防止。
+  test('test_master_entity_extension', async ({ page, db, config }) => {
+    const plugin = await MasterEntityExtensionLocal.start(page, db, config);
+
+    await plugin.インストール();
+    await plugin.有効化();
+
+    // 拡張したマスタデータ(mtb_device_type)がプルダウンに残っており、選択・保存できること
+    const masterPage = await MasterDataManagePage.go(page, config.adminRoute);
+    expect(await masterPage.選択肢が存在する('mtb_device_type'), 'mtb_device_type がプルダウンに存在する').toBe(true);
+    await masterPage.選択('mtb_device_type');
+    await masterPage.保存();
+
+    await plugin.無効化();
+    await plugin.削除();
   });
 });

--- a/src/Eccube/Doctrine/ORM/Mapping/Driver/ReloadSafeAttributeDriver.php
+++ b/src/Eccube/Doctrine/ORM/Mapping/Driver/ReloadSafeAttributeDriver.php
@@ -99,9 +99,11 @@ class ReloadSafeAttributeDriver extends TraitProxyAttributeDriver
                     $projectDir = str_replace('\\', '/', $projectDir);
                 }
 
-                // Replace /path/to/ec-cube to proxies path
-                $proxyFile = str_replace($projectDir, $this->trait_proxies_directory, $path).'/'.basename((string) $sourceFile);
-                if (file_exists($proxyFile)) {
+                // Replace /path/to/ec-cube to proxies path.
+                // Entity/Master 等のサブディレクトリ配下のクラスでもProxyパスが正しく解決されるよう、
+                // basename()でファイル名だけに丸めず$sourceFileのパス構造ごと変換する（Issue #5400 / #6273）.
+                $proxyFile = str_replace($projectDir, $this->trait_proxies_directory, (string) $sourceFile);
+                if ($proxyFile !== $sourceFile && file_exists($proxyFile)) {
                     $sourceFile = $proxyFile;
                 }
 

--- a/src/Eccube/Doctrine/ORM/Mapping/Driver/TraitProxyAttributeDriver.php
+++ b/src/Eccube/Doctrine/ORM/Mapping/Driver/TraitProxyAttributeDriver.php
@@ -78,9 +78,11 @@ class TraitProxyAttributeDriver extends AttributeDriver
                     $sourceFile = str_replace('\\', '/', $sourceFile);
                     $projectDir = str_replace('\\', '/', $projectDir);
                 }
-                // Replace /path/to/ec-cube to proxies path
-                $proxyFile = str_replace($projectDir, $this->trait_proxies_directory, $path).'/'.basename((string) $sourceFile);
-                if (file_exists($proxyFile)) {
+                // Replace /path/to/ec-cube to proxies path.
+                // Entity/Master 等のサブディレクトリ配下のクラスでもProxyパスが正しく解決されるよう、
+                // basename()でファイル名だけに丸めず$sourceFileのパス構造ごと変換する（Issue #5400 / #6273）.
+                $proxyFile = str_replace($projectDir, $this->trait_proxies_directory, (string) $sourceFile);
+                if ($proxyFile !== $sourceFile && file_exists($proxyFile)) {
                     $sourceFile = $proxyFile;
                 }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Closes #5400
Closes #6273

(関連PR: #5401 / #6274)

`Eccube\Entity\Master` 配下のマスタ Entity をプラグインの trait で拡張すると、以下の 2 つの不具合が発生していました。

1. **#5400**: マスタデータ管理ページ (`/admin/setting/system/masterdata`) のプルダウンから、拡張したテーブルが消える。
2. **#6273**: プラグインインストール時に `schema:update` が自動実行されず、trait で追加したカラムが作成されない (手動で `bin/console doctrine:schema:update --force` を実行すれば作成される)。

いずれも根本原因は同一で、Proxy パス解決を担う 2 つのドライバの `getAllClassNames()` が、Proxy パス生成時に `basename($sourceFile)` を用いて `Entity/Master/` などのサブディレクトリ情報を落としていたためです。この結果 `Entity/Master/DeviceType` の Proxy が「存在しない」と誤判定され、メタデータ収集からエンティティが漏れていました。

## 方針(Policy)

- `basename()` でファイル名だけに丸めるのをやめ、`$sourceFile` のパス構造ごと `trait_proxies_directory` へ変換するように修正しました。これは `EntityProxyService` が Proxy を生成する際のパス規則 (projectDir 相対でサブディレクトリを保持) と一致します。
- annotation 時代は **親ドライバの修正 (#5401) と子ドライバの修正 (#6274) が別々の PR** に分かれており、いずれか一方だけではプルダウン表示か schema update のどちらかしか直りませんでした。4.4 (attribute 時代) では対応する 2 ドライバの**両方**を本 PR で修正し、統合的に解決しています。
  - 親 `TraitProxyAttributeDriver` (通常のメタデータ収集 = プルダウン表示) → #5400
  - 子 `ReloadSafeAttributeDriver` (`SchemaService::executeCallback` 経由の install 時 schema update) → #6273
- `src/Eccube/Entity/` 決め打ちではなく `$sourceFile` を汎用的に変換するため、`app/Customize/Entity` や `app/Plugin/*/Entity` のサブディレクトリ配下も同時に救済します。

## 実装に関する補足(Appendix)

- 変更したコアファイルは 2 つのドライバのみです。
  - `src/Eccube/Doctrine/ORM/Mapping/Driver/TraitProxyAttributeDriver.php`
  - `src/Eccube/Doctrine/ORM/Mapping/Driver/ReloadSafeAttributeDriver.php`
- `str_replace()` が置換しなかった場合 (Proxy ディレクトリ配下に写像されないパス) は Proxy 扱いしないよう `$proxyFile !== $sourceFile` のガードを追加しています。
- 回帰テストを Codeception から Playwright へ移植しました。
  - `codeception/_data/plugins/MasterEntityExtension-1.0.0/` (trait は annotation → PHP8 属性へ移植)
  - `e2e/pages/master-data-manage.page.ts` / `e2e/models/plugins/master-entity-extension-local.ts`
  - `e2e/tests/plugin-extend.spec.ts` に `test_master_entity_extension` を追加
  - `.github/workflows/plugin-test.yml` の `plugin-extend` マトリクスに追加

## テスト（Test)

- ✅ `vendor/bin/php-cs-fixer fix` (PSR-12, 違反なし)
- ✅ `vendor/bin/phpstan analyse` (level 6, エラーなし)
- ✅ **SQLite 環境で A/B 対照実測**を実施し、因果を確認 (`mtb_device_type` を `MasterEntityExtension` プラグインで拡張):

  | ドライバ | `eccube:plugin:install` 後の `mtb_device_type` | 結果 |
  |---|---|---|
  | 修正版 | `id, name, sort_no, discriminator_type, notes` | ✅ `notes` が自動追加 |
  | 修正前 (basename) | `id, name, sort_no, discriminator_type` | ❌ カラム未追加 (#6273 再現) |

  両ケースとも install 時の一時 Proxy は `Master/` サブパスを保持して生成される (`gen -> /tmp/proxy_xxx/src/Eccube/Entity/Master/DeviceType.php`) ため、差分の唯一の要因はドライバの `basename` バグであることを確認済みです。
- E2E (Playwright `plugin-extend` / `test_master_entity_extension`) は本 PR の CI で検証されます。

## 相談（Discussion）

- annotation 時代の #5401 / #6274 は本 PR の 4.4 対応で不要になる想定です (両者を統合)。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * マスターデータ管理画面で「mtb_device_type」の選択肢を表示・選択・保存できるようにしました。
  * DeviceTypeに拡張項目「notes」を追加しました。
* **バグ修正**
  * 拡張データのプロキシ解決方法を見直し、サブディレクトリでも参照ずれが起きにくくしました。
* **テスト**
  * 拡張機能のE2Eテストを追加し、実行対象を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
