### PR TITLE
robthree/twofactorauth を 3.x へ移行する (refs #6897)

### DIFF
--- a/codeception/acceptance/EF09ThrottlingCest.php
+++ b/codeception/acceptance/EF09ThrottlingCest.php
@@ -26,6 +26,7 @@ use Page\Front\ShoppingConfirmPage;
 use Page\Front\ShoppingLoginPage;
 use Page\Front\ShoppingNonmemberPage;
 use Page\Front\ShoppingPage;
+use RobThree\Auth\Providers\Qr\QRServerProvider;
 use RobThree\Auth\TwoFactorAuth;
 
 /**
@@ -777,7 +778,7 @@ class EF09ThrottlingCest
 
         // 二段階認証のセットアップ
         $secret = $I->executeJS('return $("#admin_two_factor_auth_auth_key").val();');
-        $tfa = new TwoFactorAuth();
+        $tfa = new TwoFactorAuth(new QRServerProvider());
         $code = $tfa->getCode($secret);
         $I->fillField(['id' => 'admin_two_factor_auth_device_token'], $code);
         $I->click('登録');

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "psr/http-message": "^1.0 || ^2.0",
         "psr/log": "~2.0",
         "psr/simple-cache": "^3.0",
-        "robthree/twofactorauth": "^1.8",
+        "robthree/twofactorauth": "^3.0",
         "setasign/fpdi": "^2.2",
         "skorp/detect-incompatible-samesite-useragents": "^1.0",
         "softcreatr/jsonpath": "^0.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98f03b30b0f09f78545a7ae3f43316e9",
+    "content-hash": "afa7306c263e1ef03596918fcc246ee7",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -5187,24 +5187,25 @@
         },
         {
             "name": "robthree/twofactorauth",
-            "version": "1.8.2",
+            "version": "v3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/RobThree/TwoFactorAuth.git",
-                "reference": "65681de5a324eae05140ac58b08648a60212afc0"
+                "reference": "85408c4e775dba7c0802f2d928efd921d530bc5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RobThree/TwoFactorAuth/zipball/65681de5a324eae05140ac58b08648a60212afc0",
-                "reference": "65681de5a324eae05140ac58b08648a60212afc0",
+                "url": "https://api.github.com/repos/RobThree/TwoFactorAuth/zipball/85408c4e775dba7c0802f2d928efd921d530bc5b",
+                "reference": "85408c4e775dba7c0802f2d928efd921d530bc5b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": ">=8.2.0"
             },
             "require-dev": {
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpunit/phpunit": "@stable"
+                "friendsofphp/php-cs-fixer": "^3.13",
+                "phpstan/phpstan": "^1.9",
+                "phpunit/phpunit": "^9"
             },
             "suggest": {
                 "bacon/bacon-qr-code": "Needed for BaconQrCodeProvider provider",
@@ -5224,6 +5225,16 @@
                 {
                     "name": "Rob Janssen",
                     "homepage": "http://robiii.me",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nicolas CARPi",
+                    "homepage": "https://github.com/NicolasCARPi",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Will Power",
+                    "homepage": "https://github.com/willpower232",
                     "role": "Developer"
                 }
             ],
@@ -5253,7 +5264,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-22T16:11:07+00:00"
+            "time": "2026-01-05T13:17:41+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -15617,7 +15628,8 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.2.0"
+        "php": "8.2.0",
+        "ext-sodium": "1.0.18"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Eccube/Service/TwoFactorAuthService.php
+++ b/src/Eccube/Service/TwoFactorAuthService.php
@@ -15,6 +15,7 @@ namespace Eccube\Service;
 
 use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Member;
+use RobThree\Auth\Providers\Qr\QRServerProvider;
 use RobThree\Auth\TwoFactorAuth;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
@@ -50,7 +51,9 @@ class TwoFactorAuthService
         protected RequestStack $requestStack,
     ) {
         $this->request = $this->requestStack->getCurrentRequest();
-        $this->tfa = new TwoFactorAuth();
+        // v3 では QR プロバイダの注入が必須。QR 生成はテンプレート側(JS)で行い
+        // ライブラリの getQRCodeImage() は呼ばないため、注入しても外部通信は発生しない。
+        $this->tfa = new TwoFactorAuth(new QRServerProvider());
 
         if ($this->eccubeConfig->get('eccube_2fa_cookie_name')) {
             $this->cookieName = $this->eccubeConfig->get('eccube_2fa_cookie_name');

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/TwoFactorAuthControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/TwoFactorAuthControllerTest.php
@@ -19,6 +19,7 @@ use Eccube\Entity\Member;
 use Eccube\Repository\MemberRepository;
 use Eccube\Service\TwoFactorAuthService;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+use RobThree\Auth\Providers\Qr\QRServerProvider;
 use RobThree\Auth\TwoFactorAuth;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -35,7 +36,7 @@ final class TwoFactorAuthControllerTest extends AbstractAdminWebTestCase
         parent::setUp();
         $this->memberRepository = $this->entityManager->getRepository(Member::class);
         $this->twoFactorAuthService = static::getContainer()->get(TwoFactorAuthService::class);
-        $this->tfa = new TwoFactorAuth();
+        $this->tfa = new TwoFactorAuth(new QRServerProvider());
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Refs #6897

管理画面の2段階認証で利用している `robthree/twofactorauth` を、放棄済みの `1.8.2`（最終リリース 2022-03、PHP `>=5.6`）から現行の **v3.x**（PHP 8.2+）へ移行します。現行 `4.4` は Symfony 7.4 / PHP 8.2+ 要件で v3 と一致します。

## 方針(Policy)

- v3 の破壊的変更のうち EC-CUBE に実際に影響するのは **コンストラクタで QR プロバイダが必須化された1点のみ**。
  - namespace は v1 と同じ `RobThree\Auth`（変わっていない）。
  - `new TwoFactorAuth()` → `new TwoFactorAuth(new QRServerProvider())` に変更（QR は未使用だが第1引数が必須のため注入）。
  - EC-CUBE はライブラリの QR 生成（`getQRCodeImage()` 等）を使っておらず、QR は Twig + JS（jQuery qrcode / otpauth URI 手組み）で生成しているため、`QRServerProvider` を注入しても**構築時に外部通信は発生しません**。
- `createSecret()` の既定シークレット長は 80→160bit（16→32文字）に増えますが、`two_factor_auth_key` は `length:255`（`src/Eccube/Entity/Member.php`）のため **DB 影響はありません**（新規発行分のみ長くなる）。
- `verifyCode()` / `createSecret()` の**公開シグネチャは変更なし**。

## 実装に関する補足(Appendix)

RobThree API に直接触れているのは以下の3ファイル・4種の呼び出しのみで、`app/`（Customize・Plugin）・DI 設定には影響しません。

| ファイル | 変更 |
|---|---|
| `composer.json` / `composer.lock` | `robthree/twofactorauth` `^1.8` → `^3.0`（`1.8.2` → `v3.0.3`。他パッケージのバージョン変更なし） |
| `src/Eccube/Service/TwoFactorAuthService.php` | コンストラクタに `QRServerProvider` を注入 |
| `tests/.../TwoFactorAuthControllerTest.php` | テストが直接 `new TwoFactorAuth()` するため同様に修正 |
| `codeception/acceptance/EF09ThrottlingCest.php` | レガシー（CI 無効）だが将来の再有効化時の破綻防止のため合わせて修正 |

## テスト（Test)

**before/after パリティを実測で確認**しました。固定シークレット `GEZDGNBVGY3TQOJQ` に対し v1.8.2 と v3.0.3 の出力が完全一致:

- `getCode` の各時刻の値・`verifyCode` の結果（t=0 の端値挙動を含む）が一致
- discrepancy=2 の許容窓（−2〜+2 period のみ PASS）が一致
- 唯一の差異は `createSecret()` の長さ 16→32文字（想定どおり・既存キー検証は不変）

→ 既存 `two_factor_auth_key`（v1 発行分）でも検証が通る後方互換を確認。

ローカル QA（Docker 経由）はすべて緑:
- PHP-CS-Fixer: 違反なし
- Rector（dry-run）: 差分なし
- PHPStan（level 6）: エラーなし
- PHPUnit `TwoFactorAuthControllerTest`: **4 tests, 9 assertions OK**（2FA 認証成功 / セットアップ / 認証失敗 / MFA バイパス防止）

### 実機動作確認（v3.0.3 インストール環境・ブラウザ操作）

ローカルの Docker 環境に `robthree/twofactorauth v3.0.3` を入れた状態で、管理画面の2段階認証フローをブラウザ操作で通しで確認した（admin アカウント）。

1. 2FA セットアップ画面（`/admin/two_factor_auth/set`）を表示
   - v3 の `createSecret()` で生成されたシークレットから QR コードが正常に描画されることを確認（QR は Twig 側の JS 生成でライブラリ非依存＝本 PR の想定どおり）
   - 生成シークレットは **32文字**（= v3 の 160bit 化）。v1 の 16文字から増えるが `two_factor_auth_key` は length:255 のため保存に問題なし
2. 生成シークレットに対する正しい TOTP コードを入力して送信
   - v3 の `verifyCode($authKey, $token, 2)` がコードを受理
   - キー保存 → 認証 Cookie 発行 → ホームへリダイレクト → フラッシュ「2段階認証の設定が完了しました。」を表示
   - DB（`dtb_member.two_factor_auth_key`）に 32文字のキーが保存されたことを確認

確認できた v3 経路: `TwoFactorAuthService::__construct()`（`new TwoFactorAuth(new QRServerProvider())`）／ `createSecret()` ／ `verifyCode()` の3つがいずれも実機で正常動作。（確認後、テストで付与したキーは NULL に戻して初期状態へ復元済み）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 管理画面の二段階認証まわりで、最新の認証ライブラリに対応しました。
  * QRコード表示の扱いが見直され、認証コードの生成・確認がより安定しました。

* **Bug Fixes**
  * 二段階認証のセットアップやテスト実行時に発生しうる不整合を解消しました。
  * 依存ライブラリ更新に伴う認証処理の互換性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
