### PR TITLE
fix(agent-commerce): 決済プラグインのハンドラにタグが付かず payment_handlers が空になる問題を修正

### DIFF
--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -325,13 +325,11 @@ services:
         arguments:
             $accessTokenHandler: '@?Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface'
 
-    # Agent Commerce 決済ハンドラ (#6574 UCP / #6776 ACP)
-    # 具象ハンドラは決済プラグインが agent_commerce.payment_handler タグで寄与する。
-    _instanceof:
-        Eccube\Service\AgentCommerce\Payment\AgentCheckoutPaymentHandlerInterface:
-            tags: ['agent_commerce.payment_handler']
-
-    # 決済ハンドラレジストリ。具象ハンドラ (決済プラグイン) は agent_commerce.payment_handler タグで寄与する。
+    # Agent Commerce 決済ハンドラレジストリ (#6574 UCP / #6776 ACP)
+    # 具象ハンドラ (決済プラグイン) は agent_commerce.payment_handler タグで寄与する。
+    # タグ付けは Kernel::build() の registerForAutoconfiguration で行う (PaymentMethodInterface と同様)。
+    # services.yaml の _instanceof はファイルスコープのため、Plugin\ glob (services.php・#6915) で
+    # 登録される決済プラグインの具象ハンドラには届かない。
     Eccube\Service\AgentCommerce\Payment\AgentCheckoutPaymentHandlerRegistry:
         arguments:
             $handlers: !tagged_iterator agent_commerce.payment_handler

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -34,6 +34,7 @@ use Eccube\Doctrine\DBAL\Types\UTCDateTimeTzType;
 use Eccube\Doctrine\ORM\Mapping\Driver\TraitProxyAttributeDriver;
 use Eccube\Doctrine\Query\QueryCustomizer;
 use Eccube\Log\Logger;
+use Eccube\Service\AgentCommerce\Payment\AgentCheckoutPaymentHandlerInterface;
 use Eccube\Service\Payment\PaymentMethodInterface;
 use Eccube\Service\PurchaseFlow\DiscountProcessor;
 use Eccube\Service\PurchaseFlow\ItemHolderPostValidator;
@@ -267,6 +268,13 @@ class Kernel extends BaseKernel
         $container->registerForAutoconfiguration(PaymentMethodInterface::class)
             ->addTag(PaymentMethodPass::PAYMENT_METHOD_TAG);
         $container->addCompilerPass(new PaymentMethodPass());
+
+        // Agent Commerce 決済ハンドラ (#6574 UCP / #6776 ACP) の拡張。
+        // 決済プラグインの具象ハンドラは Plugin\ glob (services.php・#6915) で登録されるため、
+        // services.yaml のファイルスコープな _instanceof ではタグが付かない。
+        // PaymentMethodInterface と同様にコンテナ全体へ効く registerForAutoconfiguration でタグ付けする。
+        $container->registerForAutoconfiguration(AgentCheckoutPaymentHandlerInterface::class)
+            ->addTag('agent_commerce.payment_handler');
 
         // PurchaseFlow の拡張
         $container->registerForAutoconfiguration(ItemPreprocessor::class)


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

エージェントコマース (ACP/UCP) の決済ハンドラが、決済プラグインから**自動でタグ付けされなくなっている**問題を修正します。

`app/config/eccube/services.yaml` の `_instanceof` で `AgentCheckoutPaymentHandlerInterface` に `agent_commerce.payment_handler` タグを付与していましたが、**`_instanceof` はそれを記述したファイル内で定義されたサービスにしか適用されません**。#6915 で `Plugin\` の PSR-4 自動登録が `services.yaml` から `services.php` へ移ったため、決済プラグインの具象ハンドラにはタグが届かなくなっていました。

refs #6915, #6837, #6843

結果として現在の 4.4 では以下が発生します。

- `AgentCheckoutPaymentHandlerRegistry` に注入される `!tagged_iterator agent_commerce.payment_handler` が**空**になる
- UCP discovery (`/.well-known/ucp`) の `payment_handlers` が `{}` になり、登録済みハンドラが広告されない
- ACP/UCP checkout の `complete` で決済ハンドラを解決できない

実測 (`ec-cube/samplepayment44` を導入し、ACP/UCP ハンドラを 1 つずつ実装した状態):

```console
$ bin/console debug:container --tag=agent_commerce.payment_handler
Symfony Container Services Tagged with "agent_commerce.payment_handler" Tag
===========================================================================

 ------------ ------------
  Service ID   Class name
 ------------ ------------
```

