### PR TITLE
fix(agent-commerce): 与信と売上確定を区別し capture へ与信結果を引き渡す

### DIFF
--- a/e2e/agent/acp-checkout.php
+++ b/e2e/agent/acp-checkout.php
@@ -29,7 +29,7 @@
  * env:
  *   BASE_URL          … 稼働中サーバ (既定 http://127.0.0.1:8000)
  *   AGENT_E2E_TOKEN   … OAuth2 Bearer トークン (acp:checkout)。空ならフェーズ 2 を skip
- *   AGENT_E2E_ITEM_ID … checkout で使う ProductClass id (既定 1)
+ *   AGENT_E2E_ITEM_ID … checkout で使う ProductClass id (既定 2。id=1 は visible=0 の規格)
  *
  * Usage: php e2e/agent/acp-checkout.php
  */
@@ -41,7 +41,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 $baseUrl = rtrim((string) (getenv('BASE_URL') ?: 'http://127.0.0.1:8000'), '/');
 $token = (string) (getenv('AGENT_E2E_TOKEN') ?: '');
-$itemId = (int) (getenv('AGENT_E2E_ITEM_ID') ?: '1');
+$itemId = (int) (getenv('AGENT_E2E_ITEM_ID') ?: '2');
 // complete (決済実行) は決済ハンドラ (#3) が要るため、明示的に許可された時のみ実行する。
 $paymentReady = 'true' === (string) getenv('AGENT_E2E_PAYMENT_READY');
 
@@ -231,6 +231,19 @@ function runCheckout(HttpClientInterface $client, string $token, int $itemId, bo
     $body = completeAcp($client, $auth, $sid, ['handler_id' => 'card_tokenized', 'token' => 'e2e-acp-spt-decline', 'provider' => 'sample_payment']);
     assertTrue(($body['status'] ?? null) !== 'completed', 'complete (decline token) => not "completed" (handler rejected)');
     assertTrue(!empty($body['messages']), 'complete (decline token) => business messages[] present');
+
+    // (d) 負の入力 (fail-closed): token を伴わない complete。トークン欠落を「どの規約にも一致しない=正常」と
+    //     解釈して無与信のまま確定してしまう事故を防ぐ回帰ケース。想定入力だけを試すと原理的に検出できない。
+    $sid = createSession($client, $auth, $createBody);
+    $body = completeAcp($client, $auth, $sid, ['handler_id' => 'card_tokenized', 'provider' => 'sample_payment']);
+    assertTrue(($body['status'] ?? null) !== 'completed', 'complete (token 欠落) => not "completed" (fail-closed)');
+    assertTrue(!empty($body['messages']), 'complete (token 欠落) => business messages[] present');
+
+    // (e) capture 失敗: 与信は成功するが売上確定で失敗する。本体の capture 失敗分岐 (引当 rollback) を通す。
+    $sid = createSession($client, $auth, $createBody);
+    $body = completeAcp($client, $auth, $sid, ['handler_id' => 'card_tokenized', 'token' => 'e2e-acp-spt-capture-fail', 'provider' => 'sample_payment']);
+    assertTrue(($body['status'] ?? null) !== 'completed', 'complete (capture-fail token) => not "completed" (capture rejected)');
+    assertTrue(!empty($body['messages']), 'complete (capture-fail token) => business messages[] present');
 }
 
 /** complete シナリオ用に新規セッションを作成し session id を返す。 */

--- a/e2e/agent/ucp-checkout.php
+++ b/e2e/agent/ucp-checkout.php
@@ -140,16 +140,33 @@ $sid = createSession($client, $headers, $createBody);
 $body = completeUcp($client, $headers, $sid, 'e2e-ucp-ok');
 assertTrue(($body['status'] ?? null) === 'completed', 'complete (ok token) => status "completed"');
 
-// (b) escalation: REQUIRES_ACTION は UCP では requires_escalation。ハンドラが実行された証跡。
+// (b) escalation → 再開: REQUIRES_ACTION は UCP では requires_escalation。ACP と異なり認証結果は
+//     credential 経由でしか届かないため、そこへ載せて再開できることまで検証する
+//     (交換で authentication_result を落とすと requires_escalation から永久に復帰できない)。
 $sid = createSession($client, $headers, $createBody);
 $body = completeUcp($client, $headers, $sid, 'e2e-ucp-3ds');
 assertTrue(($body['status'] ?? null) === 'requires_escalation', 'complete (3ds token) => "requires_escalation" (handler ran)');
+$body = completeUcp($client, $headers, $sid, 'e2e-ucp-3ds', ['authentication_result' => ['outcome' => 'authenticated']]);
+assertTrue(($body['status'] ?? null) === 'completed', 'complete (3ds resume w/ authentication_result) => "completed"');
 
 // (c) 拒否: ハンドラが FAILED を返し確定しない (ready_for_complete) + messages[]。
 $sid = createSession($client, $headers, $createBody);
 $body = completeUcp($client, $headers, $sid, 'e2e-ucp-decline');
 assertTrue(($body['status'] ?? null) !== 'completed', 'complete (decline token) => not "completed" (handler rejected)');
 assertTrue(!empty($body['messages']), 'complete (decline token) => business messages[] present');
+
+// (d) 負の入力 (fail-closed): token を伴わない credential。トークン欠落を「どの規約にも一致しない=正常」と
+//     解釈して無与信のまま確定してしまう事故を防ぐ回帰ケース。
+$sid = createSession($client, $headers, $createBody);
+$body = completeUcp($client, $headers, $sid, null);
+assertTrue(($body['status'] ?? null) !== 'completed', 'complete (token 欠落) => not "completed" (fail-closed)');
+assertTrue(!empty($body['messages']), 'complete (token 欠落) => business messages[] present');
+
+// (e) capture 失敗: 与信は成功するが売上確定で失敗する。本体の capture 失敗分岐 (引当 rollback) を通す。
+$sid = createSession($client, $headers, $createBody);
+$body = completeUcp($client, $headers, $sid, 'e2e-ucp-capture-fail');
+assertTrue(($body['status'] ?? null) !== 'completed', 'complete (capture-fail token) => not "completed" (capture rejected)');
+assertTrue(!empty($body['messages']), 'complete (capture-fail token) => business messages[] present');
 
 fwrite(STDOUT, "\n\033[32mPASS\033[0m ({$passed} assertions, session + complete)\n");
 exit(0);
@@ -179,16 +196,23 @@ function createSession(HttpClientInterface $client, array $headers, array $creat
  * complete を呼び、HTTP 200 (2 系統エラーは messages[]) を確認してレスポンス body を返す。
  *
  * @param array<string, string> $headers
+ * @param string|null           $token           支払トークン。null なら credential にトークンを載せない (負の入力)
+ * @param array<string, mixed>  $credentialExtra credential へ追加する項目 (再開時の authentication_result 等)
  *
  * @return array<string, mixed>
  */
-function completeUcp(HttpClientInterface $client, array $headers, string $sessionId, string $token): array
+function completeUcp(HttpClientInterface $client, array $headers, string $sessionId, ?string $token, array $credentialExtra = []): array
 {
+    $credential = ['type' => 'card'] + $credentialExtra;
+    if (null !== $token) {
+        $credential['token'] = $token;
+    }
+
     $res = $client->request('POST', 'ucp/checkout-sessions/'.$sessionId.'/complete', [
         'headers' => $headers + ['Idempotency-Key' => bin2hex(random_bytes(16))],
         'json' => ['payment' => ['instruments' => [[
             'handler_id' => 'dev.ucp.payment.card',
-            'credential' => ['type' => 'card', 'token' => $token],
+            'credential' => $credential,
         ]]]],
     ]);
     $status = $res->getStatusCode();

--- a/src/Eccube/Controller/AgentCommerce/UcpCheckoutController.php
+++ b/src/Eccube/Controller/AgentCommerce/UcpCheckoutController.php
@@ -27,6 +27,8 @@ use Eccube\Service\AgentCommerce\CheckoutSession\AgentCheckoutAddress;
 use Eccube\Service\AgentCommerce\CheckoutSession\AgentCheckoutCompletionResult;
 use Eccube\Service\AgentCommerce\CheckoutSession\AgentCheckoutCompletionService;
 use Eccube\Service\AgentCommerce\CheckoutSession\AgentCheckoutLineItem;
+use Eccube\Service\AgentCommerce\CheckoutSession\AgentCheckoutMessage;
+use Eccube\Service\AgentCommerce\CheckoutSession\AgentCheckoutMessageLevel;
 use Eccube\Service\AgentCommerce\CheckoutSession\AgentCheckoutRequest;
 use Eccube\Service\AgentCommerce\CheckoutSession\CustomerResolverInterface;
 use Eccube\Service\AgentCommerce\Exception\AgentCheckoutErrorCode;
@@ -165,6 +167,13 @@ class UcpCheckoutController extends AbstractController
                 // UCP は payment.instruments[].handler_id で決済ハンドラを解決し、クレデンシャルを
                 // ゲートウェイトークンへ交換する。交換後の中立データを状態機械へ渡す。
                 $paymentData = $this->resolvePaymentData($payload);
+                if ($paymentData === null) {
+                    // ハンドラが契約に反して例外を投げた。状態機械は未実行 = 在庫引当もステータス遷移も
+                    // 起きていないため、セッションを据え置いたままビジネス系エラーで返し再試行を許す。
+                    return ['status' => 200, 'body' => $this->mapper->buildResponseFromOrder($session, $order, $this->messageMapper->toUcpMessages([
+                        new AgentCheckoutMessage(AgentCheckoutMessageLevel::ERROR, 'The payment credential could not be processed.'),
+                    ]))];
+                }
                 // complete は「中断→再開」状態機械 (#6777)。追加認証 (3DS/escalation) は
                 // エラーでなく requires_action 等の中間状態として返る。在庫引当の保持/回収・
                 // トランザクション境界・与信→売上→確定の順序は CompletionService が担う。
@@ -247,11 +256,20 @@ class UcpCheckoutController extends AbstractController
      * 与信/売上 (authorize/capture) は状態機械 (CompletionService) が実行するため、ここでは交換のみ行う。
      * ハンドラ未登録 (代引・無償等) の場合は空配列を返し、状態機械が与信不要として確定する。
      *
+     * `exchangePaymentToken()` は状態機械の**外側**の呼び出しなので、CompletionService が
+     * authorize/capture に対して持つ例外の砦が効かない。契約上ハンドラは投げてはならない
+     * ({@link \Eccube\Service\AgentCommerce\Payment\UcpPaymentHandlerInterface::exchangePaymentToken()})
+     * が、破られたときに HTTP 500 を返さないようここで捕捉し、呼び出し側がビジネス系エラーへ
+     * 写像できるよう null を返す。
+     *
+     * 捕捉対象はハンドラ呼び出しに限る。handler_id の重複登録 ({@link AgentCheckoutPaymentHandlerRegistry}
+     * が投げる `\RuntimeException`) はデプロイ不備であり、ビジネス系エラーに丸めず伝播させる。
+     *
      * @param array<string, mixed> $payload
      *
-     * @return array<string, mixed>
+     * @return array<string, mixed>|null 交換後の支払データ。ハンドラが例外を投げた場合は null
      */
-    private function resolvePaymentData(array $payload): array
+    private function resolvePaymentData(array $payload): ?array
     {
         $handlerId = $this->extractHandlerId($payload);
         if ($handlerId === null) {
@@ -266,7 +284,13 @@ class UcpCheckoutController extends AbstractController
         $instrument = $payload['payment']['instruments'][0] ?? [];
         $credential = is_array($instrument['credential'] ?? null) ? $instrument['credential'] : [];
 
-        return $handler->exchangePaymentToken($credential);
+        try {
+            return $handler->exchangePaymentToken($credential);
+        } catch (\Throwable $e) {
+            log_error('The UCP payment handler threw during exchangePaymentToken.', ['exception' => $e, 'handler_id' => $handlerId]);
+
+            return null;
+        }
     }
 
     /**

--- a/src/Eccube/Service/AgentCommerce/CheckoutSession/AgentCheckoutCompletionService.php
+++ b/src/Eccube/Service/AgentCommerce/CheckoutSession/AgentCheckoutCompletionService.php
@@ -22,9 +22,11 @@ use Eccube\Repository\Master\CheckoutSessionStatusRepository;
 use Eccube\Service\AgentCommerce\AgentCheckoutPurchaseFlowAdapter;
 use Eccube\Service\AgentCommerce\Exception\AgentCheckoutErrorCode;
 use Eccube\Service\AgentCommerce\Exception\AgentCheckoutException;
+use Eccube\Service\AgentCommerce\Payment\AgentCheckoutPaymentHandlerInterface;
 use Eccube\Service\AgentCommerce\Payment\AgentCheckoutPaymentHandlerRegistry;
 use Eccube\Service\AgentCommerce\Payment\PaymentOutcome;
 use Eccube\Service\AgentCommerce\Payment\PaymentOutcomeStatus;
+use Psr\Log\LoggerInterface;
 
 /**
  * エージェントチェックアウトの complete を「中断 → 再開」する状態機械として実行するオーケストレータ.
@@ -35,6 +37,10 @@ use Eccube\Service\AgentCommerce\Payment\PaymentOutcomeStatus;
  *
  * - 在庫引当の保持/回収 (prepare で物理引当 → REQUIRES_ACTION/PENDING では rollback せず保持、
  *   FAILED/期限切れで rollback)
+ * - capture の呼び出し制御 (authorize が AUTHORIZED を返したときだけ capture を呼ぶ。売上確定済を表す
+ *   COMPLETED に対しては呼ばない = auto-capture 型 PSP での二重売上を防ぐ)
+ * - PSP 参照 (`transaction_id` と metadata) の保持と、再開 complete でのハンドラへの引き渡し
+ * - ハンドラから漏れた例外の FAILED への写像 (500 で状態遷移ごと巻き戻さない最後の砦)
  * - CheckoutSession の正規化ステータス遷移
  * - トランザクション境界 (各 complete 呼び出しを 1 トランザクションで確定。StockReduceProcessor の
  *   悲観ロックに対応するため明示トランザクションで囲む)
@@ -50,6 +56,7 @@ class AgentCheckoutCompletionService
         private readonly AgentCheckoutPaymentHandlerRegistry $paymentHandlerRegistry,
         private readonly CheckoutSessionStatusRepository $statusRepository,
         private readonly CustomerResolverInterface $customerResolver,
+        private readonly LoggerInterface $logger,
         private readonly int $escalationExpireMinutes,
     ) {
     }
@@ -122,15 +129,26 @@ class AgentCheckoutCompletionService
             return $this->commitOrder($session, $order, $member);
         }
 
-        $outcome = $handler->authorize($order, $paymentData);
+        // 再開 complete では、中断時に保持した PSP 参照をハンドラへ渡す。エージェントの入力ではなく
+        // サーバ側の記録なので、ワンショットトークンを再償還せず同じ取引を続行できる。
+        $outcome = $this->authorize($handler, $order, $paymentData, $isResume ? ($session->getPaymentData() ?? []) : []);
 
         switch ($outcome->status) {
-            case PaymentOutcomeStatus::COMPLETED:
-                $capture = $handler->capture($order, $paymentData);
+            case PaymentOutcomeStatus::AUTHORIZED:
+                // 与信のみ成立。capture 前に PSP 参照を payment_data へ残し、capture が失敗しても
+                // どの取引が与信済みかを追跡できるようにする。
+                $this->mergePaymentData($session, $this->paymentReference($outcome));
+                $capture = $this->capture($handler, $order, $paymentData, $outcome);
                 if ($capture->status !== PaymentOutcomeStatus::COMPLETED) {
                     return $this->failOrder($session, $order, $member, $capture);
                 }
-                $this->mergePaymentData($session, $capture->metadata);
+                $this->mergePaymentData($session, $this->paymentReference($capture));
+
+                return $this->commitOrder($session, $order, $member);
+
+            case PaymentOutcomeStatus::COMPLETED:
+                // 与信と売上が 1 度で完結する auto-capture 型 PSP。capture を呼ぶと二重発行になるため呼ばない。
+                $this->mergePaymentData($session, $this->paymentReference($outcome));
 
                 return $this->commitOrder($session, $order, $member);
 
@@ -143,6 +161,45 @@ class AgentCheckoutCompletionService
             case PaymentOutcomeStatus::FAILED:
             default:
                 return $this->failOrder($session, $order, $member, $outcome);
+        }
+    }
+
+    /**
+     * ハンドラの与信を実行する. 例外は FAILED へ写像し、状態機械の外へ出さない.
+     *
+     * ハンドラは PSP 通信の失敗も {@link PaymentOutcome::failed()} で返す契約だが、漏れた例外を
+     * そのまま伝播させるとトランザクションごと巻き戻り、決済失敗が HTTP 500 になって
+     * 在庫の回収 (rollback) もセッションの状態遷移も行われない。ここが最後の砦。
+     *
+     * @param array<string, mixed> $paymentData
+     * @param array<string, mixed> $paymentReference
+     */
+    private function authorize(AgentCheckoutPaymentHandlerInterface $handler, Order $order, array $paymentData, array $paymentReference): PaymentOutcome
+    {
+        try {
+            return $handler->authorize($order, $paymentData, $paymentReference);
+        } catch (\Throwable $e) {
+            $this->logger->error('The agent payment handler threw during authorize.', ['exception' => $e, 'order_no' => $order->getOrderNo()]);
+
+            // 与信が成立したかどうかを判定できないため、参照は保持できない。retryable として ready へ戻す。
+            return PaymentOutcome::failed('payment_handler_error', 'The payment could not be processed.', true);
+        }
+    }
+
+    /**
+     * ハンドラの売上確定を実行する. 例外は FAILED へ写像し、与信の取引識別子を保持する.
+     *
+     * @param array<string, mixed> $paymentData
+     */
+    private function capture(AgentCheckoutPaymentHandlerInterface $handler, Order $order, array $paymentData, PaymentOutcome $authorization): PaymentOutcome
+    {
+        try {
+            return $handler->capture($order, $paymentData, $authorization);
+        } catch (\Throwable $e) {
+            $this->logger->error('The agent payment handler threw during capture.', ['exception' => $e, 'order_no' => $order->getOrderNo(), 'transaction_id' => $authorization->transactionId]);
+
+            // 与信は PSP 側に残る。取消・再 capture の照会ができるよう取引識別子を引き継ぐ。
+            return PaymentOutcome::failed('payment_handler_error', 'The payment could not be captured.', true, $authorization->transactionId, $authorization->metadata);
         }
     }
 
@@ -166,7 +223,7 @@ class AgentCheckoutCompletionService
      */
     private function holdForAction(CheckoutSession $session, PaymentOutcome $outcome, int $statusId): AgentCheckoutCompletionResult
     {
-        $this->mergePaymentData($session, $outcome->metadata);
+        $this->mergePaymentData($session, $this->paymentReference($outcome));
         if ($outcome->actionData !== []) {
             $metadata = $session->getMetadata() ?? [];
             $metadata['payment_action'] = $outcome->actionData;
@@ -186,6 +243,8 @@ class AgentCheckoutCompletionService
     private function failOrder(CheckoutSession $session, Order $order, ?Customer $member, PaymentOutcome $outcome): AgentCheckoutCompletionResult
     {
         $this->purchaseFlowAdapter->rollback($order, $member);
+        // 失敗した取引の PSP 参照も残す (与信済みで capture に失敗した場合の照会に必要)。
+        $this->mergePaymentData($session, $this->paymentReference($outcome));
 
         $statusId = $outcome->retryable ? CheckoutSessionStatus::READY : CheckoutSessionStatus::CANCELED;
         $session->setStatus($this->requireStatus($statusId));
@@ -196,6 +255,24 @@ class AgentCheckoutCompletionService
         );
 
         return new AgentCheckoutCompletionResult($session->getStatus() ?? $this->requireStatus($statusId), null, [$message]);
+    }
+
+    /**
+     * {@link PaymentOutcome} から payment_data へ残す PSP 参照を組み立てる.
+     *
+     * metadata に加えて transactionId を `transaction_id` として保持する。中断 (REQUIRES_ACTION /
+     * PENDING) からの再開・失敗時の照会は、この参照を辿って行う。
+     *
+     * @return array<string, mixed>
+     */
+    private function paymentReference(PaymentOutcome $outcome): array
+    {
+        $reference = $outcome->metadata;
+        if ($outcome->transactionId !== null && $outcome->transactionId !== '') {
+            $reference['transaction_id'] = $outcome->transactionId;
+        }
+
+        return $reference;
     }
 
     /**

--- a/src/Eccube/Service/AgentCommerce/CheckoutSession/AgentCheckoutCompletionService.php
+++ b/src/Eccube/Service/AgentCommerce/CheckoutSession/AgentCheckoutCompletionService.php
@@ -40,10 +40,39 @@ use Psr\Log\LoggerInterface;
  * - capture の呼び出し制御 (authorize が AUTHORIZED を返したときだけ capture を呼ぶ。売上確定済を表す
  *   COMPLETED に対しては呼ばない = auto-capture 型 PSP での二重売上を防ぐ)
  * - PSP 参照 (`transaction_id` と metadata) の保持と、再開 complete でのハンドラへの引き渡し
- * - ハンドラから漏れた例外の FAILED への写像 (500 で状態遷移ごと巻き戻さない最後の砦)
  * - CheckoutSession の正規化ステータス遷移
  * - トランザクション境界 (各 complete 呼び出しを 1 トランザクションで確定。StockReduceProcessor の
  *   悲観ロックに対応するため明示トランザクションで囲む)
+ *
+ * ## 入口ステータスと再開の扱い
+ *
+ * complete に再入できる非終端ステータスは 4 つある。**保持した PSP 参照をハンドラへ渡すのは
+ * 「在庫を引当てたまま中断した」2 状態からの再開時だけ**である。
+ *
+ * | 入口                | prepare | 保持済み参照 | 意味                                       |
+ * |---------------------|---------|--------------|--------------------------------------------|
+ * | `INCOMPLETE`        | 実行    | 渡さない     | 初回 complete                              |
+ * | `READY`             | 実行    | 渡さない     | 初回、または**失敗後の再試行** (新規与信)  |
+ * | `REQUIRES_ACTION`   | skip    | 渡す         | 追加認証 (3DS) からの再開                  |
+ * | `IN_PROGRESS`       | skip    | 渡す         | 非同期確定からの再開                       |
+ *
+ * READY で参照を渡さないのは、与信拒否で ready に戻った場合に**死んだ取引の識別子**を掴ませないため
+ * (別カードでの再試行が、拒否済み取引の続行になってしまう)。失敗時に保持する参照は照会・監査用であり、
+ * 再試行の入力ではない。
+ *
+ * ## ハンドラ例外の砦 (範囲)
+ *
+ * 漏れた例外を FAILED へ写像し、決済失敗が HTTP 500 になって在庫回収もステータス遷移も
+ * 行われない事態を防ぐ。**対象は {@link authorize()} と {@link capture()} の 2 呼び出しに限る**。
+ * 範囲外は以下のとおり:
+ *
+ * - `supports()` / `getHandlerId()` — ハンドラ解決時に呼ぶ純粋な述語。投げれば 500 になるため
+ *   {@link AgentCheckoutPaymentHandlerInterface} 側で「投げないこと」を契約としている。
+ * - `UcpPaymentHandlerInterface::exchangePaymentToken()` — 状態機械の外 (controller) で呼ばれるため、
+ *   砦も controller 側にある。
+ * - `AgentCheckoutPurchaseFlowAdapter` の prepare/commit/rollback — コア内部の呼び出しであり、
+ *   例外はトランザクションごと巻き戻して伝播させる。**capture 成功後に commit が失敗した場合、
+ *   保持した PSP 参照も巻き戻る**点は既知の制約 (回復には PSP 側の照会が要る)。
  *
  * プロトコル controller (#6776 ACP / #6574 UCP) は本サービスへ委譲し、戻り値
  * {@link AgentCheckoutCompletionResult} を各プロトコルのレスポンスへ変換する。
@@ -129,8 +158,9 @@ class AgentCheckoutCompletionService
             return $this->commitOrder($session, $order, $member);
         }
 
-        // 再開 complete では、中断時に保持した PSP 参照をハンドラへ渡す。エージェントの入力ではなく
-        // サーバ側の記録なので、ワンショットトークンを再償還せず同じ取引を続行できる。
+        // 再開 complete (REQUIRES_ACTION / IN_PROGRESS) でのみ、中断時に保持した PSP 参照を渡す。
+        // エージェントの入力ではなくサーバ側の記録なので、ワンショットトークンを再償還せず同じ取引を
+        // 続行できる。ready からの再試行では渡さない (クラス docblock の表を参照)。
         $outcome = $this->authorize($handler, $order, $paymentData, $isResume ? ($session->getPaymentData() ?? []) : []);
 
         switch ($outcome->status) {
@@ -140,7 +170,7 @@ class AgentCheckoutCompletionService
                 $this->mergePaymentData($session, $this->paymentReference($outcome));
                 $capture = $this->capture($handler, $order, $paymentData, $outcome);
                 if ($capture->status !== PaymentOutcomeStatus::COMPLETED) {
-                    return $this->failOrder($session, $order, $member, $capture);
+                    return $this->failOrder($session, $order, $member, $this->asCaptureFailure($capture, $order));
                 }
                 $this->mergePaymentData($session, $this->paymentReference($capture));
 
@@ -204,6 +234,34 @@ class AgentCheckoutCompletionService
     }
 
     /**
+     * capture の戻り値を「失敗として扱える形」へ正規化する.
+     *
+     * capture の契約は COMPLETED か FAILED のみ ({@link AgentCheckoutPaymentHandlerInterface::capture()})。
+     * PENDING 等をそのまま {@link failOrder()} へ渡すと errorCode / errorMessage が無く、
+     * **中身が空の ERROR メッセージ**がエージェントへ返る。契約違反はログに残し、明示的な失敗へ写像する。
+     */
+    private function asCaptureFailure(PaymentOutcome $capture, Order $order): PaymentOutcome
+    {
+        if ($capture->status === PaymentOutcomeStatus::FAILED) {
+            return $capture;
+        }
+
+        $this->logger->error('The agent payment handler returned an invalid status from capture.', [
+            'order_no' => $order->getOrderNo(),
+            'status' => $capture->status->value,
+            'transaction_id' => $capture->transactionId,
+        ]);
+
+        return PaymentOutcome::failed(
+            'capture_unexpected_status',
+            'The payment could not be captured.',
+            true,
+            $capture->transactionId,
+            $capture->metadata,
+        );
+    }
+
+    /**
      * 注文を確定し completed へ遷移する.
      */
     private function commitOrder(CheckoutSession $session, Order $order, ?Customer $member): AgentCheckoutCompletionResult
@@ -239,22 +297,38 @@ class AgentCheckoutCompletionService
      * 決済失敗時: 引当を rollback し、再試行可否でステータスを分岐する.
      *
      * retryable (card declined 等) は ready に戻して再 complete を許し、unrecoverable は canceled とする。
+     * ready からの再 complete は新規の authorize から始まる (capture 単独の再実行入口は無い)。
      */
     private function failOrder(CheckoutSession $session, Order $order, ?Customer $member, PaymentOutcome $outcome): AgentCheckoutCompletionResult
     {
         $this->purchaseFlowAdapter->rollback($order, $member);
-        // 失敗した取引の PSP 参照も残す (与信済みで capture に失敗した場合の照会に必要)。
+        // 失敗した取引の PSP 参照も残す。**照会・監査のための記録**であり、再試行の入力ではない
+        // (ready からの再試行でハンドラへ渡すと、死んだ取引の続行になる)。
         $this->mergePaymentData($session, $this->paymentReference($outcome));
 
         $statusId = $outcome->retryable ? CheckoutSessionStatus::READY : CheckoutSessionStatus::CANCELED;
         $session->setStatus($this->requireStatus($statusId));
 
-        $message = new AgentCheckoutMessage(
-            AgentCheckoutMessageLevel::ERROR,
-            $outcome->errorMessage !== null && $outcome->errorMessage !== '' ? $outcome->errorMessage : (string) $outcome->errorCode,
-        );
+        $message = new AgentCheckoutMessage(AgentCheckoutMessageLevel::ERROR, $this->errorMessageFor($outcome));
 
         return new AgentCheckoutCompletionResult($session->getStatus() ?? $this->requireStatus($statusId), null, [$message]);
+    }
+
+    /**
+     * エージェントへ返す ERROR メッセージ本文を決める.
+     *
+     * errorMessage → errorCode の順に採用し、双方が空でも**空文字を返さない**。
+     * 空文字だと messages[] に要素はあるのに内容が無い応答になり、エージェントは理由を判別できない。
+     */
+    private function errorMessageFor(PaymentOutcome $outcome): string
+    {
+        foreach ([$outcome->errorMessage, $outcome->errorCode] as $candidate) {
+            if ($candidate !== null && $candidate !== '') {
+                return $candidate;
+            }
+        }
+
+        return 'The payment could not be processed.';
     }
 
     /**

--- a/src/Eccube/Service/AgentCommerce/Payment/AcpPaymentHandlerInterface.php
+++ b/src/Eccube/Service/AgentCommerce/Payment/AcpPaymentHandlerInterface.php
@@ -39,9 +39,16 @@ interface AcpPaymentHandlerInterface extends AgentCheckoutPaymentHandlerInterfac
     /**
      * Shared Payment Token (SPT) を PSP の課金可能な参照へ償還する.
      *
+     * 償還は PSP 側で**ワンショット**なのが通例で、2 度目は失敗する。1 決済につき
+     * {@link AgentCheckoutPaymentHandlerInterface::authorize()} の中で 1 度だけ呼び、
+     * capture では償還し直さず与信結果 ({@link PaymentOutcome::$transactionId}) を用いること。
+     *
+     * 本メソッドは authorize の内側からのみ呼ばれるため、支払データを解決できない場合は例外を投げてよい
+     * (authorize がそれを {@link PaymentOutcome::failed()} へ写像する)。
+     *
      * @param array<string, mixed> $paymentData complete リクエストの payment_data (handler_id/instrument/credential 等)
      *
-     * @return array<string, mixed> 後続の authorize()/capture() へ渡す中立な支払データ
+     * @return array<string, mixed> authorize() が PSP へ渡す中立な支払データ
      */
     public function redeemSharedPaymentToken(array $paymentData): array;
 }

--- a/src/Eccube/Service/AgentCommerce/Payment/AgentCheckoutPaymentHandlerInterface.php
+++ b/src/Eccube/Service/AgentCommerce/Payment/AgentCheckoutPaymentHandlerInterface.php
@@ -43,16 +43,37 @@ interface AgentCheckoutPaymentHandlerInterface
      * 使って追加認証 (EMV-3DS) を完了させる。追加認証が必要な場合は例外でなく
      * {@link PaymentOutcome} の REQUIRES_ACTION を返す。
      *
-     * @param array<string, mixed> $paymentData 支払トークン等の中立表現 (再開時は authentication_result を含む)
+     * 戻り値のステータスで**続く capture の有無が決まる**。与信のみ成功したときは
+     * {@link PaymentOutcome::authorized()}、与信と売上が 1 度で完結する auto-capture 型 PSP は
+     * {@link PaymentOutcome::completed()} を返すこと (後者では capture が呼ばれない)。
+     *
+     * トークン欠落・不正など**支払データを検証できない場合は例外でなく
+     * {@link PaymentOutcome::failed()} を返す** (fail-closed)。無検証で成功を返してはならない。
+     * PSP 通信の失敗も同様に failed へ写像すること (例外を投げた場合、オーケストレータは最後の砦として
+     * failed に変換するが、その時点では PSP 参照を保持できない)。
+     *
+     * @param array<string, mixed> $paymentData      支払トークン等の中立表現 (再開時は authentication_result を含む)
+     * @param array<string, mixed> $paymentReference 中断前の complete で保持した PSP 参照 (`transaction_id` と metadata)。
+     *                                               初回 complete では空配列。**エージェントの入力ではなくサーバ側の記録**なので、
+     *                                               再開時はこちらの取引を対象にすること (ワンショットトークンの再償還を避ける)
      */
-    public function authorize(Order $order, array $paymentData): PaymentOutcome;
+    public function authorize(Order $order, array $paymentData, array $paymentReference = []): PaymentOutcome;
 
     /**
-     * 売上確定 (キャプチャ) を行う. {@link authorize()} が COMPLETED を返した後にのみ呼ぶ.
+     * 売上確定 (キャプチャ) を行う. {@link authorize()} が AUTHORIZED を返した後にのみ呼ばれる.
      *
-     * @param array<string, mixed> $paymentData 支払トークン等の中立表現
+     * 実 PSP の capture は「authorize が発行した取引に対する操作」であり、支払トークンの再償還
+     * (ACP の Shared Payment Token 等) は**ワンショットで 2 度目が失敗する**のが通例である。
+     * そのため対象取引は $paymentData から導出し直すのではなく、$authorization が持つ
+     * {@link PaymentOutcome::$transactionId} / {@link PaymentOutcome::$metadata} を用いること。
+     *
+     * authorize と同様、PSP 通信の失敗は例外でなく {@link PaymentOutcome::failed()} で返し、
+     * **与信済みの取引識別子を保持する** (与信は PSP 側に残るため、取消・再 capture の照会に要る)。
+     *
+     * @param array<string, mixed> $paymentData   authorize と同じ支払データ (冪等キー等の参照用)
+     * @param PaymentOutcome       $authorization {@link authorize()} が返した与信結果 (transactionId・metadata を含む)
      */
-    public function capture(Order $order, array $paymentData): PaymentOutcome;
+    public function capture(Order $order, array $paymentData, PaymentOutcome $authorization): PaymentOutcome;
 
     /**
      * このハンドラが指定の支払方法 (Payment.method_class 等) を扱えるか.

--- a/src/Eccube/Service/AgentCommerce/Payment/AgentCheckoutPaymentHandlerInterface.php
+++ b/src/Eccube/Service/AgentCommerce/Payment/AgentCheckoutPaymentHandlerInterface.php
@@ -68,7 +68,18 @@ interface AgentCheckoutPaymentHandlerInterface
      * {@link PaymentOutcome::$transactionId} / {@link PaymentOutcome::$metadata} を用いること。
      *
      * authorize と同様、PSP 通信の失敗は例外でなく {@link PaymentOutcome::failed()} で返し、
-     * **与信済みの取引識別子を保持する** (与信は PSP 側に残るため、取消・再 capture の照会に要る)。
+     * **与信済みの取引識別子を保持する** (与信は PSP 側に残るため、取消・照会に要る)。
+     *
+     * **戻り値は COMPLETED か FAILED のみ**。REQUIRES_ACTION / PENDING / AUTHORIZED を返しても
+     * オーケストレータは失敗として扱い在庫を回収する (非同期に確定する PSP は、capture ではなく
+     * authorize の段階で PENDING を返して IN_PROGRESS 状態で待つこと)。
+     *
+     * **capture 失敗後の再試行には capture 単独の入口が無い**。オーケストレータは在庫を回収し、
+     * $retryable に応じて ready (再試行可) / canceled へ遷移させる。ready からの再 complete は
+     * **新規の {@link authorize()} から始まり、保持した PSP 参照は渡されない** (保持は照会・監査用)。
+     * したがって**与信が PSP 側に残り、かつ同じ支払データで再 authorize できない場合
+     * (ACP の Shared Payment Token 等) は `retryable=false` を返す**こと。ready に戻しても
+     * 再試行は必ず失敗し、与信だけが残る。与信の取消は PSP 側の運用に委ねる。
      *
      * @param array<string, mixed> $paymentData   authorize と同じ支払データ (冪等キー等の参照用)
      * @param PaymentOutcome       $authorization {@link authorize()} が返した与信結果 (transactionId・metadata を含む)
@@ -77,6 +88,10 @@ interface AgentCheckoutPaymentHandlerInterface
 
     /**
      * このハンドラが指定の支払方法 (Payment.method_class 等) を扱えるか.
+     *
+     * ハンドラ解決のたびに全ハンドラへ問い合わせるため、**副作用の無い純粋な述語**として実装し、
+     * 例外を投げないこと ({@link getHandlerId()} も同様)。これらは状態機械の外で呼ばれるため
+     * authorize/capture のような例外の砦が無く、投げると HTTP 500 になる。
      */
     public function supports(Order $order): bool;
 }

--- a/src/Eccube/Service/AgentCommerce/Payment/PaymentOutcome.php
+++ b/src/Eccube/Service/AgentCommerce/Payment/PaymentOutcome.php
@@ -19,6 +19,10 @@ namespace Eccube\Service\AgentCommerce\Payment;
  * EC-CUBE 通常購入の {@link \Eccube\Service\Payment\PaymentResult} / {@link \Eccube\Service\Payment\PaymentDispatcher}
  * が成否と外部遷移を表現するのと同じ役割を、エージェント向けに Symfony Response 非依存の形で持つ
  * (エージェントは Response を解釈しないため、追加対応に必要なデータは {@link $actionData} に中立な形で載せる)。
+ *
+ * **判定は {@link $status} の照合に一本化する** (`isSuccessful()` 等の述語は持たない)。
+ * オーケストレータは全ステータスを網羅する `match` / `switch` で分岐するため、部分集合を返す述語を
+ * 併置すると判定源が二重化し、「成功」が capture 前を含むのか否かが読み手ごとにぶれる。
  */
 final readonly class PaymentOutcome
 {
@@ -90,26 +94,5 @@ final readonly class PaymentOutcome
     public static function failed(string $errorCode, string $errorMessage = '', bool $retryable = true, ?string $transactionId = null, array $metadata = []): self
     {
         return new self(PaymentOutcomeStatus::FAILED, $transactionId, [], $metadata, $errorCode, $errorMessage, $retryable);
-    }
-
-    /**
-     * 決済が失敗せず前進したか (与信済 or 売上確定済).
-     */
-    public function isSuccessful(): bool
-    {
-        return in_array($this->status, [PaymentOutcomeStatus::AUTHORIZED, PaymentOutcomeStatus::COMPLETED], true);
-    }
-
-    /**
-     * 売上確定 (capture) がこれから必要か.
-     */
-    public function needsCapture(): bool
-    {
-        return $this->status === PaymentOutcomeStatus::AUTHORIZED;
-    }
-
-    public function needsAction(): bool
-    {
-        return $this->status === PaymentOutcomeStatus::REQUIRES_ACTION;
     }
 }

--- a/src/Eccube/Service/AgentCommerce/Payment/PaymentOutcome.php
+++ b/src/Eccube/Service/AgentCommerce/Payment/PaymentOutcome.php
@@ -39,6 +39,22 @@ final readonly class PaymentOutcome
     }
 
     /**
+     * 与信のみ成功 (売上確定は未実施). オーケストレータが続けて capture を呼ぶ.
+     *
+     * @param string|null          $transactionId PSP の取引識別子。capture へそのまま引き渡される
+     * @param array<string, mixed> $metadata
+     */
+    public static function authorized(?string $transactionId = null, array $metadata = []): self
+    {
+        return new self(PaymentOutcomeStatus::AUTHORIZED, $transactionId, [], $metadata);
+    }
+
+    /**
+     * 売上確定済 (capture 済、または capture 不要な auto-capture 型 PSP).
+     *
+     * authorize がこれを返すと**オーケストレータは capture を呼ばない**。与信のみの場合は
+     * {@link self::authorized()} を使うこと。
+     *
      * @param array<string, mixed> $metadata
      */
     public static function completed(?string $transactionId = null, array $metadata = []): self
@@ -47,34 +63,49 @@ final readonly class PaymentOutcome
     }
 
     /**
-     * @param array<string, mixed> $actionData continue_url / authentication_metadata の原資
+     * @param array<string, mixed> $actionData    continue_url / authentication_metadata の原資
      * @param array<string, mixed> $metadata
+     * @param string|null          $transactionId 中断時点の PSP 取引識別子 (再開時に参照するため payment_data へ保持される)
      */
-    public static function requiresAction(array $actionData, array $metadata = []): self
+    public static function requiresAction(array $actionData, array $metadata = [], ?string $transactionId = null): self
     {
-        return new self(PaymentOutcomeStatus::REQUIRES_ACTION, null, $actionData, $metadata);
+        return new self(PaymentOutcomeStatus::REQUIRES_ACTION, $transactionId, $actionData, $metadata);
     }
 
     /**
      * @param array<string, mixed> $metadata
+     * @param string|null          $transactionId 非同期確定を待つ PSP 取引識別子 (IPN/Webhook との突合に用いる)
      */
-    public static function pending(array $metadata = []): self
+    public static function pending(array $metadata = [], ?string $transactionId = null): self
     {
-        return new self(PaymentOutcomeStatus::PENDING, null, [], $metadata);
+        return new self(PaymentOutcomeStatus::PENDING, $transactionId, [], $metadata);
     }
 
     /**
-     * @param bool $retryable 再試行可能か (card declined 等は true=セッションを ready に戻す /
-     *                         fraud block 等の不可逆失敗は false=セッションを canceled にする)
+     * @param bool                 $retryable     再試行可能か (card declined 等は true=セッションを ready に戻す /
+     *                                            fraud block 等の不可逆失敗は false=セッションを canceled にする)
+     * @param string|null          $transactionId 失敗した取引の PSP 識別子 (問い合わせ・追跡のため保持する)
+     * @param array<string, mixed> $metadata
      */
-    public static function failed(string $errorCode, string $errorMessage = '', bool $retryable = true): self
+    public static function failed(string $errorCode, string $errorMessage = '', bool $retryable = true, ?string $transactionId = null, array $metadata = []): self
     {
-        return new self(PaymentOutcomeStatus::FAILED, null, [], [], $errorCode, $errorMessage, $retryable);
+        return new self(PaymentOutcomeStatus::FAILED, $transactionId, [], $metadata, $errorCode, $errorMessage, $retryable);
     }
 
+    /**
+     * 決済が失敗せず前進したか (与信済 or 売上確定済).
+     */
     public function isSuccessful(): bool
     {
-        return $this->status === PaymentOutcomeStatus::COMPLETED;
+        return in_array($this->status, [PaymentOutcomeStatus::AUTHORIZED, PaymentOutcomeStatus::COMPLETED], true);
+    }
+
+    /**
+     * 売上確定 (capture) がこれから必要か.
+     */
+    public function needsCapture(): bool
+    {
+        return $this->status === PaymentOutcomeStatus::AUTHORIZED;
     }
 
     public function needsAction(): bool

--- a/src/Eccube/Service/AgentCommerce/Payment/PaymentOutcomeStatus.php
+++ b/src/Eccube/Service/AgentCommerce/Payment/PaymentOutcomeStatus.php
@@ -24,7 +24,21 @@ namespace Eccube\Service\AgentCommerce\Payment;
  */
 enum PaymentOutcomeStatus: string
 {
-    /** 与信/売上が成功し、注文を確定 (commit) してよい. */
+    /**
+     * 与信 (オーソリ) のみ成功し、**売上確定 (capture) が必要**.
+     *
+     * オーケストレータはこの結果を受けてはじめて {@link AgentCheckoutPaymentHandlerInterface::capture()} を呼ぶ。
+     * 与信と売上が 1 度の通信で完結する auto-capture 型 PSP は本ステータスでなく {@link self::COMPLETED}
+     * を返すこと (本ステータスを返すと capture が二重発行される)。
+     */
+    case AUTHORIZED = 'authorized';
+
+    /**
+     * 売上まで確定済で、注文を確定 (commit) してよい.
+     *
+     * capture 済 (または capture 不要な auto-capture 型 PSP) を表す。
+     * **オーケストレータは本ステータスに対して capture を呼ばない**。
+     */
     case COMPLETED = 'completed';
 
     /** 追加対応が必要 (3DS challenge / escalation)。在庫は引当のまま保持し、再開 complete を待つ. */

--- a/src/Eccube/Service/AgentCommerce/Payment/UcpPaymentHandlerInterface.php
+++ b/src/Eccube/Service/AgentCommerce/Payment/UcpPaymentHandlerInterface.php
@@ -39,9 +39,17 @@ interface UcpPaymentHandlerInterface extends AgentCheckoutPaymentHandlerInterfac
     /**
      * エージェントから渡された支払クレデンシャルを PSP のゲートウェイトークンへ交換する.
      *
+     * UCP は ACP と異なり、再開 complete の入力もこのクレデンシャル経由で届く。追加認証の結果など
+     * **再開に必要な項目を戻り値から落とさない**こと (落とすと REQUIRES_ACTION から復帰できなくなる)。
+     *
+     * 本メソッドは complete の状態機械の**外側** (controller のペイロード解決時) で呼ばれるため、
+     * **例外を投げてはならない**。トークンを解決できない入力もそのまま返し、
+     * {@link AgentCheckoutPaymentHandlerInterface::authorize()} 側で fail-closed に失敗させること
+     * (ここで投げるとビジネス系エラーでなく HTTP 500 になる)。
+     *
      * @param array<string, mixed> $credential payment.instruments[].credential の中立表現 (type/token 等)
      *
-     * @return array<string, mixed> 後続の authorize()/capture() へ渡す中立な支払データ
+     * @return array<string, mixed> authorize() が PSP へ渡す中立な支払データ
      */
     public function exchangePaymentToken(array $credential): array;
 }

--- a/src/Eccube/Service/AgentCommerce/Payment/UcpPaymentHandlerInterface.php
+++ b/src/Eccube/Service/AgentCommerce/Payment/UcpPaymentHandlerInterface.php
@@ -43,9 +43,14 @@ interface UcpPaymentHandlerInterface extends AgentCheckoutPaymentHandlerInterfac
      * **再開に必要な項目を戻り値から落とさない**こと (落とすと REQUIRES_ACTION から復帰できなくなる)。
      *
      * 本メソッドは complete の状態機械の**外側** (controller のペイロード解決時) で呼ばれるため、
-     * **例外を投げてはならない**。トークンを解決できない入力もそのまま返し、
-     * {@link AgentCheckoutPaymentHandlerInterface::authorize()} 側で fail-closed に失敗させること
-     * (ここで投げるとビジネス系エラーでなく HTTP 500 になる)。
+     * {@link \Eccube\Service\AgentCommerce\CheckoutSession\AgentCheckoutCompletionService} の
+     * authorize/capture 用の砦が効かない。**例外を投げてはならない**。トークンを解決できない入力も
+     * そのまま返し、{@link AgentCheckoutPaymentHandlerInterface::authorize()} 側で fail-closed に
+     * 失敗させること (状態機械へ入れば在庫の回収とセッション遷移が伴う)。
+     *
+     * 契約に反して投げた場合も HTTP 500 にはならない。controller が捕捉してビジネス系エラー
+     * (HTTP 200 + messages[]) へ写像し、セッションを据え置いて再試行を許す。ただしその経路では
+     * 失敗理由をエージェントへ伝えられないため、依存してはならない。
      *
      * @param array<string, mixed> $credential payment.instruments[].credential の中立表現 (type/token 等)
      *

--- a/tests/Eccube/Tests/Service/AgentCommerce/CheckoutSession/AgentCheckoutCompletionServiceTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/CheckoutSession/AgentCheckoutCompletionServiceTest.php
@@ -208,15 +208,13 @@ final class AgentCheckoutCompletionServiceTest extends EccubeTestCase
      *
      * complete に再入できる非終端ステータスのうち、初回入口の INCOMPLETE を除く 3 経路を網羅する。
      *
-     * @return array<string, array{PaymentOutcome, bool}>
+     * @return \Iterator<string, array{PaymentOutcome, bool}>
      */
-    public static function reentryScenarios(): array
+    public static function reentryScenarios(): \Iterator
     {
-        return [
-            'requires_action からの再開' => [PaymentOutcome::requiresAction(['continue_url' => 'https://example.com/3ds'], [], 'pi_first'), true],
-            'in_progress からの再開' => [PaymentOutcome::pending([], 'pi_first'), true],
-            '与信拒否で ready へ戻った後の再試行' => [PaymentOutcome::failed('card_declined', 'The card was declined.', true, 'pi_first'), false],
-        ];
+        yield 'requires_action からの再開' => [PaymentOutcome::requiresAction(['continue_url' => 'https://example.com/3ds'], [], 'pi_first'), true];
+        yield 'in_progress からの再開' => [PaymentOutcome::pending([], 'pi_first'), true];
+        yield '与信拒否で ready へ戻った後の再試行' => [PaymentOutcome::failed('card_declined', 'The card was declined.', true, 'pi_first'), false];
     }
 
     /**

--- a/tests/Eccube/Tests/Service/AgentCommerce/CheckoutSession/AgentCheckoutCompletionServiceTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/CheckoutSession/AgentCheckoutCompletionServiceTest.php
@@ -33,6 +33,7 @@ use Eccube\Service\AgentCommerce\Payment\AgentCheckoutPaymentHandlerInterface;
 use Eccube\Service\AgentCommerce\Payment\AgentCheckoutPaymentHandlerRegistry;
 use Eccube\Service\AgentCommerce\Payment\PaymentOutcome;
 use Eccube\Tests\EccubeTestCase;
+use Psr\Log\NullLogger;
 
 /**
  * Layer 3 (complete 状態機械) tests for AgentCheckoutCompletionService.
@@ -57,7 +58,7 @@ final class AgentCheckoutCompletionServiceTest extends EccubeTestCase
         $stock = $ProductClass->getProductStock();
         $session = $this->createReadySession($ProductClass, 2);
 
-        $handler = $this->stubHandler([PaymentOutcome::completed('auth_1')], PaymentOutcome::completed('cap_1'));
+        $handler = $this->stubHandler([PaymentOutcome::authorized('auth_1')], PaymentOutcome::completed('cap_1'));
         $result = $this->service($handler)->complete($session, []);
 
         $this->assertSame(CheckoutSessionStatus::COMPLETED, $result->status->getId(), 'frictionless で completed へ遷移する');
@@ -75,9 +76,9 @@ final class AgentCheckoutCompletionServiceTest extends EccubeTestCase
         $stock = $ProductClass->getProductStock();
         $session = $this->createReadySession($ProductClass, 2);
 
-        // authorize: 1 回目 REQUIRES_ACTION (3DS challenge) → 2 回目 COMPLETED (再開)。
+        // authorize: 1 回目 REQUIRES_ACTION (3DS challenge) → 2 回目 AUTHORIZED (再開)。
         $handler = $this->stubHandler(
-            [PaymentOutcome::requiresAction(['continue_url' => 'https://example.com/3ds/abc']), PaymentOutcome::completed('auth_2')],
+            [PaymentOutcome::requiresAction(['continue_url' => 'https://example.com/3ds/abc']), PaymentOutcome::authorized('auth_2')],
             PaymentOutcome::completed('cap_1'),
         );
         $service = $this->service($handler);
@@ -101,6 +102,130 @@ final class AgentCheckoutCompletionServiceTest extends EccubeTestCase
 
         $this->entityManager->refresh($stock);
         $this->assertSame(98, (int) $stock->getStock(), '再開確定後も在庫は二重に減らない');
+    }
+
+    public function testAuthorizedOutcomeHandsTransactionReferenceToCapture(): void
+    {
+        $ProductClass = $this->createPurchasableProductClass('100');
+        $session = $this->createReadySession($ProductClass, 1);
+
+        $handler = $this->stubHandler(
+            [PaymentOutcome::authorized('pi_auth_1', ['gateway' => 'stub'])],
+            PaymentOutcome::completed('pi_auth_1', ['captured' => true]),
+        );
+        $this->service($handler)->complete($session, ['token' => 'tok_visa']);
+
+        $this->assertCount(1, $handler->capturedAuthorizations, 'AUTHORIZED は capture を 1 度だけ呼ぶ');
+        $this->assertSame('pi_auth_1', $handler->capturedAuthorizations[0]->transactionId, 'capture は authorize が返した取引識別子を受け取る (トークン再償還を不要にする)');
+        $this->assertSame(['gateway' => 'stub'], $handler->capturedAuthorizations[0]->metadata, 'capture は authorize の metadata も受け取る');
+
+        $paymentData = $session->getPaymentData() ?? [];
+        $this->assertSame('pi_auth_1', $paymentData['transaction_id'] ?? null, '取引識別子が payment_data へ永続化される');
+        $this->assertTrue($paymentData['captured'] ?? false, 'capture の metadata も payment_data へマージされる');
+    }
+
+    public function testAutoCaptureGatewayIsNotCapturedTwice(): void
+    {
+        $ProductClass = $this->createPurchasableProductClass('100');
+        $stock = $ProductClass->getProductStock();
+        $session = $this->createReadySession($ProductClass, 1);
+
+        // auto-capture 型 PSP: authorize が売上確定まで済ませて COMPLETED を返す。
+        $handler = $this->stubHandler([PaymentOutcome::completed('ch_auto_1', ['gateway' => 'auto'])]);
+        $result = $this->service($handler)->complete($session, []);
+
+        $this->assertSame(CheckoutSessionStatus::COMPLETED, $result->status->getId(), 'auto-capture でも注文は確定する');
+        $this->assertSame(0, $handler->captureCount, 'COMPLETED に対して capture を呼ばない (二重売上を防ぐ)');
+
+        $paymentData = $session->getPaymentData() ?? [];
+        $this->assertSame('ch_auto_1', $paymentData['transaction_id'] ?? null, 'capture を経由しなくても PSP 参照は payment_data へ残る');
+
+        $this->entityManager->refresh($stock);
+        $this->assertInstanceOf(ProductStock::class, $stock);
+        $this->assertSame(99, (int) $stock->getStock(), '在庫は 1 だけ引き当てられる');
+    }
+
+    public function testCaptureFailureRollsBackStockAndKeepsAuthorizationReference(): void
+    {
+        $ProductClass = $this->createPurchasableProductClass('10');
+        $stock = $ProductClass->getProductStock();
+        $session = $this->createReadySession($ProductClass, 2);
+
+        $handler = $this->stubHandler(
+            [PaymentOutcome::authorized('pi_auth_2', ['gateway' => 'stub'])],
+            PaymentOutcome::failed('capture_failed', 'Capture was rejected.', true, 'pi_auth_2'),
+        );
+        $result = $this->service($handler)->complete($session, []);
+
+        $this->assertSame(CheckoutSessionStatus::READY, $result->status->getId(), 'capture 失敗 (retryable) は ready に戻す');
+        $this->assertNotInstanceOf(Order::class, $result->order, 'capture 失敗時は注文を確定しない');
+
+        $paymentData = $session->getPaymentData() ?? [];
+        $this->assertSame('pi_auth_2', $paymentData['transaction_id'] ?? null, '与信済みの取引識別子は capture 失敗後も残る (与信取消の照会に必要)');
+
+        $this->entityManager->refresh($stock);
+        $this->assertInstanceOf(ProductStock::class, $stock);
+        $this->assertSame(10, (int) $stock->getStock(), 'capture 失敗で引当をロールバックする');
+    }
+
+    public function testResumeHandsStoredPaymentReferenceToHandler(): void
+    {
+        $ProductClass = $this->createPurchasableProductClass('100');
+        $session = $this->createReadySession($ProductClass, 1);
+
+        $handler = $this->stubHandler(
+            [
+                PaymentOutcome::requiresAction(['continue_url' => 'https://example.com/3ds'], ['gateway' => 'stub'], 'pi_hold_1'),
+                PaymentOutcome::authorized('pi_hold_1'),
+            ],
+            PaymentOutcome::completed('pi_hold_1'),
+        );
+        $service = $this->service($handler);
+
+        $service->complete($session, ['token' => 'tok_one_shot']);
+        $this->assertSame([], $handler->receivedPaymentReferences[0], '初回 complete では保持済み参照が無い');
+
+        // 再開: エージェントの入力に取引識別子が無くても、中断時に保持した PSP 参照がハンドラへ届く
+        // (ワンショットトークンを再償還せず同じ取引を続行できる)。
+        $service->complete($session, ['authentication_result' => ['outcome' => 'authenticated']]);
+        $resumeReference = $handler->receivedPaymentReferences[1];
+        $this->assertSame('pi_hold_1', $resumeReference['transaction_id'] ?? null, '再開時は中断前の取引識別子がハンドラへ渡る');
+        $this->assertSame('stub', $resumeReference['gateway'] ?? null, '中断時の metadata も引き渡される');
+    }
+
+    public function testHandlerExceptionOnAuthorizeIsMappedToFailureNotFatal(): void
+    {
+        $ProductClass = $this->createPurchasableProductClass('10');
+        $stock = $ProductClass->getProductStock();
+        $session = $this->createReadySession($ProductClass, 2);
+
+        // ハンドラは failed を返す契約だが、漏れた例外で状態遷移ごと巻き戻さないことを保証する。
+        $handler = $this->stubHandler([new \RuntimeException('psp connection reset')]);
+        $result = $this->service($handler)->complete($session, []);
+
+        $this->assertSame(CheckoutSessionStatus::READY, $result->status->getId(), 'ハンドラの例外は 500 でなくビジネス系の失敗として扱う');
+        $this->assertNotEmpty($result->messages, 'エージェントには messages[] で返す');
+
+        $this->entityManager->refresh($stock);
+        $this->assertInstanceOf(ProductStock::class, $stock);
+        $this->assertSame(10, (int) $stock->getStock(), '例外時も引当をロールバックする');
+    }
+
+    public function testHandlerExceptionOnCaptureKeepsAuthorizationReference(): void
+    {
+        $ProductClass = $this->createPurchasableProductClass('10');
+        $session = $this->createReadySession($ProductClass, 1);
+
+        $handler = $this->stubHandler(
+            [PaymentOutcome::authorized('pi_auth_3', ['gateway' => 'stub'])],
+            new \RuntimeException('psp timeout'),
+        );
+        $result = $this->service($handler)->complete($session, []);
+
+        $this->assertSame(CheckoutSessionStatus::READY, $result->status->getId(), 'capture の例外も retryable な失敗として扱う');
+
+        $paymentData = $session->getPaymentData() ?? [];
+        $this->assertSame('pi_auth_3', $paymentData['transaction_id'] ?? null, '例外で巻き戻さず、与信済み取引の識別子を残す (取消・照会に必要)');
     }
 
     public function testDeclinedRetryableRollsBackStockAndReturnsToReady(): void
@@ -138,7 +263,7 @@ final class AgentCheckoutCompletionServiceTest extends EccubeTestCase
         $stock = $ProductClass->getProductStock();
         $session = $this->createReadySession($ProductClass, 2);
 
-        $handler = $this->stubHandler([PaymentOutcome::completed('auth_1')], PaymentOutcome::completed('cap_1'));
+        $handler = $this->stubHandler([PaymentOutcome::authorized('auth_1')], PaymentOutcome::completed('cap_1'));
         $service = $this->service($handler);
 
         $first = $service->complete($session, []);
@@ -165,9 +290,9 @@ final class AgentCheckoutCompletionServiceTest extends EccubeTestCase
         $stock = $ProductClass->getProductStock();
         $session = $this->createReadySession($ProductClass, 1);
 
-        // authorize: 1 回目 PENDING (非同期) → 2 回目 COMPLETED (IPN/Webhook 受信後の再開)。
+        // authorize: 1 回目 PENDING (非同期) → 2 回目 AUTHORIZED (IPN/Webhook 受信後の再開)。
         $handler = $this->stubHandler(
-            [PaymentOutcome::pending(['psp_ref' => 'pi_123']), PaymentOutcome::completed('auth_2')],
+            [PaymentOutcome::pending(['psp_ref' => 'pi_123']), PaymentOutcome::authorized('auth_2')],
             PaymentOutcome::completed('cap_1'),
         );
         $service = $this->service($handler);
@@ -245,6 +370,7 @@ final class AgentCheckoutCompletionServiceTest extends EccubeTestCase
             new AgentCheckoutPaymentHandlerRegistry($handlers),
             $statusRepository,
             self::getContainer()->get(GuestCustomerResolver::class),
+            new NullLogger(),
             15,
         );
     }
@@ -252,35 +378,52 @@ final class AgentCheckoutCompletionServiceTest extends EccubeTestCase
     /**
      * 設定可能な決済ハンドラスタブ.
      *
-     * @param array<int, PaymentOutcome> $authorizeOutcomes authorize の戻り値 (呼び出し順に消費・末尾を反復)
+     * @param array<int, PaymentOutcome|\Throwable> $authorizeOutcomes authorize の戻り値 (呼び出し順に消費・末尾を反復)。
+     *                                                                 Throwable を混ぜると authorize がそれを投げる
      */
-    private function stubHandler(array $authorizeOutcomes, ?PaymentOutcome $captureOutcome = null): AgentCheckoutPaymentHandlerInterface
+    private function stubHandler(array $authorizeOutcomes, PaymentOutcome|\Throwable|null $captureOutcome = null): AgentCheckoutPaymentHandlerInterface
     {
         return new class($authorizeOutcomes, $captureOutcome) implements AgentCheckoutPaymentHandlerInterface {
             public int $authorizeCount = 0;
 
             public int $captureCount = 0;
 
+            /** @var array<int, PaymentOutcome> capture() が受け取った与信結果 */
+            public array $capturedAuthorizations = [];
+
+            /** @var array<int, array<string, mixed>> authorize() が受け取った PSP 参照 */
+            public array $receivedPaymentReferences = [];
+
             /**
-             * @param array<int, PaymentOutcome> $authorizeOutcomes
+             * @param array<int, PaymentOutcome|\Throwable> $authorizeOutcomes
              */
             public function __construct(
                 private array $authorizeOutcomes,
-                private readonly ?PaymentOutcome $captureOutcome,
+                private readonly PaymentOutcome|\Throwable|null $captureOutcome,
             ) {
             }
 
-            public function authorize(Order $order, array $paymentData): PaymentOutcome
+            public function authorize(Order $order, array $paymentData, array $paymentReference = []): PaymentOutcome
             {
                 $outcome = $this->authorizeOutcomes[$this->authorizeCount] ?? $this->authorizeOutcomes[array_key_last($this->authorizeOutcomes)];
                 ++$this->authorizeCount;
+                $this->receivedPaymentReferences[] = $paymentReference;
+
+                if ($outcome instanceof \Throwable) {
+                    throw $outcome;
+                }
 
                 return $outcome;
             }
 
-            public function capture(Order $order, array $paymentData): PaymentOutcome
+            public function capture(Order $order, array $paymentData, PaymentOutcome $authorization): PaymentOutcome
             {
                 ++$this->captureCount;
+                $this->capturedAuthorizations[] = $authorization;
+
+                if ($this->captureOutcome instanceof \Throwable) {
+                    throw $this->captureOutcome;
+                }
 
                 return $this->captureOutcome ?? PaymentOutcome::completed('cap_'.$this->captureCount);
             }

--- a/tests/Eccube/Tests/Service/AgentCommerce/CheckoutSession/AgentCheckoutCompletionServiceTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/CheckoutSession/AgentCheckoutCompletionServiceTest.php
@@ -33,6 +33,7 @@ use Eccube\Service\AgentCommerce\Payment\AgentCheckoutPaymentHandlerInterface;
 use Eccube\Service\AgentCommerce\Payment\AgentCheckoutPaymentHandlerRegistry;
 use Eccube\Service\AgentCommerce\Payment\PaymentOutcome;
 use Eccube\Tests\EccubeTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\NullLogger;
 
 /**
@@ -166,6 +167,124 @@ final class AgentCheckoutCompletionServiceTest extends EccubeTestCase
         $this->entityManager->refresh($stock);
         $this->assertInstanceOf(ProductStock::class, $stock);
         $this->assertSame(10, (int) $stock->getStock(), 'capture 失敗で引当をロールバックする');
+    }
+
+    /**
+     * 不変条件: 保持済みの PSP 参照をハンドラへ渡すのは「在庫を引当てたまま中断した」状態
+     * (REQUIRES_ACTION / IN_PROGRESS) からの再開時のみ。ready からの再試行では渡さない.
+     *
+     * ready は在庫を回収済みで、与信拒否でここへ落ちた場合は保持している識別子が死んだ取引を指す。
+     * 渡してしまうと「別カードでの再試行」が拒否済み取引の続行になる。
+     */
+    #[DataProvider(methodName: 'reentryScenarios')]
+    public function testStoredPaymentReferenceReachesHandlerOnlyWhenResumingFromHeldStatus(PaymentOutcome $interrupted, bool $expectsReference): void
+    {
+        $ProductClass = $this->createPurchasableProductClass('100');
+        $session = $this->createReadySession($ProductClass, 1);
+        $handler = $this->stubHandler(
+            [$interrupted, PaymentOutcome::authorized('pi_second')],
+            PaymentOutcome::completed('pi_second'),
+        );
+        $service = $this->service($handler);
+
+        $service->complete($session, ['token' => 'tok_first']);
+        $this->assertSame([], $handler->receivedPaymentReferences[0], '初回 complete には保持済み参照が無い');
+
+        // 中断・失敗のいずれでも参照は payment_data に残る (照会・監査のため)。
+        $this->assertSame('pi_first', ($session->getPaymentData() ?? [])['transaction_id'] ?? null, 'PSP 参照は payment_data に保持される');
+
+        $service->complete($session, ['token' => 'tok_second']);
+        $handedBack = $handler->receivedPaymentReferences[1]['transaction_id'] ?? null;
+
+        if ($expectsReference) {
+            $this->assertSame('pi_first', $handedBack, '中断からの再開では保持済み参照がハンドラへ渡る');
+        } else {
+            $this->assertNull($handedBack, 'ready からの再試行では保持済み参照を渡さない (新規与信としてやり直す)');
+        }
+    }
+
+    /**
+     * 再入シナリオ: [中断/失敗を起こす authorize の戻り値, 再入時に参照が渡るか].
+     *
+     * complete に再入できる非終端ステータスのうち、初回入口の INCOMPLETE を除く 3 経路を網羅する。
+     *
+     * @return array<string, array{PaymentOutcome, bool}>
+     */
+    public static function reentryScenarios(): array
+    {
+        return [
+            'requires_action からの再開' => [PaymentOutcome::requiresAction(['continue_url' => 'https://example.com/3ds'], [], 'pi_first'), true],
+            'in_progress からの再開' => [PaymentOutcome::pending([], 'pi_first'), true],
+            '与信拒否で ready へ戻った後の再試行' => [PaymentOutcome::failed('card_declined', 'The card was declined.', true, 'pi_first'), false],
+        ];
+    }
+
+    /**
+     * capture 失敗 (retryable) で ready へ戻った後の再試行も、新規 authorize から始まる.
+     *
+     * {@link AgentCheckoutPaymentHandlerInterface::capture()} が「与信が残り再 authorize できない
+     * 場合は retryable=false を返せ」と定めている根拠となる挙動。
+     */
+    public function testReadyRetryAfterCaptureFailureStartsFreshAuthorize(): void
+    {
+        $ProductClass = $this->createPurchasableProductClass('100');
+        $session = $this->createReadySession($ProductClass, 1);
+
+        $handler = $this->stubHandler(
+            [PaymentOutcome::authorized('pi_auth_retry')],
+            PaymentOutcome::failed('capture_failed', 'Capture was rejected.', true, 'pi_auth_retry'),
+        );
+        $service = $this->service($handler);
+
+        $first = $service->complete($session, ['token' => 'tok_one_shot']);
+        $this->assertSame(CheckoutSessionStatus::READY, $first->status->getId());
+
+        $service->complete($session, ['token' => 'tok_one_shot']);
+
+        $this->assertSame(2, $handler->authorizeCount, 'ready からの再試行は capture の再実行ではなく新規 authorize になる');
+        $this->assertSame([], $handler->receivedPaymentReferences[1], '再試行では与信済みの取引識別子を渡さない');
+    }
+
+    /**
+     * capture が契約 (COMPLETED か FAILED) に反した status を返しても、内容のある ERROR を返す.
+     *
+     * PENDING は errorCode/errorMessage を持たないため、素通しすると messages[] に
+     * 「要素はあるが中身が空」のエラーが載る。
+     */
+    public function testCaptureContractViolationIsReportedWithNonEmptyMessage(): void
+    {
+        $ProductClass = $this->createPurchasableProductClass('10');
+        $stock = $ProductClass->getProductStock();
+        $session = $this->createReadySession($ProductClass, 2);
+
+        $handler = $this->stubHandler(
+            [PaymentOutcome::authorized('pi_auth_3')],
+            PaymentOutcome::pending([], 'pi_auth_3'),
+        );
+        $result = $this->service($handler)->complete($session, []);
+
+        $this->assertSame(CheckoutSessionStatus::READY, $result->status->getId(), 'capture の契約違反は失敗として扱う');
+        $this->assertCount(1, $result->messages);
+        $this->assertNotSame('', $result->messages[0]->message, 'エージェントへ空文字のエラーメッセージを返さない');
+
+        $this->entityManager->refresh($stock);
+        $this->assertInstanceOf(ProductStock::class, $stock);
+        $this->assertSame(10, (int) $stock->getStock(), '契約違反でも在庫は回収する (fail-closed)');
+    }
+
+    /**
+     * errorMessage も errorCode も空のまま失敗しても、メッセージ本文は空にならない.
+     */
+    public function testFailureMessageIsNeverEmpty(): void
+    {
+        $ProductClass = $this->createPurchasableProductClass('100');
+        $session = $this->createReadySession($ProductClass, 1);
+
+        $handler = $this->stubHandler([PaymentOutcome::failed('', '', true)]);
+        $result = $this->service($handler)->complete($session, []);
+
+        $this->assertCount(1, $result->messages);
+        $this->assertNotSame('', $result->messages[0]->message, 'errorCode / errorMessage が空でも本文を落とさない');
     }
 
     public function testResumeHandsStoredPaymentReferenceToHandler(): void

--- a/tests/Eccube/Tests/Service/AgentCommerce/Conformance/AgentCheckoutCoreConformanceTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/Conformance/AgentCheckoutCoreConformanceTest.php
@@ -70,19 +70,21 @@ final class AgentCheckoutCoreConformanceTest extends TestCase
     }
 
     /**
-     * 決済ハンドラの結果型は「中断→再開」状態機械を表現する 4 値を持つ.
+     * 決済ハンドラの結果型は「中断→再開」状態機械を表現する 5 値を持つ.
      *
-     * COMPLETED / REQUIRES_ACTION (3DS/escalation) / PENDING (非同期) / FAILED。
+     * AUTHORIZED (与信のみ・capture 要) / COMPLETED (売上確定済・capture 不要) /
+     * REQUIRES_ACTION (3DS/escalation) / PENDING (非同期) / FAILED。
      * 追加認証はエラー (FAILED) ではなく REQUIRES_ACTION で表現される点が要。
+     * 与信と売上確定を区別するのは、auto-capture 型 PSP で capture が二重発行されるのを防ぐため。
      */
     public function testPaymentOutcomeCoversStateMachineSignals(): void
     {
         $values = array_map(static fn (PaymentOutcomeStatus $s): string => $s->value, PaymentOutcomeStatus::cases());
 
         $this->assertEqualsCanonicalizing(
-            ['completed', 'requires_action', 'pending', 'failed'],
+            ['authorized', 'completed', 'requires_action', 'pending', 'failed'],
             $values,
-            'MUST: 決済結果型は completed/requires_action/pending/failed の 4 状態を表現できる',
+            'MUST: 決済結果型は authorized/completed/requires_action/pending/failed の 5 状態を表現できる',
         );
     }
 

--- a/tests/Eccube/Tests/Service/AgentCommerce/Discovery/UcpPaymentHandlerDiscoveryRegistryTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/Discovery/UcpPaymentHandlerDiscoveryRegistryTest.php
@@ -116,12 +116,12 @@ final readonly class InMemoryUcpDiscoveryHandler implements UcpPaymentHandlerInt
         return [];
     }
 
-    public function authorize(Order $order, array $paymentData): PaymentOutcome
+    public function authorize(Order $order, array $paymentData, array $paymentReference = []): PaymentOutcome
     {
         return PaymentOutcome::completed();
     }
 
-    public function capture(Order $order, array $paymentData): PaymentOutcome
+    public function capture(Order $order, array $paymentData, PaymentOutcome $authorization): PaymentOutcome
     {
         return PaymentOutcome::completed();
     }
@@ -146,12 +146,12 @@ final readonly class InMemoryBasePaymentHandler implements AgentCheckoutPaymentH
         return $this->handlerId;
     }
 
