### PR TITLE
chore: rector.php のルール重複登録を解消

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -73,6 +73,13 @@ return RectorConfig::configure()
                    __DIR__.'/codeception/_support/Page/Admin/OrderManagePage.php',
                    __DIR__.'/codeception/acceptance/EF06OtherCest.php',
                ],
+               // ContainerGetNameToTypeInTestsRector は $container->get('service.id') の文字列サービスIDを
+               // get(Type::class) へ変換する。クラス名のエイリアスを持たない private サービス
+               // (例: 'doctrine.debug_data_holder', 'event_dispatcher', 'twig', 'session.factory') では
+               // ServiceNotFoundException になるため, それらはサービスIDを変数へ代入して get($serviceId) の
+               // 形にし変換対象から外すこと (ルールは無効化せず変数経由で回避する)。
+               // 既存例: AbstractWebTestCase / MailServiceTest / CartServiceTest / TwigExtensionPass
+               //
                // shopping/order の各購入フローは同じ PurchaseFlow 型の別サービスであり、
                // 型解決(get(PurchaseFlow::class))に置き換えると両者の区別が失われテストが無意味化する
                ContainerGetNameToTypeInTestsRector::class => [
@@ -90,13 +97,6 @@ return RectorConfig::configure()
                EventSubscriberInterfaceToAttributeRector::class, // Doctrine EventSubscriberをAsDoctrineListenerアトリビュートに変換する
                AttributeArgumentsOrderRector::class, // すべての Attribute の引数をコンストラクタ引数順序に統一する
                NormalizePhpDocArrayGenericSpacingRector::class, // PHPDoc の配列ジェネリクス表記のカンマ後のスペースを統一する
-               // $container->get('service.id') の文字列サービスIDを get(Type::class) へ変換する。
-               // クラス名のエイリアスを持たない private サービス (例: 'doctrine.debug_data_holder',
-               // 'event_dispatcher', 'twig', 'session.factory') では ServiceNotFoundException に
-               // なるため, それらはサービスIDを変数へ代入して get($serviceId) の形にし変換対象から
-               // 外すこと (ルールは無効化せず変数経由で回避する)。
-               // 既存例: AbstractWebTestCase / MailServiceTest / CartServiceTest / TwigExtensionPass
-               ContainerGetNameToTypeInTestsRector::class,
            ])
            // よく使われるルールセットを有効化
            ->withSets([


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

`rector.php` の `withRules()` に登録している `ContainerGetNameToTypeInTestsRector` が、有効化済みのセットにも含まれているため、Rector 実行時に重複登録の警告が出ています。

```
[WARNING] These rules are registered in both sets and "withRules()". Remove
          them from "withRules()" to avoid duplications:
          * Rector\Symfony\Symfony34\Rector\Closure\ContainerGetNameToTypeInTestsRector
```

`withRules()` からの登録を削除して警告を解消します。

## 方針(Policy)

ルール自体は引き続き有効にしたいため、`withRules()` の登録のみを削除しました。
`withRules()` に添えていた運用上の注意（クラス名のエイリアスを持たない private サービスは `get($serviceId)` の形にして変換対象から外す）は、同じルールを指定している `withSkip()` の箇所へ移しています。

## 実装に関する補足(Appendix)

`vendor/bin/rector list-rules` で、削除後も `Rector\Symfony\Symfony34\Rector\Closure\ContainerGetNameToTypeInTestsRector` が Loaded Rector rules に含まれることを確認しています。
セット側で有効なため、ルールが無効化されることはありません。

## テスト（Test)

ローカル（PHP 8.3 / 現在の `composer.lock` の rector 2.3.9）で以下を実行しています。

- `vendor/bin/rector list-rules`: 警告が出ないこと、対象ルールが Loaded Rector rules に残ること
- `vendor/bin/rector process --dry-run`: 変更検出なし
- `vendor/bin/php-cs-fixer fix --dry-run`: 指摘なし
- `vendor/bin/phpstan analyse src`: エラーなし

Rector の設定ファイルのみの変更で、アプリケーションコードには手を入れていません。

## 相談（Discussion）

特にありません。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * テスト関連の静的解析設定を整理しました。
  * サービスID変換時の注意事項と、既存の対象外ケースに関するコメントを追加しました。
  * 購入フロー用テストの既存設定には変更ありません。

* **ユーザーへの影響**
  * アプリケーションの機能や表示に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->