### PR TITLE
fix: プラグイン/Customize 直下のバンドルでも Entity の redeclare fatal を防ぐ (auto_mapping の二重登録をコンパイル時に除去)

### DIFF
--- a/src/Eccube/DependencyInjection/Compiler/StripAutoMappedEntityPathsPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/StripAutoMappedEntityPathsPass.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\DependencyInjection\Compiler;
+
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * doctrine.orm.auto_mapping が生成する素の AttributeDriver から、
+ * Kernel::addEntityExtensionPass が TraitProxyAttributeDriver で明示登録している
+ * Entity ディレクトリを取り除く.
+ *
+ * doctrine-bundle は auto_mapping 対象バンドルの Entity ディレクトリを
+ * 「バンドルクラスが置かれたディレクトリ + /Entity」で検出し (DoctrineExtension::detectMetadataDriver)、
+ * 同じドライバ型のバンドルをすべて 1 つの AttributeDriver インスタンスに集約する
+ * (DoctrineExtension::registerMappingDrivers). そのため、EC-CUBE が明示登録している
+ * ディレクトリ (src/Eccube/Entity, app/Customize/Entity, app/Plugin/<Code>/Entity) が
+ * 素の AttributeDriver にも入り込む.
+ *
+ * 素のドライバは ColocatedMappingDriver::getAllClassNames() で Entity ソースを無条件に
+ * require_once するため、Kernel::loadEntityProxies() が app/proxy/entity の Proxy を
+ * 先にロードした状態では "Cannot redeclare class" で fatal になる
+ * (Entity の if (!class_exists()) ガード全廃前は、そのガードが吸収していた).
+ *
+ * MappingDriverChain は名前空間ごとに 1 ドライバしか保持しないため、EC-CUBE の明示登録で
+ * 上書きされたように見えるが、素のドライバが別の名前空間 (第三者バンドル) でチェーンに
+ * 残っていると、その getAllClassNames() が自身の全パスを走査して同じ fatal を引き起こす.
+ *
+ * バンドル名を列挙する (doctrine.orm.mappings.<Bundle>: false) 方式では、サードパーティ製
+ * プラグインが持ち込むバンドル名を事前に知ることができないため、コンパイル時にパスを
+ * 取り除く方式とする.
+ *
+ * @see https://github.com/EC-CUBE/ec-cube/pull/6895 Entity の if(!class_exists()) ガード全廃
+ * @see https://github.com/EC-CUBE/ec-cube/issues/6979
+ */
+final readonly class StripAutoMappedEntityPathsPass implements CompilerPassInterface
+{
+    /**
+     * @param string[] $explicitlyMappedPaths TraitProxyAttributeDriver で明示登録している Entity ディレクトリ
+     */
+    public function __construct(private array $explicitlyMappedPaths)
+    {
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        $explicitlyMappedPaths = [];
+        foreach ($this->explicitlyMappedPaths as $path) {
+            $resolved = $this->resolvePath($container, $path);
+            if (null !== $resolved) {
+                $explicitlyMappedPaths[] = $resolved;
+            }
+        }
+
+        if ([] === $explicitlyMappedPaths) {
+            return;
+        }
+
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (!$this->isAutoMappedAttributeDriver($container, $id, $definition)) {
+                continue;
+            }
+
+            $arguments = $definition->getArguments();
+            $paths = $arguments[0] ?? null;
+            if (!\is_array($paths)) {
+                continue;
+            }
+
+            $remaining = array_values(array_filter(
+                $paths,
+                fn ($path) => !\in_array($this->resolvePath($container, $path), $explicitlyMappedPaths, true)
+            ));
+
+            if (\count($remaining) === \count($paths)) {
+                continue;
+            }
+
+            if ([] === $remaining) {
+                // 担当パスがすべて明示登録済みになった素のドライバはチェーンから外す.
+                // paths が空のまま getAllClassNames() を呼ばれると例外になるため.
+                $this->removeFromDriverChains($container, $id);
+            }
+
+            $arguments[0] = $remaining;
+            $definition->setArguments($arguments);
+        }
+    }
+
+    /**
+     * doctrine.orm.auto_mapping が生成する素の AttributeDriver か判定する.
+     */
+    private function isAutoMappedAttributeDriver(ContainerBuilder $container, string $id, Definition $definition): bool
+    {
+        if (!str_starts_with($id, 'doctrine.orm.')
+            || !(str_ends_with($id, '_attribute_metadata_driver')
+                || str_ends_with($id, '_attribute_metadata_driver.inner'))
+        ) {
+            return false;
+        }
+
+        $class = $definition->getClass();
+        if (!\is_string($class)) {
+            return false;
+        }
+
+        $class = $container->getParameterBag()->resolveValue($class);
+
+        return \is_string($class) && is_a($class, AttributeDriver::class, true);
+    }
+
+    /**
+     * 指定したドライバサービスへの addDriver() 呼び出しを MappingDriverChain から取り除く.
+     */
+    private function removeFromDriverChains(ContainerBuilder $container, string $driverId): void
+    {
+        foreach ($container->getDefinitions() as $definition) {
+            $methodCalls = $definition->getMethodCalls();
+            $remaining = array_values(array_filter(
+                $methodCalls,
+                function (array $call) use ($driverId) {
+                    if ('addDriver' !== $call[0]) {
+                        return true;
+                    }
+
+                    $driver = $call[1][0] ?? null;
+
+                    return !($driver instanceof Reference && $driverId === (string) $driver);
+                }
+            ));
+
+            if (\count($remaining) !== \count($methodCalls)) {
+                $definition->setMethodCalls($remaining);
+            }
+        }
+    }
+
+    /**
+     * パスをコンテナパラメータ解決 + realpath で正規化する.
+     */
+    private function resolvePath(ContainerBuilder $container, mixed $path): ?string
+    {
+        if (!\is_string($path)) {
+            return null;
+        }
+
+        $resolved = $container->getParameterBag()->resolveValue($path);
+        if (!\is_string($resolved)) {
+            return null;
+        }
+
+        return realpath($resolved) ?: null;
+    }
+}

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -22,6 +22,7 @@ use Eccube\DependencyInjection\Compiler\PaymentMethodPass;
 use Eccube\DependencyInjection\Compiler\PluginPass;
 use Eccube\DependencyInjection\Compiler\PurchaseFlowPass;
 use Eccube\DependencyInjection\Compiler\QueryCustomizerPass;
+use Eccube\DependencyInjection\Compiler\StripAutoMappedEntityPathsPass;
 use Eccube\DependencyInjection\Compiler\StripReportFieldsArgPass;
 use Eccube\DependencyInjection\Compiler\TwigBlockPass;
 use Eccube\DependencyInjection\Compiler\TwigExtensionPass;