-    public function authorize(Order $order, array $paymentData): PaymentOutcome
+    public function authorize(Order $order, array $paymentData, array $paymentReference = []): PaymentOutcome
     {
         return PaymentOutcome::completed();
     }
 
-    public function capture(Order $order, array $paymentData): PaymentOutcome
+    public function capture(Order $order, array $paymentData, PaymentOutcome $authorization): PaymentOutcome
     {
         return PaymentOutcome::completed();
     }

--- a/tests/Eccube/Tests/Service/AgentCommerce/Payment/AgentCheckoutPaymentHandlerRegistryTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/Payment/AgentCheckoutPaymentHandlerRegistryTest.php
@@ -98,12 +98,12 @@ final readonly class InMemoryUcpPaymentHandler implements UcpPaymentHandlerInter
         return ['gateway_token' => 'tok_test', 'source' => $credential];
     }
 
-    public function authorize(Order $order, array $paymentData): PaymentOutcome
+    public function authorize(Order $order, array $paymentData, array $paymentReference = []): PaymentOutcome
     {
         return PaymentOutcome::completed();
     }
 
-    public function capture(Order $order, array $paymentData): PaymentOutcome
+    public function capture(Order $order, array $paymentData, PaymentOutcome $authorization): PaymentOutcome
     {
         return PaymentOutcome::completed();
     }
