### PR TITLE
受注管理>受注登録の出荷先郵便番号から HTML required 属性を除去 (#6054)

### DIFF
--- a/e2e/tests/admin-order.spec.ts
+++ b/e2e/tests/admin-order.spec.ts
@@ -63,15 +63,6 @@ async function createOrderViaUI(page: import('@playwright/test').Page, name01: s
 test.describe('Admin Order (EA04)', () => {
   test.describe.configure({ mode: 'serial' });
 
-  test('order_受注登録画面の郵便番号にrequired属性が無い (EA0405-UC01-T02)', async ({ page }) => {
-    // 管理画面の受注登録は required=false + NotBlank でサーバ側バリデーションに統一している.
-    // 出荷先の郵便番号だけ HTML の required 属性が出力されるリグレッションを検知する (#6054)
-    await page.goto(`/${adminRoute}/order/new`);
-    await expect(page.locator('#order_Shipping_postal_code')).toBeVisible();
-    expect(await page.locator('#order_Shipping_postal_code').getAttribute('required')).toBeNull();
-    expect(await page.locator('#order_postal_code').getAttribute('required')).toBeNull();
-  });
-
   test('order_受注登録 (EA0405-UC01-T01)', async ({ page }) => {
     // Create an order via the new order form
     await page.goto(`/${adminRoute}/order/new`);

--- a/e2e/tests/admin-order.spec.ts
+++ b/e2e/tests/admin-order.spec.ts
@@ -63,6 +63,15 @@ async function createOrderViaUI(page: import('@playwright/test').Page, name01: s
 test.describe('Admin Order (EA04)', () => {
   test.describe.configure({ mode: 'serial' });
 
+  test('order_受注登録画面の郵便番号にrequired属性が無い (EA0405-UC01-T02)', async ({ page }) => {
+    // 管理画面の受注登録は required=false + NotBlank でサーバ側バリデーションに統一している.
+    // 出荷先の郵便番号だけ HTML の required 属性が出力されるリグレッションを検知する (#6054)
+    await page.goto(`/${adminRoute}/order/new`);
+    await expect(page.locator('#order_Shipping_postal_code')).toBeVisible();
+    expect(await page.locator('#order_Shipping_postal_code').getAttribute('required')).toBeNull();
+    expect(await page.locator('#order_postal_code').getAttribute('required')).toBeNull();
+  });
+
   test('order_受注登録 (EA0405-UC01-T01)', async ({ page }) => {
     // Create an order via the new order form
     await page.goto(`/${adminRoute}/order/new`);

--- a/src/Eccube/Form/Type/Admin/ShippingType.php
+++ b/src/Eccube/Form/Type/Admin/ShippingType.php
@@ -91,7 +91,10 @@ class ShippingType extends AbstractType
                 ],
             ])
             ->add('postal_code', PostalType::class, [
-                'required' => true,
+                'required' => false,
+                'constraints' => [
+                    new Assert\NotBlank(),
+                ],
             ])
             ->add('address', AddressType::class, [
                 'required' => false,

--- a/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
+++ b/tests/Eccube/Tests/Form/Type/Admin/OrderTypeTest.php
@@ -182,6 +182,21 @@ final class OrderTypeTest extends AbstractTypeTestCase
         $this->assertFalse($this->form['postal_code']->isValid());
     }
 
+    public function testInvalidShippingPostalCodeBlank(): void
+    {
+        $this->formData['Shipping']['postal_code'] = '';
+        $this->form->submit($this->formData);
+        $this->assertFalse($this->form['Shipping']['postal_code']->isValid());
+    }
+
+    public function testShippingPostalCodeIsNotRequired(): void
+    {
+        // 管理画面の受注登録は required=false + NotBlank でサーバ側バリデーションに統一している.
+        // 出荷先の郵便番号だけ HTML の required 属性が出力されないことを確認する (#6054)
+        $view = $this->form->createView();
+        $this->assertFalse($view['Shipping']['postal_code']->vars['required']);
+    }
+
     public function testInValidUsePointHasMinus()
     {
         $this->formData['use_point'] = '-12345';


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Fixes #6054

受注管理 > 受注登録で、出荷情報の郵便番号にだけ HTML の `required` 属性が出力され、この 1 項目のみブラウザの HTML5 バリデーション（バブル表示）が発動していました。他の必須項目（氏名・カナ・住所・電話番号等）はサーバ側バリデーションでエラー表示されるため、挙動が不整合でした。

## 方針(Policy)

- 管理画面の受注登録フォームは fa30b06ff3 以来「`required => false` + `Assert\NotBlank`」でサーバ側バリデーションに統一する規約になっており、`Admin\ShippingType` の `postal_code` だけ `required => true` が取り残されていたため、他項目と同じ形に揃えました。
- `PostalType` は `required === true` のときだけ `NotBlank` を自動付与する（`PostalType::configureOptions()` のノーマライザ）ため、`required => false` 化に伴い**明示的な `NotBlank` を追加**し、空欄を拒否するサーバ側の挙動は変えていません。

## 実装に関する補足(Appendix)

- 変わるのは form view の `required` var → HTML `required` 属性の出力のみです。「必須」バッジはテンプレートにハードコードされているため表示に影響ありません。
- 影響画面は受注登録・編集（単一出荷、`OrderType` 経由）と出荷情報登録（複数出荷、`ShippingController` 経由）で、いずれも管理画面のみです。

## テスト（Test)

- PHPUnit（`OrderTypeTest` に追加、17/17 green）
  - `testInvalidShippingPostalCodeBlank`: 出荷先郵便番号が空欄ならサーバ側でエラーになること（NotBlank の回帰防止。修正前コードでも green＝挙動不変を確認）
  - `testShippingPostalCodeIsNotRequired`: form view の `required` が false であること（修正前コードで red になることを確認済み）
- E2E は既存の `admin-order.spec.ts`（受注登録・編集フロー）をローカルで実行し green を確認（属性検証は上記 UT で担保できるため新規テストは追加していません）
- 実機確認（Playwright）: 修正前はバリデーションバブルが郵便番号のみに表示 → 修正後は required 属性が消え、空欄送信時に他項目と同じサーバ側エラー表示に統一。有効なデータでの受注登録が正常に完了することも確認
- `php-cs-fixer` / `phpstan analyse src`（level 6）/ `rector --dry-run` すべて違反なし

## 相談（Discussion）

なし

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)
