### PR TITLE
fix: eccube:plugin:install の --if-not-exists が --path 指定時に無効化される問題を修正

### DIFF
--- a/src/Eccube/Command/PluginInstallCommand.php
+++ b/src/Eccube/Command/PluginInstallCommand.php
@@ -45,7 +45,10 @@ class PluginInstallCommand extends Command
 
         // アーカイブからインストール
         if ($path) {
-            if ($this->pluginService->install($path, $ifNotExists)) {
+            // PluginService::install() は install(string $path, int $source = 0, bool $notExists = false)
+            // のため、$source を省略すると $ifNotExists が $source に入り --if-not-exists が効かない。
+            // $source は管理画面のアーカイブアップロード (PluginController::install()) と同じ 0 を渡す。
+            if ($this->pluginService->install($path, 0, $ifNotExists)) {
                 $io->success('Installed.');
 
                 return 0;


### PR DESCRIPTION
## 概要

`eccube:plugin:install --path=... --if-not-exists` で `--if-not-exists` が効かず、インストール済みのプラグインに対して `plugin already installed.` で異常終了する問題を修正します。

Fixes #7019

## 原因

`PluginService::install()` のシグネチャは 3 引数です。

```php
public function install(string $path, int $source = 0, bool $notExists = false): bool
```

一方 `PluginInstallCommand` は 2 引数で呼んでいました。

```php
$this->pluginService->install($path, $ifNotExists)
```

このため `$ifNotExists` が第 2 引数 `int $source` に入り（`true` が `1` に型強制され）、第 3 引数 `$notExists` は既定の `false` のままになります。結果として `install()` 内の

```php
if ($e->getMessage() === 'plugin already installed.' && $notExists) {
    return true;
}
```

に入らず、`PluginException` がそのまま送出されていました。あわせて `dtb_plugin.source` に `1` が記録される副作用もありました。

## 変更内容

`$source` を明示して渡すようにしました。

```diff
-            if ($this->pluginService->install($path, $ifNotExists)) {
+            if ($this->pluginService->install($path, 0, $ifNotExists)) {
```

`$source` の値は、管理画面からアーカイブをアップロードする `PluginController::install()` が `$this->pluginService->install($tmpPath)` と呼んで既定の `0` になっているのに合わせています。これにより CLI の path インストールでも `dtb_plugin.source` が `0` になり、管理画面経由と一致します。

`--code` 側の `installWithCode(string $code, mixed $notExists = false)` は引数位置が正しいため変更していません。

## 再現手順（修正前）

```console
# 1 回目（成功するが dtb_plugin.source = 1 になる）
$ bin/console eccube:plugin:install --code=YourPlugin --path=/tmp/YourPlugin.tar.gz --if-not-exists

# 2 回目（--if-not-exists があるのに失敗する）
$ bin/console eccube:plugin:install --code=YourPlugin --path=/tmp/YourPlugin.tar.gz --if-not-exists

In PluginService.php line 462:

  plugin already installed.
```

## 動作確認

EC-CUBE 4.4 / PHP 8.2 / SQLite（`ghcr.io/ec-cube/ec-cube-php:8.2-apache-4.4`）で本事象を確認しました。

- `--path --if-not-exists` で導入した環境の `dtb_plugin.source` が `1` になっていることを確認（引数のずれの証跡）
- `--code --if-not-exists` は再実行しても成功することを確認（引数位置が正しいため）
- 実害の確認: プラグインを tar 化して起動時に導入する docker 開発環境で、`docker compose up` の 2 回目以降が `plugin already installed.` で起動失敗する（EC-CUBE/sales-report-plugin#90 で遭遇。プラグイン側は `--code` を使う形に変更して回避済み）

なお本 PR の変更後の挙動については、本体のテストスイート一式は実行できていません。CI の結果をご確認いただければ幸いです。回帰テスト（`--path --if-not-exists` の再実行が成功すること、`source` が `0` になること）が必要であれば追加します。

## 影響範囲

`eccube:plugin:install --path` の CLI 経路のみです。管理画面からのインストール、`--code` 経路には影響しません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * アーカイブからのプラグインインストール時に、既存プラグインを考慮する設定が正しく適用されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->