### PR TITLE
ci(agent-commerce): 結合 E2E の依存プラグイン参照を EC-CUBE org の 4.4 ブランチへ切り替える

### DIFF
--- a/.github/workflows/agentic-commerce-e2e.yml
+++ b/.github/workflows/agentic-commerce-e2e.yml
@@ -4,21 +4,21 @@ name: Agentic Commerce E2E
 ## 結合を検証する E2E。Job A スモーク + Job B checkout (OAuth2 認証 + create/update/complete)。
 ##
 ## 通常 CI (main.yml) から workflow_call で呼び出され、push/PR で自動実行される。
-## workflow_dispatch では fork ブランチや run_payment を手動指定できる。
-## 自動実行時は fork の feature/agentic-commerce ブランチ・run_payment=true を既定にする。
-## (プラグインの EC-CUBE org 移行後、参照 URL/ブランチは別 PR で org 参照へ差し替える。)
+## workflow_dispatch では参照ブランチや run_payment を手動指定できる。
+## 自動実行時は EC-CUBE org の 4.4 ブランチ・run_payment=true を既定にする
+## (eccube-api4#191 / sample-payment-plugin#54 が 4.4 へマージ済み)。
 
 on:
   workflow_dispatch:
     inputs:
       api4_ref:
-        description: 'eccube-api4 (nanasess fork) のブランチ'
+        description: 'EC-CUBE/eccube-api4 のブランチ'
         type: string
-        default: 'feature/agentic-commerce'
+        default: '4.4'
       sample_ref:
-        description: 'sample-payment-plugin (nanasess fork) のブランチ'
+        description: 'EC-CUBE/sample-payment-plugin のブランチ'
         type: string
-        default: 'feature/agentic-commerce'
+        default: '4.4'
       run_payment:
         description: 'complete (決済実行) まで通す'
         type: boolean
@@ -28,11 +28,11 @@ on:
       api4_ref:
         type: string
         required: false
-        default: 'feature/agentic-commerce'
+        default: '4.4'
       sample_ref:
         type: string
         required: false
-        default: 'feature/agentic-commerce'
+        default: '4.4'
       run_payment:
         type: boolean
         required: false
@@ -42,9 +42,9 @@ permissions:
   contents: read
 
 env:
-  ## VCS リポジトリ (Packagist 未公開の開発期間は fork を VCS 経由で引く)
-  API44_VCS: 'https://github.com/nanasess/eccube-api4.git'
-  SAMPLEPAYMENT44_VCS: 'https://github.com/nanasess/sample-payment-plugin.git'
+  ## リポジトリ (Packagist 未公開の開発期間は 4.4 ブランチを clone して引く)
+  API44_VCS: 'https://github.com/EC-CUBE/eccube-api4.git'
+  SAMPLEPAYMENT44_VCS: 'https://github.com/EC-CUBE/sample-payment-plugin.git'
 
 jobs:
   ## ───────────────────────────────────────────────────────────────────────
@@ -142,14 +142,15 @@ jobs:
           bin/console eccube:fixtures:load --env=dev
 
       ## ── 結合の核心: 本体に api44 と samplepayment44 を共存インストール ──
-      ## fork のデフォルトブランチが旧名 (ec-cube/api・ec-cube/SamplePayment) のため、composer の
-      ## VCS ドライバはデフォルトブランチから決まる名前で repo をキーする → 新名 (api44/samplepayment44)
-      ## の feature ブランチが名前不一致でスキップされ "not found" になる。これを避けるため、
-      ## 対象ブランチを clone して **path リポジトリ**として参照する (clone 先 composer.json の名前で解決)。
+      ## 両リポジトリのデフォルトブランチは 4.2 系で、composer 名も旧名 (ec-cube/api42・
+      ## ec-cube/samplepayment42)。composer の VCS ドライバはデフォルトブランチから決まる名前で
+      ## repo をキーするため、新名 (api44/samplepayment44) の 4.4 ブランチが名前不一致で
+      ## スキップされ "not found" になる。これを避けるため、対象ブランチを clone して
+      ## **path リポジトリ**として参照する (clone 先 composer.json の名前で解決)。
       - name: Clone plugins & register path repositories
         env:
