### PR TITLE
test: twig 3.28.0 の SyntaxError メッセージ変更に追従

### DIFF
--- a/tests/Eccube/Tests/Form/Validator/TwigLintValidatorTest.php
+++ b/tests/Eccube/Tests/Form/Validator/TwigLintValidatorTest.php
@@ -68,12 +68,13 @@ final class TwigLintValidatorTest extends AbstractTypeTestCase
         $errors = $validator->validate($value, $constraint);
         $this->assertCount(1, $errors);
         $message = $errors[0]->getMessage();
-        $this->assertStringContainsString('Unexpected "}" at line 1.', (string) $message);
+        // twig/twig 3.28.0 以降はメッセージ末尾に ` column N` が付くため、行番号までで判定する
+        $this->assertStringContainsString('Unexpected "}" at line 1', (string) $message);
 
         $value = '{% for product in products %}{% endfo %}';
         $errors = $validator->validate($value, $constraint);
         $this->assertCount(1, $errors);
         $message = $errors[0]->getMessage();
-        $this->assertStringContainsString('Unexpected "endfo" tag (expecting closing tag for the "for" tag defined near line 1) at line 1.', (string) $message);
+        $this->assertStringContainsString('Unexpected "endfo" tag (expecting closing tag for the "for" tag defined near line 1) at line 1', (string) $message);
     }
 }


### PR DESCRIPTION
## 概要

`TwigLintValidatorTest::testInValidTemplate` のアサートを、twig の版差で変わらない範囲に緩めます。テストのみの変更で、本体コードは触りません。

twig/twig 3.28.0 で [Report the column number in syntax errors](https://github.com/twigphp/Twig/pull/4834) が入り、`SyntaxError` のメッセージ末尾が `at line N.` から `at line N column M.` に変わりました。本テストは末尾の句点まで含めて含有判定していたため、`composer.lock` の twig が 3.28.0 に上がった時点で **PHPUnit の全マトリクス（16 ジョブ）が fail** します。

```diff
-        $this->assertStringContainsString('Unexpected "}" at line 1.', (string) $message);
+        $this->assertStringContainsString('Unexpected "}" at line 1', (string) $message);
```

`composer.json` の制約は `"twig/twig": "^3.21"` で 3.28 未満も許容するため、**どちらの版でも通る書き方**（行番号までの含有判定）に変更します。`{% endfo %}` 側は 3.28.0 でも column が付きませんが、同種の破綻を避けて書き方を揃えています。

## なぜ単独 PR にするか

この修正は当初 dependabot の [#7024](https://github.com/EC-CUBE/ec-cube/pull/7024) のブランチへ直接足していましたが、**同じ twig を含む dependabot PR が他にも出る**ため、base（4.4）に入れないと同じ赤を踏み続けます。実際、現時点で以下の 2 本が同じ原因で止まっています。

- [#7024](https://github.com/EC-CUBE/ec-cube/pull/7024) php-production グループ（承認 2 件済みだが `composer.lock` が衝突して `DIRTY`）
- [#7033](https://github.com/EC-CUBE/ec-cube/pull/7033) symfony グループ 33 件（17 ジョブ fail。PR 本文の表に無い `twig/twig` 3.27.0→3.28.0 の transitive bump が原因）

また dependabot ブランチへ直接足したコミットは `@dependabot rebase` の force-push で失われます。本 PR がマージされたら、両 PR は rebase するだけで復帰します。

## 動作確認

- **twig 3.27.0（現在の 4.4 の lock）**: `vendor/bin/phpunit tests/Eccube/Tests/Form/Validator/TwigLintValidatorTest.php` → OK (2 tests, 10 assertions)
- **twig 3.28.0**: #7024 の CI（全 16 ジョブ green）で確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * Twigの構文エラーメッセージ検証を更新し、行番号以降に追加される詳細情報にも対応しました。
  * Twig 3.28.0以降のエラーメッセージ形式を許容します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->