### PR TITLE
feat(order): 受注・出荷編集画面で入金日・出荷日を手動編集可能にする

### DIFF
--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -33,6 +33,7 @@ use Eccube\Service\OrderStateMachine;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
@@ -163,6 +164,18 @@ class OrderType extends AbstractType
                 'required' => false,
                 'constraints' => [
                     new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
+                ],
+            ])
+            ->add('payment_date', DateTimeType::class, [
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'with_seconds' => true,
+                'constraints' => [
+                    new Assert\Range([
+                        'min' => '0003-01-01',
+                        'minMessage' => 'form_error.out_of_range',
+                    ]),
                 ],
             ])
             ->add('Payment', EntityType::class, [

--- a/src/Eccube/Form/Type/Admin/ShippingType.php
+++ b/src/Eccube/Form/Type/Admin/ShippingType.php
@@ -32,6 +32,7 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -151,6 +152,18 @@ class ShippingType extends AbstractType
                 'required' => false,
                 'input' => 'datetime',
                 'widget' => 'single_text',
+                'constraints' => [
+                    new Assert\Range([
+                        'min' => '0003-01-01',
+                        'minMessage' => 'form_error.out_of_range',
+                    ]),
+                ],
+            ])
+            ->add('shipping_date', DateTimeType::class, [
+                'required' => false,
+                'input' => 'datetime',
+                'widget' => 'single_text',
+                'with_seconds' => true,
                 'constraints' => [
                     new Assert\Range([
                         'min' => '0003-01-01',

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -190,6 +190,13 @@ file that was distributed with this source code.
                     }
                 }
             });
+
+            // 入金日・出荷日: 鉛筆アイコン押下で入力欄を表示する(誤操作防止).
+            $(document).on('click', '.date-edit-toggle', function() {
+                var $col = $(this).closest('.col');
+                $col.find('.date-edit-view').addClass('d-none');
+                $col.find('.date-edit-input').removeClass('d-none');
+            });
         });
 
         {# ポイント機能が有効かつ会員の場合のみポイントの割引金額を変更する #}
@@ -301,13 +308,29 @@ file that was distributed with this source code.
                                         </div>
                                         <div class="row mb-3">
                                             <div class="col-3"><i class="fa fa-money fa-fw me-1" aria-hidden="true"></i>{{ 'admin.order.payment_date'|trans }}</div>
-                                            <div class="col">{{ Order.payment_date ? Order.payment_date|date_sec : '' }}</div>
+                                            <div class="col">
+                                                <span class="date-edit-view">
+                                                    {{ Order.payment_date ? Order.payment_date|date_sec : '' }}
+                                                    <a class="btn btn-ec-actionIcon date-edit-toggle" href="javascript:;" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'admin.common.edit'|trans }}"><i class="fa fa-pencil fa-lg text-secondary" aria-hidden="true"></i></a>
+                                                </span>
+                                                <span class="date-edit-input d-none">
+                                                    {{ form_widget(form.payment_date) }}
+                                                    {{ form_errors(form.payment_date) }}
+                                                </span>
+                                            </div>
                                         </div>
                                         {% if not Order.isMultiple %}
                                             <div class="row mb-3">
                                                 <div class="col-3"><i class="fa fa-truck fa-fw me-1" aria-hidden="true"></i>{{ 'admin.order.shipping_date'|trans }}</div>
                                                 <div class="col">
-                                                    {{ Order.Shippings[0].shipping_date|date_sec }}
+                                                    <span class="date-edit-view">
+                                                        {{ Order.Shippings[0].shipping_date|date_sec }}
+                                                        <a class="btn btn-ec-actionIcon date-edit-toggle" href="javascript:;" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'admin.common.edit'|trans }}"><i class="fa fa-pencil fa-lg text-secondary" aria-hidden="true"></i></a>
+                                                    </span>
+                                                    <span class="date-edit-input d-none">
+                                                        {{ form_widget(form.Shipping.shipping_date) }}
+                                                        {{ form_errors(form.Shipping.shipping_date) }}
+                                                    </span>
                                                 </div>
                                             </div>
                                         {% endif %}

--- a/src/Eccube/Resource/template/admin/Order/shipping.twig
+++ b/src/Eccube/Resource/template/admin/Order/shipping.twig
@@ -22,6 +22,13 @@ file that was distributed with this source code.
     <script src="//yubinbango.github.io/yubinbango/yubinbango.js" charset="UTF-8"></script>
 
     <script>
