### PR TITLE
fix: 受注編集の二重送信による OrderItem データ破損を防止 (#6671)

### DIFF
--- a/.claude/skills/formtype/SKILL.md
+++ b/.claude/skills/formtype/SKILL.md
@@ -77,3 +77,4 @@ class ExampleType extends AbstractType
 - ❌ 既存フォームをコアで直接改変 → ✅ `FormTypeExtension`（app/Customize）で拡張
 - ❌ 管理画面検索フォームで CSRF 無効化 → ✅ CSRF 保護を保つ
 - ❌ 具象クラス依存 → ✅ コンストラクタ DI ＋ 必要なサービスの注入
+- ❌ 既存フォームに二重送信防止/楽観ロック用の unmapped hidden を足し、サーバー側で値未送信を即エラー扱い → ✅ 値が空/未送信なら判定をスキップ（プログラム的 POST・既存テスト・外部連携を壊さない後方互換を保つ）

--- a/html/template/admin/assets/js/function.js
+++ b/html/template/admin/assets/js/function.js
@@ -125,6 +125,17 @@ if (typeof Ladda !== 'undefined') {
     $('button[type=submit].btn-ec-regular').attr('data-spinner-color', '#595959');
 }
 
+// Laddaのtimeout(2000ms)でボタンが再有効化された後の二重送信を防止する.
+// 一度submitされたフォームは以降のsubmitをキャンセルする. (Issue #6671)
+// ページ遷移(登録成功・バリデーションエラー)でJSが再初期化されるため, フラグは自動的にリセットされる.
+$('form').on('submit', function () {
+    var $form = $(this);
+    if ($form.data('ecSubmitted')) {
+        return false;
+    }
+    $form.data('ecSubmitted', true);
+});
+
 // anchorをクリックした時にformを裏で作って指定のメソッドでリクエストを飛ばす
 // Twigには以下のように埋め込む
 // <a href="PATH" {{ csrf_token_for_anchor() }} data-method="(put/delete/postのうちいずれか)" data-confirm="xxxx" data-message="xxxx">

--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -49,6 +49,7 @@ use Knp\Component\Pager\Pagination\SlidingPagination;
 use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Bridge\Twig\Attribute\Template;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -152,6 +153,15 @@ class EditController extends AbstractController
             switch ($request->get('mode')) {
                 case 'register':
                     log_info('受注登録開始', [$TargetOrder->getId()]);
+
+                    // 二重送信・多重編集による受注明細の破損を防止する.
+                    // フォーム描画時点と現在の更新日時が異なる場合は, 既に他の操作で
+                    // 更新されているため, DB を変更せずに処理を中断する. (Issue #6671)
+                    if ($TargetOrder->getId() && $this->isOrderUpdatedSinceFormRendered($form, $OriginOrder)) {
+                        log_info('受注が既に更新されているため登録を中断', [$TargetOrder->getId()]);
+                        $this->addError('admin.order.edit_conflict', 'admin');
+                        break;
+                    }
 
                     if (!$flowResult->hasError() && $form->isValid()) {
                         try {
@@ -314,6 +324,29 @@ class EditController extends AbstractController
             'id' => $id,
             'shippingDeliveryTimes' => $this->serializer->serialize($times, 'json'),
         ];
+    }
+
+    /**
+     * フォーム描画後に受注が更新されているかを判定する.
+     *
+     * フォーム描画時点の更新日時 (hidden) と, 現在の受注の更新日時を突合し,
+     * 異なる場合は二重送信・多重編集で既に更新済みと判断する. (Issue #6671)
+     */
+    private function isOrderUpdatedSinceFormRendered(FormInterface $form, Order $OriginOrder): bool
+    {
+        $currentUpdateDate = $OriginOrder->getUpdateDate();
+        if (null === $currentUpdateDate) {
+            return false;
+        }
+
+        $renderedUpdateDate = $form->get('form_update_date')->getData();
+        // 描画時点の更新日時が送信されていない場合は判定しない (後方互換のため).
+        // 通常の編集画面では hidden フィールドで必ず送信される.
+        if (null === $renderedUpdateDate || '' === $renderedUpdateDate) {
+            return false;
+        }
+
+        return $renderedUpdateDate !== $currentUpdateDate->format('Y-m-d H:i:s');
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -190,6 +190,11 @@ class OrderType extends AbstractType
             ])
             ->add('return_link', HiddenType::class, [
                 'mapped' => false,
+            ])
+            // 二重送信・多重編集による受注明細の破損を検知するため, フォーム描画時点の
+            // 更新日時を保持する. (Issue #6671)
+            ->add('form_update_date', HiddenType::class, [
+                'mapped' => false,
             ]);
 
         $builder
@@ -200,6 +205,7 @@ class OrderType extends AbstractType
                 )));
 
         $builder->addEventListener(FormEvents::POST_SET_DATA, $this->sortOrderItems(...));
