### PR TITLE
fix: プラグインで Entity 拡張時に redeclare fatal になる問題を修正 (EccubeBundle の auto_mapping を無効化)

### DIFF
--- a/app/config/eccube/packages/doctrine.yaml
+++ b/app/config/eccube/packages/doctrine.yaml
@@ -30,6 +30,12 @@ doctrine:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         auto_mapping: true
+        # EccubeBundle の Entity は Kernel::addEntityExtensionPass が TraitProxyAttributeDriver で
+        # 明示登録する。auto_mapping が同じ src/Eccube/Entity を素の AttributeDriver でも登録すると、
+        # そちらが Entity ソースを無条件に require_once するため、Proxy (app/proxy/entity) を
+        # ロード済みの状態で "Cannot redeclare class" となる (Entity の class_exists ガード全廃後).
+        mappings:
+            EccubeBundle: false
         controller_resolver:
             auto_mapping: false
         dql:

--- a/tests/Eccube/Tests/Doctrine/ORM/Mapping/EccubeEntityMetadataDriverTest.php
+++ b/tests/Eccube/Tests/Doctrine/ORM/Mapping/EccubeEntityMetadataDriverTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Doctrine\ORM\Mapping;
+
+use Doctrine\Bundle\DoctrineBundle\Mapping\MappingDriver as BundleMappingDriver;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use Eccube\Doctrine\ORM\Mapping\Driver\TraitProxyAttributeDriver;
+use Eccube\Tests\EccubeTestCase;
+
+/**
+ * src/Eccube/Entity のマッピングが TraitProxyAttributeDriver 以外から二重登録されないことの回帰テスト.
+ *
+ * Kernel::addEntityExtensionPass は src/Eccube/Entity を TraitProxyAttributeDriver で登録する.
+ * これは Proxy (app/proxy/entity) で宣言済みの Entity を再 require しない実装になっている.
+ * ところが doctrine.orm.auto_mapping が EccubeBundle を検出すると、同じ src/Eccube/Entity が
+ * 素の AttributeDriver でも登録される. 素のドライバは ColocatedMappingDriver::getAllClassNames() で
+ * Entity ソースを無条件に require_once するため、Kernel::loadEntityProxies が Proxy を
+ * 先にロードした状態では "Cannot redeclare class" で fatal になる
+ * (Entity の if (!class_exists()) ガード全廃前は、そのガードが吸収していた).
+ *
+ * @see https://github.com/EC-CUBE/ec-cube/pull/6895 Entity の if(!class_exists()) ガード全廃
+ */
+final class EccubeEntityMetadataDriverTest extends EccubeTestCase
+{
+    /**
+     * src/Eccube/Entity を担当するドライバが TraitProxyAttributeDriver だけであることを検証する.
+     */
+    public function testCoreEntityPathIsMappedOnlyByTraitProxyAttributeDriver(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $driver = $entityManager->getConfiguration()->getMetadataDriverImpl();
+
+        $coreEntityDir = realpath(__DIR__.'/../../../../../../src/Eccube/Entity');
+        $this->assertIsString($coreEntityDir);
+
+        foreach ($this->flattenDrivers($driver) as $each) {
+            if (!method_exists($each, 'getPaths')) {
+                continue;
+            }
+            foreach ($each->getPaths() as $path) {
+                if (realpath($path) !== $coreEntityDir) {
+                    continue;
+                }
+                $this->assertInstanceOf(TraitProxyAttributeDriver::class, $each, 'src/Eccube/Entity は TraitProxyAttributeDriver 以外から登録してはならない'
+                .' (素の AttributeDriver は Entity ソースを無条件に require_once するため、'
+                .'Proxy ロード済みの環境で "Cannot redeclare class" になる)');
+            }
+        }
+    }
+
+    /**
+     * MappingDriverChain を再帰的に展開して、実際にマッピングを解決するドライバを列挙する.
+     *
+     * @return list<MappingDriver>
+     */
+    private function flattenDrivers(?MappingDriver $driver): array
+    {
+        if ($driver === null) {
+            return [];
+        }
+
+        // doctrine-bundle の MappingDriver は実ドライバをラップしているため中身を取り出す
+        if ($driver instanceof BundleMappingDriver) {
+            return $this->flattenDrivers($driver->getDriver());
+        }
+
+        if (!$driver instanceof MappingDriverChain) {
+            return [$driver];
+        }
+
+        $drivers = [];
+        foreach ($driver->getDrivers() as $each) {
+            $drivers = [...$drivers, ...$this->flattenDrivers($each)];
+        }
+
+        return [...$drivers, ...$this->flattenDrivers($driver->getDefaultDriver())];
+    }
+}

