### PR TITLE
refactor(e2e): 認証情報のベタ書きを config/default.config へ集約

### DIFF
--- a/e2e/config/default.config.ts
+++ b/e2e/config/default.config.ts
@@ -1,0 +1,41 @@
+/**
+ * E2E テスト共通のクレデンシャル・接続情報。
+ *
+ * EC-CUBE 2 系の `e2e-tests/config/default.config.ts` と同じく、環境変数の
+ * フォールバック付き定数を 1 箇所へ集約する。各 spec はここから import し、
+ * パスワード等をベタ書きしない（NIST SP 800-63B-4 準拠でパスワード要件が
+ * 変わっても、修正箇所をこのファイルに閉じ込めるため）。
+ */
+
+/** 管理画面のルーティングプレフィックス（既定 `admin`）。 */
+export const ADMIN_ROUTE = process.env.ECCUBE_ADMIN_ROUTE ?? 'admin';
+
+/** 管理者ログイン ID（初期管理者）。 */
+export const ADMIN_USER = process.env.ADMIN_USER ?? 'admin';
+
+/** 管理者ログインパスワード（初期管理者の照合用。登録時要件は非適用）。 */
+export const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD ?? 'password';
+
+/** 既存フィクスチャ会員のログイン照合用パスワード。 */
+export const CUSTOMER_PASSWORD = process.env.CUSTOMER_PASSWORD ?? 'password';
+
+/**
+ * 会員登録・パスワード変更で使う「有効なパスワード」。
+ * NIST SP 800-63B-4（PR #6858 / Issue #6488）で 15 文字以上が必須になったため、
+ * 15 文字未満・ブロックリスト該当・漏洩既知の値は使用不可。
+ */
+export const VALID_PASSWORD = process.env.VALID_PASSWORD ?? 'EccubeE2ePassword1';
+
+/**
+ * NFKC 正規化テスト用のパスワード（`front-password-nist.spec.ts`）。
+ * 半角カナ + 数字。NFKC 正規化で全角へ変換され、正規化後 15 文字以上（min15 要件）。
+ * 環境変数で差し替える場合も「NFKC で正規化後の文字列が変わる（＝往復テストが成立する）」
+ * 値であること。純 ASCII など正規化で不変な値を渡すと NIST spec の往復検証が壊れる。
+ */
+export const RAW_PASSWORD = process.env.RAW_PASSWORD ?? 'ﾊﾟｽﾜｰﾄﾞﾃｽﾄ1234567';
+
+/**
+ * {@link RAW_PASSWORD} を NFKC 正規化した文字列（既定値では全角・15 文字）。
+ * RAW から導出するため、環境変数で RAW を差し替えても正規化後の値と常に整合する。
+ */
+export const NORMALIZED_PASSWORD = RAW_PASSWORD.normalize('NFKC');

--- a/e2e/fixtures/auth.setup.ts
+++ b/e2e/fixtures/auth.setup.ts
@@ -1,4 +1,5 @@
 import { test as setup, expect } from '@playwright/test';
+import { ADMIN_PASSWORD, ADMIN_ROUTE, ADMIN_USER } from '../config/default.config';
 import path from 'path';
 import fs from 'fs';
 
