### PR TITLE
fix: プラグイン同梱の非PSR-4ライブラリでコンテナビルドが失敗する問題を修正 (#6915)

### DIFF
--- a/app/config/eccube/services.php
+++ b/app/config/eccube/services.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+/*
+ * app/Plugin/* 配下のクラスを PSR-4 で自動登録する定義。
+ *
+ * 従来は services.yaml の `Plugin\` ブロックで静的な exclude のみを指定していたが,
+ * プラグインが同梱する非 PSR-4 のライブラリ (例: phpseclib の bootstrap.php) を拾って
+ * Symfony DI の FileLoader::registerClasses が "Expected to find class ... but it was not found!"
+ * 例外を投げる問題があった (#6915)。
+ *
+ * ここではライブラリ名に依存しないよう, プラグイン配下にネストした composer.json を持つ
+ * サブディレクトリ (= 同梱パッケージ) を検出し, そのサブツリーを exclude へ動的に追加する。
+ * あわせて composer の慣例ディレクトリ `vendor` も静的に除外する。
+ */
+return function (ContainerConfigurator $configurator): void {
+    // このファイルは app/config/eccube/ 配下にあるため, 3 階層上がプロジェクトルート。
+    $projectDir = \dirname(__DIR__, 3);
+    $pluginDir = $projectDir.'/app/Plugin';
+
+    // 従来 services.yaml が持っていた静的 exclude (+ 同梱ライブラリ集約用に vendor を追加)。
+    $excludes = [
+        $pluginDir.'/*/{Entity,Resource,ServiceProvider,Tests,Codeception,DoctrineMigrations,vendor}',
+    ];
+
+    // プラグイン配下のネストした composer.json (= 同梱パッケージ) を検出して除外する。
+    foreach (glob($pluginDir.'/*', GLOB_ONLYDIR) ?: [] as $plugin) {
+        $scan = static function (string $dir) use (&$scan, &$excludes): void {
+            foreach (scandir($dir) ?: [] as $entry) {
+                // vendor は上の静的 exclude 済み。走査コスト削減のため潜らない。
+                if ('.' === $entry || '..' === $entry || 'vendor' === $entry) {
+                    continue;
+                }
+                $path = $dir.'/'.$entry;
+                if (!is_dir($path)) {
+                    continue;
+                }
+                // 同梱パッケージのルートを見つけたらサブツリーごと除外し, これ以上潜らない。
+                if (is_file($path.'/composer.json')) {
+                    $excludes[] = $path;
+
+                    continue;
+                }
+                $scan($path);
+            }
+        };
+        // プラグインルート直下の composer.json (プラグイン自身の定義) は対象外。サブディレクトリのみ走査する。
+        $scan($plugin);
+    }
+
+    $services = $configurator->services();
+
+    // services.yaml の _defaults と等価な既定 (autowire / autoconfigure / private)。
+    // PurchaseFlow / OrderStateMachine の名前付き引数 ($cartPurchaseFlow 等) は,
+    // services.yaml の名前付きオートワイヤリング別名でコンテナ全体に解決されるため, ここでは bind しない
+    // (この scope のどのサービスからも使われない bind は "unused binding" エラーになるため)。
+    $services->defaults()
+        ->autowire()
+        ->autoconfigure()
+        ->private();
+
+    $services->load('Plugin\\', $pluginDir.'/*')
+        ->exclude($excludes);
+};

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -99,9 +99,18 @@ services:
         bind:
           $blockTemplates: '%eccube_twig_block_templates%'
 
-    Plugin\:
-        resource: '../../../app/Plugin/*'
-        exclude: '../../../app/Plugin/*/{Entity,Resource,ServiceProvider,Tests,Codeception,DoctrineMigrations}'
+    # Plugin\ の自動登録は services.php で定義する (#6915)。
+    # プラグインが同梱する非 PSR-4 ライブラリ (例: phpseclib) を動的に exclude するため,
+    # 静的な YAML では表現できず, ネストした composer.json を検出する PHP 設定へ移した。
+
+    # PurchaseFlow / OrderStateMachine の名前付き引数をコンテナ全体で解決するための別名。
+    # 上記 _defaults の bind はこのファイル内のサービスにのみ適用されるため, services.php で
+    # 登録するプラグインのサービス (例: 決済プラグインの Payment Method) からも解決できるよう,
+    # 名前付きオートワイヤリング別名として明示的に定義する。
+    Eccube\Service\PurchaseFlow\PurchaseFlow $cartPurchaseFlow: '@eccube.purchase.flow.cart'
+    Eccube\Service\PurchaseFlow\PurchaseFlow $shoppingPurchaseFlow: '@eccube.purchase.flow.shopping'
+    Eccube\Service\PurchaseFlow\PurchaseFlow $orderPurchaseFlow: '@eccube.purchase.flow.order'
+    Symfony\Component\Workflow\WorkflowInterface $_orderStateMachine: '@state_machine.order'
 
     Customize\:
         resource: '../../../app/Customize/*'


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Refs #6915

`app/config/eccube/services.yaml` の `Plugin\` リソースが `app/Plugin/*` を PSR-4 で自動登録する際, プラグインが同梱する **非 PSR-4 準拠のライブラリファイル**（例: phpseclib の `bootstrap.php`）を拾ってしまい, Symfony DI の `FileLoader::registerClasses` が次の例外を投げてコンテナビルド（`cache:warmup` / `cache:clear` / `doctrine:schema:update` 等）が失敗する問題を修正します。

```
Expected to find class "Plugin\AmazonPayV2_42_Bundle\phpseclib\bootstrap"
in file ".../app/Plugin/AmazonPayV2_42_Bundle/phpseclib/bootstrap.php"
while importing services from resource "../../../app/Plugin/*", but it was not found!
```

本不具合は `Plugin\` glob 導入時（`8633b4679b`, 2017-12-18）から存在する潜在バグで, Symfony **4.4 / 5.4 / 6.4 / 7.4 の全世代で同一に再現**します（`symfony/dependency-injection` 単体で隔離検証済み。Symfony メジャーバージョンの回帰ではありません）。

## 方針(Policy)

Issue の対応案のうち「対象をライブラリ名に依存させず動的に除外する」方針を採用しました。

- `Plugin\` の自動登録を `services.yaml` から **`services.php` へ移設**し, プラグイン配下に **ネストした `composer.json`（= 同梱パッケージ）を検出**して, そのサブツリーを `exclude` へ動的に追加します。これによりライブラリ名（`phpseclib` 等）をコア設定に焼き込むことなく, 直バンドル / `vendor/` 同梱のいずれにも対応します。
- あわせて composer 慣例ディレクトリ `vendor` を静的 exclude に追加します。
- 静的 exclude は従来（`Entity,Resource,ServiceProvider,Tests,Codeception,DoctrineMigrations`）を踏襲します。

## 実装に関する補足(Appendix)

- `services.yaml` の `_defaults` の `bind`（`$cartPurchaseFlow` 等）は **定義ファイル scope 限定**のため, `Plugin\` を別ファイル（`services.php`）へ移すとプラグインのサービスから解決できなくなります。決済プラグインの Payment Method 等がコア `Cash` と同様に `PurchaseFlow $shoppingPurchaseFlow` を型注入するケースを壊さないよう, `services.yaml` に **名前付きオートワイヤリング別名**（コンテナ全体で解決）を追加しました。
- 走査ロジック（`scandir` 再帰）は **コンテナのコンパイル時のみ**実行され, ダンプ済みコンテナ（`var/cache/<env>/*Container.php`）には含まれません。通常リクエストでは実行されないためランタイム性能への影響はありません（追跡リソースの `app/Plugin` Glob は従来の `Plugin\` glob と同一で, per-request コストは増えていないことを meta.json で確認済み）。

## テスト（Test)

ローカル（PHP 8.5 / Symfony 7.4.13）で以下を確認しました。

- phpseclib 同梱プラグインを配置 → `cache:warmup` が **成功**（従来は上記例外で失敗）
- 正規のプラグインサービスは登録され, 同梱ライブラリ（`phpseclib/bootstrap`・`vendor/autoload`）は `debug:container` で **未登録＝除外**を確認
- プラグイン scope で `$cart/$shopping/$orderPurchaseFlow`・`$_orderStateMachine` の注入が解決すること（名前付き別名がプラグインに届く）を確認
- `bin/console lint:container` **OK**（全サービスの型整合）
- `PurchaseFlowTest` **10/10 OK**
- `php-cs-fixer`（PSR-12・ライセンスヘッダ）**準拠**

## 相談（Discussion）

なし。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * プラグイン内のサービスが自動的に登録されるようになり、プラグインの導入・利用時の設定負担を軽減しました。
  * プラグインに同梱されたパッケージを適切に識別し、不要なサービスの読み込みを防止します。

* **改善**
  * 購入フローや注文状態に関する機能の依存関係を安定して解決できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->