@@ -119,12 +119,12 @@ final readonly class InMemoryUcpPaymentHandler implements UcpPaymentHandlerInter
  */
 final readonly class InMemoryNonUcpPaymentHandler implements AgentCheckoutPaymentHandlerInterface
 {
-    public function authorize(Order $order, array $paymentData): PaymentOutcome
+    public function authorize(Order $order, array $paymentData, array $paymentReference = []): PaymentOutcome
     {
         return PaymentOutcome::completed();
     }
 
-    public function capture(Order $order, array $paymentData): PaymentOutcome
+    public function capture(Order $order, array $paymentData, PaymentOutcome $authorization): PaymentOutcome
     {
         return PaymentOutcome::completed();
     }

--- a/tests/Eccube/Tests/Service/AgentCommerce/Payment/DefaultAgentPaymentMethodResolverTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/Payment/DefaultAgentPaymentMethodResolverTest.php
@@ -234,12 +234,12 @@ final readonly class InMemoryMethodClassPaymentHandler implements AgentCheckoutP
         return $this->handlerId;
     }
 
-    public function authorize(Order $order, array $paymentData): PaymentOutcome
+    public function authorize(Order $order, array $paymentData, array $paymentReference = []): PaymentOutcome
     {
         return PaymentOutcome::completed();
     }
 
