### PR TITLE
fix(plugin): 「既に有効/無効です」でメンテナンスモードを解除する (#7078)

### DIFF
--- a/src/Eccube/Controller/Admin/Store/PluginController.php
+++ b/src/Eccube/Controller/Admin/Store/PluginController.php
@@ -238,6 +238,8 @@ class PluginController extends AbstractController
             }
             $this->addError(trans('admin.store.plugin.already.enabled', ['%plugin_name%' => $Plugin->getName()]), 'admin');
 
+            $this->addFlash('eccube.admin.disable_maintenance', '');
+
             return $this->redirectToRoute('admin_store_plugin');
         }
         // ストアからインストールしたプラグインは依存プラグインが有効化されているかを確認
@@ -346,6 +348,8 @@ class PluginController extends AbstractController
                 return $this->json(['success' => true, 'log' => $log]);
             }
             $this->addError(trans('admin.store.plugin.already.disabled', ['%plugin_name%' => $Plugin->getName()]), 'admin');
+
+            $this->addFlash('eccube.admin.disable_maintenance', '');
 
             return $this->redirectToRoute('admin_store_plugin');
         }

--- a/tests/Eccube/Tests/Web/Admin/Store/PluginControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Store/PluginControllerTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Eccube\Tests\Web\Admin\Store;
 
 use Eccube\Entity\BaseInfo;
