### PR TITLE
fix(rector): AssertEqualsToSameRector の二重登録を削除

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -21,7 +21,6 @@ use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\Doctrine\Bundle210\Rector\Class_\EventSubscriberInterfaceToAttributeRector;
 use Rector\Doctrine\Set\DoctrineSetList;
 use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
@@ -79,7 +78,6 @@ return RectorConfig::configure()
            ])
            // 個別にルールを追加する場合はここに記述
            ->withRules([
-               AssertEqualsToSameRector::class, // PHPUnitのassertEqualsをassertSameに変換する,
                CommandConfigureToAttributeRector::class, // Symfonyコマンドのconfigureメソッドをアトリビュートに変換する
                CommandPropertyToAttributeRector::class, // Symfonyコマンドのプロパティをアトリビュートに変換する,
                StaticDataProviderClassMethodRector::class, // PHPUnitのデータプロバイダを静的メソッドに変換する


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

`rector.php` で `AssertEqualsToSameRector` が二重に登録されていたため、明示登録側を削除します。

- `withRules()` に `AssertEqualsToSameRector::class` を明示登録している
- 一方で `withSets()` の `PHPUnitSetList::PHPUNIT_CODE_QUALITY`（`config/sets/phpunit-code-quality.php`）にも同じルールが含まれている

セット側に含まれているため、明示登録は冗長です。

## 方針(Policy)

- ルールの供給元をセット（`PHPUNIT_CODE_QUALITY`）に一本化し、設定の重複を解消する。
- Rector は同一ルールを内部で重複排除するため、この変更による**変換挙動の差はない**（設定の可読性・意図の明確化が目的）。

## 実装に関する補足(Appendix)

- 削除に伴い未使用となる `use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector;` も併せて削除。
- `PHPUNIT_CODE_QUALITY` にルールが含まれることの根拠: `vendor/rector/rector/vendor/rector/rector-phpunit/config/sets/phpunit-code-quality.php`（`$rectorConfig->rules([...])` 内に `AssertEqualsToSameRector::class`）。

## テスト（Test)

- 設定ファイル（`rector.php`）のみの変更で、`src` / `tests` のコードには影響なし。
- `vendor/bin/rector process --dry-run --config=rector.php` で変換結果が変わらないことを確認。

## 相談（Discussion）

特になし。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 自動コード変換の設定を更新し、PHPUnitの`assertEquals`を`assertSame`へ自動変換しないようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->