### PR TITLE
security: CVE-2026-24765 対策として .coverage ファイル削除ステップを追加 (#6610)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
+      # CVE-2026-24765 (GHSA-vvj3-c3rp-c85p) 対策 (多層防御):
+      # 悪意ある *.coverage ファイルが PHPUnit の PHPT ランナーで unserialize され
+      # RCE に至るのを防ぐため、テスト実行前に削除する。
+      - name: Remove potentially malicious coverage files
+        run: find . -name "*.coverage" -delete
+
       ## Docker Hub からの pull はタイムアウトで CI が不安定になるため、
       ## DB はコンテナではなく setup アクション (apt) でインストールする
       - name: Setup PostgreSQL

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
+      # CVE-2026-24765 (GHSA-vvj3-c3rp-c85p) 対策 (多層防御):
+      # 悪意ある *.coverage ファイルが PHPUnit の PHPT ランナーで unserialize され
+      # RCE に至るのを防ぐため、テスト実行前に削除する。
+      - name: Remove potentially malicious coverage files
+        run: find . -name "*.coverage" -delete
+
       ## Docker Hub からの pull はタイムアウトで CI が不安定になるため、
       ## DB はコンテナではなく setup アクション (apt/同梱版) でインストールする
       - name: Setup MySQL


### PR DESCRIPTION
## 概要

[CVE-2026-24765 (GHSA-vvj3-c3rp-c85p)](https://github.com/advisories/GHSA-vvj3-c3rp-c85p) 対応 (Closes #6610)。

PHPUnit の PHPT テストランナー `cleanupForCoverage()` が未検証の `unserialize()` を行う脆弱性 (CVSS 7.8 高) への**多層防御**として、phpunit を実行するワークフローの Checkout 直後に、悪意ある `*.coverage` ファイルを削除するステップを追加する。

## 変更内容

`.github/workflows/coverage.yml` / `.github/workflows/unit-test.yml` の phpunit ジョブに以下を追加:

```yaml
- name: Remove potentially malicious coverage files
  run: find . -name "*.coverage" -delete
```

- 脆弱経路 `cleanupForCoverage()` はカバレッジ収集時に発火するため `coverage.yml` が最重要。多層防御として phpunit を叩く `unit-test.yml` にも追加。
- `coverage.yml` の codeception ジョブは `if: false` で無効化済みのため対象外。

## Issue #6610 の 3 要望の対応状況

| # | 要望 | 本 PR |
|---|------|-------|
| 1 | 外部 PR の CI 承認制 ("Require approval for all outside collaborators") | ⚠️ **未対応** — GitHub リポジトリ設定のためメンテナ作業。最優先で別途有効化が必要 |
| 2 | PHPUnit のパッチ版更新 | ✅ **対応不要** — `composer.lock` は既に `phpunit/phpunit` **11.5.55** (パッチ済み最低版 11.5.50 以上) |
| 3 | ワークフローでの `.coverage` 削除 (多層防御) | ✅ **本 PR で対応** |

## 動作確認

- `python3` で両 YAML の構文チェック済み
- ローカルで `find . -name "*.coverage" -delete` が `*.coverage` のみ削除し他ファイルを残すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PHPUnit 実行前に、ワークスペース内の不要な `*.coverage` ファイルを削除するようになりました。
  * これにより、テスト実行時の予期しない不正ファイル影響を防ぎ、CI の安全性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->