### PR TITLE
test: CalendarControllerTest を実行日に依存しないよう修正する (#6390)

### DIFF
--- a/tests/Eccube/Tests/Web/Block/CalendarControllerTest.php
+++ b/tests/Eccube/Tests/Web/Block/CalendarControllerTest.php
@@ -99,7 +99,7 @@ final class CalendarControllerTest extends AbstractWebTestCase
         $this->verify();
     }
 
-    #[DataProvider('provideTodayForWeekendHolidaysStyle')]
+    #[DataProvider(methodName: 'provideTodayForWeekendHolidaysStyle')]
     public function testWeekendHolidaysStyle(string $today): void
     {
         Carbon::setTestNow($today);
@@ -146,19 +146,17 @@ final class CalendarControllerTest extends AbstractWebTestCase
     /**
      * 月初の曜日と, 今日が土日と重なるかの組み合わせを網羅する.
      *
-     * @return array<string, array{string}>
+     * @return \Iterator<string, array{string}>
      */
-    public static function provideTodayForWeekendHolidaysStyle(): array
+    public static function provideTodayForWeekendHolidaysStyle(): \Iterator
     {
-        return [
-            '月初が日曜・今日は平日' => ['2025-06-03'],
-            '月初が日曜・今日が第一日曜(月初と同日)' => ['2025-06-01'],
-            '月初が日曜・今日が第一土曜' => ['2025-06-07'],
-            '月初が土曜・今日が第一土曜(月初と同日)' => ['2025-11-01'],
-            '月初が土曜・今日が第一日曜' => ['2025-11-02'],
-            '月初が水曜・今日は平日' => ['2025-10-15'],
-            '月初が日曜で28日まで・今日は平日' => ['2026-02-04'],
-        ];
+        yield '月初が日曜・今日は平日' => ['2025-06-03'];
+        yield '月初が日曜・今日が第一日曜(月初と同日)' => ['2025-06-01'];
+        yield '月初が日曜・今日が第一土曜' => ['2025-06-07'];
+        yield '月初が土曜・今日が第一土曜(月初と同日)' => ['2025-11-01'];
+        yield '月初が土曜・今日が第一日曜' => ['2025-11-02'];
+        yield '月初が水曜・今日は平日' => ['2025-10-15'];
+        yield '月初が日曜で28日まで・今日は平日' => ['2026-02-04'];
     }
 
     public function testTodayStyle()

--- a/tests/Eccube/Tests/Web/Block/CalendarControllerTest.php
+++ b/tests/Eccube/Tests/Web/Block/CalendarControllerTest.php
@@ -163,10 +163,10 @@ final class CalendarControllerTest extends AbstractWebTestCase
 
     public function testTodayStyle()
     {
-        $today = new \DateTime();
-
+        // 「今日」の判定は CalendarController が Carbon::now() で行うため, 期待値も Carbon に合わせる.
+        // new \DateTime() だと Carbon::setTestNow() で時刻を固定したときに実時刻とずれて破綻する.
         $crawler = $this->client->request(Request::METHOD_GET, $this->generateUrl('block_calendar'));
-        $this->expected = $today->format('j');
+        $this->expected = Carbon::now()->format('j');
         $this->actual = $crawler->filter('#today')->text();
         $this->verify();
     }

--- a/tests/Eccube/Tests/Web/Block/CalendarControllerTest.php
+++ b/tests/Eccube/Tests/Web/Block/CalendarControllerTest.php
@@ -159,7 +159,7 @@ final class CalendarControllerTest extends AbstractWebTestCase
         yield '月初が日曜で28日まで・今日は平日' => ['2026-02-04'];
     }
 
