### PR TITLE
chore(dependabot): 更新をグループ化し実効性を失った ignore を解除

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,15 @@ updates:
       prefix-development: "chore(deps-dev)"
     allow:
       - dependency-type: "all"
-    # グループは上から順に評価され、依存は最初にマッチした 1 つのグループにだけ入る。
+    # 所属グループは記載順ではなくパターンの具体性 (specificity) スコアで決まる。
+    # dependabot-core の PatternSpecificityCalculator が算出し、スコアが高い方が勝つ。
+    #   patterns 未指定 = 500 / "doctrine/*" = 95 / "symfony/*" = 94 / "*" = 1
+    # このため require-dev の symfony/* (browser-kit, phpunit-bridge) は symfony ではなく
+    # php-dev-tools に入る。phpunit-bridge は Symfony 本体とバージョン系列が揃わない
+    # (本体 7.4 系に対し 8.x) ため、これは意図した挙動。
+    # なお GitHub のドキュメントは "first group it matches" と記述しているが、
+    # 実装は 2026-05-19 に specificity 判定が常時有効化されており乖離している。
+    # https://github.com/dependabot/dependabot-core/issues/14576
     # どのグループにもマッチしない更新 (= major) は、従来どおり個別の PR になる。
     groups:
       # require-dev。CI が通れば実質そのままマージできる
@@ -32,7 +40,8 @@ updates:
       doctrine:
         patterns: [ "doctrine/*" ]
         update-types: [ "minor", "patch" ]
