### PR TITLE
fix(gitignore): html/user_data の customize.css / customize.js を再包含できるようにする (#6088)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,15 @@ node_modules
 !/html/template/install
 /html/user_data/*
 !/html/user_data/.gitkeep
+# 親ディレクトリを除外したままでは深い階層の否定パターンが効かないため,
+# customize.css / customize.js までのディレクトリを 1 階層ずつ再包含する.
+!/html/user_data/assets/
+/html/user_data/assets/*
+!/html/user_data/assets/css/
+/html/user_data/assets/css/*
 !/html/user_data/assets/css/customize.css
+!/html/user_data/assets/js/
+/html/user_data/assets/js/*
 !/html/user_data/assets/js/customize.js
 /tests/tmp/*
 /reports/*


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

`.gitignore` の `html/user_data` の記述で、`customize.css` / `customize.js` を指す否定パターンが機能していない問題を修正します。

- Fixes #6088

`/html/user_data/*` が `assets` ディレクトリごと除外するため、git はその中へ降りず、深い階層を指す
`!/html/user_data/assets/css/customize.css` が一度も評価されません。

**現状で 2 ファイルが追跡されているのは、既に追跡済みで gitignore の判定対象外だからで、パターンが機能しているからではありません。** 追跡から外すと復帰できません。

```
$ git rm --cached html/user_data/assets/css/customize.css
$ git add html/user_data/assets/css/customize.css
The following paths are ignored by one of your .gitignore files:
html/user_data/assets            ← ファイル名ではなく assets が理由
hint: Use -f if you really want to add them.
```

なお `!/html/user_data/.gitkeep` は**修正前から機能しています**。`/html/user_data/*` が除外するのは
`html/user_data` の**中身**であってディレクトリ自体ではないため、直下の `.gitkeep` は否定パターンで再包含できます。
効かないのは `assets` 以下、つまり 2 階層目より深いファイルだけです。

## 方針(Policy)

Issue の提案どおり、`customize.css` / `customize.js` までのディレクトリを 1 階層ずつ再包含し、
**各階層の中身は再度除外**しました。これにより所定の 2 ファイルだけが追跡対象になり、
店舗が置いた独自ファイルは無視されたままになります。

```
/html/user_data/*
!/html/user_data/.gitkeep
!/html/user_data/assets/
/html/user_data/assets/*
!/html/user_data/assets/css/
/html/user_data/assets/css/*
!/html/user_data/assets/css/customize.css
!/html/user_data/assets/js/
/html/user_data/assets/js/*
!/html/user_data/assets/js/customize.js
```

### `git check-ignore` は `--no-index` を付けないと判定を誤ります

既存の 2 ファイルは追跡済みのため、素の `git check-ignore` は「無視されない」と答えます（終了コード 1）。
**`--no-index` を付けると追跡状態を無視して gitignore だけで判定する**ので、追跡から外さずに実態を確認できます。

```
# 修正前の .gitignore での判定
$ git check-ignore --no-index -v html/user_data/assets/css/customize.css
.gitignore:38:/html/user_data/*	html/user_data/assets/css/customize.css   ← 除外されている

$ git check-ignore --no-index -v html/user_data/.gitkeep
.gitignore:39:!/html/user_data/.gitkeep	html/user_data/.gitkeep           ← 除外されていない（修正前から機能）
```

## 実装に関する補足(Appendix)

**`.gitkeep` は作成していません。** Issue 本文は「`.gitkeep` を作成し」としていますが、
`html/user_data/assets/css/customize.css` が追跡されている限り clone 時にディレクトリは生成されるため、
機能を持ちません。否定パターンの行は修正前から機能しているので、必要になれば置くだけで追跡されます（下の実測 4 のとおり）。

**追加すべきというご判断であれば、このPRに含めます。** ご指示ください。

## テスト（Test)

`.gitignore` の挙動は PHPUnit でも E2E でも検証できないため、CI では担保されません。
手元で次を実測しました。

| 確認内容 | 結果 |
|---|---|
| 1. `customize.css` を追跡から外して `git add` | **復帰できる**（修正前は `html/user_data/assets is ignored` で拒否） |
| 2. `customize.js` も同様 | **復帰できる** |
| 3. `assets/css/shop-own.css` / `assets/js/shop-own.js` を新規作成 | **ignored のまま**。`git status` に出ず `git add` も拒否 |
| 4. `html/user_data/.gitkeep` を `git add` | **通る**。ただし**修正前から通る**ので本 PR の効果ではない |
| 5. `html/user_data/shop-page.html` を新規作成 | **ignored のまま** |

3 と 5 は「店舗の独自ファイルを巻き込んで追跡し始めない」ことの確認です。この修正で最も重要な点なので明示的に試しました。

なお pre-push フック（Rector / PHPStan）も通過しています。

## 相談（Discussion）

上記のとおり `.gitkeep` を追加するかどうかだけご判断ください。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ユーザー向けカスタマイズ用の CSS および JavaScript ファイルが、適切にバージョン管理されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
