### PR TITLE
fix: 2段階認証の再設定ルートを /setting 配下から移動 (#6406)

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/System/TwoFactorAuthController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/TwoFactorAuthController.php
@@ -102,7 +102,7 @@ class TwoFactorAuthController extends AbstractController
     /**
      * @return RedirectResponse|array<string, mixed>
      */
-    #[Route(path: '/%eccube_admin_route%/setting/system/two_factor_auth/edit', name: 'admin_setting_system_two_factor_auth_edit', methods: ['GET', 'POST'])]
+    #[Route(path: '/%eccube_admin_route%/two_factor_auth/edit', name: 'admin_setting_system_two_factor_auth_edit', methods: ['GET', 'POST'])]
     #[Template(template: '@admin/Setting/System/two_factor_auth_edit.twig')]
     public function edit(Request $request): RedirectResponse|array
     {

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/TwoFactorAuthControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/TwoFactorAuthControllerTest.php
@@ -15,12 +15,14 @@ declare(strict_types=1);
 
 namespace Eccube\Tests\Web\Admin\Setting\System;
 
+use Eccube\Entity\AuthorityRole;
 use Eccube\Entity\Member;
 use Eccube\Repository\MemberRepository;
 use Eccube\Service\TwoFactorAuthService;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 use RobThree\Auth\TwoFactorAuth;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 final class TwoFactorAuthControllerTest extends AbstractAdminWebTestCase
 {
@@ -209,6 +211,50 @@ final class TwoFactorAuthControllerTest extends AbstractAdminWebTestCase
         $this->assertTrue(
             $response->isRedirect($this->generateUrl('admin_two_factor_auth')),
             '2FAキー設定済みユーザーが未認証で設定画面にアクセスした場合、認証画面にリダイレクトされるべき。実際のレスポンス: Status='.$response->getStatusCode().', Location='.$response->headers->get('Location')
+        );
+    }
+
+    /**
+     * 回帰テスト(#6406): 権限管理で "/setting" が拒否URLに設定されていても、
+     * 2段階認証の再設定画面にアクセスできること。
+     *
+     * 修正前は edit ルートが "/setting/system/two_factor_auth/edit" だったため
+     * 拒否URL "/setting" の前方一致で AuthorityVoter に 403 で弾かれていた。
+     */
+    public function testEditIsNotForbiddenWhenSettingUrlIsDenied()
+    {
+        if (!$this->twoFactorAuthService->isEnabled()) {
+            $this->markTestSkipped('2FAが無効のためスキップ');
+        }
+
+        // 2FA設定済みの新規メンバーを作成
+        $Member = $this->createMember();
+        $Member->setTwoFactorAuthEnabled(true);
+        $Member->setTwoFactorAuthKey($this->twoFactorAuthService->createSecret());
+        $this->entityManager->persist($Member);
+
+        // メンバーの権限に対して "/setting" 配下を拒否する権限設定を追加
+        $AuthorityRole = new AuthorityRole();
+        $AuthorityRole
+            ->setDenyUrl('/setting')
+            ->setAuthority($Member->getAuthority())
+            ->setCreator($Member)
+            ->setCreateDate(new \DateTime())
+            ->setUpdateDate(new \DateTime());
+        $this->entityManager->persist($AuthorityRole);
+        $this->entityManager->flush();
+
+        // 新しいMemberでログイン
+        $this->loginTo($Member);
+
+        // 2段階認証の再設定画面にアクセス
+        $this->client->request(Request::METHOD_GET, $this->generateUrl('admin_setting_system_two_factor_auth_edit'));
+
+        // "/setting" 拒否設定下でも 403(アクセス拒否) にならないこと
+        $this->assertNotSame(
+            Response::HTTP_FORBIDDEN,
+            $this->client->getResponse()->getStatusCode(),
+            '"/setting" が拒否URLでも2段階認証の再設定画面はアクセス拒否されないべき'
         );
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Closes #6406

権限管理でシステム設定(`/setting`)を拒否URLに設定すると、その権限を持つメンバーが**自分の2段階認証を再設定できない**問題を修正します。

2段階認証の再設定 (`admin_setting_system_two_factor_auth_edit`) は `/setting/system/two_factor_auth/edit` に配置されていたため、`AuthorityVoter` の前方一致による拒否URL判定で拒否URL `/setting` にマッチし、本人向けの操作にもかかわらず 403 (Access Denied) で弾かれていました。

一方「パスワード変更」は `/change_password`(`/setting`配下でない)のため影響を受けず、Issue の指摘通りの差になっていました。

## 方針(Policy)

- Issue のコメント（@dotani1111）で合意されている **ルーティング変更** 方針を採用しました。
- 2段階認証の再設定は「パスワード変更」と同じ**本人向けアクション**であり、システム設定(`/setting/system`)配下に置くのが不適切でした。`admin_change_password`(`/change_password`)に倣い、ルートパスを `/two_factor_auth/edit` へ移し `/setting` 名前空間から外します。既存の `admin_two_factor_auth`(`/two_factor_auth`)・`admin_two_factor_auth_set`(`/two_factor_auth/set`)とも名前空間が揃います。
- なお #6242（拒否URL前方一致の設計全般の改修）とは別の、本Issue局所の修正です。

## 実装に関する補足(Appendix)

- **ルート名 `admin_setting_system_two_factor_auth_edit` は後方互換のため据え置き**ました。メニューのリンク(`default_frame.twig`)はルート名参照(`url(...)`)のため変更不要です。プラグイン等がルート名で参照している場合も影響ありません。
- URL パス自体は変わります（旧 `/admin/setting/system/two_factor_auth/edit` は 404 になります）。この画面は管理画面右上メニューの「2段階認証 設定」からルート名で遷移するため、通常導線に影響はありません。
- `/admin` 配下のままなので `ROLE_ADMIN` の認可は引き続き有効で、認可レベルの防御は失われません（拒否URLの粒度だけが変わります＝本Issueの狙い）。

## テスト（Test)

- 回帰テスト `testEditIsNotForbiddenWhenSettingUrlIsDenied` を追加。拒否URL `/setting` を持つ権限のメンバーが再設定画面にアクセスしても 403 にならないことを検証します（修正前のパスでは 403 で失敗することも確認済み）。
- 既存の `TwoFactorAuthControllerTest`(5件) が通ることを確認。
- Docker 環境で実機再現・修正後の動作を確認（旧URL:404 / 新URL:正常）。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更はありません
  - ※ 本人向け2FA再設定画面の**URLパスのみ**変更します（ルート名は据え置き）。
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 2段階認証の再設定画面のアクセス経路を見直し、権限制限の設定によって画面が誤ってブロックされる問題を修正しました。
  * `/setting` のアクセス制限がある環境でも、2段階認証の再設定画面を開けるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->