-    public function capture(Order $order, array $paymentData): PaymentOutcome
+    public function capture(Order $order, array $paymentData, PaymentOutcome $authorization): PaymentOutcome
     {
         return PaymentOutcome::completed();
     }

--- a/tests/Eccube/Tests/Web/AgentCommerce/UcpCheckoutControllerTest.php
+++ b/tests/Eccube/Tests/Web/AgentCommerce/UcpCheckoutControllerTest.php
@@ -15,8 +15,12 @@ declare(strict_types=1);
 
 namespace Eccube\Tests\Web\AgentCommerce;
 
+use Eccube\Entity\Order;
 use Eccube\Entity\ProductClass;
 use Eccube\Repository\BaseInfoRepository;
+use Eccube\Service\AgentCommerce\Payment\AgentCheckoutPaymentHandlerRegistry;
+use Eccube\Service\AgentCommerce\Payment\PaymentOutcome;
+use Eccube\Service\AgentCommerce\Payment\UcpPaymentHandlerInterface;
 use Eccube\Tests\EccubeTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -32,6 +36,9 @@ use Symfony\Component\HttpFoundation\Response;
  */
 final class UcpCheckoutControllerTest extends EccubeTestCase
 {
+    /** 契約違反ハンドラの handler_id (匿名クラスから参照するため public)。 */
+    public const THROWING_HANDLER_ID = 'test.ucp.throwing';
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -132,6 +139,69 @@ final class UcpCheckoutControllerTest extends EccubeTestCase
         $this->assertArrayHasKey('order', $completed, 'complete 後は order を含む (MUST)');
         $this->assertNotEmpty($completed['order']['id']);
         $this->assertNotEmpty($completed['order']['permalink_url'], 'order.permalink_url は必須');
+    }
+
+    /**
+     * exchangePaymentToken() が契約に反して例外を投げても HTTP 500 にせずビジネス系エラーへ写像する.
+     *
+     * 本メソッドは complete の状態機械の**外側** (controller のペイロード解決時) で呼ばれるため、
+     * {@link \Eccube\Service\AgentCommerce\CheckoutSession\AgentCheckoutCompletionService} が
+     * authorize/capture に対して持つ例外の砦が効かない。
+     */
+    public function testPaymentTokenExchangeExceptionIsMappedToBusinessError(): void
+    {
+        // 決済ハンドラのレジストリを差し替えるため、リクエスト毎の kernel 再起動を止める。
+        $this->client->disableReboot();
+        self::getContainer()->set(
+            AgentCheckoutPaymentHandlerRegistry::class,
+            new AgentCheckoutPaymentHandlerRegistry([$this->throwingUcpHandler()]),
+        );
+
+        $ProductClass = $this->createPurchasableProductClass('100');
+        $created = $this->postJson('/ucp/checkout-sessions', $this->createPayload((int) $ProductClass->getId()));
+
+        $completed = $this->postJson('/ucp/checkout-sessions/'.$created['id'].'/complete', [
+            'payment' => ['instruments' => [['handler_id' => self::THROWING_HANDLER_ID, 'credential' => ['token' => 'tok_broken']]]],
+        ]);
+
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), 'ハンドラの例外を HTTP 500 にしない');
+        $this->assertNotSame('completed', $completed['status'], '支払データを解決できないセッションは確定しない');
+        $this->assertNotEmpty($completed['messages'] ?? [], 'ビジネス系エラーとして messages[] を返す');
+        $this->assertNotSame('', $completed['messages'][0]['content'] ?? '', 'メッセージ本文が空でない');
+        $this->assertSame('error', $completed['messages'][0]['type'] ?? null);
+    }
+
+    /**
+     * exchangePaymentToken() で例外を投げる UCP 決済ハンドラ (契約違反のシミュレート).
+     */
+    private function throwingUcpHandler(): UcpPaymentHandlerInterface
+    {
+        return new class implements UcpPaymentHandlerInterface {
+            public function getHandlerId(): string
+            {
+                return UcpCheckoutControllerTest::THROWING_HANDLER_ID;
+            }
+
+            public function exchangePaymentToken(array $credential): array
+            {
+                throw new \RuntimeException('PSP tokenization endpoint is unreachable.');
+            }
+
+            public function authorize(Order $order, array $paymentData, array $paymentReference = []): PaymentOutcome
+            {
+                return PaymentOutcome::completed('should_not_be_reached');
+            }
+
+            public function capture(Order $order, array $paymentData, PaymentOutcome $authorization): PaymentOutcome
+            {
+                return PaymentOutcome::completed('should_not_be_reached');
+            }
+
+            public function supports(Order $order): bool
+            {
+                return true;
+            }
+        };
     }
 
     public function testCreateWithoutAddressIsIncomplete(): void


