### PR TITLE
受注登録の会員検索モーダルでメールアドレスを折り返して表示崩れを解消

### DIFF
--- a/src/Eccube/Resource/template/admin/Order/search_customer.twig
+++ b/src/Eccube/Resource/template/admin/Order/search_customer.twig
@@ -73,7 +73,7 @@ file that was distributed with this source code.
             <td class="text-center"><span>{{ Customer.id }}</span></td>
             <td><span>{{ Customer.name }}</span></td>
             <td><span>{{ Customer.phone_number }}</span></td>
-            <td><span>{{ Customer.email }}</span></td>
+            <td class="text-break"><span>{{ Customer.email }}</span></td>
             <td>
                 <div class="row justify-content-end pe-2">
                     <button type="button" class="btn btn-ec-actionIcon set-customer" data-customer="{{ Customer.id }}"><i class="fa fa-plus fa-lg text-secondary" aria-hidden="true"></i></button>


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

close #6769

受注登録の「会員から検索・入力」モーダルで、長いメールアドレスが折り返されずに表示され、「お名前」列が 1 文字ずつ縦に潰れるなど表示が崩れる問題を修正します。

## 方針(Policy)

Issue コメントの提案どおり、`search_customer.twig` のメールアドレス列の `<td>` に Bootstrap 標準ユーティリティ `text-break`（`word-wrap: break-word`）を付与し、長いメールアドレスをセル内で折り返すようにしました。

- `text-break` は管理画面の `bootstrap.css` に含まれる既存ユーティリティのため、CSS のビルド・追加は不要です。
- 変更は Twig テンプレート 1 行のみです。

## 実装に関する補足(Appendix)

ダミーデータで `1779204181.8888.nnishinihonsono@example.net` 等の長いメールアドレスを持つ会員を用意して確認しています。

### 修正前

メールアドレスが折り返されず列幅を占有し、「お名前」列が縦 1 文字ずつに潰れる。

<img width="801" height="612" alt="issue6769_before_modal" src="https://github.com/user-attachments/assets/b1040cf8-2c41-4291-b003-9052a29e61f4" />

### 修正後

メールアドレスがセル内で折り返され、各列が正常な幅で表示される。

<img width="800" height="423" alt="issue6769_after_modal" src="https://github.com/user-attachments/assets/990622e5-dda3-47f1-ad97-825d7a35c4f2" />


## テスト（Test)

- ローカル環境（PostgreSQL 18 / PHP 8.2）で受注登録 → 会員検索モーダルを開き、長いメールアドレスの会員で修正前の表示崩れ再現と修正後の折り返し表示を目視確認済み
- 表示のみの変更（クラス付与）のため、既存のユニットテストへの影響はありません

## 相談（Discussion）

特になし

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 注文検索モーダルの顧客一覧で、長いメールアドレスが適切に折り返し表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->