### PR TITLE
fix(csv): 一覧をソートしてからCSVをダウンロードするとエラーになるのを修正 (#6713)

### DIFF
--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -185,12 +185,7 @@ class OrderController extends AbstractController
 
         $qb = $this->orderRepository->getQueryBuilderBySearchDataForAdmin($searchData);
 
-        // null を配列オフセットに使うのは PHP 8.5 で非推奨。null は '' として扱われるため挙動は変わらない
-        $sortKey = $searchData['sortkey'] ?? '';
-        $paginate_options = ['wrap-queries' => true];
-        if (empty($this->orderRepository::COLUMNS[$sortKey]) || $sortKey == 'order_status') {
-            $paginate_options = [];
-        }
+        $paginate_options = $this->createPaginateOptions($searchData['sortkey'] ?? null);
 
         $event = new EventArgs(
             [
@@ -299,8 +294,13 @@ class OrderController extends AbstractController
         // タイムアウトを無効にする.
         set_time_limit(0);
 
+        // 一覧画面と同じ paginate オプションを使う.
+        // sortkey は HiddenType なので, セッションに入っている値をそのまま参照できる.
+        $viewData = $this->session->get('eccube.admin.order.search', []);
+        $paginate_options = $this->createPaginateOptions($viewData['sortkey'] ?? null);
+
         $response = new StreamedResponse();
-        $response->setCallback(function () use ($request, $csvTypeId): void {
+        $response->setCallback(function () use ($request, $csvTypeId, $paginate_options): void {
             // CSV種別を元に初期化.
             $this->csvExportService->initCsvType($csvTypeId);
 
@@ -353,13 +353,36 @@ class OrderController extends AbstractController
                     // 出力.
                     $csvService->fputcsv($ExportCsvRow->getRow());
                 }
-            });
+            }, $paginate_options);
         });
 
         $response->headers->set('Content-Type', 'application/octet-stream');
         $response->headers->set('Content-Disposition', 'attachment; filename='.$fileName);
 
         return $response;
+    }
+
+    /**
+     * 受注一覧・受注CSV・配送CSVで共通の paginate オプションを組み立てる.
+     *
+     * 受注検索のクエリは Shipping / OrderItem を fetch join しているため, to-many 側の列
+     * (s.shipping_date, s.tracking_number, s.name01 等) でソートすると LimitSubqueryWalker が例外を投げる.
+     * wrap-queries を有効にするとサブクエリで包まれ, ソートを保ったまま解消できる.
+     * order_status は association (o.OrderStatus) をソート対象にするため, 従来どおり対象外とする.
+     *
+     * @return array<string, mixed>
+     */
+    private function createPaginateOptions(mixed $sortKey): array
+    {
+        // セッション由来の値も渡るため, 文字列以外は未指定として扱う.
+        // (null をそのまま配列オフセットに使うのは PHP 8.5 で非推奨)
+        $sortKey = is_string($sortKey) ? $sortKey : '';
+
+        if (empty($this->orderRepository::COLUMNS[$sortKey]) || $sortKey === 'order_status') {
+            return [];
+        }
+
+        return ['wrap-queries' => true];
     }
 
     /**

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -185,7 +185,7 @@ class OrderController extends AbstractController
 
         $qb = $this->orderRepository->getQueryBuilderBySearchDataForAdmin($searchData);
 
-        $paginate_options = $this->createPaginateOptions($searchData['sortkey'] ?? null);
+        $paginate_options = $this->createPaginateOptions($this->extractSortKey($searchData));
 
         $event = new EventArgs(
             [
@@ -296,8 +296,8 @@ class OrderController extends AbstractController
 
         // 一覧画面と同じ paginate オプションを使う.
         // sortkey は HiddenType なので, セッションに入っている値をそのまま参照できる.
-        $viewData = $this->session->get('eccube.admin.order.search', []);
-        $paginate_options = $this->createPaginateOptions($viewData['sortkey'] ?? null);
+        $sortKey = $this->extractSortKey($this->session->get('eccube.admin.order.search', []));
+        $paginate_options = $this->createPaginateOptions($sortKey);
 
         $response = new StreamedResponse();
         $response->setCallback(function () use ($request, $csvTypeId, $paginate_options): void {
@@ -363,6 +363,19 @@ class OrderController extends AbstractController
     }
 
     /**
+     * 検索条件からソートキーを取り出す.
+     *
+     * セッション由来の値も渡るため, 文字列以外は未指定として扱う.
+     * (null をそのまま配列オフセットに使うのは PHP 8.5 で非推奨)
+     */
+    private function extractSortKey(mixed $searchData): string
+    {
+        $sortKey = is_array($searchData) ? $searchData['sortkey'] ?? null : null;
+
+        return is_string($sortKey) ? $sortKey : '';
+    }
+
+    /**
      * 受注一覧・受注CSV・配送CSVで共通の paginate オプションを組み立てる.
      *
      * 受注検索のクエリは Shipping / OrderItem を fetch join しているため, to-many 側の列
@@ -372,12 +385,8 @@ class OrderController extends AbstractController
      *
      * @return array<string, mixed>
      */
