### PR TITLE
chore(composer): composer.json の残骸整理と暗黙依存の明示化

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,19 @@
     "support": {
         "issues": "https://github.com/EC-CUBE/ec-cube/issues"
     },
-    "minimum-stability": "RC",
     "prefer-stable": true,
     "require": {
         "php": "^8.2",
         "ext-curl": "*",
+        "ext-filter": "*",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
+        "ext-tokenizer": "*",
+        "ext-xml": "*",
         "ext-zip": "*",
+        "ext-zlib": "*",
         "composer/ca-bundle": "^1.1",
         "composer/composer": "^2.9",
         "doctrine/collections": "^2.1",
@@ -37,13 +40,16 @@
         "ec-cube/plugin-installer": "^2.0",
         "egulias/email-validator": "^4.0",
         "exercise/htmlpurifier-bundle": "^5.0",
+        "ezyang/htmlpurifier": "^4.14",
         "friendsofphp/php-cs-fixer": "^3.75",
         "guzzlehttp/guzzle": "^7.4.5",
+        "justinrainbow/json-schema": "^6.5",
         "knplabs/knp-paginator-bundle": "^6.8",
         "mobiledetect/mobiledetectlib": "^2.8",
         "monolog/monolog": "^3.0",
         "nanasess/bcmath-polyfill": "^1.0",
         "nesbot/carbon": "^3",
+        "phpseclib/phpseclib": "^3.0",
         "psr/cache": "^3.0",
         "psr/container": "^2.0",
         "psr/http-message": "^1.0 || ^2.0",
@@ -51,7 +57,6 @@
         "psr/simple-cache": "^3.0",
         "robthree/twofactorauth": "^3.0",
         "setasign/fpdi": "^2.2",
-        "skorp/detect-incompatible-samesite-useragents": "^1.0",
         "softcreatr/jsonpath": "^0.8",
         "symfony/asset": "^7.4",
         "symfony/cache": "^7.4",
@@ -167,19 +172,13 @@
         ]
     },
     "conflict": {
-        "symfony/symfony": "*",
-        "easycorp/easy-log-handler": "1.0.4|1.0.5"
+        "symfony/symfony": "*"
     },
     "extra": {
         "symfony": {
             "id": "01C0Q71D54BCVSB8ZWR3VECDRD",
             "allow-contrib": false
-        },
-        "symfony-web-dir": ".",
-        "bin-dir": "bin",
-        "src-dir": "src/Eccube",
-        "config-dir": "app/config/eccube",
-        "public-dir": "."
+        }
     },
     "config": {
         "platform": {
@@ -193,7 +192,6 @@
         "sort-packages": true,
         "allow-plugins": {
             "composer/*": true,
-            "kylekatarnls/update-helper": true,
             "ec-cube/plugin-installer": true,
             "phpstan/extension-installer": true,
             "symfony/flex": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b609f33937ec3f4694c1dc84c1f135f3",
+    "content-hash": "24ff6ea2484f4f8eef6753e72d0f6220",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -5338,54 +5338,6 @@
                 }
             ],
             "time": "2026-05-13T10:16:22+00:00"
-        },
-        {
-            "name": "skorp/detect-incompatible-samesite-useragents",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/skorp/detect-incompatible-samesite-useragents.git",
-                "reference": "e3277efe3c12ac618af4536ba1bdb55c33c1ef80"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/skorp/detect-incompatible-samesite-useragents/zipball/e3277efe3c12ac618af4536ba1bdb55c33c1ef80",
-                "reference": "e3277efe3c12ac618af4536ba1bdb55c33c1ef80",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Skorp\\Dissua\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kadir Özdemir"
-                }
-            ],
-            "description": "Determine if UserAgent is incompatible with SameSite=None",
-            "keywords": [
-                "cookies",
-                "safari",
-                "samesite",
-                "samesite cookie"
-            ],
-            "support": {
-                "issues": "https://github.com/skorp/detect-incompatible-samesite-useragents/issues",
-                "source": "https://github.com/skorp/detect-incompatible-samesite-useragents/tree/1.0.1"
-            },
-            "time": "2021-06-25T07:29:16+00:00"
         },
         {
             "name": "softcreatr/jsonpath",
@@ -15290,18 +15242,22 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "RC",
+    "minimum-stability": "stable",
     "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2",
         "ext-curl": "*",
+        "ext-filter": "*",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "ext-zip": "*"
+        "ext-tokenizer": "*",
+        "ext-xml": "*",
+        "ext-zip": "*",
+        "ext-zlib": "*"
     },
     "platform-dev": {},
     "platform-overrides": {

--- a/symfony.lock
+++ b/symfony.lock
@@ -26,9 +26,6 @@
     "codeception/module-webdriver": {
         "version": "1.2.0"
     },
-    "codeception/phpunit-wrapper": {
-        "version": "6.0.9"
-    },
     "codeception/stub": {
         "version": "1.0.2"
     },
@@ -64,9 +61,6 @@
         "files": [
             "app/config/eccube/packages/test/dama_doctrine_test_bundle.yaml"
         ]
-    },
-    "doctrine/cache": {
-        "version": "v1.7.1"
     },
     "doctrine/collections": {
         "version": "v1.5.0"
@@ -131,15 +125,6 @@
     },
     "doctrine/sql-formatter": {
         "version": "1.1.1"
-    },
-    "easycorp/easy-log-handler": {
-        "version": "1.0",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "1.0",
-            "ref": "70062abc2cd58794d2a90274502f81b55cd9951b"
-        }
     },
     "ec-cube/plugin-installer": {
         "version": "0.0.3"
@@ -213,23 +198,8 @@
     "phar-io/version": {
         "version": "1.0.1"
     },
-    "php-cs-fixer/diff": {
-        "version": "v1.2.0"
-    },
     "php-webdriver/webdriver": {
         "version": "1.10.0"
-    },
-    "phpdocumentor/reflection-common": {
-        "version": "1.0.1"
-    },
-    "phpdocumentor/reflection-docblock": {
-        "version": "4.3.0"
-    },
-    "phpdocumentor/type-resolver": {
-        "version": "0.4.0"
-    },
-    "phpspec/prophecy": {
-        "version": "1.7.5"
     },
     "phpstan/phpstan": {
         "version": "0.12.70"
@@ -344,12 +314,6 @@
     "setasign/fpdi": {
         "version": "v2.0.3"
     },
-    "setasign/fpdi-tcpdf": {
-        "version": "v2.0.0"
-    },
-    "skorp/detect-incompatible-samesite-useragents": {
-        "version": "1.0.0"
-    },
     "softcreatr/jsonpath": {
         "version": "0.7.5"
     },
@@ -443,9 +407,6 @@
     "symfony/http-kernel": {
         "version": "v3.4.1"
     },
-    "symfony/inflector": {
-        "version": "v3.4.1"
-    },
     "symfony/intl": {
         "version": "v3.4.1"
     },
@@ -533,9 +494,6 @@
     "symfony/polyfill-mbstring": {
         "version": "v1.6.0"
     },
-    "symfony/polyfill-php72": {
-        "version": "v1.6.0"
-    },
     "symfony/polyfill-php73": {
         "version": "v1.13.0"
     },
@@ -580,9 +538,6 @@
     },
     "symfony/security-csrf": {
         "version": "v3.4.1"
-    },
-    "symfony/security-guard": {
-        "version": "v5.4.3"
     },
     "symfony/security-http": {
         "version": "v5.4.5"
@@ -667,9 +622,6 @@
     },
     "twig/twig": {
         "version": "v2.4.4"
-    },
-    "webmozart/assert": {
-        "version": "1.3.0"
     },
     "zbateson/mail-mime-parser": {
         "version": "1.3.3"


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

`composer.json` に、既に使われていない項目や実態と乖離した宣言が残っていたため整理します。あわせて、**本番コードが他パッケージの内部都合で入っている依存に乗っている**状態を解消します。

きっかけは `conflict` の `easycorp/easy-log-handler` が残存していた点ですが、調査したところ同種の残骸が複数あり、より深刻な暗黙依存も見つかりました。

**共有レンタルサーバーでの導入経路には一切影響しません**(後述の検証参照)。

## 方針(Policy)

### 1. 残骸の削除

いずれも git 履歴で「利用側が削除された後に取り残された」ことを確認しています。

| 項目 | 根拠 |
|---|---|
| `conflict.easycorp/easy-log-handler` | 2018年に 1.0.4 回避で追加 (4ae8ed91a1) → Symfony 6 移行 (f547034d76) で本体のみ削除。lock 内の誰も require/suggest しておらず不活性 |
| `skorp/detect-incompatible-samesite-useragents` | 利用側の `SameSiteNoneCompatSessionHandler` が 3116014b07 で削除済み。SameSite 対応は Symfony ネイティブの `cookie_samesite: none` に移行済み |
| `allow-plugins.kylekatarnls/update-helper` | Carbon 2 時代の残骸。Carbon 3 は要求せず lock にも不在 |
| `minimum-stability: RC` | Symfony 3.3.0-rc1 時代 (014119afa0) の名残。現在 lock 内の非 stable は 0 件 |
| `extra` の `symfony-web-dir`/`bin-dir`/`src-dir`/`config-dir`/`public-dir` | リポジトリ内・vendor 内ともに読み手が存在しない Symfony Standard Edition 時代の遺物 |
| `symfony.lock` の孤児レシピ 13 件 | `symfony/security-guard` (Symfony 6 で廃止)、`symfony/polyfill-php72` 等、composer.lock に存在しないもの |

### 2. 暗黙依存の明示化(本 PR の主眼)

本体コードが直接 `use` しているのに、他パッケージの内部依存に相乗りしていたものを `require` に明示します。**上流のマイナー更新で消えると本番コードが壊れる**状態でした。

| パッケージ | 使用箇所 | これまでの供給元 |
|---|---|---|
| `phpseclib/phpseclib` | `UcpMessageSigner` 等の ECDSA 署名 (3ファイル) | **`nanasess/bcmath-polyfill` のみ** |
| `justinrainbow/json-schema` | `AcpFeedValidator` | **`composer/composer` のみ** |
| `ezyang/htmlpurifier` | `CsvImportController:98` が `\HTMLPurifier` を型指定 | `exercise/htmlpurifier-bundle` |

### 3. PHP 拡張の宣言漏れ

本体が直接使用し、**かつ vendor 側が既に require しているもの**に限定しました。そのため導入可能な環境は 1 つも変わりません。

| 拡張 | 本体での使用 | 既存の要求元 |
|---|---|---|
| `ext-filter` | `UcpProfileFetcher` の `filter_var` による SSRF 対策 | `friendsofphp/php-cs-fixer` |
| `ext-tokenizer` | `TraitProxyAttributeDriver` の `PhpToken` | `php-cs-fixer/shim` |
| `ext-xml` | — | `symfony/framework-bundle` 等 |
| `ext-zlib` | `UcpCatalogController` の `gzencode` | `setasign/fpdi` |

### 除外したもの

- **`ext-sodium` / `ext-bcmath`**: sodium・bcmath 非搭載の共有レンタルサーバーが実在するため追加しません。sodium は #6827 の `config.platform` による緩和を維持します。
- **`ext-pdo` / `ext-session` / `ext-phar` / `ext-fileinfo`**: 現状どのパッケージも要求しておらず、`require` に書くと**新たに導入不能な環境が生じる**ため見送りました。
- **`guzzlehttp/guzzle`**: 本体は未使用ですが、guzzle を自前宣言していないプラグインを壊す懸念があるため保留しました。

保留・積み残しは #6940 にまとめました。

## 実装に関する補足(Appendix)

`friendsofphp/php-cs-fixer` が `require`(本番)にあるのは正しい状態です。`EntityProxyService` と `ReloadSafeAttributeDriver` がプロキシ生成時に `PhpCsFixer\Tokenizer\Tokens` を実行時利用するため、`require-dev` には移せません。

同様に `symfony/debug-bundle` / `web-profiler-bundle` は `install` env で有効化されているため本番依存のままとしています。

制約はいずれも lock を動かさない緩さにしたため、**パッケージのバージョン更新は発生していません**(skorp の削除のみ)。

## テスト（Test)

`config.platform` で拡張を無効化して「拡張なしのレンタルサーバー」を再現し、`composer update --dry-run` で検証しました(`composer check-platform-reqs` は `config.platform` を無視するため使用していません)。

- **追加した 4 拡張は既に必須化済み**であることを実証。無効化すると本 PR 以前から `composer update` が失敗します。
  ```
  - setasign/fpdi require ext-zlib * -> disabled by your platform config
  - symfony/framework-bundle require ext-xml * -> disabled by your platform config
  - friendsofphp/php-cs-fixer require ext-filter * -> disabled by your platform config
  - php-cs-fixer/shim require ext-tokenizer * -> disabled by your platform config
  ```
- **対照実験**: polyfill を持たない `ext-fileinfo` を `require` に足すと `exit=2` で解決不能になることを確認。だからこそカテゴリ外の拡張は追加していません。

その他:

- [x] `composer validate` → valid
- [x] `composer check-platform-reqs` → exit=0
- [x] `composer install --dry-run` → `Nothing to install, update or remove`(孤児削除で再インストールが誘発されないことの確認)
- [x] `composer recipes` → 正常
- [x] `bin/console` 起動 → exit=0
- [x] 削除した `skorp` / `easy-log-handler` への参照がゼロであることを確認
- [x] phpseclib を直接使う `tests/Eccube/Tests/Service/AgentCommerce/Acp` → OK (24 tests, 34 assertions)

**未検証**: `tests/.../AgentCommerce/` 全体ではローカル環境の DB スキーマ未適用により 42 件エラーが出ます。内訳はすべて `no such table: dtb_base_info` 等で、`Class not found` 等の依存起因エラーは 0 件のため本変更とは無関係と判断していますが、DB を修復しての全件通過は未確認です。CI での確認をお願いします。

## 相談（Discussion）

`extra` の `symfony-web-dir` / `src-dir` / `config-dir` 等は、リポジトリ内・vendor 内に読み手が見つからないため削除しました。**ec-cube.co の自動インストーラ等、リポジトリ外のツールが参照していないか**が未検証です。心当たりがあればご指摘ください。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

なお `skorp/detect-incompatible-samesite-useragents` を vendor から除去するため、同パッケージに依存するプラグインがあれば影響します(本体からの参照は 0 件を確認済み)。

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **依存関係**
  * 必要なPHP拡張機能の要件を追加しました。
  * HTMLサニタイズ、JSONスキーマ検証、暗号化処理などに関するパッケージを更新しました。
  * 一部の不要な競合指定およびプラグイン許可設定を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
