### PR TITLE
chore(husky): pre-commit/pre-push を Docker/host 両対応にし重い解析を pre-push へ分離

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,32 @@
-npx lint-staged -q || node -e ''
+#!/usr/bin/env sh
+# Pre-commit hook (軽量): staged な *.php を php-cs-fixer で auto-fix するだけ。
+# 重い rector / phpstan は pre-push に分離。
+#
+# 実行環境は自動判定: ec-cube コンテナ稼働中なら docker compose exec、
+# 無ければ host の vendor/bin、どちらも無ければ skip。
+# 強制指定: ECCUBE_HOOK_RUNNER=docker|host|skip / バイパス: HUSKY=0 git commit
+
+[ "$HUSKY" = "0" ] && exit 0
+
+STAGED_PHP=$(git diff --cached --name-only --diff-filter=ACMR | grep '\.php$' || true)
+[ -z "$STAGED_PHP" ] && exit 0
+
+DC="docker compose"; SVC="ec-cube"
+case "${ECCUBE_HOOK_RUNNER:-auto}" in
+  docker) RUN="$DC exec -T $SVC" ;;
+  host)   RUN="" ;;
+  skip)   exit 0 ;;
+  auto)
+    if $DC exec -T "$SVC" true >/dev/null 2>&1; then RUN="$DC exec -T $SVC"
+    elif command -v php >/dev/null 2>&1 && [ -x vendor/bin/php-cs-fixer ]; then RUN=""
+    else echo "pre-commit: no container / no host php+vendor; skip (HUSKY=0 to bypass)"; exit 0
+    fi ;;
+esac
+
+echo "pre-commit: php-cs-fixer (staged)"
+if ! echo "$STAGED_PHP" | xargs $RUN vendor/bin/php-cs-fixer \
+       --config=.php-cs-fixer.dist.php --path-mode=intersection fix; then
+  echo "FAIL: php-cs-fixer"
+  exit 1
+fi
+echo "$STAGED_PHP" | xargs git add

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -21,9 +21,23 @@ case "${ECCUBE_HOOK_RUNNER:-auto}" in
     elif command -v php >/dev/null 2>&1 && [ -x vendor/bin/php-cs-fixer ]; then RUN=""
     else echo "pre-commit: no container / no host php+vendor; skip (HUSKY=0 to bypass)"; exit 0
     fi ;;
+  *) echo "pre-commit: invalid ECCUBE_HOOK_RUNNER='$ECCUBE_HOOK_RUNNER' (docker|host|skip|auto)"; exit 1 ;;
 esac
 
-echo "pre-commit: php-cs-fixer (staged)"
+# 部分ステージ安全性のため lint-staged を優先。
+# lint-staged は未ステージ差分を stash で退避してから整形・add・復元するため、
+# `git add -p` 等の部分ステージ運用でも未ステージの変更を巻き込まない。
+# host 実行かつ lint-staged が入っている場合のみ利用（コンテナには node が無い前提）。
+if [ -z "$RUN" ] && [ -x node_modules/.bin/lint-staged ]; then
+  echo "pre-commit: lint-staged"
+  npx lint-staged -q
+  exit $?
+fi
+
+# フォールバック: node/lint-staged が無い環境（コンテナ等）向けに php-cs-fixer を直接実行。
+# 注意: この経路は未ステージ差分の stash 退避を行わないため、対象ファイルを丸ごと再 add する。
+# `git add -p` で部分ステージした未ステージ分も混入し得る（node のある環境では lint-staged が使われる）。
+echo "pre-commit: php-cs-fixer (staged; fallback, 部分ステージ非保護)"
 if ! echo "$STAGED_PHP" | xargs $RUN vendor/bin/php-cs-fixer \
        --config=.php-cs-fixer.dist.php --path-mode=intersection fix; then
   echo "FAIL: php-cs-fixer"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+# Pre-push hook (重い): rector --dry-run と phpstan を push 前に project-wide 実行。
