### PR TITLE
商品CSV更新時にカンマ入りの在庫数が正しく保存されない問題を修正

### DIFF
--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -1526,7 +1526,7 @@ class CsvImportController extends AbstractCsvImportController
             } else {
                 $stock = str_replace(',', '', (string) $row[$headerByKey['stock']]);
                 if (preg_match('/^\d+$/', $stock) && $stock >= 0) {
-                    $ProductClass->setStock($row[$headerByKey['stock']]);
+                    $ProductClass->setStock($stock);
                 } else {
                     $message = trans('admin.common.csv_invalid_greater_than_zero', ['%line%' => $line, '%name%' => $headerByKey['stock']]);
                     $this->addErrors($message);

--- a/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/CsvImportControllerTest.php
@@ -454,6 +454,68 @@ final class CsvImportControllerTest extends AbstractAdminWebTestCase
         $this->assertEquals($beforeProduct->getDescriptionDetail(), $afterProduct->getDescriptionDetail());
     }
 
+    /**
+     * 既存商品の更新時, カンマ区切りの在庫数が数値として保存されることを確認する.
+     */
+    public function testCsvImportWithExistsProductsStockWithComma(): void
+    {
+        $Product = $this->createProduct('カンマ在庫商品', 1);
+        /** @var ProductClass $ProductClass */
+        $ProductClass = $Product->getProductClasses()->first();
+
+        $csv = [[
+            '商品ID',
+            '公開ステータス(ID)',
+            '商品名',
+            '販売種別(ID)',
+            '規格分類1(ID)',
+            '規格分類2(ID)',
+            '発送日目安(ID)',
+            '商品コード',
+            '在庫数',
+            '在庫数無制限フラグ',
+            '販売制限数',
+            '通常価格',
+            '販売価格',
+            '送料',
+        ]];
+        $csv[] = [
+            $Product->getId(),
+            $Product->getStatus()->getId(),
+            $Product->getName(),
+            $ProductClass->getSaleType()->getId(),
+            $ProductClass->getClassCategory1() == null ? null : $ProductClass->getClassCategory1()->getId(),
+            $ProductClass->getClassCategory2() == null ? null : $ProductClass->getClassCategory2()->getId(),
+            $ProductClass->getDeliveryDuration() == null ? null : $ProductClass->getDeliveryDuration()->getId(),
+            $ProductClass->getCode(),
+            '1,000',
+            0,
+            $ProductClass->getSaleLimit(),
+            (int) $ProductClass->getPrice01(),
+            (int) $ProductClass->getPrice02(),
+            $ProductClass->getDeliveryFee(),
+        ];
+
+        $this->filepath = $this->createCsvFromArray($csv);
+        $crawler = $this->scenario();
+
+        $this->assertMatchesRegularExpression(
+            '/CSVファイルをアップロードしました/u',
+            $crawler->filter('div.alert-success')->text()
+        );
+
+        $this->entityManager->refresh($ProductClass);
+        $this->entityManager->refresh($ProductClass->getProductStock());
+
+        $this->expected = 1000;
+        $this->actual = (int) $ProductClass->getStock();
+        $this->verify('カンマ区切りの在庫数は数値として保存される');
+
+        $this->expected = 1000;
+        $this->actual = (int) $ProductClass->getProductStock()->getStock();
+        $this->verify('在庫テーブルにも数値として反映される');
+    }
+
     // ======================================================================
     // CATEGORY Import Test
     // ======================================================================


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

close #6580

商品CSVで既存商品を更新する際、在庫数を `1,000` のようにカンマ入りで指定すると正しく保存されない問題を修正します。
カンマを除去した値でバリデーションした後、除去前の文字列を `ProductClass::setStock()` に渡しているため、MySQL(非strictモード)では `1` に切り詰めた値で保存され、PostgreSQL や strictモードでは `Incorrect decimal value` エラーになります。

## 方針(Policy)

`updateProductClass()` で、バリデーションに使用したカンマ除去済みの値を `setStock()` に渡すようにしました。
新規登録経路(`createProductClass()`)は既に同じ形で実装されているため、それに合わせています。

修正は @dk-umebius さんが 4.3 向けに出してくださっている #6581 のコミットを cherry-pick したものです。ありがとうございます。
4.4 は 4.3 と履歴が分岐しているため、base の付け替えではなく本PRとして 4.4 へ適用し、回帰テストを追加しています。

## 実装に関する補足(Appendix)

同メソッド内の `sale_limit` / `price01` / `price02` は既にカンマ除去後の変数を使用しているため、変更していません。

## テスト（Test)

- 更新経路で在庫数に `"1,000"` を指定し、`ProductClass::getStock()` と `ProductStock::getStock()` が `1000` になることを検証する回帰テストを追加
- 修正を戻すと本テストが `1 !== 1000` で失敗することを確認
- `php-cs-fixer` / `phpstan` / `rector` / 対象テストファイル全46件をローカルで実行し、すべて成功

## 相談（Discussion）

特にありません。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)
