### PR TITLE
fix(install): インストーラの推奨拡張チェックを apc から apcu へ変更

### DIFF
--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -547,8 +547,8 @@ class InstallController extends AbstractController
                 $this->addInfo(trans('install.recommend_extension_disabled', ['%module%' => 'wincache']), 'install');
             }
         } else {
-            if (!extension_loaded('apc')) {
-                $this->addInfo(trans('install.recommend_extension_disabled', ['%module%' => 'apc']), 'install');
+            if (!extension_loaded('apcu')) {
+                $this->addInfo(trans('install.recommend_extension_disabled', ['%module%' => 'apcu']), 'install');
             }
         }
         if (isset($_SERVER['SERVER_SOFTWARE']) && str_contains((string) $_SERVER['SERVER_SOFTWARE'], 'Apache')) {

--- a/src/Eccube/Util/CacheUtil.php
+++ b/src/Eccube/Util/CacheUtil.php
@@ -84,9 +84,8 @@ class CacheUtil implements EventSubscriberInterface
             opcache_reset();
         }
 
-        if (function_exists('apc_clear_cache')) {
-            apc_clear_cache('user');
-            apc_clear_cache();
+        if (function_exists('apcu_clear_cache')) {
+            apcu_clear_cache();
         }
 
         if (function_exists('wincache_ucache_clear')) {
@@ -191,9 +190,8 @@ class CacheUtil implements EventSubscriberInterface
             opcache_reset();
         }
 
-        if (function_exists('apc_clear_cache')) {
-            apc_clear_cache('user');
-            apc_clear_cache();
+        if (function_exists('apcu_clear_cache')) {
+            apcu_clear_cache();
         }
 
         if (function_exists('wincache_ucache_clear')) {


### PR DESCRIPTION
### 概要（Overview）

Issue #6512 の対応。インストール画面（step1）の推奨拡張チェックで、
古い `apc` 拡張（PHP 5.x 時代の遺物で PHP 7 以降は APCu に置き換わっている）を
チェックしていたのを `apcu` に変更する。メンテナ（@dotani1111）が Issue 上で
「apcuに変更いたします」と回答済みの方針に沿う。

### 方針（Policy）

- `InstallController::checkModules()` の非 Windows 分岐を
  `extension_loaded('apc')` → `extension_loaded('apcu')` に変更（表示メッセージの
  `%module%` も `apc` → `apcu`）。
- あわせて `CacheUtil` に残る旧 APC API 呼び出しを APCu 対応へ整理:
  `apc_clear_cache('user'); apc_clear_cache();` → `apcu_clear_cache()`
  （APCu の関数は引数を取らず、ユーザーキャッシュの一括クリアに集約される）。
- 翻訳ファイルは `%module%` プレースホルダ方式のため変更不要。

### 補足（Supplement）

このコンテナのように `apcu` はロード済みで `apc` は無い環境では、修正前は
「[推奨] apc拡張モジュールが有効になっていません。」が **誤って** 表示されていた。
修正後は APCu の有無に応じて正しく振る舞う（有効なら非表示／無効なら
「[推奨] apcu拡張モジュールが有効になっていません。」）。

### テスト範囲（Test）

- 既存 `tests/Eccube/Tests/Web/Install/InstallControllerTest.php`：13/13 パス（非破壊）。
- `checkModules()` は `protected` かつ実行環境の `extension_loaded()` 結果に依存し、
  意味のある自動テストが書きにくいため新規テストは追加していない。
- 実画面確認：`install` 環境でカーネルをブートして `/install/step1` を実レンダリングし、
  `PHP_INI_SCAN_DIR` で apcu の有無を切り替えて before/after を検証済み。
  - 修正前（apcu 有・apc 無）→ `[推奨] apc拡張モジュールが有効になっていません。`（誤表示）
  - 修正後（apcu 有）→ メッセージなし／修正後（apcu 無）→ `[推奨] apcu拡張モジュールが有効になっていません。`

### 互換性チェックリスト（Compatibility）

- [x] 既存のフックポイント・パラメータの削除／型変更はない
- [x] Service 公開関数のシグネチャ変更はない（`CacheUtil` の内部処理のみ）
- [x] CSV 等の入出力フォーマット変更はない
- [x] マイナー互換を壊す変更はない

closes #6512