--- a/tests/Eccube/Tests/Doctrine/ORM/Mapping/EccubeEntityMetadataDriverTest.php
+++ b/tests/Eccube/Tests/Doctrine/ORM/Mapping/EccubeEntityMetadataDriverTest.php
@@ -48,6 +48,7 @@ final class EccubeEntityMetadataDriverTest extends EccubeTestCase
         $coreEntityDir = realpath(__DIR__.'/../../../../../../src/Eccube/Entity');
         $this->assertIsString($coreEntityDir);
 
+        $coreEntityDrivers = [];
         foreach ($this->flattenDrivers($driver) as $each) {
             if (!method_exists($each, 'getPaths')) {
                 continue;
@@ -56,11 +57,18 @@ final class EccubeEntityMetadataDriverTest extends EccubeTestCase
                 if (realpath($path) !== $coreEntityDir) {
                     continue;
                 }
+                $coreEntityDrivers[] = $each;
                 $this->assertInstanceOf(TraitProxyAttributeDriver::class, $each, 'src/Eccube/Entity は TraitProxyAttributeDriver 以外から登録してはならない'
                 .' (素の AttributeDriver は Entity ソースを無条件に require_once するため、'
                 .'Proxy ロード済みの環境で "Cannot redeclare class" になる)');
             }
         }
+
+        // 対象ドライバが 0 件でもループが素通りするため、明示登録そのものが失われた構成も検知する
+        $this->assertNotEmpty(
+            $coreEntityDrivers,
+            'src/Eccube/Entity のマッピングドライバ (Kernel::addEntityExtensionPass の TraitProxyAttributeDriver) が登録されていない'
+        );
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Entity の `if (!class_exists())` ガードを全廃した #6895 以降、**コア Entity を trait 拡張するプラグインを導入した環境で、Proxy 生成後に全リクエストが 500 になる**問題を修正します。

```
PHP Fatal error: Cannot declare class Eccube\Entity\Customer,
because the name is already in use in src/Eccube/Entity/Customer.php on line 49
```

refs #6891, #5844, #6895

原因は `src/Eccube/Entity` のマッピングドライバが**二重に登録される**ことです。

- `Kernel::addEntityExtensionPass()` が `src/Eccube/Entity` を `TraitProxyAttributeDriver` で登録する。こちらは #6895 の追随修正（`77defa74ca`）で「宣言済みの Entity は再 `require_once` しない」ようになっている。
- 一方 `doctrine.orm.auto_mapping` は `EccubeBundle`（bundle path = `src/Eccube`）を検出し、**同じ `src/Eccube/Entity` を素の `AttributeDriver` でも登録**する。素のドライバは `ColocatedMappingDriver::getAllClassNames()` で Entity ソースを**無条件に `require_once`** する。
- `Kernel::loadEntityProxies()` が先に `app/proxy/entity` の Proxy を読み込んでいるため、素のドライバが元ソースを require した時点で二重宣言になる。ガード全廃前は各 Entity の `if (!class_exists())` がこれを吸収していた。

実際のスタックトレース（PostgreSQL / `APP_ENV=prod`）:

```
#0 doctrine/persistence/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php(188): require_once()
#1 MappingDriverChain.php(104): Doctrine\ORM\Mapping\Driver\AttributeDriver->getAllClassNames()
#2 doctrine-bundle/src/Mapping/MappingDriver.php(25): MappingDriverChain->getAllClassNames()
#3 AbstractClassMetadataFactory.php(95): MappingDriver->getAllClassNames()
#4 symfony/doctrine-bridge/CacheWarmer/ProxyCacheWarmer.php(60): getAllMetadata()
...
#9 src/Eccube/Kernel.php(137): Symfony\Component\HttpKernel\Kernel->boot()
```

