### PR TITLE
chore(deps): nanasess/bcmath-polyfill を 1.1.0 に更新

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3450,16 +3450,16 @@
         },
         {
             "name": "nanasess/bcmath-polyfill",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nanasess/bcmath-polyfill.git",
-                "reference": "9f06ad648aec3053305e6a06eedae514abbac0e4"
+                "reference": "a0fe84900b5f9d9a179b9367224b5fd198f006c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nanasess/bcmath-polyfill/zipball/9f06ad648aec3053305e6a06eedae514abbac0e4",
-                "reference": "9f06ad648aec3053305e6a06eedae514abbac0e4",
+                "url": "https://api.github.com/repos/nanasess/bcmath-polyfill/zipball/a0fe84900b5f9d9a179b9367224b5fd198f006c5",
+                "reference": "a0fe84900b5f9d9a179b9367224b5fd198f006c5",
                 "shasum": ""
             },
             "require": {
@@ -3517,7 +3517,7 @@
                 "issues": "https://github.com/nanasess/bcmath-polyfill/issues",
                 "source": "https://github.com/nanasess/bcmath-polyfill"
             },
-            "time": "2025-12-04T07:53:51+00:00"
+            "time": "2026-07-03T09:08:37+00:00"
         },
         {
             "name": "nesbot/carbon",


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

`nanasess/bcmath-polyfill` を 1.0.2 から 1.1.0 へ更新します。

1.0.3 以降で `RoundingMode` の存在判定が `enum_exists()` から `class_exists('RoundingMode', false)` に変わっています。
これにより、rector 2.4 以降が同梱する `symfony/polyfill-php84` が PHP 8.4 未満で `RoundingMode` を class として `class_alias` した場合でも、二重宣言による fatal が起きなくなります。

現在の 1.0.2 では、PHP 8.2 / 8.3 で rector 2.4 以降を入れると以下で落ちます。

```
Fatal error: Cannot declare enum RoundingMode, because the name is already in use
  in vendor/nanasess/bcmath-polyfill/lib/RoundingMode.php on line 16
```

## 方針(Policy)

1.0.3 で止める案もありますが、最新の 1.1.0 を採用します。
1.1.0 では `RoundingMode` が backed enum（`RoundingMode: string`）から pure enum に変更されており、PHP 8.4 のネイティブ実装と同じ形になります。8.1–8.3 と 8.4 以降で `->value` や `from()` の可否が食い違わなくなるため、polyfill としてはこちらが正しい挙動です。

`composer.json` の制約は `"nanasess/bcmath-polyfill": "^1.0"` のままで、`composer.lock` のみの変更です。

## 実装に関する補足(Appendix)

pure enum への変更は、`RoundingMode` を backed enum として扱っているコードには互換性のない変更です。
本体（`src/` `app/` `tests/`）に `RoundingMode` の参照はないため影響はありませんが、プラグインが `RoundingMode::HalfUp->value` のような使い方をしている場合は影響を受けます。

`lib/bcmath.php` の関数群は `ext-bcmath` が無い環境でのみ有効になるため、拡張が入っている環境では今回の更新による計算まわりの挙動変化はありません。

## テスト（Test)

ローカル（PHP 8.3.31）で以下を確認しています。

- `vendor/bin/rector process --dry-run`: 変更検出なし
- `vendor/bin/phpstan analyse src`: エラーなし
- rector 2.5.9 と組み合わせた場合に `vendor/bin/rector --version` が正常動作すること（1.0.2 では fatal）

PHPUnit はローカルで実行していません。CI の結果で確認をお願いします。

## 相談（Discussion）

pure enum 化の影響を避けたい場合は、1.0.3 に固定する形へ変更します。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか
