### PR TITLE
fix: rector 2.6 / phpstan 2.2 の指摘に追従する (#7037 の先行対応)

### DIFF
--- a/codeception/acceptance/EA09ShippingCest.php
+++ b/codeception/acceptance/EA09ShippingCest.php
@@ -12,7 +12,6 @@
  */
 
 use Codeception\Util\Fixtures;
-use Eccube\Entity\Customer;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Entity\Order;
 use Page\Admin\OrderEditPage;

--- a/rector.php
+++ b/rector.php
@@ -72,6 +72,11 @@ return RectorConfig::configure()
                    __DIR__.'/codeception/_support/Page/Admin/CustomerManagePage.php',
                    __DIR__.'/codeception/_support/Page/Admin/OrderManagePage.php',
                    __DIR__.'/codeception/acceptance/EF06OtherCest.php',
+                   // scandir() / explode() の戻り値要素はバージョンによって string と推論されたり
+                   // されなかったりし、 キャストを外すと NullToStrictStringFuncCallArgRector が
+                   // 付け直す往復になるため、 こちらもキャストを維持する
+                   __DIR__.'/codeception/_support/Helper/Acceptance.php',
+                   __DIR__.'/src/Eccube/Service/Composer/OutputParser.php',
                ],
                // shopping/order の各購入フローは同じ PurchaseFlow 型の別サービスであり、
                // 型解決(get(PurchaseFlow::class))に置き換えると両者の区別が失われテストが無意味化する

--- a/src/Eccube/Command/GenerateProxyCommand.php
+++ b/src/Eccube/Command/GenerateProxyCommand.php
@@ -29,11 +29,6 @@ class GenerateProxyCommand extends Command
     }
 
     #[\Override]
-    protected function configure(): void
-    {
-    }
-
-    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $projectDir = $this->eccubeConfig->get('kernel.project_dir');

--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -118,11 +118,6 @@ class InstallerCommand extends Command
     }
 
     #[\Override]
-    protected function configure(): void
-    {
-    }
-
-    #[\Override]
     protected function interact(InputInterface $input, OutputInterface $output): void
     {
         $this->io->title('EC-CUBE Installer Interactive Wizard');
@@ -302,8 +297,6 @@ class InstallerCommand extends Command
     }
 
     /**
-     * @return false|string
-     *
      * @throws \Doctrine\DBAL\Exception
      */
     protected function getDatabaseServerVersion(string $databaseUrl): false|string

--- a/src/Eccube/Command/PluginSchemaUpdateCommand.php
+++ b/src/Eccube/Command/PluginSchemaUpdateCommand.php
@@ -13,7 +13,6 @@
 
 namespace Eccube\Command;
 
-use Eccube\Entity\Plugin;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -40,7 +39,6 @@ class PluginSchemaUpdateCommand extends Command
 
         $code = $input->getArgument('code');
 
-        /** @var Plugin|null $Plugin */
         $Plugin = $this->pluginRepository->findByCode($code);
         if (!$Plugin) {
             $io->error("No such plugin `{$code}`.");

--- a/src/Eccube/Command/PluginUpdateCommand.php
+++ b/src/Eccube/Command/PluginUpdateCommand.php
@@ -13,7 +13,6 @@
 
 namespace Eccube\Command;
 
-use Eccube\Entity\Plugin;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -40,7 +39,6 @@ class PluginUpdateCommand extends Command
 
         $code = $input->getArgument('code');
 
-        /** @var Plugin|null $Plugin */
         $Plugin = $this->pluginRepository->findByCode($code);
 
         if (!$Plugin) {

--- a/src/Eccube/Controller/AbstractShoppingController.php
+++ b/src/Eccube/Controller/AbstractShoppingController.php
@@ -35,7 +35,6 @@ class AbstractShoppingController extends AbstractController
      */
     protected function executePurchaseFlow(ItemHolderInterface $itemHolder, bool $returnResponse = true): PurchaseFlowResult|RedirectResponse|null
     {
-        /** @var PurchaseFlowResult $flowResult */
         $flowResult = $this->purchaseFlow->validate($itemHolder, new PurchaseContext(clone $itemHolder, $itemHolder->getCustomer()));
         foreach ($flowResult->getWarning() as $warning) {
             $this->addWarning($warning->getMessage());

--- a/src/Eccube/Controller/Admin/AbstractCsvImportController.php
+++ b/src/Eccube/Controller/Admin/AbstractCsvImportController.php
@@ -40,8 +40,6 @@ class AbstractCsvImportController extends AbstractController
 
     /**
      * アップロードされたCSVファイルの行ごとの処理
-     *
-     * @return CsvImportService<int, mixed>|bool
      */
     protected function getImportData(UploadedFile $formFile): CsvImportService|bool
     {

--- a/src/Eccube/Controller/Admin/Content/FileController.php
+++ b/src/Eccube/Controller/Admin/Content/FileController.php
@@ -417,7 +417,7 @@ class FileController extends AbstractController
                 'path' => $path,
                 'type' => $type,
                 'depth' => $depth,
-                'open' => (in_array($path, $openDirs)) ? true : false,
+                'open' => in_array($path, $openDirs),
             ];
         }
 
@@ -477,7 +477,7 @@ class FileController extends AbstractController
                 'file_size' => FilesystemUtil::sizeToHumanReadable($dir->getSize()),
                 'file_time' => $dir->getmTime(),
                 'is_dir' => true,
-                'is_empty' => $countNumber == 0 ? true : false,
+                'is_empty' => $countNumber == 0,
             ];
         }
         foreach ($files as $file) {

--- a/src/Eccube/Controller/Admin/Customer/CustomerController.php
+++ b/src/Eccube/Controller/Admin/Customer/CustomerController.php
@@ -14,7 +14,6 @@
 namespace Eccube\Controller\Admin\Customer;
 
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
-use Doctrine\ORM\QueryBuilder;
 use Eccube\Common\Constant;
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\Customer;
@@ -117,7 +116,6 @@ class CustomerController extends AbstractController
             $searchData = FormUtil::submitAndGetData($searchForm, $viewData);
         }
 
-        /** @var QueryBuilder $qb */
         $qb = $this->customerRepository->getQueryBuilderBySearchData($searchData);
 
         $paginate_options = [];

--- a/src/Eccube/Controller/Admin/Order/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Order/CsvImportController.php
@@ -16,7 +16,6 @@ namespace Eccube\Controller\Admin\Order;
 use Doctrine\DBAL\ConnectionException;
 use Eccube\Controller\Admin\AbstractCsvImportController;
 use Eccube\Entity\Master\OrderStatus;
-use Eccube\Entity\Shipping;
 use Eccube\Form\Type\Admin\CsvImportType;
 use Eccube\Repository\ShippingRepository;
 use Eccube\Service\CsvImportService;

--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -48,7 +48,6 @@ use Eccube\Service\TaxRuleService;
 use Knp\Component\Pager\Pagination\SlidingPagination;
 use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Bridge\Twig\Attribute\Template;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -583,7 +582,6 @@ class EditController extends AbstractController
 
             $forms = [];
             foreach ($Products as $Product) {
-                /** @var FormBuilderInterface $builder */
                 $builder = $this->formFactory->createNamedBuilder('', AddCartType::class, null, [
                     'product' => $Product,
                 ]);

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -52,7 +52,6 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\ConstraintViolationInterface;
-use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class OrderController extends AbstractController
@@ -469,7 +468,6 @@ class OrderController extends AbstractController
         $trackingNumber = $request->get('tracking_number') ?? '';
         $trackingNumber = mb_convert_kana((string) $trackingNumber, 'a', 'utf-8');
 
-        /** @var ConstraintViolationListInterface $errors */
         $errors = $this->validator->validate(
             $trackingNumber,
             [

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -686,7 +686,6 @@ class CsvImportController extends AbstractCsvImportController
                     $this->entityManager->getConnection()->beginTransaction();
                     // CSVファイルの登録処理
                     foreach ($data as $row) {
-                        /** @var Category $Category */
                         $Category = new Category();
                         if (isset($row[$headerByKey['id']]) && strlen($row[$headerByKey['id']]) > 0) {
                             if (!preg_match('/^\d+$/', $row[$headerByKey['id']])) {
@@ -844,7 +843,6 @@ class CsvImportController extends AbstractCsvImportController
                     // CSVファイルの登録処理
                     foreach ($data as $row) {
                         // dump($row,$headerByKey);exit;
-                        /** @var ClassName $ClassName */
                         $ClassName = new ClassName();
                         if (isset($row[$headerByKey['id']]) && strlen($row[$headerByKey['id']]) > 0) {
                             if (!preg_match('/^\d+$/', $row[$headerByKey['id']])) {
@@ -958,7 +956,6 @@ class CsvImportController extends AbstractCsvImportController
                     // CSVファイルの登録処理
                     foreach ($data as $row) {
                         // dump($row,$headerByKey);exit;
-                        /** @var ClassCategory $ClassCategory */
                         $ClassCategory = new ClassCategory();
 
                         if (isset($row[$headerByKey['id']]) && strlen($row[$headerByKey['id']]) > 0) {

--- a/src/Eccube/Controller/Admin/Setting/Shop/TaxRuleController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/TaxRuleController.php
@@ -23,7 +23,6 @@ use Eccube\Form\Type\Admin\TaxRuleType;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\TaxRuleRepository;
 use Symfony\Bridge\Twig\Attribute\Template;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -100,7 +99,6 @@ class TaxRuleController extends AbstractController
         $errors = [];
         /** @var TaxRule $TaxRule */
         foreach ($TaxRules as $TaxRule) {
-            /** @var FormBuilderInterface $builder */
             $builder = $this->formFactory->createBuilder(TaxRuleType::class, $TaxRule);
             if ($TaxRule->isDefaultTaxRule()) {
                 $builder->remove('apply_date');

--- a/src/Eccube/Controller/AgentCommerce/UcpCatalogController.php
+++ b/src/Eccube/Controller/AgentCommerce/UcpCatalogController.php
@@ -16,7 +16,6 @@ namespace Eccube\Controller\AgentCommerce;
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\Master\ProductStatus;
 use Eccube\Entity\Product;
-use Eccube\Entity\ProductClass;
 use Eccube\Repository\ProductRepository;
 use Eccube\Service\AgentCommerce\Catalog\AgentCatalogItemDto;
 use Eccube\Service\AgentCommerce\Catalog\CatalogMapper;

--- a/src/Eccube/Controller/AgentCommerce/UcpCheckoutController.php
+++ b/src/Eccube/Controller/AgentCommerce/UcpCheckoutController.php
@@ -17,7 +17,6 @@ use Eccube\Controller\AbstractController;
 use Eccube\Entity\CheckoutSession;
 use Eccube\Entity\Master\AgentProtocol;
 use Eccube\Entity\Master\CheckoutSessionStatus;
-use Eccube\Entity\Order;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\CheckoutSessionRepository;
 use Eccube\Repository\Master\AgentProtocolRepository;

--- a/src/Eccube/Controller/EntryController.php
+++ b/src/Eccube/Controller/EntryController.php
@@ -14,7 +14,6 @@
 namespace Eccube\Controller;
 
 use Eccube\Entity\BaseInfo;
-use Eccube\Entity\Customer;
 use Eccube\Entity\Master\CustomerStatus;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
@@ -26,8 +25,6 @@ use Eccube\Repository\PageRepository;
 use Eccube\Service\CartService;
 use Eccube\Service\MailService;
 use Symfony\Bridge\Twig\Attribute\Template;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -76,10 +73,8 @@ class EntryController extends AbstractController
             return $this->redirectToRoute('mypage');
         }
 
-        /** @var Customer $Customer */
         $Customer = $this->customerRepository->newCustomer();
 
-        /** @var FormBuilderInterface $builder */
         $builder = $this->formFactory->createBuilder(EntryType::class, $Customer);
 
         $event = new EventArgs(
@@ -91,7 +86,6 @@ class EntryController extends AbstractController
         );
         $this->eventDispatcher->dispatch($event, EccubeEvents::FRONT_ENTRY_INDEX_INITIALIZE);
 
-        /** @var FormInterface $form */
         $form = $builder->getForm();
 
         $form->handleRequest($request);

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -968,8 +968,6 @@ class InstallController extends AbstractController
 
     /**
      * @param array<string, mixed> $params
-     *
-     * @return $this
      */
     protected function sendAppData(array $params, EntityManager $em): static
     {

--- a/src/Eccube/Controller/Mypage/ChangeController.php
+++ b/src/Eccube/Controller/Mypage/ChangeController.php
@@ -23,8 +23,6 @@ use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\CustomerRepository;
 use Eccube\Service\MailService;
 use Symfony\Bridge\Twig\Attribute\Template;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -58,7 +56,6 @@ class ChangeController extends AbstractController
         $Customer = $this->getUser();
         $Customer->setPlainPassword($this->eccubeConfig['eccube_default_password']);
 
-        /** @var FormBuilderInterface $builder */
         $builder = $this->formFactory->createBuilder(EntryType::class, $Customer);
 
         $event = new EventArgs(
@@ -70,7 +67,6 @@ class ChangeController extends AbstractController
         );
         $this->eventDispatcher->dispatch($event, EccubeEvents::FRONT_MYPAGE_CHANGE_INDEX_INITIALIZE);
 
-        /** @var FormInterface $form */
         $form = $builder->getForm();
         $form->handleRequest($request);
 

--- a/src/Eccube/Controller/ProductController.php
+++ b/src/Eccube/Controller/ProductController.php
@@ -33,8 +33,6 @@ use Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination;
 use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bridge\Twig\Attribute\Template;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -89,7 +87,6 @@ class ProductController extends AbstractController
         }
 
         // searchForm
-        /** @var FormBuilderInterface $builder */
         $builder = $this->formFactory->createNamedBuilder('', SearchProductType::class);
 
         if ($request->getMethod() === 'GET') {
@@ -104,7 +101,6 @@ class ProductController extends AbstractController
         );
         $this->eventDispatcher->dispatch($event, EccubeEvents::FRONT_PRODUCT_INDEX_INITIALIZE);
 
-        /** @var FormInterface $searchForm */
         $searchForm = $builder->getForm();
 
         $searchForm->handleRequest($request);
@@ -142,7 +138,6 @@ class ProductController extends AbstractController
         // addCart form
         $forms = [];
         foreach ($pagination as $Product) {
-            /** @var FormBuilderInterface $builder */
             $builder = $this->formFactory->createNamedBuilder(
                 '',
                 AddCartType::class,
@@ -351,7 +346,6 @@ class ProductController extends AbstractController
         );
         $this->eventDispatcher->dispatch($event, EccubeEvents::FRONT_PRODUCT_CART_ADD_INITIALIZE);
 
-        /** @var FormInterface $form */
         $form = $builder->getForm();
         $form->handleRequest($request);
 

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -41,7 +41,6 @@ use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Eccube\Service\PurchaseFlow\PurchaseFlow;
 use Psr\Container\ContainerInterface;
 use Symfony\Bridge\Twig\Attribute\Template;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -1132,7 +1131,6 @@ class ShoppingController extends AbstractShoppingController
             return $this->redirectToRoute('shopping');
         }
 
-        /** @var FormBuilderInterface $builder */
         $builder = $this->formFactory->createNamedBuilder('', CustomerLoginType::class);
 
         if ($this->isGranted('IS_AUTHENTICATED_REMEMBERED')) {

--- a/src/Eccube/DependencyInjection/Compiler/PurchaseFlowPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/PurchaseFlowPass.php
@@ -68,7 +68,6 @@ class PurchaseFlowPass implements CompilerPassInterface
             }
             /** @var string $flowType */
             foreach ($allMethod as $flowType => $flowMethod) {
-                /** @var Definition|null $purchaseFlowDef */
                 $purchaseFlowDef = $flowTypes[$flowType] ?? null;
                 if (!is_null($purchaseFlowDef)) {
                     // flow_typeごとにソートをしてセットする

--- a/src/Eccube/Doctrine/Common/CsvDataFixtures/CsvFixture.php
+++ b/src/Eccube/Doctrine/Common/CsvDataFixtures/CsvFixture.php
@@ -14,7 +14,6 @@
 namespace Eccube\Doctrine\Common\CsvDataFixtures;
 
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\EntityManagerInterface;
@@ -59,7 +58,6 @@ class CsvFixture implements FixtureInterface
         // ファイル名からテーブル名を取得
         $table_name = str_replace('.'.$this->file->getExtension(), '', $this->file->getFilename());
         $sql = $this->getSql($table_name, $headers);
-        /** @var Connection $Connection */
         $Connection = $manager->getConnection();
         $Connection->beginTransaction();
 

--- a/src/Eccube/Doctrine/Query/JoinClause.php
+++ b/src/Eccube/Doctrine/Query/JoinClause.php
@@ -55,8 +55,6 @@ class JoinClause
 
     /**
      * WHERE句を追加します。
-     *
-     * @return $this
      */
     public function addWhere(WhereClause $whereClause): static
     {
@@ -67,8 +65,6 @@ class JoinClause
 
     /**
      * ORDER BY句を追加します。
-     *
-     * @return $this
      */
     public function addOrderBy(OrderByClause $orderByClause): static
     {

--- a/src/Eccube/Entity/BaseInfo.php
+++ b/src/Eccube/Entity/BaseInfo.php
@@ -883,8 +883,6 @@ class BaseInfo extends AbstractEntity
 
     /**
      * @deprecated 使用していないため、削除予定
-     *
-     * @return $this
      */
     public function setPhpPath(?string $php_path): static
     {

--- a/src/Eccube/Entity/Cart.php
+++ b/src/Eccube/Entity/Cart.php
@@ -205,8 +205,6 @@ class Cart extends AbstractEntity implements PurchaseInterface, ItemHolderInterf
 
     /**
      * Set total.
-     *
-     * @return $this
      */
     public function setTotalPrice(string $total_price): static
     {
@@ -224,8 +222,6 @@ class Cart extends AbstractEntity implements PurchaseInterface, ItemHolderInterf
      * Alias of setTotalPrice.
      *
      * @param string $total
-     *
-     * @return $this
      */
     #[\Override]
     public function setTotal($total): static
@@ -280,8 +276,6 @@ class Cart extends AbstractEntity implements PurchaseInterface, ItemHolderInterf
      * {@inheritdoc}
      *
      * @param string $total
-     *
-     * @return $this
      */
     #[\Override]
     public function setDeliveryFeeTotal($total): static
@@ -370,8 +364,6 @@ class Cart extends AbstractEntity implements PurchaseInterface, ItemHolderInterf
      * {@inheritdoc}
      *
      * @param string $total
-     *
-     * @return $this
      */
     #[\Override]
     public function setDiscount($total): static
@@ -384,8 +376,6 @@ class Cart extends AbstractEntity implements PurchaseInterface, ItemHolderInterf
      * {@inheritdoc}
      *
      * @param string $total
-     *
-     * @return $this
      */
     #[\Override]
     public function setCharge($total): static
@@ -398,8 +388,6 @@ class Cart extends AbstractEntity implements PurchaseInterface, ItemHolderInterf
      * {@inheritdoc}
      *
      * @param string $total
-     *
-     * @return $this
      *
      * @deprecated
      */

--- a/src/Eccube/Entity/CartItem.php
+++ b/src/Eccube/Entity/CartItem.php
@@ -177,9 +177,6 @@ class CartItem extends AbstractEntity implements ItemInterface
         return $ItemType;
     }
 
-    /**
-     * @return $this
-     */
     public function setProductClass(ProductClass $ProductClass): static
     {
         $this->ProductClass = $ProductClass;
@@ -211,9 +208,6 @@ class CartItem extends AbstractEntity implements ItemInterface
         return $this->Cart;
     }
 
-    /**
-     * @return $this
-     */
     public function setCart(Cart $Cart): static
     {
         $this->Cart = $Cart;

--- a/src/Eccube/Entity/Customer.php
+++ b/src/Eccube/Entity/Customer.php
@@ -423,9 +423,6 @@ class Customer extends AbstractEntity implements UserInterface, PasswordAuthenti
         return $this->birth;
     }
 
-    /**
-     * @return $this
-     */
     public function setPlainPassword(?string $password): static
     {
         // NIST SP 800-63B-4 に従い, 保存時とログイン照合時で表記ゆれを統一するため NFKC 正規化する.

--- a/src/Eccube/Entity/DeliveryTime.php
+++ b/src/Eccube/Entity/DeliveryTime.php
@@ -105,8 +105,6 @@ class DeliveryTime extends AbstractEntity implements \Stringable
 
     /**
      * Set sort_no.
-     *
-     * @return $this
      */
     public function setSortNo(int $sort_no): static
     {

--- a/src/Eccube/Entity/ItemHolderInterface.php
+++ b/src/Eccube/Entity/ItemHolderInterface.php
@@ -31,8 +31,6 @@ interface ItemHolderInterface
 
     /**
      * 合計金額を設定します。
-     *
-     * @return $this
      */
     public function setTotal(string $total): static;
 
@@ -43,8 +41,6 @@ interface ItemHolderInterface
 
     /**
      * 送料合計を設定します。
-     *
-     * @return $this
      */
     public function setDeliveryFeeTotal(string $total): static;
 
@@ -55,22 +51,16 @@ interface ItemHolderInterface
 
     /**
      * 値引き合計を設定します。
-     *
-     * @return $this
      */
     public function setDiscount(string $total): static;
 
     /**
      * 手数料合計を設定します。
-     *
-     * @return $this
      */
     public function setCharge(string $total): static;
 
     /**
      * 税額合計を設定します。
-     *
-     * @return $this
      *
      * @deprecated 明細ごとに集計した税額と差異が発生する場合があるため非推奨
      */
@@ -78,8 +68,6 @@ interface ItemHolderInterface
 
     /**
      * 加算ポイントを設定します。
-     *
-     * @return $this
      */
     public function setAddPoint(string $addPoint): static;
 
@@ -90,8 +78,6 @@ interface ItemHolderInterface
 
     /**
      * 利用ポイントを設定します。
-     *
-     * @return $this
      */
     public function setUsePoint(string $usePoint): static;
 

--- a/src/Eccube/Entity/ItemInterface.php
+++ b/src/Eccube/Entity/ItemInterface.php
@@ -67,18 +67,12 @@ interface ItemInterface
 
     public function getQuantity(): string;
 
-    /**
-     * @return $this
-     */
     public function setQuantity(string $quantity): static;
 
     public function getId(): ?int;
 
     public function getPointRate(): ?string;
 
-    /**
-     * @return $this
-     */
     public function setPrice(?string $price): static;
 
     public function getPriceIncTax(): string;

--- a/src/Eccube/Entity/MailTemplate.php
+++ b/src/Eccube/Entity/MailTemplate.php
@@ -184,9 +184,6 @@ class MailTemplate extends AbstractEntity implements \Stringable
         return $this->deletable;
     }
 
-    /**
-     * @return $this
-     */
     public function setDeletable(bool $deletable): static
     {
         $this->deletable = $deletable;

--- a/src/Eccube/Entity/Master/AbstractMasterEntity.php
+++ b/src/Eccube/Entity/Master/AbstractMasterEntity.php
@@ -42,8 +42,6 @@ abstract class AbstractMasterEntity extends AbstractEntity implements \Stringabl
 
     /**
      * Set id.
-     *
-     * @return $this
      */
     public function setId(int $id): static
     {
@@ -62,8 +60,6 @@ abstract class AbstractMasterEntity extends AbstractEntity implements \Stringabl
 
     /**
      * Set name.
-     *
-     * @return $this
      */
     public function setName(?string $name): static
     {
@@ -82,8 +78,6 @@ abstract class AbstractMasterEntity extends AbstractEntity implements \Stringabl
 
     /**
      * Set sortNo.
-     *
-     * @return $this
      */
     public function setSortNo(int $sortNo): static
     {

--- a/src/Eccube/Entity/Member.php
+++ b/src/Eccube/Entity/Member.php
@@ -191,8 +191,6 @@ class Member extends AbstractEntity implements UserInterface, PasswordAuthentica
 
     /**
      * @param string $password
-     *
-     * @return $this
      */
     public function setPlainPassword(?string $password): static
     {

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -280,7 +280,7 @@ class Order extends AbstractEntity implements PurchaseInterface, ItemHolderInter
             }
         }
 
-        return count($Shippings) > 1 ? true : false;
+        return count($Shippings) > 1;
     }
 
     /**
@@ -399,7 +399,7 @@ class Order extends AbstractEntity implements PurchaseInterface, ItemHolderInter
     private ?string $discount = '0';
 
     #[ORM\Column(name: 'delivery_fee_total', type: Types::DECIMAL, precision: 12, scale: 2, options: ['unsigned' => true, 'default' => 0])]
-    private ?string $delivery_fee_total = '0';
+    private ?string $delivery_fee_total;
 
     #[ORM\Column(name: 'charge', type: Types::DECIMAL, precision: 12, scale: 2, options: ['unsigned' => true, 'default' => 0])]
     private ?string $charge = '0';
@@ -894,8 +894,6 @@ class Order extends AbstractEntity implements PurchaseInterface, ItemHolderInter
      * Set deliveryFeeTotal.
      *
      * @param string $deliveryFeeTotal
-     *
-     * @return $this
      */
     #[\Override]
     public function setDeliveryFeeTotal($deliveryFeeTotal): static
@@ -918,8 +916,6 @@ class Order extends AbstractEntity implements PurchaseInterface, ItemHolderInter
      * Set charge.
      *
      * @param string $charge
-     *
-     * @return $this
      */
     #[\Override]
     public function setCharge($charge): static
@@ -941,8 +937,6 @@ class Order extends AbstractEntity implements PurchaseInterface, ItemHolderInter
      * Set tax.
      *
      * @param string $tax
-     *
-     * @return $this
      *
      * @deprecated 明細ごとに集計した税額と差異が発生する場合があるため非推奨
      */
@@ -1122,8 +1116,6 @@ class Order extends AbstractEntity implements PurchaseInterface, ItemHolderInter
 
     /**
      * Set currencyCode.
-     *
-     * @return $this
      */
     public function setCurrencyCode(?string $currencyCode = null): static
     {
@@ -1137,9 +1129,6 @@ class Order extends AbstractEntity implements PurchaseInterface, ItemHolderInter
         return $this->complete_message;
     }
 
-    /**
-     * @return $this
-     */
     public function setCompleteMessage(?string $complete_message = null): static
     {
         $this->complete_message = $complete_message;
@@ -1147,9 +1136,6 @@ class Order extends AbstractEntity implements PurchaseInterface, ItemHolderInter
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function appendCompleteMessage(?string $complete_message = null): static
     {
         $this->complete_message .= $complete_message;

--- a/src/Eccube/Entity/OrderItem.php
+++ b/src/Eccube/Entity/OrderItem.php
@@ -326,8 +326,6 @@ class OrderItem extends AbstractEntity implements ItemInterface
 
     /**
      * Set price.
-     *
-     * @return $this
      */
     public function setPrice(?string $price): static
     {
@@ -349,8 +347,6 @@ class OrderItem extends AbstractEntity implements ItemInterface
      * Set quantity.
      *
      * @param string $quantity
-     *
-     * @return $this
      */
     #[\Override]
     public function setQuantity($quantity): static
@@ -374,9 +370,6 @@ class OrderItem extends AbstractEntity implements ItemInterface
         return $this->tax;
     }
 
-    /**
-     * @return $this
-     */
     public function setTax(string $tax): static
     {
         $this->tax = $tax;
@@ -448,8 +441,6 @@ class OrderItem extends AbstractEntity implements ItemInterface
 
     /**
      * Set processorName.
-     *
-     * @return $this
      */
     public function setProcessorName(?string $processorName = null): static
     {
@@ -468,8 +459,6 @@ class OrderItem extends AbstractEntity implements ItemInterface
 
     /**
      * Set orderMemo.
-     *
-     * @return $this
      */
     public function setOrderMemo(?string $orderMemo = null): static
     {
@@ -565,9 +554,6 @@ class OrderItem extends AbstractEntity implements ItemInterface
         return $this->RoundingType;
     }
 
-    /**
-     * @return $this
-     */
     public function setRoundingType(?RoundingType $RoundingType = null): static
     {
         $this->RoundingType = $RoundingType;

--- a/src/Eccube/Entity/OrderPdf.php
+++ b/src/Eccube/Entity/OrderPdf.php
@@ -71,9 +71,6 @@ class OrderPdf extends AbstractEntity
         return $this->member_id;
     }
 
-    /**
-     * @return $this
-     */
     public function setMemberId(int $member_id): static
     {
         $this->member_id = $member_id;
@@ -86,9 +83,6 @@ class OrderPdf extends AbstractEntity
         return $this->title;
     }
 
-    /**
-     * @return $this
-     */
     public function setTitle(string $title): static
     {
         $this->title = $title;
@@ -101,9 +95,6 @@ class OrderPdf extends AbstractEntity
         return $this->message1;
     }
 
-    /**
-     * @return $this
-     */
     public function setMessage1(?string $message1): static
     {
         $this->message1 = $message1;
@@ -116,9 +107,6 @@ class OrderPdf extends AbstractEntity
         return $this->message2;
     }
 
-    /**
-     * @return $this
-     */
     public function setMessage2(?string $message2): static
     {
         $this->message2 = $message2;
@@ -131,9 +119,6 @@ class OrderPdf extends AbstractEntity
         return $this->message3;
     }
 
-    /**
-     * @return $this
-     */
     public function setMessage3(?string $message3): static
     {
         $this->message3 = $message3;
@@ -146,9 +131,6 @@ class OrderPdf extends AbstractEntity
         return $this->note1;
     }
 
-    /**
-     * @return $this
-     */
     public function setNote1(?string $note1): static
     {
         $this->note1 = $note1;
@@ -161,9 +143,6 @@ class OrderPdf extends AbstractEntity
         return $this->note2;
     }
 
-    /**
-     * @return $this
-     */
     public function setNote2(?string $note2): static
     {
         $this->note2 = $note2;
@@ -176,9 +155,6 @@ class OrderPdf extends AbstractEntity
         return $this->note3;
     }
 
-    /**
-     * @return $this
-     */
     public function setNote3(?string $note3): static
     {
         $this->note3 = $note3;
@@ -194,9 +170,6 @@ class OrderPdf extends AbstractEntity
         return $this->create_date;
     }
 
-    /**
-     * @return $this
-     */
     public function setCreateDate(\DateTime $create_date): static
     {
         $this->create_date = $create_date;
@@ -212,9 +185,6 @@ class OrderPdf extends AbstractEntity
         return $this->update_date;
     }
 
-    /**
-     * @return $this
-     */
     public function setUpdateDate(\DateTime $update_date): static
     {
         $this->update_date = $update_date;

--- a/src/Eccube/Entity/PointRateTrait.php
+++ b/src/Eccube/Entity/PointRateTrait.php
@@ -23,8 +23,6 @@ trait PointRateTrait
 
     /**
      * Set pointRate
-     *
-     * @return $this
      */
     public function setPointRate(?string $pointRate): static
     {

--- a/src/Eccube/Entity/PointTrait.php
+++ b/src/Eccube/Entity/PointTrait.php
@@ -26,8 +26,6 @@ trait PointTrait
 
     /**
      * Set addPoint
-     *
-     * @return $this
      */
     public function setAddPoint(string $addPoint): static
     {
@@ -46,8 +44,6 @@ trait PointTrait
 
     /**
      * Set usePoint
-     *
-     * @return $this
      */
     public function setUsePoint(?string $usePoint): static
     {

--- a/src/Eccube/Entity/ProductClass.php
+++ b/src/Eccube/Entity/ProductClass.php
@@ -400,8 +400,6 @@ class ProductClass extends AbstractEntity
 
     /**
      * Set currencyCode.
-     *
-     * @return $this
      */
     public function setCurrencyCode(?string $currencyCode = null): static
     {

--- a/src/Eccube/Entity/Shipping.php
+++ b/src/Eccube/Entity/Shipping.php
@@ -596,8 +596,6 @@ class Shipping extends AbstractEntity
 
     /**
      * Product class of shipment item (temp)
-     *
-     * @return $this
      */
     public function setProductClassOfTemp(ProductClass $ProductClassOfTemp): static
     {
@@ -608,8 +606,6 @@ class Shipping extends AbstractEntity
 
     /**
      * Set order.
-     *
-     * @return $this
      */
     public function setOrder(Order $Order): static
     {

--- a/src/Eccube/Entity/Tag.php
+++ b/src/Eccube/Entity/Tag.php
@@ -63,8 +63,6 @@ class Tag extends AbstractEntity implements \Stringable
 
     /**
      * Set id.
-     *
-     * @return $this
      */
     public function setId(int $id): static
     {
@@ -83,8 +81,6 @@ class Tag extends AbstractEntity implements \Stringable
 
     /**
      * Set name.
-     *
-     * @return $this
      */
     public function setName(?string $name): static
     {
@@ -103,8 +99,6 @@ class Tag extends AbstractEntity implements \Stringable
 
     /**
      * Set sort_no.
-     *
-     * @return $this
      */
     public function setSortNo(int $sort_no): static
     {

--- a/src/Eccube/Event/TemplateEvent.php
+++ b/src/Eccube/Event/TemplateEvent.php
@@ -108,8 +108,6 @@ class TemplateEvent extends Event
      * javascriptの読み込みやcssの読み込みに利用する.
      *
      * @param bool $include twigファイルとしてincludeするかどうか
-     *
-     * @return $this
      */
     public function addAsset(string $asset, bool $include = true): static
     {
@@ -126,8 +124,6 @@ class TemplateEvent extends Event
      * ここで追加したコードは, </body>タグ直前に出力される
      *
      * @param bool $include twigファイルとしてincludeするかどうか
-     *
-     * @return $this
      */
     public function addSnippet(string $snippet, bool $include = true): static
     {

--- a/src/Eccube/EventListener/TransactionListener.php
+++ b/src/Eccube/EventListener/TransactionListener.php
@@ -13,7 +13,6 @@
 
 namespace Eccube\EventListener;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -60,7 +59,6 @@ class TransactionListener implements EventSubscriberInterface
             return;
         }
 
-        /** @var Connection $Connection */
         $Connection = $this->em->getConnection();
         // DBAL 4 では Connection::connect() が protected になったため, 接続の明示確立には
         // getNativeConnection() を用いる。autoCommit を false にする前に接続しておくことが重要で,

--- a/src/Eccube/EventListener/TwigInitializeListener.php
+++ b/src/Eccube/EventListener/TwigInitializeListener.php
@@ -22,8 +22,6 @@ use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Layout;
 use Eccube\Entity\Master\DeviceType;
 use Eccube\Entity\Member;
-use Eccube\Entity\Page;
-use Eccube\Entity\PageLayout;
 use Eccube\Repository\AuthorityRoleRepository;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\BlockPositionRepository;
@@ -35,7 +33,6 @@ use Eccube\Request\Context;
 use Eccube\Service\SiteStructuredDataService;
 use Eccube\Service\SystemService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -123,7 +120,6 @@ class TwigInitializeListener implements EventSubscriberInterface
         // 引数は後方互換のため任意にしており、渡されなければここで取得する。
         $BaseInfo ??= $this->baseInfoRepository->get();
         $request = $event->getRequest();
-        /** @var ParameterBag $attributes */
         $attributes = $request->attributes;
         $route = $attributes->get('_route');
         if ($route == 'user_data') {
@@ -137,10 +133,8 @@ class TwigInitializeListener implements EventSubscriberInterface
         }
 
         // URLからPageを取得
-        /** @var Page $Page */
         $Page = $this->pageRepository->getPageByRoute($route);
 
-        /** @var PageLayout[] $PageLayouts */
         $PageLayouts = $Page->getPageLayouts();
 
         // Pageに紐づくLayoutからDeviceTypeが一致するLayoutを探す

--- a/src/Eccube/Form/Type/Admin/MasterdataType.php
+++ b/src/Eccube/Form/Type/Admin/MasterdataType.php
@@ -14,7 +14,6 @@
 namespace Eccube\Form\Type\Admin;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Eccube\Entity\Master\CustomerOrderStatus;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Entity\Master\OrderStatusColor;

--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -175,7 +175,6 @@ class ProductType extends AbstractType
         ;
 
         $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event): void {
-            /** @var FormInterface $form */
             $form = $event->getForm();
             $saveImgDir = $this->eccubeConfig['eccube_save_image_dir'];
             $tempImgDir = $this->eccubeConfig['eccube_temp_image_dir'];

--- a/src/Eccube/Service/AgentCommerce/Acp/AcpCheckoutSessionMapper.php
+++ b/src/Eccube/Service/AgentCommerce/Acp/AcpCheckoutSessionMapper.php
@@ -355,9 +355,6 @@ class AcpCheckoutSessionMapper
         return new AgentCheckoutAddress(
             name01: $familyName,
             name02: $givenName,
-            kana01: null,
-            kana02: null,
-            companyName: null,
             postalCode: $this->stringOrNull($address['postal_code'] ?? null),
             prefId: $pref?->getId(),
             addr01: $this->stringOrNull($address['city'] ?? null),

--- a/src/Eccube/Service/AgentCommerce/Catalog/CatalogMapper.php
+++ b/src/Eccube/Service/AgentCommerce/Catalog/CatalogMapper.php
@@ -148,7 +148,6 @@ class CatalogMapper
             availabilityStatus: $this->resolveAvailabilityStatus($productClass),
             sku: $productClass->getCode(),
             listPriceMinorUnits: $listPriceMinor,
-            description: null,
             url: $productId !== null ? $this->generateProductUrl($productId) : null,
             options: $this->mapOptions($productClass),
             barcodes: $this->mapBarcodes(),

--- a/src/Eccube/Service/AgentCommerce/Ucp/UcpCheckoutSessionMapper.php
+++ b/src/Eccube/Service/AgentCommerce/Ucp/UcpCheckoutSessionMapper.php
@@ -341,9 +341,6 @@ class UcpCheckoutSessionMapper
         return new AgentCheckoutAddress(
             name01: $familyName,
             name02: $givenName,
-            kana01: null,
-            kana02: null,
-            companyName: null,
             postalCode: $this->stringOrNull($postal['postal_code'] ?? null),
             prefId: $pref?->getId(),
             addr01: $this->stringOrNull($postal['address_locality'] ?? null),

--- a/src/Eccube/Service/Calculator/OrderItemCollection.php
+++ b/src/Eccube/Service/Calculator/OrderItemCollection.php
@@ -32,7 +32,7 @@ class OrderItemCollection extends ArrayCollection
     public function __construct(?array $OrderItems = null, ?string $type = null)
     {
         // $OrderItems が Collection だったら toArray(); する
-        $this->type = is_null($type) ? Order::class : $type;
+        $this->type = $type ?? Order::class;
         parent::__construct($OrderItems);
     }
 

--- a/src/Eccube/Service/MailService.php
+++ b/src/Eccube/Service/MailService.php
@@ -627,7 +627,6 @@ class MailService
 
         $MailTemplate = $this->mailTemplateRepository->find($this->eccubeConfig['eccube_shipping_notify_mail_template_id']);
 
-        /** @var Order $Order */
         $Order = $Shipping->getOrder();
         $body = $this->getShippingNotifyMailBody($Shipping, $Order, $MailTemplate->getFileName());
 
@@ -706,7 +705,7 @@ class MailService
 
         if ($is_html) {
             $htmlFileName = $this->getHtmlTemplate($fileName);
-            $fileName = !is_null($htmlFileName) ? $htmlFileName : $fileName;
+            $fileName = $htmlFileName ?? $fileName;
         }
 
         return $this->twig->render($fileName, [

--- a/src/Eccube/Service/Mcp/ToolInputSchema.php
+++ b/src/Eccube/Service/Mcp/ToolInputSchema.php
@@ -36,9 +36,13 @@ final readonly class ToolInputSchema
     public function __construct(Tool $tool)
     {
         // sdk は引数なしツールの properties を空配列でなく \stdClass に正規化する (Tool::normalizeSchemaProperties)。
-        // inputSchema の PHPDoc は properties: array と宣言するが実体は array|\stdClass なので、 その型で受けて配列化する。
-        /** @var array<string, mixed>|\stdClass $rawProperties */
-        $rawProperties = $tool->inputSchema['properties'] ?? [];
+        // inputSchema の PHPDoc は properties を必須・非 nullable の array と宣言するが実体は
+        // array|\stdClass であり、 キー自体も存在しないことがある。 宣言どおりの array shape のまま扱うと
+        // 下の正規化が「常に成立する冗長なコード」と解析されてしまうため、 素の配列として受け直す。
+        /** @var array<string, mixed> $inputSchema */
+        $inputSchema = $tool->inputSchema;
+
+        $rawProperties = $inputSchema['properties'] ?? [];
         $this->properties = \is_array($rawProperties) ? $rawProperties : [];
 
         // required は上記の正規化対象外で常に配列 (SDK は required の型を変換しない)。

--- a/src/Eccube/Service/OrderPdfService.php
+++ b/src/Eccube/Service/OrderPdfService.php
@@ -804,9 +804,9 @@ class OrderPdfService extends Fpdi
         $result = $this->getMargins();
 
         // 基準座標を指定する
-        $actualX = is_null($x) ? $result['left'] : $x;
+        $actualX = $x ?? $result['left'];
         $this->SetX($actualX);
-        $actualY = is_null($y) ? $result['top'] : $y;
+        $actualY = $y ?? $result['top'];
         $this->SetY($actualY);
     }
 

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -154,7 +154,6 @@ class PluginService
             $requires = $this->getPluginRequired($config);
             $notInstalledOrDisabled = array_filter($requires, function ($req) {
                 $code = preg_replace('/^ec-cube\//i', '', (string) $req['name']);
-                /** @var Plugin|null $DependPlugin */
                 $DependPlugin = $this->pluginRepository->findByCode($code);
 
                 return $DependPlugin ? $DependPlugin->isEnabled() == false : true;
@@ -199,7 +198,6 @@ class PluginService
     public function postInstall(array $config, string|int $source): void
     {
         try {
-            /** @var Plugin|null $Plugin */
             $Plugin = $this->pluginRepository->findByCode($config['code']);
 
             if (!$Plugin) {
@@ -710,7 +708,7 @@ class PluginService
 
             $this->callPluginManagerMethod($config, $enable ? 'enable' : 'disable');
 
-            $plugin->setEnabled($enable ? true : false);
+            $plugin->setEnabled($enable);
             $em->persist($plugin);
 
             // Proxyだけ再生成してスキーマは更新しない
@@ -976,8 +974,6 @@ class PluginService
      * Plugin is exist check
      *
      * @param array<int, array<string, mixed>> $plugins get from api（各行に product_code を含む）
-     *
-     * @return false|int|string
      */
     public function checkPluginExist(array $plugins, string $pluginCode): false|int|string
     {

--- a/src/Eccube/Service/ProductStructuredDataService.php
+++ b/src/Eccube/Service/ProductStructuredDataService.php
@@ -13,7 +13,6 @@
 
 namespace Eccube\Service;
 
-use Eccube\Entity\Category;
 use Eccube\Entity\Product;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;

--- a/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeeFreeByShippingPreprocessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeeFreeByShippingPreprocessor.php
@@ -46,7 +46,6 @@ class DeliveryFeeFreeByShippingPreprocessor implements ItemHolderPreprocessor
 
         // Orderの場合はお届け先ごとに判定する.
         if ($itemHolder instanceof Order) {
-            /** @var Order $Order */
             $Order = $itemHolder;
             foreach ($Order->getShippings() as $Shipping) {
                 $isFree = false;

--- a/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeePreprocessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeePreprocessor.php
@@ -23,7 +23,6 @@ use Eccube\Entity\Master\TaxDisplayType;
 use Eccube\Entity\Master\TaxType;
 use Eccube\Entity\Order;
 use Eccube\Entity\OrderItem;
-use Eccube\Entity\Shipping;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\DeliveryFeeRepository;
 use Eccube\Repository\TaxRuleRepository;

--- a/tests/Eccube/Tests/Command/UpdateSchemaDoctrineCommandTest.php
+++ b/tests/Eccube/Tests/Command/UpdateSchemaDoctrineCommandTest.php
@@ -26,7 +26,6 @@ use Eccube\Repository\PluginRepository;
 use Eccube\Service\PluginService;
 use Eccube\Service\SchemaService;
 use Eccube\Tests\EccubeTestCase;
-use Faker\Generator;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -157,7 +156,6 @@ final class UpdateSchemaDoctrineCommandTest extends EccubeTestCase
             '--no-proxy is do not use proxy'
         );
 
-        /** @var AbstractSchemaManager $schema */
         $schema = $this->getSchemaManager();
         $columns = $schema->listTableColumns('dtb_customer');
 
@@ -189,7 +187,6 @@ final class UpdateSchemaDoctrineCommandTest extends EccubeTestCase
         $display = $commandTester->getDisplay();
         $this->assertStringContainsString('[OK] Nothing to update', $display, 'Use proxy');
 
-        /** @var AbstractSchemaManager $schema */
         $schema = $this->getSchemaManager();
         $columns = $schema->listTableColumns('dtb_customer');
 
@@ -222,7 +219,6 @@ final class UpdateSchemaDoctrineCommandTest extends EccubeTestCase
 
         $this->assertStringContainsString('[OK] Nothing to update', (string) $display, '--no-proxy is do not use proxy');
 
-        /** @var AbstractSchemaManager $schema */
         $schema = $this->getSchemaManager();
         $columns = $schema->listTableColumns('dtb_customer');
 
@@ -256,7 +252,6 @@ final class UpdateSchemaDoctrineCommandTest extends EccubeTestCase
         $display = $commandTester->getDisplay();
         $this->assertStringContainsString('[OK] Nothing to update', $display, 'Use proxy');
 
-        /** @var AbstractSchemaManager $schema */
         $schema = $this->getSchemaManager();
         $columns = $schema->listTableColumns('dtb_customer');
 
@@ -299,7 +294,6 @@ final class UpdateSchemaDoctrineCommandTest extends EccubeTestCase
             '--no-proxy is do not use proxy'
         );
 
-        /** @var AbstractSchemaManager $schema */
         $schema = $this->getSchemaManager();
         $columns = $schema->listTableColumns('dtb_customer');
 
@@ -336,7 +330,6 @@ final class UpdateSchemaDoctrineCommandTest extends EccubeTestCase
         $display = $commandTester->getDisplay();
         $this->assertStringContainsString('[OK] Nothing to update', $display, 'Use proxy');
 
-        /** @var AbstractSchemaManager $schema */
         $schema = $this->getSchemaManager();
         $columns = $schema->listTableColumns('dtb_customer');
 
@@ -431,7 +424,6 @@ EOT
      */
     private function createComposerJsonFile($config): array
     {
-        /** @var Generator $faker */
         $faker = $this->getFaker();
 
         return [

--- a/tests/Eccube/Tests/Doctrine/Query/WhereClauseTest.php
+++ b/tests/Eccube/Tests/Doctrine/Query/WhereClauseTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 namespace Eccube\Tests\Doctrine\Query;
 
 use Doctrine\ORM\Query\Parameter;
-use Doctrine\ORM\QueryBuilder;
 use Eccube\Doctrine\Query\WhereClause;
 use Eccube\Tests\EccubeTestCase;
 
@@ -189,7 +188,6 @@ final class WhereClauseTest extends EccubeTestCase
 
     private function asString(WhereClause $clause)
     {
-        /** @var QueryBuilder $builder */
         $builder = $this->entityManager->createQueryBuilder();
         $clause->build($builder);
 
@@ -198,7 +196,6 @@ final class WhereClauseTest extends EccubeTestCase
 
     private function getParams(WhereClause $clause)
     {
-        /** @var QueryBuilder $builder */
         $builder = $this->entityManager->createQueryBuilder();
         $clause->build($builder);
 

--- a/tests/Eccube/Tests/EccubeTestCase.php
+++ b/tests/Eccube/Tests/EccubeTestCase.php
@@ -87,8 +87,6 @@ abstract class EccubeTestCase extends WebTestCase
      *
      * @param string $locale ロケールを指定する. デフォルト ja_JP
      *
-     * @return \Faker\Generator
-     *
      * @see https://github.com/fzaninotto/Faker
      */
     public function getFaker(string $locale = 'ja_JP'): \Faker\Generator

--- a/tests/Eccube/Tests/Entity/Master/AbstractMasterEntityTest.php
+++ b/tests/Eccube/Tests/Entity/Master/AbstractMasterEntityTest.php
@@ -25,11 +25,6 @@ use Eccube\Tests\EccubeTestCase;
  */
 final class AbstractMasterEntityTest extends EccubeTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function testGetConstant()
     {
         $this->assertSame(1, TestSexDecorator::TEST_MALE, 'constant access');

--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -833,7 +833,6 @@ class Generator
     public function createPage(): Page
     {
         $faker = $this->getFaker();
-        /** @var Page $Page */
         $Page = $this->pageRepository->newPage();
         do {
             $url = $faker->word();

--- a/tests/Eccube/Tests/Plugin/PluginManagerTest.php
+++ b/tests/Eccube/Tests/Plugin/PluginManagerTest.php
@@ -24,11 +24,6 @@ use Plugin\MigrationSample\PluginManager;
 #[Group('plugin-service')]
 final class PluginManagerTest extends EccubeTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function testMigration()
     {
         $pluginManager = new PluginManager();

--- a/tests/Eccube/Tests/Repository/CalendarRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/CalendarRepositoryTest.php
@@ -56,7 +56,6 @@ final class CalendarRepositoryTest extends EccubeTestCase
      */
     public function createCalendar(string $title = 'title', ?\DateTime $holiday = null): Calendar
     {
-        /** @var Calendar $Calendar */
         $Calendar = new Calendar();
         if (is_null($holiday)) {
             $holiday = $this->DateTimeNow;

--- a/tests/Eccube/Tests/Service/AgentCommerce/Catalog/Acp/AcpFeedProductSerializerTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/Catalog/Acp/AcpFeedProductSerializerTest.php
@@ -78,8 +78,6 @@ final class AcpFeedProductSerializerTest extends TestCase
         $product = new AgentCatalogItemDto(
             id: '100',
             title: 'Coffee',
-            description: null,
-            url: null,
             media: [],
             variants: [$this->minimalVariant()],
         );
@@ -225,10 +223,7 @@ final class AcpFeedProductSerializerTest extends TestCase
             currency: 'JPY',
             available: true,
             availabilityStatus: AvailabilityStatus::IN_STOCK,
-            sku: null,
             listPriceMinorUnits: $listPriceMinorUnits,
-            description: null,
-            url: null,
             options: $options,
             barcodes: $barcodes,
             media: [],

--- a/tests/Eccube/Tests/Service/AgentCommerce/Catalog/Ucp/UcpCatalogProductSerializerTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/Catalog/Ucp/UcpCatalogProductSerializerTest.php
@@ -87,7 +87,6 @@ final class UcpCatalogProductSerializerTest extends TestCase
         $product = new AgentCatalogItemDto(
             id: '100',
             title: 'Coffee',
-            description: null,
             variants: [$this->variant('200', 1200)],
         );
 
@@ -115,7 +114,6 @@ final class UcpCatalogProductSerializerTest extends TestCase
         $product = new AgentCatalogItemDto(
             id: '100',
             title: 'Coffee',
-            url: null,
             media: [],
             categories: [],
             variants: [$this->variant('200', 1200)],
@@ -219,9 +217,6 @@ final class UcpCatalogProductSerializerTest extends TestCase
             available: $available,
             availabilityStatus: $status,
             sku: $sku,
-            listPriceMinorUnits: null,
-            description: null,
-            url: null,
             options: $options,
             barcodes: [],
             media: [],

--- a/tests/Eccube/Tests/Service/PluginServiceTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceTest.php
@@ -24,7 +24,6 @@ use Eccube\Entity\Plugin;
 use Eccube\Exception\PluginException;
 use Eccube\Repository\PluginRepository;
 use Eccube\Service\PluginService;
-use Faker\Generator;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -758,7 +757,6 @@ EOD;
      */
     private function createComposerJsonFile($config): array
     {
-        /** @var Generator $faker */
         $faker = $this->getFaker();
 
         return [

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PointDiffProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PointDiffProcessorTest.php
@@ -19,7 +19,6 @@ use Eccube\Entity\Customer;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Entity\Order;
 use Eccube\Entity\OrderItem;
-use Eccube\Entity\ProductClass;
 use Eccube\Repository\Master\OrderStatusRepository;
 use Eccube\Service\PurchaseFlow\Processor\PointDiffProcessor;
 use Eccube\Service\PurchaseFlow\Processor\PointProcessor;

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PointProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/PointProcessorTest.php
@@ -22,7 +22,6 @@ use Eccube\Entity\Master\TaxDisplayType;
 use Eccube\Entity\Master\TaxType;
 use Eccube\Entity\Order;
 use Eccube\Entity\OrderItem;
-use Eccube\Entity\ProductClass;
 use Eccube\Service\PurchaseFlow\Processor\AddPointProcessor;
 use Eccube\Service\PurchaseFlow\Processor\PointProcessor;
 use Eccube\Service\PurchaseFlow\ProcessResult;

--- a/tests/Eccube/Tests/Service/PurchaseFlow/Processor/StockDiffProcessorTest.php
+++ b/tests/Eccube/Tests/Service/PurchaseFlow/Processor/StockDiffProcessorTest.php
@@ -20,7 +20,6 @@ use Eccube\Entity\Master\OrderItemType;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Entity\Order;
 use Eccube\Entity\OrderItem;
-use Eccube\Entity\ProductClass;
 use Eccube\Entity\ProductStock;
 use Eccube\Repository\Master\OrderItemTypeRepository;
 use Eccube\Repository\Master\OrderStatusRepository;

--- a/tests/Eccube/Tests/Util/EntityUtilTest.php
+++ b/tests/Eccube/Tests/Util/EntityUtilTest.php
@@ -27,11 +27,6 @@ use Eccube\Util\EntityUtil;
  */
 final class EntityUtilTest extends EccubeTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function testDumpToArray()
     {
         $arrProps = [

--- a/tests/Eccube/Tests/Web/AbstractShoppingControllerTestCase.php
+++ b/tests/Eccube/Tests/Web/AbstractShoppingControllerTestCase.php
@@ -30,16 +30,6 @@ use Symfony\Component\HttpFoundation\Request;
  */
 abstract class AbstractShoppingControllerTestCase extends AbstractWebTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     public function createShippingFormData()
     {
         $faker = $this->getFaker();

--- a/tests/Eccube/Tests/Web/AbstractWebTestCase.php
+++ b/tests/Eccube/Tests/Web/AbstractWebTestCase.php
@@ -25,16 +25,6 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 abstract class AbstractWebTestCase extends EccubeTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     /**
      * @deprecated AbstractWebTestCase::loginTo() を使用してください.
      *

--- a/tests/Eccube/Tests/Web/Admin/AdminControllerProductNonStockTest.php
+++ b/tests/Eccube/Tests/Web/Admin/AdminControllerProductNonStockTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 namespace Eccube\Tests\Web\Admin;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Client;
 
 /**
  * Class AdminControllerProductNonStockTest.

--- a/tests/Eccube/Tests/Web/Admin/Customer/CustomerControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Customer/CustomerControllerTest.php
@@ -64,14 +64,6 @@ final class CustomerControllerTest extends AbstractAdminWebTestCase
     }
 
     /**
-     * tearDown
-     */
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
-    /**
      * testIndex
      */
     public function testIndex()

--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -684,7 +684,6 @@ final class EditControllerTest extends AbstractEditControllerTestCase
     {
         /** @var RoundingType $RoundingType */
         $RoundingType = $this->entityManager->find(RoundingType::class, RoundingType::ROUND);
-        /** @var Product $Product */
         $Product = $this->createProduct(null, 1);
         $this->entityManager->persist($Product);
 

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
@@ -31,7 +31,6 @@ use Eccube\Repository\PaymentRepository;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
-use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Mime\Email;
@@ -298,7 +297,6 @@ final class OrderControllerTest extends AbstractAdminWebTestCase
             '_token' => 'dummy',
             'email' => 'user-1',
         ];
-        /** @var Crawler $crawler */
         $crawler = $this->client->request(
             Request::METHOD_POST,
             $this->generateUrl('admin_order'),

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
@@ -25,7 +25,6 @@ use Eccube\Repository\Master\OrderStatusRepository;
 use Eccube\Repository\OrderPdfRepository;
 use Eccube\Repository\OrderRepository;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
-use Faker\Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form;
@@ -81,9 +80,6 @@ final class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $Order = $this->createOrderForSearch();
         $Shippings = $Order->getShippings();
         $shippingId = $Shippings[0]->getId();
-        /**
-         * @var Crawler
-         */
         $crawler = $this->client->request(
             Request::METHOD_GET,
             $this->generateUrl('admin_order')
@@ -105,9 +101,6 @@ final class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $Shippings = $Order->getShippings();
         $shippingId = $Shippings[0]->getId();
 
-        /**
-         * @var Crawler
-         */
         $crawler = $this->client->request(Request::METHOD_POST,
             $this->generateUrl('admin_order_export_pdf'),
             [
@@ -132,9 +125,6 @@ final class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $Shippings = $Order->getShippings();
         $shippingId = $Shippings[0]->getId();
 
-        /**
-         * @var Crawler
-         */
         $crawler = $this->client->request(Request::METHOD_POST,
             $this->generateUrl('admin_order_export_pdf'),
             [
@@ -144,9 +134,6 @@ final class OrderPdfControllerTest extends AbstractAdminWebTestCase
 
         $form = $this->getForm($crawler);
 
-        /**
-         * @var Generator
-         */
         $faker = $this->getFaker();
         $form['order_pdf[title]'] = $faker->text(50);
         $form['order_pdf[message1]'] = $faker->text(30);
@@ -186,9 +173,6 @@ final class OrderPdfControllerTest extends AbstractAdminWebTestCase
     {
         $this->client->request(Request::METHOD_GET, $this->generateUrl('admin_order_export_pdf'));
         $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('admin_order')));
-        /**
-         * @var Crawler
-         */
         $crawler = $this->client->followRedirect();
 
         $html = $crawler->filter('.alert')->html();
@@ -229,9 +213,6 @@ final class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $this->assertStringContainsString('ご確認くださいますよう、お願いいたします。', $html);
 
         $form = $this->getForm($crawler);
-        /**
-         * @var Generator
-         */
         $faker = $this->getFaker();
         $form["$field"] = $faker->text(1000);
         $crawler = $client->submit($form);
@@ -301,9 +282,6 @@ final class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $Shippings = $Order->getShippings();
         $shippingId = $Shippings[0]->getId();
 
-        /**
-         * @var Generator
-         */
         $faker = $this->getFaker();
         $adminTest = $this->createMember();
 
@@ -369,9 +347,6 @@ final class OrderPdfControllerTest extends AbstractAdminWebTestCase
             ]
         );
 
-        /**
-         * @var Form
-         */
         $form = $this->getForm($crawler);
         // fields set to empty.
         $form->setValues([

--- a/tests/Eccube/Tests/Web/Admin/Order/RefundRequestControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/RefundRequestControllerTest.php
@@ -27,11 +27,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class RefundRequestControllerTest extends AbstractAdminWebTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function testIndex(): void
     {
         $this->client->request(

--- a/tests/Eccube/Tests/Web/Admin/Order/ShippingControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/ShippingControllerTest.php
@@ -15,10 +15,8 @@ declare(strict_types=1);
 
 namespace Eccube\Tests\Web\Admin\Order;
 
-use Eccube\Entity\Customer;
 use Eccube\Entity\Master\OrderItemType;
 use Eccube\Entity\Order;
-use Eccube\Entity\Product;
 use Eccube\Entity\ProductClass;
 use Eccube\Entity\Shipping;
 use Eccube\Repository\ShippingRepository;
@@ -54,7 +52,6 @@ final class ShippingControllerTest extends AbstractEditControllerTestCase
     public function testShippingMessageNoticeWhenPost()
     {
         $Customer = $this->createCustomer();
-        /** @var Order $Order */
         $Order = $this->createOrder($Customer);
 
         $crawler = $this->client->request(
@@ -311,7 +308,6 @@ final class ShippingControllerTest extends AbstractEditControllerTestCase
     #[Group(name: 'decimal')]
     public function testCalculateTax()
     {
-        /** @var Product $Product */
         $Product = $this->createProduct('test', 2);
         /** @var ProductClass $ProductClass1 */
         $ProductClass1 = $Product->getProductClasses()[0];
@@ -325,7 +321,6 @@ final class ShippingControllerTest extends AbstractEditControllerTestCase
         $this->entityManager->persist($ProductClass2);
         $this->entityManager->flush();
 
-        /** @var Customer $Customer */
         $Customer = $this->createCustomer();
         $Order = $this->createOrderWithProductClasses($Customer, [$ProductClass1]);
         $Shipping = $Order->getShippings()->first();

--- a/tests/Eccube/Tests/Web/Admin/Product/ClassCategoryControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ClassCategoryControllerTest.php
@@ -21,7 +21,6 @@ use Eccube\Entity\ClassName;
 use Eccube\Repository\ClassCategoryRepository;
 use Eccube\Repository\ClassNameRepository;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
-use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
 final class ClassCategoryControllerTest extends AbstractAdminWebTestCase
@@ -229,7 +228,6 @@ final class ClassCategoryControllerTest extends AbstractAdminWebTestCase
             ['HTTP_X-Requested-With' => 'XMLHttpRequest']
         );
         $this->assertTrue($client->getResponse()->isSuccessful());
-        /** @var Crawler $crawler */
         $crawler = $client->request(Request::METHOD_GET, $this->generateUrl('admin_product_class_category', ['class_name_id' => 1]));
 
         // チョコ, 抹茶, バニラ sort by rank setup above.

--- a/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
@@ -23,8 +23,8 @@ use Eccube\Entity\ProductClass;
 use Eccube\Entity\ProductImage;
 use Eccube\Repository\CategoryRepository;
 use Eccube\Repository\ProductRepository;
+use Eccube\Tests\Fixture\Generator;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
-use Faker\Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
@@ -713,7 +713,6 @@ final class CsvImportControllerTest extends AbstractAdminWebTestCase
     {
         $Products = $this->productRepo->findAll();
         $this->expected = count($Products) + 1;
-        /** @var Generator $faker */
         $faker = $this->getFaker();
         // 1 product case stock_unlimited = true
         $csv[] = ['公開ステータス(ID)', '商品名', '販売種別(ID)', '在庫数無制限フラグ', '販売価格'];
@@ -774,7 +773,6 @@ final class CsvImportControllerTest extends AbstractAdminWebTestCase
     #[DataProvider(methodName: 'dataStatusProvider')]
     public function testImportProductWithPublicIdIsIncorrect($status, $expectedMessage)
     {
-        /** @var Generator $faker */
         $faker = $this->getFaker();
         // 1 product
         $csv[] = ['公開ステータス(ID)', '商品名', '販売種別(ID)', '在庫数無制限フラグ', '販売価格'];
@@ -1006,7 +1004,6 @@ final class CsvImportControllerTest extends AbstractAdminWebTestCase
         $ProductClass = $Product->getProductClasses()->filter(
             fn (ProductClass $ProductClass) => $ProductClass->getClassCategory1() !== null
         )[0];
-        /** @var Generator $faker */
         $faker = $this->getFaker();
         $csv[] = ['商品ID', '公開ステータス(ID)', '商品名', '販売種別(ID)', '在庫数無制限フラグ', '販売価格', '規格分類1(ID)', '規格分類2(ID)', '商品規格表示フラグ'];
         $csv[] = [$Product->getId(),
@@ -1037,7 +1034,6 @@ final class CsvImportControllerTest extends AbstractAdminWebTestCase
         $ProductClass = $Product->getProductClasses()->filter(
             fn (ProductClass $ProductClass) => $ProductClass->getClassCategory1() !== null
         )[0];
-        /** @var Generator $faker */
         $faker = $this->getFaker();
         $csv[] = ['商品ID', '公開ステータス(ID)', '商品名', '販売種別(ID)', '在庫数無制限フラグ', '販売価格', '規格分類1(ID)', '規格分類2(ID)', '商品規格表示フラグ'];
         $csv[] = [$Product->getId(),
@@ -1066,8 +1062,8 @@ final class CsvImportControllerTest extends AbstractAdminWebTestCase
      */
     public function testDeleteImage()
     {
-        /** @var \Eccube\Tests\Fixture\Generator $generator */
-        $generator = static::getContainer()->get(\Eccube\Tests\Fixture\Generator::class);
+        /** @var Generator $generator */
+        $generator = static::getContainer()->get(Generator::class);
         $Product1 = $generator->createProduct(null, 0, true);
         $Product2 = $generator->createProduct(null, 0, true);
 

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductClassControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductClassControllerTest.php
@@ -27,7 +27,6 @@ use Eccube\Repository\ProductRepository;
 use Eccube\Repository\TaxRuleRepository;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
-use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
@@ -664,7 +664,6 @@ final class ProductControllerTest extends AbstractAdminWebTestCase
         $searchForm = $this->createSearchForm();
         $searchForm['id'] = 'Product name';
 
-        /** @var Crawler $crawler */
         $crawler = $this->client->request(
             Request::METHOD_POST,
             $this->generateUrl('admin_product'),

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/AuthorityControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/AuthorityControllerTest.php
@@ -20,7 +20,6 @@ use Eccube\Entity\Master\Authority;
 use Eccube\Entity\Member;
 use Eccube\Repository\AuthorityRoleRepository;
 use Eccube\Repository\Master\AuthorityRepository;
-use Eccube\Repository\MemberRepository;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/LogControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/LogControllerTest.php
@@ -16,9 +16,7 @@ declare(strict_types=1);
 namespace Eccube\Tests\Web\Admin\Setting\System;
 
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
-use Faker\Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -111,7 +109,6 @@ final class LogControllerTest extends AbstractAdminWebTestCase
 
         $this->formData['line_max'] = $value;
 
-        /** @var Crawler $crawler */
         $crawler = $this->client->request(
             Request::METHOD_POST,
             $this->generateUrl('admin_setting_system_log'),
@@ -141,7 +138,6 @@ final class LogControllerTest extends AbstractAdminWebTestCase
 
     private function createTestFile($number)
     {
-        /** @var Generator $faker */
         $faker = $this->getFaker();
 
         if (!file_exists($this->logTest)) {

--- a/tests/Eccube/Tests/Web/Admin/Setting/System/MasterdataControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/System/MasterdataControllerTest.php
@@ -25,11 +25,6 @@ use Symfony\Component\HttpFoundation\Request;
  */
 final class MasterdataControllerTest extends AbstractAdminWebTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     protected $entityTest = 'Eccube-Entity-Master-Sex';
 
     /**

--- a/tests/Eccube/Tests/Web/CartValidationTest.php
+++ b/tests/Eccube/Tests/Web/CartValidationTest.php
@@ -46,14 +46,6 @@ final class CartValidationTest extends AbstractWebTestCase
         $this->BaseInfo = $this->entityManager->find(BaseInfo::class, 1);
     }
 
-    /**
-     * tear down
-     */
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     // 商品詳細画面からカート画面のvalidation
 
     /**
@@ -61,7 +53,6 @@ final class CartValidationTest extends AbstractWebTestCase
      */
     public function testValidationStock()
     {
-        /** @var Product $Product */
         $Product = $this->createProduct('test1');
 
         /** @var ProductClass $ProductClass */
@@ -115,7 +106,6 @@ final class CartValidationTest extends AbstractWebTestCase
      */
     public function testProductInCartDeleted()
     {
-        /** @var Product $Product */
         $Product = $this->createProduct('test', 1, 1);
 
         $productClassId = $Product->getProductClasses()->first()->getId();
@@ -152,7 +142,6 @@ final class CartValidationTest extends AbstractWebTestCase
      */
     public function testProductInCartIsPrivate()
     {
-        /** @var Product $Product */
         $Product = $this->createProduct('test', 1, 1);
 
         $productClassId = $Product->getProductClasses()->first()->getId();
@@ -194,7 +183,6 @@ final class CartValidationTest extends AbstractWebTestCase
     {
         $this->markTestIncomplete('在庫がゼロの場合フォームエラーになってしまう');
 
-        /** @var Product $Product */
         $Product = $this->createProduct('test', 0, 1);
         $ProductClass = $Product->getProductClasses()->first();
 
@@ -245,7 +233,6 @@ final class CartValidationTest extends AbstractWebTestCase
      */
     public function testProductInCartIsStockOutWithProductClass()
     {
-        /** @var Product $Product */
         $Product = $this->createProduct('test', 2, 1);
         $ProductClass = $Product->getProductClasses()->first();
 
@@ -302,7 +289,6 @@ final class CartValidationTest extends AbstractWebTestCase
     {
         $stock = 1;
         $productName = $this->getFaker()->word;
-        /** @var Product $Product */
         $Product = $this->createProduct($productName, 1, $stock);
         $ProductClass = $Product->getProductClasses()->first();
 
@@ -358,7 +344,6 @@ final class CartValidationTest extends AbstractWebTestCase
     public function testProductInCartIsNotEnoughAndLimit()
     {
         $productName = $this->getFaker()->word;
-        /** @var Product $Product */
         $Product = parent::createProduct($productName, 1);
         $ProductClass = $Product->getProductClasses()->first();
         $ProductClass->setPrice02('999999911');
@@ -511,7 +496,6 @@ final class CartValidationTest extends AbstractWebTestCase
         $limit = 5;
 
         $productName = $this->getFaker()->word;
-        /** @var Product $Product */
         $Product = $this->createProduct($productName, 1, $stock);
         $ProductClass = $Product->getProductClasses()->first();
 
@@ -570,7 +554,6 @@ final class CartValidationTest extends AbstractWebTestCase
         $Customer = $this->createCustomer();
         $this->loginTo($Customer);
 
-        /** @var Product $Product */
         $Product = $this->createProduct('test', 1, 1);
         /** @var ProductClass $ProductClass */
         $ProductClass = $Product->getProductClasses()->get(0);
@@ -597,7 +580,6 @@ final class CartValidationTest extends AbstractWebTestCase
     public function testProductInCartIsPrivateFromShopping()
     {
         $Customer = $this->createCustomer();
-        /** @var Product $Product */
         $Product = $this->createProduct('test', 1, 1);
         /** @var ProductClass $productClass */
         $ProductClass = $Product->getProductClasses()->first();
@@ -748,7 +730,6 @@ final class CartValidationTest extends AbstractWebTestCase
 
         // product type A
         $productName = $this->getFaker()->word;
-        /** @var Product $Product */
         $Product = $this->createProduct($productName, $productClassNum, $productStock);
         /** @var ProductClass $ProductClass */
         $ProductClass = $Product->getProductClasses()->first();

--- a/tests/Eccube/Tests/Web/EntryControllerTest.php
+++ b/tests/Eccube/Tests/Web/EntryControllerTest.php
@@ -26,11 +26,6 @@ final class EntryControllerTest extends AbstractWebTestCase
 {
     use MailerAssertionsTrait;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     protected function createFormData()
     {
         $faker = $this->getFaker();

--- a/tests/Eccube/Tests/Web/Mypage/WithdrawControllerTest.php
+++ b/tests/Eccube/Tests/Web/Mypage/WithdrawControllerTest.php
@@ -34,11 +34,6 @@ final class WithdrawControllerTest extends AbstractWebTestCase
         $this->Customer = $this->createCustomer();
     }
 
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     public function testIndex()
     {
         $this->logInTo($this->Customer);

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleNonmemberTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleNonmemberTest.php
@@ -44,11 +44,6 @@ final class ShoppingControllerWithMultipleNonmemberTest extends AbstractShopping
         $this->orderRepository = $this->entityManager->getRepository(Order::class);
     }
 
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     /**
      * 非会員情報入力→購入確認画面→複数配送設定→お届け先追加→複数配送設定→購入確認画面→完了画面
      */
@@ -238,7 +233,7 @@ final class ShoppingControllerWithMultipleNonmemberTest extends AbstractShopping
 
         $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('shopping')));
 
-        $Order = $Order = $this->getLastOrder();
+        $Order = $this->getLastOrder();
 
         // One shipping
         $Shipping = $Order->getShippings();

--- a/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
+++ b/tests/Eccube/Tests/Web/ShoppingControllerWithMultipleTest.php
@@ -65,14 +65,6 @@ final class ShoppingControllerWithMultipleTest extends AbstractShoppingControlle
     }
 
     /**
-     * tearDown: rollback and clear mail
-     */
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
-    /**
      * カート→購入確認画面→複数配送設定画面→購入確認画面→完了画面
      */
     public function testCompleteWithLogin()

--- a/tests/Eccube/Tests/Web/TemplateEventListenerTest.php
+++ b/tests/Eccube/Tests/Web/TemplateEventListenerTest.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 
 namespace Eccube\Tests\Web;
 
-use Eccube\Event\TemplateEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/tests/Eccube/Tests/Web/TradeLawControllerTest.php
+++ b/tests/Eccube/Tests/Web/TradeLawControllerTest.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 
 namespace Eccube\Tests\Web;
 
-use Eccube\Entity\Page;
 use Eccube\Entity\TradeLaw;
 use Eccube\Repository\TradeLawRepository;
 use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
## 概要

dependabot の php-dev-tools グループ更新 #7037 を通すための先行対応です。
このPR自体は composer.lock を含まず、本体コードだけを新しいツールに追従させます。

#7037 では静的解析の 2 ジョブが落ちています。

| ジョブ | 原因 |
| --- | --- |
| phpstan | phpstan 2.1.44 → 2.2.8 で新規エラー 2 件 |
| rector | rector 2.3.9 → 2.6.1 で dry-run 差分 96 ファイル |

## 変更内容

### rector 2.6 への追従

`SetList::DEAD_CODE` に新ルールが追加されたことによる指摘に追従します。内訳は以下のとおりで、いずれも docblock とデッドコードの除去です。

| ルール | 件数 |
| --- | --- |
| `RemoveUselessVarTagRector` | 34 |
| `RemoveDuplicatedReturnSelfDocblockRector` | 21 |
| `RemoveParentDelegatingClassMethodRector` | 13 |
| `RemoveNullNamedArgOnNullDefaultParamRector` | 5 |
| `CommandConfigureToAttributeRector` | 4 |
| `RemoveUselessTernaryRector` / `TernaryToNullCoalescingRector` ほか | 各 1〜3 |

### 新旧 rector でルールが競合する 2 ファイルの調整 (`rector.php`)

`codeception/_support/Helper/Acceptance.php` と `src/Eccube/Service/Composer/OutputParser.php` は、
2.6.1 の `RecastingRemovalRector` が外した `(string)` キャストを 2.3.9 の
`NullToStrictStringFuncCallArgRector` が付け直す往復になります。
既存の同種スキップに倣い `RecastingRemovalRector` の対象外にしてキャストを維持しました。

### `Order::$delivery_fee_total` の既定値削除

`RemoveDefaultValueFromAssignedPropertyRector` による指摘です。実挙動は変わりません。

- `Order::__construct()` が必ず `setDeliveryFeeTotal('0')` を通す
- DB 側の既定値は `#[ORM\Column(options: ['default' => 0])]` が保持する
- リフレクション経由の読み出しも `AbstractEntity::toArray()` が未初期化プロパティを除外する

同じ条件の金額プロパティが他に 6 個ありますが、rector が指摘するのはこの 1 個だけです。
この 1 行を消した状態で rector 2.6.1 の差分がゼロになることは確認済みで、残り 6 個へは波及しません。

### phpstan 2.2 で顕在化した型の不整合 2 件

`src/Eccube/Service/Mcp/ToolInputSchema.php` は `Mcp\Schema\Tool::$inputSchema` の array shape を
そのまま辿っており、shape が `properties` を必須・非 nullable と宣言しているため `?? []` が
「常に成立する冗長なコード」と判定されます。実体は sdk が `\stdClass` に正規化することがあり
(`Tool::normalizeSchemaProperties`)、キー自体も `Tool` のコンストラクタでは必須にされていないため、
防御そのものは必要です。shape を信用せず素の配列として受け直しました。

`src/Eccube/EventListener/TwigInitializeListener.php` の `@var PageLayout[]` は元から誤りで、
`Page::getPageLayouts()` の戻り値は `Collection<int, PageLayout>` です。
これまでは直前の `@var Page` によって `$Page` のネイティブ型が失われ検査対象外になっていましたが、
rector がその `@var` を除去したことで顕在化しました。メソッド側の `@return` が既に正確な型を
宣言しているため、誤った `@var` を削除しています。

## 動作確認

新旧どちらのバージョンでも緑になることをローカルで実測しました。

| | rector | phpstan |
| --- | --- | --- |
| 旧 (rector 2.3.9 / phpstan 2.1.44) = このPRのCI | 差分 0 | 0 件 |
| 新 (rector 2.6.1 / phpstan 2.2.8) = #7037 rebase 後 | 差分 0 | 0 件 |

php-cs-fixer は変更ファイルすべてで違反なしを確認済みです。

## マージ後の手順

このPRがマージされたあと #7037 に `@dependabot` の rebase コマンドをコメントすると、
静的解析 2 ジョブが緑になり、以降スキップされていた unit-test / e2e-test / plugin-test / coverage が実際に走ります。

Refs #7037


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 各種処理の安定性を維持しながら、入力データの扱いを見直しました。
  - 管理画面のファイル表示や注文関連処理の判定を簡潔化しました。

- **品質向上**
  - 内部コードやテストを整理し、保守性と静的解析への対応を改善しました。
  - 既存の購入、会員登録、商品・注文管理などの機能動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->