### PR TITLE
ci: success ゲートが赤テストを skip 扱いで素通りさせる穴を塞ぐ

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,9 +56,19 @@ jobs:
 #    needs: [ plugin-test ]
 #    uses: ./.github/workflows/deny-test.yml
   success:
-    needs: [ e2e-test-throttling, dockerbuild ]
+    # 全ジョブを直接 needs する。チェーン依存(success←throttling←plugin-test←unit-test)だと
+    # 上流の failure が各ホップで skipped に化けて末端へ届かず、必須チェック success が
+    # skipped=パス扱いとなって赤テストのまま auto-merge されてしまうため(#6840)。
+    needs: [ rector, phpstan, php-cs-fixer, unit-test, e2e-test, plugin-test, e2e-test-throttling, dockerbuild ]
+    # 上流が失敗しても success 自体は必ず実行する(skip させない)
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
+      # skipped は許容(dependabot の coverage 等、正当な skip がある)。
+      # failure / cancelled のみを赤として扱い、auto-merge をブロックする。
+      - name: Check required jobs
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: echo "::error::required job failed or was cancelled" && exit 1
       - name: success
         run: echo "::notice::success!"
   coverage:


### PR DESCRIPTION
## 背景 / 問題

4.4 のブランチ保護で必須ステータスチェックは **`success` ジョブ 1 つだけ**です。しかし `success` は以下の**チェーン依存**になっていました。

```
success ← e2e-test-throttling ← plugin-test ← unit-test
```

GitHub Actions は `needs` の上流が失敗した下流ジョブを **`failure` ではなく `skipped`** にします。そのため `unit-test`（PHPUnit）が落ちると、

```
unit-test = failure
  → plugin-test = skipped
    → e2e-test-throttling = skipped
      → success = skipped
```

と連鎖 skip し、**ブランチ保護は「skip された必須チェック」をパス扱い**にします。結果、PHPUnit が赤のまま auto-merge が成立してしまいます。実際に #6840 はこの経路で、全マトリクスの unit-test が fail したまま 4.4 へマージされました（回帰は #6960 で別途修正）。

## 修正

`success` を**全ジョブへ直接 `needs`** させ、上流の `failure` を `failure` のまま検知できるようにします。

- `if: ${{ !cancelled() }}` … 上流が失敗しても `success` 自体は必ず実行する（skip させない）。
- `needs.*.result` に `failure` / `cancelled` が含まれるときだけ `exit 1` で赤にする。
- **`skipped` は許容**する。dependabot の `coverage` skip 等、正当な skip があるため（skip を一律 fail にすると正当な PR までブロックしてしまう）。

```yaml
  success:
    needs: [ rector, phpstan, php-cs-fixer, unit-test, e2e-test, plugin-test, e2e-test-throttling, dockerbuild ]
    if: ${{ !cancelled() }}
    runs-on: ubuntu-latest
    steps:
      - name: Check required jobs
        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
        run: echo "::error::required job failed or was cancelled" && exit 1
      - name: success
        run: echo "::notice::success!"
```

## 確認

- `success` がいずれかのジョブ失敗時に赤くなること（本PRの CI 自体でチェーンが正しく走ることを確認）。
- 正常時は従来どおり緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 必須チェックの失敗やキャンセルが、誤って成功として扱われる問題を修正しました。
  * すべての必須ジョブの結果を確認し、失敗またはキャンセルがある場合は処理を明確に失敗させるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->