このとき問題の素の `AttributeDriver` が持つ paths は次の通りで、`src/Eccube/Entity` が第三者バンドルのマッピングと**同一ドライバに合流**しています。

```
paths = src/Eccube/Entity, vendor/league/oauth2-server-bundle/src/Entity
```

## 方針(Policy)

`auto_mapping` 全体を無効化するのではなく、**`EccubeBundle` の自動マッピングのみ無効化**します（`mappings: { EccubeBundle: false }`）。

- コアの Entity（`src/Eccube/Entity`）・`app/Customize/Entity`・各プラグインの `Entity` は、いずれも `Kernel::addEntityExtensionPass()` が `TraitProxyAttributeDriver` で明示登録しているため、auto_mapping による重複登録は不要。
- 他バンドル（例: `league/oauth2-server-bundle`）の auto_mapping はそのまま維持されるため、プラグインが依存するバンドルの Entity は従来どおりマッピングされる。

## 実装に関する補足(Appendix)

- **再現には「Entity を持つ第三者バンドル」が必要**です。素の `AttributeDriver` は doctrine-bundle が auto_mapping 対象バンドルをまとめて 1 つのドライバにするため、`EccubeBundle` 単独ではチェーンに残らず（EC-CUBE 側の明示登録が同一 namespace を上書きするため）、`league/oauth2-server-bundle` のような別 namespace のバンドルが加わって初めて `src/Eccube/Entity` を含むドライバがチェーンに露出します。
- 追加したテストは「`src/Eccube/Entity` を担当するドライバが `TraitProxyAttributeDriver` 以外に存在しない」という不変条件を固定するものです。上記の理由から、第三者バンドルが無いコアのテスト環境では修正前でも green になります（fatal そのものの再現はプラグイン導入環境が前提）。不変条件を将来にわたって守るためのガードとして追加しています。

## テスト（Test)

ローカル（SQLite / `APP_ENV=prod` / `ec-cube/api44`（→ `league/oauth2-server-bundle`）と `ec-cube/samplepayment44`（コア `Customer`・`Order` を trait 拡張）を実際に導入）で確認しました。

- **修正前**: `SamplePayment44` を enable して `app/proxy/entity/src/Eccube/Entity/Customer.php` が生成された状態で、`bin/console cache:clear` およびビルトインサーバへの全リクエストが上記 redeclare fatal で失敗（`Compile Error: Cannot declare class Eccube\Entity\Customer ...`）。
- **修正後**: `cache:clear` / `cache:warmup` が成功し、リクエストも 200 を返す。
- `bin/console doctrine:mapping:info` は修正前後とも **82 entities**（`league/oauth2-server-bundle` の 5 entity を含む）で、マッピング対象に増減がないことを確認。
- `vendor/bin/phpunit tests/Eccube/Tests/Doctrine/ORM/Mapping/` = OK（追加テスト＋既存 `TraitProxyAttributeDriverTest`）。
- `vendor/bin/phpstan analyse src` = No errors、`php-cs-fixer --dry-run` = 0 件、`rector --dry-run` = 差分なし（指摘は適用済み）。

## 相談（Discussion）

- 本 PR は「重複登録をやめる」方向の修正です。別解として `TraitProxyAttributeDriver` 側で吸収する（素のドライバの登録自体は許容する）案もありますが、素のドライバは doctrine-bundle が生成するためコア側で挙動を制御できず、`auto_mapping` から外すのが確実と判断しました。
- 同種の問題は「コア Entity を trait 拡張するプラグイン」＋「Entity を持つ第三者バンドル」の組み合わせで発生します。プラグインテストのマトリクスに api プラグイン導入時の起動確認を含めるべきか、ご意見をいただけると助かります。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * Doctrine の Entity マッピング設定を見直し、Proxy 読み込み時にクラスが二重定義される競合を回避できるようにしました。

* **テスト**
  * コア Entity が意図したメタデータドライバ経由でのみマッピングされることを検証する回帰テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->