-      # 上記以外の production。exclude-patterns は評価順に依存しないための保険
+      # 上記以外。patterns が "*" (スコア 1) のため symfony/doctrine には競り負けるが、
+      # exclude-patterns で contains? の時点から明示的に外しておく
       php-production:
         patterns: [ "*" ]
         exclude-patterns: [ "symfony/*", "doctrine/*" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,8 @@
 version: 2
 updates:
+  # ------------------------------------------------------------------
+  # PHP (composer)
+  # ------------------------------------------------------------------
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
@@ -9,19 +12,35 @@ updates:
       timezone: "Asia/Tokyo"
     cooldown:
       default-days: 5
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     allow:
       - dependency-type: "all"
-    ignore:
-      - dependency-name: "twig/twig"
-        versions: [ ">=3.8.0" ]
-      - dependency-name: "robthree/twofactorauth"
-        versions: [ ">=2.0.0" ]
-      - dependency-name: "doctrine/lexer"
-        versions: [ ">=3.0.0" ]
-      - dependency-name: "psr/log"
-        versions: [ ">=3.0.0" ]
+    # グループは上から順に評価され、依存は最初にマッチした 1 つのグループにだけ入る。
+    # どのグループにもマッチしない更新 (= major) は、従来どおり個別の PR になる。
+    groups:
+      # require-dev。CI が通れば実質そのままマージできる
+      php-dev-tools:
+        dependency-type: "development"
+        update-types: [ "minor", "patch" ]
+      # Symfony は同時リリースでバージョンが揃うため 1 本にまとめる
+      symfony:
+        patterns: [ "symfony/*" ]
+        update-types: [ "minor", "patch" ]
+      doctrine:
+        patterns: [ "doctrine/*" ]
+        update-types: [ "minor", "patch" ]
+      # 上記以外の production。exclude-patterns は評価順に依存しないための保険
+      php-production:
+        patterns: [ "*" ]
+        exclude-patterns: [ "symfony/*", "doctrine/*" ]
+        update-types: [ "minor", "patch" ]
 
-  # GitHub アクションの依存関係を維持する
+  # ------------------------------------------------------------------
+  # GitHub Actions
+  # ------------------------------------------------------------------
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -31,8 +50,17 @@ updates:
       timezone: "Asia/Tokyo"
     cooldown:
       default-days: 5
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns: [ "*" ]
+        update-types: [ "minor", "patch" ]
 
-  # npm の依存関係を維持する
+  # ------------------------------------------------------------------
+  # npm (ルート: 管理画面・店頭アセット)
+  # ------------------------------------------------------------------
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -42,8 +70,55 @@ updates:
       timezone: "Asia/Tokyo"
     cooldown:
       default-days: 5
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     allow:
       - dependency-type: "all"
-    ignore:
-      - dependency-name: "sort-css-media-queries"
-        versions: [ ">=2.4.0" ]
+    groups:
+      # 画面に描画されるライブラリ。目視確認が要るのはこの 1 本だけにする
+      npm-frontend:
+        patterns:
+          - "@popperjs/core"
+          - "ace-builds"
+          - "bootstrap"
+          - "chart.js"
+          - "filepond"
+          - "filepond-plugin-*"
+          - "jquery"
+          - "jquery-ui"
+          - "jquery.qrcode"
+          - "ladda"
+          - "normalize.css"
+          - "slick-carousel"
+          - "spin.js"
+        update-types: [ "minor", "patch" ]
+      # ビルドツールと間接依存 (package-lock.json のみの更新)
+      npm-build:
+        patterns: [ "*" ]
+        update-types: [ "minor", "patch" ]
+
+  # ------------------------------------------------------------------
+  # npm (E2E: Playwright)
+  # ------------------------------------------------------------------
+  - package-ecosystem: "npm"
+    directory: "/e2e"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 5
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    allow:
+      - dependency-type: "all"
+    groups:
+      # グループ名に数字は使えないため "e2e" ではなく "playwright"
+      playwright:
+        patterns: [ "*" ]
+        update-types: [ "minor", "patch" ]


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Dependabot の更新をグループ化してレビュー負担を減らします。あわせて、実効性を失っていた `ignore` を全解除します。

Refs #6940 (5. 直接依存のメジャーバージョン遅れ)

### 現状の課題

週次で最大 15 本の PR が立ちますが、その大半は判断が不要なものです。直近 (2026-07-26) の 13 本の内訳:

| 分類 | 件数 | 例 |
|---|---|---|
| npm の間接依存 (`package-lock.json` のみ変更) | 5 | postcss, binary-extensions, node.extend, vinyl-fs, gulp-cli |
| github-actions | 3 | actions/checkout, docker/login-action, upload-code-coverage |
| composer の patch | 3 | doctrine/dbal 4.4.3→4.4.4, doctrine/migrations, phpstan-doctrine |
| **major (判断が要るもの)** | **2** | symfony/phpunit-bridge 7.4→8.1, actions/checkout 6→7 |

13 本のうち、実際にレビュー判断が要るのは 2 本でした。

## 方針(Policy)

### 1. 「レビュー時に何を見るか」でグループを切る

major を意図的にどのグループにも含めないことで、**破壊的変更だけが個別 PR として残る**構成にしています (グループにマッチしない更新は従来どおり個別 PR になる仕様を利用)。

| グループ | 内容 | レビュー時に見るもの |
|---|---|---|
| `symfony` | `symfony/*` の minor/patch | コアへの影響、CI 全体 |
| `doctrine` | `doctrine/*` の minor/patch | スキーマ / DBAL 周り |
| `php-dev-tools` | require-dev の minor/patch | CI が緑なら実質そのまま |
| `php-production` | 残りの production minor/patch | CI + 変更内容 |
| `npm-frontend` | bootstrap / jquery / chart.js 等 | **画面の目視確認が要る唯一の枠** |
| `npm-build` | ビルドツール + 間接依存 | ビルドが通れば OK |
| `github-actions` | Actions の minor/patch | CI が緑なら OK |
| `playwright` | `/e2e` の minor/patch | E2E が緑なら OK |
| (グループ外) | **すべての major** | ここだけ本格的にレビュー |

グループは上から順に評価され、依存は最初にマッチした 1 つにだけ入ります。`php-production` には順序に依存しないよう `exclude-patterns` も併記しています。

上記を 7/26 の 13 本に当てはめると **6 本** (うち要判断は major の 2 本のみ) になります。

### 2. `/e2e` を version update の対象に追加

`directory` が `"/"` のみだったため、`e2e/package.json` は **version update の対象外**でした。`tar` の PR が届いていたのは security update が設定と無関係に全マニフェストへ出るためで、平常時の更新は止まっていました。

### 3. `open-pull-requests-limit` を明示

本 PR 作成時点の open PR 数:

| エコシステム | open PR | 状態 |
|---|---|---|
| composer | 5 本 | **既定の上限ちょうど** |
| github-actions | 5 本 | **既定の上限ちょうど** |
| npm | 6 本 | 上限付近 |

全エコシステムが既定の 5 に張り付き、古い open PR が枠を占有し続けています。#6940 の 5 に挙がっている major 遅れ (`mobiledetect/mobiledetectlib` 2.8→4.11、`doctrine/persistence` 3→4 等) の PR が届いていないのは、この滞留が原因の可能性があります (因果は状況証拠のため未検証)。グループ化で 1 グループ = 1 PR にまとまるため、枠にも余裕が生まれます。

### 4. `ignore` の全解除

`composer.json` 側の制約だけが 4.4 (Symfony 7.4) 化で引き上げられ、`dependabot.yml` が 2025-05 時点 (5bffb19) のまま取り残されていました。

| パッケージ | ignore 条件 | 現在の制約 | lock 実バージョン | 判定 |
|---|---|---|---|---|
| `twig/twig` | `>=3.8.0` | `^3.21` | **v3.27.0** | 稼働中バージョンが ignore 範囲の内側 → **更新が完全凍結** |
| `robthree/twofactorauth` | `>=2.0.0` | `^3.0` | **v3.0.3** | 同上 |
| `doctrine/lexer` | `>=3.0.0` | `^3.0` | **3.0.1** | 同上 |
| `psr/log` | `>=3.0.0` | `~2.0` | 2.0.0 | 制約が効くため ignore は冗長 |
| `sort-css-media-queries` | `>=2.4.0` | (間接依存) | 2.2.0 | 親が固定指定しており無効 |

上 3 件は **セキュリティ更新を含めて更新が止まっていました** (`allow` / `ignore` は security updates にも適用されるため)。とくに `twig/twig` はテンプレートエンジンであり、更新経路を塞いだままにするのは望ましくないと判断しました。

元の意図は 2024-08-14 の 9664e5b (`fix: lock Twig version`) で `composer.json` を `"twig/twig": "3.8.0"` に固定した際のもので、その後 `^3.21` へ引き上げられた時点で役目を終えていたものです。

## 実装に関する補足(Appendix)

- **グループ名に数字は使えない**ため、`/e2e` のグループ名は `e2e` ではなく `playwright` としています (識別子は letters / `|` / `_` / `-` のみ)。
- `allow: dependency-type: "all"` は**変更していません**。npm の間接依存 PR を根本的に減らすには `direct` にする手もありますが、`allow` は security updates にも適用されるため間接依存の脆弱性修正まで止まるリスクがあります。今回はグループ化で束ねる方を選びました。
- SHA pin されている Actions (`nanasess/setup-php` 等) が `update-types: [minor, patch]` のグループに入るかは**未検証**です。入らなければ従来どおり個別 PR として残ります (月 1〜2 本程度の見込み)。初回の実行結果で確認が必要です。
- `Dockerfile` は `FROM php:${TAG}` の変数形式、`zap/Dockerfile` はタグ指定なしのため、docker ecosystem を追加しても更新対象になりません。今回は追加していません。

### `psr/log` の解除について

`ignore` を外しても `composer.json` の `"psr/log": "~2.0"` が効くため、そのままでは 3.0 は入りません。Dependabot が制約自体を引き上げる PR を出す可能性があり、その場合は major として個別 PR になります。

依存解決上のブロッカーは root の制約のみであることを実測済みです:

```
$ composer why-not psr/log 3.0
ec-cube/ec-cube 4.4.x-dev requires psr/log (~2.0)
```

他パッケージは 3.0 を許容しているため、残る論点は #6940 に記載のとおりコード側の BC 影響 (型宣言) のみです。PR が出た時点で改めて判断できます。

## テスト（Test)

- YAML のパースとグループ定義の妥当性 (識別子の規則、`update-types` の値、未知のキーの有無) をローカルで検証済み。
- `dependabot.yml` は既定ブランチにマージされて初めて有効になるため、**実際の挙動確認はマージ後の初回実行 (月曜 07:00 JST) が必要**です。確認すべき点:
  - 意図したグループに集約されているか
  - major が個別 PR として分離されているか
  - SHA pin の Actions の扱い (上記 Appendix 参照)
  - `/e2e` の PR が出るか

## 相談（Discussion）

- グループの粒度についてご意見をいただければと思います。とくに `php-production` は Symfony / Doctrine 以外をまとめて 1 本にしているため、CI が落ちた際の切り分けが必要になる可能性があります。
- `github-actions` は minor/patch のみをまとめ、major を個別にしています。Actions の更新は CI 自身が検証するため major も束ねる選択肢もありますが、切り分けやすさを優先しました。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Composer / GitHub Actions / npm の依存更新設定を整理し、用途別にグループ化しました。
  - プルリク上限とコミットメッセージ接頭辞を各エコシステムで統一し、更新タイプを minor/patch に制限できるようにしました。
  - npm で E2E（Playwright）用セクションを追加し、GitHub Actions の ignore と npm の一部 ignore を削除しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->