@@ -292,12 +293,16 @@ class Kernel extends BaseKernel
     {
         $projectDir = $container->getParameter('kernel.project_dir');
 
+        // TraitProxyAttributeDriver で明示登録した Entity ディレクトリ
+        $explicitlyMappedPaths = [];
+
         // Eccube
         $paths = ['%kernel.project_dir%/src/Eccube/Entity'];
         $namespaces = ['Eccube\\Entity'];
         $driver = new Definition(TraitProxyAttributeDriver::class, [$paths]);
         $driver->addMethodCall('setTraitProxiesDirectory', [$projectDir.'/app/proxy/entity']);
         $container->addCompilerPass(new DoctrineOrmMappingsPass($driver, $namespaces, []));
+        $explicitlyMappedPaths = [...$explicitlyMappedPaths, ...$paths];
 
         // Customize
         $customizePaths = ['%kernel.project_dir%/app/Customize/Entity'];
@@ -305,6 +310,7 @@ class Kernel extends BaseKernel
         $customizeDriver = new Definition(TraitProxyAttributeDriver::class, [$customizePaths]);
         $customizeDriver->addMethodCall('setTraitProxiesDirectory', [$projectDir.'/app/proxy/entity']);
         $container->addCompilerPass(new DoctrineOrmMappingsPass($customizeDriver, $customizeNamespaces, []));
+        $explicitlyMappedPaths = [...$explicitlyMappedPaths, ...$customizePaths];
 
         // Plugin
         $pluginDir = $projectDir.'/app/Plugin';
@@ -322,8 +328,17 @@ class Kernel extends BaseKernel
                 $driver = new Definition(TraitProxyAttributeDriver::class, [$paths]);
                 $driver->addMethodCall('setTraitProxiesDirectory', [$projectDir.'/app/proxy/entity']);
                 $container->addCompilerPass(new DoctrineOrmMappingsPass($driver, $namespaces, []));
+                $explicitlyMappedPaths = [...$explicitlyMappedPaths, ...$paths];
             }
         }
+
+        // 明示登録した Entity ディレクトリを auto_mapping の素の AttributeDriver から取り除く.
+        // StripReportFieldsArgPass が paths を第1引数へ正規化した後に実行する必要があるため、優先度を-1001に設定
+        $container->addCompilerPass(
+            new StripAutoMappedEntityPathsPass($explicitlyMappedPaths),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            -1001
+        );
     }
 
     protected function loadEntityProxies(): void

--- a/tests/Eccube/Tests/DependencyInjection/Compiler/StripAutoMappedEntityPathsPassTest.php
+++ b/tests/Eccube/Tests/DependencyInjection/Compiler/StripAutoMappedEntityPathsPassTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\DependencyInjection\Compiler;
+
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use Eccube\DependencyInjection\Compiler\StripAutoMappedEntityPathsPass;
+use Eccube\Doctrine\ORM\Mapping\Driver\TraitProxyAttributeDriver;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * doctrine.orm.auto_mapping が生成する素の AttributeDriver から、EC-CUBE が
+ * TraitProxyAttributeDriver で明示登録している Entity ディレクトリが取り除かれることの回帰テスト.
+ *
+ * 素のドライバは ColocatedMappingDriver::getAllClassNames() で Entity ソースを無条件に
+ * require_once するため、Kernel::loadEntityProxies() が Proxy をロード済みの状態では
+ * "Cannot redeclare class" で fatal になる.
+ *
+ * DoctrineBundle の実挙動 (バンドル横断で 1 つの AttributeDriver に paths を集約し、
+ * prefix ごとに MappingDriverChain::addDriver する) を模したコンテナで検証する.
+ *
+ * @see https://github.com/EC-CUBE/ec-cube/issues/6979
+ */
+final class StripAutoMappedEntityPathsPassTest extends TestCase
+{
+    private const DRIVER_ID = 'doctrine.orm.default_attribute_metadata_driver';
+
+    private const CHAIN_ID = 'doctrine.orm.default_metadata_driver';
+
+    private string $projectDir;
+
+    private string $coreEntityDir;
+
+    private string $pluginEntityDir;
+
+    private string $vendorEntityDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->projectDir = sys_get_temp_dir().'/strip_auto_mapped_entity_paths_'.uniqid('', true);
+        $this->coreEntityDir = $this->projectDir.'/src/Eccube/Entity';
+        $this->pluginEntityDir = $this->projectDir.'/app/Plugin/Foo/Entity';
+        $this->vendorEntityDir = $this->projectDir.'/vendor/acme/extra-bundle/src/Entity';
+
+        (new Filesystem())->mkdir([$this->coreEntityDir, $this->pluginEntityDir, $this->vendorEntityDir]);
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->projectDir);
+
+        parent::tearDown();
+    }
+
+    /**
+     * 明示登録済みのパスだけが取り除かれ、第三者バンドルのパスは残ること.
+     */
+    public function testExplicitlyMappedPathsAreStripped(): void
+    {
+        $container = $this->createContainer([
+            'Eccube\\Entity' => $this->coreEntityDir,
+            'Plugin\\Foo\\Entity' => $this->pluginEntityDir,
+            'Acme\\ExtraBundle\\Entity' => $this->vendorEntityDir,
+        ]);
+
+        $this->process($container);
+
+        $this->assertSame(
+            [$this->vendorEntityDir],
+            $container->getDefinition(self::DRIVER_ID)->getArgument(0),
+            '明示登録済みの Entity ディレクトリは素の AttributeDriver から取り除かれる'
+        );
+    }
+
+    /**
+     * パスが残る場合は MappingDriverChain への登録を維持すること.
+     */
+    public function testDriverStaysInChainWhenPathsRemain(): void
+    {
+        $container = $this->createContainer([
+            'Eccube\\Entity' => $this->coreEntityDir,
+            'Acme\\ExtraBundle\\Entity' => $this->vendorEntityDir,
+        ]);
+
+        $this->process($container);
+
+        $this->assertSame(
+            ['Eccube\\Entity', 'Acme\\ExtraBundle\\Entity'],
+            $this->autoMappedPrefixesInChain($container),
+            '第三者バンドルのマッピングを解決するため、素のドライバはチェーンに残す'
+        );
+    }
+
+    /**
+     * 全パスが明示登録済みになった素のドライバは MappingDriverChain から外すこと.
+     *
+     * paths が空のまま getAllClassNames() を呼ばれると
+     * MappingException::pathRequiredForDriver で例外になるため.
+     */
+    public function testDriverIsRemovedFromChainWhenAllPathsAreStripped(): void
+    {
+        $container = $this->createContainer([
+            'Eccube\\Entity' => $this->coreEntityDir,
+            'Plugin\\Foo\\Entity' => $this->pluginEntityDir,
+        ]);
+
+        $this->process($container);
+
+        $this->assertSame([], $container->getDefinition(self::DRIVER_ID)->getArgument(0));
+        $this->assertSame([], $this->autoMappedPrefixesInChain($container));
+
+        // EC-CUBE が明示登録した TraitProxyAttributeDriver の登録は残す
+        $this->assertSame(
+            ['Eccube\\Entity', 'Plugin\\Foo\\Entity'],
+            $this->explicitlyMappedPrefixesInChain($container)
+        );
+    }
+
+    /**
+     * 明示登録側がコンテナパラメータ表記でも解決されること.
+     */
+    public function testParameterPlaceholderIsResolved(): void
+    {
+        $container = $this->createContainer([
+            'Eccube\\Entity' => $this->coreEntityDir,
+            'Acme\\ExtraBundle\\Entity' => $this->vendorEntityDir,
+        ]);
+
+        (new StripAutoMappedEntityPathsPass(['%kernel.project_dir%/src/Eccube/Entity']))->process($container);
+
+        $this->assertSame([$this->vendorEntityDir], $container->getDefinition(self::DRIVER_ID)->getArgument(0));
+    }
+
+    /**
+     * doctrine.orm.auto_mapping 由来でないドライバ定義は変更しないこと.
+     */
+    public function testUnrelatedDriverIsNotTouched(): void
+    {
+        $container = $this->createContainer([
+            'Acme\\ExtraBundle\\Entity' => $this->vendorEntityDir,
+        ]);
+        $container->setDefinition(
+            'acme.custom_metadata_driver',
+            new Definition(AttributeDriver::class, [[$this->coreEntityDir]])
+        );
+
+        $this->process($container);
+
+        $this->assertSame(
+            [$this->coreEntityDir],
+            $container->getDefinition('acme.custom_metadata_driver')->getArgument(0)
+        );
+    }
+
+    /**
+     * DoctrineBundle が生成するコンテナ構造を模して組み立てる.
+     *
+     * @param array<string, string> $autoMappedPaths prefix => Entity ディレクトリ
+     */
+    private function createContainer(array $autoMappedPaths): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', $this->projectDir);
+
+        // DoctrineExtension::registerMappingDrivers 相当:
+        // 同じドライバ型のバンドルを 1 インスタンスに集約し、prefix ごとにチェーンへ登録する
+        $container->setDefinition(
+            self::DRIVER_ID,
+            new Definition(AttributeDriver::class, [array_values($autoMappedPaths)])
+        );
+
+        $chain = new Definition(MappingDriverChain::class);
+        foreach (array_keys($autoMappedPaths) as $prefix) {
+            $chain->addMethodCall('addDriver', [new Reference(self::DRIVER_ID), $prefix]);
+        }
+
+        // Kernel::addEntityExtensionPass 相当: 明示登録は同じ prefix を後から上書きする
+        foreach ($this->explicitlyMappedPaths() as $prefix => $path) {
+            $chain->addMethodCall('addDriver', [new Definition(TraitProxyAttributeDriver::class, [[$path]]), $prefix]);
+        }
+
+        $container->setDefinition(self::CHAIN_ID, $chain);
+
+        return $container;
+    }
+
+    private function process(ContainerBuilder $container): void
+    {
+        (new StripAutoMappedEntityPathsPass(array_values($this->explicitlyMappedPaths())))->process($container);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function explicitlyMappedPaths(): array
+    {
+        return [
+            'Eccube\\Entity' => $this->coreEntityDir,
+            'Plugin\\Foo\\Entity' => $this->pluginEntityDir,
+        ];
+    }
+
+    /**
+     * 素の AttributeDriver がチェーンに登録されている prefix.
+     *
+     * @return list<string>
+     */
+    private function autoMappedPrefixesInChain(ContainerBuilder $container): array
+    {
+        $prefixes = [];
+        foreach ($container->getDefinition(self::CHAIN_ID)->getMethodCalls() as [$method, $arguments]) {
+            if ('addDriver' === $method && $arguments[0] instanceof Reference && self::DRIVER_ID === (string) $arguments[0]) {
+                $prefixes[] = $arguments[1];
+            }
+        }
+
+        return $prefixes;
+    }
+
+    /**
+     * TraitProxyAttributeDriver がチェーンに登録されている prefix.
+     *
+     * @return list<string>
+     */
+    private function explicitlyMappedPrefixesInChain(ContainerBuilder $container): array
+    {
+        $prefixes = [];
+        foreach ($container->getDefinition(self::CHAIN_ID)->getMethodCalls() as [$method, $arguments]) {
+            if ('addDriver' === $method && $arguments[0] instanceof Definition
+                && TraitProxyAttributeDriver::class === $arguments[0]->getClass()) {
+                $prefixes[] = $arguments[1];
+            }
+        }
+
+        return $prefixes;
+    }
+}

