### PR TITLE
fix: ESI/fragments を既定で無効化する

### DIFF
--- a/app/config/eccube/packages/framework.yaml
+++ b/app/config/eccube/packages/framework.yaml
@@ -18,11 +18,14 @@ framework:
         cookie_secure: auto
         cookie_samesite: none
 
-    # When using the HTTP Cache, ESI allows to render page fragments separately
-    # and with different cache configurations for each fragment
-    # https://symfony.com/doc/current/book/http_cache.html#edge-side-includes
-    esi: { enabled: true }
-    fragments: { enabled: true }
+    # ESI / fragments are disabled by default.
+    # The core renders blocks via the inline fragment renderer ({{ render(path(...)) }}),
+    # which does not require the fragments listener nor the public /_fragment endpoint.
+    # Keeping them disabled avoids exposing /_fragment. Enable them only if a project
+    # actually uses render_esi() / render_hinclude() with an HTTP cache (ESI) gateway.
+    # https://symfony.com/doc/current/http_cache/esi.html
+    esi: { enabled: false }
+    fragments: { enabled: false }
     php_errors:
         log: true
     assets:


### PR DESCRIPTION
## 概要

EC-CUBE コアはブロック描画に inline フラグメントレンダラ (`{{ render(path(...)) }}`) のみを使用しており、ESI / hinclude レンダラや fragments リスナー(公開エンドポイント `/_fragment`)を利用していません。未使用のまま既定で有効化しておくと `/_fragment` が露出するため、既定で無効化して攻撃面を削減します。

## 変更内容

`app/config/eccube/packages/framework.yaml` の `esi` / `fragments` を `enabled: false` に変更しました。

## 影響調査

- コア(`src/Eccube`)およびテンプレートで `render_esi()` / `render_hinclude()` / `esi:include` / `hx:include` の使用なし
- `HttpCache` / `Surrogate` など ESI ゲートウェイの登録なし
- 無効化後も inline レンダラ(`fragment.renderer.inline`)と `fragment.handler` は維持され、ブロック描画は従来通り動作
- `cache:clear`(prod) が正常完了（コンパイルエラーなし）
- 無効化により除去されるのは `fragment.listener`(`/_fragment`) と、未使用の `fragment.renderer.esi` / `fragment.renderer.hinclude` のみ

## 有効化が必要なケース

`render_esi()` / `render_hinclude()` を HTTP キャッシュ(ESI)ゲートウェイと組み合わせて使うプロジェクトは、個別に `enabled: true` へ戻してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * フラグメント機能の設定を見直し、インライン方式で処理するよう変更しました。
  * フラグメント用の公開エンドポイントを無効化し、不要な外部アクセスを防止します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->