### PR TITLE
feat(dotenv): .env ロードを symfony/dotenv に一本化し bootEnv()/.env.local.php に対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ node_modules
 .vscode/
 *.php~
 .env
+.env.local
+.env.local.php
+.env.*.local
 .maintenance
 *.neon
 

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-use Dotenv\Dotenv;
+use Symfony\Component\Dotenv\Dotenv;
 use Eccube\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -17,9 +17,9 @@ if (!class_exists(Application::class)) {
 }
 if (!isset($_SERVER['APP_ENV'])) {
     if (file_exists(__DIR__.'/../.env')) {
-        (Dotenv::createUnsafeMutable(__DIR__.'/../'))->load();
+        (new Dotenv())->overload(__DIR__.'/../.env');
     } else {
-        (Dotenv::createUnsafeMutable(__DIR__.'/../', '.env.install'))->load();
+        (new Dotenv())->overload(__DIR__.'/../.env.install');
     }
 }
 

--- a/bin/console
+++ b/bin/console
@@ -20,9 +20,12 @@ $dotenvExists = file_exists(__DIR__.'/../.env')
     || file_exists(__DIR__.'/../.env.local.php');
 
 // OS 環境変数 APP_ENV が設定済みの場合は .env を読み込まない（従来の bin/console の挙動）。