--- a/tests/Eccube/Tests/Doctrine/ORM/Mapping/AutoMappedEntityPathsBootTest.php
+++ b/tests/Eccube/Tests/Doctrine/ORM/Mapping/AutoMappedEntityPathsBootTest.php
@@ -47,6 +47,11 @@ use Symfony\Component\Process\Process;
  * 同一プロセスで起動すると tearDown が実行されず fixture が残るため、
  * 子プロセスに閉じ込めて終了コードで判定する.
  *
+ * サブプロセスは専用の APP_ENV で実行する. fixture を反映させるにはコンテナの再生成が必要だが、
+ * var/cache/test を削除すると、同一プロセスで実行中の他テストがコンテナから遅延ロードする
+ * サービス定義ファイルまで消えてしまうため (Kernel::configureContainer は
+ * packages/<env> を is_dir で判定するので、専用環境名でも共通設定だけで起動できる).
+ *
  * 実プロジェクトのファイルを一時的に置き換えるため、既存ファイルは setUp で退避し tearDown で復元する.
  *
  * @see https://github.com/EC-CUBE/ec-cube/issues/6979
@@ -60,6 +65,9 @@ final class AutoMappedEntityPathsBootTest extends TestCase
     private const EXTRA_ENTITY = StripAutoMappedExtra::class;
 
     private const PROXY_PATH = 'app/proxy/entity/app/Customize/Entity/StripAutoMappedTarget.php';
+
+    /** サブプロセス専用の環境名. var/cache/test を他テストと共有しないために分ける */
+    private const SUBPROCESS_ENV = 'test_auto_mapped';
 
     /**
      * 本テストが作成・削除するパス (プロジェクトルートからの相対).
@@ -101,13 +109,13 @@ final class AutoMappedEntityPathsBootTest extends TestCase
         );
 
         // 明示登録・auto_mapping ともにコンパイル時に決まるため、コンテナを作り直させる
-        $this->fs->remove($this->projectDir.'/var/cache/test');
+        $this->fs->remove($this->subprocessCacheDir());
     }
 
     protected function tearDown(): void
     {
         $this->restoreStashedFiles();
-        $this->fs->remove($this->projectDir.'/var/cache/test');
+        $this->fs->remove($this->subprocessCacheDir());
         parent::tearDown();
     }
 
@@ -119,7 +127,11 @@ final class AutoMappedEntityPathsBootTest extends TestCase
      */
     public function testMappingIsResolvedWithRootLevelBundleAndProxy(): void
     {
-        $process = new Process(['bin/console', 'doctrine:mapping:info'], $this->projectDir, ['APP_ENV' => 'test']);
+        $process = new Process(
+            ['bin/console', 'doctrine:mapping:info'],
+            $this->projectDir,
+            ['APP_ENV' => self::SUBPROCESS_ENV]
+        );
         $process->run();
 
         $output = $process->getOutput().$process->getErrorOutput();
@@ -140,6 +152,11 @@ final class AutoMappedEntityPathsBootTest extends TestCase
             $output,
             'auto_mapping 側のパス除去が過剰で、第三者バンドルの Entity まで失われている'
         );