+        // 出荷日: 鉛筆アイコン押下で入力欄を表示する(誤操作防止).
+        $(document).on('click', '.date-edit-toggle', function() {
+            var $col = $(this).closest('.col');
+            $col.find('.date-edit-view').addClass('d-none');
+            $col.find('.date-edit-input').removeClass('d-none');
+        });
+
         // 商品追加
         $('.addProduct-button').on('click', function() {
             var no = $(this).data('shipping-no');
@@ -469,7 +476,14 @@ file that was distributed with this source code.
                                                 <div class="col">
                                                     {% if shippingForm.vars.value.shipping_date %}
                                                         {# 登録済みの出荷で出荷日が設定されている場合は出荷日を表示する #}
-                                                        <span>{{ shippingForm.vars.value.shipping_date|date_min }}</span>
+                                                        <span class="date-edit-view">
+                                                            {{ shippingForm.vars.value.shipping_date|date_min }}
+                                                            <a class="btn btn-ec-actionIcon date-edit-toggle" href="javascript:;" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'admin.common.edit'|trans }}"><i class="fa fa-pencil fa-lg text-secondary" aria-hidden="true"></i></a>
+                                                        </span>
+                                                        <span class="date-edit-input d-none">
+                                                            {{ form_widget(shippingForm.shipping_date) }}
+                                                            {{ form_errors(shippingForm.shipping_date) }}
+                                                        </span>
                                                     {% elseif shippingForm.vars.value.id %}
                                                         {# 登録済みの出荷で出荷日が設定されていない場合 #}
                                                         <!-- 出荷済にするボタン -->

--- a/src/Eccube/Service/OrderStateMachine.php
+++ b/src/Eccube/Service/OrderStateMachine.php
@@ -108,7 +108,10 @@ class OrderStateMachine implements EventSubscriberInterface
     {
         /* @var Order $Order */
         $Order = $event->getSubject()->getOrder();
-        $Order->setPaymentDate(new \DateTime());
+        // 管理者が入金日を手動でセットしている場合は上書きしない.
+        if (null === $Order->getPaymentDate()) {
+            $Order->setPaymentDate(new \DateTime());
+        }
     }
 
     /**

--- a/tests/Eccube/Tests/Service/OrderStateMachineTest.php
+++ b/tests/Eccube/Tests/Service/OrderStateMachineTest.php
@@ -103,6 +103,19 @@ final class OrderStateMachineTest extends EccubeTestCase
         $this->assertInstanceOf(\DateTime::class, $Order->getPaymentDate(), '入金済みになれば入金日が設定される');
     }
 
+    public function testTransitionPayKeepsManualPaymentDate()
+    {
+        $Order = $this->createOrder($this->createCustomer());
+        $Order->setOrderStatus($this->statusOf(OrderStatus::NEW));
+        // 管理者が手動で入金日を設定済みのケース.
+        $manualPaymentDate = new \DateTime('2020-01-01 12:34:56');
+        $Order->setPaymentDate($manualPaymentDate);
+
+        $this->stateMachine->apply($Order, $this->statusOf(OrderStatus::PAID));
+
+        $this->assertEquals($manualPaymentDate, $Order->getPaymentDate(), '手動設定した入金日は入金済み遷移で上書きされない');
+    }
+
     public function testTransitionCancel()
     {
         /** @var ProductClass[] $ProductClasses */

--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -157,6 +157,112 @@ final class EditControllerTest extends AbstractEditControllerTestCase
     }
 
     /**
+     * 受注編集画面で入金日を手動で編集できることを確認するテスト.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6528
+     */
+    public function testEditPaymentDate()
+    {
+        $Customer = $this->createCustomer();
+        $Order = $this->createOrder($Customer);
+        $Order->setOrderStatus($this->entityManager->find(OrderStatus::class, OrderStatus::NEW));
+        $this->entityManager->flush($Order);
+
+        $formData = $this->createFormData($Customer, $this->Product);
+        // ステータス遷移を発生させず入金日の編集のみを検証する.
+        $formData['OrderStatus'] = OrderStatus::NEW;
+        $formData['payment_date'] = '2021-05-06T07:08:09';
+
+        $this->client->request(
+            Request::METHOD_POST,
+            $this->generateUrl('admin_order_edit', ['id' => $Order->getId()]),
+            [
+                'order' => $formData,
+                'mode' => 'register',
+            ]
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('admin_order_edit', ['id' => $Order->getId()])));
+
+        $EditedOrder = $this->orderRepository->find($Order->getId());
+        // タイムゾーン表現に依存せず, 指し示す時刻(instant)が一致することを確認する.
+        $this->expected = (new \DateTime('2021-05-06T07:08:09'))->getTimestamp();
+        $this->assertInstanceOf(Order::class, $EditedOrder);
+        $this->actual = $EditedOrder->getPaymentDate()->getTimestamp();
+        $this->verify();
+    }
+
+    /**
+     * 受注編集画面で出荷日を手動で編集できることを確認するテスト.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6528
+     */
+    public function testEditShippingDate()
+    {
+        $Customer = $this->createCustomer();
+        $Order = $this->createOrder($Customer);
+        $Order->setOrderStatus($this->entityManager->find(OrderStatus::class, OrderStatus::NEW));
+        $this->entityManager->flush($Order);
+
+        $formData = $this->createFormData($Customer, $this->Product);
+        $formData['OrderStatus'] = OrderStatus::NEW;
+        $formData['Shipping']['shipping_date'] = '2021-05-06T07:08:09';
+
+        $this->client->request(
+            Request::METHOD_POST,
+            $this->generateUrl('admin_order_edit', ['id' => $Order->getId()]),
+            [
+                'order' => $formData,
+                'mode' => 'register',
+            ]
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('admin_order_edit', ['id' => $Order->getId()])));
+
+        $EditedOrder = $this->orderRepository->find($Order->getId());
+        // タイムゾーン表現に依存せず, 指し示す時刻(instant)が一致することを確認する.
+        $this->expected = (new \DateTime('2021-05-06T07:08:09'))->getTimestamp();
+        $this->assertInstanceOf(Order::class, $EditedOrder);
+        $this->actual = $EditedOrder->getShippings()->first()->getShippingDate()->getTimestamp();
+        $this->verify();
+    }
+
+    /**
+     * 手動で入金日を設定しつつ入金済みへ遷移させても, 手動値が自動セットで上書きされないことを確認するテスト.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6528
+     */
+    public function testEditPaymentDateNotOverwrittenOnPayTransition()
+    {
+        $Customer = $this->createCustomer();
+        $Order = $this->createOrder($Customer);
+        $Order->setOrderStatus($this->entityManager->find(OrderStatus::class, OrderStatus::NEW));
+        $this->entityManager->flush($Order);
+
+        $formData = $this->createFormData($Customer, $this->Product);
+        // 入金済みへ遷移させつつ, 入金日を手動で設定する.
+        $formData['OrderStatus'] = OrderStatus::PAID;
+        $formData['payment_date'] = '2021-05-06T07:08:09';
+
+        $this->client->request(
+            Request::METHOD_POST,
+            $this->generateUrl('admin_order_edit', ['id' => $Order->getId()]),
+            [
+                'order' => $formData,
+                'mode' => 'register',
+            ]
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('admin_order_edit', ['id' => $Order->getId()])));
+
+        $EditedOrder = $this->orderRepository->find($Order->getId());
+        $this->assertInstanceOf(Order::class, $EditedOrder);
+        // 入金済みに遷移していること.
+        $this->assertSame(OrderStatus::PAID, $EditedOrder->getOrderStatus()->getId());
+        // 手動で設定した入金日が, 遷移時の自動セット(現在日時)で上書きされていないこと.
+        $this->expected = (new \DateTime('2021-05-06T07:08:09'))->getTimestamp();
+        $this->actual = $EditedOrder->getPaymentDate()->getTimestamp();
+        $this->verify();
+    }
+
+    /**
      * 危険なXSS htmlインジェクションが削除されたことを確認するテスト
      *
      * 下記のものをチェックします。

--- a/tests/Eccube/Tests/Web/Admin/Order/ShippingControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/ShippingControllerTest.php
@@ -105,6 +105,44 @@ final class ShippingControllerTest extends AbstractEditControllerTestCase
     }
 
     /**
+     * 出荷編集画面(複数配送対応の ShippingController)で出荷日を手動編集できることを確認するテスト.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6528
+     */
+    public function testEditShippingDate()
+    {
+        $Order = $this->createOrder($this->createCustomer());
+        /** @var Shipping $Shipping */
+        $Shipping = $Order->getShippings()->first();
+        $shippingId = $Shipping->getId();
+
+        $shippingFormData = $this->createShippingFormDataForEdit($Shipping);
+        $shippingFormData['shipping_date'] = '2021-05-06T07:08:09';
+
+        $formData['shippings'] = [$shippingFormData];
+        $formData['_token'] = 'dummy';
+        $formData['add_shipping'] = '';
+
+        $this->client->request(
+            Request::METHOD_POST,
+            $this->generateUrl('admin_shipping_edit', ['id' => $Order->getId()]),
+            [
+                'form' => $formData,
+                'mode' => 'register',
+            ]
+        );
+        $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('admin_shipping_edit', ['id' => $Order->getId()])));
+
+        $expectedShipping = $this->entityManager->find(Shipping::class, $shippingId);
+        $this->assertInstanceOf(Shipping::class, $expectedShipping);
+        // タイムゾーン表現に依存せず, 指し示す時刻(instant)が一致することを確認する.
+        $this->assertSame(
+            (new \DateTime('2021-05-06T07:08:09'))->getTimestamp(),
+            $expectedShipping->getShippingDate()->getTimestamp()
+        );
+    }
+
+    /**
      * 出荷先の追加と削除のテスト
      */
     public function testAddAndDeleteShipping()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Closes #6528