-    private function createPaginateOptions(mixed $sortKey): array
+    private function createPaginateOptions(string $sortKey): array
     {
-        // セッション由来の値も渡るため, 文字列以外は未指定として扱う.
-        // (null をそのまま配列オフセットに使うのは PHP 8.5 で非推奨)
-        $sortKey = is_string($sortKey) ? $sortKey : '';
-
         if (empty($this->orderRepository::COLUMNS[$sortKey]) || $sortKey === 'order_status') {
             return [];
         }

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -378,7 +378,7 @@ class OrderController extends AbstractController
     /**
      * 受注一覧・受注CSV・配送CSVで共通の paginate オプションを組み立てる.
      *
-     * 受注検索のクエリは Shipping / OrderItem を fetch join しているため, to-many 側の列
+     * 受注検索のクエリは Shipping を fetch join しているため (OrderItem は join のみ), to-many 側の列
      * (s.shipping_date, s.tracking_number, s.name01 等) でソートすると LimitSubqueryWalker が例外を投げる.
      * wrap-queries を有効にするとサブクエリで包まれ, ソートを保ったまま解消できる.
      * order_status は association (o.OrderStatus) をソート対象にするため, 従来どおり対象外とする.

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -185,7 +185,7 @@ class ProductController extends AbstractController
 
         $qb = $this->productRepository->getQueryBuilderBySearchDataForAdmin($searchData);
 
-        $paginate_options = $this->createPaginateOptions($searchData['sortkey'] ?? null);
+        $paginate_options = $this->createPaginateOptions($this->extractSortKey($searchData));
 
         $event = new EventArgs(
             [
@@ -932,13 +932,15 @@ class ProductController extends AbstractController
 
         // 一覧画面と同じ paginate オプションを使う.
         // sortkey は HiddenType なので, セッションに入っている値をそのまま参照できる.
-        $viewData = $this->session->get('eccube.admin.product.search', []);
-        $sortKey = is_string($viewData['sortkey'] ?? null) ? $viewData['sortkey'] : '';
+        $sortKey = $this->extractSortKey($this->session->get('eccube.admin.product.search', []));
         $paginate_options = $this->createPaginateOptions($sortKey);
-        $sortsByProductClass = str_starts_with($this->productRepository::COLUMNS[$sortKey] ?? '', 'pc.');
+
+        // ProductClass の列でソートしている場合は, その列を select 句に載せる必要がある.
+        $sortColumn = $this->productRepository::COLUMNS[$sortKey] ?? '';
+        $hiddenSortColumn = str_starts_with($sortColumn, 'pc.') ? $sortColumn : null;
 
         $response = new StreamedResponse();
-        $response->setCallback(function () use ($request, $paginate_options, $sortsByProductClass): void {
+        $response->setCallback(function () use ($request, $paginate_options, $hiddenSortColumn): void {
             // CSV種別を元に初期化.
             $this->csvExportService->initCsvType(CsvType::CSV_TYPE_PRODUCT);
 
@@ -965,15 +967,21 @@ class ProductController extends AbstractController
             // http://uedatakeshi.blogspot.jp/2010/04/distinct-oeder-by-postgresmysql.html
             $qb->resetDQLPart('select');
 
-            // ProductClass の列でソートしている場合は pc も select する.
-            // DISTINCT と併用するため, ORDER BY の対象が select 句に無いと
-            // PostgreSQL が「ORDER BY expressions must appear in select list」で拒否する.
-            if ($isOutOfStock || $sortsByProductClass) {
+            if ($isOutOfStock) {
                 $qb->select('p, pc')
                     ->distinct();
             } else {
                 $qb->select('p')
                     ->distinct();
+
+                // ProductClass の列でソートしている場合は, その列を HIDDEN で select 句に載せる.
+                // DISTINCT と併用するため, ORDER BY の対象が select 句に無いと
+                // PostgreSQL が「ORDER BY expressions must appear in select list」で拒否する.
+                // pc を fetch join すると ProductClasses が pc.visible の条件で部分初期化され,
+                // 非表示の規格の行が出力から落ちてしまうため, HIDDEN で取得対象には含めない.
+                if ($hiddenSortColumn !== null) {
+                    $qb->addSelect($hiddenSortColumn.' AS HIDDEN sort_key_value');
+                }
             }
             // データ行の出力.
             $this->csvExportService->setExportQueryBuilder($qb);
@@ -1031,6 +1039,19 @@ class ProductController extends AbstractController
     }
 
     /**
+     * 検索条件からソートキーを取り出す.
+     *
+     * セッション由来の値も渡るため, 文字列以外は未指定として扱う.
+     * (null をそのまま配列オフセットに使うのは PHP 8.5 で非推奨)
+     */
+    private function extractSortKey(mixed $searchData): string
+    {
+        $sortKey = is_array($searchData) ? $searchData['sortkey'] ?? null : null;
+
+        return is_string($sortKey) ? $sortKey : '';
+    }
+
+    /**
      * 商品一覧・商品CSVで共通の paginate オプションを組み立てる.
      *
      * 商品検索のクエリは ProductClass を to-many で join しているため, ProductClass 側の列
@@ -1040,12 +1061,9 @@ class ProductController extends AbstractController
      *
      * @return array<string, mixed>
      */
-    private function createPaginateOptions(mixed $sortKey): array
+    private function createPaginateOptions(string $sortKey): array
     {
-        // セッション由来の値も渡るため, 文字列以外は未指定として扱う.
-        $sortKey = is_string($sortKey) ? $sortKey : '';
-
-        if (empty($this->productRepository::COLUMNS[$sortKey]) || $sortKey === 'code' || $sortKey === 'status') {
+        if (empty($this->productRepository::COLUMNS[$sortKey]) || $sortKey === 'status') {
             return [];
         }
 

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -967,6 +967,9 @@ class ProductController extends AbstractController
             // http://uedatakeshi.blogspot.jp/2010/04/distinct-oeder-by-postgresmysql.html
             $qb->resetDQLPart('select');
 
+            // stock_status は SearchProductType に無く, コアからは設定されない
+            // (管理画面の在庫切れ絞り込みは別キーの stock を使う). プラグイン等が
+            // セッションへ入れたときだけ通る経路なので, 従来の形を維持する.
             if ($isOutOfStock) {
                 $qb->select('p, pc')
                     ->distinct();

--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -185,12 +185,7 @@ class ProductController extends AbstractController
 
         $qb = $this->productRepository->getQueryBuilderBySearchDataForAdmin($searchData);
 
-        // null を配列オフセットに使うのは PHP 8.5 で非推奨。null は '' として扱われるため挙動は変わらない
-        $sortKey = $searchData['sortkey'] ?? '';
-        $paginate_options = ['wrap-queries' => true];
-        if (empty($this->productRepository::COLUMNS[$sortKey]) || $sortKey == 'code' || $sortKey == 'status') {
-            $paginate_options = [];
-        }
+        $paginate_options = $this->createPaginateOptions($searchData['sortkey'] ?? null);
 
         $event = new EventArgs(
             [
@@ -935,8 +930,15 @@ class ProductController extends AbstractController
         // タイムアウトを無効にする.
         set_time_limit(0);
 
+        // 一覧画面と同じ paginate オプションを使う.
+        // sortkey は HiddenType なので, セッションに入っている値をそのまま参照できる.
+        $viewData = $this->session->get('eccube.admin.product.search', []);
+        $sortKey = is_string($viewData['sortkey'] ?? null) ? $viewData['sortkey'] : '';
+        $paginate_options = $this->createPaginateOptions($sortKey);
+        $sortsByProductClass = str_starts_with($this->productRepository::COLUMNS[$sortKey] ?? '', 'pc.');
+
         $response = new StreamedResponse();
-        $response->setCallback(function () use ($request): void {
+        $response->setCallback(function () use ($request, $paginate_options, $sortsByProductClass): void {
             // CSV種別を元に初期化.
             $this->csvExportService->initCsvType(CsvType::CSV_TYPE_PRODUCT);
 
@@ -963,7 +965,10 @@ class ProductController extends AbstractController
             // http://uedatakeshi.blogspot.jp/2010/04/distinct-oeder-by-postgresmysql.html
             $qb->resetDQLPart('select');
 
-            if ($isOutOfStock) {
+            // ProductClass の列でソートしている場合は pc も select する.
+            // DISTINCT と併用するため, ORDER BY の対象が select 句に無いと
+            // PostgreSQL が「ORDER BY expressions must appear in select list」で拒否する.
+            if ($isOutOfStock || $sortsByProductClass) {
                 $qb->select('p, pc')
                     ->distinct();
             } else {
@@ -1012,7 +1017,7 @@ class ProductController extends AbstractController
                     // 出力.
                     $csvService->fputcsv($ExportCsvRow->getRow());
                 }
-            });
+            }, $paginate_options);
         });
 
         $now = new \DateTime();
@@ -1023,6 +1028,28 @@ class ProductController extends AbstractController
         log_info('商品CSV出力ファイル名', [$filename]);
 
         return $response;
+    }
+
+    /**
+     * 商品一覧・商品CSVで共通の paginate オプションを組み立てる.
+     *
+     * 商品検索のクエリは ProductClass を to-many で join しているため, ProductClass 側の列
+     * (pc.code, pc.stock) でソートすると LimitSubqueryWalker が例外を投げる.
+     * wrap-queries を有効にするとサブクエリで包まれ, ソートを保ったまま解消できる.
+     * status は association (p.Status) をソート対象にするため, 従来どおり対象外とする.
+     *
+     * @return array<string, mixed>
+     */
+    private function createPaginateOptions(mixed $sortKey): array
+    {
+        // セッション由来の値も渡るため, 文字列以外は未指定として扱う.
+        $sortKey = is_string($sortKey) ? $sortKey : '';
+
+        if (empty($this->productRepository::COLUMNS[$sortKey]) || $sortKey === 'code' || $sortKey === 'status') {
+            return [];
+        }
+
+        return ['wrap-queries' => true];
     }
 
     /**

--- a/src/Eccube/Service/CsvExportService.php
+++ b/src/Eccube/Service/CsvExportService.php
@@ -170,8 +170,10 @@ class CsvExportService
     /**
      * クエリビルダにもとづいてデータ行を出力する.
      * このメソッドを使う場合は, 事前にsetExportQueryBuilder($qb)で出力対象のクエリビルダをわたしておく必要がある.
+     *
+     * @param array<string, mixed> $paginateOptions KnpPaginator に渡すオプション. 一覧画面と同じ値をわたす.
      */
-    public function exportData(\Closure $closure): void
+    public function exportData(\Closure $closure, array $paginateOptions = []): void
     {
         if (is_null($this->qb) || is_null($this->entityManager)) {
             throw new \LogicException('query builder not set.');
@@ -183,7 +185,7 @@ class CsvExportService
 
         $page = 1;
         $limit = 100;
-        while ($results = $this->paginator->paginate($this->qb, $page, $limit)) {
+        while ($results = $this->paginator->paginate($this->qb, $page, $limit, $paginateOptions)) {
             /** @var AbstractPagination<int, mixed> $results */
             if (!$results->valid()) {
                 break;

--- a/tests/Eccube/Tests/Web/Admin/AbstractAdminWebTestCase.php
+++ b/tests/Eccube/Tests/Web/Admin/AbstractAdminWebTestCase.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Eccube\Tests\Web\Admin;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Tests\Web\AbstractWebTestCase;
 
 abstract class AbstractAdminWebTestCase extends AbstractWebTestCase
@@ -40,5 +41,45 @@ abstract class AbstractAdminWebTestCase extends AbstractWebTestCase
         $this->loginTo($user);
 
         return $user;
+    }
+
+    /**
+     * CSV のレコード数を返す（ヘッダ行を除く）.
+     */
+    protected function countCsvRows(string $csv): int
+    {
+        return count($this->parseCsv($csv)) - 1;
+    }
+
+    /**
+     * CSV をレコード単位にパースする（ヘッダ行を含む）.
+     *
+     * 項目の値に改行が含まれるため, 行数は改行では数えられない.
+     * 出力は eccube_csv_export_encoding のエンコーディングなので UTF-8 に戻してから読む
+     * (SJIS は 2 バイト目に 0x5C を含む文字があり, escape と誤認して行が結合される).
+     * escape は PHP 8.4 以降の既定値に合わせて '' を明示する
+     * (省略すると deprecation。'\\' はデータ中のバックスラッシュで行が結合される).
+     *
+     * @return array<int, array<int, string|null>>
+     */
+    protected function parseCsv(string $csv): array
+    {
+        $eccubeConfig = static::getContainer()->get(EccubeConfig::class);
+        $csv = (string) mb_convert_encoding($csv, 'UTF-8', $eccubeConfig->get('eccube_csv_export_encoding'));
+
+        $fp = fopen('php://memory', 'r+');
+        $this->assertNotFalse($fp);
+        fwrite($fp, $csv);
+        rewind($fp);
+
+        $records = [];
+        while (($row = fgetcsv($fp, null, $eccubeConfig->get('eccube_csv_export_separator'), '"', '')) !== false) {
+            if ($row !== [null]) {
+                $records[] = $row;
+            }
+        }
+        fclose($fp);
+
+        return $records;
     }
 }

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
@@ -39,6 +39,11 @@ final class OrderControllerTest extends AbstractAdminWebTestCase
 {
     use MailerAssertionsTrait;
 
+    /**
+     * Shipping (to-many) の列をソート対象にするキー.
+     */
+    private const TO_MANY_SORT_KEYS = ['shipping_status', 'tracking_number', 'delivery'];
+
     protected ?OrderStatusRepository $orderStatusRepository = null;
 
     protected ?PaymentRepository $paymentRepository = null;
@@ -354,6 +359,88 @@ final class OrderControllerTest extends AbstractAdminWebTestCase
 
         $content = $this->client->getInternalResponse()->getContent();
         $this->assertMatchesRegularExpression('/user-[0-9]@example.com/', $content);
+    }
+
+    /**
+     * ソートの有無で受注CSVの行数が変わらないことのテスト.
+     *
+     * to-many の関連を select 句に載せると, 関連側の絞り込み条件でコレクションが部分初期化され,
+     * ソートしたときだけ出力行数が減ることがある. 行数で担保して出力内容の変化を検知する.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6713
+     */
+    public function testExportOrderRowCountIsNotAffectedBySort(): void
+    {
+        $expected = $this->countExportedRows('admin_order_export_order', '');
+        $this->assertGreaterThan(0, $expected);
+
+        foreach (self::TO_MANY_SORT_KEYS as $sortKey) {
+            $this->assertSame($expected, $this->countExportedRows('admin_order_export_order', $sortKey), $sortKey);
+        }
+    }
+
+    /**
+     * ソートの有無で配送CSVの行数が変わらないことのテスト.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6713
+     */
+    public function testExportShippingRowCountIsNotAffectedBySort(): void
+    {
+        $expected = $this->countExportedRows('admin_order_export_shipping', '');
+        $this->assertGreaterThan(0, $expected);
+
+        foreach (self::TO_MANY_SORT_KEYS as $sortKey) {
+            $this->assertSame($expected, $this->countExportedRows('admin_order_export_shipping', $sortKey), $sortKey);
+        }
+    }
+
+    /**
+     * ソートしてから CSV を出力し, ヘッダ行を除いたレコード数を返す.
+     */
+    private function countExportedRows(string $route, string $sortKey): int
+    {
+        $this->client->request(
+            Request::METHOD_POST,
+            $this->generateUrl('admin_order'),
+            [
+                'admin_search_order' => [
+                    '_token' => 'dummy',
+                    'email' => 'user-',
+                    'sortkey' => $sortKey,
+                    'sorttype' => 'a',
+                ],
+            ]
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $this->client->request(Request::METHOD_GET, $this->generateUrl($route));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        return $this->countCsvRows($this->client->getInternalResponse()->getContent());
+    }
+
+    /**
+     * CSV のレコード数を返す.
+     *
+     * 項目の値に改行が含まれるため, 改行の数ではなく fgetcsv でレコード単位に数える.
+     */
+    private function countCsvRows(string $csv): int
+    {
+        $fp = fopen('php://memory', 'r+');
+        $this->assertNotFalse($fp);
+        fwrite($fp, $csv);
+        rewind($fp);
+        fgetcsv($fp); // ヘッダ行.
+
+        $rows = 0;
+        while (($row = fgetcsv($fp)) !== false) {
+            if ($row !== [null]) {
+                ++$rows;
+            }
+        }
+        fclose($fp);
+
+        return $rows;
     }
 
     /**

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
@@ -287,6 +287,93 @@ final class OrderControllerTest extends AbstractAdminWebTestCase
     }
 
     /**
+     * ソートしてから受注CSVをダウンロードしてもエラーにならないことのテスト.
+     *
+     * 受注検索のクエリは Shipping を fetch join しているため, Shipping 側の列でソートすると
+     * LimitSubqueryWalker が例外を投げ, CSV が最後まで出力されなかった.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6713
+     */
+    #[DataProvider(methodName: 'dataSortKeyProvider')]
+    public function testExportOrderWithSortKey(string $sortKey): void
+    {
+        $this->client->request(
+            Request::METHOD_POST,
+            $this->generateUrl('admin_order'),
+            [
+                'admin_search_order' => [
+                    '_token' => 'dummy',
+                    'email' => 'user-',
+                    'sortkey' => $sortKey,
+                    'sorttype' => 'a',
+                ],
+            ]
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $this->client->request(
+            Request::METHOD_GET,
+            $this->generateUrl('admin_order_export_order')
+        );
+
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        // ヘッダ行だけでなくデータ行が出力されていること.
+        $content = $this->client->getInternalResponse()->getContent();
+        $this->assertMatchesRegularExpression('/user-[0-9]@example.com/', $content);
+    }
+
+    /**
+     * 配送CSVも同じクエリビルダを使うため, 同様にソート後もエラーにならないこと.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6713
+     */
+    #[DataProvider(methodName: 'dataSortKeyProvider')]
+    public function testExportShippingWithSortKey(string $sortKey): void
+    {
+        $this->client->request(
+            Request::METHOD_POST,
+            $this->generateUrl('admin_order'),
+            [
+                'admin_search_order' => [
+                    '_token' => 'dummy',
+                    'email' => 'user-',
+                    'sortkey' => $sortKey,
+                    'sorttype' => 'a',
+                ],
+            ]
+        );
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $this->client->request(
+            Request::METHOD_GET,
+            $this->generateUrl('admin_order_export_shipping')
+        );
+
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $content = $this->client->getInternalResponse()->getContent();
+        $this->assertMatchesRegularExpression('/user-[0-9]@example.com/', $content);
+    }
+
+    /**
+     * @return \Iterator<int<0, max>, array{string}>
+     */
+    public static function dataSortKeyProvider(): \Iterator
+    {
+        // Shipping (to-many) の列。#6713 で報告されたエラーになる3キー。
+        yield ['shipping_status'];
+        yield ['tracking_number'];
+        yield ['delivery'];
+        // association (o.OrderStatus) のため wrap-queries の対象外。従来どおり動くこと。
+        yield ['order_status'];
+        // Order (to-one) の列。従来どおり動くこと。
+        yield ['purchase_price'];
+        // ソート未指定。
+        yield [''];
+    }
+
+    /**
      * Test for issue 1995
      *
      * @see https://github.com/EC-CUBE/ec-cube/issues/1995

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 namespace Eccube\Tests\Web\Admin\Order;
 
 use Eccube\Common\Constant;
-use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Customer;
 use Eccube\Entity\Master\CsvType;
 use Eccube\Entity\Master\OrderStatus;
@@ -418,46 +417,6 @@ final class OrderControllerTest extends AbstractAdminWebTestCase
         $this->assertTrue($this->client->getResponse()->isSuccessful());
 
         return $this->countCsvRows($this->client->getInternalResponse()->getContent());
-    }
-
-    /**
-     * CSV のレコード数を返す（ヘッダ行を除く）.
-     */
-    private function countCsvRows(string $csv): int
-    {
-        return count($this->parseCsv($csv)) - 1;
-    }
-
-    /**
-     * CSV をレコード単位にパースする（ヘッダ行を含む）.
-     *
-     * 項目の値に改行が含まれるため, 行数は改行では数えられない.
-     * 出力は eccube_csv_export_encoding のエンコーディングなので UTF-8 に戻してから読む
-     * (SJIS は 2 バイト目に 0x5C を含む文字があり, escape と誤認して行が結合される).
-     * escape は PHP 8.4 以降の既定値に合わせて '' を明示する
-     * (省略すると deprecation。'\\' はデータ中のバックスラッシュで行が結合される).
-     *
-     * @return array<int, array<int, string|null>>
-     */
-    private function parseCsv(string $csv): array
-    {
-        $eccubeConfig = static::getContainer()->get(EccubeConfig::class);
-        $csv = (string) mb_convert_encoding($csv, 'UTF-8', $eccubeConfig->get('eccube_csv_export_encoding'));
-
-        $fp = fopen('php://memory', 'r+');
-        $this->assertNotFalse($fp);
-        fwrite($fp, $csv);
-        rewind($fp);
-
-        $records = [];
-        while (($row = fgetcsv($fp, null, $eccubeConfig->get('eccube_csv_export_separator'), '"', '')) !== false) {
-            if ($row !== [null]) {
-                $records[] = $row;
-            }
-        }
-        fclose($fp);
-
-        return $records;
     }
 
     /**

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderControllerTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Eccube\Tests\Web\Admin\Order;
 
 use Eccube\Common\Constant;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Customer;
 use Eccube\Entity\Master\CsvType;
 use Eccube\Entity\Master\OrderStatus;
@@ -420,27 +421,43 @@ final class OrderControllerTest extends AbstractAdminWebTestCase
     }
 
     /**
-     * CSV のレコード数を返す.
-     *
-     * 項目の値に改行が含まれるため, 改行の数ではなく fgetcsv でレコード単位に数える.
+     * CSV のレコード数を返す（ヘッダ行を除く）.
      */
     private function countCsvRows(string $csv): int
     {
+        return count($this->parseCsv($csv)) - 1;
+    }
+
+    /**
+     * CSV をレコード単位にパースする（ヘッダ行を含む）.
+     *
+     * 項目の値に改行が含まれるため, 行数は改行では数えられない.
+     * 出力は eccube_csv_export_encoding のエンコーディングなので UTF-8 に戻してから読む
+     * (SJIS は 2 バイト目に 0x5C を含む文字があり, escape と誤認して行が結合される).
+     * escape は PHP 8.4 以降の既定値に合わせて '' を明示する
+     * (省略すると deprecation。'\\' はデータ中のバックスラッシュで行が結合される).
+     *
+     * @return array<int, array<int, string|null>>
+     */
+    private function parseCsv(string $csv): array
+    {
+        $eccubeConfig = static::getContainer()->get(EccubeConfig::class);
+        $csv = (string) mb_convert_encoding($csv, 'UTF-8', $eccubeConfig->get('eccube_csv_export_encoding'));
+
         $fp = fopen('php://memory', 'r+');
         $this->assertNotFalse($fp);
         fwrite($fp, $csv);
         rewind($fp);
-        fgetcsv($fp); // ヘッダ行.
 
-        $rows = 0;
-        while (($row = fgetcsv($fp)) !== false) {
+        $records = [];
+        while (($row = fgetcsv($fp, null, $eccubeConfig->get('eccube_csv_export_separator'), '"', '')) !== false) {
             if ($row !== [null]) {
-                ++$rows;
+                $records[] = $row;
             }
         }
         fclose($fp);
 
-        return $rows;
+        return $records;
     }
 
     /**

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Eccube\Tests\Web\Admin\Product;
 
 use Eccube\Common\Constant;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Master\ProductStatus;
 use Eccube\Entity\Master\RoundingType;
@@ -1068,11 +1069,8 @@ final class ProductControllerTest extends AbstractAdminWebTestCase
         $this->searchProduct($searchForm);
         $this->assertTrue($this->client->getResponse()->isSuccessful());
 
-        $content = $this->exportProductCsv();
-
         // ヘッダ行だけでなくデータ行が出力されていること.
-        $lines = preg_split('/\R/', trim($content)) ?: [];
-        $this->assertGreaterThan(1, count($lines));
+        $this->assertGreaterThan(0, $this->countCsvRows($this->exportProductCsv()));
     }
 
     /**
@@ -1102,6 +1100,57 @@ final class ProductControllerTest extends AbstractAdminWebTestCase
     }
 
     /**
+     * ソートが商品CSVの並び順に反映されることのテスト.
+     *
+     * ソートを保ったまま LimitSubqueryWalker の例外を解消するのが目的なので,
+     * エラーにならないことだけでなく並び順そのものを担保する.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6713
+     */
+    public function testExportProductKeepsSortOrder(): void
+    {
+        // 商品コードの昇順が商品IDの昇順と一致しないよう, 逆順に登録する.
+        // 規格を登録すると 規格なし既定の ProductClass は非表示になるが, CSV には出力される.
+        $prefix = 'Product for sort order '.uniqid();
+        foreach (['c', 'b', 'a'] as $code) {
+            $Product = $this->createProduct($prefix.' '.$code, 1);
+            $no = 1;
+            foreach ($Product->getProductClasses() as $ProductClass) {
+                $ProductClass->setCode($code.$no++);
+            }
+        }
+        $this->entityManager->flush();
+
+        $searchForm = $this->createSearchForm();
+        $searchForm['id'] = $prefix;
+        $searchForm['sortkey'] = 'product_code';
+
+        $searchForm['sorttype'] = 'a';
+        $this->searchProduct($searchForm);
+        $this->assertSame(['a1', 'a2', 'b1', 'b2', 'c1', 'c2'], $this->extractProductCodes($this->exportProductCsv()));
+
+        $searchForm['sorttype'] = 'd';
+        $this->searchProduct($searchForm);
+        $this->assertSame(['c1', 'c2', 'b1', 'b2', 'a1', 'a2'], $this->extractProductCodes($this->exportProductCsv()));
+    }
+
+    /**
+     * CSV から商品コード列の値を出力順に取り出す.
+     *
+     * @return array<int, string>
+     */
+    private function extractProductCodes(string $csv): array
+    {
+        $records = $this->parseCsv($csv);
+        $header = array_shift($records);
+        $this->assertIsArray($header);
+        $index = array_search('商品コード', $header, true);
+        $this->assertIsInt($index);
+
+        return array_map(fn (array $row): string => (string) $row[$index], $records);
+    }
+
+    /**
      * ソートしてから商品CSVを出力し, ヘッダ行を除いたレコード数を返す.
      *
      * @param array<string, mixed> $searchForm
@@ -1113,24 +1162,47 @@ final class ProductControllerTest extends AbstractAdminWebTestCase
         $this->searchProduct($searchForm);
         $this->assertTrue($this->client->getResponse()->isSuccessful());
 
-        $csv = $this->exportProductCsv();
+        return $this->countCsvRows($this->exportProductCsv());
+    }
 
-        // 項目の値に改行が含まれるため, 改行の数ではなく fgetcsv でレコード単位に数える.
+    /**
+     * CSV のレコード数を返す（ヘッダ行を除く）.
+     */
+    private function countCsvRows(string $csv): int
+    {
+        return count($this->parseCsv($csv)) - 1;
+    }
+
+    /**
+     * CSV をレコード単位にパースする（ヘッダ行を含む）.
+     *
+     * 項目の値に改行が含まれるため, 行数は改行では数えられない.
+     * 出力は eccube_csv_export_encoding のエンコーディングなので UTF-8 に戻してから読む
+     * (SJIS は 2 バイト目に 0x5C を含む文字があり, escape と誤認して行が結合される).
+     * escape は PHP 8.4 以降の既定値に合わせて '' を明示する
+     * (省略すると deprecation。'\\' はデータ中のバックスラッシュで行が結合される).
+     *
+     * @return array<int, array<int, string|null>>
+     */
+    private function parseCsv(string $csv): array
+    {
+        $eccubeConfig = static::getContainer()->get(EccubeConfig::class);
+        $csv = (string) mb_convert_encoding($csv, 'UTF-8', $eccubeConfig->get('eccube_csv_export_encoding'));
+
         $fp = fopen('php://memory', 'r+');
         $this->assertNotFalse($fp);
         fwrite($fp, $csv);
         rewind($fp);
-        fgetcsv($fp); // ヘッダ行.
 
-        $rows = 0;
-        while (($row = fgetcsv($fp)) !== false) {
+        $records = [];
+        while (($row = fgetcsv($fp, null, $eccubeConfig->get('eccube_csv_export_separator'), '"', '')) !== false) {
             if ($row !== [null]) {
-                ++$rows;
+                $records[] = $row;
             }
         }
         fclose($fp);
 
-        return $rows;
+        return $records;
     }
 
     /**

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
@@ -1108,10 +1108,12 @@ final class ProductControllerTest extends AbstractAdminWebTestCase
      */
     public function testExportProductKeepsSortOrder(): void
     {
-        // 商品コードの昇順が商品IDの昇順と一致しないよう, 逆順に登録する.
+        // ソート未指定時の既定は p.update_date DESC, p.id DESC なので, 登録順を b, c, a にして
+        // 既定の並び (a, c, b) が昇順 (a, b, c) とも降順 (c, b, a) とも一致しないようにする.
+        // 一致していると, ソートが効かなくてもその向きのアサートが通ってしまう.
         // 規格を登録すると 規格なし既定の ProductClass は非表示になるが, CSV には出力される.
         $prefix = 'Product for sort order '.uniqid();
-        foreach (['c', 'b', 'a'] as $code) {
+        foreach (['b', 'c', 'a'] as $code) {
             $Product = $this->createProduct($prefix.' '.$code, 1);
             $no = 1;
             foreach ($Product->getProductClasses() as $ProductClass) {

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
@@ -1051,6 +1051,48 @@ final class ProductControllerTest extends AbstractAdminWebTestCase
     }
 
     /**
+     * ソートしてから商品CSVをダウンロードしてもエラーにならないことのテスト.
+     *
+     * 商品検索のクエリは ProductClass を to-many で join しているため, ProductClass 側の列
+     * (pc.code, pc.stock) でソートすると LimitSubqueryWalker が例外を投げ,
+     * CSV が最後まで出力されなかった.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6713
+     */
+    #[DataProvider(methodName: 'dataProductSortKeyProvider')]
+    public function testExportProductWithSortKey(string $sortKey): void
+    {
+        $searchForm = $this->createSearchForm();
+        $searchForm['sortkey'] = $sortKey;
+        $searchForm['sorttype'] = 'a';
+        $this->searchProduct($searchForm);
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $content = $this->exportProductCsv();
+
+        // ヘッダ行だけでなくデータ行が出力されていること.
+        $lines = preg_split('/\R/', trim($content)) ?: [];
+        $this->assertGreaterThan(1, count($lines));
+    }
+
+    /**
+     * @return \Iterator<int<0, max>, array{string}>
+     */
+    public static function dataProductSortKeyProvider(): \Iterator
+    {
+        // ProductClass (to-many) の列。修正前はエラーになる2キー。
+        yield ['product_code'];
+        yield ['stock'];
+        // association (p.Status) のため wrap-queries の対象外。従来どおり動くこと。
+        yield ['status'];
+        // Product (to-one) の列。従来どおり動くこと。
+        yield ['product_id'];
+        yield ['name'];
+        // ソート未指定。
+        yield [''];
+    }
+
+    /**
      * 商品検索を実行し, 検索条件をセッションに保持する.
      *
      * @param array<string, mixed> $searchForm

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 namespace Eccube\Tests\Web\Admin\Product;
 
 use Eccube\Common\Constant;
-use Eccube\Common\EccubeConfig;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Master\ProductStatus;
 use Eccube\Entity\Master\RoundingType;
@@ -1127,19 +1126,23 @@ final class ProductControllerTest extends AbstractAdminWebTestCase
 
         $searchForm['sorttype'] = 'a';
         $this->searchProduct($searchForm);
-        $this->assertSame(['a1', 'a2', 'b1', 'b2', 'c1', 'c2'], $this->extractProductCodes($this->exportProductCsv()));
+        $this->assertSame(['a', 'a', 'b', 'b', 'c', 'c'], $this->extractSortedProductGroups($this->exportProductCsv()));
 
         $searchForm['sorttype'] = 'd';
         $this->searchProduct($searchForm);
-        $this->assertSame(['c1', 'c2', 'b1', 'b2', 'a1', 'a2'], $this->extractProductCodes($this->exportProductCsv()));
+        $this->assertSame(['c', 'c', 'b', 'b', 'a', 'a'], $this->extractSortedProductGroups($this->exportProductCsv()));
     }
 
     /**
-     * CSV から商品コード列の値を出力順に取り出す.
+     * CSV から商品コードの先頭 1 文字を出力順に取り出す.
+     *
+     * 商品コードは `<商品を表す 1 文字><規格ごとの連番>` で登録する.
+     * 商品内の行順は `Product::$ProductClasses` の取得順（`#[ORM\OrderBy]` が無く DB 依存）
+     * に左右されるため, 商品間の並びだけを見るよう連番を落として比較する.
      *
      * @return array<int, string>
      */
-    private function extractProductCodes(string $csv): array
+    private function extractSortedProductGroups(string $csv): array
     {
         $records = $this->parseCsv($csv);
         $header = array_shift($records);
@@ -1147,7 +1150,7 @@ final class ProductControllerTest extends AbstractAdminWebTestCase
         $index = array_search('商品コード', $header, true);
         $this->assertIsInt($index);
 
-        return array_map(fn (array $row): string => (string) $row[$index], $records);
+        return array_map(fn (array $row): string => substr((string) $row[$index], 0, 1), $records);
     }
 
     /**
@@ -1163,46 +1166,6 @@ final class ProductControllerTest extends AbstractAdminWebTestCase
         $this->assertTrue($this->client->getResponse()->isSuccessful());
 
         return $this->countCsvRows($this->exportProductCsv());
-    }
-
-    /**
-     * CSV のレコード数を返す（ヘッダ行を除く）.
-     */
-    private function countCsvRows(string $csv): int
-    {
-        return count($this->parseCsv($csv)) - 1;
-    }
-
-    /**
-     * CSV をレコード単位にパースする（ヘッダ行を含む）.
-     *
-     * 項目の値に改行が含まれるため, 行数は改行では数えられない.
-     * 出力は eccube_csv_export_encoding のエンコーディングなので UTF-8 に戻してから読む
-     * (SJIS は 2 バイト目に 0x5C を含む文字があり, escape と誤認して行が結合される).
-     * escape は PHP 8.4 以降の既定値に合わせて '' を明示する
-     * (省略すると deprecation。'\\' はデータ中のバックスラッシュで行が結合される).
-     *
-     * @return array<int, array<int, string|null>>
-     */
-    private function parseCsv(string $csv): array
-    {
-        $eccubeConfig = static::getContainer()->get(EccubeConfig::class);
-        $csv = (string) mb_convert_encoding($csv, 'UTF-8', $eccubeConfig->get('eccube_csv_export_encoding'));
-
-        $fp = fopen('php://memory', 'r+');
-        $this->assertNotFalse($fp);
-        fwrite($fp, $csv);
-        rewind($fp);
-
-        $records = [];
-        while (($row = fgetcsv($fp, null, $eccubeConfig->get('eccube_csv_export_separator'), '"', '')) !== false) {
-            if ($row !== [null]) {
-                $records[] = $row;
-            }
-        }
-        fclose($fp);
-
-        return $records;
     }
 
     /**

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductControllerTest.php
@@ -1076,6 +1076,64 @@ final class ProductControllerTest extends AbstractAdminWebTestCase
     }
 
     /**
+     * ソートの有無で商品CSVの行数が変わらないことのテスト.
+     *
+     * ProductClass を select 句に載せると pc.visible の条件でコレクションが部分初期化され,
+     * ソートしたときだけ非表示の規格の行が落ちることがある. 行数で担保して検知する.
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6713
+     */
+    public function testExportProductRowCountIsNotAffectedBySort(): void
+    {
+        // 規格を 2 件登録した商品. 規格を登録すると 規格なし既定の ProductClass は非表示になるが,
+        // ソートしない CSV には 3 行とも出力される.
+        $productName = 'Product for csv sort '.uniqid();
+        $Product = $this->createProduct($productName, 2);
+
+        $searchForm = $this->createSearchForm();
+        $searchForm['id'] = $productName;
+
+        $expected = $this->countExportedRows($searchForm, '');
+        $this->assertSame(count($Product->getProductClasses()), $expected);
+
+        foreach (['product_code', 'stock'] as $sortKey) {
+            $this->assertSame($expected, $this->countExportedRows($searchForm, $sortKey), $sortKey);
+        }
+    }
+
+    /**
+     * ソートしてから商品CSVを出力し, ヘッダ行を除いたレコード数を返す.
+     *
+     * @param array<string, mixed> $searchForm
+     */
+    private function countExportedRows(array $searchForm, string $sortKey): int
+    {
+        $searchForm['sortkey'] = $sortKey;
+        $searchForm['sorttype'] = 'a';
+        $this->searchProduct($searchForm);
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $csv = $this->exportProductCsv();
+
+        // 項目の値に改行が含まれるため, 改行の数ではなく fgetcsv でレコード単位に数える.
+        $fp = fopen('php://memory', 'r+');
+        $this->assertNotFalse($fp);
+        fwrite($fp, $csv);
+        rewind($fp);
+        fgetcsv($fp); // ヘッダ行.
+
+        $rows = 0;
+        while (($row = fgetcsv($fp)) !== false) {
+            if ($row !== [null]) {
+                ++$rows;
+            }
+        }
+        fclose($fp);
+
+        return $rows;
+    }
+
+    /**
      * @return \Iterator<int<0, max>, array{string}>
      */
     public static function dataProductSortKeyProvider(): \Iterator


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Refs #6713

一覧をソートしてから CSV をダウンロードするとエラーになる不具合を修正します。

**Issue は受注一覧の報告ですが、調査したところ同じ原因で 3 経路・5 キーが壊れていました。**

| 経路 | 壊れるソートキー |
|---|---|
| 受注CSV | 出荷状況 (`s.shipping_date`) / お問い合わせ番号 (`s.tracking_number`) / お届け先 (`s.name01`) |
| 配送CSV | 同上（同じクエリビルダを使うため） |
| **商品CSV** | **商品コード (`pc.code`) / 在庫数 (`pc.stock`)** |

いずれも検索クエリが to-many の関連を join しているため、その関連側の列でソートした状態で
ページングすると `LimitSubqueryWalker` が例外を投げます。

```
Cannot select distinct identifiers from query with LIMIT and ORDER BY
on a column from a fetch joined to-many association. Use output walkers.
```

ブラウザで確認した結果、**HTTP 500 になりダウンロードは発生しません**（`APP_ENV=dev` で実測）。

なお Issue には「ヘッダ行だけ書き出された壊れた CSV がダウンロードされたうえでエラー」と
報告されています。`exportHeader()` が `php://output` にヘッダ行を書いた後で
`exportData()` が例外を投げる構造なので、出力バッファの状態次第で部分的な CSV が
クライアントへ届くことは起こり得ます（こちらは未実測です）。
いずれにしても CSV は最後まで出力されません。

| ソートキー | 対象カラム | 修正前 |
|---|---|---|
| 出荷状況 | `s.shipping_date` | エラー |
| お問い合わせ番号 | `s.tracking_number` | エラー |
| お届け先 | `s.name01` | エラー |
| 商品コード | `pc.code` | エラー |
| 在庫数 | `pc.stock` | エラー |
| 注文者 / 支払方法 / 対応状況 / 購入金額 / 商品ID / 商品名 / 公開状態 | `o.*` `p.*` | 正常 |

**受注CSVと配送CSVは同じクエリビルダ（`CsvExportService::getOrderQueryBuilder()`）を
使うため、配送CSVも同じ不具合を抱えていました。** Issue には記載がありませんが、
追加したテストで両方の再現を確認しています。

## 方針(Policy)

**一覧画面では既に `wrap-queries` で回避済みだったので、CSV 出力でも同じ判定を使います。**

`OrderController::index()` は以前から次のように書かれていました。

```php
$paginate_options = ['wrap-queries' => true];
if (empty($this->orderRepository::COLUMNS[$sortKey]) || $sortKey == 'order_status') {
    $paginate_options = [];
}
```

この判定を `createPaginateOptions()` に切り出し、一覧・受注CSV・配送CSV で共有します。
商品側も同じ形にしました。新しい方針を持ち込まず、**一覧の既存挙動に CSV を合わせる**
形にしています。

### `order_status` / `status` を対象外にしている理由

`OrderRepository::COLUMNS` の `order_status` は `'o.OrderStatus'`、
`ProductRepository::COLUMNS` の `status` は `'p.Status'` で、いずれもスカラー列ではなく
**association** です。一覧側が以前から明示的に除外しているので、CSV 側でも除外を維持します。
無条件に `wrap-queries` を有効にすると、現在正常に出力できているソートの挙動を変えてしまいます。

### 商品CSVは `wrap-queries` だけでは足りない

商品CSVは `wrap-queries` を有効にすると `LimitSubqueryWalker` は解消しますが、
今度は PostgreSQL が別のエラーで拒否します。

```
SQLSTATE[42P10]: for SELECT DISTINCT, ORDER BY expressions must appear in select list
```

商品CSVの出力パスは `resetDQLPart('select')` の後に `select('p')->distinct()` で
select を絞るため、`ORDER BY pc.code` が select 句に無いことが原因です。

**そこで `ProductClass` の列でソートしている場合だけ、その列を `HIDDEN` で select 句に
載せるようにしました。**

```php
$qb->select('p')->distinct();

if ($hiddenSortColumn !== null) {
    $qb->addSelect($hiddenSortColumn.' AS HIDDEN sort_key_value');
}
```

`HIDDEN` なので取得結果には含まれず、`ORDER BY` の対象が select 句にある状態だけを作れます。

形ごとに実測した結果です（PostgreSQL・1 ケース 1 トランザクションで隔離。
商品 469 件 / 規格 1149 件、うち非表示 448 件）。

| select | wrap-queries | `pc.code` / `pc.stock` でソート | 出力行数 |
|---|---|---|---|
| `p` | なし（**修正前**） | `LimitSubqueryWalker` の例外 | — |
| `p` | あり | `42P10` DISTINCT/ORDER BY の例外 | — |
| `p, pc` | あり | OK | **701 行（不採用）** |
| **`p` ＋ `HIDDEN`** | **あり** | **OK（本PR）** | **1149 行** |

**`select('p, pc')` を採らなかった理由は、出力行数が変わってしまうからです。**
`pc` を fetch join すると、検索クエリが持つ `pc.visible = true` の条件で `ProductClasses`
コレクションが**部分初期化**され、`getProductClasses()` が表示中の規格しか返さなくなります。
商品CSVは規格ごとに 1 行を出力するため、**規格を登録すると非表示になる 規格なし既定の
`ProductClass`**（`class_category_id1 IS NULL`）の行が落ちます。
上記データでは 448 商品で各 1 行、**1149 行 → 701 行**の差になりました。
ソートリンクを押したかどうかで CSV の内容が変わってしまうため採用していません。

`HIDDEN` 方式では `ProductClasses` は遅延ロードのままなので、この問題が起きません。
**ソートキー 5 種すべて（未指定 / `product_code` / `stock` / `name` / `status`）で
1149 行に一致することを実測しました。**

在庫切れ絞り込み（`$isOutOfStock`）の `select('p, pc')` は従来どおりです。
この絞り込みではソートの有無で select が変わらないため、内部で不整合は生じません。

### `CsvExportService::exportData()` を引数で受け取る形にした理由

`exportData()` は **受注・商品・会員・カテゴリ・規格分類・規格名** の CSV 出力で
共有されています（計 6 経路）。ここで無条件に `wrap-queries` を有効にすると、
無関係な経路の挙動まで変わってしまいます。

そのため呼び出し側からオプションを渡す形にし、**既定値を `[]`** にしました。
**会員・カテゴリ・規格分類・規格名の 4 経路は引数を渡していないため、挙動は変わりません。**

> **互換性の注意:** `exportData()` に省略可能引数を追加しているため、
> **このメソッドを override している外部プラグインは `must be compatible with` の
> fatal error になります**（本体・同梱プラグインに override はありません）。
> 4.4 はメジャー更新なので破壊自体は許容範囲と判断していますが、影響がある場合は
> `setPaginateOptions()` の新設など BC を保つ形に変更できます。

## 実装に関する補足(Appendix)

- CSV 出力では `sortkey` をセッション（`eccube.admin.order.search` /
  `eccube.admin.product.search`）から読んでいます。`sortkey` は `SearchOrderType` /
  `SearchProductType` で `HiddenType` として定義されているため、セッションの view data と
  submit 後の値は同じ文字列になります。
- セッション由来の値を扱うため、ソートキーの正規化は `extractSortKey()` に寄せました
  （文字列以外は未指定として扱う。`null` をそのまま配列オフセットに使うのは PHP 8.5 で非推奨）。
  `createPaginateOptions()` は `string` を受け取るだけで、一覧・CSV のどちらからも同じ形で呼びます。
- 商品側の判定にあった `$sortKey === 'code'` は削除しました。`ProductRepository::COLUMNS` に
  `'code'` キーは無く（商品コードは `'product_code'`）、手前の `empty()` で必ず打ち切られる
  到達不能な条件でした。判定結果は変わりません。

## テスト（Test)

受注CSV・配送CSV・商品CSVそれぞれに回帰テストを追加しました（計 21 ケース）。

| テスト | ケース数 | 内容 |
|---|---|---|
| `OrderControllerTest::testExportOrderWithSortKey` | ソートキー 6 種 | エラーにならず、データ行が出力されること |
| `OrderControllerTest::testExportShippingWithSortKey` | ソートキー 6 種 | 同上 |
| `ProductControllerTest::testExportProductWithSortKey` | ソートキー 6 種 | 同上 |
| `OrderControllerTest::testExportOrderRowCountIsNotAffectedBySort` | 1 | **ソートの有無で行数が変わらないこと** |
| `OrderControllerTest::testExportShippingRowCountIsNotAffectedBySort` | 1 | 同上 |
| `ProductControllerTest::testExportProductRowCountIsNotAffectedBySort` | 1 | 同上 |

- **修正前（`4.4`）**: 21 件のうち **11 件が失敗**（受注/配送 各 3 キー = 6 件、商品 2 キー = 2 件、行数テスト 3 件）
- **修正後**: 21 件すべてパス

`order_status` / `status` / `purchase_price` / `product_id` / `name` / ソート未指定の
ケースは修正前後どちらもパスするため、**除外条件が効いていること・従来動いていたキーが
壊れていないこと**を同時に担保します。

行数テストは、上記の `select('p, pc')` で起きる行の欠落を検知するために入れています。
**行数は改行の数では数えられません**（商品CSVは説明文に改行を含むため、`preg_split('/\R/')`
では 1149 行が 1594 行に膨らみます）。`fgetcsv` でレコード単位に数えています。

### 管理画面での動作確認（Playwright / Chrome）

**実ブラウザで、一覧のソートリンクをクリックしてから CSV をダウンロードする経路を確認しました。**
機能テストは `sortkey` を POST で直接渡すため、JS 駆動のソート UI
（`js-listSort` のクリックで `js-listSort-key` に値が入る）を通っていないので、別途確認しています。

| 操作 | 修正前 | 修正後 |
|---|---|---|
| 出荷状況でソート → 受注CSV | **HTTP 500**（`LimitSubqueryWalker` の uncaught 例外・ダウンロードなし） | 110 行の CSV をダウンロード |
| お問い合わせ番号でソート → 受注CSV | 同上 | 110 行の CSV をダウンロード |
| お届け先でソート → 受注CSV | 同上 | 110 行の CSV をダウンロード |
| 出荷状況でソート → 出荷CSV | 同上 | 110 行の CSV をダウンロード |
| 対応状況でソート → 受注CSV | 正常 | 正常（除外条件が効いていること） |
| 商品コードでソート → 商品CSV | **HTTP 500** | 正常 |

ブラウザ確認は `select('p, pc')` 方式のときに実施したものです。`HIDDEN` 方式に変更した後は、
**出力行数（5 ソートキーすべて 1149 行）と並び順を実測で再確認**しています。

**ソートが CSV まで維持されていることも確認しました。** 「お届け先」でソートした状態の
一覧の表示順（受注 25 件）と、ダウンロードした CSV の受注の並びが**完全に一致**しました。
`order_status`（wrap-queries 対象外）でも同様に一致します。
商品CSVも、一覧と同じクエリで 4 ページ分（100 件）取得した商品ID列と、CSV 側クエリの
先頭 100 件が完全に一致しました。エラーが消えただけでなく、並び順が正しく保たれています。

ブラウザのコンソールエラーは 0 件です。

受注一覧のソートリンクは 8 種（`orderer` / `order` / `payment_method` / `order_status` /
`purchase_price` / `shipping_status` / `tracking_number` / `delivery`）で、
テストはこのうち 5 種と「ソート未指定」を網羅しています。
未カバーの `orderer` / `order` / `payment_method` はいずれも `o.*` のスカラー列で、
カバー済みの `purchase_price` と同じ扱いになります。
商品一覧のソートリンクは 7 種で、テストは `product_code` / `stock` / `status` /
`product_id` / `name` と「ソート未指定」を網羅しています。
未カバーの `create_date` / `update_date` は `p.*` のスカラー列です。

### 自動テストの実行結果（Docker / PHP 8.2.31 / PostgreSQL）:

- CSV 関連 21 ケース … すべてパス
- `OrderControllerTest` … 32 tests, 140 assertions すべてパス
- `ProductControllerTest` … 57 tests。1 件失敗するが**本 PR とは無関係**
  （`testProductSearchAll` の件数アサート。ローカル DB にテストが残した商品が蓄積して
  480 件あり、フィクスチャの期待値 13 件と合わない。修正前のコードでも同じ結果）
- `CsvExportServiceTest` / `PaginationTest` / `CustomerControllerTest` … 26 tests パス
- PHPStan（level 6・変更した `src` の 3 ファイル）… エラーなし
- PHP-CS-Fixer … 差分なし
- Rector … 指摘なし

## 相談（Discussion）

Issue では「CSV 出力時はソートを使わない方針にする」案も出ていましたが、
本 PR は**ソートを維持したまま解消する**方針で作っています。
報告者の @ishida20284 からは、既存のソート機能を維持できることと性能面の劣化が
無いことを確認したうえで同意をいただいています。

**@dotani1111 当初「出力時にページのソートを利用しない方針にしようか」とご提案いただいた
点について、この方針で問題ないかご判断をお願いします。**

性能は受注 5,011 件 / 明細 30,051 件（27.5 MB）で A/B を交互に 6 往復して計測し、
中央値 42.9 秒 → 45.2 秒でレンジが重複しており、有意差は確認できませんでした。

**商品CSVを本 PR に含めるかについてもご意見をください。** Issue は受注一覧の報告ですが、
原因が同一で修正パターンも共通なので、まとめて直すほうが取りこぼしが無いと判断しました。
分けたほうがよければ商品CSV分を別 PR / 別 Issue に切り出します。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

> `CsvExportService::exportData()` に**省略可能な引数を追加**しています。
> 引数の削除・型変更ではなく、既存の呼び出し（引数 1 個）はそのまま動作します。
> ただし、このメソッドを override している外部プラグインは fatal になります（上記の互換性の注意）。
>
> CSV の内容は変わりません。**受注CSVは 6 ソートキーすべてで 110 行 / 受注 25 件、
> 商品CSVは 5 ソートキーすべてで 1149 行**で一致することを実測しています。
> 従来はエラーで出力が途切れていたものが、最後まで出力されるようになります。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 管理画面の受注・配送・商品CSV出力で、一覧画面と同じ検索条件やソート条件を適用できるよう改善しました。
  * ソート条件によってCSV出力にエラーが発生したり、出力件数が変わったりする問題を解消しました。
  * 商品CSVでは、指定した並び順が正しく反映されるようになりました。
* **テスト**
  * 各種ソート条件でのCSV出力、出力件数、並び順を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->