### PR TITLE
refactor(pdf): 納品書PDF のエンジンを TCPDF から FPDF へ移行する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "php": "^8.2",
         "ext-curl": "*",
         "ext-filter": "*",
+        "ext-gd": "*",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "php": "^8.2",
         "ext-curl": "*",
         "ext-filter": "*",
-        "ext-gd": "*",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
         "psr/log": "~2.0",
         "psr/simple-cache": "^3.0",
         "robthree/twofactorauth": "^3.0",
-        "setasign/fpdi": "^2.2",
+        "setasign/fpdf": "^1.8.6",
+        "setasign/fpdi": "^2.6",
         "softcreatr/jsonpath": "^0.8",
         "symfony/asset": "^7.4",
         "symfony/cache": "^7.4",
@@ -102,7 +103,6 @@
         "symfony/web-profiler-bundle": "^7.4",
         "symfony/workflow": "^7.4",
         "symfony/yaml": "^7.4",
-        "tecnickcom/tcpdf": "^6.2",
         "twig/extra-bundle": "^3.21",
         "twig/intl-extra": "^3.21",
         "twig/twig": "^3.21"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c69a31f51f1f36e0e2cff1ea1fe6ca07",
+    "content-hash": "8f48617c57eea7cb7f6226827eb74616",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -6020,6 +6020,52 @@
                 "source": "https://github.com/Seldaek/signal-handler/tree/2.0.2"
             },
             "time": "2023-09-03T09:24:00+00:00"
+        },
+        {
+            "name": "setasign/fpdf",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDF.git",
+                "reference": "051b70e4c57dedc88df41b1eff1c62894e5f9ed0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Setasign/FPDF/zipball/051b70e4c57dedc88df41b1eff1c62894e5f9ed0",
+                "reference": "051b70e4c57dedc88df41b1eff1c62894e5f9ed0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gd": "*",
+                "ext-zlib": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "fpdf.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Olivier Plathey",
+                    "email": "oliver@fpdf.org",
+                    "homepage": "http://fpdf.org/"
+                }
+            ],
+            "description": "FPDF is a PHP class which allows to generate PDF files with pure PHP. F from FPDF stands for Free: you may use it for any kind of usage and modify it to suit your needs.",
+            "homepage": "http://www.fpdf.org",
+            "keywords": [
+                "fpdf",
+                "pdf"
+            ],
+            "support": {
+                "source": "https://github.com/Setasign/FPDF/tree/1.9.0"
+            },
+            "time": "2026-05-31T14:25:29+00:00"
         },
         {
             "name": "setasign/fpdi",
@@ -12603,77 +12649,6 @@
                 }
             ],
             "time": "2026-07-21T15:13:06+00:00"
-        },
-        {
-            "name": "tecnickcom/tcpdf",
-            "version": "6.11.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/tecnickcom/TCPDF.git",
-                "reference": "e1e2ade18e574e963473f53271591edd8c0033ec"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/e1e2ade18e574e963473f53271591edd8c0033ec",
-                "reference": "e1e2ade18e574e963473f53271591edd8c0033ec",
-                "shasum": ""
-            },
-            "require": {
-                "ext-curl": "*",
-                "php": ">=7.1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "config",
-                    "include",
-                    "tcpdf.php",
-                    "tcpdf_barcodes_1d.php",
-                    "tcpdf_barcodes_2d.php",
-                    "include/tcpdf_colors.php",
-                    "include/tcpdf_filters.php",
-                    "include/tcpdf_font_data.php",
-                    "include/tcpdf_fonts.php",
-                    "include/tcpdf_images.php",
-                    "include/tcpdf_static.php",
-                    "include/barcodes/datamatrix.php",
-                    "include/barcodes/pdf417.php",
-                    "include/barcodes/qrcode.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Nicola Asuni",
-                    "email": "info@tecnick.com",
-                    "role": "lead"
-                }
-            ],
-            "description": "TCPDF is a PHP class for generating PDF documents and barcodes.",
-            "homepage": "http://www.tcpdf.org/",
-            "keywords": [
-                "PDFD32000-2008",
-                "TCPDF",
-                "barcodes",
-                "datamatrix",
-                "pdf",
-                "pdf417",
-                "qrcode"
-            ],
-            "support": {
-                "issues": "https://github.com/tecnickcom/TCPDF/issues",
-                "source": "https://github.com/tecnickcom/TCPDF/tree/6.11.2"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/donate/?hosted_button_id=NZUEC5XS8MFBJ",
-                    "type": "custom"
-                }
-            ],
-            "time": "2026-03-03T08:58:10+00:00"
         },
         {
             "name": "twig/extra-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f943fde32f73ff979f37819d6f5063f",
+    "content-hash": "8f48617c57eea7cb7f6226827eb74616",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -16377,7 +16377,6 @@
         "php": "^8.2",
         "ext-curl": "*",
         "ext-filter": "*",
-        "ext-gd": "*",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f48617c57eea7cb7f6226827eb74616",
+    "content-hash": "9f943fde32f73ff979f37819d6f5063f",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -16377,6 +16377,7 @@
         "php": "^8.2",
         "ext-curl": "*",
         "ext-filter": "*",
+        "ext-gd": "*",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f48617c57eea7cb7f6226827eb74616",
+    "content-hash": "9f943fde32f73ff979f37819d6f5063f",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -16365,6 +16365,7 @@
         "php": "^8.2",
         "ext-curl": "*",
         "ext-filter": "*",
+        "ext-gd": "*",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
@@ -16379,5 +16380,5 @@
         "php": "8.2.0",
         "ext-sodium": "1.0.18"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/llms.txt
+++ b/llms.txt
@@ -71,7 +71,7 @@ EC-CUBE is purpose-built for Japanese e-commerce and includes features that most
 - **Product Classes**: Matrix-style product variations (e.g., size × color) with per-variation pricing and stock
 - **Delivery Management**: Flexible delivery fee calculation by region and shipping method
 - **Payment Integration**: Pluggable payment gateway architecture
-- **PDF Generation**: Built-in order PDF / delivery slip generation via TCPDF
+- **PDF Generation**: Built-in order PDF / delivery slip generation via FPDF + FPDI
 - **Two-Factor Authentication**: TOTP-based 2FA for admin accounts
 - **Mail Templates**: Twig-based customizable email templates
 - **CSV Import/Export**: Bulk product, order, and customer data management

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -587,7 +587,7 @@ class OrderController extends AbstractController
             ]);
         }
 
-        // TCPDF::Outputを実行するとプロパティが初期化されるため、ファイル名を事前に取得しておく
+        // PDF を出力するとページ数が確定した状態を失うため、ファイル名を事前に取得しておく
         $pdfFileName = $this->orderPdfService->getPdfFileName();
 
         // ダウンロードする

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -587,7 +587,8 @@ class OrderController extends AbstractController
             ]);
         }
 
-        // PDF を出力するとページ数が確定した状態を失うため、ファイル名を事前に取得しておく
+        // ファイル名はページ数で決まる。出力前に取得する（4.3 の TCPDF は Output() で
+        // 文書を閉じてページ数を失ったため必須だった。現在の描画器は出力しても状態を保つ）
         $pdfFileName = $this->orderPdfService->getPdfFileName();
 
         // ダウンロードする

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -81,14 +81,13 @@ class InstallController extends AbstractController
         'fileinfo',
         'intl',
         'sodium',
+        'gd',
     ];
     /**
      * @var string[]
      */
     protected array $recommendedModules = [
         'hash',
-        // 納品書 PDF の GIF ロゴを描くときだけ使う. 無い場合はロゴを省いて出力する
-        'gd',
     ];
     /**
      * @var string[]

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -81,13 +81,14 @@ class InstallController extends AbstractController
         'fileinfo',
         'intl',
         'sodium',
-        'gd',
     ];
     /**
      * @var string[]
      */
     protected array $recommendedModules = [
         'hash',
+        // 納品書 PDF の GIF ロゴを描くときだけ使う. 無い場合はロゴを省いて出力する
+        'gd',
     ];
     /**
      * @var string[]

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -81,6 +81,7 @@ class InstallController extends AbstractController
         'fileinfo',
         'intl',
         'sodium',
+        'gd',
     ];
     /**
      * @var string[]

--- a/src/Eccube/Service/OrderPdfService.php
+++ b/src/Eccube/Service/OrderPdfService.php
@@ -754,6 +754,19 @@ class OrderPdfService
             if ((277 - $this->pdfWriter->getY()) < ($h * 4)) {
                 $this->pdfWriter->checkPageBreak($this->pdfWriter->getPageBreakTrigger() + 1);
             }
+            // 上の判定が確保するのは 4 行ぶん(16mm)だけなので, それを超えて折り返す明細は
+            // ここで高さを測って一度だけ送る。1 度目の描画に測定を兼ねさせると, その途中で
+            // 改ページが起きて直後の setXY() が旧ページの座標を新ページへ適用してしまう
+            // （文字は分割されて送られる一方, 罫線だけが新ページの下端に取り残される）
+            $rowHeight = $h;
+            $i = 0;
+            foreach ($row as $col) {
+                $rowHeight = max($rowHeight, $this->pdfWriter->measureMultiCellHeight((float) $w[$i], $h, $col));
+                ++$i;
+            }
+            if ($rowHeight > ($h * 4)) {
+                $this->pdfWriter->checkPageBreak($rowHeight);
+            }
 
             $x = $this->pdfWriter->getX();
             $y = $this->pdfWriter->getY();

--- a/src/Eccube/Service/OrderPdfService.php
+++ b/src/Eccube/Service/OrderPdfService.php
@@ -21,20 +21,15 @@ use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\OrderPdfRepository;
 use Eccube\Repository\OrderRepository;
 use Eccube\Repository\ShippingRepository;
+use Eccube\Service\Pdf\PdfWriter;
 use Eccube\Twig\Extension\EccubeExtension;
 use Eccube\Twig\Extension\TaxExtension;
-use setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException;
-use setasign\Fpdi\PdfParser\Filter\FilterException;
-use setasign\Fpdi\PdfParser\PdfParserException;
-use setasign\Fpdi\PdfParser\Type\PdfTypeException;
-use setasign\Fpdi\PdfReader\PdfReaderException;
-use setasign\Fpdi\Tcpdf\Fpdi;
 
 /**
  * Class OrderPdfService.
  * Do export pdf function.
  */
