### PR TITLE
refactor(entity): 再発した if (!class_exists()) ガードを除去する (refs #6891)

### DIFF
--- a/src/Eccube/Entity/Master/RefundRequestStatus.php
+++ b/src/Eccube/Entity/Master/RefundRequestStatus.php
@@ -16,27 +16,25 @@ namespace Eccube\Entity\Master;
 use Doctrine\ORM\Mapping as ORM;
 use Eccube\Repository\Master\RefundRequestStatusRepository;
 
-if (!class_exists(RefundRequestStatus::class, false)) {
-    /**
-     * RefundRequestStatus
-     */
-    #[ORM\Table(name: 'mtb_refund_request_status')]
-    #[ORM\InheritanceType('SINGLE_TABLE')]
-    #[ORM\DiscriminatorColumn(name: 'discriminator_type', type: 'string', length: 255)]
-    #[ORM\HasLifecycleCallbacks]
-    #[ORM\Entity(repositoryClass: RefundRequestStatusRepository::class)]
-    #[ORM\Cache(usage: 'NONSTRICT_READ_WRITE')]
-    class RefundRequestStatus extends AbstractMasterEntity
-    {
-        /** 新規申請. */
-        public const NEW = 1;
-        /** 処理中. */
-        public const PROCESSING = 2;
-        /** 承認済. */
-        public const ACCEPTED = 3;
-        /** 却下. */
-        public const DECLINED = 4;
-        /** 追加情報依頼. */
-        public const INFO_REQUESTED = 5;
-    }
+/**
+ * RefundRequestStatus
+ */
+#[ORM\Table(name: 'mtb_refund_request_status')]
+#[ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'discriminator_type', type: 'string', length: 255)]
+#[ORM\HasLifecycleCallbacks]
+#[ORM\Entity(repositoryClass: RefundRequestStatusRepository::class)]
+#[ORM\Cache(usage: 'NONSTRICT_READ_WRITE')]
+class RefundRequestStatus extends AbstractMasterEntity
+{
+    /** 新規申請. */
+    public const NEW = 1;
+    /** 処理中. */
+    public const PROCESSING = 2;
+    /** 承認済. */
+    public const ACCEPTED = 3;
+    /** 却下. */
+    public const DECLINED = 4;
+    /** 追加情報依頼. */
+    public const INFO_REQUESTED = 5;
 }

--- a/src/Eccube/Entity/RateLimiter.php
+++ b/src/Eccube/Entity/RateLimiter.php
@@ -16,116 +16,114 @@ namespace Eccube\Entity;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
-if (!class_exists(RateLimiter::class)) {
+/**
+ * RateLimiter.
+ *
+ * スロットリング(レートリミッター)のデータストレージ用テーブル.
+ *
+ * 実体は Symfony\Component\Cache\Adapter\DoctrineDbalAdapter が読み書きするキャッシュテーブルで,
+ * カラム名は services.yaml で定義した DoctrineDbalAdapter の options
+ * (db_id_col / db_data_col / db_lifetime_col / db_time_col) と厳密に一致させている.
+ * これによりテーブルを ORM のメタデータ管理下に置き, プラグイン削除やスキーマ再構築で
+ * 削除されないようにするとともに, symfony/cache・DBAL のバージョンアップで既定カラム名が
+ * 変わってもサイレントに壊れないようにする.
+ *
+ * NOTE: dtb_* テーブルは通常 integer の id を主キーに持つが, 本テーブルは adapter が
+ * キャッシュキー(文字列)を主キーとして SELECT/DELETE するため, 文字列カラムを主キーにしている.
+ */
+#[ORM\Table(name: 'dtb_rate_limiter')]
+#[ORM\Entity]
+class RateLimiter extends AbstractEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(name: 'cache_key', type: Types::STRING, length: 255)]
+    private string $cacheKey;
+
     /**
-     * RateLimiter.
-     *
-     * スロットリング(レートリミッター)のデータストレージ用テーブル.
-     *
-     * 実体は Symfony\Component\Cache\Adapter\DoctrineDbalAdapter が読み書きするキャッシュテーブルで,
-     * カラム名は services.yaml で定義した DoctrineDbalAdapter の options
-     * (db_id_col / db_data_col / db_lifetime_col / db_time_col) と厳密に一致させている.
-     * これによりテーブルを ORM のメタデータ管理下に置き, プラグイン削除やスキーマ再構築で
-     * 削除されないようにするとともに, symfony/cache・DBAL のバージョンアップで既定カラム名が
-     * 変わってもサイレントに壊れないようにする.
-     *
-     * NOTE: dtb_* テーブルは通常 integer の id を主キーに持つが, 本テーブルは adapter が
-     * キャッシュキー(文字列)を主キーとして SELECT/DELETE するため, 文字列カラムを主キーにしている.
+     * @var resource|string|null
      */
-    #[ORM\Table(name: 'dtb_rate_limiter')]
-    #[ORM\Entity]
-    class RateLimiter extends AbstractEntity
+    #[ORM\Column(name: 'cache_data', type: Types::BLOB)]
+    private $cacheData;
+
+    #[ORM\Column(name: 'cache_lifetime', type: Types::INTEGER, nullable: true, options: ['unsigned' => true])]
+    private ?int $cacheLifetime = null;
+
+    #[ORM\Column(name: 'cache_time', type: Types::INTEGER, options: ['unsigned' => true])]
+    private int $cacheTime;
+
+    /**
+     * Get cacheKey.
+     */
+    public function getCacheKey(): string
     {
-        #[ORM\Id]
-        #[ORM\Column(name: 'cache_key', type: Types::STRING, length: 255)]
-        private string $cacheKey;
+        return $this->cacheKey;
+    }
 
-        /**
-         * @var resource|string|null
-         */
-        #[ORM\Column(name: 'cache_data', type: Types::BLOB)]
-        private $cacheData;
+    /**
+     * Set cacheKey.
+     */
+    public function setCacheKey(string $cacheKey): RateLimiter
+    {
+        $this->cacheKey = $cacheKey;
 
-        #[ORM\Column(name: 'cache_lifetime', type: Types::INTEGER, nullable: true, options: ['unsigned' => true])]
-        private ?int $cacheLifetime = null;
+        return $this;
+    }
 
-        #[ORM\Column(name: 'cache_time', type: Types::INTEGER, options: ['unsigned' => true])]
-        private int $cacheTime;
+    /**
+     * Get cacheData.
+     *
+     * @return resource|string|null
+     */
+    public function getCacheData(): mixed
+    {
+        return $this->cacheData;
+    }
 
-        /**
-         * Get cacheKey.
-         */
-        public function getCacheKey(): string
-        {
-            return $this->cacheKey;
-        }
+    /**
+     * Set cacheData.
+     *
+     * @param resource|string|null $cacheData
+     */
+    public function setCacheData(mixed $cacheData): RateLimiter
+    {
+        $this->cacheData = $cacheData;
 
-        /**
-         * Set cacheKey.
-         */
-        public function setCacheKey(string $cacheKey): RateLimiter
-        {
-            $this->cacheKey = $cacheKey;
+        return $this;
+    }
 
-            return $this;
-        }
+    /**
+     * Get cacheLifetime.
+     */
+    public function getCacheLifetime(): ?int
+    {
+        return $this->cacheLifetime;
+    }
 
-        /**
-         * Get cacheData.
-         *
-         * @return resource|string|null
-         */
-        public function getCacheData(): mixed
-        {
-            return $this->cacheData;
-        }
+    /**
+     * Set cacheLifetime.
+     */
+    public function setCacheLifetime(?int $cacheLifetime = null): RateLimiter
+    {
+        $this->cacheLifetime = $cacheLifetime;
 
-        /**
-         * Set cacheData.
-         *
-         * @param resource|string|null $cacheData
-         */
-        public function setCacheData(mixed $cacheData): RateLimiter
-        {
-            $this->cacheData = $cacheData;
+        return $this;
+    }
 
-            return $this;
-        }
+    /**
+     * Get cacheTime.
+     */
+    public function getCacheTime(): int
+    {
+        return $this->cacheTime;
+    }
 
-        /**
-         * Get cacheLifetime.
-         */
-        public function getCacheLifetime(): ?int
-        {
-            return $this->cacheLifetime;
-        }
+    /**
+     * Set cacheTime.
+     */
+    public function setCacheTime(int $cacheTime): RateLimiter
+    {
+        $this->cacheTime = $cacheTime;
 
-        /**
-         * Set cacheLifetime.
-         */
-        public function setCacheLifetime(?int $cacheLifetime = null): RateLimiter
-        {
-            $this->cacheLifetime = $cacheLifetime;
-
-            return $this;
-        }
-
-        /**
-         * Get cacheTime.
-         */
-        public function getCacheTime(): int
-        {
-            return $this->cacheTime;
-        }
-
-        /**
-         * Set cacheTime.
-         */
-        public function setCacheTime(int $cacheTime): RateLimiter
-        {
-            $this->cacheTime = $cacheTime;
-
-            return $this;
-        }
+        return $this;
     }
 }

--- a/src/Eccube/Entity/RefundRequest.php
+++ b/src/Eccube/Entity/RefundRequest.php
@@ -20,215 +20,213 @@ use Doctrine\ORM\Mapping as ORM;
 use Eccube\Entity\Master\RefundRequestStatus;
 use Eccube\Repository\RefundRequestRepository;
 
-if (!class_exists(RefundRequest::class)) {
+/**
+ * RefundRequest
+ *
+ * 返品申請（商品＝注文明細単位）.
+ */
+#[ORM\Table(name: 'dtb_refund_request')]
+#[ORM\Index(columns: ['order_item_id'], name: 'dtb_refund_request_order_item_id_idx')]
+#[ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'discriminator_type', type: 'string', length: 255)]
+#[ORM\HasLifecycleCallbacks]
+#[ORM\Entity(repositoryClass: RefundRequestRepository::class)]
+class RefundRequest extends AbstractEntity
+{
+    #[ORM\Column(name: 'id', type: Types::INTEGER, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'quantity', type: Types::DECIMAL, precision: 10, scale: 0, options: ['default' => 0])]
+    private ?string $quantity = '0';
+
+    #[ORM\Column(name: 'reason', type: Types::TEXT)]
+    private ?string $reason = null;
+
+    #[ORM\Column(name: 'admin_note', type: Types::TEXT, nullable: true)]
+    private ?string $admin_note = null;
+
     /**
-     * RefundRequest
-     *
-     * 返品申請（商品＝注文明細単位）.
+     * @var \DateTime
      */
-    #[ORM\Table(name: 'dtb_refund_request')]
-    #[ORM\Index(columns: ['order_item_id'], name: 'dtb_refund_request_order_item_id_idx')]
-    #[ORM\InheritanceType('SINGLE_TABLE')]
-    #[ORM\DiscriminatorColumn(name: 'discriminator_type', type: 'string', length: 255)]
-    #[ORM\HasLifecycleCallbacks]
-    #[ORM\Entity(repositoryClass: RefundRequestRepository::class)]
-    class RefundRequest extends AbstractEntity
+    #[ORM\Column(name: 'create_date', type: Types::DATETIMETZ_MUTABLE)]
+    private $create_date;
+
+    /**
+     * @var \DateTime
+     */
+    #[ORM\Column(name: 'update_date', type: Types::DATETIMETZ_MUTABLE)]
+    private $update_date;
+
+    #[ORM\ManyToOne(targetEntity: Order::class)]
+    #[ORM\JoinColumn(name: 'order_id', referencedColumnName: 'id')]
+    private ?Order $Order = null;
+
+    #[ORM\ManyToOne(targetEntity: OrderItem::class)]
+    #[ORM\JoinColumn(name: 'order_item_id', referencedColumnName: 'id')]
+    private ?OrderItem $OrderItem = null;
+
+    #[ORM\ManyToOne(targetEntity: Customer::class)]
+    #[ORM\JoinColumn(name: 'customer_id', referencedColumnName: 'id')]
+    private ?Customer $Customer = null;
+
+    #[ORM\ManyToOne(targetEntity: RefundRequestStatus::class)]
+    #[ORM\JoinColumn(name: 'refund_request_status_id', referencedColumnName: 'id')]
+    private ?RefundRequestStatus $RefundRequestStatus = null;
+
+    /**
+     * @var Collection<int, RefundRequestFile>
+     */
+    #[ORM\OneToMany(targetEntity: RefundRequestFile::class, mappedBy: 'RefundRequest', cascade: ['persist', 'remove'])]
+    #[ORM\OrderBy(['sort_no' => 'ASC'])]
+    private Collection $RefundRequestFiles;
+
+    public function __construct()
     {
-        #[ORM\Column(name: 'id', type: Types::INTEGER, options: ['unsigned' => true])]
-        #[ORM\Id]
-        #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-        private ?int $id = null;
+        $this->RefundRequestFiles = new ArrayCollection();
+    }
 
-        #[ORM\Column(name: 'quantity', type: Types::DECIMAL, precision: 10, scale: 0, options: ['default' => 0])]
-        private ?string $quantity = '0';
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
 
-        #[ORM\Column(name: 'reason', type: Types::TEXT)]
-        private ?string $reason = null;
+    public function setQuantity(string $quantity): self
+    {
+        $this->quantity = $quantity;
 
-        #[ORM\Column(name: 'admin_note', type: Types::TEXT, nullable: true)]
-        private ?string $admin_note = null;
+        return $this;
+    }
 
-        /**
-         * @var \DateTime
-         */
-        #[ORM\Column(name: 'create_date', type: Types::DATETIMETZ_MUTABLE)]
-        private $create_date;
+    public function getQuantity(): ?string
+    {
+        return $this->quantity;
+    }
 
-        /**
-         * @var \DateTime
-         */
-        #[ORM\Column(name: 'update_date', type: Types::DATETIMETZ_MUTABLE)]
-        private $update_date;
+    public function setReason(?string $reason): self
+    {
+        $this->reason = $reason;
 
-        #[ORM\ManyToOne(targetEntity: Order::class)]
-        #[ORM\JoinColumn(name: 'order_id', referencedColumnName: 'id')]
-        private ?Order $Order = null;
+        return $this;
+    }
 
-        #[ORM\ManyToOne(targetEntity: OrderItem::class)]
-        #[ORM\JoinColumn(name: 'order_item_id', referencedColumnName: 'id')]
-        private ?OrderItem $OrderItem = null;
+    public function getReason(): ?string
+    {
+        return $this->reason;
+    }
 
-        #[ORM\ManyToOne(targetEntity: Customer::class)]
-        #[ORM\JoinColumn(name: 'customer_id', referencedColumnName: 'id')]
-        private ?Customer $Customer = null;
+    public function setAdminNote(?string $adminNote): self
+    {
+        $this->admin_note = $adminNote;
 
-        #[ORM\ManyToOne(targetEntity: RefundRequestStatus::class)]
-        #[ORM\JoinColumn(name: 'refund_request_status_id', referencedColumnName: 'id')]
-        private ?RefundRequestStatus $RefundRequestStatus = null;
+        return $this;
+    }
 
-        /**
-         * @var Collection<int, RefundRequestFile>
-         */
-        #[ORM\OneToMany(targetEntity: RefundRequestFile::class, mappedBy: 'RefundRequest', cascade: ['persist', 'remove'])]
-        #[ORM\OrderBy(['sort_no' => 'ASC'])]
-        private Collection $RefundRequestFiles;
+    public function getAdminNote(): ?string
+    {
+        return $this->admin_note;
+    }
 
-        public function __construct()
-        {
-            $this->RefundRequestFiles = new ArrayCollection();
+    public function setCreateDate(\DateTime $createDate): self
+    {
+        $this->create_date = $createDate;
+
+        return $this;
+    }
+
+    public function getCreateDate(): ?\DateTime
+    {
+        return $this->create_date;
+    }
+
+    public function setUpdateDate(\DateTime $updateDate): self
+    {
+        $this->update_date = $updateDate;
+
+        return $this;
+    }
+
+    public function getUpdateDate(): ?\DateTime
+    {
+        return $this->update_date;
+    }
+
+    public function setOrder(?Order $order = null): self
+    {
+        $this->Order = $order;
+
+        return $this;
+    }
+
+    public function getOrder(): ?Order
+    {
+        return $this->Order;
+    }
+
+    public function setOrderItem(?OrderItem $orderItem = null): self
+    {
+        $this->OrderItem = $orderItem;
+
+        return $this;
+    }
+
+    public function getOrderItem(): ?OrderItem
+    {
+        return $this->OrderItem;
+    }
+
+    public function setCustomer(?Customer $customer = null): self
+    {
+        $this->Customer = $customer;
+
+        return $this;
+    }
+
+    public function getCustomer(): ?Customer
+    {
+        return $this->Customer;
+    }
+
+    public function setRefundRequestStatus(?RefundRequestStatus $refundRequestStatus = null): self
+    {
+        $this->RefundRequestStatus = $refundRequestStatus;
+
+        return $this;
+    }
+
+    public function getRefundRequestStatus(): ?RefundRequestStatus
+    {
+        return $this->RefundRequestStatus;
+    }
+
+    /**
+     * @return Collection<int, RefundRequestFile>
+     */
+    public function getRefundRequestFiles(): Collection
+    {
+        return $this->RefundRequestFiles;
+    }
+
+    public function addRefundRequestFile(RefundRequestFile $refundRequestFile): self
+    {
+        if (!$this->RefundRequestFiles->contains($refundRequestFile)) {
+            $this->RefundRequestFiles[] = $refundRequestFile;
+            $refundRequestFile->setRefundRequest($this);
         }
 
-        public function getId(): ?int
-        {
-            return $this->id;
+        return $this;
+    }
+
+    public function removeRefundRequestFile(RefundRequestFile $refundRequestFile): bool
+    {
+        if (!$this->RefundRequestFiles->removeElement($refundRequestFile)) {
+            return false;
+        }
+        if ($refundRequestFile->getRefundRequest() === $this) {
+            $refundRequestFile->setRefundRequest();
         }
 
-        public function setQuantity(string $quantity): self
-        {
-            $this->quantity = $quantity;
-
-            return $this;
-        }
-
-        public function getQuantity(): ?string
-        {
-            return $this->quantity;
-        }
-
-        public function setReason(?string $reason): self
-        {
-            $this->reason = $reason;
-
-            return $this;
-        }
-
-        public function getReason(): ?string
-        {
-            return $this->reason;
-        }
-
-        public function setAdminNote(?string $adminNote): self
-        {
-            $this->admin_note = $adminNote;
-
-            return $this;
-        }
-
-        public function getAdminNote(): ?string
-        {
-            return $this->admin_note;
-        }
-
-        public function setCreateDate(\DateTime $createDate): self
-        {
-            $this->create_date = $createDate;
-
-            return $this;
-        }
-
-        public function getCreateDate(): ?\DateTime
-        {
-            return $this->create_date;
-        }
-
-        public function setUpdateDate(\DateTime $updateDate): self
-        {
-            $this->update_date = $updateDate;
-
-            return $this;
-        }
-
-        public function getUpdateDate(): ?\DateTime
-        {
-            return $this->update_date;
-        }
-
-        public function setOrder(?Order $order = null): self
-        {
-            $this->Order = $order;
-
-            return $this;
-        }
-
-        public function getOrder(): ?Order
-        {
-            return $this->Order;
-        }
-
-        public function setOrderItem(?OrderItem $orderItem = null): self
-        {
-            $this->OrderItem = $orderItem;
-
-            return $this;
-        }
-
-        public function getOrderItem(): ?OrderItem
-        {
-            return $this->OrderItem;
-        }
-
-        public function setCustomer(?Customer $customer = null): self
-        {
-            $this->Customer = $customer;
-
-            return $this;
-        }
-
-        public function getCustomer(): ?Customer
-        {
-            return $this->Customer;
-        }
-
-        public function setRefundRequestStatus(?RefundRequestStatus $refundRequestStatus = null): self
-        {
-            $this->RefundRequestStatus = $refundRequestStatus;
-
-            return $this;
-        }
-
-        public function getRefundRequestStatus(): ?RefundRequestStatus
-        {
-            return $this->RefundRequestStatus;
-        }
-
-        /**
-         * @return Collection<int, RefundRequestFile>
-         */
-        public function getRefundRequestFiles(): Collection
-        {
-            return $this->RefundRequestFiles;
-        }
-
-        public function addRefundRequestFile(RefundRequestFile $refundRequestFile): self
-        {
-            if (!$this->RefundRequestFiles->contains($refundRequestFile)) {
-                $this->RefundRequestFiles[] = $refundRequestFile;
-                $refundRequestFile->setRefundRequest($this);
-            }
-
-            return $this;
-        }
-
-        public function removeRefundRequestFile(RefundRequestFile $refundRequestFile): bool
-        {
-            if (!$this->RefundRequestFiles->removeElement($refundRequestFile)) {
-                return false;
-            }
-            if ($refundRequestFile->getRefundRequest() === $this) {
-                $refundRequestFile->setRefundRequest();
-            }
-
-            return true;
-        }
+        return true;
     }
 }

--- a/src/Eccube/Entity/RefundRequestFile.php
+++ b/src/Eccube/Entity/RefundRequestFile.php
@@ -17,137 +17,135 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Eccube\Repository\RefundRequestFileRepository;
 
-if (!class_exists(RefundRequestFile::class)) {
+/**
+ * RefundRequestFile
+ *
+ * 返品申請のエビデンスファイル（画像・動画）.
+ */
+#[ORM\Table(name: 'dtb_refund_request_file')]
+#[ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'discriminator_type', type: 'string', length: 255)]
+#[ORM\HasLifecycleCallbacks]
+#[ORM\Entity(repositoryClass: RefundRequestFileRepository::class)]
+class RefundRequestFile extends AbstractEntity
+{
+    #[ORM\Column(name: 'id', type: Types::INTEGER, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'file_name', type: Types::STRING, length: 255)]
+    private ?string $file_name = null;
+
+    #[ORM\Column(name: 'mime_type', type: Types::STRING, length: 100)]
+    private ?string $mime_type = null;
+
+    #[ORM\Column(name: 'file_size', type: Types::INTEGER, options: ['unsigned' => true])]
+    private ?int $file_size = null;
+
+    #[ORM\Column(name: 'sort_no', type: Types::SMALLINT, options: ['unsigned' => true, 'default' => 0])]
+    private ?int $sort_no = 0;
+
     /**
-     * RefundRequestFile
-     *
-     * 返品申請のエビデンスファイル（画像・動画）.
+     * @var \DateTime
      */
-    #[ORM\Table(name: 'dtb_refund_request_file')]
-    #[ORM\InheritanceType('SINGLE_TABLE')]
-    #[ORM\DiscriminatorColumn(name: 'discriminator_type', type: 'string', length: 255)]
-    #[ORM\HasLifecycleCallbacks]
-    #[ORM\Entity(repositoryClass: RefundRequestFileRepository::class)]
-    class RefundRequestFile extends AbstractEntity
+    #[ORM\Column(name: 'create_date', type: Types::DATETIMETZ_MUTABLE)]
+    private $create_date;
+
+    #[ORM\ManyToOne(targetEntity: RefundRequest::class, inversedBy: 'RefundRequestFiles')]
+    #[ORM\JoinColumn(name: 'refund_request_id', referencedColumnName: 'id')]
+    private ?RefundRequest $RefundRequest = null;
+
+    public function getId(): ?int
     {
-        #[ORM\Column(name: 'id', type: Types::INTEGER, options: ['unsigned' => true])]
-        #[ORM\Id]
-        #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-        private ?int $id = null;
+        return $this->id;
+    }
 
-        #[ORM\Column(name: 'file_name', type: Types::STRING, length: 255)]
-        private ?string $file_name = null;
+    public function setFileName(?string $fileName): self
+    {
+        $this->file_name = $fileName;
 
-        #[ORM\Column(name: 'mime_type', type: Types::STRING, length: 100)]
-        private ?string $mime_type = null;
+        return $this;
+    }
 
-        #[ORM\Column(name: 'file_size', type: Types::INTEGER, options: ['unsigned' => true])]
-        private ?int $file_size = null;
+    public function getFileName(): ?string
+    {
+        return $this->file_name;
+    }
 
-        #[ORM\Column(name: 'sort_no', type: Types::SMALLINT, options: ['unsigned' => true, 'default' => 0])]
-        private ?int $sort_no = 0;
+    public function setMimeType(?string $mimeType): self
+    {
+        $this->mime_type = $mimeType;
 
-        /**
-         * @var \DateTime
-         */
-        #[ORM\Column(name: 'create_date', type: Types::DATETIMETZ_MUTABLE)]
-        private $create_date;
+        return $this;
+    }
 
-        #[ORM\ManyToOne(targetEntity: RefundRequest::class, inversedBy: 'RefundRequestFiles')]
-        #[ORM\JoinColumn(name: 'refund_request_id', referencedColumnName: 'id')]
-        private ?RefundRequest $RefundRequest = null;
+    public function getMimeType(): ?string
+    {
+        return $this->mime_type;
+    }
 
-        public function getId(): ?int
-        {
-            return $this->id;
-        }
+    public function setFileSize(?int $fileSize): self
+    {
+        $this->file_size = $fileSize;
 
-        public function setFileName(?string $fileName): self
-        {
-            $this->file_name = $fileName;
+        return $this;
+    }
 
-            return $this;
-        }
+    public function getFileSize(): ?int
+    {
+        return $this->file_size;
+    }
 
-        public function getFileName(): ?string
-        {
-            return $this->file_name;
-        }
+    public function setSortNo(?int $sortNo): self
+    {
+        $this->sort_no = $sortNo;
 
-        public function setMimeType(?string $mimeType): self
-        {
-            $this->mime_type = $mimeType;
+        return $this;
+    }
 
-            return $this;
-        }
+    public function getSortNo(): ?int
+    {
+        return $this->sort_no;
+    }
 
-        public function getMimeType(): ?string
-        {
-            return $this->mime_type;
-        }
+    public function setCreateDate(\DateTime $createDate): self
+    {
+        $this->create_date = $createDate;
 
-        public function setFileSize(?int $fileSize): self
-        {
-            $this->file_size = $fileSize;
+        return $this;
+    }
 
-            return $this;
-        }
+    public function getCreateDate(): ?\DateTime
+    {
+        return $this->create_date;
+    }
 
-        public function getFileSize(): ?int
-        {
-            return $this->file_size;
-        }
+    public function setRefundRequest(?RefundRequest $refundRequest = null): self
+    {
+        $this->RefundRequest = $refundRequest;
 
-        public function setSortNo(?int $sortNo): self
-        {
-            $this->sort_no = $sortNo;
+        return $this;
+    }
 
-            return $this;
-        }
+    public function getRefundRequest(): ?RefundRequest
+    {
+        return $this->RefundRequest;
+    }
 
-        public function getSortNo(): ?int
-        {
-            return $this->sort_no;
-        }
+    /**
+     * ファイルが画像かどうか.
+     */
+    public function isImage(): bool
+    {
+        return str_starts_with((string) $this->mime_type, 'image/');
+    }
 
-        public function setCreateDate(\DateTime $createDate): self
-        {
-            $this->create_date = $createDate;
-
-            return $this;
-        }
-
-        public function getCreateDate(): ?\DateTime
-        {
-            return $this->create_date;
-        }
-
-        public function setRefundRequest(?RefundRequest $refundRequest = null): self
-        {
-            $this->RefundRequest = $refundRequest;
-
-            return $this;
-        }
-
-        public function getRefundRequest(): ?RefundRequest
-        {
-            return $this->RefundRequest;
-        }
-
-        /**
-         * ファイルが画像かどうか.
-         */
-        public function isImage(): bool
-        {
-            return str_starts_with((string) $this->mime_type, 'image/');
-        }
-
-        /**
-         * ファイルが動画かどうか.
-         */
-        public function isVideo(): bool
-        {
-            return str_starts_with((string) $this->mime_type, 'video/');
-        }
+    /**
+     * ファイルが動画かどうか.
+     */
+    public function isVideo(): bool
+    {
+        return str_starts_with((string) $this->mime_type, 'video/');
     }
 }


### PR DESCRIPTION
## 概要

#6891 の「Entity の `if (!class_exists())` ガード全廃」は #6895 で Entity 76 ファイルに適用済みですが、**その後にマージされた機能ブランチが古いパターンの Entity を持ち込み、4 ファイルで再発**していました。他の Entity と同じ形に揃えます。

| ファイル | 導入コミット |
| --- | --- |
| `src/Eccube/Entity/RateLimiter.php` | `6cf220b290` スロットリングのデータストレージ |
| `src/Eccube/Entity/RefundRequest.php` | `194534c624` 返品申請のデータ層 |
| `src/Eccube/Entity/RefundRequestFile.php` | `194534c624` 同上 |
| `src/Eccube/Entity/Master/RefundRequestStatus.php` | `194534c624` 同上 |

いずれの導入コミットも **#6895 のマージコミット `01866828fe` の祖先ではない**ため、#6895 の取りこぼしではなくマージ順による再発です。

## 変更内容

`if (!class_exists(X::class)) {` のラップを外し、本体を 4 スペース dedent しただけです。クラス定義・属性・メソッドの中身は一切変えていません。

## 安全性の根拠

#6891 の調査結果どおり、**コア Entity のガードは現行実装では機能していません**。

- `ReloadSafeAttributeDriver` がトークン解析でクラス名を抽出し、原ソースを require せずに新規 Proxy を改名して require するため、ガードに依存していない
- `EntityProxyService::scanTraits()` が原ソースを `require_once` する対象は `app/Customize/Entity` と有効プラグインの `Entity` のみで、`src/Eccube/Entity` は含まれない
- #6895 が同一の変更を 76 ファイルへ適用し、4.4 で 2026-07-15 から問題なく稼働している

## 動作確認

ローカル（Docker / PostgreSQL）で確認しました。

- `php -l` … 4 ファイルすべて構文エラーなし
- `vendor/bin/phpstan analyse src`（level 6）… **0 件**
- `vendor/bin/rector process --dry-run` … **差分ゼロ**
- `vendor/bin/php-cs-fixer fix` … 4 ファイルすべて違反なし
- `bin/console eccube:generate:proxies` … 正常終了
- `bin/console doctrine:schema:update --dump-sql` … **`dtb_refund_request` / `dtb_refund_request_file` / `mtb_refund_request_status` / `dtb_rate_limiter` に関する SQL は 0 件**（＝4 エンティティのマッピングは変更前と同一）
- 管理画面・店頭ともレスポンス正常（admin 302 / front 200）
- PHPUnit **97 テスト green**
  - `RefundRequestRepositoryTest` / `RefundRequestStateMachineTest` / `RefundRequestServiceTest`（60 tests, 126 assertions）
  - `RefundRequestControllerTest` / `RateLimiterListenerTest` / `SearchRefundRequestTypeTest` / `RefundRequestTypeTest`（37 tests, 83 assertions）

なお本環境には Entity を trait 拡張するプラグインを導入していないため、`app/proxy/entity/` の生成物は 0 件で、**Proxy 生成経路そのものは実走していません**。この経路はコア Entity を対象に含まないこと（上記）と、#6895 の実績で担保されると判断しています。

## 残る作業

#6891 本体（ガードを再発させない仕組み、およびプラグイン/Customize 側の `scanTraits` 依存の解消）は本 PR の範囲外です。そのため #6891 はクローズせず `refs` にしています。

Refs #6891


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 返金申請関連のステータス、申請情報、添付ファイル、およびレート制限機能の内部構成を整理しました。
  * 既存のデータ項目、状態、関連設定、公開メソッドの動作は維持されています。
  * エンドユーザーが利用する機能や画面上の挙動に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->