+    }
+
+    private function subprocessCacheDir(): string
+    {
+        return $this->projectDir.'/var/cache/'.self::SUBPROCESS_ENV;
     }
 
     /**

--- a/tests/Eccube/Tests/Doctrine/ORM/Mapping/AutoMappedEntityPathsBootTest.php
+++ b/tests/Eccube/Tests/Doctrine/ORM/Mapping/AutoMappedEntityPathsBootTest.php
@@ -17,18 +17,18 @@ namespace Eccube\Tests\Doctrine\ORM\Mapping;
 
 use Customize\Entity\StripAutoMappedTarget;
 use Customize\Lib\Entity\StripAutoMappedExtra;
-use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
 
 /**
- * auto_mapping による Entity ディレクトリの二重登録が、実際に Kernel を boot した状態で
+ * auto_mapping による Entity ディレクトリの二重登録が、実際にアプリケーションを起動した状態で
  * redeclare fatal を起こさないことの回帰テスト.
  *
  * StripAutoMappedEntityPathsPassTest は ContainerBuilder を組み立てるコンパイル時の単体テスト、
  * EccubeEntityMetadataDriverTest は素の構成でのドライバ種別の検証であり、いずれも
- * issue #6979 の再現構成そのものは組み立てていない. 本テストは再現に必要な 3 要素を実際に配置して
- * boot し、メタデータ解決まで到達することを検証する.
+ * issue #6979 の再現構成そのものは組み立てていない. 本テストは再現に必要な 3 要素を実際に配置し、
+ * メタデータ解決まで到達することを検証する.
  *
  * 再現に必要な 3 要素 (issue #6979 の対照実験 A / B で確定):
  *
@@ -41,38 +41,62 @@ use Symfony\Component\Filesystem\Filesystem;
  *      EC-CUBE が明示登録している app/Customize/Entity が素のドライバの paths にも入る.
  *   3. 同一 FQCN の Proxy (app/proxy/entity/app/Customize/Entity/...)
  *      Kernel::loadEntityProxies() が先にロードするため、素のドライバが元ソースを
- *      require_once した時点で "Cannot declare class ..." になる.
+ *      require_once した時点で "Cannot redeclare class ..." になる.
  *
- * 修正 (StripAutoMappedEntityPathsPass) が失われると、このテストは
- * アサーション失敗ではなく PHP の fatal error でプロセスごと停止する.
- * TraitProxyAttributeDriverTest と同じ性質のテストである.
+ * 検証は bin/console をサブプロセスで実行して行う. 回帰時の redeclare は PHP の fatal であり、
+ * 同一プロセスで起動すると tearDown が実行されず fixture が残るため、
+ * 子プロセスに閉じ込めて終了コードで判定する.
+ *
+ * 実プロジェクトのファイルを一時的に置き換えるため、既存ファイルは setUp で退避し tearDown で復元する.
  *
  * @see https://github.com/EC-CUBE/ec-cube/issues/6979
  * @see https://github.com/EC-CUBE/ec-cube/pull/6895 Entity の if(!class_exists()) ガード全廃
  */