なお、この問題は #6963 で修正した redeclare fatal (全リクエストが HTTP 500) に隠れており、そちらが解消して初めて観測可能になりました。両者は別サブシステム・別起因の独立した不具合です。

## 方針(Policy)

`_instanceof` をやめ、**`Kernel::build()` の `registerForAutoconfiguration()` でコンテナ全体にタグ付けする**方式へ移行します。

これは同ファイルで `PaymentMethodInterface` / `PurchaseProcessor` / `ItemPreprocessor` / `QueryCustomizer` など既存 11 件が採用している方式で、**agent commerce のハンドラだけが `_instanceof` を使っていた**状態でした。本 PR で流儀が揃います。

`_instanceof` を維持したまま `services.php` 側にも複製する案は、正典が 2 箇所に分かれ再発しやすいため採りませんでした。

## 実装に関する補足(Appendix)

**プラグイン側の期待挙動について**

決済プラグインが自身の `Resource/config/services.yaml` で明示的に `tags: ['agent_commerce.payment_handler']` と書けば、本修正が無くてもタグは付きます (自ファイルスコープのため #6915 の影響を受けない)。壊れているのは**インターフェイスを実装するだけで載る「ゼロ設定」の契約**の方です。

`UcpPaymentHandlerDiscoveryRegistry` の docblock も「UCP ハンドラを登録するだけで discovery にも自動的に広告される (ゼロ設定)」と記載しており、修正しないとドキュメントと実挙動が食い違ったままになります。

**互換性への影響**

- `AgentCheckoutPaymentHandlerInterface` の具象実装は `src/` にも `app/Customize/` にも存在しない (インターフェイス定義と、それを消費する Registry/Discovery のみ) ため、`registerForAutoconfiguration` はコア既存サービスに対して no-op です。
- `_instanceof` は `autoconfigure: false` のサービスにも効きますが `registerForAutoconfiguration` は効きません。`services.yaml` の `autoconfigure: false` は `IgnoreRoutingNotFoundExtension` / `InitSubscriber` / `InitDriver` の 3 件のみで、いずれも決済ハンドラではないため差は生じません。
- 削除した `_instanceof` は設定全体で唯一のもので、他のタグ規則を巻き込みません。

## テスト（Test)

ローカル (SQLite / `ec-cube/api44` + `ec-cube/samplepayment44` を実際に導入) で確認しました。

- **修正前**: `bin/console debug:container --tag=agent_commerce.payment_handler` が **0 件**
- **修正後**: 同コマンドで **2 件** (`Plugin\SamplePayment44\Service\AgentCommerce\Acp\AcpSampleCardHandler` / `...\Ucp\UcpSampleCardHandler`)
- ビルトインサーバの `/.well-known/ucp` が `"payment_handlers":{"dev.ucp.payment.card":[{"id":"dev.ucp.payment.card","version":"2026-04-08"}]}` を返すことを確認 (修正前は `{}`)
- `php-cs-fixer --dry-run src/Eccube/Kernel.php` = 0 件

あわせて、本修正を取り込んだ結合 E2E ワークフロー (本体 + `api44` + `samplepayment44`) が全ジョブ green であることを確認済みです。

- Integration smoke: PHP 8.2 / 8.3 / 8.4 / 8.5 × PostgreSQL / MySQL の 8 マトリクス全 pass
- Checkout E2E: ACP 31 assertions / UCP 23 assertions。`complete` (決済実行) まで到達し、成功 / 3DS 中断・再開 / 拒否の各シナリオでハンドラが実際に実行されることを確認

## 相談（Discussion）

DI のタグ配線を固定するテストが現状ありません。既存の `UcpPaymentHandlerDiscoveryRegistryTest` は in-memory ハンドラを使う純ロジックの `TestCase` のため、今回の回帰を検知できませんでした。

`agent_commerce.payment_handler` タグが付いたサービスが解決できることを確認する機能テストの追加を検討していますが、テスト環境にはプラグインが導入されないため、テスト用のダミーハンドラを `app/Customize` 相当に置く等の工夫が要ります。本 PR に含めるべきか、別 PR とすべきかご意見をいただけると助かります。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 決済プラグインのハンドラー登録方法を見直し、プラグインの配置にかかわらず、Agent Commerce の決済処理が一貫して認識されるようになりました。
  * 決済機能の構成を整理し、設定による登録漏れが発生しにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->