+# push のたびに 1 回。stdin の ref 情報は使わず常に全体を検査する。
+#
+# 実行環境は自動判定: ec-cube コンテナ稼働中なら docker compose exec、
+# 無ければ host の vendor/bin、どちらも無ければ skip。
+# 強制指定: ECCUBE_HOOK_RUNNER=docker|host|skip / バイパス: HUSKY=0 git push
+
+[ "$HUSKY" = "0" ] && exit 0
+
+DC="docker compose"; SVC="ec-cube"
+case "${ECCUBE_HOOK_RUNNER:-auto}" in
+  docker) RUN="$DC exec -T $SVC" ;;
+  host)   RUN="" ;;
+  skip)   exit 0 ;;
+  auto)
+    if $DC exec -T "$SVC" true >/dev/null 2>&1; then RUN="$DC exec -T $SVC"
+    elif command -v php >/dev/null 2>&1 && [ -x vendor/bin/phpstan ]; then RUN=""
+    else echo "pre-push: no container / no host php+vendor; skip (HUSKY=0 to bypass)"; exit 0
+    fi ;;
+esac
+[ -n "$RUN" ] && echo "pre-push: running in Docker ($SVC)" || echo "pre-push: running on host"
+
+echo "[1/2] rector (dry-run)"
+if ! $RUN vendor/bin/rector process --dry-run --ansi --config=rector.php; then
+  echo "FAIL: Rector で修正点が検出されました。修正: vendor/bin/rector process --config=rector.php"
+  exit 1
+fi
+
+echo "[2/2] phpstan analyze src/"
+if ! $RUN vendor/bin/phpstan analyze src/; then
+  echo "FAIL: PHPStan エラーが検出されました"
+  exit 1
+fi
+
+echo "pre-push: all checks passed"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -15,11 +15,25 @@ case "${ECCUBE_HOOK_RUNNER:-auto}" in
   skip)   exit 0 ;;
   auto)
     if $DC exec -T "$SVC" true >/dev/null 2>&1; then RUN="$DC exec -T $SVC"
-    elif command -v php >/dev/null 2>&1 && [ -x vendor/bin/phpstan ]; then RUN=""
+    elif command -v php >/dev/null 2>&1 && [ -x vendor/bin/rector ] && [ -x vendor/bin/phpstan ]; then RUN=""
     else echo "pre-push: no container / no host php+vendor; skip (HUSKY=0 to bypass)"; exit 0
     fi ;;
+  *) echo "pre-push: invalid ECCUBE_HOOK_RUNNER='$ECCUBE_HOOK_RUNNER' (docker|host|skip|auto)"; exit 1 ;;
 esac
 [ -n "$RUN" ] && echo "pre-push: running in Docker ($SVC)" || echo "pre-push: running on host"
+
+# rector.php は dev の Symfony コンテナ XML (var/cache/dev/Eccube_KernelDevDebugContainer.xml) を
+# 参照する。fresh clone / cache:clear 直後など XML が無い cold 状態だと rector が全ファイルで
+# read error → exit 非ゼロになり push がブロックされる。無ければ dev キャッシュを生成しておく。
+# （cache:warmup では XML が再生成されないため cache:clear を使う）
+CONTAINER_XML="var/cache/dev/Eccube_KernelDevDebugContainer.xml"
+if ! $RUN test -f "$CONTAINER_XML"; then
+  echo "pre-push: dev container XML 不在のため cache:clear --env=dev で生成"
+  if ! $RUN bin/console cache:clear --env=dev; then
+    echo "FAIL: cache:clear（dev コンテナ XML を生成できませんでした）"
+    exit 1
+  fi
+fi
 
 echo "[1/2] rector (dry-run)"
 if ! $RUN vendor/bin/rector process --dry-run --ansi --config=rector.php; then


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Git フック（husky）を **Docker 環境・host 環境のどちらでも動く**ようにし、あわせて **重い静的解析を pre-commit から pre-push へ分離**します。