-// これにより `cache:warmup --env=dev` のように CLI で env を切り替える際、
-// .env（prod）の APP_DEBUG=0 が読み込まれて debug=false になり、
-// dev の debug コンテナ（Eccube_KernelDevDebugContainer.xml）が生成されない問題を避ける。
+// これにより、rector CI のように `APP_ENV=dev bin/console cache:warmup --env=dev` と
+// OS 環境変数で env を切り替える際、.env（prod）の APP_DEBUG=0 が読み込まれて
+// debug=false になり、dev の debug コンテナ（Eccube_KernelDevDebugContainer.xml）が
+// 生成されない問題を避ける。
+// 注: CLI 引数 --env のみ（OS 環境変数 APP_ENV なし）では $_SERVER['APP_ENV'] は
+// セットされずこの分岐に入らないため、.env は読み込まれる。
 if (!isset($_SERVER['APP_ENV'])) {
     // OS 環境変数 APP_ENV が未設定の環境: .env を設定の源泉として読み込む。
     // bootEnv は .env.local.php を優先し、無ければ .env 系をカスケード読み込みする。

--- a/bin/console
+++ b/bin/console
@@ -19,6 +19,10 @@ $dotenvExists = file_exists(__DIR__.'/../.env')
     || file_exists(__DIR__.'/../.env.local')
     || file_exists(__DIR__.'/../.env.local.php');
 
+// OS 環境変数 APP_ENV が設定済みの場合は .env を読み込まない（従来の bin/console の挙動）。
+// これにより `cache:warmup --env=dev` のように CLI で env を切り替える際、
+// .env（prod）の APP_DEBUG=0 が読み込まれて debug=false になり、
+// dev の debug コンテナ（Eccube_KernelDevDebugContainer.xml）が生成されない問題を避ける。
 if (!isset($_SERVER['APP_ENV'])) {
     // OS 環境変数 APP_ENV が未設定の環境: .env を設定の源泉として読み込む。
     // bootEnv は .env.local.php を優先し、無ければ .env 系をカスケード読み込みする。
@@ -28,10 +32,6 @@ if (!isset($_SERVER['APP_ENV'])) {
     } else {
         (new Dotenv())->overload(__DIR__.'/../.env.install');
     }
-} elseif ($dotenvExists) {
-    // OS 環境変数 APP_ENV が設定済みの環境（Docker など）。
-    // 第4引数 false = 既存の OS 環境変数は上書きしない。
-    (new Dotenv())->bootEnv(__DIR__.'/../.env', 'dev', ['test'], false);
 }
 
 $input = new ArgvInput();

--- a/bin/console
+++ b/bin/console
@@ -28,10 +28,9 @@ $dotenvExists = file_exists(__DIR__.'/../.env')
 // セットされずこの分岐に入らないため、.env は読み込まれる。
 if (!isset($_SERVER['APP_ENV'])) {
     // OS 環境変数 APP_ENV が未設定の環境: .env を設定の源泉として読み込む。
-    // bootEnv は .env.local.php を優先し、無ければ .env 系をカスケード読み込みする。
-    // 第4引数 true = .env 系の値が既存値より優先（従来の overload 相当）。
+    // 第2引数 true = .env 系の値が既存値より優先（従来の overload 相当）。
     if ($dotenvExists) {
-        (new Dotenv())->bootEnv(__DIR__.'/../.env', 'dev', ['test'], true);
+        boot_env(__DIR__.'/../.env', true);
     } else {
         (new Dotenv())->overload(__DIR__.'/../.env.install');
     }

--- a/bin/console
+++ b/bin/console
@@ -15,12 +15,23 @@ require __DIR__.'/../vendor/autoload.php';
 if (!class_exists(Application::class)) {
     throw new \RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
 }
+$dotenvExists = file_exists(__DIR__.'/../.env')
+    || file_exists(__DIR__.'/../.env.local')
+    || file_exists(__DIR__.'/../.env.local.php');
+
 if (!isset($_SERVER['APP_ENV'])) {
-    if (file_exists(__DIR__.'/../.env')) {
-        (new Dotenv())->overload(__DIR__.'/../.env');
+    // OS 環境変数 APP_ENV が未設定の環境: .env を設定の源泉として読み込む。
+    // bootEnv は .env.local.php を優先し、無ければ .env 系をカスケード読み込みする。
+    // 第4引数 true = .env 系の値が既存値より優先（従来の overload 相当）。
+    if ($dotenvExists) {
+        (new Dotenv())->bootEnv(__DIR__.'/../.env', 'dev', ['test'], true);
     } else {
         (new Dotenv())->overload(__DIR__.'/../.env.install');
     }
+} elseif ($dotenvExists) {
+    // OS 環境変数 APP_ENV が設定済みの環境（Docker など）。
+    // 第4引数 false = 既存の OS 環境変数は上書きしない。
+    (new Dotenv())->bootEnv(__DIR__.'/../.env', 'dev', ['test'], false);
 }
 
 $input = new ArgvInput();

--- a/codeception/acceptance/_bootstrap.php
+++ b/codeception/acceptance/_bootstrap.php
@@ -27,7 +27,6 @@ use Eccube\Entity\Shipping;
 use Eccube\Kernel;
 use Eccube\Tests\Fixture\Generator;
 use Faker\Factory as Faker;
-use Symfony\Component\Dotenv\Dotenv;
 
 $config = parse_ini_file(__DIR__.'/config.ini', true);
 
@@ -42,7 +41,7 @@ require_once __DIR__.'/../../vendor/autoload.php';
 if (file_exists(__DIR__.'/../../.env')
     || file_exists(__DIR__.'/../../.env.local')
     || file_exists(__DIR__.'/../../.env.local.php')) {
-    (new Dotenv())->bootEnv(__DIR__.'/../../.env', 'dev', ['test'], true);
+    boot_env(__DIR__.'/../../.env', true);
 }
 $kernel = new Kernel('test', false);
 $kernel->boot();

--- a/codeception/acceptance/_bootstrap.php
+++ b/codeception/acceptance/_bootstrap.php
@@ -39,8 +39,10 @@ $config = parse_ini_file(__DIR__.'/config.ini', true);
  */
 require_once __DIR__.'/../../vendor/autoload.php';
 
-if (file_exists(__DIR__.'/../../.env')) {
-    (new Dotenv())->overload(__DIR__.'/../../.env');
+if (file_exists(__DIR__.'/../../.env')
+    || file_exists(__DIR__.'/../../.env.local')
+    || file_exists(__DIR__.'/../../.env.local.php')) {
+    (new Dotenv())->bootEnv(__DIR__.'/../../.env', 'dev', ['test'], true);
 }
 $kernel = new Kernel('test', false);
 $kernel->boot();

--- a/codeception/acceptance/_bootstrap.php
+++ b/codeception/acceptance/_bootstrap.php
@@ -12,7 +12,6 @@
  */
 
 use Codeception\Util\Fixtures;
-use Dotenv\Dotenv;
 use Eccube\Common\EccubeConfig;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Category;
@@ -28,6 +27,7 @@ use Eccube\Entity\Shipping;
 use Eccube\Kernel;
 use Eccube\Tests\Fixture\Generator;
 use Faker\Factory as Faker;
+use Symfony\Component\Dotenv\Dotenv;
 
 $config = parse_ini_file(__DIR__.'/config.ini', true);
 
@@ -40,7 +40,7 @@ $config = parse_ini_file(__DIR__.'/config.ini', true);
 require_once __DIR__.'/../../vendor/autoload.php';
 
 if (file_exists(__DIR__.'/../../.env')) {
-    Dotenv::createUnsafeMutable(__DIR__.'/../../')->load();
+    (new Dotenv())->overload(__DIR__.'/../../.env');
 }
 $kernel = new Kernel('test', false);
 $kernel->boot();

--- a/composer.json
+++ b/composer.json
@@ -100,8 +100,7 @@
         "tecnickcom/tcpdf": "^6.2",
         "twig/extra-bundle": "^3.21",
         "twig/intl-extra": "^3.21",
-        "twig/twig": "^3.21",
-        "vlucas/phpdotenv": "^5.6"
+        "twig/twig": "^3.21"
     },
     "require-dev": {
         "captbaritone/mailcatcher-codeception-module": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1647bfa3f3b5c8f5aa869fdcc3a6561",
+    "content-hash": "7440173cca8b3a8ab7b53341c4be1d9d",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -2680,68 +2680,6 @@
             "time": "2026-02-20T16:13:53+00:00"
         },
         {
-            "name": "graham-campbell/result-type",
-            "version": "v1.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/GrahamCampbell/Result-Type.git",
-                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/e01f4a821471308ba86aa202fed6698b6b695e3b",
-                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.41 || ^9.6.22 || ^10.5.45 || ^11.5.7"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "GrahamCampbell\\ResultType\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                }
-            ],
-            "description": "An Implementation Of The Result Type",
-            "keywords": [
-                "Graham Campbell",
-                "GrahamCampbell",
-                "Result Type",
-                "Result-Type",
-                "result"
-            ],
-            "support": {
-                "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
-                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/graham-campbell/result-type",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-12-27T19:43:20+00:00"
-        },
-        {
             "name": "guzzlehttp/guzzle",
             "version": "7.12.1",
             "source": {
@@ -3968,81 +3906,6 @@
                 "source": "https://github.com/paragonie/random_compat"
             },
             "time": "2020-10-15T08:29:30+00:00"
-        },
-        {
-            "name": "phpoption/phpoption",
-            "version": "1.9.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/75365b91986c2405cf5e1e012c5595cd487a98be",
-                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5 || ^8.0"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25 || ^10.5.53 || ^11.5.34"
-            },
-            "type": "library",
-            "extra": {
-                "bamarni-bin": {
-                    "bin-links": true,
-                    "forward-command": false
-                },
-                "branch-alias": {
-                    "dev-master": "1.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpOption\\": "src/PhpOption/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Johannes M. Schmitt",
-                    "email": "schmittjoh@gmail.com",
-                    "homepage": "https://github.com/schmittjoh"
-                },
-                {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                }
-            ],
-            "description": "Option Type for PHP",
-            "keywords": [
-                "language",
-                "option",
-                "php",
-                "type"
-            ],
-            "support": {
-                "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/1.9.5"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpoption/phpoption",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-12-27T19:41:33+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -12090,90 +11953,6 @@
                 }
             ],
             "time": "2026-05-27T13:05:51+00:00"
-        },
-        {
-            "name": "vlucas/phpdotenv",
-            "version": "v5.6.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
-                "shasum": ""
-            },
-            "require": {
-                "ext-pcre": "*",
-                "graham-campbell/result-type": "^1.1.4",
-                "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.5",
-                "symfony/polyfill-ctype": "^1.26",
-                "symfony/polyfill-mbstring": "^1.26",
-                "symfony/polyfill-php80": "^1.26"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.2",
-                "ext-filter": "*",
-                "phpunit/phpunit": "^8.5.34 || ^9.6.13 || ^10.4.2"
-            },
-            "suggest": {
-                "ext-filter": "Required to use the boolean validator."
-            },
-            "type": "library",
-            "extra": {
-                "bamarni-bin": {
-                    "bin-links": true,
-                    "forward-command": false
-                },
-                "branch-alias": {
-                    "dev-master": "5.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Dotenv\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                },
-                {
-                    "name": "Vance Lucas",
-                    "email": "vance@vancelucas.com",
-                    "homepage": "https://github.com/vlucas"
-                }
-            ],
-            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
-            "keywords": [
-                "dotenv",
-                "env",
-                "environment"
-            ],
-            "support": {
-                "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/vlucas/phpdotenv",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-12-27T19:49:13+00:00"
         }
     ],
     "packages-dev": [
@@ -15631,5 +15410,5 @@
         "php": "8.2.0",
         "ext-sodium": "1.0.18"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/e2e/setup-fixtures.php
+++ b/e2e/setup-fixtures.php
@@ -18,8 +18,10 @@ use Eccube\Entity\Master\OrderStatus;
 use Eccube\Kernel;
 use Faker\Factory as Faker;
 
-if (file_exists(__DIR__.'/../.env')) {
-    (new Dotenv())->overload(__DIR__.'/../.env');
+if (file_exists(__DIR__.'/../.env')
+    || file_exists(__DIR__.'/../.env.local')
+    || file_exists(__DIR__.'/../.env.local.php')) {
+    (new Dotenv())->bootEnv(__DIR__.'/../.env', 'dev', ['test'], true);
 }
 
 $appEnv = getenv('APP_ENV') ?: 'codeception';

--- a/e2e/setup-fixtures.php
+++ b/e2e/setup-fixtures.php
@@ -11,7 +11,6 @@
 
 require_once __DIR__.'/../vendor/autoload.php';
 
-use Symfony\Component\Dotenv\Dotenv;
 use Eccube\Entity\Customer;
 use Eccube\Entity\Master\CustomerStatus;
 use Eccube\Entity\Master\OrderStatus;
@@ -21,7 +20,7 @@ use Faker\Factory as Faker;
 if (file_exists(__DIR__.'/../.env')
     || file_exists(__DIR__.'/../.env.local')
     || file_exists(__DIR__.'/../.env.local.php')) {
-    (new Dotenv())->bootEnv(__DIR__.'/../.env', 'dev', ['test'], true);
+    boot_env(__DIR__.'/../.env', true);
 }
 
 $appEnv = getenv('APP_ENV') ?: 'codeception';

--- a/e2e/setup-fixtures.php
+++ b/e2e/setup-fixtures.php
@@ -11,7 +11,7 @@
 
 require_once __DIR__.'/../vendor/autoload.php';
 
-use Dotenv\Dotenv;
+use Symfony\Component\Dotenv\Dotenv;
 use Eccube\Entity\Customer;
 use Eccube\Entity\Master\CustomerStatus;
 use Eccube\Entity\Master\OrderStatus;
@@ -19,7 +19,7 @@ use Eccube\Kernel;
 use Faker\Factory as Faker;
 
 if (file_exists(__DIR__.'/../.env')) {
-    Dotenv::createUnsafeMutable(__DIR__.'/../')->load();
+    (new Dotenv())->overload(__DIR__.'/../.env');
 }
 
 $appEnv = getenv('APP_ENV') ?: 'codeception';

--- a/index.php
+++ b/index.php
@@ -3,9 +3,7 @@
 use Eccube\Kernel;
 use Eccube\Service\SystemService;
 use Symfony\Component\ErrorHandler\Debug;
-use Dotenv\Dotenv;
-use Dotenv\Repository\Adapter\PutenvAdapter;
-use Dotenv\Repository\RepositoryBuilder;
+use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\Request;
 
 // システム要件チェック
@@ -27,29 +25,22 @@ if (!isset($_SERVER['APP_ENV'])) {
     }
 
     if (file_exists(__DIR__.'/.env')) {
-        (Dotenv::createUnsafeMutable(__DIR__))->load();
+        (new Dotenv())->overload(__DIR__.'/.env');
 
-        if (strpos(getenv('DATABASE_URL'), 'sqlite') !== false && !extension_loaded('pdo_sqlite')) {
-            (Dotenv::createUnsafeMutable(__DIR__, '.env.install'))->load();
+        if (str_contains($_SERVER['DATABASE_URL'] ?? '', 'sqlite') && !extension_loaded('pdo_sqlite')) {
+            (new Dotenv())->overload(__DIR__.'/.env.install');
         }
     } else {
-        (Dotenv::createUnsafeMutable(__DIR__, '.env.install'))->load();
+        (new Dotenv())->overload(__DIR__.'/.env.install');
     }
 } elseif (class_exists(Dotenv::class) && file_exists(__DIR__.'/.env')) {
     // APP_ENV が環境変数として設定されている場合（Docker など）でも .env を読み込む。
     // ただし既存の環境変数（Docker で設定済みのもの）は上書きしない。
     // これにより管理画面からのテンプレート切り替えが .env への書き込みで反映される。
     //
-    // 既定の createImmutable は $_ENV / $_SERVER / Apache CGI でのみ既存値を判定し、
-    // putenv 経由の値は見ない。Apache の PassEnv で渡されない変数 (DATABASE_URL 等) や
-    // PHP の variables_order に E が含まれない構成では、本来 Docker から渡された env が
-    // 「未設定」と誤判定され、.env の値で $_SERVER 等を上書きしてしまう。
-    // PutenvAdapter を明示的に追加することで getenv 側の既存値も尊重する。
-    $repository = RepositoryBuilder::createWithDefaultAdapters()
-        ->addAdapter(PutenvAdapter::class)
-        ->immutable()
-        ->make();
-    Dotenv::create($repository, __DIR__)->safeLoad();
+    // symfony/dotenv の load() は $_ENV / $_SERVER に既存値がある変数を上書きしない。
+    // putenv は使わない（スレッド安全性のため）ので、env() 関数（$_ENV / $_SERVER 優先）と整合する。
+    (new Dotenv())->load(__DIR__.'/.env');
 }
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
 

--- a/index.php
+++ b/index.php
@@ -30,10 +30,8 @@ if (!isset($_SERVER['APP_ENV'])) {
     }
 
     if ($dotenvExists) {
-        // bootEnv は .env.local.php（dump-env の最適化済みスナップショット）を優先し、
-        // 無ければ .env → .env.local → .env.$env → .env.$env.local をカスケード読み込みする。
-        // 第4引数 true = .env 系の値が既存値より優先（従来の overload 相当）。
-        (new Dotenv())->bootEnv(__DIR__.'/.env', 'dev', ['test'], true);
+        // 第2引数 true = .env 系の値が既存値より優先（従来の overload 相当）。
+        boot_env(__DIR__.'/.env', true);
 
         if (str_contains($_SERVER['DATABASE_URL'] ?? '', 'sqlite') && !extension_loaded('pdo_sqlite')) {
             (new Dotenv())->overload(__DIR__.'/.env.install');
@@ -43,11 +41,11 @@ if (!isset($_SERVER['APP_ENV'])) {
     }
 } elseif (class_exists(Dotenv::class) && $dotenvExists) {
     // OS 環境変数 APP_ENV が設定済みの環境（Docker など）でも .env を読み込む。
-    // 第4引数 false = 既存の OS 環境変数（Docker で設定済みのもの）は上書きしない。
+    // 第2引数 false = 既存の OS 環境変数（Docker で設定済みのもの）は上書きしない。
     // OS 環境変数を保護しつつ、.env 側の非 OS 変数（ECCUBE_TEMPLATE_CODE 等）は反映される。
     // これにより管理画面からのテンプレート切り替えが .env への書き込みで反映される。
     // putenv は使わない（スレッド安全性のため）ので、env() 関数（$_ENV / $_SERVER 優先）と整合する。
-    (new Dotenv())->bootEnv(__DIR__.'/.env', 'dev', ['test'], false);
+    boot_env(__DIR__.'/.env', false);
 }
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
 

--- a/index.php
+++ b/index.php
@@ -19,13 +19,21 @@ if (!file_exists($autoload) && !is_readable($autoload)) {
 require $autoload;
 
 // The check is to ensure we don't use .env in production
+$dotenvExists = file_exists(__DIR__.'/.env')
+    || file_exists(__DIR__.'/.env.local')
+    || file_exists(__DIR__.'/.env.local.php');
+
 if (!isset($_SERVER['APP_ENV'])) {
+    // OS 環境変数 APP_ENV が未設定の環境: .env を設定の源泉として読み込む。
     if (!class_exists(Dotenv::class)) {
         throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
     }
 
-    if (file_exists(__DIR__.'/.env')) {
-        (new Dotenv())->overload(__DIR__.'/.env');
+    if ($dotenvExists) {
+        // bootEnv は .env.local.php（dump-env の最適化済みスナップショット）を優先し、
+        // 無ければ .env → .env.local → .env.$env → .env.$env.local をカスケード読み込みする。
+        // 第4引数 true = .env 系の値が既存値より優先（従来の overload 相当）。
+        (new Dotenv())->bootEnv(__DIR__.'/.env', 'dev', ['test'], true);
 
         if (str_contains($_SERVER['DATABASE_URL'] ?? '', 'sqlite') && !extension_loaded('pdo_sqlite')) {
             (new Dotenv())->overload(__DIR__.'/.env.install');
@@ -33,14 +41,13 @@ if (!isset($_SERVER['APP_ENV'])) {
     } else {
         (new Dotenv())->overload(__DIR__.'/.env.install');
     }
-} elseif (class_exists(Dotenv::class) && file_exists(__DIR__.'/.env')) {
-    // APP_ENV が環境変数として設定されている場合（Docker など）でも .env を読み込む。
-    // ただし既存の環境変数（Docker で設定済みのもの）は上書きしない。
+} elseif (class_exists(Dotenv::class) && $dotenvExists) {
+    // OS 環境変数 APP_ENV が設定済みの環境（Docker など）でも .env を読み込む。
+    // 第4引数 false = 既存の OS 環境変数（Docker で設定済みのもの）は上書きしない。
+    // OS 環境変数を保護しつつ、.env 側の非 OS 変数（ECCUBE_TEMPLATE_CODE 等）は反映される。
     // これにより管理画面からのテンプレート切り替えが .env への書き込みで反映される。
-    //
-    // symfony/dotenv の load() は $_ENV / $_SERVER に既存値がある変数を上書きしない。
     // putenv は使わない（スレッド安全性のため）ので、env() 関数（$_ENV / $_SERVER 優先）と整合する。
-    (new Dotenv())->load(__DIR__.'/.env');
+    (new Dotenv())->bootEnv(__DIR__.'/.env', 'dev', ['test'], false);
 }
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
 

--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
@@ -229,8 +230,10 @@ class InstallerCommand extends Command
         // インストールは .env を再生成するため, dump-env 済みの .env.local.php は
         // 古いスナップショットとなり, 起動時に新しい .env より優先されてしまう.
         // 存在すれば削除し, 再最適化を促す.
-        if (file_exists($envDir.'/.env.local.php')) {
-            @unlink($envDir.'/.env.local.php');
+        $fs = new Filesystem();
+        if ($fs->exists($envDir.'/.env.local.php')) {
+            // 削除失敗時は Filesystem が IOException を送出するため, エラーを握りつぶさない.
+            $fs->remove($envDir.'/.env.local.php');
             $this->io->note('.env.local.php を削除しました。最適化を再適用するには `composer symfony:dump-env prod` を実行してください。');
         }
 

--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -224,10 +224,19 @@ class InstallerCommand extends Command
     #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $envDir = $this->eccubeConfig->get('kernel.project_dir');
+
+        // インストールは .env を再生成するため, dump-env 済みの .env.local.php は
+        // 古いスナップショットとなり, 起動時に新しい .env より優先されてしまう.
+        // 存在すれば削除し, 再最適化を促す.
+        if (file_exists($envDir.'/.env.local.php')) {
+            @unlink($envDir.'/.env.local.php');
+            $this->io->note('.env.local.php を削除しました。最適化を再適用するには `composer symfony:dump-env prod` を実行してください。');
+        }
+
         // Process実行時に, APP_ENV/APP_DEBUGが子プロセスに引き継がれてしまうため,
         // 生成された.envをロードして上書きする.
         if ($input->isInteractive()) {
-            $envDir = $this->eccubeConfig->get('kernel.project_dir');
             if (file_exists($envDir.'/.env')) {
                 (new Dotenv())->overload($envDir.'/.env');
             }

--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -14,7 +14,6 @@
 namespace Eccube\Command;
 
 use Doctrine\DBAL\DriverManager;
-use Dotenv\Dotenv;
 use Eccube\Common\EccubeConfig;
 use Eccube\Util\StringUtil;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -23,6 +22,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
@@ -229,13 +229,13 @@ class InstallerCommand extends Command
         if ($input->isInteractive()) {
             $envDir = $this->eccubeConfig->get('kernel.project_dir');
             if (file_exists($envDir.'/.env')) {
-                Dotenv::createUnsafeMutable($envDir)->load();
+                (new Dotenv())->overload($envDir.'/.env');
             }
         }
 
         // 対話モード実行時, eccubeConfig->get('eccube_database_url')では
-        // 更新後の値が取得できないため, getenv()を使用する.
-        $databaseUrl = getenv('DATABASE_URL');
+        // 更新後の値が取得できないため, overload() で更新された $_SERVER を使用する.
+        $databaseUrl = $_SERVER['DATABASE_URL'] ?? '';
         $databaseName = $this->getDatabaseName($databaseUrl);
 
         $databaseCreate = ['doctrine:database:create'];

--- a/src/Eccube/Controller/Admin/Store/TemplateController.php
+++ b/src/Eccube/Controller/Admin/Store/TemplateController.php
@@ -72,9 +72,14 @@ class TemplateController extends AbstractController
 
             $this->addSuccess('admin.common.save_complete', 'admin');
 
-            // ECCUBE_TEMPLATE_CODE がプロセス環境変数として設定されている場合（Docker などで明示的に設定した場合）、
-            // createImmutable では上書きされないため .env への書き込みが反映されない。
-            if (false !== getenv('ECCUBE_TEMPLATE_CODE')) {
+            // 次のいずれかの場合、.env への書き込みが起動時のロードで反映されない:
+            //   1. ECCUBE_TEMPLATE_CODE がプロセス環境変数として設定されている（Docker などで明示的に設定した場合）。
+            //      bootEnv は OS 環境変数を上書きしないため .env の値が使われない。
+            //   2. .env.local.php（dump-env の最適化済みスナップショット）が存在する。
+            //      bootEnv は .env より .env.local.php を優先するため、再度 `composer symfony:dump-env` を
+            //      実行するまで .env の変更が反映されない。
+            $envLocalPhp = $this->getParameter('kernel.project_dir').'/.env.local.php';
+            if (false !== getenv('ECCUBE_TEMPLATE_CODE') || file_exists($envLocalPhp)) {
                 $this->addWarning('admin.store.template.env_override_warning', 'admin');
             }
 

--- a/src/Eccube/Resource/functions/env.php
+++ b/src/Eccube/Resource/functions/env.php
@@ -11,6 +11,33 @@
  * file that was distributed with this source code.
  */
 
+use Symfony\Component\Dotenv\Dotenv;
+
+/**
+ * .env 系ファイルを読み込む.
+ *
+ * Dotenv::bootEnv() は .env.local.php（dump-env の最適化済みスナップショット）を優先し,
+ * 無ければ .env → .env.local → .env.$env → .env.$env.local をカスケード読み込みする.
+ *
+ * ただし bootEnv() は APP_ENV が prod 以外のとき APP_DEBUG を自動導出して
+ * $_SERVER / $_ENV へ書き込む. EC-CUBE は APP_DEBUG 未定義を「未指定」として扱い,
+ * デバッグ判定は index.php / bin/console 側で, 画面表示は env('APP_DEBUG') で行うため,
+ * 導出値が混入すると .env に APP_DEBUG を持たない環境（APP_ENV=codeception 等）で
+ * 挙動が変わってしまう. これを避けるため, 導出先を未使用のキーへ逃がして破棄する.
+ * .env 系や OS 環境変数に APP_DEBUG が定義されている場合は, 従来どおりその値が使われる.
+ *
+ * @param string $path .env ファイルのパス
+ * @param bool $overrideExistingVars true の場合, .env 系の値が既存の環境変数より優先される
+ */
+function boot_env(string $path, bool $overrideExistingVars = false): void
+{
+    $unusedDebugKey = '__ECCUBE_UNUSED_APP_DEBUG';
+
+    (new Dotenv('APP_ENV', $unusedDebugKey))->bootEnv($path, 'dev', ['test'], $overrideExistingVars);
+
+    unset($_SERVER[$unusedDebugKey], $_ENV[$unusedDebugKey]);
+}
+
 /**
  * Gets the value of an environment variable. Supports boolean, null and empty values.
  *

--- a/symfony.lock
+++ b/symfony.lock
@@ -171,9 +171,6 @@
             "ref": "bb31a3bbec00a8fc8aa1c9fbf9b0ef9fc492f93d"
         }
     },
-    "graham-campbell/result-type": {
-        "version": "v1.0.4"
-    },
     "guzzlehttp/guzzle": {
         "version": "6.3.0"
     },
@@ -230,9 +227,6 @@
     },
     "phpdocumentor/type-resolver": {
         "version": "0.4.0"
-    },
-    "phpoption/phpoption": {
-        "version": "1.8.1"
     },
     "phpspec/prophecy": {
         "version": "1.7.5"
@@ -673,9 +667,6 @@
     },
     "twig/twig": {
         "version": "v2.4.4"
-    },
-    "vlucas/phpdotenv": {
-        "version": "v2.4.0"
     },
     "webmozart/assert": {
         "version": "1.3.0"


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

EC-CUBE 本体の `.env` ロードを `vlucas/phpdotenv` から `symfony/dotenv` に一本化し、さらに Symfony 標準の `bootEnv()` へ移行します。これにより以下を獲得します。

- `.env` カスケード: `.env` → `.env.local` → `.env.$APP_ENV` → `.env.$APP_ENV.local`
- `composer symfony:dump-env` による **`.env.local.php` 最適化**（実行時の `.env` パースを省略し起動を高速化）
- 依存パッケージの削減（`vlucas/phpdotenv` + `phpoption` + `graham-campbell/result-type` を除去）

テストは既に `symfony/dotenv`（`bootEnv()`）を使用しており、本 PR で本体・CLI と揃い全体が一本化されます。

## 方針(Policy)

- **`index.php` のロードパターンを維持**: `if (!isset($_SERVER['APP_ENV']))` → `.env` を読み込む分岐は、OS 環境変数 `APP_ENV` を設定しない環境（共有ホスティング等）が依存するため、構造・条件を崩さずに `bootEnv()` へ置換。
- **上書き優先順位を現行と一致**させるため `overrideExistingVars` を分岐ごとに設定:
  - `APP_ENV` 未設定の環境 = `true`（`.env` が優先。従来の `overload()` 相当）
  - `APP_ENV` 設定済み（Docker 等） = `false`（OS 環境変数を保護。従来の `load()` 相当）
  - `symfony/dotenv` は dotenv 由来の変数を `SYMFONY_DOTENV_VARS` で追跡するため、`false` でも `.env.local` 等のカスケード上書きは機能する（実測で確認）。
- **`putenv` は不使用**（スレッド安全性）。`env()` は既に `$_ENV`/`$_SERVER` 優先のため整合。`getenv('DATABASE_URL')` 参照箇所は `$_SERVER['DATABASE_URL']` に変更。
- **`.env` 一本の既存運用は不変**: `.env.local.php` は CLI（`composer symfony:dump-env`）が必要なため、CLI を使えない環境では生成されず `.env` 直読みが継続。管理画面からの `.env` 書き換え（テンプレート切替）も従来どおり反映される。

## 実装に関する補足(Appendix)

`.env.local.php`（dump-env スナップショット）が存在すると `bootEnv()` は `.env` より優先するため、実行時の `.env` 書き換えが起動まで反映されません。これに対する安全策:

- **`InstallerCommand`**: インストールは `.env` を再生成するため、古い `.env.local.php` を削除し、再最適化（`composer symfony:dump-env prod`）を促す note を表示。
- **`TemplateController`**: `.env.local.php` 存在時はテンプレート切替の警告を表示（`putenv` 撤廃により従来の `getenv()` 検知が効かないため、ファイル存在で判定）。
- **子プロセスへの環境変数伝播**: `putenv` なしでも `overload()`/`bootEnv()` が書く `$_ENV` を `Process::getDefaultEnv()`（`$_ENV + getenv()`）が継承するため、`InstallerCommand` が spawn する子プロセス（`doctrine:*` 等）に `DATABASE_URL`/`APP_ENV` が正しく伝播する。

## テスト（Test)

PHPStan（level 6）/ php-cs-fixer（PSR-12）/ 各エントリの構文チェックに加え、以下を**ローカル実測**しました。

### CLI（`bin/console`）のテスト方法

```bash
# 1. bin/console の起動と .env ロード確認（APP_ENV 未設定環境＝.env 経路）
bin/console about            # Environment=prod で起動すること

# 2. dump-env 最適化が優先されること
composer symfony:dump-env dev
bin/console about            # Environment=dev（.env.local.php が .env に優先）
rm -f .env.local.php
bin/console about            # Environment=prod に復帰

# 3. 非対話インストールの完走（子プロセスへの env 伝播の検証）
bin/console eccube:install -n
#   → doctrine:database:create / schema:create / eccube:fixtures:load /
#     cache:clear（prod environment）まで完走し [OK] installation successful（exit 0）
#   → SQLite DB（var/eccube.db）が再構築される

# 4. インストール時に古い .env.local.php が削除されること
composer symfony:dump-env prod
bin/console eccube:install -n
#   → 冒頭に「.env.local.php を削除しました…」の [NOTE] が表示され、
#     インストール後にファイルが削除されていること
```

### 検証済み項目

- [x] `.env.local.php` 無し（`APP_ENV` 未設定環境）= 従来挙動を維持（`bin/console about` = prod）
- [x] Docker 分岐（`overrideExistingVars=false`）= OS 環境変数 `DATABASE_URL` を保護
- [x] `.env.local` カスケード = `overrideExistingVars=false` でも `.env` を上書き
- [x] `.env.local.php`（dump-env）= `.env` より優先されて使用される
- [x] `.env.local` / `.env.local.php` が `.gitignore` で無視される
- [x] `bin/console eccube:install -n` 完走（子プロセス伝播）… exit 0 / DB 再構築
- [x] インストール時に古い `.env.local.php` を削除
- [x] PHPStan level 6 / php-cs-fixer / 構文チェック

> SQLite（`var/eccube.db`）はテストで再作成しています。

## 相談（Discussion）

- `.env.local.php` は「デプロイ後に env が不変な本番環境向けの opt-in 最適化」です。管理画面からの `.env` 編集に依存する運用では使わない想定で、上記の警告・削除で緩和しています。この方針・警告文言についてご意見あればお願いします。

## マイナーバージョン互換性保持のための制限事項チェックリスト

<!-- 本 PR は 4.4（メジャー更新）向け。.env ロード基盤の変更で、ランタイムの外部挙動（.env 一本のロード）は維持しています。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * `.env`、`.env.local`、`.env.local.php` の読み込みを見直し、`APP_ENV` に応じて適切に反映しつつ、既存の環境変数の上書きを抑制しました。
  * インストール/起動時の初期化とデータベース設定の反映を調整しました。
  * テンプレート設定が反映されないケースの警告条件を拡張しました。
  * ローカル用の `.env*local` をGit追跡から除外しました。
* **テスト**
  * 受け入れ/E2E テストでもローカル環境設定を正しく利用できるよう更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->