### PR TITLE
docs(agents): AI 向けドキュメントのインデックスと定義ファイル配置原則を AGENTS.md に追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ AI エージェント向けの情報は、この `AGENTS.md` を**正典（ハ�
 
 | ファイル | 役割 | 主な読み手 |
 |---|---|---|
-| `AGENTS.md`（本ファイル） | ベンダー中立の正典。規約・アーキテクチャ・Skill 索引の入口 | 全エージェント＋人間。`AGENTS.md` をネイティブ参照するツール（Cursor / GitHub Copilot / Codex CLI / Google Antigravity 等）は本ファイルを直接読む |
-| `CLAUDE.md` | 薄いポインタ（`@./AGENTS.md`）。Claude Code は `CLAUDE.md` を native に読むため | Claude Code |
+| `AGENTS.md`（本ファイル） | ベンダー中立の正典。規約・アーキテクチャ・Skill 索引の入口 | 全エージェント＋人間。`AGENTS.md` をネイティブに読むツール（Cursor / GitHub Copilot / Codex CLI / Google Antigravity 等）はこれを直接参照する |
+| `CLAUDE.md` | 薄いポインタ（`@./AGENTS.md`）。Claude Code は `CLAUDE.md` をネイティブに読むため | Claude Code |
 | `GEMINI.md` | 薄いポインタ。Gemini CLI は Skill 非対応のため索引経由で `SKILL.md` へ誘導 | Gemini CLI |
 | `llms.txt` | 外部 LLM・クローラ向けの英語サマリ（llmstxt.org 準拠。公開 URL 前提） | LLM クローラ・外部 LLM |
 | `.claude/skills/<name>/SKILL.md` | レイヤ別の詳細規約（末端）。`.codex/skills`・`.agents/skills` は symlink 共有 | Skill 対応ツール（詳細は「Skill の配置と各ツールの読み込み」節） |
@@ -24,8 +24,8 @@ AI エージェント向けの情報は、この `AGENTS.md` を**正典（ハ�
 ### 定義ファイルを増やすときの原則
 
 - **ポインタ定義ファイルは「`AGENTS.md` をネイティブに読まないツール」にだけ置く。** それ以外は正典を二重に指すだけの冗長ファイルになるため作らない。
-  - 必要な例: Claude Code → `CLAUDE.md`、Gemini CLI → `GEMINI.md`（いずれも `AGENTS.md` を native に読まない）。
-  - 不要な例: **Cursor / GitHub Copilot / Codex CLI は `AGENTS.md` を native に読む**ため、`.cursor/rules/*` や `.github/copilot-instructions.md` は追加しない。
+  - 必要な例: Claude Code → `CLAUDE.md`、Gemini CLI → `GEMINI.md`（いずれも `AGENTS.md` をネイティブに読まない）。
+  - 不要な例: **Cursor / GitHub Copilot / Codex CLI は `AGENTS.md` をネイティブに読む**ため、`.cursor/rules/*` や `.github/copilot-instructions.md` は追加しない。
 - 新しい定義ファイルを足すときは、上のインデックス表にも 1 行追加し、所在を本節で一元管理する。
 - 設計思想・アーキテクチャの詳細文書（`DESIGN.md` / `ARCHITECTURE.md`）は現状未整備。整備する場合も本ファイルはハブに留め、詳細はそれらへリンクして本節の表に追記する。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,26 @@ EC-CUBE 4.4 を扱う際に従う共通の入口であり、**ベンダー中立
 - このファイルは `CLAUDE.md` / `GEMINI.md` を参照し返しません（上流）。
 - レイヤ別規約は各 Skill 本文（`.claude/skills/<name>/SKILL.md`）が末端で、上流を参照し返しません。
 
