### PR TITLE
fix(e2e): front-mail の会員登録パスワードを NIST 要件(15文字以上)に合わせる

### DIFF
--- a/e2e/tests/front-mail.spec.ts
+++ b/e2e/tests/front-mail.spec.ts
@@ -52,8 +52,8 @@ test.describe('会員登録メール (EF04)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(newEmail);
     await page.locator('#entry_email_second').fill(newEmail);
-    await page.locator('#entry_plain_password_first').fill('password1234');
-    await page.locator('#entry_plain_password_second').fill('password1234');
+    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
     await page.locator('#entry_job').selectOption({ value: '1' });
     await page.locator('#entry_user_policy_check').check();
 


### PR DESCRIPTION
## 概要

`e2e-test / Playwright (front-mail)` が複数の PR（#6844 / #6840 / #6838 / #6833 など）で一律に失敗していた。原因は base(`4.4`) 側にあり、各 PR 固有の変更は無関係。

## 原因

- `e2e/tests/front-mail.spec.ts` の会員登録は 12 文字の `password1234` を使用していた。
- `4.4` に NIST パスワード要件（#6858）がマージされ `eccube_password_min_len: 15` に。12 文字はバリデーション違反となり `/entry` の確認画面に進めず、`.ec-registerRole` の email 検証（`front-mail.spec.ts:63`）が 30s タイムアウトして失敗していた。
- 当該テストは `63ca5df0ea`（mailpit 版 front-mail 追加）で導入され、NIST 要件マージ後に壊れた。

```
Error: expect(locator).toContainText(expected) failed
Timeout: 30000ms
> 63 |     await expect(page.locator('.ec-registerRole')).toContainText(newEmail);
```

## 修正

会員登録パスワードを、他 spec（`front-customer` / `front-throttling` / `admin-basicinfo`）で実績のある NIST 合格値 **`EccubeE2ePassword1`**（18 文字・ブロックリスト非該当）に統一。1 ファイル 2 行のみ。

## 確認

- ローカル（`/entry`）で `EccubeE2ePassword1` により確認画面へ遷移し、`.ec-registerRole` に入力 email がテキスト表示されること（＝失敗していた assertion）を Playwright で確認。
- メール検証部分は CI の `front-mail` ジョブ（mailpit）で確認。

マージ後、対象 PR は `4.4` を取り込めば `front-mail` が green になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 会員登録メールのE2Eテストで使用するパスワードを更新し、より実運用に近い値で検証するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->