受注の**入金日**は「入金済み」への遷移時、**出荷日**は「発送済み」への遷移時に自動セットされますが、ステータス変更の誤りや遅延によって、記録される日付が実際の入金・出荷日時とずれるケースがあります。

管理者が手動で訂正できるよう、**受注編集画面・出荷編集画面に入金日・出荷日の編集項目**を追加します（Issue 本文の要望＋メンテナのメモ「入金日と出荷日の両方を変更できるようにする」に対応）。

## 方針(Policy)

- 入金日は `OrderType`、出荷日は `ShippingType` に `DateTimeType`（`single_text` / `with_seconds`）で追加。既存の `NewsType::publish_date` / `ShippingType::shipping_delivery_date` の定義パターンに倣う。
- 誤操作防止（Issue コメントの「ダブルクリックか変更ボタンで有効化」の要望）として、通常は表示のみとし、**鉛筆アイコン（`fa-pencil`）押下で入力欄を有効化**する。管理画面の既存インライン編集パターン（`tax_rule.twig` 等）を踏襲。
- `ShippingType` に追加することで、受注編集画面（単一配送）・出荷編集画面（複数配送・`CollectionType`）の両方をカバー。
- 入金日の自動セット（`OrderStateMachine::updatePaymentDate`）は無条件に現在日時で上書きしていたため、**null のときだけセットする**ようガードを追加。手動設定した入金日が入金済み遷移で潰れないようにする（出荷日側は既存の `!isShipped()` ガードがあるため変更不要）。