+## AI 向けドキュメント インデックス（定義ファイルと読み込み）
+
+AI エージェント向けの情報は、この `AGENTS.md` を**正典（ハブ）**とし、周辺の定義ファイルはすべてここへ収斂します。所在の一覧は次の通り。
+
+| ファイル | 役割 | 主な読み手 |
+|---|---|---|
+| `AGENTS.md`（本ファイル） | ベンダー中立の正典。規約・アーキテクチャ・Skill 索引の入口 | 全エージェント＋人間。`AGENTS.md` をネイティブ参照するツール（Cursor / GitHub Copilot / Codex CLI / Google Antigravity 等）は本ファイルを直接読む |
+| `CLAUDE.md` | 薄いポインタ（`@./AGENTS.md`）。Claude Code は `CLAUDE.md` を native に読むため | Claude Code |
+| `GEMINI.md` | 薄いポインタ。Gemini CLI は Skill 非対応のため索引経由で `SKILL.md` へ誘導 | Gemini CLI |
+| `llms.txt` | 外部 LLM・クローラ向けの英語サマリ（llmstxt.org 準拠。公開 URL 前提） | LLM クローラ・外部 LLM |
+| `.claude/skills/<name>/SKILL.md` | レイヤ別の詳細規約（末端）。`.codex/skills`・`.agents/skills` は symlink 共有 | Skill 対応ツール（詳細は「Skill の配置と各ツールの読み込み」節） |
+
+### 定義ファイルを増やすときの原則
+
+- **ポインタ定義ファイルは「`AGENTS.md` をネイティブに読まないツール」にだけ置く。** それ以外は正典を二重に指すだけの冗長ファイルになるため作らない。
+  - 必要な例: Claude Code → `CLAUDE.md`、Gemini CLI → `GEMINI.md`（いずれも `AGENTS.md` を native に読まない）。
+  - 不要な例: **Cursor / GitHub Copilot / Codex CLI は `AGENTS.md` を native に読む**ため、`.cursor/rules/*` や `.github/copilot-instructions.md` は追加しない。
+- 新しい定義ファイルを足すときは、上のインデックス表にも 1 行追加し、所在を本節で一元管理する。
+- 設計思想・アーキテクチャの詳細文書（`DESIGN.md` / `ARCHITECTURE.md`）は現状未整備。整備する場合も本ファイルはハブに留め、詳細はそれらへリンクして本節の表に追記する。
+
 ## プロジェクト概要
 
 EC-CUBE は日本で広く使われる OSS の EC プラットフォームです。本ブランチ（4.4）は **Symfony 7.4 / PHP 8.2+** 上に構築されています。


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

`AGENTS.md` に **「AI 向けドキュメント インデックス（定義ファイルと読み込み）」節** を追加します。AI エージェント向けの定義ファイル（`AGENTS.md` 正典 / `CLAUDE.md` / `GEMINI.md` / `llms.txt` / `.claude/skills/*/SKILL.md`）の**所在・役割・読み手を一覧化**し、`AGENTS.md` をハブ（インデックス）として一元管理できるようにします。

あわせて、**定義ファイルを増やすときの原則**を明文化します：ポインタ定義ファイルは「`AGENTS.md` をネイティブに読まないツール」にだけ置く（＝正典を二重に指すだけの冗長ファイルは作らない）。

純粋なドキュメント追記で、`AGENTS.md` 1 ファイルへの 20 行追加のみです（新規ファイルの追加なし・コード変更なし）。

## 方針(Policy)

- 各 AI コーディングツールの `AGENTS.md` ネイティブ対応状況を確認：**Cursor / GitHub Copilot（2025-08 対応）/ Codex CLI / Google Antigravity は `AGENTS.md` を直接読む**。一方 **Claude Code は `CLAUDE.md`、Gemini CLI は `GEMINI.md`** が native で `AGENTS.md` を読まない。
- この事実から、既存の `CLAUDE.md` / `GEMINI.md`（薄いポインタ）は「AGENTS.md を読まないツール向け」という一貫した原則で存在していることを明文化。Cursor / Copilot 向けの `.cursor/rules/*` や `.github/copilot-instructions.md` は**冗長になるため追加しない**方針を記録した。
- `AGENTS.md` の既存の一方向参照トポロジ（`CLAUDE.md`/`GEMINI.md` → `AGENTS.md` → `SKILL.md`）と整合させ、正典の単一性を保つ。

## 実装に関する補足(Appendix)

- 追加位置は冒頭の参照トポロジ説明の直後（「## プロジェクト概要」の前）。インデックスとして最も発見しやすい位置に配置。
- 既存の「## Skill の配置と各ツールの読み込み」節（Skill ディレクトリの読み込み表）とは役割が異なる（本節はルート定義ファイルの索引）ため、SKILL.md 行から当該節へ相互参照するに留め、内容は重複させていない。
- `DESIGN.md` / `ARCHITECTURE.md` は本 PR のスコープ外（設計文書であり別途整備）。インデックスに「未整備・整備時は本節へ追記」とだけ記載。

## テスト（Test)

- ドキュメント（`.md`）のみの変更で、アプリケーションコード・スキーマ・テンプレートへの影響はありません。
- CI ゲート（php-cs-fixer / phpstan / rector / phpunit）はいずれも `.md` を対象としないため、挙動への影響はありません。

## 相談（Discussion）

特になし。原則の文言について意見があればご指摘ください。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * AI エージェント向けの案内を更新し、参照の起点となる正本ファイルと周辺ドキュメントの役割を整理しました。  
  * 新しい定義ファイルを追加する際の基本方針（重複回避や索引への追記）も追記し、案内を拡張しやすくしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->