-          API4_REF: ${{ inputs.api4_ref || 'feature/agentic-commerce' }}
-          SAMPLE_REF: ${{ inputs.sample_ref || 'feature/agentic-commerce' }}
+          API4_REF: ${{ inputs.api4_ref || '4.4' }}
+          SAMPLE_REF: ${{ inputs.sample_ref || '4.4' }}
         run: |
           git clone --depth 1 --branch "${API4_REF}" "${API44_VCS}" "${RUNNER_TEMP}/api44"
           git clone --depth 1 --branch "${SAMPLE_REF}" "${SAMPLEPAYMENT44_VCS}" "${RUNNER_TEMP}/samplepayment44"
@@ -327,9 +328,9 @@ jobs:
           DATABASE_CHARSET: ${{ matrix.database_charset }}
           ECCUBE_AUTH_MAGIC: ${{ env.ECCUBE_AUTH_MAGIC }}
           ## untrusted な可能性のある dispatch 入力は env 経由で受ける
-          API4_REF: ${{ inputs.api4_ref || 'feature/agentic-commerce' }}
-          SAMPLE_REF: ${{ inputs.sample_ref || 'feature/agentic-commerce' }}
-          ## 公開フォークの VCS 解決に GitHub トークンを渡す (レート制限回避)
+          API4_REF: ${{ inputs.api4_ref || '4.4' }}
+          SAMPLE_REF: ${{ inputs.sample_ref || '4.4' }}
+          ## 依存パッケージの dist 取得に GitHub トークンを渡す (レート制限回避)
           COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GITHUB_TOKEN }}"}}'
         run: |
           echo "APP_ENV=${APP_ENV}" > .env
@@ -339,7 +340,7 @@ jobs:
           bin/console doctrine:database:create --env=dev
           bin/console doctrine:schema:create --env=dev
           bin/console eccube:fixtures:load --env=dev
-          ## fork デフォルトブランチの旧名問題を避けるため path リポジトリで取り込む (Job A と同方針)
+          ## デフォルトブランチ (4.2 系) の旧名問題を避けるため path リポジトリで取り込む (Job A と同方針)
           git clone --depth 1 --branch "${API4_REF}" "${API44_VCS}" "${RUNNER_TEMP}/api44"
           git clone --depth 1 --branch "${SAMPLE_REF}" "${SAMPLEPAYMENT44_VCS}" "${RUNNER_TEMP}/samplepayment44"
           ## api44 は extra.id を持たないため path インストール用にダミー id を注入 (Job A と同方針)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
     # plugin-test と並列で実行する (同じ needs)。
     needs: [ unit-test, e2e-test ]
     # 本体 ↔ eccube-api4 ↔ sample-payment-plugin の結合 E2E。
-    # 依存プラグインは fork の feature/agentic-commerce を既定参照 (org 移行後に別 PR で差し替え)。
+    # 依存プラグインは EC-CUBE org の 4.4 ブランチを既定参照 (eccube-api4#191 / sample-payment-plugin#54)。
     uses: ./.github/workflows/agentic-commerce-e2e.yml
   dockerbuild:
     uses: ./.github/workflows/dockerbuild.yml

--- a/e2e/agent/README.md
+++ b/e2e/agent/README.md
@@ -1,8 +1,16 @@
 # Agentic Commerce E2E — PHP エージェントシミュレータ
 