-    public function testTodayStyle()
+    public function testTodayStyle(): void
     {
         // 「今日」の判定は CalendarController が Carbon::now() で行うため, 期待値も Carbon に合わせる.
         // new \DateTime() だと Carbon::setTestNow() で時刻を固定したときに実時刻とずれて破綻する.

--- a/tests/Eccube/Tests/Web/Block/CalendarControllerTest.php
+++ b/tests/Eccube/Tests/Web/Block/CalendarControllerTest.php
@@ -18,10 +18,20 @@ namespace Eccube\Tests\Web\Block;
 use Carbon\Carbon;
 use Eccube\Entity\Calendar;
 use Eccube\Tests\Web\AbstractWebTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Request;
 
 final class CalendarControllerTest extends AbstractWebTestCase
 {
+    protected function tearDown(): void
+    {
+        // Carbon::setTestNow() はプロセス全体に効くため, 後続のテストへ漏れないよう必ず戻す.
+        // テストメソッドの末尾で戻すとアサーション失敗時に到達せず, 以降のテストを巻き込む.
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
     public function testRoutingCalendar()
     {
         $this->client->request(Request::METHOD_GET, '/block/calendar');
@@ -89,48 +99,66 @@ final class CalendarControllerTest extends AbstractWebTestCase
         $this->verify();
     }
 
-    public function testWeekendHolidaysStyle()
+    #[DataProvider('provideTodayForWeekendHolidaysStyle')]
+    public function testWeekendHolidaysStyle(string $today): void
     {
-        // 月初日を取得
-        $firstDayOfThisMonth = Carbon::now()->firstOfMonth();
+        Carbon::setTestNow($today);
 
-        // 月初の日曜日を取得
-        $sunday = null;
-        $sundayDayOfWeekNumber = $firstDayOfThisMonth->dayOfWeek;
-        if ($sundayDayOfWeekNumber == 0) { // Sun
-            $sunday = $firstDayOfThisMonth->copy();
-        } elseif ($sundayDayOfWeekNumber == 1) { // Mon
-            $sunday = $firstDayOfThisMonth->copy()->addDays(6);
-        } elseif ($sundayDayOfWeekNumber == 2) { // Tue
-            $sunday = $firstDayOfThisMonth->copy()->addDays(5);
-        } elseif ($sundayDayOfWeekNumber == 3) { // Wed
-            $sunday = $firstDayOfThisMonth->copy()->addDays(4);
-        } elseif ($sundayDayOfWeekNumber == 4) { // Thu
-            $sunday = $firstDayOfThisMonth->copy()->addDays(3);
-        } elseif ($sundayDayOfWeekNumber == 5) { // Fri
-            $sunday = $firstDayOfThisMonth->copy()->addDays(2);
-        } elseif ($sundayDayOfWeekNumber == 6) { // Sat
-            $sunday = $firstDayOfThisMonth->copy()->addDays(1);
-        }
-        // 日曜の前日が今月かどうかで月初の土曜日を取得
-        $saturday = null;
-        if ($sunday->copy()->addDays(-1)->isCurrentMonth()) {
-            $saturday = $sunday->copy()->addDays(-1);
-        } else {
-            $saturday = $sunday->copy()->addDays(6);
-        }
+        // 当月の最初の土曜日・日曜日を取得
+        $saturday = Carbon::now()->firstOfMonth(Carbon::SATURDAY);
+        $sunday = Carbon::now()->firstOfMonth(Carbon::SUNDAY);
+
+        // 期待値と CSS セレクタを同じ変数から組み立てるため, 日付の取得自体が誤っていても
+        // アサーションは通ってしまう. 取得結果が本当に土日で当月かをここで担保する.
+        $this->assertTrue($saturday->isSaturday(), '当月の最初の土曜日が取得できていない');
+        $this->assertTrue($sunday->isSunday(), '当月の最初の日曜日が取得できていない');
+        $this->assertLessThanOrEqual(7, (int) $saturday->format('j'), '最初の土曜日は 7 日以内のはず');
+        $this->assertLessThanOrEqual(7, (int) $sunday->format('j'), '最初の日曜日は 7 日以内のはず');
 
         $crawler = $this->client->request(Request::METHOD_GET, $this->generateUrl('block_calendar'));
 
         // 土曜日の確認
         $this->expected = $saturday->format('j');
-        $this->actual = $crawler->filter('#this-month-holiday-'.$this->expected)->text();
+        $this->actual = $crawler->filter($this->weekendCellSelector($saturday))->text();
         $this->verify();
 
         // 日曜日の確認
         $this->expected = $sunday->format('j');
-        $this->actual = $crawler->filter('#this-month-holiday-'.$this->expected)->text();
+        $this->actual = $crawler->filter($this->weekendCellSelector($sunday))->text();
         $this->verify();
+    }
+
+    /**
+     * 土日のセルを指す CSS セレクタを返す.
+     *
+     * 対象日が今日の場合, テンプレートは #this-month-holiday-X より #today を優先するため ID が変わる.
+     * (このテストでは定休日を登録していないので #today-and-holiday にはならない)
+     *
+     * @see src/Eccube/Resource/template/default/Block/calendar.twig
+     */
+    private function weekendCellSelector(Carbon $day): string
+    {
+        return $day->isSameDay(Carbon::now())
+            ? '#today'
+            : '#this-month-holiday-'.$day->format('j');
+    }
+
+    /**
+     * 月初の曜日と, 今日が土日と重なるかの組み合わせを網羅する.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function provideTodayForWeekendHolidaysStyle(): array
+    {
+        return [
+            '月初が日曜・今日は平日' => ['2025-06-03'],
+            '月初が日曜・今日が第一日曜(月初と同日)' => ['2025-06-01'],
+            '月初が日曜・今日が第一土曜' => ['2025-06-07'],
+            '月初が土曜・今日が第一土曜(月初と同日)' => ['2025-11-01'],
+            '月初が土曜・今日が第一日曜' => ['2025-11-02'],
+            '月初が水曜・今日は平日' => ['2025-10-15'],
+            '月初が日曜で28日まで・今日は平日' => ['2026-02-04'],
+        ];
     }
 
     public function testTodayStyle()


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Closes #6390

`CalendarControllerTest` が **実行日に依存して失敗する** 問題を修正します。

`testWeekendHolidaysStyle` は当月の第一土曜日・第一日曜日のセルを `#this-month-holiday-X` で探していますが、
その日が「今日」と重なると `calendar.twig` が `#today` を優先するため要素が見つからず、
`InvalidArgumentException: The current node list is empty.` で落ちます。

Issue には「月初日が日曜日の場合の第一土曜日」とありますが、**実測すると月初の曜日に関係なく
第一土曜日と第一日曜日の 2 日**で発生します（毎月 2 日）。修正前のコードに時刻固定だけを入れて確認した結果:

| 固定日 | 曜日 | 結果 |
|---|---|---|
| 2025-06-01 | 日（第一日曜） | ERROR |
| 2025-06-07 | 土（第一土曜） | ERROR |
| 2025-06-08 | 日（第二日曜） | OK |
| 2025-06-02 | 月 | OK |

## 方針(Policy)

Issue の「修正案」に沿いつつ、次の 4 点で構成しました。

1. **`Carbon::setTestNow()` と `#[DataProvider]` で実行日を固定する** — 月初の曜日 × 今日が土日と重なるか、の組み合わせを 7 パターン網羅します。`CalendarController` に `loopCount === 28` の専用分岐があるため、2 月がちょうど 28 日で日曜始まりのケースも含めています。
2. **対象日が今日のときは `#today` を参照する** — `calendar.twig` の ID 優先順位（`#today-and-holiday` → `#today` → `#this-month-holiday-X`）に合わせます。
3. **`setTestNow()` のリセットは `tearDown()` で行う** — Issue の修正案にある「メソッド末尾でリセット」は、途中のアサーションが失敗すると到達せず、同一プロセスの後続テストを巻き込みます。実際に再現用パッチを当てた状態でクラス全体を流したところ、`testWeekendHolidaysStyle` ではなく `testTodayStyle` が失敗しました。
4. **月初からの曜日計算を `firstOfMonth(曜日)` に置き換える** — 元の `if/elseif` 7 分岐と「日曜の前日が今月かどうか」の判定が不要になります。

## 実装に関する補足(Appendix)

**ガード用のアサーションを追加しています。** このテストは期待値と CSS セレクタを同じ変数から組み立てているため、
日付の取得自体が誤っていてもアサーションが通ってしまいます（元のコードからある性質です）。
計算方法を置き換えた以上そのままにはできないので、取得結果が本当に土曜／日曜で 7 日以内かを検証しています。

**`testTodayStyle` も併せて修正しています。** こちらは Issue の範囲外ですが、期待値を `new \DateTime()` で
組み立てており、描画側の `Carbon::now()` と不揃いでした。通常実行では一致するため表面化しませんが、
**時刻を固定した瞬間に必ず壊れます**。同クラスの他のテストは既に `Carbon::now()` を使っており、これだけが例外でした。

**修正範囲は実測で決めました。** `setUp()` に一時的なハーネスを入れて外から時刻を与え、
2025-06〜2026-03 の各月について 1 日 / 月末 / 月末前日 の計 30 日でクラス全体を実行したところ、
**全日で落ちるのは `testTodayStyle` だけ**でした。`testHolidayStyle` の土日回避ロジックは
見た目こそ複雑ですが月末・年境界・2 月末を含む全日で正しく動いていたため、**手を付けていません**。

## テスト（Test)

コードスタイル / 静的解析 / リファクタ規約 / ユニットテストの 4 ゲートをローカルで通しています。

| ゲート | 結果 |
|---|---|
| php-cs-fixer | 0 件 |
| phpstan (level 6, `src`) | No errors |
| rector | Rector is done!（`YieldDataProviderRector` / `AttributeArgumentsOrderRector` に追従済み） |
| phpunit `tests/Eccube/Tests/Web/Block/` | OK (17 tests, 66 assertions) |

**修正が実際にゲートとして機能するかを、部分ごとに外して確認しました。**

| 実験 | 結果 |
|---|---|
| セレクタ切替（`#today` 対応）を外す | 土日が今日と重なる **4 ケースだけ** ERROR、平日 3 ケースは OK |
| `tearDown()` のリセットを外す | `testTodayStyle` が失敗（`setTestNow` の漏れ） |

**時刻を固定した通し確認も行っています。**

- 2025-06〜2026-03 の各月 1 日 / 月末 / 月末前日 / 15 日 = **32 日で全テスト緑**
- ランダム実行順（seed 2 種）で緑 — `tearDown()` のリセットが効いていること
- `--filter` 単体実行で緑 — 他テストへの依存がないこと
- 連続 2 回実行で緑 — `dtb_calendar` は実行前後とも 0 件で汚染なし

## 相談（Discussion）

- コミットは「Issue 本体の修正」「`testTodayStyle` の整合修正」「rector 追従」の 3 本に分けています。まとめたい場合は squash してください。
- `testHolidayStyle` は上記のとおり実測では全日通るため今回は触っていません。日付固定に揃えるべきかはご判断ください。

## マイナーバージョン互換性保持のための制限事項チェックリスト

テストコードのみの変更で、`src/` には一切手を入れていません。

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * カレンダーの週末・休日表示について、月初を含む複数の日付条件で検証できるようになりました。
  * テスト後の日付設定を適切に解除し、テスト間の影響を防止しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