-class OrderPdfService extends Fpdi
+class OrderPdfService
 {
     protected OrderPdfRepository $orderPdfRepository;
 
@@ -74,6 +69,8 @@ class OrderPdfService extends Fpdi
     // ====================================
     public BaseInfo $baseInfoRepository;
 
+    protected PdfWriter $pdfWriter;
+
     /** 購入詳細情報 ラベル配列
      * @var array<int, string>
      */
@@ -90,11 +87,11 @@ class OrderPdfService extends Fpdi
     // --------------------------------------
     // Font情報のバックアップデータ
     /** @var string フォント名 */
-    protected string $bakFontFamily;
+    protected string $bakFontFamily = '';
     /** @var string フォントスタイル */
-    protected string $bakFontStyle;
-    /** @var string|float|null フォントサイズ */
-    protected string|float|null $bakFontSize = null;
+    protected string $bakFontStyle = '';
+    /** @var float フォントサイズ(pt) */
+    protected float $bakFontSize = 0.0;
     // --------------------------------------
     // lfTextのoffset
     protected int $baseOffsetX = 0;
@@ -115,7 +112,7 @@ class OrderPdfService extends Fpdi
     {
         $this->baseInfoRepository = $baseInfoRepository->get();
 
-        parent::__construct();
+        $this->pdfWriter = $this->createPdfWriter();
 
         // 購入詳細情報の設定を行う
         // 動的に入れ替えることはない
@@ -126,18 +123,10 @@ class OrderPdfService extends Fpdi
         $this->widthCell = [110.3, 12, 21.7, 24.5];
 
         // Fontの設定しておかないと文字化けを起こす
-        $this->SetFont(self::FONT_SJIS);
+        $this->pdfWriter->setFont(self::FONT_SJIS, '', 12);
 
         // PDFの余白(上左右)を設定
-        $this->SetMargins(15, 20);
-
-        // ヘッダーの出力を無効化
-        $this->setPrintHeader(false);
-
-        // フッターの出力を無効化
-        $this->setPrintFooter(true);
-        $this->setFooterMargin();
-        $this->setFooterFont([self::FONT_SJIS, '', 8]);
+        $this->pdfWriter->setMargins(15, 20);
     }
 
     /**
@@ -164,12 +153,6 @@ class OrderPdfService extends Fpdi
      *  note1: 備考1行目
      *  note2: 備考2行目
      *  note3: 備考3行目
-     *
-     * @throws CrossReferenceException
-     * @throws FilterException
-     * @throws PdfParserException
-     * @throws PdfReaderException
-     * @throws PdfTypeException
      */
     public function makePdf(array $formData): bool
     {
@@ -182,6 +165,9 @@ class OrderPdfService extends Fpdi
         if (!$formData['ids']) {
             return false;
         }
+
+        // フッタは全ページ共通で発行日を右寄せで出す
+        $this->pdfWriter->setFooter($this->issueDate, [self::FONT_SJIS, '', 8]);
 
         // 出荷番号をStringからarrayに変換
         $ids = explode(',', (string) $formData['ids']);
@@ -205,7 +191,7 @@ class OrderPdfService extends Fpdi
             } else {
                 $userPath = $this->eccubeConfig->get('eccube_html_admin_dir').'/assets/pdf/nouhinsyo.pdf';
             }
-            $this->setSourceFile($userPath);
+            $this->pdfWriter->setTemplateFile($userPath);
 
             // PDFにページを追加する
             $this->addPdfPage();
@@ -242,7 +228,7 @@ class OrderPdfService extends Fpdi
      */
     public function outputPdf(): string
     {
-        return $this->Output($this->getPdfFileName(), 'S');
+        return $this->pdfWriter->output();
     }
 
     /**
@@ -257,7 +243,7 @@ class OrderPdfService extends Fpdi
             return $this->downloadFileName;
         }
         $this->downloadFileName = self::DEFAULT_PDF_FILE_NAME;
-        if ($this->PageNo() == 1) {
+        if ($this->pdfWriter->getPageCount() == 1) {
             $this->downloadFileName = 'nouhinsyo-No'.$this->lastOrderId.'.pdf';
         }
 
@@ -265,34 +251,22 @@ class OrderPdfService extends Fpdi
     }
 
     /**
-     * フッターに発行日を出力する.
+     * 描画器を組み立てる.
+     *
+     * テンプレート PDF・ロゴ・フォント定義はいずれもファイルから読むため,
+     * 読み込みを許可するディレクトリを明示する（tc-lib-pdf は既定で全て拒否する）.
      */
-    #[\Override]
-    public function Footer(): void
+    protected function createPdfWriter(): PdfWriter
     {
-        $this->Cell(0, 0, $this->issueDate, 0, 0, 'R');
+        return new PdfWriter();
     }
 
     /**
      * 作成するPDFのテンプレートファイルを指定する.
-     *
-     * @throws CrossReferenceException
-     * @throws FilterException
-     * @throws PdfParserException
-     * @throws PdfTypeException
-     * @throws PdfReaderException
      */
     protected function addPdfPage(): void
     {
-        // ページを追加
-        $this->AddPage();
-
-        // テンプレートに使うテンプレートファイルのページ番号を取得
-        $tplIdx = $this->importPage(1);
-
-        // テンプレートに使うテンプレートファイルのページ番号を指定
-        $this->useTemplate($tplIdx, 0, 0, null, null, true);
-        $this->setPageMark();
+        $this->pdfWriter->addPage();
     }
 
     /**
@@ -374,6 +348,15 @@ class OrderPdfService extends Fpdi
             $y += $lineHeight;
         }
 
+        // ロゴは店舗情報の描画後に重ねる（PDFは後から描いた要素が上になるため、元の重なり順を維持する）
+        $this->renderLogo();
+    }
+
+    /**
+     * ロゴ画像を描画する.
+     */
+    protected function renderLogo(): void
+    {
         // user_dataにlogo.pngが配置されている場合は優先的に読み込む
         $logoFile = $this->eccubeConfig->get('eccube_html_dir').'/user_data/assets/pdf/logo.png';
 
@@ -381,8 +364,7 @@ class OrderPdfService extends Fpdi
             $logoFile = $this->eccubeConfig->get('eccube_html_admin_dir').'/assets/pdf/logo.png';
         }
 
-        // ロゴは店舗情報の描画後に重ねる（PDFは後から描いた要素が上になるため、元の重なり順を維持する）
-        $this->Image($logoFile, self::LOGO_X, self::LOGO_Y, self::LOGO_WIDTH);
+        $this->pdfWriter->image($logoFile, self::LOGO_X, self::LOGO_Y, self::LOGO_WIDTH);
     }
 
     /**
@@ -407,21 +389,21 @@ class OrderPdfService extends Fpdi
         // フォント情報のバックアップ
         $this->backupFont();
 
-        $this->Cell(0, 10, '', 0, 1, 'C', false, '');
+        $this->pdfWriter->cell(0, 10, '', 0, 1, 'C');
 
         // 行頭近くの場合、表示崩れがあるためもう一個字下げする
-        if (270 <= $this->GetY()) {
-            $this->Cell(0, 10, '', 0, 1, 'C', false, '');
+        if (270 <= $this->pdfWriter->getY()) {
+            $this->pdfWriter->cell(0, 10, '', 0, 1, 'C');
         }
-        $this->SetFont(self::FONT_GOTHIC, 'B', 9);
-        $this->MultiCell(0, 6, '＜ 備考 ＞', 'T', 'L', false, 0);
+        $this->pdfWriter->setFont(self::FONT_GOTHIC, 'B', 9);
+        $this->pdfWriter->multiCell(0, 6, '＜ 備考 ＞', 'T', 'L', false, 0);
 
-        $this->SetFont(self::FONT_SJIS, '', 8);
+        $this->pdfWriter->setFont(self::FONT_SJIS, '', 8);
 
-        $this->Ln();
+        $this->pdfWriter->newLine();
         // rtrimを行う
         $text = preg_replace('/\s+$/us', '', $formData['note1']."\n".$formData['note2']."\n".$formData['note3']);
-        $this->MultiCell(0, 4, $text, '', 'L', false, 0);
+        $this->pdfWriter->multiCell(0, 4, (string) $text, '', 'L', false, 0);
 
         // フォント情報の復元
         $this->restoreFont();
@@ -439,10 +421,10 @@ class OrderPdfService extends Fpdi
         $this->backupFont();
 
         // 文書タイトル（納品書・請求書）
-        $this->SetFont(self::FONT_GOTHIC, '', 15);
-        $this->Cell(0, 10, $title, 0, 2, 'C', false, '');
-        $this->Cell(0, 66, '', 0, 2, 'R', false, '');
-        $this->Cell(5, 0, '', 0, 0, 'R', false, '');
+        $this->pdfWriter->setFont(self::FONT_GOTHIC, '', 15);
+        $this->pdfWriter->cell(0, 10, $title, 0, 2, 'C');
+        $this->pdfWriter->cell(0, 66, '', 0, 2, 'R');
+        $this->pdfWriter->cell(5, 0, '', 0, 0, 'R');
 
         // フォント情報の復元
         $this->restoreFont();
@@ -473,7 +455,6 @@ class OrderPdfService extends Fpdi
         }
 
         // 購入者都道府県+住所1
-        // $text = $Order->getPref().$Order->getAddr01();
         $text = $Shipping->getPref().$Shipping->getAddr01();
         $this->lfText(27, 47, $text, 10);
         $this->lfText(27, 51, $Shipping->getAddr02(), 10); // 購入者住所2
@@ -494,7 +475,7 @@ class OrderPdfService extends Fpdi
         // =========================================
         // お買い上げ明細部
         // =========================================
-        $this->SetFont(self::FONT_SJIS, '', 10);
+        $this->pdfWriter->setFont(self::FONT_SJIS, '', 10);
 
         // ご注文日
         $orderDate = $Order->getCreateDate()->format('Y/m/d H:i');
@@ -508,13 +489,13 @@ class OrderPdfService extends Fpdi
 
         // 総合計金額
         if (!$Order->isMultiple()) {
-            $this->SetFont(self::FONT_SJIS, 'B', 15);
+            $this->pdfWriter->setFont(self::FONT_SJIS, 'B', 15);
             $paymentTotalText = $this->eccubeExtension->getPriceFilter($Order->getPaymentTotal());
 
             $this->setBasePosition(120, self::PAYMENT_TOTAL_BASE_Y);
-            $this->Cell(5, 7, '', 0, 0, '', false, '');
-            $this->Cell(67, 8, $paymentTotalText, 0, 2, 'R', false, '');
-            $this->Cell(0, 45, '', 0, 2, '', false, '');
+            $this->pdfWriter->cell(5, 7, '', 0, 0, '');
+            $this->pdfWriter->cell(67, 8, $paymentTotalText, 0, 2, 'R');
+            $this->pdfWriter->cell(0, 45, '', 0, 2, '');
         }
 
         // フォント情報の復元
@@ -654,23 +635,23 @@ class OrderPdfService extends Fpdi
 
         // インボイス対応
         $this->backupFont();
-        $this->SetLineWidth(.3);
-        $this->SetFont(self::FONT_SJIS, '', 6);
+        $this->pdfWriter->setLineWidth(.3);
+        $this->pdfWriter->setFont(self::FONT_SJIS, '', 6);
 
-        $this->Cell(0, 0, '', 0, 1, 'C', false, '');
+        $this->pdfWriter->cell(0, 0, '', 0, 1, 'C');
         // 行頭近くの場合、表示崩れがあるためもう一個字下げする
-        if (270 <= $this->GetY()) {
-            $this->Cell(0, 0, '', 0, 1, 'C', false, '');
+        if (270 <= $this->pdfWriter->getY()) {
+            $this->pdfWriter->cell(0, 0, '', 0, 1, 'C');
         }
         $width = array_reduce($this->widthCell, fn (float $n, float $w) => $n + $w, 0.0);
-        $this->SetX(20);
+        $this->pdfWriter->setX(20);
         $message = '';
         foreach ($Order->getTotalByTaxRate() as $rate => $total) {
             $message .= '('.$rate.'%対象: ';
             $message .= $this->eccubeExtension->getPriceFilter($total);
             $message .= ' 内消費税: '.$this->eccubeExtension->getPriceFilter($Order->getTaxByTaxRate()[$rate]).')'.PHP_EOL;
         }
-        $this->MultiCell($width, 4, $message, 0, 'R', false, 1);
+        $this->pdfWriter->multiCell($width, 4, $message, 0, 'R', false, 1);
 
         $this->restoreFont();
     }
@@ -687,14 +668,14 @@ class OrderPdfService extends Fpdi
     protected function lfText(int $x, int $y, ?string $text, int $size = 0, string $style = ''): void
     {
         // 退避
-        $bakFontStyle = $this->FontStyle;
-        $bakFontSize = $this->FontSizePt;
+        $bakFontStyle = $this->pdfWriter->getFontStyle();
+        $bakFontSize = $this->pdfWriter->getFontSizePt();
 
-        $this->SetFont('', $style, $size);
-        $this->Text($x + $this->baseOffsetX, $y + $this->baseOffsetY, $text ?? '');
+        $this->pdfWriter->setFont(null, $style, $size);
+        $this->pdfWriter->text($x + $this->baseOffsetX, $y + $this->baseOffsetY, $text ?? '');
 
         // 復元
-        $this->SetFont('', $bakFontStyle, $bakFontSize);
+        $this->pdfWriter->setFont(null, $bakFontStyle, $bakFontSize);
     }
 
     /**
@@ -702,7 +683,7 @@ class OrderPdfService extends Fpdi
      *
      * @param array<int, string> $header 出力するラベル名一覧
      * @param array<int, array<int, string>> $data 出力するデータ
-     * @param array<int, int> $w 出力するセル幅一覧
+     * @param array<int, float|int> $w 出力するセル幅一覧
      */
     protected function setFancyTable(array $header, array $data, array $w): void
     {
@@ -713,30 +694,29 @@ class OrderPdfService extends Fpdi
         $this->setBasePosition(0, 149);
 
         // Colors, line width and bold font
-        $this->SetFillColor(216, 216, 216);
-        $this->SetTextColor(0);
-        $this->SetDrawColor(0, 0, 0);
-        $this->SetLineWidth(.3);
-        $this->SetFont(self::FONT_SJIS, 'B', 8);
-        $this->SetFont('', 'B');
+        $this->pdfWriter->setFillColor(216, 216, 216);
+        $this->pdfWriter->setTextColor(0, 0, 0);
+        $this->pdfWriter->setDrawColor(0, 0, 0);
+        $this->pdfWriter->setLineWidth(.3);
+        $this->pdfWriter->setFont(self::FONT_SJIS, 'B', 8);
 
         // Header
-        $this->Cell(5, 7, '', 0, 0, '', false, '');
+        $this->pdfWriter->cell(5, 7, '', 0, 0, '');
         $count = count($header);
         for ($i = 0; $i < $count; ++$i) {
-            $this->Cell($w[$i], 7, $header[$i], 1, 0, 'C', true);
+            $this->pdfWriter->cell((float) $w[$i], 7, $header[$i], 1, 0, 'C', true);
         }
-        $this->Ln();
+        $this->pdfWriter->newLine();
 
         // Color and font restoration
-        $this->SetFillColor(235, 235, 235);
-        $this->SetTextColor(0);
-        $this->SetFont('');
+        $this->pdfWriter->setFillColor(235, 235, 235);
+        $this->pdfWriter->setTextColor(0, 0, 0);
+        $this->pdfWriter->setFont(null, '');
         // Data
-        $fill = 0;
-        $writeRow = function ($row, $cellHeight, $fill, $isBorder) use ($w) {
+        $fill = false;
+        $writeRow = function (array $row, float $cellHeight, bool $fill, bool $isBorder) use ($w): float {
             $i = 0;
-            $h = 0;
+            $h = 0.0;
             foreach ($row as $col) {
                 // 列の処理
                 // TODO: 汎用的ではない処理。この指定は呼び出し元で行うようにしたい。
@@ -752,8 +732,8 @@ class OrderPdfService extends Fpdi
                 // (0: 右へ移動(既定)/1: 次の行へ移動/2: 下へ移動)
                 $ln = ($i == (count($row) - 1)) ? 1 : 0;
 
-                $this->MultiCell(
-                    $w[$i], // セル幅
+                $this->pdfWriter->multiCell(
+                    (float) $w[$i], // セル幅
                     $cellHeight, // セルの最小の高さ
                     !$isBorder ? $col : '', // 文字列
                     $isBorder ? 1 : 0, // 境界線の描画方法を指定
@@ -761,7 +741,7 @@ class OrderPdfService extends Fpdi
                     $fill, // 背景の塗つぶし指定
                     $ln // 出力後のカーソルの移動方法
                 );
-                $h = $this->getLastH();
+                $h = $this->pdfWriter->getLastCellHeight();
                 $i++;
             }
 
@@ -770,26 +750,26 @@ class OrderPdfService extends Fpdi
 
         foreach ($data as $row) {
             // 行の処理
-            $h = 4;
-            $this->Cell(5, $h, '', 0, 0, '', false, '');
-            if ((277 - $this->getY()) < ($h * 4)) {
-                $this->checkPageBreak($this->PageBreakTrigger + 1);
+            $h = 4.0;
+            $this->pdfWriter->cell(5, $h, '', 0, 0, '');
+            if ((277 - $this->pdfWriter->getY()) < ($h * 4)) {
+                $this->pdfWriter->checkPageBreak($this->pdfWriter->getPageBreakTrigger() + 1);
             }
 
-            $x = $this->getX();
-            $y = $this->getY();
+            $x = $this->pdfWriter->getX();
+            $y = $this->pdfWriter->getY();
             // 1度目は文字だけ出力し、行の高さ最大を取得
             $h = $writeRow($row, $h, $fill, false);
-            $this->setXY($x, $y);
+            $this->pdfWriter->setXY($x, $y);
             // 2度目に最大の高さに合わせて、境界線を描画
             $writeRow($row, $h, $fill, true);
 
             $fill = !$fill;
         }
-        $h = 4;
-        $this->Cell(5, $h, '', 0, 0, '', false, '');
-        $this->Cell(array_sum($w), 0, '', 'T');
-        $this->SetFillColor(255);
+        $h = 4.0;
+        $this->pdfWriter->cell(5, $h, '', 0, 0, '');
+        $this->pdfWriter->cell((float) array_sum($w), 0, '', 'T');
+        $this->pdfWriter->setFillColor(255, 255, 255);
 
         // フォント情報の復元
         $this->restoreFont();
@@ -797,17 +777,18 @@ class OrderPdfService extends Fpdi
 
     /**
      * 基準座標を設定する.
+     *
+     * 注意: y の設定は x を左余白へ戻す。よって引数の $x は結果に残らない
+     * （4.3 までの TCPDF でも同じ挙動で、この順序に依存した座標で組まれている）。
      */
     protected function setBasePosition(int|float|null $x = null, int|float|null $y = null): void
     {
         // 現在のマージンを取得する
-        $result = $this->getMargins();
+        $result = $this->pdfWriter->getMargins();
 
         // 基準座標を指定する
-        $actualX = $x ?? $result['left'];
-        $this->SetX($actualX);
-        $actualY = $y ?? $result['top'];
-        $this->SetY($actualY);
+        $this->pdfWriter->setX((float) ($x ?? $result['left']));
+        $this->pdfWriter->setY((float) ($y ?? $result['top']));
     }
 
     /**
@@ -816,9 +797,9 @@ class OrderPdfService extends Fpdi
     protected function backupFont(): void
     {
         // フォント情報のバックアップ
-        $this->bakFontFamily = $this->FontFamily;
-        $this->bakFontStyle = $this->FontStyle;
-        $this->bakFontSize = $this->FontSizePt;
+        $this->bakFontFamily = $this->pdfWriter->getFontFamily();
+        $this->bakFontStyle = $this->pdfWriter->getFontStyle();
+        $this->bakFontSize = $this->pdfWriter->getFontSizePt();
     }
 
     /**
@@ -826,6 +807,6 @@ class OrderPdfService extends Fpdi
      */
     protected function restoreFont(): void
     {
-        $this->SetFont($this->bakFontFamily, $this->bakFontStyle, $this->bakFontSize);
+        $this->pdfWriter->setFont($this->bakFontFamily, $this->bakFontStyle, $this->bakFontSize);
     }
 }

--- a/src/Eccube/Service/OrderPdfService.php
+++ b/src/Eccube/Service/OrderPdfService.php
@@ -253,8 +253,7 @@ class OrderPdfService
     /**
      * 描画器を組み立てる.
      *
-     * テンプレート PDF・ロゴ・フォント定義はいずれもファイルから読むため,
-     * 読み込みを許可するディレクトリを明示する（tc-lib-pdf は既定で全て拒否する）.
+     * 差し替え点として protected にしてある（プラグインが独自の描画器を返せる）.
      */
     protected function createPdfWriter(): PdfWriter
     {

--- a/src/Eccube/Service/Pdf/Font/JapaneseCidFont.php
+++ b/src/Eccube/Service/Pdf/Font/JapaneseCidFont.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Pdf\Font;
+
+/**
+ * 帳票で使う日本語フォント（Adobe-Japan1 の CID フォント）の定義.
+ *
+ * 字形データは持たない. PDF へ埋め込まず, 書体名と文字幅とフォント記述子だけを書き出して,
+ * 表示側（PDF ビューア）に Adobe-Japan1 対応のフォントで代替描画させる.
+ * そのため出力サイズは増えないが, **字形は閲覧環境に依存する**.
+ *
+ * ## 文字幅
+ *
+ * 欧文 95 文字（U+0020..U+007E）だけを持ち, それ以外は {@see DEFAULT_WIDTH} を使う.
+ * 和文は全角固定なのでこれで足りる. 値は EC-CUBE 2系 `data/module/fpdi/japanese.php` と同じ
+ * （FPDF 公式スクリプト由来）で, KozMinPro-Regular のメトリクスにあたる.
+ *
+ * ゴシックも同じ幅表を使う. ゴシック専用の値は持たない.
+ * 差が出るのは欧文を中央寄せ・右寄せしたときの位置だけで, 文書タイトルで最大 0.45mm,
+ * 既定の日本語タイトルでは 0.0053mm に収まる.
+ *
+ * ## フォント記述子
+ *
+ * {@see ASCENT} と {@see DESCENT} は日本語フォントで共通の em 配分（IPA明朝・Noto CJK JP と同値）.
+ * この 2 つは文字のベースライン位置を決めるため, 変えると帳票の全行が動く.
+ * `Flags` は PDF 仕様のビットフラグで, 明朝はセリフ体（2）＋シンボリック（4）, ゴシックはシンボリックのみ.
+ * 残り（`StemV` `CapHeight` `FontBBox`）は代替フォント選択のヒントにすぎないため一般値を置く.
+ */
+final class JapaneseCidFont
+{
+    /** 明朝のフォントキー（{@see \Eccube\Service\OrderPdfService::FONT_SJIS} と対応） */
+    public const MINCHO = 'kozminproregular';
+
+    /** ゴシックのフォントキー（{@see \Eccube\Service\OrderPdfService::FONT_GOTHIC} と対応） */
+    public const GOTHIC = 'kozgopromedium';
+
+    /** 幅表に無い文字の幅（和文は全角固定） */
+    public const DEFAULT_WIDTH = 1000;
+
+    /** アセント. 日本語フォント共通の em 配分 */
+    public const ASCENT = 880;
+
+    /** ディセント. 同上 */
+    public const DESCENT = -120;
+
+    /** 縦ステムの幅. 和文の標準的な太さ */
+    public const STEM_V_REGULAR = 90;
+
+    /** 縦ステムの幅（ボールド）. 表示側が太字の代替フォントを選ぶための値 */
+    public const STEM_V_BOLD = 160;
+
+    /**
+     * 欧文 95 文字（U+0020..U+007E）の幅. 単位は 1/1000 em.
+     *
+     * @var array<int, int> Unicode コードポイント => 幅
+     */
+    public const LATIN_WIDTHS = [
+        32 => 278, 33 => 299, 34 => 353, 35 => 614, 36 => 614, 37 => 721, 38 => 735, 39 => 216,
+        40 => 323, 41 => 323, 42 => 449, 43 => 529, 44 => 219, 45 => 306, 46 => 219, 47 => 453,
+        48 => 614, 49 => 614, 50 => 614, 51 => 614, 52 => 614, 53 => 614, 54 => 614, 55 => 614,
+        56 => 614, 57 => 614, 58 => 219, 59 => 219, 60 => 529, 61 => 529, 62 => 529, 63 => 486,
+        64 => 744, 65 => 646, 66 => 604, 67 => 617, 68 => 681, 69 => 567, 70 => 537, 71 => 647,
+        72 => 738, 73 => 320, 74 => 433, 75 => 637, 76 => 566, 77 => 904, 78 => 710, 79 => 716,
+        80 => 605, 81 => 716, 82 => 623, 83 => 517, 84 => 601, 85 => 690, 86 => 668, 87 => 990,
+        88 => 681, 89 => 634, 90 => 578, 91 => 316, 92 => 614, 93 => 316, 94 => 529, 95 => 500,
+        96 => 387, 97 => 509, 98 => 566, 99 => 478, 100 => 565, 101 => 503, 102 => 337, 103 => 549,
+        104 => 580, 105 => 275, 106 => 266, 107 => 544, 108 => 276, 109 => 854, 110 => 579, 111 => 550,
+        112 => 578, 113 => 566, 114 => 410, 115 => 444, 116 => 340, 117 => 575, 118 => 512, 119 => 760,
+        120 => 503, 121 => 529, 122 => 453, 123 => 326, 124 => 380, 125 => 326, 126 => 387,
+    ];
+
+    /**
+     * 書体ごとの PostScript 名と `Flags`.
+     *
+     * @var array<string, array{psName: string, flags: int}>
+     */
+    private const FACES = [
+        self::MINCHO => ['psName' => 'KozMinPro-Regular-Acro', 'flags' => 6],
+        self::GOTHIC => ['psName' => 'KozGoPro-Medium-Acro', 'flags' => 4],
+    ];
+
+    /**
+     * 登録すべき書体を「フォントキー => 定義」で返す.
+     *
+     * ボールドは PostScript 名へ `,Bold` を付けたものを別書体として登録する.
+     * キーの末尾 `B` は FPDF が `strtolower(family).strtoupper(style)` で作るものに合わせている.
+     *
+     * @return array<string, array{name: string, desc: array<string, int|string>}>
+     */
+    public static function faces(): array
+    {
+        $faces = [];
+        foreach (self::FACES as $key => $face) {
+            foreach (['' => '', 'B' => ',Bold'] as $style => $suffix) {
+                $faces[$key.$style] = [
+                    'name' => $face['psName'].$suffix,
+                    'desc' => [
+                        'Ascent' => self::ASCENT,
+                        'Descent' => self::DESCENT,
+                        'CapHeight' => self::ASCENT,
+                        'Flags' => $face['flags'],
+                        'FontBBox' => '[0 -200 1000 900]',
+                        'ItalicAngle' => 0,
+                        // 表示側は StemV を見て代替フォントの太さを決める.
+                        // ボールドで通常と同じ値を出すと, 太字が細く描かれる.
+                        'StemV' => $style === 'B' ? self::STEM_V_BOLD : self::STEM_V_REGULAR,
+                    ],
+                ];
+            }
+        }
+
+        return $faces;
+    }
+
+    /**
+     * 文字列の幅を 1/1000 em で返す.
+     */
+    public static function stringWidth(string $text): int
+    {
+        $width = 0;
+        foreach (self::codePoints($text) as $codePoint) {
+            $width += self::LATIN_WIDTHS[$codePoint] ?? self::DEFAULT_WIDTH;
+        }
+
+        return $width;
+    }
+
+    /**
+     * UTF-8 の文字列をコードポイントの配列へ分解する.
+     *
+     * @return list<int>
+     */
+    public static function codePoints(string $text): array
+    {
+        if ($text === '') {
+            return [];
+        }
+
+        $chars = preg_split('//u', $text, -1, PREG_SPLIT_NO_EMPTY);
+        if ($chars === false) {
+            return [];
+        }
+
+        return array_map(static fn (string $char): int => mb_ord($char, 'UTF-8'), $chars);
+    }
+}

--- a/src/Eccube/Service/Pdf/FpdfEngine.php
+++ b/src/Eccube/Service/Pdf/FpdfEngine.php
@@ -239,10 +239,10 @@ class FpdfEngine extends Fpdi
      * PNG/JPEG の解析・アルファの分離・XObject の登録は FPDF に任せ,
      * ページへ直接書かれる命令だけを取り出す.
      */
-    public function getSetImage(string $file, float $x, float $y, float $width, float $height): string
+    public function getSetImage(string $file, float $x, float $y, float $width, float $height, string $type = ''): string
     {
-        return $this->capture(function () use ($file, $x, $y, $width, $height): void {
-            $this->Image($file, $x, $y, $width, $height);
+        return $this->capture(function () use ($file, $x, $y, $width, $height, $type): void {
+            $this->Image($file, $x, $y, $width, $height, $type);
         });
     }
 

--- a/src/Eccube/Service/Pdf/FpdfEngine.php
+++ b/src/Eccube/Service/Pdf/FpdfEngine.php
@@ -1,0 +1,419 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Pdf;
+
+use Eccube\Service\Pdf\Font\JapaneseCidFont;
+use setasign\Fpdi\Fpdi;
+
+/**
+ * FPDF を「描画命令の文字列を組み立てる部品」として使うための内部クラス.
+ *
+ * FPDF の protected（`_out()` `$fonts` `_newobj()` `_put()`）へ触るのはここだけ.
+ * {@see PdfWriter} の private プロパティとしてのみ保持し, 外へは出さない.
+ *
+ * ## FPDF の Cell / MultiCell / Text は使わない
+ *
+ * FPDF は文字のベースラインを `y + 高さ/2 + 0.3 x フォントサイズ` に置く（係数は固定）.
+ * 4.3 まで使っていた TCPDF は `y + (高さ + アセント - ディセント) / 2` で, アセント 880 /
+ * ディセント -120 なら `y + 高さ/2 + 0.38 x フォントサイズ` になる.
+ * この差はフォントサイズに比例し, 8pt で 0.23mm ずれる. 帳票の座標を変えないため,
+ * セルの組み立ては {@see PdfWriter} が持ち, ここは命令の文字列化だけを担う.
+ *
+ * ## 日本語フォント
+ *
+ * FPDF は日本語を持たないので, Adobe-Japan1 の CID フォント（非埋め込み）を
+ * `$fonts` へ直接登録し, `_putfonts()` が未知の種別を `_put<type>()` へ委譲する仕組みを使って
+ * {@see _puttype0()} で書き出す. 定義は {@see JapaneseCidFont}.
+ *
+ * @internal {@see PdfWriter} からのみ使う
+ */
+class FpdfEngine extends Fpdi
+{
+    /** 非 null の間, _out() の出力をここへ溜める */
+    private ?string $captured = null;
+
+    /** 現在のフォントの PDF リソース番号（/F<n>） */
+    private int $fontIndex = 1;
+
+    /** 選択中のフォントサイズ(pt)。FPDF の $FontSizePt とは独立に持つ */
+    private float $selectedSizePt = 12.0;
+
+    /** 取り込んだテンプレートページの id（FPDI の $templateId とは別物） */
+    private mixed $importedPageId = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->SetAutoPageBreak(false);
+        $this->SetCompression(true);
+        $this->registerJapaneseFonts();
+    }
+
+    /**
+     * ヘッダは使わない（帳票のヘッダはテンプレート PDF が持つ）.
+     */
+    #[\Override]
+    public function Header(): void
+    {
+    }
+
+    /**
+     * フッタは {@see PdfWriter::renderFooter()} が自前で描く.
+     */
+    #[\Override]
+    public function Footer(): void
+    {
+    }
+
+    /**
+     * pt を mm へ換算する.
+     */
+    public function toUnit(float $points): float
+    {
+        return $points / $this->k;
+    }
+
+    /**
+     * テンプレート PDF を読み, 1 ページ目を取り込む.
+     *
+     * @return array{width: float, height: float} 用紙サイズ(mm)
+     */
+    public function loadTemplate(string $path): array
+    {
+        $this->setSourceFile($path);
+        $this->importedPageId = $this->importPage(1);
+        $size = $this->getTemplateSize($this->importedPageId);
+
+        return ['width' => (float) $size['width'], 'height' => (float) $size['height']];
+    }
+
+    /**
+     * ページを追加する.
+     */
+    public function beginPage(float $width, float $height): void
+    {
+        $this->AddPage('P', [$width, $height]);
+    }
+
+    /**
+     * 取り込んだテンプレートを現在のページへ重ねる.
+     */
+    public function overlayTemplate(float $width, float $height): void
+    {
+        if ($this->importedPageId === null) {
+            return;
+        }
+
+        $this->useTemplate($this->importedPageId, 0, 0, $width, $height);
+    }
+
+    /**
+     * 命令列を現在のページへ書き出す.
+     */
+    public function addContent(string $ops): void
+    {
+        if ($ops === '') {
+            return;
+        }
+
+        $this->_out(rtrim($ops, "\n"));
+    }
+
+    /**
+     * PDF のバイナリを返す.
+     */
+    public function render(): string
+    {
+        return $this->Output('S');
+    }
+
+    /**
+     * フォントを選び, アセント・ディセント(pt)を返す.
+     *
+     * 命令は出さない（{@see getTextLine()} が毎回 `Tf` を含めるため）.
+     *
+     * @return array{ascent: float, descent: float}
+     */
+    public function selectFont(string $family, string $style, float $sizePt): array
+    {
+        $key = strtolower($family).strtoupper($style);
+        if (!isset($this->fonts[$key])) {
+            $this->Error(sprintf('未登録のフォントです: %s (%s)', $family, $style));
+        }
+
+        $this->fontIndex = (int) $this->fonts[$key]['i'];
+        $this->selectedSizePt = $sizePt;
+
+        return [
+            'ascent' => JapaneseCidFont::ASCENT * $sizePt / 1000,
+            'descent' => JapaneseCidFont::DESCENT * $sizePt / 1000,
+        ];
+    }
+
+    /**
+     * 文字列の幅(pt)を返す.
+     */
+    public function getStringWidthPt(string $text): float
+    {
+        return JapaneseCidFont::stringWidth($text) * $this->selectedSizePt / 1000;
+    }
+
+    /**
+     * 1 行のテキストを描く命令を返す.
+     *
+     * 座標は mm・左上原点. `$baseline` はベースラインの y.
+     * フォント選択を同じ `q ... Q` の中に含めることで, 命令列を単独で完結させる.
+     */
+    public function getTextLine(string $text, float $x, float $baseline, string $colorHex): string
+    {
+        if ($text === '') {
+            return '';
+        }
+
+        $encoded = mb_convert_encoding($text, 'UTF-16BE', 'UTF-8');
+
+        return sprintf(
+            "q %s BT /F%d %.2F Tf %.6F %.6F Td (%s) Tj ET Q\n",
+            self::fillColorCmd($colorHex),
+            $this->fontIndex,
+            $this->selectedSizePt,
+            $x * $this->k,
+            ($this->h - $baseline) * $this->k,
+            $this->_escape($encoded)
+        );
+    }
+
+    /**
+     * 矩形を描く命令を返す.
+     *
+     * @param string               $mode  'f' = 塗り / 'S' = 線
+     * @param array<string, mixed> $style 'fillColor' / 'lineColor' / 'lineWidth'
+     */
+    public function getBasicRect(float $x, float $y, float $width, float $height, string $mode, array $style = []): string
+    {
+        $shape = sprintf(
+            '%.6F %.6F %.6F %.6F re %s',
+            $x * $this->k,
+            ($this->h - $y) * $this->k,
+            $width * $this->k,
+            -$height * $this->k,
+            $mode
+        );
+
+        return sprintf("q %s%s Q\n", $this->getStyleCmd($mode, $style), $shape);
+    }
+
+    /**
+     * 線を描く命令を返す.
+     *
+     * @param array<string, mixed> $style
+     */
+    public function getLine(float $x1, float $y1, float $x2, float $y2, array $style = []): string
+    {
+        $shape = sprintf(
+            '%.6F %.6F m %.6F %.6F l S',
+            $x1 * $this->k,
+            ($this->h - $y1) * $this->k,
+            $x2 * $this->k,
+            ($this->h - $y2) * $this->k
+        );
+
+        return sprintf("q %s%s Q\n", $this->getStyleCmd('S', $style), $shape);
+    }
+
+    /**
+     * 画像を配置する命令を返す.
+     *
+     * PNG/JPEG の解析・アルファの分離・XObject の登録は FPDF に任せ,
+     * ページへ直接書かれる命令だけを取り出す.
+     */
+    public function getSetImage(string $file, float $x, float $y, float $width, float $height): string
+    {
+        return $this->capture(function () use ($file, $x, $y, $width, $height): void {
+            $this->Image($file, $x, $y, $width, $height);
+        });
+    }
+
+    /**
+     * $draw の実行中に FPDF が出した命令列を返す（ページへは書かない）.
+     */
+    private function capture(callable $draw): string
+    {
+        $previous = $this->captured;
+        $this->captured = '';
+
+        try {
+            $draw();
+            $ops = $this->captured;
+        } finally {
+            $this->captured = $previous;
+        }
+
+        return $ops;
+    }
+
+    /**
+     * FPDF の唯一の出力口. capture 中はページへ書かずに溜める.
+     *
+     * FPDI の `FpdfTpl` が public で上書きしているため public のままにする.
+     *
+     * 親（FPDF）が型宣言を持たないため, 引数の型は PHPDoc で示す.
+     *
+     * @param string $s
+     *
+     * @internal FPDF の内部呼び出し用. 外から使わない（命令の書き出しは {@see addContent()}）
+     */
+    #[\Override]
+    public function _out($s): void
+    {
+        if ($this->captured !== null) {
+            $this->captured .= $s."\n";
+
+            return;
+        }
+
+        parent::_out($s);
+    }
+
+    /**
+     * グラフィック状態（色・線幅・線端）の命令を返す.
+     *
+     * 線端は TCPDF の既定と同じ square（`2 J`）を明示する.
+     * butt にすると罫線の両端が線幅の半分ずつ短くなり, 表の角が欠ける.
+     *
+     * @param array<string, mixed> $style
+     */
+    private function getStyleCmd(string $mode, array $style): string
+    {
+        $cmd = '';
+        if ($mode === 'f' && isset($style['fillColor'])) {
+            $cmd .= self::fillColorCmd((string) $style['fillColor']);
+        }
+        if ($mode === 'S') {
+            $cmd .= '2 J ';
+            if (isset($style['lineColor'])) {
+                $cmd .= self::strokeColorCmd((string) $style['lineColor']);
+            }
+            if (isset($style['lineWidth'])) {
+                $cmd .= sprintf('%.6F w ', (float) $style['lineWidth'] * $this->k);
+            }
+        }
+
+        return $cmd;
+    }
+
+    /**
+     * 塗り色の命令（`rg`）.
+     */
+    private static function fillColorCmd(string $hex): string
+    {
+        [$r, $g, $b] = self::rgb($hex);
+
+        return sprintf('%.3F %.3F %.3F rg ', $r, $g, $b);
+    }
+
+    /**
+     * 線色の命令（`RG`）.
+     */
+    private static function strokeColorCmd(string $hex): string
+    {
+        [$r, $g, $b] = self::rgb($hex);
+
+        return sprintf('%.3F %.3F %.3F RG ', $r, $g, $b);
+    }
+
+    /**
+     * `#rrggbb` を 0..1 の三つ組へ.
+     *
+     * @return array{float, float, float}
+     */
+    private static function rgb(string $hex): array
+    {
+        $hex = ltrim($hex, '#');
+        if (strlen($hex) !== 6) {
+            return [0.0, 0.0, 0.0];
+        }
+
+        return [
+            hexdec(substr($hex, 0, 2)) / 255,
+            hexdec(substr($hex, 2, 2)) / 255,
+            hexdec(substr($hex, 4, 2)) / 255,
+        ];
+    }
+
+    /**
+     * 日本語フォント（CID0・非埋め込み）を FPDF のフォント表へ登録する.
+     */
+    private function registerJapaneseFonts(): void
+    {
+        foreach (JapaneseCidFont::faces() as $key => $face) {
+            $this->fonts[$key] = [
+                'i' => count($this->fonts) + 1,
+                'type' => 'Type0',
+                'name' => $face['name'],
+                'desc' => $face['desc'],
+                'up' => -120,
+                'ut' => 40,
+                'cw' => JapaneseCidFont::LATIN_WIDTHS,
+                'subsetted' => false,
+            ];
+        }
+    }
+
+    /**
+     * CID フォント（Adobe-Japan1・非埋め込み）を書き出す.
+     *
+     * FPDF の `_putfonts()` が未知のフォント種別を `_put<type>()` へ委譲するのを使う.
+     * `/W` は Adobe-Japan1 の CID 1..95 が U+0020..U+007E に対応することを前提に,
+     * 欧文 95 文字の幅を並べる. それ以外は `/DW` が使われる.
+     *
+     * @param array<string, mixed> $font
+     */
+    protected function _puttype0(array $font): void
+    {
+        $name = (string) $font['name'];
+
+        // 親フォント（Type0）
+        $this->_newobj();
+        $this->_put('<</Type /Font');
+        $this->_put('/Subtype /Type0');
+        $this->_put('/BaseFont /'.$name.'-UniJIS-UCS2-H');
+        $this->_put('/Encoding /UniJIS-UCS2-H');
+        $this->_put('/DescendantFonts ['.($this->n + 1).' 0 R]');
+        $this->_put('>>');
+        $this->_put('endobj');
+
+        // 子フォント（CIDFontType0）
+        $this->_newobj();
+        $this->_put('<</Type /Font');
+        $this->_put('/Subtype /CIDFontType0');
+        $this->_put('/BaseFont /'.$name);
+        $this->_put('/CIDSystemInfo <</Registry (Adobe) /Ordering (Japan1) /Supplement 4>>');
+        $this->_put('/FontDescriptor '.($this->n + 1).' 0 R');
+        $this->_put('/DW '.JapaneseCidFont::DEFAULT_WIDTH);
+        $this->_put('/W [1 ['.implode(' ', $font['cw']).']]');
+        $this->_put('>>');
+        $this->_put('endobj');
+
+        // フォント記述子
+        $this->_newobj();
+        $descriptor = '<</Type /FontDescriptor /FontName /'.$name;
+        foreach ($font['desc'] as $key => $value) {
+            $descriptor .= ' /'.$key.' '.$value;
+        }
+        $this->_put($descriptor.'>>');
+        $this->_put('endobj');
+    }
+}

--- a/src/Eccube/Service/Pdf/PdfWriter.php
+++ b/src/Eccube/Service/Pdf/PdfWriter.php
@@ -482,11 +482,13 @@ class PdfWriter
         $type = match ($size[2]) {
             IMAGETYPE_PNG => 'png',
             IMAGETYPE_JPEG => 'jpg',
-            IMAGETYPE_GIF => 'gif',
+            // GIF の解析だけ FPDF が GD へ委譲する（_parsegif が imagecreatefromgif を呼び,
+            // 無ければ Error で PDF 全体が落ちる）。ext-gd は推奨止まりなので自前で弾く
+            IMAGETYPE_GIF => \function_exists('imagecreatefromgif') ? 'gif' : null,
             default => null,
         };
         if ($type === null) {
-            // FPDF が解析できない形式。ロゴを描かないだけにして帳票自体は出す
+            // FPDF が解析できない形式, または GD 不在の GIF。ロゴを描かないだけにして帳票自体は出す
             return;
         }
 

--- a/src/Eccube/Service/Pdf/PdfWriter.php
+++ b/src/Eccube/Service/Pdf/PdfWriter.php
@@ -340,6 +340,9 @@ class PdfWriter
         $width = $this->resolveWidth($width);
         $height = max($height, $this->minCellHeight());
 
+        // TCPDF の Cell() と同じく, 収まらなければ描画前に改ページする
+        $this->checkPageBreak($height);
+
         $this->addDecoration($this->cellDecorationOps($this->x, $this->y, $width, $height, $border, $fill));
         if ($text !== '') {
             $this->addContent($this->textOps($text, $this->x, $this->y, $height, $width, $align));
@@ -376,6 +379,18 @@ class PdfWriter
         $paddingTop = in_array(self::BORDER_TOP, $this->borderSides($border), true) ? ($this->lineWidth / 2) : 0.0;
         $cellHeight = max($height, $paddingTop + (count($lines) * $lineHeight));
 
+        // 収まらないときだけ改ページする。罫線も塗りも無いセルは TCPDF の MultiCell() と
+        // 同じく行単位で送る。装飾があるセルは矩形をまとめて描くため行では割れないので,
+        // セルごと次ページへ送る（setFancyTable が事前に改ページするため実際には起きない）。
+        $decorated = $fill || $this->borderSides($border) !== [];
+        if (!$decorated && ($this->y + $cellHeight) > $this->getPageBreakTrigger()) {
+            $this->writeLinesWithPageBreak($lines, $width, $lineHeight, $align, $lineBreak);
+
+            return;
+        }
+
+        $this->checkPageBreak($cellHeight);
+
         $originX = $this->x;
         $originY = $this->y;
 
@@ -389,6 +404,36 @@ class PdfWriter
 
         $this->lastCellHeight = $cellHeight;
         $this->advanceCursor($originX, $originY, $width, $cellHeight, $lineBreak);
+    }
+
+    /**
+     * 装飾の無い折り返しセルを 1 行ずつ描き, 収まらない行の前で改ページする.
+     *
+     * TCPDF の MultiCell() と同じ分割位置になる.
+     *
+     * @param string[] $lines
+     */
+    private function writeLinesWithPageBreak(array $lines, float $width, float $lineHeight, string $align, int $lineBreak): void
+    {
+        $originX = $this->x;
+        $height = 0.0;
+
+        foreach ($lines as $line) {
+            if ($this->checkPageBreak($lineHeight)) {
+                // 改ページしたら, その行がこのセルの新しい起点になる
+                $this->x = $originX;
+                $height = 0.0;
+            }
+            if ($line !== '') {
+                $this->addContent($this->textOps($line, $this->x, $this->y, $lineHeight, $width, $align));
+            }
+            $this->y += $lineHeight;
+            $height += $lineHeight;
+        }
+
+        $this->lastCellHeight = $height;
+        // ここまでで y は最終行の下端。advanceCursor に渡す起点へ戻して共通処理に合わせる
+        $this->advanceCursor($originX, $this->y - $height, $width, $height, $lineBreak);
     }
 
     /**

--- a/src/Eccube/Service/Pdf/PdfWriter.php
+++ b/src/Eccube/Service/Pdf/PdfWriter.php
@@ -372,6 +372,10 @@ class PdfWriter
      *
      * セルの高さは「指定した最小高さ」と「行数 x 行送り」の大きい方になる.
      *
+     * ただし罫線も塗りも無いセルが紙面に収まらないときは行単位で次ページへ送るため,
+     * {@see getLastCellHeight()} は送られた側の行数ぶんだけを返し, 最小高さを下回ることがある.
+     * TCPDF の MultiCell() も収まらない分を次ページへ持ち越すので最小高さは保たない.
+     *
      * @param float $width セル幅. 0 以下なら右余白まで広げる
      * @param float $height セルの最小高さ
      * @param int|string $border 罫線. {@see cell()} と同じ

--- a/src/Eccube/Service/Pdf/PdfWriter.php
+++ b/src/Eccube/Service/Pdf/PdfWriter.php
@@ -482,13 +482,11 @@ class PdfWriter
         $type = match ($size[2]) {
             IMAGETYPE_PNG => 'png',
             IMAGETYPE_JPEG => 'jpg',
-            // GIF の解析だけ FPDF が GD へ委譲する（_parsegif が imagecreatefromgif を呼び,
-            // 無ければ Error で PDF 全体が落ちる）。ext-gd は推奨止まりなので自前で弾く
-            IMAGETYPE_GIF => \function_exists('imagecreatefromgif') ? 'gif' : null,
+            IMAGETYPE_GIF => 'gif',
             default => null,
         };
         if ($type === null) {
-            // FPDF が解析できない形式, または GD 不在の GIF。ロゴを描かないだけにして帳票自体は出す
+            // FPDF が解析できない形式。ロゴを描かないだけにして帳票自体は出す
             return;
         }
 

--- a/src/Eccube/Service/Pdf/PdfWriter.php
+++ b/src/Eccube/Service/Pdf/PdfWriter.php
@@ -1,0 +1,758 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Pdf;
+
+/**
+ * tc-lib-pdf の上に「カーソルを持つ帳票描画」を載せる薄い書き込み器.
+ *
+ * 帳票は「現在位置から幅と高さを指定してセルを置き, カーソルが右か下へ進む」という
+ * 組み方で作られている. tc-lib-pdf はページ内の絶対座標で描く API しか持たないため,
+ * その間を埋めるのがこのクラスの役割.
+ *
+ * 単位は mm, 用紙は A4 縦, 原点は左上（下方向が y の正）で固定する.
+ *
+ * ## 座標の決め方
+ *
+ * セルの高さは「指定値」と「フォントサイズ x {@see CELL_HEIGHT_RATIO}」の大きい方.
+ * 文字はセル内で上下中央に置く. ベースラインはセル上端から
+ * `(セル高 + アセント - ディセント) / 2` の位置になる.
+ * 左右は既定で {@see CELL_PADDING_X} だけ内側へ寄せる.
+ *
+ * これらは 4.3 まで使っていた TCPDF の既定値をそのまま引き継いだもので,
+ * 納品書の座標を変えないための値. 変更すると既存の帳票の見た目が動く.
+ */
+class PdfWriter
+{
+    /** セル高さ / フォントサイズ の比 */
+    public const CELL_HEIGHT_RATIO = 1.25;
+
+    /** セルの左右パディング(mm) */
+    public const CELL_PADDING_X = 1.0;
+
+    /** 用紙サイズ(mm)の既定値. A4 縦 */
+    public const DEFAULT_PAGE_WIDTH = 210.0;
+    public const DEFAULT_PAGE_HEIGHT = 297.0;
+
+    /** 用紙下端から自動改ページ位置までの距離(mm) */
+    private const PAGE_BREAK_MARGIN = 20.0;
+
+    /** セルの罫線の向き. tc-lib-pdf のスタイル配列のキーに対応する */
+    private const BORDER_TOP = 0;
+    private const BORDER_RIGHT = 1;
+    private const BORDER_BOTTOM = 2;
+    private const BORDER_LEFT = 3;
+
+    private readonly FpdfEngine $engine;
+
+    private float $pageWidth = self::DEFAULT_PAGE_WIDTH;
+    private float $pageHeight = self::DEFAULT_PAGE_HEIGHT;
+
+    private float $leftMargin = 10.0;
+    private float $topMargin = 10.0;
+    private float $rightMargin = 10.0;
+
+    /** フッタの下端からの距離(mm) */
+    private float $footerMargin = 10.0;
+
+    private float $x = 0.0;
+    private float $y = 0.0;
+
+    /** 直前に描画したセルの高さ(mm) */
+    private float $lastCellHeight = 0.0;
+
+    private string $fontFamily = '';
+    private string $fontStyle = '';
+    private float $fontSizePt = 12.0;
+
+    /** 現在フォントのアセント・ディセント(mm, いずれも正の値) */
+    private float $fontAscent = 0.0;
+    private float $fontDescent = 0.0;
+
+    private string $fillColor = '#ffffff';
+    private string $textColor = '#000000';
+    private string $drawColor = '#000000';
+    private float $lineWidth = 0.2;
+
+    /** 各ページへ重ねるテンプレート PDF. null なら重ねない */
+    private bool $hasTemplate = false;
+
+    /** フッタへ右寄せで出す文字列 */
+    private string $footerText = '';
+
+    /**
+     * フッタのフォント指定 [フォント名, スタイル, サイズ(pt)]
+     *
+     * @var array{0: string, 1: string, 2: float}|null
+     */
+    private ?array $footerFont = null;
+
+    private int $pageCount = 0;
+
+    /** 確定前のページに積んだ塗り・罫線の命令 */
+    private string $background = '';
+
+    /** 確定前のページに積んだ文字・画像の命令 */
+    private string $foreground = '';
+
+    public function __construct()
+    {
+        $this->engine = new FpdfEngine();
+    }
+
+    public function getPageWidth(): float
+    {
+        return $this->pageWidth;
+    }
+
+    public function getPageHeight(): float
+    {
+        return $this->pageHeight;
+    }
+
+    /**
+     * 余白を設定する. 右余白を省略すると左と同じ値になる.
+     */
+    public function setMargins(float $left, float $top, ?float $right = null): void
+    {
+        $this->leftMargin = $left;
+        $this->topMargin = $top;
+        $this->rightMargin = $right ?? $left;
+    }
+
+    /**
+     * @return array{left: float, top: float, right: float}
+     */
+    public function getMargins(): array
+    {
+        return [
+            'left' => $this->leftMargin,
+            'top' => $this->topMargin,
+            'right' => $this->rightMargin,
+        ];
+    }
+
+    /**
+     * 自動改ページ位置(mm). この位置を超える描画は次ページへ送る.
+     */
+    public function getPageBreakTrigger(): float
+    {
+        return $this->pageHeight - self::PAGE_BREAK_MARGIN;
+    }
+
+    public function setFooterMargin(float $margin): void
+    {
+        $this->footerMargin = $margin;
+    }
+
+    /**
+     * フッタの内容を設定する.
+     *
+     * @param array{0: string, 1: string, 2: float} $font [フォント名, スタイル, サイズ(pt)]
+     */
+    public function setFooter(string $text, array $font): void
+    {
+        $this->footerText = $text;
+        $this->footerFont = $font;
+    }
+
+    /**
+     * 以降のページへ重ねるテンプレート PDF を読み込む.
+     *
+     * 用紙サイズはテンプレートに合わせる（テンプレートは A4 ちょうどとは限らない）.
+     */
+    public function setTemplateFile(string $path): void
+    {
+        $size = $this->engine->loadTemplate($path);
+
+        $this->hasTemplate = true;
+        $this->pageWidth = $size['width'];
+        $this->pageHeight = $size['height'];
+    }
+
+    /**
+     * ページを追加し, カーソルを左上の余白位置へ戻す.
+     */
+    public function addPage(bool $withTemplate = true): void
+    {
+        // 次のページへ移る前に, 今のページへ積んだ分を確定させる
+        $this->flushContent();
+
+        $this->engine->beginPage($this->pageWidth, $this->pageHeight);
+        ++$this->pageCount;
+
+        if ($withTemplate && $this->hasTemplate) {
+            $this->engine->overlayTemplate($this->pageWidth, $this->pageHeight);
+        }
+
+        $this->x = $this->leftMargin;
+        $this->y = $this->topMargin;
+
+        $this->renderFooter();
+
+        // フッタ描画でフォントが変わっているので, 呼び出し側の指定へ戻す
+        if ($this->fontFamily !== '') {
+            $this->applyFont($this->fontFamily, $this->fontStyle, $this->fontSizePt);
+        }
+    }
+
+    public function getPageCount(): int
+    {
+        return $this->pageCount;
+    }
+
+    /**
+     * フォントを設定する. 空文字は現在値の据え置きを意味する.
+     */
+    public function setFont(?string $family = null, ?string $style = null, float|int|null $sizePt = null): void
+    {
+        $family = ($family === null || $family === '') ? $this->fontFamily : $family;
+        $style ??= $this->fontStyle;
+        $sizePt = ($sizePt === null || (float) $sizePt <= 0.0) ? $this->fontSizePt : (float) $sizePt;
+
+        $this->applyFont($family, $style, $sizePt);
+    }
+
+    public function getFontFamily(): string
+    {
+        return $this->fontFamily;
+    }
+
+    public function getFontStyle(): string
+    {
+        return $this->fontStyle;
+    }
+
+    public function getFontSizePt(): float
+    {
+        return $this->fontSizePt;
+    }
+
+    /**
+     * フォントサイズを mm で返す.
+     */
+    public function getFontSize(): float
+    {
+        return $this->engine->toUnit($this->fontSizePt);
+    }
+
+    public function getX(): float
+    {
+        return $this->x;
+    }
+
+    public function getY(): float
+    {
+        return $this->y;
+    }
+
+    public function setX(float $x): void
+    {
+        $this->x = $x;
+    }
+
+    /**
+     * y 座標を設定する. 既定では x も左余白へ戻す.
+     */
+    public function setY(float $y, bool $resetX = true): void
+    {
+        $this->y = $y;
+        if ($resetX) {
+            $this->x = $this->leftMargin;
+        }
+    }
+
+    public function setXY(float $x, float $y): void
+    {
+        $this->y = $y;
+        $this->x = $x;
+    }
+
+    /**
+     * 直前に描画したセルの高さ(mm).
+     */
+    public function getLastCellHeight(): float
+    {
+        return $this->lastCellHeight;
+    }
+
+    public function setFillColor(int $red, int $green, int $blue): void
+    {
+        $this->fillColor = $this->toHexColor($red, $green, $blue);
+    }
+
+    public function setTextColor(int $red, int $green, int $blue): void
+    {
+        $this->textColor = $this->toHexColor($red, $green, $blue);
+    }
+
+    public function setDrawColor(int $red, int $green, int $blue): void
+    {
+        $this->drawColor = $this->toHexColor($red, $green, $blue);
+    }
+
+    public function setLineWidth(float $width): void
+    {
+        $this->lineWidth = $width;
+    }
+
+    /**
+     * 指定座標へ 1 行だけ文字を描く. カーソルは動かさない.
+     */
+    public function text(float $x, float $y, string $text): void
+    {
+        if ($text === '') {
+            return;
+        }
+
+        $height = $this->minCellHeight();
+        $this->addContent($this->textOps($text, $x + self::CELL_PADDING_X, $y, $height));
+    }
+
+    /**
+     * 1 行のセルを描画し, カーソルを進める.
+     *
+     * @param float $width セル幅. 0 以下なら右余白まで広げる
+     * @param float $height セルの最小高さ
+     * @param int|string $border 罫線. 1 で四辺, 'T' 'R' 'B' 'L' の並びで各辺
+     * @param int $lineBreak 描画後のカーソル移動. 0=右へ / 1=次行の左端へ / 2=真下へ
+     * @param string $align 水平位置 'L' 'C' 'R'
+     */
+    public function cell(
+        float $width,
+        float $height = 0,
+        string $text = '',
+        int|string $border = 0,
+        int $lineBreak = 0,
+        string $align = '',
+        bool $fill = false,
+    ): void {
+        $width = $this->resolveWidth($width);
+        $height = max($height, $this->minCellHeight());
+
+        $this->addDecoration($this->cellDecorationOps($this->x, $this->y, $width, $height, $border, $fill));
+        if ($text !== '') {
+            $this->addContent($this->textOps($text, $this->x, $this->y, $height, $width, $align));
+        }
+
+        $this->lastCellHeight = $height;
+        $this->advanceCursor($this->x, $this->y, $width, $height, $lineBreak);
+    }
+
+    /**
+     * 折り返しのあるセルを描画し, カーソルを進める.
+     *
+     * セルの高さは「指定した最小高さ」と「行数 x 行送り」の大きい方になる.
+     *
+     * @param float $width セル幅. 0 以下なら右余白まで広げる
+     * @param float $height セルの最小高さ
+     * @param int|string $border 罫線. {@see cell()} と同じ
+     * @param string $align 水平位置 'L' 'C' 'R'
+     * @param int $lineBreak 描画後のカーソル移動. 0=右へ / 1=次行の左端へ / 2=真下へ
+     */
+    public function multiCell(
+        float $width,
+        float $height,
+        string $text,
+        int|string $border = 0,
+        string $align = 'L',
+        bool $fill = false,
+        int $lineBreak = 1,
+    ): void {
+        $width = $this->resolveWidth($width);
+        $lineHeight = $this->minCellHeight();
+        $lines = $this->splitLines($text, $width - (2 * self::CELL_PADDING_X));
+        // 上罫線と文字が重ならないよう, 罫線がある側は線幅の半分だけ内側へ寄せる
+        $paddingTop = in_array(self::BORDER_TOP, $this->borderSides($border), true) ? ($this->lineWidth / 2) : 0.0;
+        $cellHeight = max($height, $paddingTop + (count($lines) * $lineHeight));
+
+        $originX = $this->x;
+        $originY = $this->y;
+
+        $this->addDecoration($this->cellDecorationOps($originX, $originY, $width, $cellHeight, $border, $fill));
+        foreach ($lines as $index => $line) {
+            if ($line === '') {
+                continue;
+            }
+            $this->addContent($this->textOps($line, $originX, $originY + $paddingTop + ($index * $lineHeight), $lineHeight, $width, $align));
+        }
+
+        $this->lastCellHeight = $cellHeight;
+        $this->advanceCursor($originX, $originY, $width, $cellHeight, $lineBreak);
+    }
+
+    /**
+     * 次の行へ送る. 高さを省略すると直前のセルの高さ分だけ送る.
+     */
+    public function newLine(?float $height = null): void
+    {
+        $this->x = $this->leftMargin;
+        $this->y += $height ?? $this->lastCellHeight;
+    }
+
+    /**
+     * 残り高さが足りなければ改ページする.
+     *
+     * @return bool 改ページしたら true
+     */
+    public function checkPageBreak(float $height): bool
+    {
+        if (($this->y + $height) <= $this->getPageBreakTrigger()) {
+            return false;
+        }
+
+        // 自動改ページで増えたページにはテンプレート PDF を重ねない。
+        // 4.3 までも重ね書きは addPdfPage() の 1 回だけで, あふれた明細が載る
+        // 2 ページ目以降は白紙の上に描いていた（重ねると納品書の枠が二重に出る）。
+        // 改ページしても x は引き継ぐ（表の途中で送られたとき列位置を保つため）。
+        $x = $this->x;
+        $this->addPage(withTemplate: false);
+        $this->x = $x;
+
+        return true;
+    }
+
+    /**
+     * 画像を配置する. 高さは画像の縦横比から決まる.
+     */
+    public function image(string $file, float $x, float $y, float $width): void
+    {
+        $size = @getimagesize($file);
+        if ($size === false || $size[0] <= 0) {
+            return;
+        }
+
+        $height = $width * $size[1] / $size[0];
+        $this->addContent($this->engine->getSetImage($file, $x, $y, $width, $height));
+    }
+
+    /**
+     * PDF のバイナリを返す.
+     */
+    public function output(): string
+    {
+        $this->flushContent();
+
+        return $this->engine->render();
+    }
+
+    /**
+     * 文字列の描画幅(mm)を返す.
+     */
+    public function getStringWidth(string $text): float
+    {
+        if ($text === '') {
+            return 0.0;
+        }
+
+        return $this->engine->toUnit($this->engine->getStringWidthPt($text));
+    }
+
+    /**
+     * フォントを実際に切り替え, ページへ選択命令を出す.
+     */
+    private function applyFont(string $family, string $style, float $sizePt): void
+    {
+        $metric = $this->engine->selectFont($family, $style, $sizePt);
+
+        $this->fontFamily = $family;
+        $this->fontStyle = $style;
+        $this->fontSizePt = $sizePt;
+        // アセント・ディセントは mm の正値へ揃える
+        $this->fontAscent = $this->engine->toUnit($metric['ascent']);
+        $this->fontDescent = $this->engine->toUnit(-$metric['descent']);
+    }
+
+    /**
+     * 現在のフォントで文字が収まる最小のセル高さ(mm).
+     */
+    private function minCellHeight(): float
+    {
+        return round($this->getFontSize() * self::CELL_HEIGHT_RATIO, 6);
+    }
+
+    private function resolveWidth(float $width): float
+    {
+        if ($width > 0) {
+            return $width;
+        }
+
+        return $this->pageWidth - $this->rightMargin - $this->x;
+    }
+
+    /**
+     * セル内の 1 行を描く命令を返す.
+     */
+    private function textOps(string $text, float $x, float $y, float $height, ?float $width = null, string $align = ''): string
+    {
+        // ベースラインはセル内で上下中央に置いたときの位置
+        $baseline = $y + (($height + $this->fontAscent - $this->fontDescent) / 2);
+
+        if ($width === null) {
+            $posX = $x;
+        } else {
+            $posX = $x + $this->alignOffset($text, $width, $align);
+        }
+
+        return $this->engine->getTextLine($text, $posX, $baseline, $this->textColor);
+    }
+
+    /**
+     * セル左端から文字の左端までの距離(mm).
+     */
+    private function alignOffset(string $text, float $width, string $align): float
+    {
+        return match ($align) {
+            'C' => ($width - $this->getStringWidth($text)) / 2,
+            'R' => $width - self::CELL_PADDING_X - $this->getStringWidth($text),
+            default => self::CELL_PADDING_X,
+        };
+    }
+
+    /**
+     * セルの背景と罫線を描く命令を返す.
+     */
+    private function cellDecorationOps(float $x, float $y, float $width, float $height, int|string $border, bool $fill): string
+    {
+        $ops = '';
+
+        if ($fill) {
+            $ops .= $this->engine->getBasicRect($x, $y, $width, $height, 'f', ['fillColor' => $this->fillColor]);
+        }
+
+        $sides = $this->borderSides($border);
+        if ($sides === []) {
+            return $ops;
+        }
+
+        // lineCap は TCPDF の既定と同じ square。butt にすると罫線の両端が
+        // 線幅の半分ずつ短くなり, 表の角が欠ける
+        $style = ['lineColor' => $this->drawColor, 'lineWidth' => $this->lineWidth, 'lineCap' => 'square'];
+        if (count($sides) === 4) {
+            return $ops.$this->engine->getBasicRect($x, $y, $width, $height, 'S', $style);
+        }
+
+        $corners = [
+            self::BORDER_TOP => [$x, $y, $x + $width, $y],
+            self::BORDER_RIGHT => [$x + $width, $y, $x + $width, $y + $height],
+            self::BORDER_BOTTOM => [$x, $y + $height, $x + $width, $y + $height],
+            self::BORDER_LEFT => [$x, $y, $x, $y + $height],
+        ];
+        foreach ($sides as $side) {
+            [$x1, $y1, $x2, $y2] = $corners[$side];
+            $ops .= $this->engine->getLine($x1, $y1, $x2, $y2, $style);
+        }
+
+        return $ops;
+    }
+
+    /**
+     * 罫線指定を辺の一覧へ正規化する.
+     *
+     * @return array<int, int>
+     */
+    private function borderSides(int|string $border): array
+    {
+        if ($border === 1 || $border === '1' || $border === 'LTRB') {
+            return [self::BORDER_TOP, self::BORDER_RIGHT, self::BORDER_BOTTOM, self::BORDER_LEFT];
+        }
+
+        if (!is_string($border) || $border === '') {
+            return [];
+        }
+
+        $map = [
+            'T' => self::BORDER_TOP,
+            'R' => self::BORDER_RIGHT,
+            'B' => self::BORDER_BOTTOM,
+            'L' => self::BORDER_LEFT,
+        ];
+
+        $sides = [];
+        foreach ($map as $letter => $side) {
+            if (str_contains($border, $letter)) {
+                $sides[] = $side;
+            }
+        }
+
+        return $sides;
+    }
+
+    /**
+     * 描画後のカーソル移動.
+     */
+    private function advanceCursor(float $originX, float $originY, float $width, float $height, int $lineBreak): void
+    {
+        switch ($lineBreak) {
+            case 1:
+                $this->x = $this->leftMargin;
+                $this->y = $originY + $height;
+                break;
+            case 2:
+                $this->x = $originX;
+                $this->y = $originY + $height;
+                break;
+            default:
+                $this->x = $originX + $width;
+                $this->y = $originY;
+                break;
+        }
+    }
+
+    /**
+     * 指定幅で折り返した行の一覧を返す.
+     *
+     * 改行文字で必ず折り, 幅を超えたら直前の空白位置で折る.
+     * 空白が無ければ超えた位置で折る（日本語のようにそもそも空白が無い文字列のため）.
+     *
+     * @return array<int, string>
+     */
+    private function splitLines(string $text, float $maxWidth): array
+    {
+        $text = str_replace("\r\n", "\n", $text);
+        // 末尾の改行は「次の行がある」ことを意味しない（4.3 までの TCPDF も 1 行と数える）
+        if (str_ends_with($text, "\n")) {
+            $text = substr($text, 0, -1);
+        }
+
+        $lines = [];
+        foreach (explode("\n", $text) as $paragraph) {
+            if ($paragraph === '') {
+                $lines[] = '';
+                continue;
+            }
+            if ($maxWidth <= 0) {
+                $lines[] = $paragraph;
+                continue;
+            }
+            foreach ($this->wrap($paragraph, $maxWidth) as $line) {
+                $lines[] = $line;
+            }
+        }
+
+        return $lines === [] ? [''] : $lines;
+    }
+
+    /**
+     * 1 段落を指定幅で折り返す.
+     *
+     * @return array<int, string>
+     */
+    private function wrap(string $paragraph, float $maxWidth): array
+    {
+        $chars = preg_split('//u', $paragraph, -1, PREG_SPLIT_NO_EMPTY);
+        if ($chars === false || $chars === []) {
+            return [$paragraph];
+        }
+
+        $lines = [];
+        $current = '';
+        $lastSpace = null;
+        foreach ($chars as $char) {
+            $candidate = $current.$char;
+            if ($current !== '' && $this->getStringWidth($candidate) > $maxWidth) {
+                if ($lastSpace !== null) {
+                    $lines[] = rtrim(mb_substr($current, 0, $lastSpace));
+                    $current = mb_substr($current, $lastSpace);
+                } else {
+                    $lines[] = $current;
+                    $current = '';
+                }
+                $lastSpace = null;
+                $candidate = $current.$char;
+            }
+            $current = $candidate;
+            if ($char === ' ') {
+                $lastSpace = mb_strlen($current);
+            }
+        }
+
+        // 文字が 1 つ以上ある段落しか渡されないので, 最後の行は必ず残っている
+        $lines[] = $current;
+
+        return $lines;
+    }
+
+    private function renderFooter(): void
+    {
+        if ($this->footerText === '' || $this->footerFont === null) {
+            return;
+        }
+
+        $previous = [$this->fontFamily, $this->fontStyle, $this->fontSizePt];
+        $this->applyFont((string) $this->footerFont[0], (string) $this->footerFont[1], (float) $this->footerFont[2]);
+
+        $footerY = $this->pageHeight - $this->footerMargin;
+        $width = $this->pageWidth - $this->leftMargin - $this->rightMargin;
+        $height = $this->minCellHeight();
+        // フッタはセルのパディングを持たない
+        $offset = $width - $this->getStringWidth($this->footerText);
+        $this->addContent($this->textOps($this->footerText, $this->leftMargin + $offset, $footerY, $height));
+
+        [$family, $style, $size] = $previous;
+        if ($family !== '') {
+            $this->applyFont($family, $style, $size);
+        }
+    }
+
+    /**
+     * 文字や画像の描画命令を積む.
+     */
+    private function addContent(string $ops): void
+    {
+        if ($ops === '') {
+            return;
+        }
+
+        $this->foreground .= $ops;
+    }
+
+    /**
+     * セルの塗りと罫線を積む.
+     *
+     * **文字とは別の入れ物へ積み, ページ確定時に文字より前へ出す。**
+     * 帳票は「1 行目は文字だけ描き, 高さが確定してから 2 行目で罫線を描く」というように
+     * 同じ場所を複数回描くことがあり, 素直に出力順どおりへ並べると
+     * 後から出した塗りが先に描いた文字を覆って**文字が消える**.
+     * 4.3 まで使っていた TCPDF も同じ理由で塗りと罫線だけをページ先頭側へ差し込んでいる
+     * （`TCPDF::setPageMark()` のコメント "Borders and fills are always created after
+     * content and inserted on the position marked by this method."）.
+     */
+    private function addDecoration(string $ops): void
+    {
+        if ($ops === '') {
+            return;
+        }
+
+        $this->background .= $ops;
+    }
+
+    /**
+     * 積んだ描画命令を現在のページへ書き出す. 塗り・罫線が先, 文字が後.
+     */
+    private function flushContent(): void
+    {
+        $ops = $this->background.$this->foreground;
+        $this->background = '';
+        $this->foreground = '';
+
+        if ($ops !== '') {
+            $this->engine->addContent($ops);
+        }
+    }
+
+    private function toHexColor(int $red, int $green, int $blue): string
+    {
+        return sprintf('#%02x%02x%02x', max(0, min(255, $red)), max(0, min(255, $green)), max(0, min(255, $blue)));
+    }
+}

--- a/src/Eccube/Service/Pdf/PdfWriter.php
+++ b/src/Eccube/Service/Pdf/PdfWriter.php
@@ -353,6 +353,21 @@ class PdfWriter
     }
 
     /**
+     * 折り返しのあるセルの高さを, 描画も改ページもせずに測る.
+     *
+     * 描画を兼ねて高さを測ると, その途中で自動改ページが起きたときに
+     * 呼び出し側が退避した座標を使えなくなる. 先に高さだけ知りたい場合はこちらを使う.
+     *
+     * @param float $width セル幅. 0 以下なら右余白まで広げる
+     * @param float $height セルの最小高さ
+     * @param int|string $border 罫線. {@see cell()} と同じ
+     */
+    public function measureMultiCellHeight(float $width, float $height, string $text, int|string $border = 0): float
+    {
+        return $this->layoutMultiCell($this->resolveWidth($width), $height, $text, $border)[2];
+    }
+
+    /**
      * 折り返しのあるセルを描画し, カーソルを進める.
      *
      * セルの高さは「指定した最小高さ」と「行数 x 行送り」の大きい方になる.
@@ -374,10 +389,7 @@ class PdfWriter
     ): void {
         $width = $this->resolveWidth($width);
         $lineHeight = $this->minCellHeight();
-        $lines = $this->splitLines($text, $width - (2 * self::CELL_PADDING_X));
-        // 上罫線と文字が重ならないよう, 罫線がある側は線幅の半分だけ内側へ寄せる
-        $paddingTop = in_array(self::BORDER_TOP, $this->borderSides($border), true) ? ($this->lineWidth / 2) : 0.0;
-        $cellHeight = max($height, $paddingTop + (count($lines) * $lineHeight));
+        [$lines, $paddingTop, $cellHeight] = $this->layoutMultiCell($width, $height, $text, $border);
 
         // 収まらないときだけ改ページする。罫線も塗りも無いセルは TCPDF の MultiCell() と
         // 同じく行単位で送る。装飾があるセルは矩形をまとめて描くため行では割れないので,
@@ -612,6 +624,22 @@ class PdfWriter
         }
 
         return $ops;
+    }
+
+    /**
+     * 折り返しセルの行・上パディング・高さを求める.
+     *
+     * @param float $width 解決済みのセル幅
+     *
+     * @return array{0: string[], 1: float, 2: float} 行・上パディング・セル高さ
+     */
+    private function layoutMultiCell(float $width, float $height, string $text, int|string $border): array
+    {
+        $lines = $this->splitLines($text, $width - (2 * self::CELL_PADDING_X));
+        // 上罫線と文字が重ならないよう, 罫線がある側は線幅の半分だけ内側へ寄せる
+        $paddingTop = in_array(self::BORDER_TOP, $this->borderSides($border), true) ? ($this->lineWidth / 2) : 0.0;
+
+        return [$lines, $paddingTop, max($height, $paddingTop + (count($lines) * $this->minCellHeight()))];
     }
 
     /**

--- a/src/Eccube/Service/Pdf/PdfWriter.php
+++ b/src/Eccube/Service/Pdf/PdfWriter.php
@@ -14,10 +14,10 @@
 namespace Eccube\Service\Pdf;
 
 /**
- * tc-lib-pdf の上に「カーソルを持つ帳票描画」を載せる薄い書き込み器.
+ * FPDF の上に「カーソルを持つ帳票描画」を載せる薄い書き込み器.
  *
  * 帳票は「現在位置から幅と高さを指定してセルを置き, カーソルが右か下へ進む」という
- * 組み方で作られている. tc-lib-pdf はページ内の絶対座標で描く API しか持たないため,
+ * 組み方で作られている. {@see FpdfEngine} はページ内の絶対座標で描く API しか持たないため,
  * その間を埋めるのがこのクラスの役割.
  *
  * 単位は mm, 用紙は A4 縦, 原点は左上（下方向が y の正）で固定する.
@@ -47,7 +47,7 @@ class PdfWriter
     /** 用紙下端から自動改ページ位置までの距離(mm) */
     private const PAGE_BREAK_MARGIN = 20.0;
 
-    /** セルの罫線の向き. tc-lib-pdf のスタイル配列のキーに対応する */
+    /** セルの罫線の向き. {@see borderSides()} が返す配列の要素に使う */
     private const BORDER_TOP = 0;
     private const BORDER_RIGHT = 1;
     private const BORDER_BOTTOM = 2;
@@ -477,8 +477,21 @@ class PdfWriter
             return;
         }
 
+        // 形式は拡張子ではなく中身から決める。FPDF は $type 省略時に拡張子で解析器を選び,
+        // 中身と食い違うと Error で PDF 全体が落ちる（4.3 までの TCPDF は中身で判定していた）。
+        $type = match ($size[2]) {
+            IMAGETYPE_PNG => 'png',
+            IMAGETYPE_JPEG => 'jpg',
+            IMAGETYPE_GIF => 'gif',
+            default => null,
+        };
+        if ($type === null) {
+            // FPDF が解析できない形式。ロゴを描かないだけにして帳票自体は出す
+            return;
+        }
+
         $height = $width * $size[1] / $size[0];
-        $this->addContent($this->engine->getSetImage($file, $x, $y, $width, $height));
+        $this->addContent($this->engine->getSetImage($file, $x, $y, $width, $height, $type));
     }
 
     /**

--- a/symfony.lock
+++ b/symfony.lock
@@ -608,9 +608,6 @@
     "symfony/yaml": {
         "version": "v3.4.1"
     },
-    "tecnickcom/tcpdf": {
-        "version": "6.2.17"
-    },
     "theseer/tokenizer": {
         "version": "1.1.0"
     },

--- a/tests/Eccube/Tests/Service/OrderPdfBaselineDumpTest.php
+++ b/tests/Eccube/Tests/Service/OrderPdfBaselineDumpTest.php
@@ -32,7 +32,7 @@ use Eccube\Twig\Extension\TaxExtension;
  * PDF エンジン差し替えの前後で出力を機械比較するための基準を作る。
  * 通常の CI では意味を持たないため, 明示的に --filter で呼び出して使う。
  *
- * @see temp/tcpdf-modernize/README.md
+ * 使い方と比較手順は本クラスの各テストの docblock に記す（移行の経緯は #7083）。
  */
 final class OrderPdfBaselineDumpTest extends AbstractServiceTestCase
 {
@@ -254,7 +254,7 @@ final class OrderPdfBaselineDumpTest extends AbstractServiceTestCase
 
             $productName = match (true) {
                 $longName => sprintf('非常に長い商品名のサンプル%02d 折り返し確認用のダミーテキストをここに詰めています', $i),
-                // 欧文字幅表(U+0020..U+007E)の外側。TCPDF は cw を持つが案E では DW=1000 になる
+                // 欧文字幅表(U+0020..U+007E)の外側。TCPDF は cw を持つが本実装では DW=1000 になる
                 $latin1 => sprintf('Café Crème Brûlée Größe ×%d ½ Ø £ ¥ § © ® ± µ ¿ Æ Þ ß æ ÷ ø ÿ', $i),
                 default => sprintf('サンプル商品%02d', $i),
             };

--- a/tests/Eccube/Tests/Service/OrderPdfBaselineDumpTest.php
+++ b/tests/Eccube/Tests/Service/OrderPdfBaselineDumpTest.php
@@ -65,7 +65,14 @@ final class OrderPdfBaselineDumpTest extends AbstractServiceTestCase
     }
 
     /**
-     * 出力パターン定義. 実コードの分岐（README の「網羅すべき出力パターン」）に対応する.
+     * 出力パターン定義.
+     *
+     * 描画コードの分岐を一通り通すために選んである。網羅の基準は次の 4 つ:
+     *
+     * 1. 店舗情報の表示・非表示（`BaseInfo` のフラグと値の有無の組み合わせ）
+     * 2. 明細の形（規格の段数・軽減税率・送料/手数料の明細・複数出荷・改ページ）
+     * 3. 折り返しと字幅（長い商品名・欧文タイトル・Latin-1・備考の最大長）
+     * 4. 外部ファイル（user_data のロゴを読むか, 管理画面既定へ落ちるか）
      *
      * @return array<string, array<string, mixed>>
      */
@@ -135,14 +142,28 @@ final class OrderPdfBaselineDumpTest extends AbstractServiceTestCase
      *
      * @return callable(): void 復元処理
      */
+    /**
+     * user_data のロゴを判別可能な画像へ差し替え, 後始末の関数を返す.
+     *
+     * 読み込み先は `eccube_html_dir` から組み立てられる固定パスで差し替えられないため,
+     * 実ファイルを退避して上書きする。復元は finally で行うが, プロセスが強制終了すると
+     * `.baseline-bak` が残るので, 次回の呼び出し時に戻してから始める。
+     */
     private function hideUserLogo(): callable
     {
         $config = static::getContainer()->get(EccubeConfig::class);
         $logo = $config->get('eccube_html_dir').'/user_data/assets/pdf/logo.png';
+        $backup = $logo.'.baseline-bak';
+
+        // 前回が強制終了していると退避したまま残る。先に戻してから始める
+        if (file_exists($backup)) {
+            @unlink($logo);
+            rename($backup, $logo);
+        }
+
         if (!file_exists($logo)) {
             return static function (): void {};
         }
-        $backup = $logo.'.baseline-bak';
         rename($logo, $backup);
 
         // user_data と管理画面既定のロゴは既定で同一ファイルのため, 退避しただけでは

--- a/tests/Eccube/Tests/Service/OrderPdfBaselineDumpTest.php
+++ b/tests/Eccube/Tests/Service/OrderPdfBaselineDumpTest.php
@@ -140,14 +140,11 @@ final class OrderPdfBaselineDumpTest extends AbstractServiceTestCase
     /**
      * user_data のロゴを一時的に退避し, 管理画面既定へフォールバックさせる.
      *
-     * @return callable(): void 復元処理
-     */
-    /**
-     * user_data のロゴを判別可能な画像へ差し替え, 後始末の関数を返す.
-     *
      * 読み込み先は `eccube_html_dir` から組み立てられる固定パスで差し替えられないため,
-     * 実ファイルを退避して上書きする。復元は finally で行うが, プロセスが強制終了すると
+     * 実ファイルを退避する。復元は finally で行うが, プロセスが強制終了すると
      * `.baseline-bak` が残るので, 次回の呼び出し時に戻してから始める。
+     *
+     * @return callable(): void 復元処理
      */
     private function hideUserLogo(): callable
     {

--- a/tests/Eccube/Tests/Service/OrderPdfBaselineDumpTest.php
+++ b/tests/Eccube/Tests/Service/OrderPdfBaselineDumpTest.php
@@ -1,0 +1,394 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Service;
+
+use Eccube\Common\EccubeConfig;
+use Eccube\Entity\BaseInfo;
+use Eccube\Entity\Master\Pref;
+use Eccube\Entity\Order;
+use Eccube\Entity\OrderItem;
+use Eccube\Entity\Shipping;
+use Eccube\Service\OrderPdfService;
+use Eccube\Service\TaxRuleService;
+use Eccube\Twig\Extension\EccubeExtension;
+use Eccube\Twig\Extension\TaxExtension;
+
+/**
+ * 納品書 PDF の基準ファイルを出力する移行用ツール.
+ *
+ * PDF エンジン差し替えの前後で出力を機械比較するための基準を作る。
+ * 通常の CI では意味を持たないため, 明示的に --filter で呼び出して使う。
+ *
+ * @see temp/tcpdf-modernize/README.md
+ */
+final class OrderPdfBaselineDumpTest extends AbstractServiceTestCase
+{
+    private const FIXED_DATE = '2026-01-01 00:00:00';
+
+    /** 出力先. ORDER_PDF_DUMP_DIR で差し替えて移行前後を並べて比較する */
+    private ?string $outDir = null;
+
+    public function testDumpBaseline(): void
+    {
+        $outDir = getenv('ORDER_PDF_DUMP_DIR');
+        if ($outDir === false || $outDir === '') {
+            self::markTestSkipped('出力先が未指定. ORDER_PDF_DUMP_DIR を指定したときだけ実行する');
+        }
+        $this->outDir = $outDir;
+
+        if (!is_dir($this->outDir) && !mkdir($this->outDir, 0777, true) && !is_dir($this->outDir)) {
+            self::fail(sprintf('出力先を作成できない: %s (コンテナは www-data で動くため書き込み権限を確認する)', $this->outDir));
+        }
+
+        $written = [];
+        foreach ($this->patterns() as $name => $spec) {
+            $written[$name] = $this->dumpOne($name, $spec);
+        }
+
+        $this->assertCount(count($this->patterns()), $written, '全パターンが生成されていること');
+        foreach ($written as $name => $size) {
+            $this->assertGreaterThan(1000, $size, "$name のサイズが小さすぎる");
+        }
+    }
+
+    /**
+     * 出力パターン定義. 実コードの分岐（README の「網羅すべき出力パターン」）に対応する.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function patterns(): array
+    {
+        return [
+            '01-all-visible' => ['baseInfo' => 'allVisible'],
+            '02-minimal' => ['baseInfo' => 'allHidden', 'products' => 1, 'feeItems' => false, 'class' => 'none', 'productCode' => false],
+            '03-visible-but-empty' => ['baseInfo' => 'visibleButEmpty'],
+            '04-address-partial' => ['baseInfo' => 'addressPartial'],
+            // 01 と同条件にならないよう, 規格 2 段 + 商品コード無しにする
+            '05-class-two' => ['baseInfo' => 'allVisible', 'class' => 'two', 'productCode' => false],
+            '06-class-one' => ['baseInfo' => 'allVisible', 'class' => 'one', 'productCode' => false],
+            '07-reduced-tax' => ['baseInfo' => 'allVisible', 'reducedTax' => true],
+            '08-fee-items' => ['baseInfo' => 'allVisible', 'feeItems' => true],
+            '09-pagebreak' => ['baseInfo' => 'allVisible', 'products' => 40],
+            '10-multiple-shipping' => ['baseInfo' => 'allVisible', 'products' => 2, 'multiple' => true],
+            '11-long-product-name' => ['baseInfo' => 'allVisible', 'longName' => true],
+            '12-user-logo' => ['baseInfo' => 'allVisible', 'userLogo' => false],
+            // 13-15: エンジン移行で差が出やすい条件。タイトルは中央寄せなので字幅がそのまま位置に出る
+            '13-title-en' => ['baseInfo' => 'allVisible', 'title' => 'Delivery Slip'],
+            '14-title-ascii-short' => ['baseInfo' => 'allVisible', 'title' => 'INVOICE'],
+            // 欧文字幅表(U+0020..U+007E)の外側。折り返しと整列に差が出るか
+            '15-latin1' => ['baseInfo' => 'allVisible', 'latin1' => true],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     *
+     * @return int 書き出したバイト数
+     */
+    private function dumpOne(string $name, array $spec): int
+    {
+        $restore = ($spec['userLogo'] ?? true) ? null : $this->hideUserLogo();
+
+        try {
+            $Shipping = $this->buildShipping($name, $spec);
+            $pdf = $this->makePdf(
+                $Shipping,
+                $this->baseInfo((string) ($spec['baseInfo'] ?? 'allVisible')),
+                (string) ($spec['title'] ?? '納品書')
+            );
+        } finally {
+            if ($restore !== null) {
+                $restore();
+            }
+        }
+
+        $this->assertStringStartsWith('%PDF', $pdf, "$name が PDF になっていない");
+
+        $path = $this->outDir."/$name.pdf";
+        $this->assertNotFalse(file_put_contents($path, $pdf), "書き込めない: $path");
+        $this->assertFileExists($path);
+        $this->assertSame(strlen($pdf), filesize($path));
+
+        return strlen($pdf);
+    }
+
+    /**
+     * user_data のロゴを一時的に退避し, 管理画面既定へフォールバックさせる.
+     *
+     * @return callable(): void 復元処理
+     */
+    private function hideUserLogo(): callable
+    {
+        $config = static::getContainer()->get(EccubeConfig::class);
+        $logo = $config->get('eccube_html_dir').'/user_data/assets/pdf/logo.png';
+        if (!file_exists($logo)) {
+            return static function (): void {};
+        }
+        $backup = $logo.'.baseline-bak';
+        rename($logo, $backup);
+
+        // user_data と管理画面既定のロゴは既定で同一ファイルのため, 退避しただけでは
+        // 出力が変わらずフォールバック経路を検証できない. 判別可能な別画像を置く.
+        //
+        // 寸法は実物と同じ 301x38 にすること. Image() は幅のみ指定で高さを縦横比から決めるため,
+        // 比率が違うとロゴが縦に伸びて店舗情報の行（Y=54mm 始まり）に重なり,
+        // 「どちらのファイルが読まれたか」ではなくレイアウト差を見てしまう.
+        [$w, $h] = [301, 38];
+        $distinct = imagecreatetruecolor($w, $h);
+        imagefilledrectangle($distinct, 0, 0, $w - 1, $h - 1, imagecolorallocate($distinct, 0, 102, 204));
+        imagestring($distinct, 5, 8, 12, 'USER LOGO', imagecolorallocate($distinct, 255, 255, 255));
+        imagepng($distinct, $logo);
+        imagedestroy($distinct);
+
+        return static function () use ($logo, $backup): void {
+            @unlink($logo);
+            if (file_exists($backup)) {
+                rename($backup, $logo);
+            }
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     */
+    private function buildShipping(string $name, array $spec): Shipping
+    {
+        $productCount = (int) ($spec['products'] ?? 3);
+
+        $Customer = $this->createCustomer(sprintf('baseline-%s@example.com', $name));
+        $ProductClasses = [];
+        while (count($ProductClasses) < $productCount) {
+            $Product = $this->createProduct('サンプル商品', min(3, $productCount - count($ProductClasses)));
+            foreach ($Product->getProductClasses() as $ProductClass) {
+                $ProductClasses[] = $ProductClass;
+            }
+        }
+        $ProductClasses = array_slice($ProductClasses, 0, $productCount);
+
+        $Order = $this->createOrderWithProductClasses($Customer, $ProductClasses);
+        $this->normalize($Order, $spec);
+
+        if ($spec['multiple'] ?? false) {
+            $this->splitIntoTwoShippings($Order);
+        }
+
+        $this->entityManager->flush();
+
+        $Shipping = $Order->getShippings()->first();
+        $this->assertInstanceOf(Shipping::class, $Shipping, "$name の Shipping が取得できない");
+
+        return $Shipping;
+    }
+
+    /**
+     * 実行日・乱数に依存しない値へ固定し, spec に従って明細を整形する.
+     *
+     * フィクスチャは Faker で都道府県・価格などを毎回変えるため, PDF に描画される値を
+     * すべて固定しないと基準として使えない（同一コードでも指紋が変わる）。
+     *
+     * @param array<string, mixed> $spec
+     */
+    private function normalize(Order $Order, array $spec): void
+    {
+        $Pref = $this->entityManager->getRepository(Pref::class)->find(27); // 大阪府
+        $fixedDate = new \DateTime(self::FIXED_DATE);
+
+        $Order->setOrderNo('BASELINE-0001')
+            ->setName01('納品')->setName02('太郎')
+            ->setKana01('ノウヒン')->setKana02('タロウ')
+            ->setCompanyName('株式会社サンプル')
+            ->setPostalCode('5300001')
+            ->setPref($Pref)
+            ->setAddr01('大阪市北区梅田2-4-9')
+            ->setAddr02('ブリーゼタワー13F')
+            ->setPhoneNumber('0612345678')
+            ->setOrderDate($fixedDate)
+            ->setCreateDate($fixedDate);
+
+        foreach ($Order->getShippings() as $Shipping) {
+            $Shipping->setName01('納品')->setName02('太郎')
+                ->setKana01('ノウヒン')->setKana02('タロウ')
+                ->setCompanyName('株式会社サンプル')
+                ->setPostalCode('5300001')
+                ->setPref($Pref)
+                ->setAddr01('大阪市北区梅田2-4-9')
+                ->setAddr02('ブリーゼタワー13F')
+                ->setPhoneNumber('0612345678');
+        }
+
+        // 送料・手数料・値引きの明細を落とすか
+        if (($spec['feeItems'] ?? false) === false) {
+            foreach ($Order->getOrderItems() as $OrderItem) {
+                if (!$OrderItem->isProduct()) {
+                    $Order->removeOrderItem($OrderItem);
+                    $this->entityManager->remove($OrderItem);
+                }
+            }
+        }
+
+        $class = (string) ($spec['class'] ?? 'two');
+        $withCode = (bool) ($spec['productCode'] ?? true);
+        $longName = (bool) ($spec['longName'] ?? false);
+        $latin1 = (bool) ($spec['latin1'] ?? false);
+        $reduced = (bool) ($spec['reducedTax'] ?? false);
+
+        $i = 0;
+        $subtotal = '0';
+        foreach ($Order->getOrderItems() as $OrderItem) {
+            ++$i;
+            $price = 1000 * $i;
+            $quantity = ($i % 3) + 1;
+
+            $productName = match (true) {
+                $longName => sprintf('非常に長い商品名のサンプル%02d 折り返し確認用のダミーテキストをここに詰めています', $i),
+                // 欧文字幅表(U+0020..U+007E)の外側。TCPDF は cw を持つが案E では DW=1000 になる
+                $latin1 => sprintf('Café Crème Brûlée Größe ×%d ½ Ø £ ¥ § © ® ± µ ¿ Æ Þ ß æ ÷ ø ÿ', $i),
+                default => sprintf('サンプル商品%02d', $i),
+            };
+
+            $OrderItem->setProductName($productName)
+                ->setProductCode($withCode ? sprintf('CODE-%03d', $i) : null)
+                ->setPrice((string) $price)
+                ->setQuantity((string) $quantity)
+                // getTotalPrice() は getPriceIncTax()×数量 で, 税表示区分が税込でなければ
+                // price + tax になる. tax を固定しないとフィクスチャの乱数が残る.
+                ->setTax('0')
+                // 既定の TaxRule は 10%. 8% にすると軽減税率対象と判定される.
+                ->setTaxRate($reduced && $OrderItem->isProduct() ? '8' : '10');
+
+            $this->applyClassCategory($OrderItem, $class, $i);
+
+            $subtotal = bcadd($subtotal, bcmul((string) $price, (string) $quantity, 2), 2);
+        }
+
+        // 複数配送では商品以外の明細（送料・手数料・値引き）も描画される。
+        // これらは Order のコレクションから外しても Shipping 側には残るため,
+        // 値を固定しないとフィクスチャの乱数が出力に出る。
+        foreach ($Order->getShippings() as $Shipping) {
+            foreach ($Shipping->getOrderItems() as $OrderItem) {
+                if (!$OrderItem instanceof OrderItem || $OrderItem->isProduct()) {
+                    continue;
+                }
+                $OrderItem->setPrice('0')->setQuantity('1')->setTax('0')->setTaxRate('10');
+            }
+        }
+
+        $Order->setSubtotal($subtotal)
+            ->setDiscount('0')
+            ->setDeliveryFeeTotal('0')
+            ->setCharge('0')
+            ->setTax('0')
+            ->setTotal($subtotal)
+            ->setPaymentTotal($subtotal);
+    }
+
+    private function applyClassCategory(OrderItem $OrderItem, string $class, int $i): void
+    {
+        match ($class) {
+            'two' => $OrderItem->setClassCategoryName1(sprintf('サイズ%d', $i))
+                ->setClassCategoryName2(sprintf('カラー%d', $i)),
+            'one' => $OrderItem->setClassCategoryName1(sprintf('サイズ%d', $i))
+                ->setClassCategoryName2(''),
+            default => $OrderItem->setClassCategoryName1()->setClassCategoryName2(),
+        };
+    }
+
+    /**
+     * 明細を 2 つの Shipping へ分け, $Order->isMultiple() を真にする.
+     */
+    private function splitIntoTwoShippings(Order $Order): void
+    {
+        $First = $Order->getShippings()->first();
+        $this->assertInstanceOf(Shipping::class, $First);
+
+        $Second = clone $First;
+        $Second->setName01('納品')->setName02('次郎');
+        $this->entityManager->persist($Second);
+        $Order->addShipping($Second);
+
+        $items = array_values($Order->getOrderItems()->toArray());
+        // 末尾の明細だけ 2 つ目の Shipping へ移す
+        $Last = end($items);
+        if ($Last instanceof OrderItem) {
+            $Last->setShipping($Second);
+        }
+    }
+
+    private function makePdf(Shipping $Shipping, BaseInfo $BaseInfo, string $title = '納品書'): string
+    {
+        $container = static::getContainer();
+
+        $service = new OrderPdfService(
+            $container->get(EccubeConfig::class),
+            $this->entityManager->getRepository(Order::class),
+            $this->entityManager->getRepository(Shipping::class),
+            $container->get(TaxRuleService::class),
+            $this->entityManager->getRepository(BaseInfo::class),
+            $container->get(EccubeExtension::class),
+            $container->get(TaxExtension::class)
+        );
+        // プロパティ名に反して実体は BaseInfo エンティティ. dtb_base_info を書き換えず差し替える.
+        $service->baseInfoRepository = $BaseInfo;
+
+        $service->makePdf([
+            'ids' => (string) $Shipping->getId(),
+            'issue_date' => new \DateTime(self::FIXED_DATE),
+            'title' => $title,
+            'message1' => 'この度はお買い上げいただきありがとうございます。',
+            'message2' => '内容にご不明な点がございましたらご連絡ください。',
+            'message3' => '今後ともよろしくお願いいたします。',
+            'note1' => '備考1',
+            'note2' => '備考2',
+            'note3' => '備考3',
+            'default' => false,
+        ]);
+
+        return $service->outputPdf();
+    }
+
+    private function baseInfo(string $kind): BaseInfo
+    {
+        $values = static fn (BaseInfo $b): BaseInfo => $b->setShopName('テスト店舗')
+            ->setShopNameEng('Test Shop')
+            ->setPostalCode('5300001')
+            ->setAddr01('大阪市北区梅田2-4-9')
+            ->setAddr02('ブリーゼタワー13F')
+            ->setCompanyName('テスト株式会社')
+            // PhoneNumberType は Assert\Type('digit') で数字のみ. ハイフン入りは UI から入力できない.
+            ->setPhoneNumber('0612345678')
+            ->setBusinessHour('10:00-19:00')
+            ->setEmail01('test@example.com')
+            ->setInvoiceRegistrationNumber('T1234567890123');
+
+        $allFlags = static fn (BaseInfo $b, bool $on): BaseInfo => $b->setOrderPdfVisibleShopName($on)
+            ->setOrderPdfVisibleShopNameEng($on)
+            ->setOrderPdfVisibleAddress($on)
+            ->setOrderPdfVisibleCompanyName($on)
+            ->setOrderPdfVisiblePhoneNumber($on)
+            ->setOrderPdfVisibleBusinessHour($on)
+            ->setOrderPdfVisibleEmail($on)
+            ->setOrderPdfVisibleInvoiceNumber($on);
+
+        return match ($kind) {
+            'allHidden' => $allFlags($values(new BaseInfo()), false),
+            // フラグは ON だが値が空 = 「フラグ AND 値」の判定を検証する
+            'visibleButEmpty' => $allFlags(new BaseInfo(), true),
+            // 住所だけ部分欠け（郵便番号なし・addr02 なし）
+            'addressPartial' => $allFlags($values(new BaseInfo())->setPostalCode()->setAddr02(), true),
+            default => $allFlags($values(new BaseInfo()), true),
+        };
+    }
+}

--- a/tests/Eccube/Tests/Service/OrderPdfBaselineDumpTest.php
+++ b/tests/Eccube/Tests/Service/OrderPdfBaselineDumpTest.php
@@ -90,6 +90,10 @@ final class OrderPdfBaselineDumpTest extends AbstractServiceTestCase
             '14-title-ascii-short' => ['baseInfo' => 'allVisible', 'title' => 'INVOICE'],
             // 欧文字幅表(U+0020..U+007E)の外側。折り返しと整列に差が出るか
             '15-latin1' => ['baseInfo' => 'allVisible', 'latin1' => true],
+            // 16-17: 備考が最大長 (eccube_stext_len 255 x 3 行) のとき紙面からあふれないか。
+            // 表が下端まで伸びるほど備考の開始位置が下がるので, 明細数を変えて 2 通り見る
+            '16-long-note' => ['baseInfo' => 'allVisible', 'longNote' => true],
+            '17-long-note-tall-table' => ['baseInfo' => 'allVisible', 'products' => 12, 'longNote' => true],
         ];
     }
 
@@ -107,7 +111,8 @@ final class OrderPdfBaselineDumpTest extends AbstractServiceTestCase
             $pdf = $this->makePdf(
                 $Shipping,
                 $this->baseInfo((string) ($spec['baseInfo'] ?? 'allVisible')),
-                (string) ($spec['title'] ?? '納品書')
+                (string) ($spec['title'] ?? '納品書'),
+                (bool) ($spec['longNote'] ?? false)
             );
         } finally {
             if ($restore !== null) {
@@ -327,7 +332,7 @@ final class OrderPdfBaselineDumpTest extends AbstractServiceTestCase
         }
     }
 
-    private function makePdf(Shipping $Shipping, BaseInfo $BaseInfo, string $title = '納品書'): string
+    private function makePdf(Shipping $Shipping, BaseInfo $BaseInfo, string $title = '納品書', bool $longNote = false): string
     {
         $container = static::getContainer();
 
@@ -350,9 +355,9 @@ final class OrderPdfBaselineDumpTest extends AbstractServiceTestCase
             'message1' => 'この度はお買い上げいただきありがとうございます。',
             'message2' => '内容にご不明な点がございましたらご連絡ください。',
             'message3' => '今後ともよろしくお願いいたします。',
-            'note1' => '備考1',
-            'note2' => '備考2',
-            'note3' => '備考3',
+            'note1' => $longNote ? '1'.str_repeat('あ', 253).'X' : '備考1',
+            'note2' => $longNote ? '2'.str_repeat('い', 253).'Y' : '備考2',
+            'note3' => $longNote ? '3'.str_repeat('う', 253).'Z' : '備考3',
             'default' => false,
         ]);
 

--- a/tests/Eccube/Tests/Service/OrderPdfServiceTest.php
+++ b/tests/Eccube/Tests/Service/OrderPdfServiceTest.php
@@ -27,7 +27,7 @@ use Eccube\Twig\Extension\TaxExtension;
 /**
  * 納品書PDFの店舗情報欄の描画座標を検証する (#6197).
  *
- * PDF のバイナリからは座標を検証できないため, TCPDF へ描画する直前の座標を
+ * PDF のバイナリからは座標を検証できないため, 描画する直前の座標を
  * {@see OrderPdfLayoutProbe} で記録して検証する.
  */
 final class OrderPdfServiceTest extends AbstractServiceTestCase
@@ -193,7 +193,7 @@ final class OrderPdfServiceTest extends AbstractServiceTestCase
 /**
  * 店舗情報欄の描画座標を記録するテスト用サブクラス.
  *
- * TCPDF のページ生成を行わずに座標だけを取り出すため, 描画系のメソッドを差し替える.
+ * ページを生成せずに座標だけを取り出すため, 描画系のメソッドを差し替える.
  */
 final class OrderPdfLayoutProbe extends OrderPdfService
 {
@@ -224,7 +224,7 @@ final class OrderPdfLayoutProbe extends OrderPdfService
     }
 
     #[\Override]
-    public function Image($file, $x = null, $y = null, $w = 0, $h = 0, $type = '', $link = '', $align = '', $resize = false, $dpi = 300, $palign = '', $ismask = false, $imgmask = false, $border = 0, $fitbox = false, $hidden = false, $fitonpage = false, $alt = false, $altimgs = [])
+    protected function renderLogo(): void
     {
         // ページが無い状態では画像を描画できない
     }

--- a/tests/Eccube/Tests/Service/Pdf/Font/JapaneseCidFontTest.php
+++ b/tests/Eccube/Tests/Service/Pdf/Font/JapaneseCidFontTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Service\Pdf\Font;
+
+use Eccube\Service\Pdf\Font\JapaneseCidFont;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * 納品書の字送りとベースライン位置を決める値を固定する.
+ *
+ * 文字幅が変わると欧文の整列と折り返しが動き, アセント・ディセントが変わると
+ * 帳票の全行が縦に動く. どちらも 4.3 までの TCPDF と同じ値でなければならない.
+ */
+final class JapaneseCidFontTest extends TestCase
+{
+    /**
+     * 文字幅は欧文 95 文字（U+0020..U+007E）を隙間なく持つこと.
+     */
+    public function testLatinWidthsCoverPrintableAscii(): void
+    {
+        $widths = JapaneseCidFont::LATIN_WIDTHS;
+
+        $this->assertCount(95, $widths);
+        $this->assertSame(range(0x20, 0x7E), array_keys($widths));
+        $this->assertSame(278, $widths[0x20], '半角スペース');
+        $this->assertSame(387, $widths[0x7E], 'チルダ');
+    }
+
+    /**
+     * アセント・ディセントは日本語フォント共通の em 配分であること.
+     *
+     * ベースラインは `y + (セル高 + アセント - ディセント) / 2` で決まるため,
+     * ここが変わると帳票の全行がフォントサイズに比例してずれる.
+     */
+    public function testEmMetricsAreFixed(): void
+    {
+        $this->assertSame(880, JapaneseCidFont::ASCENT);
+        $this->assertSame(JapaneseCidFont::DESCENT, -120);
+        $this->assertSame(1000, JapaneseCidFont::DEFAULT_WIDTH);
+    }
+
+    /**
+     * 明朝・ゴシックの通常とボールドで 4 書体を返すこと.
+     */
+    public function testFacesRegisterFourStyles(): void
+    {
+        $faces = JapaneseCidFont::faces();
+
+        $this->assertSame([
+            'kozminproregular',
+            'kozminproregularB',
+            'kozgopromedium',
+            'kozgopromediumB',
+        ], array_keys($faces));
+
+        $this->assertSame('KozMinPro-Regular-Acro', $faces['kozminproregular']['name']);
+        $this->assertSame('KozMinPro-Regular-Acro,Bold', $faces['kozminproregularB']['name']);
+        $this->assertSame('KozGoPro-Medium-Acro', $faces['kozgopromedium']['name']);
+        $this->assertSame('KozGoPro-Medium-Acro,Bold', $faces['kozgopromediumB']['name']);
+    }
+
+    /**
+     * Flags は明朝がセリフ体, ゴシックがサンセリフ体であること.
+     *
+     * 2 = Serif / 4 = Symbolic（PDF 仕様のビットフラグ）.
+     */
+    public function testFlagsDistinguishSerif(): void
+    {
+        $faces = JapaneseCidFont::faces();
+
+        $this->assertSame(6, $faces['kozminproregular']['desc']['Flags'], '明朝は Serif + Symbolic');
+        $this->assertSame(4, $faces['kozgopromedium']['desc']['Flags'], 'ゴシックは Symbolic のみ');
+    }
+
+    /**
+     * 文字幅は欧文が字幅表, それ以外が既定値になること.
+     */
+    public function testStringWidthUsesTableForLatinAndDefaultForOthers(): void
+    {
+        // 'A' 646 + 'B' 604
+        $this->assertSame(1250, JapaneseCidFont::stringWidth('AB'));
+        // 和文は全角固定
+        $this->assertSame(2000, JapaneseCidFont::stringWidth('あい'));
+        // 半角カナも字幅表に無いので既定値（4.3 までの TCPDF と同じ扱い）
+        $this->assertSame(1000, JapaneseCidFont::stringWidth('ｱ'));
+        $this->assertSame(0, JapaneseCidFont::stringWidth(''));
+    }
+
+    /**
+     * 文書タイトルの中央寄せに使う幅が, 想定どおりの値になること.
+     */
+    public function testStringWidthOfDefaultTitle(): void
+    {
+        // 全角 10 文字 + 半角括弧 2 つ（323 x 2）
+        $this->assertSame(10000 + 646, JapaneseCidFont::stringWidth('お買上げ明細書(納品書)'));
+    }
+
+    public function testCodePoints(): void
+    {
+        $this->assertSame([0x41, 0x3042], JapaneseCidFont::codePoints('Aあ'));
+        $this->assertSame([], JapaneseCidFont::codePoints(''));
+    }
+}

--- a/tests/Eccube/Tests/Service/Pdf/PdfWriterTest.php
+++ b/tests/Eccube/Tests/Service/Pdf/PdfWriterTest.php
@@ -178,6 +178,54 @@ final class PdfWriterTest extends TestCase
     }
 
     /**
+     * 折り返しセルの高さを, 描画も改ページもせずに測れること.
+     *
+     * 納品書の明細表は行の高さを先に測ってから改ページする. 測定が描画を兼ねると
+     * その途中で自動改ページが起き, 退避しておいた座標が使えなくなる（文字は分割されて
+     * 送られる一方, 罫線だけが新しいページの下端に取り残される）.
+     */
+    public function testMeasureMultiCellHeightNeitherDrawsNorBreaksPage(): void
+    {
+        $writer = $this->createWriter();
+        $writer->setTemplateFile(self::projectDir().'/html/template/admin/assets/pdf/nouhinsyo.pdf');
+        $writer->setMargins(15, 20);
+        $writer->setFont('kozminproregular', '', 8);
+        $writer->addPage();
+        $lineHeight = $writer->getFontSize() * PdfWriter::CELL_HEIGHT_RATIO;
+
+        // 明細表の事前判定が確保する 4 行ぶん(16mm)しか残っていない位置に置く
+        $writer->setXY(15, $writer->getPageBreakTrigger() - 16.0);
+        $pageCount = $writer->getPageCount();
+        $y = $writer->getY();
+
+        // 商品名列は 110.3mm 幅・8pt なので 1 行あたり約 38 全角文字
+        $height = $writer->measureMultiCellHeight(110.3, 4.0, str_repeat('あ', 38 * 5));
+
+        $this->assertGreaterThan(4 * $lineHeight, $height, '5 行に折り返すので 16mm を超える');
+        $this->assertSame($pageCount, $writer->getPageCount(), '測定で改ページしてはいけない');
+        $this->assertSame($y, $writer->getY(), '測定でカーソルが動いてはいけない');
+    }
+
+    /**
+     * 測定した高さが multiCell() が実際に使うセル高さと一致すること.
+     */
+    public function testMeasureMultiCellHeightMatchesRenderedHeight(): void
+    {
+        $writer = $this->createWriter();
+        $writer->setMargins(15, 20);
+        $writer->setFont('kozminproregular', '', 8);
+        $writer->addPage();
+
+        foreach (['1行', "1行目\n2行目\n3行目", str_repeat('あ', 60)] as $text) {
+            $measured = $writer->measureMultiCellHeight(30, 4.0, $text);
+            $writer->setXY(15, 20);
+            $writer->multiCell(30, 4.0, $text, 0, 'L', false, 1);
+
+            $this->assertEqualsWithDelta($measured, $writer->getLastCellHeight(), 0.001, $text);
+        }
+    }
+
+    /**
      * セル上端から文字ベースラインまでの距離(mm).
      */
     private function baselineOffset(float $cellHeight, float $fontSizePt): float

--- a/tests/Eccube/Tests/Service/Pdf/PdfWriterTest.php
+++ b/tests/Eccube/Tests/Service/Pdf/PdfWriterTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Service\Pdf;
+
+use Eccube\Service\Pdf\PdfWriter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * 帳票の座標が動いていないことを検証する.
+ *
+ * 納品書は座標をハードコードした帳票で, セルの高さ・ベースライン・パディングの
+ * どれか一つが変わるだけで印字位置がずれる. ここではその計算規則を固定する.
+ */
+final class PdfWriterTest extends TestCase
+{
+    /** 1mm あたりのポイント数 */
+    private const POINTS_PER_MM = 72 / 25.4;
+
+    /** テストで使うフォントのアセント・ディセント(千分率). kozgopromedium / kozminproregular 共通 */
+    private const FONT_ASCENT = 0.88;
+    private const FONT_DESCENT = 0.12;
+
+    private static function projectDir(): string
+    {
+        return \dirname(__DIR__, 5);
+    }
+
+    private function createWriter(): PdfWriter
+    {
+        return new PdfWriter();
+    }
+
+    /**
+     * 用紙サイズはテンプレート PDF に合わせること.
+     *
+     * 納品書のテンプレートは A4 ちょうど(210x297mm)ではない. ここが A4 固定に戻ると
+     * 紙面下端を基準にする描画（フッタ・改ページ）が全てずれる.
+     */
+    public function testPageSizeFollowsTemplate(): void
+    {
+        $writer = $this->createWriter();
+        $writer->setTemplateFile(self::projectDir().'/html/template/admin/assets/pdf/nouhinsyo.pdf');
+
+        // テンプレートの MediaBox は 595.2 x 841.68pt
+        $this->assertEqualsWithDelta(209.9733, $writer->getPageWidth(), 0.001);
+        $this->assertEqualsWithDelta(296.9260, $writer->getPageHeight(), 0.001);
+        // 自動改ページは用紙下端から 20mm
+        $this->assertEqualsWithDelta(276.9260, $writer->getPageBreakTrigger(), 0.001);
+    }
+
+    /**
+     * 文字はセル内で上下中央に置かれ, 左は既定のパディング分だけ内側へ入ること.
+     */
+    public function testCellPlacesTextAtVerticalCenter(): void
+    {
+        $writer = $this->createWriter();
+        $writer->setMargins(15, 20);
+        $writer->setFont('kozgopromedium', '', 15);
+        $writer->addPage();
+        $writer->setXY(15, 20);
+        $writer->cell(80, 10, 'あ', 0, 0, 'L');
+
+        [$x, $y] = $this->firstTextPosition($writer);
+
+        $this->assertEqualsWithDelta(15 + PdfWriter::CELL_PADDING_X, $x, 0.01);
+        $this->assertEqualsWithDelta(20 + $this->baselineOffset(10.0, 15.0), $y, 0.01);
+    }
+
+    /**
+     * 右寄せは「セル右端 - パディング - 文字幅」に揃うこと.
+     */
+    public function testCellAlignsRight(): void
+    {
+        $writer = $this->createWriter();
+        $writer->setMargins(15, 20);
+        $writer->setFont('kozgopromedium', '', 15);
+        $writer->addPage();
+        $writer->setXY(15, 20);
+        $writer->cell(80, 10, 'あ', 0, 0, 'R');
+
+        [$x] = $this->firstTextPosition($writer);
+
+        $expected = 15 + 80 - PdfWriter::CELL_PADDING_X - $writer->getStringWidth('あ');
+        $this->assertEqualsWithDelta($expected, $x, 0.01);
+    }
+
+    /**
+     * セルの高さは指定値とフォントサイズ由来の下限の大きい方になること.
+     */
+    public function testCellHeightHasFontSizedMinimum(): void
+    {
+        $writer = $this->createWriter();
+        $writer->setMargins(15, 20);
+        $writer->setFont('kozgopromedium', '', 15);
+        $writer->addPage();
+        $writer->setXY(15, 20);
+
+        // 指定 0 でも フォントサイズ x CELL_HEIGHT_RATIO まで広がる
+        $writer->cell(80, 0, '', 0, 2);
+        $minimum = ($writer->getFontSize() * PdfWriter::CELL_HEIGHT_RATIO);
+        $this->assertEqualsWithDelta($minimum, $writer->getLastCellHeight(), 0.001);
+        $this->assertEqualsWithDelta(20 + $minimum, $writer->getY(), 0.001);
+    }
+
+    /**
+     * カーソルの進み方: 0=右へ / 1=次行の左端へ / 2=真下へ.
+     */
+    public function testCursorAdvance(): void
+    {
+        $writer = $this->createWriter();
+        $writer->setMargins(15, 20);
+        $writer->setFont('kozgopromedium', '', 15);
+        $writer->addPage();
+
+        $writer->setXY(30, 50);
+        $writer->cell(40, 10, '', 0, 0);
+        $this->assertSame([70.0, 50.0], [$writer->getX(), $writer->getY()]);
+
+        $writer->setXY(30, 50);
+        $writer->cell(40, 10, '', 0, 1);
+        $this->assertSame([15.0, 60.0], [$writer->getX(), $writer->getY()]);
+
+        $writer->setXY(30, 50);
+        $writer->cell(40, 10, '', 0, 2);
+        $this->assertSame([30.0, 60.0], [$writer->getX(), $writer->getY()]);
+    }
+
+    /**
+     * 折り返しセルの高さは行数ぶんに広がること. 末尾の改行は行数に数えない.
+     */
+    public function testMultiCellHeightGrowsWithLineCount(): void
+    {
+        $writer = $this->createWriter();
+        $writer->setMargins(15, 20);
+        $writer->setFont('kozminproregular', '', 8);
+        $writer->addPage();
+        $lineHeight = $writer->getFontSize() * PdfWriter::CELL_HEIGHT_RATIO;
+
+        $writer->setXY(15, 20);
+        $writer->multiCell(80, 4, "1行目\n2行目\n3行目", 0, 'L', false, 1);
+        $this->assertEqualsWithDelta(3 * $lineHeight, $writer->getLastCellHeight(), 0.001);
+
+        // 末尾の改行で 1 行増えてはいけない（4.3 までの挙動）
+        $writer->setXY(15, 20);
+        $writer->multiCell(80, 4, "1行目\n", 0, 'L', false, 1);
+        $this->assertEqualsWithDelta(4.0, $writer->getLastCellHeight(), 0.001, '1行なので最小高さのまま');
+    }
+
+    /**
+     * 幅に収まらない文字列は折り返され, 行数ぶん高さが増えること.
+     */
+    public function testMultiCellWrapsLongText(): void
+    {
+        $writer = $this->createWriter();
+        $writer->setMargins(15, 20);
+        $writer->setFont('kozminproregular', '', 8);
+        $writer->addPage();
+        $lineHeight = $writer->getFontSize() * PdfWriter::CELL_HEIGHT_RATIO;
+
+        $writer->setXY(15, 20);
+        // 全角 20 文字 = 8pt x 20 で約 56.4mm. 幅 30mm なら 2 行以上になる
+        $writer->multiCell(30, 4, str_repeat('あ', 20), 0, 'L', false, 1);
+
+        $this->assertGreaterThan(2 * $lineHeight, $writer->getLastCellHeight());
+    }
+
+    /**
+     * セル上端から文字ベースラインまでの距離(mm).
+     */
+    private function baselineOffset(float $cellHeight, float $fontSizePt): float
+    {
+        $ascent = self::FONT_ASCENT * $fontSizePt / self::POINTS_PER_MM;
+        $descent = self::FONT_DESCENT * $fontSizePt / self::POINTS_PER_MM;
+
+        return ($cellHeight + $ascent - $descent) / 2;
+    }
+
+    /**
+     * 出力 PDF から最初のテキスト描画位置(mm, 用紙左上原点)を取り出す.
+     *
+     * @return array{0: float, 1: float}
+     */
+    private function firstTextPosition(PdfWriter $writer): array
+    {
+        $pdf = $writer->output();
+        $this->assertStringStartsWith('%PDF', $pdf);
+
+        foreach ($this->contentStreams($pdf) as $content) {
+            if (preg_match('/([-\d.]+)\s+([-\d.]+)\s+Td\s*\(/', $content, $matches) === 1) {
+                return [
+                    (float) $matches[1] / self::POINTS_PER_MM,
+                    $writer->getPageHeight() - ((float) $matches[2] / self::POINTS_PER_MM),
+                ];
+            }
+        }
+
+        self::fail('テキストの描画命令が見つからない');
+    }
+
+    /**
+     * @return \Generator<int, string>
+     */
+    private function contentStreams(string $pdf): \Generator
+    {
+        $offset = 0;
+        while (($start = strpos($pdf, "stream\n", $offset)) !== false) {
+            $start += 7;
+            $end = strpos($pdf, 'endstream', $start);
+            if ($end === false) {
+                return;
+            }
+            $raw = rtrim(substr($pdf, $start, $end - $start), "\r\n");
+            $inflated = @gzuncompress($raw);
+            // 'endstream' の中の 'stream' を次のストリーム開始と誤認しないよう読み飛ばす
+            $offset = $end + 9;
+            yield $inflated === false ? $raw : $inflated;
+        }
+    }
+}

--- a/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/OrderPdfControllerTest.php
@@ -147,6 +147,7 @@ final class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $this->actual = $this->client->getResponse()->headers->get('Content-Type');
         $this->expected = 'application/pdf';
         $this->verify();
+        $this->assertPdfBody();
 
         $crawler = $this->client->request(Request::METHOD_GET, $this->generateUrl('admin_order_export_pdf'),
             [
@@ -271,6 +272,7 @@ final class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $this->actual = $client->getResponse()->headers->get('Content-Type');
         $this->expected = 'application/pdf';
         $this->verify();
+        $this->assertPdfBody();
     }
 
     /**
@@ -329,6 +331,7 @@ final class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $this->actual = $client->getResponse()->headers->get('Content-Type');
         $this->expected = 'application/pdf';
         $this->verify();
+        $this->assertPdfBody();
     }
 
     /**
@@ -365,6 +368,7 @@ final class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $this->actual = $this->client->getResponse()->headers->get('Content-Type');
         $this->expected = 'application/pdf';
         $this->verify();
+        $this->assertPdfBody();
 
         $OrderPdfs = $this->orderPdfRepository->findAll();
         $this->assertCount(1, $OrderPdfs, '1件保存されているはず');
@@ -475,5 +479,20 @@ final class OrderPdfControllerTest extends AbstractAdminWebTestCase
         $this->orderRepo->changeStatus($Order->getId(), $Status);
 
         return $Order;
+    }
+
+    /**
+     * レスポンス本文が PDF として成立していることを確かめる.
+     *
+     * Content-Type はコントローラが無条件に付けるため, ヘッダだけでは
+     * 「例外で空になった」「フォントが解決できず真っ白」を検出できない.
+     */
+    private function assertPdfBody(): void
+    {
+        $content = (string) $this->client->getResponse()->getContent();
+
+        $this->assertStringStartsWith('%PDF', $content, 'PDF になっていない');
+        // 基準セットで最小の 02-minimal が約 20KB. 半分を下回るのは異常
+        $this->assertGreaterThan(10000, \strlen($content), 'PDF が小さすぎる');
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

納品書PDF の生成エンジンを `tecnickcom/tcpdf` から `setasign/fpdf` へ移行します。

`tecnickcom/tcpdf` は 7.0.0（2026-06-18）で deprecated となり `tecnickcom/tc-lib-pdf` の
互換ファサードに置き換わりました。7.x では `setasign/fpdi` の TCPDF ブリッジが動かず、
納品書が壊れます（調査は #7041）。

- Refs #7083
- Refs #7041

## 方針(Policy)

移行先として 2 案を比較し、**fpdf + fpdi** を採りました。

| | 現行 | tc-lib-pdf | **fpdf + fpdi** |
|---|---|---|---|
| 依存パッケージ | 2 | **14**（すべて LGPL） | **2**（どちらも MIT） |
| PHP 拡張の追加要件 | ― | **ext-bcmath** | **ext-gd**（fpdf 1.9.0 が require） |
| EC-CUBE 2系との関係 | ― | 別物 | **同じ構成（2系は 2011 年から）** |

依存が 14 パッケージに増えるのは依存削減の方針と合わないと判断しました。fpdf + fpdi は
2 パッケージのままです。

**訂正: 追加の PHP 拡張はどちらの案でも 1 つ必要です。** 当初この表に「fpdf 側は追加要件なし」と
書いていましたが誤りでした。`setasign/fpdf` は 1.9.0 で `ext-gd` を require に追加しており
（1.8.6 以前は require 空）、`^1.8.6` の指定では 1.9.0 が解決されます。移行前の
composer.lock には `ext-gd` を要求するパッケージが 1 つも無い（tcpdf 6.11.2 は `ext-curl` のみ）
ため、**本 PR は動作環境に `ext-gd` を追加します**。

本体 `composer.json` の require から外しても fpdf 側の要求は消えず、GD の無い環境では
`composer install` / `create-project` が platform チェックで落ちます。実態に合わせて必須として
宣言しています（`321aaa8271`）。fpdf を 1.8.6 に固定すれば避けられますが、1.9 の
「Removed a deprecation notice on PHP 8.5」を失うため、PHP 8.5 対応で `failOnDeprecation` を
有効にしている 4.4 では採れませんでした。

実行時に GD を使うのは FPDF の GIF / WebP 解析だけで、既定のロゴは PNG です。要件として
効くのはインストール時の拡張チェックのみになります。

日本語フォントは Adobe-Japan1 の CID フォント（非埋め込み）を自前で持ちます。
`tc-lib-pdf-font` も FPDF もフォント定義を同梱しておらず、上流の配布データにも
Adobe-Japan1 の CID フォントが無いためです。**本体に持つのは次の 4 つだけで、
LGPL 由来のデータは含みません。**

| 項目 | 値 | 出所 |
|---|---|---|
| 欧文の文字幅 95 個 | U+0020〜U+007E | EC-CUBE 2系 `data/module/fpdi/japanese.php`（FPDF 公式スクリプト由来・MIT）。TCPDF 6.x の値と数値が完全一致することを確認 |
| アセント 880 / ディセント −120 | ベースライン位置を決める | 日本語フォント共通の em 配分。IPA明朝・Noto CJK JP の OS/2 と同値 |
| `Flags` | 明朝 6 / ゴシック 4 | PDF 仕様のビットフラグ（Serif 2 ＋ Symbolic 4）。「セリフ体かどうか」の分類 |
| 書体名 2 つ | `KozMinPro-Regular-Acro` / `KozGoPro-Medium-Acro` | Adobe のフォント名 |

`StemV` `CapHeight` `FontBBox` は一般値を置いています。現行と同じ実測値にしても
画素差が 1 件も変わらないことを確認したため、TCPDF から写す必要がありませんでした。

## 実装に関する補足(Appendix)

### 描画エンジンへの依存を 1 クラスに閉じ込めた

```
Eccube\Service\OrderPdfService              継承をやめ、描画は委譲する
  └ holds Eccube\Service\Pdf\PdfWriter      カーソルを持つ帳票描画。座標計算はここ
       └ holds Eccube\Service\Pdf\FpdfEngine   FPDF の protected に触る唯一の場所
            └ uses Eccube\Service\Pdf\Font\JapaneseCidFont
```

`OrderPdfService` の座標定数と描画ロジックは変えていません。

### FPDF の Cell / MultiCell / Text は使っていない

ベースラインの計算式が違うためです。

| | 式 | Ascent 880 / Descent −120 のとき |
|---|---|---|
| TCPDF（4.3 まで） | `y + (高さ + アセント − ディセント) / 2` | `y + 高さ/2 + 0.38 × サイズ` |
| FPDF | `y + 高さ/2 + 0.3 × サイズ`（固定係数） | 同左 |

差はフォントサイズに比例し、8pt で 0.23mm ずれます。実測でも、アセントを 880 → 800 に
変えると全テキストが `0.08 × サイズ` 動くことを確認しました。帳票の座標を保つため、
セルの組み立ては `PdfWriter` が持ち、`FpdfEngine` は命令の文字列化だけを担います。

TCPDF の最小セル高さ（`サイズ × 1.25`）とセル内余白（左右 1mm）も維持しています。
罫線は TCPDF と同じ `2 J`（square）を明示しています（butt にすると罫線の両端が線幅の半分ずつ短くなる）。

なお `PdfWriter` は FPDF を継承せず内部に持つ形にしました。PHP はメソッド名の大小を
区別しないため、`cell` / `Cell`、`output` / `Output` など約 15 件が衝突して fatal になります。

## テスト（Test)

### 出力の等価性（15 パターン・150dpi の画素比較）

移行前後で同じ 15 パターンを出力し、描画命令の座標と画素の両方で比較しました。
座標の一致は同じ絵になることを保証しないため、判定は画素で行っています。

- テキスト座標の差は**最大 0.0017mm**、矩形はユニーク **63 / 63 が一致**
- `09-pagebreak` の 1 ページ目は**画素差 0（完全一致）**

差が出るのは次の 3 点で、いずれもゴシック専用の文字幅を持たないことによるものです。

| 差 | 大きさ | 出るところ |
|---|---|---|
| 備考見出しの空白が広がる | 0.17mm（150dpi で 1 画素） | 全パターン |
| 英字タイトルの中央寄せがずれる | 最大 0.45mm。既定の日本語タイトルは 0.0053mm | タイトルに ASCII を使った場合 |
| Latin-1 を含む商品名が間延びする | 文字ごとに全角ぶんの送り | 商品名に `é` `×` 等がある場合 |

3 番目は EC-CUBE 2系と同じ挙動です（2系も欧文 95 文字ぶんしか持ちません）。

### 4.3 のバグを 1 件直しています（意図的な差）

`setFancyTable()` は 1 度目の描画で明細行の高さを測り、`setXY()` で元の座標へ戻して 2 度目に
罫線を描きます。事前の改ページ判定が確保するのは 4 行ぶん（16mm）だけなので、それを超えて
折り返す明細では 1 度目の途中で自動改ページが起き、直後の `setXY()` が旧ページの座標を
新しいページへ適用していました。文字は分割されて送られる一方、罫線だけが新しいページの
下端に取り残されます。**この構造は 4.3 / 移行前の 4.4 と同一で、TCPDF 版でも同じように壊れます。**

`PdfWriter::measureMultiCellHeight()`（描画も改ページもせず高さだけ返す）を足し、
`setFancyTable()` が行の最大高さを先に測ってから一度だけ改ページするようにしました。

既存の基準出力は変わりません。17 パターンで最長の明細（長い商品名 + 商品コード + 規格 2 つ +
軽減税率マークの 74 文字）が 3 行 10.58mm で、追加の判定に掛かるのは合計が全角 160 文字以上の
ときだけです。4 行以内の明細は従来の 16mm ルールだけで送られます。

基準は現ブランチで取り直し、15 パターンの指紋がすべて互いに異なること（分岐が
効いている証拠）と、2 回生成して 15/15 一致すること（再現性）を先に確認しています。
各ページのインク量が下限を超えていること（和文が消えていないこと）も確認しました。

### 自動テスト

- **`PdfWriterTest`（新規・7 件）** — ベースライン位置・最小セル高さ・水平整列・
  カーソル移動・折り返し・テンプレートの用紙サイズ。DB 不要なので CI で毎回回ります
- **`JapaneseCidFontTest`（新規・7 件）** — 文字幅 95 個とアセント / ディセント
- **`OrderPdfControllerTest`（変更）** — レスポンス本文が `%PDF` で始まりサイズが妥当なことを
  4 箇所へ追加しました。`Content-Type` はコントローラが無条件に付けるため、ヘッダだけでは
  「例外で空になった」「フォントが解決できず真っ白」を検出できませんでした
- **`OrderPdfBaselineDumpTest`（新規）** — 移行前後を機械比較するための基準 PDF 生成器。
  `ORDER_PDF_DUMP_DIR` 未指定なら skip するので通常の CI では動きません

ローカルで PHPUnit 34 件・PHPStan level 6（src 全体）・PHP-CS-Fixer・Rector が通り、
E2E（`admin-order` の納品書の単体／一括出力、`admin-basicinfo` の出力項目トグル）も通過しています。
**ただし確認できたのは PHP 8.2 のみで、8.3 / 8.4 / 8.5 は CI の結果を待っています。**

## 相談（Discussion）

### Latin-1 を含む商品名の間延びを許容してよいか

商品名に `é` `×` `½` などが入ると文字ごとに全角ぶんの送りが入り、一目で分かる差になります。
この範囲の文字幅を持てば解消しますが、値の出所は TCPDF（LGPL-3.0）しかなく、
「LGPL 由来のデータを本体に持ち込まない」という前提と衝突します。

参考に IPAex 明朝から実測すると、平均誤差は 447 → 171 /1000em へ改善します
（`é` は 503 対 500 でほぼ一致、`±` `×` `÷` は IPAex 側が全角扱いで改善しません）。
今回は 2系と同じ挙動として許容する方針にしていますが、ご意見をいただけると助かります。

### 字形の確認をお願いしたい

フォントを埋め込まない方式のため字形は閲覧環境に依存します。検証に使った poppler では
明朝もゴシックも Noto Sans で描かれ、これは**移行前の出力でも同じ**でした
（住所欄の明朝が Sans になります）。明朝とゴシックの区別は Adobe Reader などで
実際に開いて確認する必要があります。

## マイナーバージョン互換性保持のための制限事項チェックリスト

**本 PR はメジャー更新（4.4）向けで、互換性を損なう変更を含みます。**

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [ ] ~~Serviceクラスの公開関数の、引数の削除・データ型の変更はありません~~
  → **`OrderPdfService` が `setasign\Fpdi\Tcpdf\Fpdi` の継承をやめます。**
  同クラスを継承して `Cell()` `MultiCell()` `SetFont()` `getLastH()` 等の TCPDF の API を
  呼んでいるプラグインは動かなくなります。本体内の参照は `OrderController` とテストのみで、
  同梱プラグインに該当はありませんでした。ストアのプラグインへの影響評価をお願いします。
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません
- [ ] ~~動作環境（PHP 拡張）の変更はありません~~
  → **`ext-gd` が必須になります。** `setasign/fpdf` 1.9.0 の require によるもので、
  移行前は `ext-gd` を要求するパッケージが 1 つもありませんでした。GD が無い環境では
  `composer install` の時点で弾かれます。インストーラの必須モジュール検査にも追加しています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 納品書PDFの生成方式を刷新し、テンプレート、文字、画像、表などの描画品質と互換性を改善しました。
  * 日本語フォントに対応し、PDF内の日本語表示を安定化しました。

* **バグ修正**
  * PDF出力時のページ分割、文字配置、画像表示を改善しました。
  * 折り返しの多い明細が適切に改ページされるようになりました。

* **テスト**
  * 注文情報、レイアウト、フォント、PDFダウンロードの検証を拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

