### PR TITLE
test: 商品CSVインポートテンプレートの期待カラムに受注管理用メモを追加 (#6840 の回帰修正)

### DIFF
--- a/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
@@ -380,6 +380,7 @@ final class CsvImportControllerTest extends AbstractAdminWebTestCase
             '商品説明(詳細)',
             '検索ワード',
             'フリーエリア',
+            '受注管理用メモ',
             '商品削除フラグ',
             '商品画像',
             '商品カテゴリ(ID)',


### PR DESCRIPTION
## 概要

#6840（受注管理用メモ機能の追加）のマージにより、**4.4 の PHPUnit が全マトリクス（PHP 8.2〜8.5 × sqlite/mysql/pgsql/pgsql13、計16ジョブ）で fail** しています。本PRはその回帰を修正します。

## 原因

#6840 は商品CSVインポートテンプレートへ「受注管理用メモ」(`order_memo`)列を **フリーエリアの直後** に追加しました（`CsvImportController` の列定義）。しかし既存テスト `CsvImportControllerTest::testCsvTemplateWithProduct` の期待カラム配列を更新し忘れており、テンプレートの全カラム完全一致検証が失敗していました。

```
Eccube\Tests\Web\Admin\Product\CsvImportControllerTest::testCsvTemplateWithProduct
Failed asserting that two arrays are identical.
```

※ #6840 は**マージ前の時点で unit-test が赤**のまま取り込まれていました。

## 修正内容

`testCsvTemplateWithProduct` の期待カラム配列に、`CsvImportController` の列定義順（フリーエリアの直後）に合わせて `'受注管理用メモ'` を追加。

## 確認

```
$ vendor/bin/phpunit tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
OK (45 tests, 226 assertions)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 商品CSVテンプレートに「受注管理用メモ」列が含まれることを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->