## 実装に関する補足(Appendix)

- `payment_date` / `shipping_date` はいずれも既存の nullable な `DATETIMETZ` カラムで、スキーマ変更・マイグレーションは不要。
- `OrderType` の `Shipping` は `mapped => false` だが `data` に実 `Shipping` エンティティが渡るため、子フィールドは実体に書き戻され cascade で永続化される。

## テスト（Test)

- `EditControllerTest::testEditPaymentDate` … 受注編集で入金日が永続化される
- `EditControllerTest::testEditShippingDate` … 受注編集で出荷日（単一配送）が永続化される
- `EditControllerTest::testEditPaymentDateNotOverwrittenOnPayTransition` … 入金済み遷移と同時に手動設定した入金日が上書きされない（Issue の核心シナリオ）
- `ShippingControllerTest::testEditShippingDate` … 出荷編集画面（複数配送経路）で出荷日が永続化される
- `OrderStateMachineTest::testTransitionPayKeepsManualPaymentDate` … `pay` 遷移で手動入金日が保持される
- 実機（管理画面）で「入力→保存→再表示」「触らず保存で保持」「上書き→再表示更新」を確認済み。JST 入力↔UTC 保存の往復整合も確認。
- ローカルで php-cs-fixer / phpstan(level 6, `src`) / rector（変更ファイル）/ phpunit（関連スイート）を通過。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません（表示のみだった項目に編集手段を追加。自動セットの通常フローは不変）
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 管理画面で入金日・出荷日を鉛筆アイコンから手動編集できるようになりました。
  * 日時を秒単位で入力できるようになりました。
  * 不正な日付にはエラーを表示します。

* **不具合修正**
  * 手動設定した入金日が、入金済みへのステータス変更時に上書きされなくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->