-final class AutoMappedEntityPathsBootTest extends KernelTestCase
+final class AutoMappedEntityPathsBootTest extends TestCase
 {
     // fixture を app/Customize へ配置して初めて実体を持つクラス. ::class は静的解決のためロードは発生しない
     private const TARGET_ENTITY = StripAutoMappedTarget::class;
 
     private const EXTRA_ENTITY = StripAutoMappedExtra::class;
 
+    private const PROXY_PATH = 'app/proxy/entity/app/Customize/Entity/StripAutoMappedTarget.php';
+
+    /**
+     * 本テストが作成・削除するパス (プロジェクトルートからの相対).
+     * 実プロジェクトに同名のものがある場合は退避して復元する.
+     */
+    private const MANAGED_PATHS = [
+        'app/Customize/CustomizeRootBundle.php',
+        'app/Customize/Entity/StripAutoMappedTarget.php',
+        'app/Customize/Lib',
+        'app/Customize/Resource/config/bundles.php',
+        self::PROXY_PATH,
+    ];
+
     private string $projectDir;
 
+    private string $backupDir;
+
     private Filesystem $fs;
+
+    /** @var array<string, string> 退避したパス (相対パス => 退避先) */
+    private array $backups = [];
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->projectDir = \dirname(__DIR__, 6);
+        $this->backupDir = sys_get_temp_dir().'/eccube_auto_mapped_backup_'.uniqid('', true);
         $this->fs = new Filesystem();
+
+        $this->stashExistingFiles();
 
         $this->fs->mirror(\dirname(__DIR__, 5).'/Fixtures/CustomizeRootBundle', $this->projectDir.'/app/Customize');
 
         // eccube:generate:proxies 相当. 元ソースと同一 FQCN の Proxy を配置する
         $this->fs->copy(
             $this->projectDir.'/app/Customize/Entity/StripAutoMappedTarget.php',
-            $this->proxyFile(),
+            $this->projectDir.'/'.self::PROXY_PATH,
             true
         );
 
@@ -82,49 +106,96 @@ final class AutoMappedEntityPathsBootTest extends KernelTestCase
 
     protected function tearDown(): void
     {
-        $this->fs->remove([
-            $this->projectDir.'/app/Customize/CustomizeRootBundle.php',
-            $this->projectDir.'/app/Customize/Entity/StripAutoMappedTarget.php',
-            $this->projectDir.'/app/Customize/Lib',
-            $this->projectDir.'/app/Customize/Resource/config/bundles.php',
-            $this->proxyFile(),
-            $this->projectDir.'/var/cache/test',
-        ]);
-        // Restore exception handler to prevent risky test warnings
-        restore_exception_handler();
+        $this->restoreStashedFiles();
+        $this->fs->remove($this->projectDir.'/var/cache/test');
         parent::tearDown();
     }
 
     /**
-     * 再現構成のまま boot してメタデータを解決できること.
+     * 再現構成のままアプリケーションを起動し、メタデータを解決できること.
      *
      * 併せて、二重登録を取り除いても Entity のマッピング自体は失われないこと
      * (issue #6979 の検証 5 と同じ観点) を確認する.
      */
-    public function testBootResolvesMetadataWithRootLevelBundleAndProxy(): void
+    public function testMappingIsResolvedWithRootLevelBundleAndProxy(): void
     {
-        static::bootKernel();
+        $process = new Process(['bin/console', 'doctrine:mapping:info'], $this->projectDir, ['APP_ENV' => 'test']);
+        $process->run();
 
-        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
-        $classNames = array_map(
-            static fn ($metadata) => $metadata->getName(),
-            $entityManager->getMetadataFactory()->getAllMetadata()
+        $output = $process->getOutput().$process->getErrorOutput();
+
+        $this->assertSame(
+            0,
+            $process->getExitCode(),
+            'app/Customize 直下の Bundle と Proxy が共存する構成でメタデータを解決できない.'
+            .' auto_mapping による Entity ディレクトリの二重登録が残っている可能性がある:'.\PHP_EOL.$output
         );
-
-        $this->assertContains(
+        $this->assertStringContainsString(
             self::TARGET_ENTITY,
-            $classNames,
+            $output,
             '明示登録 (TraitProxyAttributeDriver) された app/Customize/Entity のマッピングが失われている'
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             self::EXTRA_ENTITY,
-            $classNames,
+            $output,
             'auto_mapping 側のパス除去が過剰で、第三者バンドルの Entity まで失われている'
         );
     }
 
-    private function proxyFile(): string
+    /**
+     * 実プロジェクトに同名のファイル・ディレクトリがあれば退避する.
+     */
+    private function stashExistingFiles(): void
     {
-        return $this->projectDir.'/app/proxy/entity/app/Customize/Entity/StripAutoMappedTarget.php';
+        foreach (self::MANAGED_PATHS as $relative) {
+            $path = $this->projectDir.'/'.$relative;
+            if (!$this->fs->exists($path)) {
+                continue;
+            }
+
+            $backup = $this->backupDir.'/'.str_replace('/', '__', $relative);
+            $this->fs->mkdir($this->backupDir);
+            $this->fs->rename($path, $backup, true);
+            $this->backups[$relative] = $backup;
+        }
+    }
+
+    /**
+     * 本テストが配置したファイルを取り除き、退避したものを元に戻す.
+     */
+    private function restoreStashedFiles(): void
+    {
+        foreach (self::MANAGED_PATHS as $relative) {
+            $this->fs->remove($this->projectDir.'/'.$relative);
+        }
+
+        foreach ($this->backups as $relative => $backup) {
+            $this->fs->rename($backup, $this->projectDir.'/'.$relative, true);
+        }
+
+        $this->removeEmptyProxyDirectories();
+
+        $this->fs->remove($this->backupDir);
+        $this->backups = [];
+    }
+
+    /**
+     * Proxy の配置で作られたディレクトリを、空になった場合のみ取り除く.
+     * 実運用で生成された Proxy を巻き込まないよう、中身がある場合は残す.
+     */
+    private function removeEmptyProxyDirectories(): void
+    {
+        $directories = [
+            'app/proxy/entity/app/Customize/Entity',
+            'app/proxy/entity/app/Customize',
+            'app/proxy/entity/app',
+        ];
+
+        foreach ($directories as $relative) {
+            $path = $this->projectDir.'/'.$relative;
+            if (is_dir($path) && !(new \FilesystemIterator($path))->valid()) {
+                $this->fs->remove($path);
+            }
+        }
     }
 }

--- a/tests/Eccube/Tests/Doctrine/ORM/Mapping/AutoMappedEntityPathsBootTest.php
+++ b/tests/Eccube/Tests/Doctrine/ORM/Mapping/AutoMappedEntityPathsBootTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Doctrine\ORM\Mapping;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * auto_mapping による Entity ディレクトリの二重登録が、実際に Kernel を boot した状態で
+ * redeclare fatal を起こさないことの回帰テスト.
+ *
+ * StripAutoMappedEntityPathsPassTest は ContainerBuilder を組み立てるコンパイル時の単体テスト、
+ * EccubeEntityMetadataDriverTest は素の構成でのドライバ種別の検証であり、いずれも
+ * issue #6979 の再現構成そのものは組み立てていない. 本テストは再現に必要な 3 要素を実際に配置して
+ * boot し、メタデータ解決まで到達することを検証する.
+ *
+ * 再現に必要な 3 要素 (issue #6979 の対照実験 A / B で確定):
+ *
+ *   1. Entity を持つ第三者バンドル (Customize\Lib\CustomizeLibBundle)
+ *      prefix Customize\Lib\Entity は明示登録の対象外なので、auto_mapping が生成する
+ *      素の AttributeDriver がこの prefix で MappingDriverChain に残る.
+ *      これが無いと共有ドライバはチェーンから消えるため fatal にならない (対照実験 A).
+ *   2. app/Customize 直下に置かれた Bundle (Customize\CustomizeRootBundle)
+ *      doctrine-bundle は「Bundle クラスのあるディレクトリ + /Entity」を auto_mapping 対象とするため、
+ *      EC-CUBE が明示登録している app/Customize/Entity が素のドライバの paths にも入る.
+ *   3. 同一 FQCN の Proxy (app/proxy/entity/app/Customize/Entity/...)
+ *      Kernel::loadEntityProxies() が先にロードするため、素のドライバが元ソースを
+ *      require_once した時点で "Cannot declare class ..." になる.
+ *
+ * 修正 (StripAutoMappedEntityPathsPass) が失われると、このテストは
+ * アサーション失敗ではなく PHP の fatal error でプロセスごと停止する.
+ * TraitProxyAttributeDriverTest と同じ性質のテストである.
+ *
+ * @see https://github.com/EC-CUBE/ec-cube/issues/6979
+ * @see https://github.com/EC-CUBE/ec-cube/pull/6895 Entity の if(!class_exists()) ガード全廃
+ */
+final class AutoMappedEntityPathsBootTest extends KernelTestCase
+{
+    private const TARGET_ENTITY = 'Customize\\Entity\\StripAutoMappedTarget';
+
+    private const EXTRA_ENTITY = 'Customize\\Lib\\Entity\\StripAutoMappedExtra';
+
+    private string $projectDir;
+
+    private Filesystem $fs;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->projectDir = \dirname(__DIR__, 6);
+        $this->fs = new Filesystem();
+
+        $this->fs->mirror(\dirname(__DIR__, 5).'/Fixtures/CustomizeRootBundle', $this->projectDir.'/app/Customize');
+
+        // eccube:generate:proxies 相当. 元ソースと同一 FQCN の Proxy を配置する
+        $this->fs->copy(
+            $this->projectDir.'/app/Customize/Entity/StripAutoMappedTarget.php',
+            $this->proxyFile(),
+            true
+        );
+
+        // 明示登録・auto_mapping ともにコンパイル時に決まるため、コンテナを作り直させる
+        $this->fs->remove($this->projectDir.'/var/cache/test');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fs->remove([
+            $this->projectDir.'/app/Customize/CustomizeRootBundle.php',
+            $this->projectDir.'/app/Customize/Entity/StripAutoMappedTarget.php',
+            $this->projectDir.'/app/Customize/Lib',
+            $this->projectDir.'/app/Customize/Resource/config/bundles.php',
+            $this->proxyFile(),
+            $this->projectDir.'/var/cache/test',
+        ]);
+        // Restore exception handler to prevent risky test warnings
+        restore_exception_handler();
+        parent::tearDown();
+    }
+
+    /**
+     * 再現構成のまま boot してメタデータを解決できること.
+     *
+     * 併せて、二重登録を取り除いても Entity のマッピング自体は失われないこと
+     * (issue #6979 の検証 5 と同じ観点) を確認する.
+     */
+    public function testBootResolvesMetadataWithRootLevelBundleAndProxy(): void
+    {
+        static::bootKernel();
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $classNames = array_map(
+            static fn ($metadata) => $metadata->getName(),
+            $entityManager->getMetadataFactory()->getAllMetadata()
+        );
+
+        $this->assertContains(
+            self::TARGET_ENTITY,
+            $classNames,
+            '明示登録 (TraitProxyAttributeDriver) された app/Customize/Entity のマッピングが失われている'
+        );
+        $this->assertContains(
+            self::EXTRA_ENTITY,
+            $classNames,
+            'auto_mapping 側のパス除去が過剰で、第三者バンドルの Entity まで失われている'
+        );
+    }
+
+    private function proxyFile(): string
+    {
+        return $this->projectDir.'/app/proxy/entity/app/Customize/Entity/StripAutoMappedTarget.php';
+    }
+}

--- a/tests/Eccube/Tests/Doctrine/ORM/Mapping/AutoMappedEntityPathsBootTest.php
+++ b/tests/Eccube/Tests/Doctrine/ORM/Mapping/AutoMappedEntityPathsBootTest.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace Eccube\Tests\Doctrine\ORM\Mapping;
 
+use Customize\Entity\StripAutoMappedTarget;
+use Customize\Lib\Entity\StripAutoMappedExtra;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Filesystem\Filesystem;
@@ -50,9 +52,10 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class AutoMappedEntityPathsBootTest extends KernelTestCase
 {
-    private const TARGET_ENTITY = 'Customize\\Entity\\StripAutoMappedTarget';
+    // fixture を app/Customize へ配置して初めて実体を持つクラス. ::class は静的解決のためロードは発生しない
+    private const TARGET_ENTITY = StripAutoMappedTarget::class;
 
-    private const EXTRA_ENTITY = 'Customize\\Lib\\Entity\\StripAutoMappedExtra';
+    private const EXTRA_ENTITY = StripAutoMappedExtra::class;
 
     private string $projectDir;
 

--- a/tests/Eccube/Tests/Doctrine/ORM/Mapping/EccubeEntityMetadataDriverTest.php
+++ b/tests/Eccube/Tests/Doctrine/ORM/Mapping/EccubeEntityMetadataDriverTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Doctrine\ORM\Mapping;
+
+use Doctrine\Bundle\DoctrineBundle\Mapping\MappingDriver as BundleMappingDriver;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use Eccube\Doctrine\ORM\Mapping\Driver\TraitProxyAttributeDriver;
+use Eccube\Tests\EccubeTestCase;
+
+/**
+ * EC-CUBE が明示登録している Entity ディレクトリが、TraitProxyAttributeDriver 以外から
+ * 二重登録されないことの回帰テスト.
+ *
+ * Kernel::addEntityExtensionPass は src/Eccube/Entity・app/Customize/Entity・
+ * app/Plugin/<Code>/Entity を TraitProxyAttributeDriver で登録する.
+ * これは Proxy (app/proxy/entity) で宣言済みの Entity を再 require しない実装になっている.
+ * ところが doctrine.orm.auto_mapping がこれらのディレクトリを持つバンドルを検出すると、
+ * 同じディレクトリが素の AttributeDriver でも登録される. 素のドライバは
+ * ColocatedMappingDriver::getAllClassNames() で Entity ソースを無条件に require_once するため、
+ * Kernel::loadEntityProxies が Proxy を先にロードした状態では "Cannot redeclare class" で
+ * fatal になる (Entity の if (!class_exists()) ガード全廃前は、そのガードが吸収していた).
+ *
+ * 二重登録は StripAutoMappedEntityPathsPass がコンパイル時に取り除く.
+ *
+ * @see https://github.com/EC-CUBE/ec-cube/pull/6895 Entity の if(!class_exists()) ガード全廃
+ * @see https://github.com/EC-CUBE/ec-cube/issues/6979 プラグイン/Customize 直下にバンドルを置いた場合の再発
+ */
+final class EccubeEntityMetadataDriverTest extends EccubeTestCase
+{
+    /**
+     * 明示登録した Entity ディレクトリを担当するドライバが TraitProxyAttributeDriver だけであることを検証する.
+     */
+    public function testExplicitlyMappedPathsAreMappedOnlyByTraitProxyAttributeDriver(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $driver = $entityManager->getConfiguration()->getMetadataDriverImpl();
+
+        $explicitlyMappedPaths = $this->explicitlyMappedPaths();
+        $this->assertNotEmpty($explicitlyMappedPaths);
+
+        $mappedPaths = [];
+        foreach ($this->flattenDrivers($driver) as $each) {
+            if (!method_exists($each, 'getPaths')) {
+                continue;
+            }
+            foreach ($each->getPaths() as $path) {
+                $path = realpath($path);
+                if (!\in_array($path, $explicitlyMappedPaths, true)) {
+                    continue;
+                }
+                $mappedPaths[] = $path;
+                $this->assertInstanceOf(TraitProxyAttributeDriver::class, $each, $path.' は TraitProxyAttributeDriver 以外から登録してはならない'
+                    .' (素の AttributeDriver は Entity ソースを無条件に require_once するため、'
+                    .'Proxy ロード済みの環境で "Cannot redeclare class" になる)');
+            }
+        }
+
+        // 対象ドライバが 0 件でもループが素通りするため、明示登録そのものが失われた構成も検知する
+        $coreEntityDir = realpath(static::getContainer()->getParameter('kernel.project_dir').'/src/Eccube/Entity');
+        $this->assertContains(
+            $coreEntityDir,
+            $mappedPaths,
+            'src/Eccube/Entity のマッピングドライバ (Kernel::addEntityExtensionPass の TraitProxyAttributeDriver) が登録されていない'
+        );
+    }
+
+    /**
+     * Kernel::addEntityExtensionPass が TraitProxyAttributeDriver で明示登録するディレクトリ.
+     *
+     * @return list<string>
+     */
+    private function explicitlyMappedPaths(): array
+    {
+        $projectDir = static::getContainer()->getParameter('kernel.project_dir');
+
+        $paths = [
+            $projectDir.'/src/Eccube/Entity',
+            $projectDir.'/app/Customize/Entity',
+            ...glob($projectDir.'/app/Plugin/*/Entity', GLOB_ONLYDIR),
+        ];
+
+        return array_values(array_filter(array_map(realpath(...), $paths)));
+    }
+
+    /**
+     * MappingDriverChain を再帰的に展開して、実際にマッピングを解決するドライバを列挙する.
+     *
+     * @return list<MappingDriver>
+     */
+    private function flattenDrivers(?MappingDriver $driver): array
+    {
+        if ($driver === null) {
+            return [];
+        }
+
+        // doctrine-bundle の MappingDriver は実ドライバをラップしているため中身を取り出す
+        if ($driver instanceof BundleMappingDriver) {
+            return $this->flattenDrivers($driver->getDriver());
+        }
+
+        if (!$driver instanceof MappingDriverChain) {
+            return [$driver];
+        }
+
+        $drivers = [];
+        foreach ($driver->getDrivers() as $each) {
+            $drivers = [...$drivers, ...$this->flattenDrivers($each)];
+        }
+
+        return [...$drivers, ...$this->flattenDrivers($driver->getDefaultDriver())];
+    }
+}

--- a/tests/Fixtures/CustomizeRootBundle/CustomizeRootBundle.php
+++ b/tests/Fixtures/CustomizeRootBundle/CustomizeRootBundle.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Customize;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * app/Customize 直下に置かれた Bundle (issue #6979 の再現構成).
+ *
+ * doctrine-bundle は Bundle クラスファイルのあるディレクトリ + /Entity を auto_mapping 対象にするため、
+ * この配置では app/Customize/Entity が prefix Customize\Entity で素の AttributeDriver にも登録される.
+ */
+class CustomizeRootBundle extends Bundle
+{
+}

--- a/tests/Fixtures/CustomizeRootBundle/CustomizeRootBundle.php
+++ b/tests/Fixtures/CustomizeRootBundle/CustomizeRootBundle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of EC-CUBE
  *

--- a/tests/Fixtures/CustomizeRootBundle/Entity/StripAutoMappedTarget.php
+++ b/tests/Fixtures/CustomizeRootBundle/Entity/StripAutoMappedTarget.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of EC-CUBE
  *

--- a/tests/Fixtures/CustomizeRootBundle/Entity/StripAutoMappedTarget.php
+++ b/tests/Fixtures/CustomizeRootBundle/Entity/StripAutoMappedTarget.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Customize\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * app/Customize/Entity に置かれる Entity (issue #6979 の再現構成).
+ *
+ * テスト実行時に同一 FQCN の Proxy が app/proxy/entity 配下に複製され、
+ * Kernel::loadEntityProxies() が先にロードする.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'dtb_strip_auto_mapped_target')]
+class StripAutoMappedTarget
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/CustomizeRootBundle/Entity/StripAutoMappedTarget.php
+++ b/tests/Fixtures/CustomizeRootBundle/Entity/StripAutoMappedTarget.php
@@ -13,6 +13,7 @@
 
 namespace Customize\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -26,7 +27,7 @@ use Doctrine\ORM\Mapping as ORM;
 class StripAutoMappedTarget
 {
     #[ORM\Id]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     #[ORM\GeneratedValue]
     private ?int $id = null;
 

--- a/tests/Fixtures/CustomizeRootBundle/Lib/CustomizeLibBundle.php
+++ b/tests/Fixtures/CustomizeRootBundle/Lib/CustomizeLibBundle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of EC-CUBE
  *

--- a/tests/Fixtures/CustomizeRootBundle/Lib/CustomizeLibBundle.php
+++ b/tests/Fixtures/CustomizeRootBundle/Lib/CustomizeLibBundle.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Customize\Lib;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * Entity を持つ第三者バンドル相当 (issue #6979 の「準備1」/ 実環境では league/oauth2-server-bundle).
+ *
+ * prefix が Customize\Lib\Entity になり Kernel::addEntityExtensionPass の明示登録対象外のため、
+ * auto_mapping が生成する素の AttributeDriver がこの prefix で MappingDriverChain に残る.
+ * 素のドライバは 1 インスタンスに集約されているため、その getAllClassNames() は
+ * app/Customize/Entity を含む自身の全パスを走査してしまう (= redeclare の発火条件).
+ */
+class CustomizeLibBundle extends Bundle
+{
+}

--- a/tests/Fixtures/CustomizeRootBundle/Lib/Entity/StripAutoMappedExtra.php
+++ b/tests/Fixtures/CustomizeRootBundle/Lib/Entity/StripAutoMappedExtra.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of EC-CUBE
  *

--- a/tests/Fixtures/CustomizeRootBundle/Lib/Entity/StripAutoMappedExtra.php
+++ b/tests/Fixtures/CustomizeRootBundle/Lib/Entity/StripAutoMappedExtra.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Customize\Lib\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * 第三者バンドルが持つ Entity. この prefix (Customize\Lib\Entity) は明示登録の対象外なので、
+ * 素の AttributeDriver が MappingDriverChain に残り続ける.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'dtb_strip_auto_mapped_extra')]
+class StripAutoMappedExtra
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/CustomizeRootBundle/Lib/Entity/StripAutoMappedExtra.php
+++ b/tests/Fixtures/CustomizeRootBundle/Lib/Entity/StripAutoMappedExtra.php
@@ -13,6 +13,7 @@
 
 namespace Customize\Lib\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -24,7 +25,7 @@ use Doctrine\ORM\Mapping as ORM;
 class StripAutoMappedExtra
 {
     #[ORM\Id]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     #[ORM\GeneratedValue]
     private ?int $id = null;
 

--- a/tests/Fixtures/CustomizeRootBundle/Resource/config/bundles.php
+++ b/tests/Fixtures/CustomizeRootBundle/Resource/config/bundles.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Customize\CustomizeRootBundle;
+use Customize\Lib\CustomizeLibBundle;
+
+return [
+    CustomizeRootBundle::class => ['all' => true],
+    CustomizeLibBundle::class => ['all' => true],
+];

--- a/tests/Fixtures/CustomizeRootBundle/Resource/config/bundles.php
+++ b/tests/Fixtures/CustomizeRootBundle/Resource/config/bundles.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of EC-CUBE
  *


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Entity の `if (!class_exists())` ガードを全廃した #6895 以降、**Proxy 生成後に全リクエスト・全コンソールコマンドが redeclare fatal で失敗する**問題を修正します。

```
PHP Fatal error: Cannot redeclare class Eccube\Entity\Customer,
because the name is already in use in src/Eccube/Entity/Customer.php on line 49
```

fixes #6979 / **#6963 を置き換えます**（#6963 の方式では塞げない経路が #6979 で報告されたため、方式を変更して出し直したものです。#6963 はクローズします）

refs #6979, #6963, #6895, #6891, #5844

### 原因

`doctrine.orm.auto_mapping` が、EC-CUBE が明示登録しているのと**同じ Entity ディレクトリを素の `AttributeDriver` にも登録**することが原因です。

1. `Kernel::addEntityExtensionPass()` は `src/Eccube/Entity` / `app/Customize/Entity` / `app/Plugin/<Code>/Entity` を `TraitProxyAttributeDriver` で登録する。こちらは #6895 の追随修正（`77defa74ca`）で「宣言済みの Entity は再 `require_once` しない」ようになっている。
2. 一方 doctrine-bundle は、**バンドルクラスが置かれたディレクトリ + `/Entity`** を auto_mapping の対象として検出する（`DoctrineExtension::detectMetadataDriver()` / `getMappingDriverBundleConfigDefaults()`）。

```php
// DoctrineExtension::getMappingDriverBundleConfigDefaults()
$bundleClassDir = dirname($bundle->getFileName());
...
$bundleConfig['dir'] = $bundleClassDir . '/' . $this->getMappingObjectDefaultName();  // 'Entity'
```

3. さらに `registerMappingDrivers()` は**同じドライバ型のバンドルを 1 つの Definition に集約**する。

```php
$mappingDriverDef = new Definition($this->getMetadataDriverClass($driverType), [
    array_values($driverPaths),      // 全バンドルのパスが 1 インスタンスに入る
]);
foreach ($driverPaths as $prefix => $driverPath) {
    $chainDriverDef->addMethodCall('addDriver', [new Reference($mappingService), $prefix]);
}
```

4. 素のドライバは `ColocatedMappingDriver::getAllClassNames()` で Entity ソースを**無条件に `require_once`** する。`Kernel::loadEntityProxies()` が先に `app/proxy/entity` の Proxy を読み込んでいるため、二重宣言になる。ガード全廃前は各 Entity の `if (!class_exists())` がこれを吸収していた。

`MappingDriverChain` は名前空間ごとに 1 ドライバしか保持しないため、EC-CUBE の明示登録で上書きされたように見えます。しかし `getAllClassNames()` は**ドライバインスタンス単位**で走査するため、素のドライバが別の名前空間（第三者バンドル）でチェーンに残っていると、そのタイミングで自身の全パスを `require_once` して同じ fatal になります。

```php
// MappingDriverChain::getAllClassNames()
foreach ($this->drivers as $namespace => $driver) {
    $oid = spl_object_hash($driver);
    if (! isset($driverClasses[$oid])) {
        $driverClasses[$oid] = $driver->getAllClassNames();   // ← ここで全パスを require_once
    }
    ...
}
```

実際のスタックトレース（PostgreSQL / `APP_ENV=prod`）:

```
#0 doctrine/persistence/src/Persistence/Mapping/Driver/ColocatedMappingDriver.php(188): require_once()
#1 MappingDriverChain.php(104): Doctrine\ORM\Mapping\Driver\AttributeDriver->getAllClassNames()
#2 doctrine-bundle/src/Mapping/MappingDriver.php(25): MappingDriverChain->getAllClassNames()
#3 AbstractClassMetadataFactory.php(95): MappingDriver->getAllClassNames()
#4 symfony/doctrine-bridge/CacheWarmer/ProxyCacheWarmer.php(60): getAllMetadata()
...
#9 src/Eccube/Kernel.php(137): Symfony\Component\HttpKernel\Kernel->boot()
```

## 方針(Policy)

**`Kernel::addEntityExtensionPass()` が明示登録した Entity ディレクトリを、コンパイル時に auto_mapping 側のドライバの `paths` から取り除きます**（`StripAutoMappedEntityPathsPass`）。

- 対象は `doctrine.orm.<em>_attribute_metadata_driver`（および `.inner`）のみ。第三者バンドルのパスはそのまま残るため、プラグインが依存するバンドル（`league/oauth2-server-bundle` 等）の Entity は従来どおりマッピングされます。
- 除去対象のパスは `addEntityExtensionPass()` が登録したものをそのまま pass に渡すため、**明示登録とパス一覧が二重管理になりません**。
- 全パスが取り除かれた場合は、`paths` が空のまま `getAllClassNames()` を呼ばれると `MappingException::pathRequiredForDriver` になるため、`MappingDriverChain` の `addDriver()` 呼び出しからも外します。

### バンドル名を列挙する方式を採らなかった理由

当初 #6963 では `doctrine.orm.mappings: { EccubeBundle: false }` でコア分だけ無効化していましたが、#6979 で **`app/Plugin/<Code>/` や `app/Customize/` の直下にバンドルクラスを置いた構成では同じ fatal が残る**ことが報告されました（@kurozumi さんによる詳細な調査・再現手順に感謝します）。

```
PHP Fatal error: Cannot declare class Plugin\Foo\Entity\Bar,
because the name is already in use in app/Plugin/Foo/Entity/Bar.php on line 6
```

サードパーティ製プラグインが持ち込むバンドル名は事前に知ることができないため、列挙方式ではこの経路を塞げません。バンドル名に依存せず、**EC-CUBE が明示登録しているディレクトリという確実な情報**でパスを取り除く方式に変更しました。

なお #6979 で言及されているとおり、`TraitProxyAttributeDriver` 側で吸収する案は成立しません。実際に走査して `require_once` しているのは doctrine-bundle が生成する素の `AttributeDriver` であり、受け側では届かないためです。

## 実装に関する補足(Appendix)

- 本 PR は #6963 が直すケース（コア Entity の redeclare）も解消します。**#6963 の上位互換**であり、`app/config/eccube/packages/doctrine.yaml` への変更は不要になりました。
- **再現には「Entity を持つ第三者バンドル」が必要**です。素のドライバは EC-CUBE の明示登録と同じ prefix しか持たない場合チェーンから消える（明示登録が上書きする）ため、別 namespace のバンドルが加わって初めてチェーンに露出します。#6979 の対照実験（検証 A / B）と一致します。
- 現状、公式プラグインで該当する構成のものはありません（`eccube-api4` は `Bundle/ApiBundle.php` 配置のため対象外）。サードパーティ製プラグインが `app/Plugin/Foo/FooBundle.php` という配置を選んだ場合に踏みます。

## テスト（Test)

ローカル（PHP 8.5 / SQLite / `APP_ENV=prod` および `dev`）で、#6979 の再現手順どおりの構成を作って確認しました。

再現用の構成:

- 第三者バンドル相当: `app/Plugin/ExtraBundle/Lib/ExtraLibBundle.php` + `Lib/Entity/ExtraThing.php`（prefix が `Plugin\ExtraBundle\Lib\Entity` になり明示登録の対象外＝チェーンに残る）
- ルート直下バンドル: `app/Plugin/Foo/FooBundle.php` + `Entity/Bar.php`
- Customize 版: `app/Customize/CustomizeBundle.php` + `Entity/MyThing.php`
- Proxy: `app/proxy/entity/` 配下に同一 FQCN を配置（`eccube:generate:proxies` 相当）

| # | 構成 | 修正前 | 本 PR 適用後 |
| --- | --- | --- | --- |
| 1 | 第三者バンドル + コア Proxy | `Cannot redeclare class Eccube\Entity\Customer` | **OK** |
| 2 | 上記 + `app/Plugin/Foo/FooBundle.php` + Proxy | `Cannot redeclare class Plugin\Foo\Entity\Bar` （#6963 適用時） | **OK** |
| 3 | 上記 + `app/Customize/CustomizeBundle.php` + Proxy | `Cannot redeclare class Customize\Entity\MyThing` （#6963 適用時） | **OK** |
| 4 | 素の構成（第三者バンドルなし） | OK | **OK** |

- `bin/console cache:warmup` が **prod / dev とも成功**、`bin/console eccube:generate:proxies` も正常終了。
- `bin/console doctrine:mapping:info`:
  - 素の構成: **72 entities**（修正前後で同数。マッピングの増減なし）
  - 上記フィクスチャ併存時: **75 entities**。`Plugin\ExtraBundle\Lib\Entity\ExtraThing`（auto_mapping 経由）・`Plugin\Foo\Entity\Bar`・`Customize\Entity\MyThing` がいずれも `[OK]`
- 追加テスト
  - `tests/Eccube/Tests/DependencyInjection/Compiler/StripAutoMappedEntityPathsPassTest.php`（新規・DB 非依存）— doctrine-bundle が生成するコンテナ構造を模し、明示登録済みパスだけが除去されること / 第三者バンドルのパスが残ること / 全除去時にチェーンから外れること / パラメータ表記の解決 / 無関係なドライバ定義を変更しないこと を検証
  - `tests/Eccube/Tests/Doctrine/ORM/Mapping/EccubeEntityMetadataDriverTest.php`（新規）— コンパイル済みコンテナ上で、明示登録した全ディレクトリ（コア / Customize / 各プラグイン）を担当するドライバが `TraitProxyAttributeDriver` だけであることを固定する回帰テスト
- CI ゲート: `phpstan analyse src` = 本 PR 由来のエラーなし（既存 15 件から増減なし）、`php-cs-fixer --dry-run` = 0 件、`rector --dry-run` = 差分なし（指摘は適用済み）、`phpunit tests/Eccube/Tests/Doctrine/ORM/Mapping tests/Eccube/Tests/DependencyInjection/Compiler/StripAutoMappedEntityPathsPassTest.php` = OK（7 tests）

## 相談（Discussion）

- 同種の問題は「コア Entity または自前 Entity を Proxy 生成するプラグイン」＋「Entity を持つ第三者バンドル」の組み合わせで発生します。プラグインテストのマトリクスに api プラグイン導入時の起動確認を含めるべきか、ご意見をいただけると助かります。
- 現状 Bundle クラスの置き場所は規約で縛られていません。今回の修正はどこに置かれても効きますが、`eccube:plugin:generate` のスケルトンや開発ドキュメントで推奨配置を示す価値はあるかもしれません。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - Doctrine の自動マッピングから、EC-CUBE が明示的に登録した Entity ディレクトリに対応するパスを除外し、重複による不整合や致命的エラーの発生を抑制しました。
- **テスト**
  - パス除外・ドライバ維持/削除・パラメータ解決の確認に加え、ルートレベルのバンドルと Proxy が共存するケースでもマッピングが正しく解決されることを回帰テストで検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->