-本体 (ACP/UCP) ↔ [eccube-api4](https://github.com/EC-CUBE/eccube-api4) (OAuth2) ↔ sample-payment-plugin (決済ハンドラ) の結合を、
+本体 (ACP/UCP) ↔ [eccube-api4](https://github.com/EC-CUBE/eccube-api4) (OAuth2) ↔
+[sample-payment-plugin](https://github.com/EC-CUBE/sample-payment-plugin) (決済ハンドラ) の結合を、
 「AI エージェント役」のクライアントが **外部 HTTP** で検証するハーネス。CI からは
-[`.github/workflows/agentic-commerce-e2e.yml`](../../.github/workflows/agentic-commerce-e2e.yml) (`workflow_dispatch`) が呼び出す。
+[`.github/workflows/agentic-commerce-e2e.yml`](../../.github/workflows/agentic-commerce-e2e.yml) が呼び出す
+(`main.yml` からの `workflow_call` で push/PR 時に自動実行。`workflow_dispatch` では参照ブランチを手動指定できる)。
+
+依存プラグインは両リポジトリの **`4.4` ブランチ**を参照する
+([eccube-api4#191](https://github.com/EC-CUBE/eccube-api4/pull/191) /
+[sample-payment-plugin#54](https://github.com/EC-CUBE/sample-payment-plugin/pull/54) がマージ済み)。
+どちらもデフォルトブランチは 4.2 系 (composer 名が旧名の `ec-cube/api42` / `ec-cube/samplepayment42`) のため、
+CI は `4.4` ブランチを clone して composer の **path リポジトリ**として取り込む。
 
 ## 構成
 
@@ -19,8 +27,10 @@
    (`acp_checkout_enabled` ゲート) の生存・形状 (秘密鍵非混入・`merchant_id` 非混入等) を検証。
    api4 / 決済ハンドラに非依存なので **day 1 から green**。
 2. **checkout フロー** — `AGENT_E2E_TOKEN` がある時のみ。OAuth2 Bearer で ACP 5 エンドポイントを叩く。
-   トークン発行は **eccube-api4#188 (client_credentials + `acp:`/`ucp:` scope)** と決済ハンドラの
-   landing が前提。未 landing の間は `AGENT_E2E_TOKEN` が空のまま → フェーズ 1 のみ実行して正常終了。
+   トークン発行は **eccube-api4 の client_credentials + `acp:`/`ucp:` scope** に依存する
+   (#188 / #191 で 4.4 に landing 済み)。CI では `/token` から実トークンを発行するため常に実行される。
+   ローカルで `AGENT_E2E_TOKEN` を省いた場合はフェーズ 1 のみ実行して正常終了する
+   (discovery だけ確認したいときの意図的なゲート)。
 
 ### `ucp-checkout.php` (UCP)
 
@@ -37,19 +47,21 @@
 bin/console dbal:run-sql "UPDATE dtb_base_info SET acp_checkout_enabled = 1, ucp_checkout_enabled = 1"
 bin/console cache:pool:clear --all
 
-# 2. ビルトインサーバ起動 (EC-CUBE は public-dir="." のため codeception/router.php を router にする)
-php -S 127.0.0.1:8000 codeception/router.php &
+# 2. ビルトインサーバ起動。EC-CUBE は public-dir="." のため front controller はルートの index.php。
+#    codeception/router.php は GET に対し false を返し、静的フォールバック挙動が PHP バージョン依存で
+#    404 になり得るため、index.php を直接 router にして確実に kernel へ通す (CI と同じ方針)。
+php -S 127.0.0.1:8000 index.php &
 
 # 3. ACP discovery-only (トークン無し)
 BASE_URL=http://127.0.0.1:8000 php e2e/agent/acp-checkout.php
 
-# 3'. ACP checkout 込み (api4#188 + 決済ハンドラ landing 後)
+# 3'. ACP checkout 込み (Api44 で client_credentials トークンを発行して渡す)
 BASE_URL=http://127.0.0.1:8000 AGENT_E2E_TOKEN=<bearer> php e2e/agent/acp-checkout.php
 
 # 4. UCP checkout セッションのみ (署名なし・api4 非依存)
 BASE_URL=http://127.0.0.1:8000 php e2e/agent/ucp-checkout.php
 
-# 4'. UCP complete 込み (決済ハンドラ landing 後)
+# 4'. UCP complete 込み (SamplePayment44 の UCP 決済ハンドラを使う)
 BASE_URL=http://127.0.0.1:8000 AGENT_E2E_PAYMENT_READY=true php e2e/agent/ucp-checkout.php
 ```
 
@@ -59,9 +71,9 @@ BASE_URL=http://127.0.0.1:8000 AGENT_E2E_PAYMENT_READY=true php e2e/agent/ucp-ch
 |---|---|---|
 | `BASE_URL` | `http://127.0.0.1:8000` | 稼働中サーバ |
 | `AGENT_E2E_TOKEN` | (空) | OAuth2 Bearer (ACP のみ)。空ならフェーズ 2 を skip |
-| `AGENT_E2E_PAYMENT_READY` | `false` | `true` の時のみ complete (決済) を実行。ACP/UCP 共通 |
-| `AGENT_E2E_ITEM_ID` | ACP=`1` / UCP=`2` | checkout で使う ProductClass id (UCP の `1` は visible=0 の規格) |
+| `AGENT_E2E_PAYMENT_READY` | `false` | `true` の時のみ complete (決済) を実行。ACP/UCP 共通。CI は既定 `true` (`run_payment`) |
+| `AGENT_E2E_ITEM_ID` | `2` (ACP/UCP 共通) | checkout で使う ProductClass id。`1` は fixtures の visible=0 なダミー規格で purchase flow が明細を除去するため使わない |
 
-> **注意**: このブランチ (`feature/agentic-commerce-e2e`) は ACP/UCP/feed/共通基盤を 1 本に集約した
-> **テスト専用の統合ブランチ**。各機能は個別 PR (#6802/#6815/#6825/#6837/#6843) で 4.4 へマージされる。
-> E2E 成果物は 4.4 マージ後に専用 PR で移送する。
+> **経緯**: エージェントコマースのコア実装は共通基盤 (#6802) / feed・catalog・discovery (#6815) /
+> CheckoutSession 中核 (#6825) / UCP checkout (#6837) / ACP checkout (#6843) に分割して 4.4 へマージ済み。
+> 本ハーネスと通常 CI への統合は #6872 で取り込まれた。

--- a/e2e/agent/acp-checkout.php
+++ b/e2e/agent/acp-checkout.php
@@ -23,8 +23,8 @@
  *   1. discovery スモーク   … 常に実行 (api4/決済ハンドラ非依存)。/.well-known/{ucp,acp.json} の生存と形状。
  *   2. checkout フロー      … AGENT_E2E_TOKEN がある時のみ。create→update→get→complete。
  *
- * AGENT_E2E_TOKEN が空 (api4#188 の client_credentials/scope 未 landing) のときは
- * フェーズ 1 のみ実行して正常終了する (= CI を赤にしない skip ゲート)。
+ * AGENT_E2E_TOKEN が空のときはフェーズ 1 のみ実行して正常終了する
+ * (discovery だけ確認したいローカル実行向けの skip ゲート。CI は /token で実トークンを発行するため常に通す)。
  *
  * env:
  *   BASE_URL          … 稼働中サーバ (既定 http://127.0.0.1:8000)
@@ -115,7 +115,7 @@ try {
 // フェーズ 2: checkout フロー (AGENT_E2E_TOKEN がある時のみ)
 // ─────────────────────────────────────────────────────────────────────────
 if ('' === $token) {
-    fwrite(STDOUT, "\n\033[33m⏸ Phase 2 (checkout) skipped:\033[0m AGENT_E2E_TOKEN 未設定 (api4#188 + 決済ハンドラ landing 待ち)\n");
+    fwrite(STDOUT, "\n\033[33m⏸ Phase 2 (checkout) skipped:\033[0m AGENT_E2E_TOKEN 未設定 (Api44 で client_credentials トークンを発行して渡す)\n");
     fwrite(STDOUT, "\n\033[32mPASS\033[0m ({$passed} assertions, discovery-only)\n");
     exit(0);
 }
@@ -152,9 +152,9 @@ function containsKey(mixed $data, string $key): bool
 /**
  * ACP checkout 5 エンドポイントを順に叩く (create→update→get→complete)。
  *
- * TODO(api4#188 + 決済ハンドラ): トークン発行が有効化されたら payload を
- * {@link \Eccube\Service\AgentCommerce\Acp\AcpCheckoutSessionMapper} の契約に対して
+ * TODO: payload を {@link \Eccube\Service\AgentCommerce\Acp\AcpCheckoutSessionMapper} の契約に対して
  * 実データで突き合わせる (本関数の payload は ACP 2026-04-17 spec ベースの暫定形)。
+ * トークン発行側の前提 (client_credentials + scope) は eccube-api4 4.4 で解消済み。
  */
 function runCheckout(HttpClientInterface $client, string $token, int $itemId, bool $paymentReady): void
 {
@@ -202,10 +202,10 @@ function runCheckout(HttpClientInterface $client, string $token, int $itemId, bo
     assertTrue(($res->toArray(false)['id'] ?? null) === $sessionId, 'get returns the same session id');
 
     // 4. complete (POST /acp/checkout_sessions/{id}/complete)
-    // 決済実行は sample-payment 決済ハンドラ (#3) が前提のため、許可された時のみ実行する。
+    // 決済実行は SamplePayment44 の ACP 決済ハンドラが前提のため、許可された時のみ実行する。
     // 各シナリオは状態が確定するため新規セッションで実行する。
     if (!$paymentReady) {
-        fwrite(STDOUT, "  \033[33m⏸\033[0m complete skipped: AGENT_E2E_PAYMENT_READY!=true (#3 決済ハンドラ待ち)\n");
+        fwrite(STDOUT, "  \033[33m⏸\033[0m complete skipped: AGENT_E2E_PAYMENT_READY!=true\n");
 
         return;
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

エージェントコマース結合 E2E (`agentic-commerce-e2e.yml`) が参照している依存プラグインを、開発期間中の fork から **EC-CUBE org の `4.4` ブランチ**へ切り替えます。

以下 2 件がマージされ、fork を参照する必要がなくなったためです。

- EC-CUBE/eccube-api4#191 → `4.4` (merge commit `bca124e6`)
- EC-CUBE/sample-payment-plugin#54 → `4.4` (merge commit `d5ab9b33`)

あわせて、`e2e/agent/` のドキュメントが実装と食い違っていた箇所を修正します（#6872 で本体にマージされた後、記述が実態と乖離していました）。

## 方針(Policy)

**path リポジトリ方式とダミー `extra.id` の注入は org 移行後も必要なため維持しました。** 「org に移ったので通常の VCS 参照に戻せる」とは判断できず、実際に確認した結果は次のとおりです。

| リポジトリ | デフォルトブランチ | デフォルトの composer 名 | `4.4` の composer 名 | `4.4` の `extra.id` |
|---|---|---|---|---|
| EC-CUBE/eccube-api4 | `4.2` | `ec-cube/api42` | `ec-cube/api44` (4.4.0) | **なし** |
| EC-CUBE/sample-payment-plugin | `4.2` | `ec-cube/samplepayment42` | `ec-cube/samplepayment44` (3.0.0) | `999999` |

- composer の VCS ドライバはデフォルトブランチ由来の名前で repo をキーするため、新名の `4.4` ブランチが名前不一致でスキップされ "not found" になります。この制約は fork 固有ではなく org でも同じでした。
- `api44` は `4.4` ブランチでも `composer.json` に `extra.id` を持たないため、`ec-cube/plugin-installer` 用のダミー id 注入も引き続き必要です。

そのため機構は変えず、**コメントの理由書きのみ実態（デフォルトブランチが 4.2 系）に合わせて更新**しています。

## 実装に関する補足(Appendix)

### CI 設定

- `API44_VCS` / `SAMPLEPAYMENT44_VCS` を EC-CUBE org の URL に変更
- 参照ブランチ既定値を `feature/agentic-commerce` → `4.4` に変更（`workflow_dispatch` / `workflow_call` の inputs 各 2 箇所、Job A/B のフォールバック 4 箇所）
- `main.yml` の caller 側コメントを更新（「org 移行後に別 PR で差し替え」の TODO を解消）

### ドキュメントの実装との齟齬修正

landing 待ち表記の更新に加え、突き合わせで見つかった以下 3 件を修正しました。

1. **ローカル実行手順の router が誤り** — README は `php -S 127.0.0.1:8000 codeception/router.php` を指示していましたが、`codeception/router.php` は GET に対し `return false` を返し、PHP built-in server の静的フォールバック挙動が PHP バージョン依存で app ルートを 404 にし得ます。workflow 自身はこれを理由に `index.php` を直接 router にしているため、README も CI と同じ方式に統一しました。
2. **`AGENT_E2E_ITEM_ID` の既定値が誤り** — README は「ACP=`1` / UCP=`2`」としていましたが、実装は `acp-checkout.php` / `ucp-checkout.php` ともに `2` です。`1` は fixtures の `visible=0` なダミー規格で purchase flow が明細を除去するため、ACP で `1` を既定とする記述は成立しません。
3. **統合ブランチ運用の注意書きが陳腐化** — 「このブランチ (`feature/agentic-commerce-e2e`) はテスト専用の統合ブランチ」という注記が、#6872 で本体 4.4 にマージされた後も残っており参照先が存在しない状態でした。コア実装のマージ経緯（#6802/#6815/#6825/#6837/#6843/#6872）の記載に差し替えました。

`acp-checkout.php` の TODO は、ブロッカー（トークン発行の landing）は解消済みですが**作業本体（payload を `AcpCheckoutSessionMapper` の契約に実データで突き合わせる）は未実施**のため、項目自体は残し前提条件の記述のみ更新しています。

## テスト（Test)

### ローカルで実施済み

- `4.4` ブランチの `git clone --depth 1 --branch 4.4`（両リポジトリ・匿名 HTTPS）が成功し、HEAD が上記 merge commit そのものであることを確認
- clone した `composer.json` の名前・version が workflow の require（`ec-cube/api44:*` / `ec-cube/samplepayment44:*`）と、plugin code が `--code=Api44` / `--code=SamplePayment44` と一致することを確認
- Job A が assert する `dev.ucp.payment.card` が `UcpSampleCardHandler::HANDLER_ID` に存在することを確認
- Job B の前提（`client_credentials` / `acp:checkout` `ucp:checkout` scope / `ECCUBE_OAUTH2_ENCRYPTION_KEY`）が api44 の `4.4` に存在することを確認
- 両 workflow の YAML parse と、解決後のブランチ既定値が全て `4.4` になることを確認
- `php -l e2e/agent/*.php` / Rector / PHPStan level 6 いずれも green（pre-push hook で実行）

### CI で確認したいこと

- [ ] `Agentic Commerce E2E` の Job A (integration smoke, PHP 8.2-8.5 × pgsql/mysql) が green
- [ ] Job B (checkout E2E, OAuth2 トークン発行 + ACP/UCP セッション + complete) が green

## 相談（Discussion）

Packagist 公開後は path リポジトリ方式ごと通常の `composer require` に単純化できます。本 PR では機構を変えず参照先の切り替えに留めました。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

> CI 設定 (`.github/workflows/`) と E2E ハーネスのドキュメントのみの変更で、`src/` 配下の製品コードには一切触れていません。

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * E2E テスト環境の参照先を EC-CUBE 4.4 系に統一しました。
  * 決済 API の認証条件とサンプル決済機能に関する案内を更新しました。
  * ローカル実行時のルーティング設定、環境変数、商品 ID の説明を改善しました。
  * CI 実行および依存リポジトリの利用手順を最新化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->