`docker-compose` で開発している環境では、host に PHP / node を持たない構成が一般的です。現行および #6761 の hook は `vendor/bin/*` / `npx` を **host 実行前提**にしているため、そうした環境では hook が失敗、または握り潰し（`|| node -e ''`）によって**無音で素通り**し「掛けているつもりで実は掛かっていない」状態になりがちでした。

Refs #6761（pre-commit 強化の提案。本 PR はその Docker/host 両対応版・別案です）

## 方針(Policy)

- **実行環境を自動判定**する `RUN` プレフィックスを導入:
  - `ec-cube` コンテナ稼働中 → `docker compose exec -T ec-cube …`
  - コンテナ無し & host に `php` + `vendor/bin` → host 実行
  - どちらも無い → **握り潰さず明示スキップ**（`command -v php` まで見て「phar は在るが php ランタイム無し」の誤判定も回避）
  - `ECCUBE_HOOK_RUNNER=docker|host|skip` で強制切替、`HUSKY=0` でバイパス
- **フックを役割で分離**（commit は頻繁＝軽く、push は「人に渡す境界」＝ CI と同じ役割）:

  | フック | 中身 | 手元実測 |
  |---|---|---|
  | `pre-commit` | php-cs-fixer（**staged のみ** auto-fix） | 約 0.5 秒 |
  | `pre-push` | rector --dry-run ＋ phpstan（`src` 全体） | 初回 ~35 秒 / 以降 ~4.5 秒 |

- **`npx lint-staged` を直接 `php-cs-fixer --path-mode=intersection` + `git add` に置換**：コンテナに node/lint-staged が無くても動くようにするため（host でも同じ経路）。
- **キャッシュ削除（`rm -rf var/rector_cache` / `/tmp/phpstan`）を廃止**：commit/push ごとに消すと毎回コールドで遅い。incremental キャッシュを活かし、pre-push は 2 回目以降 ~4.5 秒に収まります。

## 実装に関する補足(Appendix)

- husky v9 は `npm install` 時に `.husky/_/` 配下へ全 git フックのラッパを生成するため、`.husky/pre-push` を追加するだけで push 時に発火します（追加設定不要）。
- `package.json` の `lint-staged` 設定は今回のフックからは呼ばれなくなります（残置しても無害。整理は follow-up 可）。
- 変更は **shell フック 2 本のみ**で、PHP・Twig・エンティティ等のプロダクトコードには一切触れていません。

## テスト（Test)

手元の Docker 環境（`ec-cube` サービス）で end-to-end 確認済み:

- `pre-commit`: staged .php 1 件 → php-cs-fixer 実行、**約 0.5 秒**で完了（exit 0）。.php 未 staged の commit は即素通り。
- `pre-push`: `rector --dry-run`（OK）→ `phpstan analyze src/`（**No errors**, 611 files）まで完走（exit 0）。初回 ~35 秒、キャッシュ維持で 2 回目以降 **~4.5 秒**。
- 環境判定が `running in Docker (ec-cube)` に解決することを確認。`ECCUBE_HOOK_RUNNER=host` で host 実行にも切替可能（host に PHP 8.3 + vendor がある環境で確認）。

shell フックのため PHPUnit のテスト追加対象はありません。

## 相談（Discussion）

- 「pre-commit / pre-push 分離」までは不要で「自動判定だけ入れて従来どおり全部 pre-commit」でも、環境両対応の効果は得られます。分離の要否はメンテナ方針次第なのでご相談させてください。
- #6761 との棲み分け（本 PR で置き換えるか、#6761 に取り込むか）についても方針に合わせます。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません（開発用フックのみ・実行時挙動に影響なし）
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * コミット前に、ステージ済みのPHPを自動整形し、変更を再ステージするようになりました（代替手段での整形も含む）。
  * プッシュ前に、コード改善の事前確認（dry-run）と静的解析を順次実行するようになりました。
* **改善**
  * 実行環境を自動判定し、利用可能な場合のみ適切な手段で実行します。
  * 開発環境で必要なキャッシュが未生成の場合は生成処理を追加しました。
  * 失敗時は中断し、対象がなければ早期終了します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->