### PR TITLE
ci: merge ジョブ名の matrix 参照をやめて未展開表示を解消

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -150,7 +150,10 @@ jobs:
   # ダイジェストをマニフェストリストに束ねてタグを付ける。
   # 単一プラットフォーム (CI) でも同じ経路を通り、 結果は従来と同じタグになる。
   merge:
-    name: merge ${{ matrix.php }}
+    # name で matrix を参照しない。 job レベルの if が false のとき matrix は展開されず、
+    # 参照していると checks 一覧に `merge ${{ matrix.php }}` がそのまま表示されるため。
+    # 参照しない場合は GitHub が matrix 値を後置し、 展開時は `merge (8.2)` になる。
+    name: merge
     needs: dockerbuild
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

PR の checks 一覧に `dockerbuild / merge ${{ matrix.php }}` が未展開のまま表示される問題を解消します。

`dockerbuild.yml` の `merge` ジョブは `if: github.event_name != 'pull_request'` を持つため、PR では job レベルで skip されます。
job レベルの `if` が false のときは matrix が展開されないので、`name:` に書いた `${{ matrix.php }}` が置換されず、テンプレート文字列のまま表示されます。

実際の表示例です（該当ジョブは 4 件ではなく 1 件・skipped）。

- https://github.com/EC-CUBE/ec-cube/actions/runs/31060614706

## 方針(Policy)

`name:` から matrix 参照を外しました。

`name:` が matrix を参照していない場合、GitHub は matrix の値を括弧で後置します。
本リポジトリ内の既存ジョブがそのまま実例です。

| 定義 | 実行時の表示 |
|---|---|
| `name: dockerbuild`（dockerbuild.yml） | `dockerbuild (linux/amd64, 8.3, pgsql)` |
| `name: PHPUnit`（unit-test.yml） | `PHPUnit (ubuntu-24.04, 8.2, pgsql13)` |

このため `name: merge` としても、展開されるとき（push / tag）の表示は `merge (8.2)` 〜 `merge (8.5)` となり、従来の `merge 8.2` と情報量は変わりません。
skip されるときは name に式が含まれないため、テンプレート文字列は表示されません。

## 実装に関する補足(Appendix)

- 変更は `name:` の 1 行とその意図を残すコメントのみ
- ジョブの実行条件・matrix・steps は変更なし
- 必須チェックは集約ジョブ `success` のみのため、ジョブ名の変更による branch protection への影響はなし

## テスト（Test)

- `actionlint` を実行し、本変更による新規指摘がないことを確認（既存の SC2086 info 3 件のみで、変更前後で同一）
- PR での表示は本 PR の checks で確認できます（`merge` が 1 件・skipped）
- 展開時の表示（`merge (8.2)` 〜）はマージ後の push 実行で確認できます

## 相談（Discussion）

`e2e-test.yml` の `playwright` ジョブも同じ構造で、`workflow_dispatch` 実行時に `Playwright (${{ matrix.suite }})` が未展開で表示されます（fork で workflow_dispatch を回して確認済みです）。
ただしこちらは matrix が php / db / suite の 3 軸あり、同じ対処をすると 22 件の check 名が `Playwright (8.5, pgsql, admin-top)` の形に変わります。
表示が長くなる割に効果が手動実行時に限られるため本 PR には含めていませんが、揃えた方がよければ別 PR で対応いたします。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - GitHub Actions のジョブ表示名を整理し、PHP バージョンごとの実行結果をより分かりやすく確認できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->