@@ -11,10 +12,10 @@ setup('admin login', async ({ page }) => {
     fs.mkdirSync(authDir, { recursive: true });
   }
 
-  const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+  const adminRoute = ADMIN_ROUTE;
   await page.goto(`/${adminRoute}/`);
-  await page.locator('#login_id').fill(process.env.ADMIN_USER || 'admin');
-  await page.locator('#password').fill(process.env.ADMIN_PASSWORD || 'password');
+  await page.locator('#login_id').fill(ADMIN_USER);
+  await page.locator('#password').fill(ADMIN_PASSWORD);
   await page.getByRole('button', { name: 'ログイン' }).click();
   await expect(page.locator('.c-pageTitle__titles')).toContainText('ホーム', { timeout: 30_000 });
 

--- a/e2e/fixtures/plugin-test.ts
+++ b/e2e/fixtures/plugin-test.ts
@@ -1,4 +1,5 @@
 import { test as base, expect } from '@playwright/test';
+import { ADMIN_ROUTE } from '../config/default.config';
 import { createDbClient, DbClient } from '../helpers/db-client';
 import { compressPlugin, emptyDir } from '../helpers/tar-helper';
 import path from 'path';
@@ -33,7 +34,7 @@ export const test = base.extend<PluginFixtures>({
   config: async ({}, use) => {
     const config: PluginTestConfig = {
       projectDir: process.env.ECCUBE_PROJECT_DIR || path.resolve(__dirname, '..', '..'),
-      adminRoute: process.env.ECCUBE_ADMIN_ROUTE || 'admin',
+      adminRoute: ADMIN_ROUTE,
       reposDir: process.env.REPOS_DIR || path.resolve(__dirname, '..', '..', 'repos'),
       pluginDataDir: process.env.PLUGIN_DATA_DIR || path.resolve(__dirname, '..', '..', 'codeception', '_data', 'plugins'),
     };

--- a/e2e/tests/admin-auth.spec.ts
+++ b/e2e/tests/admin-auth.spec.ts
@@ -1,11 +1,12 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_PASSWORD, ADMIN_ROUTE, ADMIN_USER } from '../config/default.config';
 
-const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+const adminRoute = ADMIN_ROUTE;
 
 // 認証テストはログイン/ログアウトを繰り返すため、共有storageStateを使わない
 test.use({ storageState: { cookies: [], origins: [] } });
 
-async function loginAsAdmin(page: import('@playwright/test').Page, loginId = process.env.ADMIN_USER || 'admin', password = process.env.ADMIN_PASSWORD || 'password') {
+async function loginAsAdmin(page: import('@playwright/test').Page, loginId = ADMIN_USER, password = ADMIN_PASSWORD) {
   await page.goto(`/${adminRoute}/`);
   await page.locator('#login_id').fill(loginId);
   await page.locator('#password').fill(password);
@@ -121,11 +122,11 @@ test.describe('Admin Authentication (EA02)', () => {
 
     // ログアウトして旧パスワードではログインできないことを確認
     await logoutAsAdmin(page);
-    await submitLoginForm(page, 'admin', 'password');
+    await submitLoginForm(page, ADMIN_USER, ADMIN_PASSWORD);
     await expect(page.locator('#form1 > div:nth-child(5) > span')).toContainText('ログインできませんでした。');
 
     // password1 でログインできることを確認
-    await loginAsAdmin(page, 'admin', password1);
+    await loginAsAdmin(page, ADMIN_USER, password1);
 
     // 画面右上のパスワード変更で password2 に変更する
     await page.goto(`/${adminRoute}/change_password`);
@@ -139,10 +140,10 @@ test.describe('Admin Authentication (EA02)', () => {
 
     // password1 ではログインできないことを確認
     await logoutAsAdmin(page);
-    await submitLoginForm(page, 'admin', password1);
+    await submitLoginForm(page, ADMIN_USER, password1);
     await expect(page.locator('#form1 > div:nth-child(5) > span')).toContainText('ログインできませんでした。');
 
     // password2 でログインできることを確認
-    await loginAsAdmin(page, 'admin', password2);
+    await loginAsAdmin(page, ADMIN_USER, password2);
   });
 });

--- a/e2e/tests/admin-basicinfo.spec.ts
+++ b/e2e/tests/admin-basicinfo.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_PASSWORD, ADMIN_ROUTE, ADMIN_USER, CUSTOMER_PASSWORD, VALID_PASSWORD } from '../config/default.config';
 
-const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+const adminRoute = ADMIN_ROUTE;
 
 /**
  * Helper: Re-login to admin if session expired.
@@ -9,8 +10,8 @@ const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
  */
 async function ensureAdminLoggedIn(page: import('@playwright/test').Page) {
   if (await page.locator('#login_id').count() > 0) {
-    await page.locator('#login_id').fill(process.env.ADMIN_USER || 'admin');
-    await page.locator('#password').fill(process.env.ADMIN_PASSWORD || 'password');
+    await page.locator('#login_id').fill(ADMIN_USER);
+    await page.locator('#password').fill(ADMIN_PASSWORD);
     await page.getByRole('button', { name: 'ログイン' }).click();
     await page.waitForLoadState('load');
   }
@@ -572,7 +573,7 @@ test.describe('Admin Basic Info (EA07)', () => {
     await frontPage.goto('/mypage/login');
     await frontPage.waitForLoadState('load');
     await frontPage.locator('input[name="login_email"]').fill(email);
-    await frontPage.locator('input[name="login_pass"]').fill('password');
+    await frontPage.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
     await frontPage.locator('#login_mypage button[type="submit"]').click();
     await frontPage.waitForLoadState('load');
 
@@ -626,8 +627,8 @@ test.describe('Admin Basic Info (EA07)', () => {
 
     // Re-login if session expired
     if (await page.locator('#login_id').count() > 0) {
-      await page.locator('#login_id').fill(process.env.ADMIN_USER || 'admin');
-      await page.locator('#password').fill(process.env.ADMIN_PASSWORD || 'password');
+      await page.locator('#login_id').fill(ADMIN_USER);
+      await page.locator('#password').fill(ADMIN_PASSWORD);
       await page.getByRole('button', { name: 'ログイン' }).click();
       await page.waitForLoadState('load');
       await page.goto(`/${adminRoute}/setting/shop`);
@@ -657,7 +658,7 @@ test.describe('Admin Basic Info (EA07)', () => {
     await frontPage.goto('/mypage/login');
     await frontPage.waitForLoadState('load');
     await frontPage.locator('input[name="login_email"]').fill(email);
-    await frontPage.locator('input[name="login_pass"]').fill('password');
+    await frontPage.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
     await frontPage.locator('#login_mypage button[type="submit"]').click();
     await frontPage.waitForLoadState('load');
 
@@ -732,8 +733,8 @@ test.describe('Admin Basic Info (EA07)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(email1);
     await page.locator('#entry_email_second').fill(email1);
-    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
-    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_first').fill(VALID_PASSWORD);
+    await page.locator('#entry_plain_password_second').fill(VALID_PASSWORD);
     await page.locator('#entry_user_policy_check').check();
     await page.locator('button.ec-blockBtn--action[type="submit"]').click();
     await page.waitForLoadState('load');
@@ -794,8 +795,8 @@ test.describe('Admin Basic Info (EA07)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(email2);
     await page.locator('#entry_email_second').fill(email2);
-    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
-    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_first').fill(VALID_PASSWORD);
+    await page.locator('#entry_plain_password_second').fill(VALID_PASSWORD);
     await page.locator('#entry_user_policy_check').check();
     await page.locator('button.ec-blockBtn--action[type="submit"]').click();
     await page.waitForLoadState('load');
@@ -856,7 +857,7 @@ test.describe('Admin Basic Info (EA07)', () => {
     await frontPage.goto('/mypage/login');
     await frontPage.waitForLoadState('load');
     await frontPage.locator('input[name="login_email"]').fill(email);
-    await frontPage.locator('input[name="login_pass"]').fill('password');
+    await frontPage.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
     await frontPage.locator('#login_mypage button[type="submit"]').click();
     await frontPage.waitForLoadState('load');
 
@@ -901,7 +902,7 @@ test.describe('Admin Basic Info (EA07)', () => {
     await frontPage2.goto('/mypage/login');
     await frontPage2.waitForLoadState('load');
     await frontPage2.locator('input[name="login_email"]').fill(email);
-    await frontPage2.locator('input[name="login_pass"]').fill('password');
+    await frontPage2.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
     await frontPage2.locator('#login_mypage button[type="submit"]').click();
     await frontPage2.waitForLoadState('load');
 
@@ -1272,8 +1273,8 @@ test.describe('Admin Basic Info (EA07)', () => {
     await page.goto(`/${adminRoute}/setting/shop/calendar`);
     await page.waitForLoadState('load');
     if (page.url().includes('/login')) {
-      await page.locator('#login_id').fill(process.env.ADMIN_USER || 'admin');
-      await page.locator('#password').fill(process.env.ADMIN_PASSWORD || 'password');
+      await page.locator('#login_id').fill(ADMIN_USER);
+      await page.locator('#password').fill(ADMIN_PASSWORD);
       await page.getByRole('button', { name: 'ログイン' }).click();
       await page.waitForLoadState('load');
       await page.goto(`/${adminRoute}/setting/shop/calendar`);

--- a/e2e/tests/admin-contents.spec.ts
+++ b/e2e/tests/admin-contents.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_ROUTE } from '../config/default.config';
 import path from 'path';
 import fs from 'fs';
 
-const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+const adminRoute = ADMIN_ROUTE;
 
 // ---------------------------------------------------------------------------
 // News management

--- a/e2e/tests/admin-customer.spec.ts
+++ b/e2e/tests/admin-customer.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_ROUTE, VALID_PASSWORD } from '../config/default.config';
 
-const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+const adminRoute = ADMIN_ROUTE;
 const pageTitle = '.c-pageTitle';
 const searchBtn = '#search_form .c-outsideBlock__contents button';
 const searchResultMsg = '#search_form > div.c-outsideBlock__contents.mb-5 > span';
@@ -49,8 +50,8 @@ test.describe('Admin Customer (EA05)', () => {
     await page.locator('#admin_customer_address_addr02').fill('ブリーゼタワー13F');
     await page.locator('#admin_customer_email').fill(createdCustomerEmail);
     await page.locator('#admin_customer_phone_number').fill('111111111');
-    await page.locator('#admin_customer_plain_password_first').fill('EccubeE2ePassword1');
-    await page.locator('#admin_customer_plain_password_second').fill('EccubeE2ePassword1');
+    await page.locator('#admin_customer_plain_password_first').fill(VALID_PASSWORD);
+    await page.locator('#admin_customer_plain_password_second').fill(VALID_PASSWORD);
 
     // Submit
     await page.locator('#customer_form .c-conversionArea button[type="submit"]').click();
@@ -234,8 +235,8 @@ test.describe('Admin Customer (EA05)', () => {
     await page.locator('#admin_customer_address_addr02').fill('梅田');
     await page.locator('#admin_customer_email').fill(cancelTestEmail);
     await page.locator('#admin_customer_phone_number').fill('111111111');
-    await page.locator('#admin_customer_plain_password_first').fill('EccubeE2ePassword1');
-    await page.locator('#admin_customer_plain_password_second').fill('EccubeE2ePassword1');
+    await page.locator('#admin_customer_plain_password_first').fill(VALID_PASSWORD);
+    await page.locator('#admin_customer_plain_password_second').fill(VALID_PASSWORD);
     await page.locator('#customer_form .c-conversionArea button[type="submit"]').click();
     await page.waitForLoadState('load');
     await expect(page.locator(successAlert)).toContainText('保存しました');
@@ -297,8 +298,8 @@ test.describe('Admin Customer (EA05)', () => {
     await page.locator('#admin_customer_address_addr02').fill('梅田');
     await page.locator('#admin_customer_email').fill(editTestEmail);
     await page.locator('#admin_customer_phone_number').fill('111111111');
-    await page.locator('#admin_customer_plain_password_first').fill('EccubeE2ePassword1');
-    await page.locator('#admin_customer_plain_password_second').fill('EccubeE2ePassword1');
+    await page.locator('#admin_customer_plain_password_first').fill(VALID_PASSWORD);
+    await page.locator('#admin_customer_plain_password_second').fill(VALID_PASSWORD);
     await page.locator('#customer_form .c-conversionArea button[type="submit"]').click();
     await page.waitForLoadState('load');
     await expect(page.locator(successAlert)).toContainText('保存しました');

--- a/e2e/tests/admin-order.spec.ts
+++ b/e2e/tests/admin-order.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_ROUTE } from '../config/default.config';
 
-const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+const adminRoute = ADMIN_ROUTE;
 const pageTitle = '.c-pageTitle';
 const searchResultMsg = '#search_form #search_total_count';
 const searchErrorMsg = '.c-contentsArea__primaryCol .text-center';

--- a/e2e/tests/admin-product.spec.ts
+++ b/e2e/tests/admin-product.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_ROUTE } from '../config/default.config';
 import path from 'path';
 
-const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+const adminRoute = ADMIN_ROUTE;
 const pageTitle = '.c-pageTitle';
 const searchResultMsg = '#search_form > div.c-outsideBlock__contents.mb-5 > span';
 const searchResultList = '#page_admin_product table tbody';

--- a/e2e/tests/admin-shipping.spec.ts
+++ b/e2e/tests/admin-shipping.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_ROUTE } from '../config/default.config';
 import path from 'path';
 
-const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+const adminRoute = ADMIN_ROUTE;
 
 test.describe('Admin Shipping (EA09)', () => {
 

--- a/e2e/tests/admin-system.spec.ts
+++ b/e2e/tests/admin-system.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_PASSWORD, ADMIN_ROUTE, ADMIN_USER, VALID_PASSWORD } from '../config/default.config';
 import path from 'path';
 
-const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+const adminRoute = ADMIN_ROUTE;
 const authFile = path.join(__dirname, '..', '.auth', 'admin.json');
 
 test.describe('Admin System Info (EA08)', () => {
@@ -44,8 +45,8 @@ test.describe('Admin System Info (EA08)', () => {
     await page.locator('#admin_member_name').fill('admintest');
     await page.locator('#admin_member_department').fill('admintest department');
     await page.locator('#admin_member_login_id').fill('admintest');
-    await page.locator('#admin_member_plain_password_first').fill('EccubeE2ePassword1');
-    await page.locator('#admin_member_plain_password_second').fill('EccubeE2ePassword1');
+    await page.locator('#admin_member_plain_password_first').fill(VALID_PASSWORD);
+    await page.locator('#admin_member_plain_password_second').fill(VALID_PASSWORD);
     await page.locator('#admin_member_Authority').selectOption({ label: 'システム管理者' });
     await page.locator('#admin_member_Work_1').check();
 
@@ -73,8 +74,8 @@ test.describe('Admin System Info (EA08)', () => {
     await page.locator('#admin_member_name').fill('admintest2');
     await page.locator('#admin_member_department').fill('admintest department');
     await page.locator('#admin_member_login_id').fill('admintest');
-    await page.locator('#admin_member_plain_password_first').fill('EccubeE2ePassword1');
-    await page.locator('#admin_member_plain_password_second').fill('EccubeE2ePassword1');
+    await page.locator('#admin_member_plain_password_first').fill(VALID_PASSWORD);
+    await page.locator('#admin_member_plain_password_second').fill(VALID_PASSWORD);
     await page.locator('#admin_member_Authority').selectOption({ label: 'システム管理者' });
     await page.locator('#admin_member_Work_1').check();
 
@@ -216,8 +217,8 @@ test.describe('Admin System Info (EA08)', () => {
     // Login via the new admin URL
     await page.goto('/admin2/');
     await page.waitForLoadState('load');
-    await page.locator('#login_id').fill(process.env.ADMIN_USER || 'admin');
-    await page.locator('#password').fill(process.env.ADMIN_PASSWORD || 'password');
+    await page.locator('#login_id').fill(ADMIN_USER);
+    await page.locator('#password').fill(ADMIN_PASSWORD);
     await page.getByRole('button', { name: 'ログイン' }).click();
     await expect(page.locator('.c-pageTitle__titles')).toContainText('ホーム', { timeout: 30_000 });
 
@@ -231,8 +232,8 @@ test.describe('Admin System Info (EA08)', () => {
     // Login again via the original admin URL and save auth state for subsequent tests
     await page.goto(`/${adminRoute}/`);
     await page.waitForLoadState('load');
-    await page.locator('#login_id').fill(process.env.ADMIN_USER || 'admin');
-    await page.locator('#password').fill(process.env.ADMIN_PASSWORD || 'password');
+    await page.locator('#login_id').fill(ADMIN_USER);
+    await page.locator('#password').fill(ADMIN_PASSWORD);
     await page.getByRole('button', { name: 'ログイン' }).click();
     await expect(page.locator('.c-pageTitle__titles')).toContainText('ホーム', { timeout: 30_000 });
 
@@ -577,12 +578,12 @@ test.describe('Admin System Info (EA08)', () => {
     await page.waitForLoadState('load');
     await expect(page.locator('.c-pageTitle')).toContainText('ログイン履歴');
 
-    await page.locator('#admin_search_login_history_multi').fill('admin');
+    await page.locator('#admin_search_login_history_multi').fill(ADMIN_USER);
     await page.locator('#search_form .c-outsideBlock__contents button').click();
     await page.waitForLoadState('load');
 
     // Verify first result contains 'admin' and '成功'
-    await expect(page.locator('#search_form table tbody tr:nth-child(1) td:nth-child(2)')).toContainText('admin');
+    await expect(page.locator('#search_form table tbody tr:nth-child(1) td:nth-child(2)')).toContainText(ADMIN_USER);
     await expect(page.locator('#search_form table tbody tr:nth-child(1) td:nth-child(5) span')).toContainText('成功');
   });
 });

--- a/e2e/tests/admin-top.spec.ts
+++ b/e2e/tests/admin-top.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_ROUTE } from '../config/default.config';
 
-const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+const adminRoute = ADMIN_ROUTE;
 const pageTitle = '.c-pageTitle h2.c-pageTitle__title';
 
 test.describe('Admin Top (EA01)', () => {

--- a/e2e/tests/front-customer.spec.ts
+++ b/e2e/tests/front-customer.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_ROUTE, VALID_PASSWORD } from '../config/default.config';
 
 test.describe('Front Customer Registration (EF04)', () => {
 
@@ -21,8 +22,8 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(email);
     await page.locator('#entry_email_second').fill(email);
-    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
-    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_first').fill(VALID_PASSWORD);
+    await page.locator('#entry_plain_password_second').fill(VALID_PASSWORD);
     await page.locator('#entry_job').selectOption({ value: '1' });
     await page.locator('#entry_user_policy_check').check();
 
@@ -59,8 +60,8 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(email);
     await page.locator('#entry_email_second').fill(email);
-    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
-    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_first').fill(VALID_PASSWORD);
+    await page.locator('#entry_plain_password_second').fill(VALID_PASSWORD);
 
     // 「同意する」ボタンを押下
     await page.locator('button.ec-blockBtn--action[type="submit"]').click();
@@ -106,8 +107,8 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(email);
     await page.locator('#entry_email_second').fill(email);
-    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
-    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_first').fill(VALID_PASSWORD);
+    await page.locator('#entry_plain_password_second').fill(VALID_PASSWORD);
     await page.locator('#entry_job').selectOption({ value: '1' });
     await page.locator('#entry_user_policy_check').check();
 
@@ -145,8 +146,8 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(existingEmail);
     await page.locator('#entry_email_second').fill(existingEmail);
-    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
-    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_first').fill(VALID_PASSWORD);
+    await page.locator('#entry_plain_password_second').fill(VALID_PASSWORD);
 
     // 「同意する」ボタンを押下
     await page.locator('button.ec-blockBtn--action[type="submit"]').click();
@@ -175,8 +176,8 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(newEmail);
     await page.locator('#entry_email_second').fill(newEmail);
-    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
-    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_first').fill(VALID_PASSWORD);
+    await page.locator('#entry_plain_password_second').fill(VALID_PASSWORD);
     await page.locator('#entry_job').selectOption({ value: '1' });
     await page.locator('#entry_user_policy_check').check();
 
@@ -201,7 +202,7 @@ test.describe('Front Customer Registration (EF04)', () => {
     // アクティベーション(メール確認はスキップ。DBを直接操作してアクティベートする)
     // DB上のCustomerStatusをactivateするためにadminから会員を検索して本会員にする
     // admin認証を使うためにブラウザコンテキストを分ける
-    const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+    const adminRoute = ADMIN_ROUTE;
     const browser = page.context().browser()!;
     const fs = await import('fs');
     const path = await import('path');
@@ -232,7 +233,7 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.goto('/mypage/login');
     await page.waitForLoadState('load');
     await page.locator('input[name="login_email"]').fill(newEmail);
-    await page.locator('input[name="login_pass"]').fill('EccubeE2ePassword1');
+    await page.locator('input[name="login_pass"]').fill(VALID_PASSWORD);
     await page.locator('#login_mypage button[type="submit"]').click();
     await page.waitForLoadState('load');
 
@@ -285,8 +286,8 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(newEmail);
     await page.locator('#entry_email_second').fill(newEmail);
-    await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
-    await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
+    await page.locator('#entry_plain_password_first').fill(VALID_PASSWORD);
+    await page.locator('#entry_plain_password_second').fill(VALID_PASSWORD);
     await page.locator('#entry_job').selectOption({ value: '1' });
     await page.locator('#entry_user_policy_check').check();
 
@@ -307,7 +308,7 @@ test.describe('Front Customer Registration (EF04)', () => {
     await page.waitForLoadState('load');
 
     // DBで直接アクティベート(adminで操作)
-    const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+    const adminRoute = ADMIN_ROUTE;
     const browser = page.context().browser()!;
     const fs = await import('fs');
     const path = await import('path');
@@ -339,7 +340,7 @@ test.describe('Front Customer Registration (EF04)', () => {
 
     // ログイン
     await page.locator('input[name="login_email"]').fill(newEmail);
-    await page.locator('input[name="login_pass"]').fill('EccubeE2ePassword1');
+    await page.locator('input[name="login_pass"]').fill(VALID_PASSWORD);
     await page.getByRole('button', { name: 'ログイン' }).click();
     await page.waitForLoadState('load');
 

--- a/e2e/tests/front-invoice.spec.ts
+++ b/e2e/tests/front-invoice.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, Page, BrowserContext } from '@playwright/test';
+import { ADMIN_PASSWORD, ADMIN_ROUTE, ADMIN_USER, CUSTOMER_PASSWORD } from '../config/default.config';
 
-const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+const adminRoute = ADMIN_ROUTE;
 
 /**
  * Helper: Login as admin user in a given page.
@@ -8,8 +9,8 @@ const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
 async function loginAsAdmin(page: Page) {
   await page.goto(`/${adminRoute}/`);
   await page.waitForLoadState('load');
-  await page.locator('#login_id').fill(process.env.ADMIN_USER || 'admin');
-  await page.locator('#password').fill(process.env.ADMIN_PASSWORD || 'password');
+  await page.locator('#login_id').fill(ADMIN_USER);
+  await page.locator('#password').fill(ADMIN_PASSWORD);
   await page.getByRole('button', { name: 'ログイン' }).click();
   await page.waitForLoadState('load');
 }
@@ -21,7 +22,7 @@ async function loginAsTestCustomer(page: Page) {
   await page.goto('/mypage/login');
   await page.waitForLoadState('load');
   await page.locator('input[name="login_email"]').fill('playwright@test.test');
-  await page.locator('input[name="login_pass"]').fill('password');
+  await page.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
   await page.getByRole('button', { name: 'ログイン' }).click();
   await page.waitForLoadState('load');
 }

--- a/e2e/tests/front-mail.spec.ts
+++ b/e2e/tests/front-mail.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
+import { VALID_PASSWORD } from '../config/default.config';
 
 /**
  * mailpit の REST API(既定 8025) からメールを読む。
@@ -52,8 +53,8 @@ test.describe('会員登録メール (EF04)', () => {
     await page.locator('#entry_phone_number').fill('111-111-111');
     await page.locator('#entry_email_first').fill(newEmail);
     await page.locator('#entry_email_second').fill(newEmail);
-    await page.locator('#entry_plain_password_first').fill('password1234');
-    await page.locator('#entry_plain_password_second').fill('password1234');
+    await page.locator('#entry_plain_password_first').fill(VALID_PASSWORD);
+    await page.locator('#entry_plain_password_second').fill(VALID_PASSWORD);
     await page.locator('#entry_job').selectOption({ value: '1' });
     await page.locator('#entry_user_policy_check').check();
 

--- a/e2e/tests/front-mypage.spec.ts
+++ b/e2e/tests/front-mypage.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import { ADMIN_PASSWORD, ADMIN_ROUTE, ADMIN_USER, CUSTOMER_PASSWORD, VALID_PASSWORD } from '../config/default.config';
 
 /**
  * Helper: Login as the test customer via /mypage/login.
@@ -7,7 +8,7 @@ async function loginAsTestCustomer(page: Page) {
   await page.goto('/mypage/login');
   await page.waitForLoadState('load');
   await page.locator('input[name="login_email"]').fill('playwright@test.test');
-  await page.locator('input[name="login_pass"]').fill('password');
+  await page.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
   await page.getByRole('button', { name: 'ログイン' }).click();
   await page.waitForLoadState('load');
 }
@@ -18,15 +19,15 @@ async function loginAsTestCustomer(page: Page) {
  * which may require email confirmation.
  */
 async function createCustomerViaAdmin(page: Page): Promise<{ email: string; password: string }> {
-  const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+  const adminRoute = ADMIN_ROUTE;
   const email = `test_withdraw_${Date.now()}@example.com`;
-  const password = 'EccubeE2ePassword1';
+  const password = VALID_PASSWORD;
 
   const adminPage = await page.context().newPage();
   await adminPage.goto(`/${adminRoute}/`);
   await adminPage.waitForLoadState('load');
-  await adminPage.locator('#login_id').fill(process.env.ADMIN_USER || 'admin');
-  await adminPage.locator('#password').fill(process.env.ADMIN_PASSWORD || 'password');
+  await adminPage.locator('#login_id').fill(ADMIN_USER);
+  await adminPage.locator('#password').fill(ADMIN_PASSWORD);
   await adminPage.getByRole('button', { name: 'ログイン' }).click();
   await adminPage.waitForLoadState('load');
 
@@ -165,13 +166,13 @@ async function getLatestOrderNo(page: Page): Promise<string> {
  * on global ordering), and saves the tracking number.
  */
 async function setTrackingNumberViaAdmin(page: Page, orderNo: string, trackingNumber: string) {
-  const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+  const adminRoute = ADMIN_ROUTE;
 
   const adminPage = await page.context().newPage();
   await adminPage.goto(`/${adminRoute}/`);
   await adminPage.waitForLoadState('load');
-  await adminPage.locator('#login_id').fill(process.env.ADMIN_USER || 'admin');
-  await adminPage.locator('#password').fill(process.env.ADMIN_PASSWORD || 'password');
+  await adminPage.locator('#login_id').fill(ADMIN_USER);
+  await adminPage.locator('#password').fill(ADMIN_PASSWORD);
   await adminPage.getByRole('button', { name: 'ログイン' }).click();
   await adminPage.waitForLoadState('load');
 

--- a/e2e/tests/front-order.spec.ts
+++ b/e2e/tests/front-order.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { CUSTOMER_PASSWORD } from '../config/default.config';
 
 /**
  * Helper: Add a product to cart and go to the cart page.
@@ -23,7 +24,7 @@ async function loginAsTestCustomer(page: import('@playwright/test').Page) {
   await page.goto('/mypage/login');
   await page.waitForLoadState('load');
   await page.locator('input[name="login_email"]').fill('playwright@test.test');
-  await page.locator('input[name="login_pass"]').fill('password');
+  await page.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
   await page.getByRole('button', { name: 'ログイン' }).click();
   await page.waitForLoadState('load');
 }
@@ -78,7 +79,7 @@ test.describe('Front Order (EF03)', () => {
     // ショッピングログインページでログイン
     await expect(page).toHaveURL(/\/shopping\/login/);
     await page.locator('input[name="login_email"]').fill('playwright@test.test');
-    await page.locator('input[name="login_pass"]').fill('password');
+    await page.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
     await page.getByRole('button', { name: 'ログイン' }).click();
     await page.waitForLoadState('load');
 
@@ -352,7 +353,7 @@ test.describe('Front Order (EF03)', () => {
 
     // ログイン
     await page.locator('input[name="login_email"]').fill('playwright@test.test');
-    await page.locator('input[name="login_pass"]').fill('password');
+    await page.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
     await page.getByRole('button', { name: 'ログイン' }).click();
     await page.waitForLoadState('load');
 
@@ -382,7 +383,7 @@ test.describe('Front Order (EF03)', () => {
 
     // ログイン
     await page.locator('input[name="login_email"]').fill('playwright@test.test');
-    await page.locator('input[name="login_pass"]').fill('password');
+    await page.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
     await page.getByRole('button', { name: 'ログイン' }).click();
     await page.waitForLoadState('load');
 
@@ -452,7 +453,7 @@ test.describe('Front Order (EF03)', () => {
     await page1.goto('/mypage/login');
     await page1.waitForLoadState('load');
     await page1.locator('input[name="login_email"]').fill('playwright@test.test');
-    await page1.locator('input[name="login_pass"]').fill('password');
+    await page1.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
     await page1.getByRole('button', { name: 'ログイン' }).click();
     await page1.waitForLoadState('load');
 
@@ -462,7 +463,7 @@ test.describe('Front Order (EF03)', () => {
     await page2.goto('/mypage/login');
     await page2.waitForLoadState('load');
     await page2.locator('input[name="login_email"]').fill('playwright@test.test');
-    await page2.locator('input[name="login_pass"]').fill('password');
+    await page2.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
     await page2.getByRole('button', { name: 'ログイン' }).click();
     await page2.waitForLoadState('load');
 
@@ -502,7 +503,7 @@ test.describe('Front Order (EF03)', () => {
     await page1.goto('/mypage/login');
     await page1.waitForLoadState('load');
     await page1.locator('input[name="login_email"]').fill('playwright@test.test');
-    await page1.locator('input[name="login_pass"]').fill('password');
+    await page1.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
     await page1.getByRole('button', { name: 'ログイン' }).click();
     await page1.waitForLoadState('load');
 
@@ -535,7 +536,7 @@ test.describe('Front Order (EF03)', () => {
     await page2.goto('/mypage/login');
     await page2.waitForLoadState('load');
     await page2.locator('input[name="login_email"]').fill('playwright@test.test');
-    await page2.locator('input[name="login_pass"]').fill('password');
+    await page2.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
     await page2.getByRole('button', { name: 'ログイン' }).click();
     await page2.waitForLoadState('load');
 
@@ -684,7 +685,7 @@ test.describe('Front Order (EF03)', () => {
 
     // Login at shopping login page
     await page.locator('input[name="login_email"]').fill('playwright@test.test');
-    await page.locator('input[name="login_pass"]').fill('password');
+    await page.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
     await page.getByRole('button', { name: 'ログイン' }).click();
     await page.waitForLoadState('load');
 

--- a/e2e/tests/front-other.spec.ts
+++ b/e2e/tests/front-other.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_ROUTE, CUSTOMER_PASSWORD, VALID_PASSWORD } from '../config/default.config';
 import fs from 'fs';
 import path from 'path';
 
-const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+const adminRoute = ADMIN_ROUTE;
 
 /**
  * Helper: get an active customer email from admin storage state.
@@ -37,7 +38,7 @@ test.describe('Front Other Pages (EF06)', () => {
     await page.waitForLoadState('load');
 
     await page.locator('input[name="login_email"]').fill(email);
-    await page.locator('input[name="login_pass"]').fill('password');
+    await page.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
     await page.locator('#login_mypage button[type="submit"]').click();
     await page.waitForLoadState('load');
 
@@ -59,7 +60,7 @@ test.describe('Front Other Pages (EF06)', () => {
 
   test('EF0601-UC01-T02 ログイン異常 仮会員', async ({ page }) => {
     // 仮会員を作成するためにadminから新規会員を仮会員ステータスで登録
-    const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+    const adminRoute = ADMIN_ROUTE;
     const browser = page.context().browser()!;
     const authFile = path.join(__dirname, '..', '.auth', 'admin.json');
     const storageState = JSON.parse(fs.readFileSync(authFile, 'utf-8'));
@@ -82,8 +83,8 @@ test.describe('Front Other Pages (EF06)', () => {
     await adminPage.locator('#admin_customer_address_addr02').fill('梅田');
     await adminPage.locator('#admin_customer_phone_number').fill('111111111');
     await adminPage.locator('#admin_customer_email').fill(tempEmail);
-    await adminPage.locator('#admin_customer_plain_password_first').fill('EccubeE2ePassword1');
-    await adminPage.locator('#admin_customer_plain_password_second').fill('EccubeE2ePassword1');
+    await adminPage.locator('#admin_customer_plain_password_first').fill(VALID_PASSWORD);
+    await adminPage.locator('#admin_customer_plain_password_second').fill(VALID_PASSWORD);
     // ステータスを仮会員(1)に設定
     await adminPage.locator('#admin_customer_status').selectOption({ value: '1' });
     await adminPage.locator('button.btn-ec-conversion').click();
@@ -95,7 +96,7 @@ test.describe('Front Other Pages (EF06)', () => {
     await page.goto('/mypage/login');
     await page.waitForLoadState('load');
     await page.locator('input[name="login_email"]').fill(tempEmail);
-    await page.locator('input[name="login_pass"]').fill('EccubeE2ePassword1');
+    await page.locator('input[name="login_pass"]').fill(VALID_PASSWORD);
     await page.locator('#login_mypage button[type="submit"]').click();
     await page.waitForLoadState('load');
 
@@ -109,7 +110,7 @@ test.describe('Front Other Pages (EF06)', () => {
 
     // 存在しないメールアドレスでログイン
     await page.locator('input[name="login_email"]').fill('nonexistent_wrong@test.test.bad');
-    await page.locator('input[name="login_pass"]').fill('password');
+    await page.locator('input[name="login_pass"]').fill(CUSTOMER_PASSWORD);
     await page.locator('#login_mypage button[type="submit"]').click();
     await page.waitForLoadState('load');
 

--- a/e2e/tests/front-password-nist.spec.ts
+++ b/e2e/tests/front-password-nist.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import { ADMIN_PASSWORD, ADMIN_ROUTE, ADMIN_USER, NORMALIZED_PASSWORD, RAW_PASSWORD } from '../config/default.config';
 
 /**
  * NIST SP 800-63B-4 対応(#6488)の E2E。
@@ -11,12 +12,7 @@ import { test, expect, Page } from '@playwright/test';
  * PRE_SUBMIT で NFKC 正規化されるため, 保存値は正規化後の文字列になる。
  */
 
-const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
-
-// 半角カナ + 数字(NFKC で全角へ正規化される)。正規化後 15 文字以上(min15 要件)。
-const RAW_PASSWORD = 'ﾊﾟｽﾜｰﾄﾞﾃｽﾄ1234567';
-// 上記を NFKC 正規化した文字列(全角)。15 文字。
-const NORMALIZED_PASSWORD = 'パスワードテスト1234567';
+const adminRoute = ADMIN_ROUTE;
 
 /**
  * 管理画面から本会員を作成し, メールアドレスを返す。
@@ -27,8 +23,8 @@ async function createActiveCustomerViaAdmin(page: Page, password: string): Promi
   const adminPage = await page.context().newPage();
   await adminPage.goto(`/${adminRoute}/`);
   await adminPage.waitForLoadState('load');
-  await adminPage.locator('#login_id').fill(process.env.ADMIN_USER || 'admin');
-  await adminPage.locator('#password').fill(process.env.ADMIN_PASSWORD || 'password');
+  await adminPage.locator('#login_id').fill(ADMIN_USER);
+  await adminPage.locator('#password').fill(ADMIN_PASSWORD);
   await adminPage.getByRole('button', { name: 'ログイン' }).click();
   await adminPage.waitForLoadState('load');
 

--- a/e2e/tests/front-product.spec.ts
+++ b/e2e/tests/front-product.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_PASSWORD, ADMIN_ROUTE, ADMIN_USER } from '../config/default.config';
 
 test.describe('Front Product (EF02)', () => {
 
@@ -342,13 +343,13 @@ test.describe('Front Product (EF02)', () => {
     // This uses the admin API to set stock to 0, then checks front display.
     // We'll check product 2 (チェリーアイスサンド) which is a simple product.
     // First, set stock to 0 via admin
-    const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+    const adminRoute = ADMIN_ROUTE;
     await page.goto(`/${adminRoute}/product/product/2/edit`);
     await page.waitForLoadState('load');
     // May need to login
     if (await page.locator('#login_id').count() > 0) {
-      await page.locator('#login_id').fill(process.env.ADMIN_USER || 'admin');
-      await page.locator('#password').fill(process.env.ADMIN_PASSWORD || 'password');
+      await page.locator('#login_id').fill(ADMIN_USER);
+      await page.locator('#password').fill(ADMIN_PASSWORD);
       await page.getByRole('button', { name: 'ログイン' }).click();
       await page.waitForLoadState('load');
       await page.goto(`/${adminRoute}/product/product/2/edit`);
@@ -466,12 +467,12 @@ test.describe('Front Product (EF02)', () => {
 
   test('EF0202-UC03-T01 商品詳細カート7 在庫数<注文数', async ({ page }) => {
     // Use admin to set stock to 3 for product 2 (チェリーアイスサンド)
-    const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+    const adminRoute = ADMIN_ROUTE;
     await page.goto(`/${adminRoute}/product/product/2/edit`);
     await page.waitForLoadState('load');
     if (await page.locator('#login_id').count() > 0) {
-      await page.locator('#login_id').fill(process.env.ADMIN_USER || 'admin');
-      await page.locator('#password').fill(process.env.ADMIN_PASSWORD || 'password');
+      await page.locator('#login_id').fill(ADMIN_USER);
+      await page.locator('#password').fill(ADMIN_PASSWORD);
       await page.getByRole('button', { name: 'ログイン' }).click();
       await page.waitForLoadState('load');
       await page.goto(`/${adminRoute}/product/product/2/edit`);

--- a/e2e/tests/front-throttling.spec.ts
+++ b/e2e/tests/front-throttling.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_PASSWORD, ADMIN_ROUTE, ADMIN_USER, CUSTOMER_PASSWORD, VALID_PASSWORD } from '../config/default.config';
 import { authenticator } from '@otplib/preset-default';
 
-const adminRoute = process.env.ECCUBE_ADMIN_ROUTE || 'admin';
+const adminRoute = ADMIN_ROUTE;
 
 /**
  * EF09 Throttling Tests
@@ -19,7 +20,7 @@ test.use({ storageState: { cookies: [], origins: [] } });
 /**
  * Helper: Log in as a customer on the front site.
  */
-async function loginAsMember(page: import('@playwright/test').Page, email: string, password = 'password') {
+async function loginAsMember(page: import('@playwright/test').Page, email: string, password = CUSTOMER_PASSWORD) {
   await page.goto('/mypage/login');
   await page.waitForLoadState('load');
   await page.locator('input[name="login_email"]').fill(email);
@@ -36,7 +37,7 @@ function getTestCustomerEmail(): string {
 }
 
 function getTestCustomerPassword(): string {
-  return process.env.CUSTOMER_PASSWORD || 'password';
+  return CUSTOMER_PASSWORD;
 }
 
 /**
@@ -93,8 +94,8 @@ async function submitEntryFormWithConfirm(page: import('@playwright/test').Page)
   await page.locator('#entry_phone_number').fill('111-111-111');
   await page.locator('#entry_email_first').fill(email);
   await page.locator('#entry_email_second').fill(email);
-  await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
-  await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
+  await page.locator('#entry_plain_password_first').fill(VALID_PASSWORD);
+  await page.locator('#entry_plain_password_second').fill(VALID_PASSWORD);
   await page.locator('#entry_user_policy_check').check();
 
   // Click agree/submit button
@@ -128,8 +129,8 @@ async function submitEntryFormWithoutConfirm(page: import('@playwright/test').Pa
   await page.locator('#entry_phone_number').fill('111-111-111');
   await page.locator('#entry_email_first').fill(email);
   await page.locator('#entry_email_second').fill(email);
-  await page.locator('#entry_plain_password_first').fill('EccubeE2ePassword1');
-  await page.locator('#entry_plain_password_second').fill('EccubeE2ePassword1');
+  await page.locator('#entry_plain_password_first').fill(VALID_PASSWORD);
+  await page.locator('#entry_plain_password_second').fill(VALID_PASSWORD);
 
   // Submit without checking user_policy_check (goes to confirm without mode=complete)
   await page.locator('button.ec-blockBtn--action[type="submit"]').click();
@@ -927,14 +928,14 @@ test.describe('Throttling (EF09)', () => {
 
     await adminPage.goto(`/${adminRoute}/`);
     await adminPage.waitForLoadState('load');
-    await adminPage.locator('#login_id').fill(process.env.ADMIN_USER || 'admin');
-    await adminPage.locator('#password').fill(process.env.ADMIN_PASSWORD || 'password');
+    await adminPage.locator('#login_id').fill(ADMIN_USER);
+    await adminPage.locator('#password').fill(ADMIN_PASSWORD);
     await adminPage.getByRole('button', { name: 'ログイン' }).click();
     await expect(adminPage.locator('.c-pageTitle__titles')).toContainText('ホーム', { timeout: 30_000 });
 
     // Create a new member with 2FA enabled
     const loginId = 'admin_2fa_' + Date.now().toString(36);
-    const memberPassword = 'EccubeE2ePassword1';
+    const memberPassword = VALID_PASSWORD;
 
     await adminPage.goto(`/${adminRoute}/setting/system/member/new`);
     await adminPage.waitForLoadState('load');


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

E2E テスト（`e2e/`）に散在していた管理者/会員のログイン ID・パスワード等の認証情報を、`e2e/config/default.config.ts` へ集約しました。EC-CUBE 2 系の `e2e-tests/config/default.config.ts` と同じく、環境変数フォールバック付きの定数として一元管理します。

NIST SP 800-63B-4 対応（#6858 / #6488）でパスワード要件が変わっても、修正箇所をこの 1 ファイルに閉じ込めることが狙いです。

## 方針(Policy)

- EC-CUBE 2 系 `e2e-tests/config/default.config.ts` の集約パターンに倣う
- 環境変数名は既存 CI（`e2e-test.yml` / `e2e-test-throttling.yml`）が既に渡している `ECCUBE_ADMIN_ROUTE` / `ADMIN_USER` / `ADMIN_PASSWORD` / `CUSTOMER_PASSWORD` に一致させ、CI 側の変更を不要にした
- import は相対パス（`../config/default.config`）を採用。tsconfig の `paths` エイリアス（`@helpers` 等）は定義のみで実使用ゼロ・Playwright 実行時解決の実績が確認できなかったため、堅実な相対 import とした
- NIST 正規化テスト用の `RAW_PASSWORD` は env 対応にしつつ、`NORMALIZED_PASSWORD` は `RAW_PASSWORD.normalize('NFKC')` で**導出**。RAW を env で差し替えても NFKC 往復テストの整合が保たれる

## 実装に関する補足(Appendix)

集約した定数（すべて環境変数フォールバック付き）:

| 定数 | 用途 |
|---|---|
| `ADMIN_ROUTE` | 管理画面ルーティングプレフィックス |
| `ADMIN_USER` / `ADMIN_PASSWORD` | 初期管理者ログイン |
| `CUSTOMER_PASSWORD` | 既存フィクスチャ会員のログイン照合 |
| `VALID_PASSWORD` | 会員登録・パスワード変更で使う有効値（15 文字以上等の要件を満たす） |
| `RAW_PASSWORD` / `NORMALIZED_PASSWORD` | NIST NFKC 正規化テスト用（後者は前者から導出） |

- 19 の spec / fixture のベタ書きを import へ置換
- **意図的に保持した値**: ログイン失敗テストの `'invalid'` / `'invalidpassword'`、NIST 検証用の無効値 `'Short12345'`（15 文字未満）・`'passwordpassword'`（ブロックリスト掲載）、パスワード変更テストの動的値 `password1` / `password2`

## テスト（Test)

静的検証のみ実施（実ブラウザ E2E は CI に委譲）:

- `npx tsc --noEmit -p tsconfig.json` → エラーなし
- `npx playwright test --list` → 302 tests / 27 files を正常収集（import 解決・パース OK）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * E2E テストで使う管理画面ルートや認証情報、会員登録・パスワード変更用の共通パスワードを集約し、テスト間で一貫して利用できるようにしました。
  * NFKC 正規化の検証に使う元／正規化後パスワードを共通化しました。

* **Bug Fixes**
  * 環境変数やハードコードにばらつきがあったログイン・入力値を置き換え、管理画面／フロント画面の認証フローの安定性を高めました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->