+        $builder->addEventListener(FormEvents::POST_SET_DATA, $this->keepFormUpdateDate(...));
         $builder->addEventListener(FormEvents::POST_SET_DATA, $this->addOrderStatusForm(...));
         $builder->addEventListener(FormEvents::POST_SET_DATA, $this->addShippingForm(...));
         $builder->addEventListener(FormEvents::POST_SUBMIT, $this->copyFields(...));
@@ -242,6 +248,26 @@ class OrderType extends AbstractType
 
         $form = $event->getForm();
         $form['OrderItems']->setData($OrderItems);
+    }
+
+    /**
+     * フォーム描画時点の受注の更新日時を hidden フィールドへ保持する.
+     *
+     * 二重送信や多重編集で受注が既に更新されている場合に,
+     * 送信されたインデックスと DB 上の明細順がずれてデータが破損するのを防ぐため,
+     * コントローラ側で描画時点と現在の更新日時を突合する. (Issue #6671)
+     */
+    public function keepFormUpdateDate(FormEvent $event): void
+    {
+        /** @var Order|null $Order */
+        $Order = $event->getData();
+        if (null === $Order || null === $Order->getUpdateDate()) {
+            return;
+        }
+
+        $event->getForm()->get('form_update_date')->setData(
+            $Order->getUpdateDate()->format('Y-m-d H:i:s')
+        );
     }
 
     /**

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -936,6 +936,7 @@ admin.order.search_customer_title: Search Customers
 admin.order.product_info: Product Info
 admin.order.edit_multiple_shipping: Edit Delivery Address
 admin.order.edit_multiple_shipping_description: If you selected multiple delivery addresses, you can edit each of them from the this button.
+admin.order.edit_conflict: The order was updated by another operation and could not be saved. Please reload the page and try again.
 admin.order.product_item_not_found: No item is found
 admin.order.delivery_note_create_date: Date of Issue
 admin.order.delivery_note_title: Title

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -935,6 +935,7 @@ admin.order.search_customer_title: 会員を検索
 admin.order.product_info: 商品情報
 admin.order.edit_multiple_shipping: お届け先を編集
 admin.order.edit_multiple_shipping_description: 複数配送を指定している場合は、こちらのボタンからそれぞれの配送設定の編集ができます
+admin.order.edit_conflict: 受注情報が別の操作で更新されたため、登録できませんでした。画面を再読み込みしてからやり直してください。
 admin.order.product_item_not_found: 商品が追加されていません
 admin.order.delivery_note_create_date: 発行日
 admin.order.delivery_note_title: タイトル

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -255,6 +255,7 @@ file that was distributed with this source code.
         <input type="hidden" name="mode" value="">
         {{ form_widget(form._token) }}
         {{ form_widget(form.return_link) }}
+        {{ form_widget(form.form_update_date) }}
         <div class="c-contentsArea__cols">
             <div class="c-contentsArea__primaryCol">
                 <div class="c-primaryCol">

--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -748,4 +748,49 @@ final class EditControllerTest extends AbstractEditControllerTestCase
 
         $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
+
+    /**
+     * 二重送信・多重編集による受注明細の破損を防止するテスト.
+     *
+     * フォーム描画時点の更新日時と現在の更新日時が異なる場合は, 既に別の操作で
+     * 更新済みと判断し, 登録処理を中断する.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6671
+     */
+    public function testOrderEditRejectedWhenUpdateDateIsStale()
+    {
+        $Customer = $this->createCustomer();
+        $Order = $this->createOrder($Customer);
+        $Order->setOrderStatus($this->entityManager->find(OrderStatus::class, OrderStatus::NEW));
+        $this->entityManager->flush();
+
+        $url = $this->generateUrl('admin_order_edit', ['id' => $Order->getId()]);
+        $formData = $this->createFormData($Customer, $this->Product);
+
+        // 描画時点の更新日時が一致していれば登録できる.
+        $EditedOrder = $this->orderRepository->find($Order->getId());
+        $this->assertInstanceOf(Order::class, $EditedOrder);
+        $formData['form_update_date'] = $EditedOrder->getUpdateDate()->format('Y-m-d H:i:s');
+        $this->client->request(
+            Request::METHOD_POST, $url, ['order' => $formData, 'mode' => 'register']
+        );
+        $this->assertTrue(
+            $this->client->getResponse()->isRedirect($url),
+            '更新日時が一致する場合は登録できる'
+        );
+
+        // 描画時点の更新日時が古い(＝別の操作で更新済み)場合は登録を中断する.
+        $formData['form_update_date'] = '2000-01-01 00:00:00';
+        $this->client->request(
+            Request::METHOD_POST, $url, ['order' => $formData, 'mode' => 'register']
+        );
+        $this->assertFalse(
+            $this->client->getResponse()->isRedirect(),
+            '更新日時が古い場合は登録されない'
+        );
+        $this->assertStringContainsString(
+            '別の操作で更新',
+            (string) $this->client->getResponse()->getContent()
+        );
+    }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Refs #6671