### PR DESCRIPTION
## 概要

エージェントチェックアウトの決済ハンドラ契約 (`AgentCheckoutPaymentHandlerInterface` / `PaymentOutcome`) に 2 つの欠落があり、実 PSP を接続したときに実害が出ます。[EC-CUBE/sample-payment-plugin#54](https://github.com/EC-CUBE/sample-payment-plugin/pull/54) のレビューで顕在化したものを本体側で修正します。

いずれもエージェントコマース (#6777 / #6776 / #6574) が 4.4 で導入した未リリースの API であり、既存の決済プラグイン (通常購入の `PaymentMethodInterface`) には影響しません。

## 破壊的変更 (決済ハンドラを実装するプラグイン向け)

`AgentCheckoutPaymentHandlerInterface` の 2 メソッドのシグネチャを変更しています。**古いシグネチャのまま実装しているとインターフェース実装制約により fatal error になります** (`authorize()` は第 3 引数にデフォルト値がありますが、実装側で省略すると同様に fatal です)。

```diff
-public function authorize(Order $order, array $paymentData): PaymentOutcome;
+public function authorize(Order $order, array $paymentData, array $paymentReference = []): PaymentOutcome;

-public function capture(Order $order, array $paymentData): PaymentOutcome;
+public function capture(Order $order, array $paymentData, PaymentOutcome $authorization): PaymentOutcome;
```

- **影響範囲**: エージェントコマースの決済ハンドラ (`AgentCheckoutPaymentHandlerInterface` / `AcpPaymentHandlerInterface` / `UcpPaymentHandlerInterface`) を実装するプラグインのみ。通常購入の `PaymentMethodInterface` を実装する既存の決済プラグインには影響しません。
- **リリース済み API ではありません**: 本インターフェースは 4.4 の開発サイクル中に #6825 で追加されたもので、`Constant::VERSION` は `4.4.0-dev`・4.4 のタグは未発行です。コア本体に具象実装はなく (テストダブルのみ・本 PR で更新済み)、リリース済みのプラグイン API を壊すものではありません。
- **移行方法**: 上記のとおり引数を追加します。`$paymentReference` は**再開 complete のときだけ**中断前の PSP 参照 (`transaction_id` と metadata) が入り、初回は空配列です。`capture()` は `$paymentData` から取引を導出し直さず `$authorization->transactionId` を使ってください。移行の実例は [EC-CUBE/sample-payment-plugin#54](https://github.com/EC-CUBE/sample-payment-plugin/pull/54) を参照してください。

## 修正 1: 与信 (authorized) と売上確定 (completed) を区別する

`PaymentOutcomeStatus::COMPLETED` が「与信のみ (requires_capture)」と「売上確定済 (succeeded)」の両方を表していたため、`AgentCheckoutCompletionService` は COMPLETED を受けると**必ず** `capture()` を呼んでいました。

与信と売上が 1 度の通信で完結する **auto-capture 型 PSP** を差し込むと capture が二重発行されます。

- `PaymentOutcomeStatus::AUTHORIZED` を追加し、**AUTHORIZED のときだけ capture を呼ぶ**。
- `COMPLETED` は「capture 済/不要」を表し、capture を呼ばずに注文を確定する。
- `PaymentOutcome::authorized()` を追加。

## 修正 2: capture へ authorize の結果を引き渡す

`capture()` には authorize と同じ `$paymentData` しか渡っておらず、authorize が返した取引識別子・metadata を引き継ぐ経路がありませんでした。ハンドラは対象取引を支払データから導出し直すほかなく、ACP の Shared Payment Token のような**ワンショット償還**のトークンでは 2 度目の償還が失敗します (実際に sample-payment で SPT が 1 決済につき 2 回償還されていました)。

```diff
-public function capture(Order $order, array $paymentData): PaymentOutcome;
+public function capture(Order $order, array $paymentData, PaymentOutcome $authorization): PaymentOutcome;
```

## 併せて: 中断・失敗時に PSP 参照を追跡できるようにする

- `PaymentOutcome::requiresAction()` / `pending()` / `failed()` が `transactionId` を受け取れるようにした (DTO 自体は元から保持していたが、ファクトリが受け取らず捨てていた)。
- `payment_data` へ metadata に加えて `transaction_id` を保持し、**capture 失敗時にも残す** (与信済みの取引を照会・取消するために必要)。
- authorize が支払データを検証できない場合は fail-closed で `failed()` を返す旨を interface に明記。トークン欠落を「異常でない」と解釈して無与信のまま受注確定する事故を防ぐ。
- `UcpPaymentHandlerInterface::exchangePaymentToken()` は complete の状態機械の**外側** (controller のペイロード解決時) で呼ばれるため、**例外を投げてはならない**旨を明記 (投げるとビジネス系エラーでなく HTTP 500 になる)。
- `AcpPaymentHandlerInterface::redeemSharedPaymentToken()` はワンショットであり authorize 内で 1 度だけ呼ぶ旨を明記。

## 結合 E2E の拡充

想定入力からしかテストを作っていなかったため、**負の入力**と **capture 失敗**の経路が一度も通っていませんでした。`e2e/agent/{acp,ucp}-checkout.php` に追加します。

- ACP / UCP 共通: **トークン欠落** (fail-closed の回帰) / **capture 失敗**
- UCP: **3DS 中断 → 再開** (ACP と対称に。UCP は認証結果が credential 経由でしか届かないため、そこを落とすと `requires_escalation` から復帰できない)
- `acp-checkout.php` の `AGENT_E2E_ITEM_ID` 既定値を UCP 側と揃えて `2` に修正 (`id=1` は `visible=0` の規格でローカル実行が必ず失敗していた。CI は `2` を明示指定しているため CI には影響なし)

## 検証

| 項目 | 結果 |
|---|---|
| PHPStan level 6 (`analyse src`) | `No errors` |
| PHP-CS-Fixer | 0 件 |
| PHPUnit (`tests/Eccube/Tests/Service/AgentCommerce` のうち本 PR の変更範囲 = CheckoutSession / Payment / Discovery / AgentCheckoutCoreConformance) | 33 tests, 101 assertions, 0 失敗 |
| 結合 E2E (ACP・ローカル HTTPS + api44 + samplepayment44) | 41 assertions PASS |
| 結合 E2E (UCP・同上) | 35 assertions PASS |

追加したテストケース:

- `testAuthorizedOutcomeHandsTransactionReferenceToCapture` — capture が authorize の取引識別子・metadata を受け取り、`payment_data` に永続化される
- `testAutoCaptureGatewayIsNotCapturedTwice` — authorize が COMPLETED を返したとき capture を呼ばない
- `testCaptureFailureRollsBackStockAndKeepsAuthorizationReference` — capture 失敗で引当を戻しつつ取引識別子は残す

## 関連

- 決済プラグイン側の対応: [EC-CUBE/sample-payment-plugin#54](https://github.com/EC-CUBE/sample-payment-plugin/pull/54) (本 PR とセットで green になります)
- エージェントコマース基盤: #6777 / #6776 (ACP) / #6574 (UCP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 決済結果に「与信済み」状態を追加しました。
  - PSPの取引IDや決済メタデータを保存し、決済状況を追跡しやすくしました。
  - 3DS認証後の決済再開に対応しました。
- **不具合修正**
  - オートキャプチャ決済での二重実行を防止しました。
  - トークン不足時は安全側で処理を中断します。
  - キャプチャ失敗時は注文を未完了として扱い、エラー情報を返します。
  - 決済トークン交換時のエラーを、適切な業務エラーとして表示します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
