### PR TITLE
docs: Docker 環境の HTTPS アクセス手順を README に追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,48 @@
 
 開発ドキュメントの [インストール方法](https://doc4.ec-cube.net/quickstart/install) の手順に従ってインストールしてください。
 
+### Docker 環境へのアクセス
+
+`docker compose ... up -d` で起動後、以下の URL でアクセスします。
+
+- フロント: `https://127.0.0.1:4430/`
+- 管理画面: `https://127.0.0.1:4430/admin/`（初期ログインは `admin` / `password`）
+- MailCatcher（送信メールの確認）: `http://localhost:1080/`
+
+> **HTTP（`http://localhost:8080`）ではログインできません。**
+> セッションクッキーが `SameSite=None` で発行されるため、ブラウザの仕様上 HTTPS 接続でないとクッキーが破棄され、ログイン・カートなどセッションを使う操作が成立しません（設定: `app/config/eccube/packages/framework.yaml` の `cookie_secure: auto` / `cookie_samesite: none`）。開発時は HTTPS（4430 番ポート）を使用してください。
+
+#### 「保護されていない通信」の警告を消す（任意）
+
+HTTPS でアクセスすると、ブラウザに「保護されていない通信」の警告が表示されます。これは Docker イメージが Apache の自己署名証明書（snakeoil）を使っているためで、動作上の問題はありません。そのまま「詳細設定」→「127.0.0.1 にアクセスする（安全ではありません）」で進めば利用できます。
+
+警告自体を消したい場合は、[mkcert](https://github.com/FiloSottile/mkcert) でローカル信頼の証明書を発行し、コンテナの証明書と差し替えます。
+
+```shell
+# 1. ローカル CA を OS に登録し、127.0.0.1 用の証明書を発行する
+mkcert -install
+mkcert 127.0.0.1 localhost
+# → 127.0.0.1+1.pem（証明書）と 127.0.0.1+1-key.pem（秘密鍵）が生成される
+```
+
+`docker-compose.dev.yml` の `ec-cube` サービスに、生成した証明書をコンテナの snakeoil 証明書へ上書きマウントする設定を追記します。
+
+```yaml
+services:
+  ec-cube:
+    volumes:
+      - ".:/var/www/html:cached"
+      - "./127.0.0.1+1.pem:/etc/ssl/certs/ssl-cert-snakeoil.pem"
+      - "./127.0.0.1+1-key.pem:/etc/ssl/private/ssl-cert-snakeoil.key"
+```
+
+```shell
+# 2. コンテナを再作成して反映する
+docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml up -d
+```
+
+> 生成した `*.pem` / `*-key.pem`（特に秘密鍵）はリポジトリにコミットしないでください（`.gitignore` に追加するなどしてください）。
+
 ### CSS の編集・ビルド方法
 
 [Sass](https://sass-lang.com) を使用して記述されています。
@@ -147,7 +189,9 @@ Key differentiators:
 git clone https://github.com/EC-CUBE/ec-cube.git
 cd ec-cube
 docker compose -f docker-compose.yml -f docker-compose.pgsql.yml up -d
-# Access http://localhost:8080
+# Access https://127.0.0.1:4430/ (admin: https://127.0.0.1:4430/admin/)
+# Note: login does not work over HTTP (http://localhost:8080) because the
+# session cookie is issued with SameSite=None, which browsers only accept over HTTPS.
 ```
 
 #### Composer

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose
 
 > 生成した `*.pem` / `*-key.pem`（特に秘密鍵）はリポジトリにコミットしないでください（`.gitignore` に追加するなどしてください）。
 
+> **WSL2 + Windows のブラウザを使う場合**: WSL 内で `mkcert -install` を実行しても、Windows 側ブラウザ（Chrome / Edge は Windows の証明書ストアを参照）には反映されません。`mkcert -CAROOT` にある `rootCA.pem` を Windows にコピーし、Windows 側で「信頼されたルート証明機関」に取り込んでください（例: PowerShell で `Import-Certificate -FilePath <path> -CertStoreLocation Cert:\CurrentUser\Root`）。取り込み後はブラウザを完全に再起動します。
+
 ### CSS の編集・ビルド方法
 
 [Sass](https://sass-lang.com) を使用して記述されています。


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

`docker compose ... up -d` で起動した開発環境のアクセス方法について、README が `http://localhost:8080` のみを案内していますが、この URL では**ログインできません**。

dev/prod 環境のセッションクッキーは `app/config/eccube/packages/framework.yaml` で `cookie_samesite: none`（＋ `cookie_secure: auto`）で発行されます。`SameSite=None` のクッキーはブラウザ仕様上 `Secure` 属性（＝HTTPS 接続）が必須で、HTTP 接続だとクッキーが破棄されるため、ログイン・カートなどセッションを使う操作が成立しません。

実際に必要な HTTPS（`https://127.0.0.1:4430/` = docker-compose.yml の `4430:443`）でのアクセス方法と、自己署名証明書（Apache snakeoil）による「保護されていない通信」警告の解消手順を追記します。

## 方針(Policy)

- 日本語インストール節に「Docker 環境へのアクセス」小節を新設し、アクセス URL・HTTP でログイン不可の理由・mkcert による警告解消手順を記載。
- 英語版 Quick Start の `# Access http://localhost:8080` を HTTPS 案内へ訂正。
- ドキュメント（README.md）のみの変更で、コード・設定・挙動の変更はありません。

## 実装に関する補足(Appendix)

- HTTPS 化（`a2enmod ssl` / `default-ssl.conf` / `EXPOSE 443`）は Dockerfile に以前から存在します。今回はコードは変えず、README の案内を実態に合わせるものです。
- mkcert 手順は任意（警告を消したい開発者向け）で、証明書はコミットしない旨を注記しています。

## テスト（Test)

ドキュメントのみの変更のため、テスト・静的解析の対象はありません。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * Docker環境でのHTTPSアクセス手順（アクセス先の切替を含む）を追加しました。
  * HTTPではログインできない理由（SameSite cookieによりHTTPS必須）を明記しました。
  * 自己署名証明書による警告の扱いと、`mkcert`でローカル信頼証明書を発行してコンテナへ反映する手順を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->