### PR TITLE
chore(deps-dev): rector を 2.4 未満に制限する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,12 @@ updates:
       # Symfony のメジャーバージョンアップは除外
       - dependency-name: "symfony/*"
         update-types: [ "version-update:semver-major" ]
+      # rector 2.4 以降は同梱の symfony/polyfill-php84 が PHP 8.4 未満で RoundingMode を
+      # class として class_alias する。nanasess/bcmath-polyfill 1.0.2 以前は enum_exists で
+      # 存在判定するため衝突を検知できず、PHP 8.2/8.3 では rector が起動時に fatal になる。
+      # bcmath-polyfill を 1.0.3 以降へ更新したらこの除外と composer.json の上限を解除する。
+      - dependency-name: "rector/rector"
+        versions: [ ">=2.4" ]
     # 所属グループは記載順ではなくパターンの具体性 (specificity) スコアで決まる。
     # dependabot-core の PatternSpecificityCalculator が算出し、スコアが高い方が勝つ。
     #   patterns 未指定 = 500 / "doctrine/*" = 95 / "symfony/*" = 94 / "*" = 1

--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.1",
+        "rector/rector": ">=2.1 <2.4",
         "symfony/browser-kit": "^7.4",
         "symfony/phpunit-bridge": "^8.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "35edcc3590aa585986967f7bd65793f7",
+    "content-hash": "58f6e36be984f57e0c0ec82e8b383ecb",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

rector 2.4 以降を導入すると、EC-CUBE がサポートする PHP 8.2 / 8.3 で rector が起動できなくなります。
`vendor/bin/rector --version` の時点で fatal になります。

```
Fatal error: Cannot declare enum RoundingMode, because the name is already in use
  in vendor/nanasess/bcmath-polyfill/lib/RoundingMode.php on line 16
```

原因は `RoundingMode` というグローバル名を、2 つのライブラリが別の種類で定義しようとすることです。

1. rector に同梱された `symfony/polyfill-php84` が、PHP 8.4 未満で `RoundingMode` を **class** として定義し `class_alias(..., 'RoundingMode', false)` でグローバル名を占有する
2. `nanasess/bcmath-polyfill` 1.0.2 以前は `enum_exists('RoundingMode')` で存在判定する。占有しているのは class なので false になり、**enum** の宣言に進んで衝突する

PHP 8.4 以上ではネイティブの `RoundingMode` enum があるため、どちらの polyfill も定義に進まず衝突しません。
Rector ジョブは PHP 8.5 固定（`.github/workflows/rector.yml`）のため、CI では検知できません。

このため composer.json の制約と dependabot の ignore で、rector 2.4 以降が入らないようにします。

## 方針(Policy)

解決とバージョンアップ提案の両方を止めるため、2 箇所に設定しました。

- `composer.json`: `"rector/rector": "^2.1"` → `">=2.1 <2.4"`
- `.github/dependabot.yml`: `rector/rector` の `>=2.4` を ignore に追加

制約だけでは dependabot が制約自体の引き上げを提案し得るため、ignore も併せて設定しています。

恒久対応は `nanasess/bcmath-polyfill` の更新です。1.0.3 以降は `class_exists('RoundingMode', false)` で判定するようになっており、この衝突は起きません。
更新後はこの制限（composer.json の上限と dependabot の ignore）を解除できます。解除条件はコメントとして `.github/dependabot.yml` に残しています。

## 実装に関する補足(Appendix)

ローカル（PHP 8.3.31）で以下を確認しています。

- rector 2.3.9: `vendor/bin/rector --version` が正常に動作
- rector 2.5.9: 同コマンドで上記の fatal が発生
- rector 2.5.9 + bcmath-polyfill 1.1.0: 正常に動作

2.4 が境界であることは、`nanasess/bcmath-polyfill` 側のコメント（"the Rector 2.4+ scoped polyfill that exposes a class via class_alias"）に基づいています。2.4 系そのものでの再現は未確認です。

`composer.lock` の差分は制約変更に伴う `content-hash` のみで、パッケージのバージョンは変わりません（`composer update --lock`）。

## テスト（Test)

- `composer validate`: valid
- `vendor/bin/rector process --dry-run`: 変更検出なし
- `vendor/bin/phpstan analyse src`: エラーなし

## 相談（Discussion）

bcmath-polyfill の更新を先に入れる方針であれば、この PR は不要になります。
その場合はクローズしていただいて構いません。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * PHP 8.2／8.3環境で発生する起動時エラーや丸め処理関連の衝突を回避し、安定して利用できるようにしました。
* **安定性**
  * 互換性が確認されたバージョン範囲に固定し、今後の更新による予期せぬ不具合を防止します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->