### PR TITLE
fix(mail): メールテンプレートの更新時に削除可否を変更しないようにする (#7053)

### DIFF
--- a/src/Eccube/Controller/Admin/Setting/Shop/MailController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/MailController.php
@@ -94,7 +94,11 @@ class MailController extends AbstractController
 
             if ($form->isSubmitted() && $form->isValid()) {
                 $Mail = $form->getData();
-                $Mail->setDeletable(true);
+                // 新規登録したテンプレートのみ削除可能にする.
+                // 更新時に設定すると, 削除不可のシステム用テンプレートが削除可能になってしまう.
+                if (null === $Mail->getId()) {
+                    $Mail->setDeletable(true);
+                }
                 $this->entityManager->persist($Mail);
                 $this->entityManager->flush();
 

--- a/tests/Eccube/Tests/Web/Admin/Setting/Shop/MailControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Setting/Shop/MailControllerTest.php
@@ -51,10 +51,18 @@ final class MailControllerTest extends AbstractAdminWebTestCase
         // 新規登録
         $crawler = $this->senarioCreate();
         $this->assertTrue($this->client->getResponse()->isRedirect());
+        $location = $this->client->getResponse()->headers->get('location');
+        $id = str_replace('/admin/setting/shop/mail/', '', $location);
+
         $crawler = $this->client->followRedirect();
         $this->actual = $crawler->filter('div.alert')->text();
         $this->expected = '保存しました';
         $this->verify();
+
+        // 新規登録したテンプレートは削除できる
+        $MailTemplate = $this->entityManager->find(MailTemplate::class, $id);
+        $this->assertInstanceOf(MailTemplate::class, $MailTemplate);
+        $this->assertTrue($MailTemplate->isDeletable());
     }
 
     /**
@@ -210,6 +218,45 @@ final class MailControllerTest extends AbstractAdminWebTestCase
     /**
      * 削除不可のテンプレートを削除
      */
+    /**
+     * 削除不可のテンプレートは、更新しても削除不可のままであることを確認
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/7053
+     */
+    public function testEditKeepsNotDeletable(): void
+    {
+        // 新規登録
+        $this->senarioCreate();
+        $this->assertTrue($this->client->getResponse()->isRedirect());
+        $location = $this->client->getResponse()->headers->get('location');
+        $id = str_replace('/admin/setting/shop/mail/', '', $location);
+        $this->client->followRedirect();
+
+        // deletable => falseに更新し, システム用テンプレート相当の状態にする.
+        // 実在のシステム用テンプレートを更新すると, eccube_theme_front_dir に
+        // コアのメールテンプレートを上書きするファイルが生成されてしまうため使用しない.
+        $MailTemplate = $this->entityManager->find(MailTemplate::class, $id);
+        $this->assertInstanceOf(MailTemplate::class, $MailTemplate);
+        $MailTemplate->setDeletable(false);
+        $this->entityManager->flush();
+
+        // 件名を更新
+        $subject = 'test_edit_not_deletable_mail_subject';
+        $this->senarioEdit($id, ['mail_subject' => $subject]);
+
+        $crawler = $this->client->followRedirect();
+        $this->actual = $crawler->filter('div.alert')->text();
+        $this->expected = '保存しました';
+        $this->verify();
+
+        // 更新されていることを確認
+        $this->entityManager->refresh($MailTemplate);
+        $this->assertSame($subject, $MailTemplate->getMailSubject());
+
+        // 更新しても削除不可のままであることを確認
+        $this->assertFalse($MailTemplate->isDeletable());
+    }
+
     public function testDeleteNotDeletable(): void
     {
         // 新規登録


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

fixes #7053

システム用テンプレート（注文受付メール等）を 1 回保存すると削除ボタンが出現し、削除できてしまう不具合を修正します。

削除すると `dtb_mail_template` の行だけでなく `Mail/order.twig` などの**テンプレートファイルも消える**ため（`MailController::delete()`）、メールが送信できなくなり、復旧にはファイルの復元が必要になります。

## 方針(Policy)

原因は `aa6f4f85be`「削除ボタン表示のタイミングを調整」（2024-04-16）です。`setDeletable(true)` を `MailType` の `POST_SUBMIT` からコントローラへ移した際に、**元々あった `if (null === $data->getId())`（新規のみ）の条件が落ちていました。**

そのため保存パスで新規のときだけフラグを立てる形に戻します。判定方法は `MailType` が既に 2 箇所（`file_name` 項目の追加・ファイル名重複チェック）で使っている `null === $data->getId()` に揃えました。

`delete()` には既に `if (!$Mail->isDeletable())` のガードがあるため、そちらは変更していません。

### 検討して採らなかった案

- **`setDeletable(true)` の行を単に削除する** — `MailTemplate::$deletable` は既定 `false` なので、ユーザーが作成したテンプレートも削除できなくなります。`MailControllerTest::testDelete()` と `admin-basicinfo.spec.ts` の「テンプレート新規作成 → 削除」が落ちます
- **生成時（`$Mail ??= new MailTemplate()`）に立てる / Repository に生成メソッドを新設する** — `index()` は新規画面でもビューに `Mail` を渡しており、`mail.twig` が `{% if Mail.isDeletable %}` で削除ボタンと削除モーダルを出し分けています。生成時に立てると**未保存の新規フォームに削除ボタンが出ます**。モーダルの削除リンクは `url('admin_setting_shop_mail_delete', {id: Mail.id})` で `Mail.id` が `null` になり壊れた URL になります。これは `aa6f4f85be` が調整した「タイミング」そのものです

なお同じ `deletable` 列を持つ `Block` では `BlockRepository::newBlock()` が生成時にだけフラグを立て、`BlockController` の保存処理は `deletable` に一切触れません。本修正はこの作法と整合します。

## テスト（Test)

`MailControllerTest` に以下を追加しました。

- `testEditKeepsNotDeletable()` — 削除不可のテンプレートを更新しても削除不可のままであることを確認
- `testCreate()` に「新規登録したテンプレートは削除できる」アサートを追加（`aa6f4f85be` の意図に対する退行ガード）

修正前は `testEditKeepsNotDeletable` が `Failed asserting that true is false.` で落ちることを確認済みです（空振りでないことの担保）。

| 実行 | 結果 |
|---|---|
| `MailControllerTest`（10 本） | OK (10 tests, 39 assertions) |
| `vendor/bin/phpstan analyse src` | No errors |
| `vendor/bin/php-cs-fixer fix --dry-run`（変更 2 ファイル） | Found 0 of 2 files |

実機（`APP_ENV=dev`）でも Issue の再現手順を踏んで確認しました。

1. 注文受付メールを選択 → 削除ボタン 0 件
2. 保存 → 「保存しました」
3. **保存後も削除ボタン・削除モーダルとも 0 件**
4. `dtb_mail_template` の `deletable` も `false` のまま

## 実装に関する補足(Appendix)

- **既にフラグが立ってしまった行は、この修正では戻りません。** 退行は `4.3.0` / `4.3.0-rc` / `4.3.1` / `4.3.1-p1` に出荷済みで、システム用テンプレートを 1 回でも保存した環境では `deletable` が `true` のまま残ります。補正が必要であれば、`app/DoctrineMigrations` の既存の作法（`Version20200303053716` のように id と旧値でガードした `UPDATE`）で対応できますが、Issue のスコープを超えるため本 PR には含めていません。別途ご判断ください
- `origin/4.3` にも同じ形で残っています（`MailController.php:101`）。4.3 系への対応が必要かはメンテナ判断にお任せします
- `e2e/tests/admin-basicinfo.spec.ts` は出荷通知メール（id=8）を保存しており、**修正前はこの spec を流すだけで id=8 の `deletable` が `true` に書き換わっていました。** 修正後は書き換わりません

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

新規登録時の挙動は従来どおり（削除可能）で、変わるのは「更新時に `deletable` を書き換えない」点のみです。

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **不具合修正**
  * メールテンプレート更新時に、システム用テンプレートが誤って削除可能になる問題を修正しました。
  * 新規作成したテンプレートは引き続き削除可能として保存されます。

* **テスト**
  * 新規作成・更新時の削除可否と件名変更が正しく反映されることを確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->