+use Eccube\Entity\Plugin;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -25,6 +26,19 @@ use Symfony\Component\HttpFoundation\Response;
 #[Group('cache-clear')]
 final class PluginControllerTest extends AbstractAdminWebTestCase
 {
+    /**
+     * プラグインの有効化/無効化は処理前にメンテナンスモードへ入る.
+     * 解除はブラウザ側の JS が行うためテストでは残るので, 後続のテストに影響しないよう削除する.
+     */
+    protected function tearDown(): void
+    {
+        $maintenanceFilePath = static::getContainer()->getParameter('eccube_content_maintenance_file_path');
+        if (file_exists($maintenanceFilePath)) {
+            unlink($maintenanceFilePath);
+        }
+        parent::tearDown();
+    }
+
     public function testRoutingAuthentication()
     {
         $this->client->request(
@@ -53,6 +67,72 @@ final class PluginControllerTest extends AbstractAdminWebTestCase
         $this->expected = $form['php_path'];
         $this->actual = $this->entityManager->getRepository(BaseInfo::class)->get()->getPhpPath();
         $this->verify();
+    }
+
+    /**
+     * 既に有効なプラグインを有効化してもメンテナンスモードが解除されることを確認
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/7078
+     */
+    public function testEnableAlreadyEnabledReleasesMaintenance(): void
+    {
+        $session = $this->createSession($this->client);
+        $Plugin = $this->createPlugin('AlreadyEnabled', true);
+
+        $this->client->request(
+            Request::METHOD_POST,
+            $this->generateUrl('admin_store_plugin_enable', ['id' => $Plugin->getId()])
+        );
+
+        $redirectUrl = $this->generateUrl('admin_store_plugin');
+        $this->assertTrue($this->client->getResponse()->isRedirect($redirectUrl));
+
+        // 「既に有効です。」でもメンテナンスモード解除のフラッシュが設定される.
+        // これが無いとメンテナンスモードが解除されず, フロントが 503 のまま残る.
+        $this->assertNotEmpty($session->getFlashBag()->get('eccube.admin.disable_maintenance'));
+    }
+
+    /**
+     * 既に無効なプラグインを無効化してもメンテナンスモードが解除されることを確認
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/7078
+     */
+    public function testDisableAlreadyDisabledReleasesMaintenance(): void
+    {
+        $session = $this->createSession($this->client);
+        $Plugin = $this->createPlugin('AlreadyDisabled', false);
+
+        $this->client->request(
+            Request::METHOD_POST,
+            $this->generateUrl('admin_store_plugin_disable', ['id' => $Plugin->getId()])
+        );
+
+        $redirectUrl = $this->generateUrl('admin_store_plugin');
+        $this->assertTrue($this->client->getResponse()->isRedirect($redirectUrl));
+
+        // 「既に無効です。」でもメンテナンスモード解除のフラッシュが設定される
+        $this->assertNotEmpty($session->getFlashBag()->get('eccube.admin.disable_maintenance'));
+    }
+
+    /**
+     * 「既に有効/無効」の分岐は $Plugin->isEnabled() の判定だけで完結するため、
+     * プラグイン本体のファイルを設置しなくても検証できる.
+     */
+    private function createPlugin(string $code, bool $enabled): Plugin
+    {
+        $Plugin = new Plugin();
+        $Plugin
+            ->setName($code)
+            ->setCode($code)
+            ->setVersion('1.0.0')
+            ->setSource('')
+            ->setEnabled($enabled)
+            ->setInitialized(true);
+
+        $this->entityManager->persist($Plugin);
+        $this->entityManager->flush();
+
+        return $Plugin;
     }
 
     /**


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

fixes #7078

プラグイン一覧で「既に有効です。」「既に無効です。」が返る操作をすると、**メンテナンスモードが解除されず、フロントが 503 のまま残る**不具合を修正します。

## 方針(Policy)

有効化/無効化は処理前に `SystemService::switchMaintenance(true)` でメンテナンスモードへ入り、解除は「`eccube.admin.disable_maintenance` フラッシュ → テンプレートの JS が `admin_disable_maintenance` へ POST」という経路で行われます。

**「既に有効です。」「既に無効です。」の早期 return だけが、このフラッシュを付けずに戻っていました。** 同メソッド内の他の return はいずれも付けており、この 2 箇所だけ揃っていない状態でした。最小の修正として、他と同じようにフラッシュを追加します。

`SystemService` には `KernelEvents::TERMINATE` で解除する `disableMaintenance()` もありますが、呼び出しているのは `Admin\Content\MaintenanceController` と `InstallPluginController` だけで、この経路からは呼ばれないため自動では解除されません。

`XmlHttpRequest` 側は影響しません。呼び出し元の `Store/plugin_confirm.twig` は `maintenance_mode` を明示して呼ぶため `switchMaintenance(true)` の分岐に入らず、かつ JS が自分で解除を POST します。今回直したのは `plugin_table.twig` / `plugin_table_official.twig` の一覧ボタン（通常のリンク）からの経路です。

## テスト（Test)

`PluginControllerTest` に有効化・無効化それぞれの確認を追加しました。「既に有効/無効」の分岐は `$Plugin->isEnabled()` の判定だけで完結するため、**プラグイン本体のファイルを設置せず DB のレコードだけで検証できます**。

あわせて `tearDown()` でメンテナンスファイルを削除するようにしました。有効化/無効化のテストは必ずメンテナンスモードへ入り、解除はブラウザ側の JS が行うためテストでは残り続けます。放置すると**後続のフロント側テストが 503 になる**ため、`Admin\Content\MaintenanceControllerTest` と同じ作法で片付けます。

| 実行 | 結果 |
|---|---|
| `PluginControllerTest`（10 本） | OK (10 tests, 18 assertions) |
| `vendor/bin/phpstan analyse src` | No errors |
| `vendor/bin/php-cs-fixer fix --dry-run`（変更 2 ファイル） | Found 0 of 2 files |

修正前は追加した 2 本が `Failed asserting that an array is not empty.` で落ちることを確認済みです（空振りでないことの担保）。

### 実機での A/B 比較

同じ操作（一覧を有効化リンク付きで読み込む → 別経路で有効化される → 古い画面の有効化ボタンを押す）で、結果が反転することを確認しました。

| | `.maintenance` | フロント |
|---|---|---|
| 修正前 | **残る** | **503** |
| 修正後 | 残らない | 200 |

いずれも「「〇〇」は既に有効です。」が表示される点は同じです。

## 実装に関する補足(Appendix)

- Issue では「付け忘れる構造そのものを直す（`switchMaintenance(true)` とセットで解除を保証する形に寄せる）」案にも触れましたが、本 PR は**最小修正**に留めています。構造の見直しが必要であれば別途ご判断ください
- この経路は #7077 で有効化した E2E（`plugin-misc.spec.ts` の `test_install_enable_enable` / `test_install_disable_disable`）が通ります。ただしテスト内では後続の無効化・削除が通常経路で解除するため、**それらのテストはこの不具合を検出しません**

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

追加したのは既存の他の return と同じフラッシュ 1 行ずつで、正常系の挙動は変わりません。

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * すでに有効なプラグインの有効化、またはすでに無効なプラグインの無効化を行った場合でも、メンテナンスモードが解除されるようになりました。

* **テスト**
  * 上記ケースでメンテナンスモードが正しく解除されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->