管理画面の受注編集で「登録」ボタン押下後、サーバー処理が2秒以上かかると Ladda の `timeout: 2000` によりボタンが再有効化され、二重送信が可能になります。2回目のリクエストでは1回目の保存で DB の `OrderItem` 数が変わり、`OrderType::sortOrderItems`（`POST_SET_DATA`）の再ソートで POST インデックスとエンティティの対応がずれ、送料・手数料等のデータが別明細（新規追加した商品明細など）へ上書きされて破損します。

**4.4 での再現を確認済み**（新規追加した商品エンティティが `order_item_type=送料` に上書きされ、`product_id`/`product_code` だけ商品のまま残る不整合レコードが生成される）。

## 方針(Policy)

Issue で提案された JS ガードは XHR 経由の二重送信を防げないため、**クライアント側の一次防御＋サーバー側の堅牢化**の二段で対応しました。

- **サーバー側（本命）**: フォーム描画時点の `update_date` を unmapped hidden (`form_update_date`) で保持し、`register` 時に現在の `update_date` と突合。異なれば「別操作で既に更新済み」と判断し **DB を変更せず処理を中断**します。既存の programmatic POST・外部連携を壊さないため、**値が未送信/空のときは判定しません**（後方互換）。Doctrine の `@Version` 追加（コアテーブルへのスキーマ変更）を避けた軽量な楽観ロック相当です。
- **クライアント側**: Ladda の再有効化後の二重 submit を form 単位でキャンセル。

## 実装に関する補足(Appendix)

- `dtb_order.update_date` は `datetime_precision = 0`（秒精度）のため、突合は `Y-m-d H:i:s` で過不足なく一致します。`register` は毎回 `update_date` を更新するので、本 Issue の前提（サーバー処理 > 2秒）では描画時と1回目保存時の秒は必ず異なります。
- 新たに「描画後に受注が更新されていた場合、登録を中断してエラー表示する」挙動が加わります（正常な単一送信には影響しません）。
- スキーマ変更・マイグレーションはありません。

## テスト（Test)

- `EditControllerTest::testOrderEditRejectedWhenUpdateDateIsStale` を追加（更新日時が一致→保存成功 / 古い→拒否＋競合メッセージ）。
- `EditControllerTest` / `EditControllerWithMultipleTest` 全件パスを確認（回帰なし）。
- 実機（管理画面 受注編集）で二重 XHR を再現し、1回目=保存成功・2回目=競合エラーで拒否・DB 無傷を確認。
- php-cs-fixer / phpstan(level6) / rector(dry-run) をローカルで通過。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません（正常系の挙動は不変。異常系＝二重送信/多重編集の破損を防ぐガードの追加のみ）
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません（hidden フィールドの追加描画のみ）
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 注文編集で更新日時の整合性を確認し、競合時は保存を中断します。
* **バグ修正**
  * 送信ボタンの連打による二重送信を防止します。
  * 競合時は再読み込みを促すエラーを表示します。
* **ドキュメント**
  * 「よくある間違い」に、`unmapped hidden` を扱う際の注意を追記しました。
* **テスト**
  * 更新日時が古い場合の拒否動作を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->