### PR TITLE
test(e2e): 受注の注文取消しで在庫が戻ることを検証する (#7016)

### DIFF
--- a/.claude/skills/eccube-e2e/SKILL.md
+++ b/.claude/skills/eccube-e2e/SKILL.md
@@ -41,6 +41,7 @@ description: EC-CUBE 4.4 の E2E テスト（Playwright・`e2e/` 配下）を実
 - ❌ テスト境界で管理者セッションが切れて 401 → ✅ `ensureAdminLoggedIn()` 等で再ログインしてから操作（`admin-basicinfo.spec.ts` 修正例）。
 - ❌ retry でプラグイン/データが残留し「既にインストール済み」で再失敗 → ✅ `beforeEach`/`afterEach` で cleanup（無効化→削除→ディレクトリ削除。`plugin-misc.spec.ts` 修正例）。
 - ❌ パスワードを見た目の文字数で作る → ✅ NFKC 正規化後で 15 文字以上か数える（min15。`[...str.normalize('NFKC')].length` で確認。#6488）。
+- ❌ 更新直後の値を、それを表示する任意の画面から読んで検証する → ✅ **`APP_ENV=e2e` は Doctrine の結果キャッシュが有効**（dev/test は `result_cache_driver: ~` で無効）。`enableResultCache` を使う画面は最大 10 秒前の値を返すので、キャッシュしない画面から読む（#7016 の在庫は商品編集画面ではなく商品一覧）。
 - ❌ 在庫を戻す受注ステータス遷移を PHPUnit の Web テストで書く → ✅ 悲観ロックが `TransactionRequiredException` になるため E2E で書く（test 環境は `TransactionListener` 無効・e2e は有効。#7016）。
 - ❌ 新規 `admin-*`/`front-*` spec を作ったのに CI で実行されない → ✅ `.github/workflows/e2e-test.yml` の `suite:` 配列にファイル名（接尾辞 `.spec.ts` 抜き）を追加する。
 

--- a/.claude/skills/eccube-e2e/SKILL.md
+++ b/.claude/skills/eccube-e2e/SKILL.md
@@ -41,6 +41,7 @@ description: EC-CUBE 4.4 の E2E テスト（Playwright・`e2e/` 配下）を実
 - ❌ テスト境界で管理者セッションが切れて 401 → ✅ `ensureAdminLoggedIn()` 等で再ログインしてから操作（`admin-basicinfo.spec.ts` 修正例）。
 - ❌ retry でプラグイン/データが残留し「既にインストール済み」で再失敗 → ✅ `beforeEach`/`afterEach` で cleanup（無効化→削除→ディレクトリ削除。`plugin-misc.spec.ts` 修正例）。
 - ❌ パスワードを見た目の文字数で作る → ✅ NFKC 正規化後で 15 文字以上か数える（min15。`[...str.normalize('NFKC')].length` で確認。#6488）。
+- ❌ 在庫を戻す受注ステータス遷移を PHPUnit の Web テストで書く → ✅ 悲観ロックが `TransactionRequiredException` になるため E2E で書く（test 環境は `TransactionListener` 無効・e2e は有効。#7016）。
 - ❌ 新規 `admin-*`/`front-*` spec を作ったのに CI で実行されない → ✅ `.github/workflows/e2e-test.yml` の `suite:` 配列にファイル名（接尾辞 `.spec.ts` 抜き）を追加する。
 
 ## 実行・確認方法

--- a/e2e/tests/admin-order.spec.ts
+++ b/e2e/tests/admin-order.spec.ts
@@ -61,24 +61,26 @@ async function createOrderViaUI(page: import('@playwright/test').Page, name01: s
 }
 
 /**
- * 商品一覧から規格なし商品の編集画面へ入り, 在庫数を読む.
+ * 商品一覧から規格なし商品の在庫数を読む.
  *
- * 受注のキャンセルで在庫が戻ることを確認するために使う.
+ * 商品編集画面ではなく一覧から読むのは, 編集画面が使う
+ * ProductRepository::findWithSortedClassCategories() が結果キャッシュ
+ * (eccube_result_cache_lifetime_short = 10 秒) を有効にしており,
+ * 直前の在庫更新が最大 10 秒間反映されないため。一覧の検索クエリはキャッシュしない。
  */
 async function getProductStock(page: import('@playwright/test').Page, productName: string): Promise<number> {
   await page.goto(`/${adminRoute}/product`);
-  await page.waitForLoadState('load');
   await page.locator('#admin_search_product_id').fill(productName);
   await page.locator('#search_form .c-outsideBlock__contents button').click();
-  await page.waitForLoadState('load');
 
-  await page.locator('#form_bulk table tbody tr:first-child td:nth-child(4) a').click();
-  await page.waitForLoadState('load');
+  // 検索が反映されるまで待つ。行は商品名で特定し, 位置に依存しない。
+  const row = page.locator('#form_bulk table tbody tr').filter({ hasText: productName });
+  await expect(row).toHaveCount(1);
 
-  const stock = page.locator('#admin_product_class_stock');
-  await expect(stock).toBeVisible();
+  // 列: チェックボックス / 商品ID / 画像 / 商品名 / 商品コード / 販売価格 / 在庫数
+  const stock = (await row.locator('td').nth(6).innerText()).trim();
 
-  return Number(await stock.inputValue());
+  return Number(stock);
 }
 
 test.describe('Admin Order (EA04)', () => {
@@ -470,16 +472,18 @@ test.describe('Admin Order (EA04)', () => {
     const ordererName = `取消${Date.now().toString(36)}`;
     await createOrderViaUI(page, ordererName, '太郎');
 
-    // 受注登録で在庫が減る
+    // 受注登録で在庫が 1 減る
     const stockAfterOrder = await getProductStock(page, productName);
-    expect(stockAfterOrder).toBeLessThan(stockBeforeOrder);
+    expect(stockAfterOrder).toBe(stockBeforeOrder - 1);
 
     // 受注編集画面でステータスを注文取消しへ変更する（workflow の cancel 遷移）
     await goOrderList(page);
     await searchOrder(page, ordererName);
-    await expect(page.locator(searchResultMsg)).not.toContainText('検索結果：0件が該当しました');
-    await page.locator('#search_result tbody tr:first-child a.action-edit').click();
-    await page.waitForLoadState('load');
+    // 検索が反映されるまで待つ。行は受注者名で特定し, 位置に依存しない。
+    const orderRow = page.locator('#search_result > tbody > tr').filter({ hasText: ordererName });
+    await expect(orderRow).toHaveCount(1);
+    await orderRow.locator('a.action-edit').click();
+    await expect(page.locator('#order_name_name01')).toHaveValue(ordererName);
 
     await page.locator('#order_OrderStatus').selectOption({ label: '注文取消し' });
     await page.locator('#form1 button[value="register"]').click();

--- a/e2e/tests/admin-order.spec.ts
+++ b/e2e/tests/admin-order.spec.ts
@@ -60,6 +60,27 @@ async function createOrderViaUI(page: import('@playwright/test').Page, name01: s
   await expect(page.locator('.alert-success').first()).toContainText('保存しました');
 }
 
+/**
+ * 商品一覧から規格なし商品の編集画面へ入り, 在庫数を読む.
+ *
+ * 受注のキャンセルで在庫が戻ることを確認するために使う.
+ */
+async function getProductStock(page: import('@playwright/test').Page, productName: string): Promise<number> {
+  await page.goto(`/${adminRoute}/product`);
+  await page.waitForLoadState('load');
+  await page.locator('#admin_search_product_id').fill(productName);
+  await page.locator('#search_form .c-outsideBlock__contents button').click();
+  await page.waitForLoadState('load');
+
+  await page.locator('#form_bulk table tbody tr:first-child td:nth-child(4) a').click();
+  await page.waitForLoadState('load');
+
+  const stock = page.locator('#admin_product_class_stock');
+  await expect(stock).toBeVisible();
+
+  return Number(await stock.inputValue());
+}
+
 test.describe('Admin Order (EA04)', () => {
   test.describe.configure({ mode: 'serial' });
 
@@ -434,6 +455,40 @@ test.describe('Admin Order (EA04)', () => {
     // Wait for completion
     await page.waitForSelector('#bulkChangeComplete', { state: 'visible', timeout: 30_000 });
     await expect(page.locator('#bulkChangeComplete')).toBeVisible();
+  });
+
+  test('order_受注ステータスを注文取消しへ変更すると在庫が戻る (EA0401-UC06-T01)', async ({ page }) => {
+    // 受注のキャンセルは OrderStateMachine の cancel 遷移で StockReduceProcessor::rollback() を呼び,
+    // その中で ProductStock に悲観ロック (PESSIMISTIC_WRITE) を掛ける。
+    // この経路は PHPUnit の Web テストでは TransactionRequiredException になり検証できないため,
+    // E2E で担保する。詳細は #7016。
+    const productName = 'チェリーアイスサンド';
+    const stockBeforeOrder = await getProductStock(page, productName);
+
+    await createOrderViaUI(page, 'キャンセルテスト', '太郎');
+
+    // 受注登録で在庫が減る
+    const stockAfterOrder = await getProductStock(page, productName);
+    expect(stockAfterOrder).toBeLessThan(stockBeforeOrder);
+
+    // 受注編集画面でステータスを注文取消しへ変更する（workflow の cancel 遷移）
+    await goOrderList(page);
+    await searchOrder(page, 'キャンセルテスト');
+    await expect(page.locator(searchResultMsg)).not.toContainText('検索結果：0件が該当しました');
+    await page.locator('#search_result tbody tr:first-child a.action-edit').click();
+    await page.waitForLoadState('load');
+
+    await page.locator('#order_OrderStatus').selectOption({ label: '注文取消し' });
+    await page.locator('#form1 button[value="register"]').click();
+    await page.waitForLoadState('load');
+
+    // 500 にならず保存され, ステータスが注文取消しになる
+    await expect(page.locator('.alert-success').first()).toContainText('保存しました');
+    await expect(page.locator('#order_OrderStatus option:checked')).toHaveText('注文取消し');
+
+    // rollbackStock が走り在庫が戻る
+    const stockAfterCancel = await getProductStock(page, productName);
+    expect(stockAfterCancel).toBeGreaterThan(stockAfterOrder);
   });
 
   test('order_一括メール通知 (EA0402-UC02-T01)', async ({ page }) => {

--- a/e2e/tests/admin-order.spec.ts
+++ b/e2e/tests/admin-order.spec.ts
@@ -465,7 +465,10 @@ test.describe('Admin Order (EA04)', () => {
     const productName = 'チェリーアイスサンド';
     const stockBeforeOrder = await getProductStock(page, productName);
 
-    await createOrderViaUI(page, 'キャンセルテスト', '太郎');
+    // 再試行で前回の受注が残ると先頭行が別の受注になるため, 受注者名を実行ごとに一意化する。
+    // 氏名は 16 文字以下の制約があるため, ミリ秒を 36 進数にして桁を詰める（2 + 8 文字）。
+    const ordererName = `取消${Date.now().toString(36)}`;
+    await createOrderViaUI(page, ordererName, '太郎');
 
     // 受注登録で在庫が減る
     const stockAfterOrder = await getProductStock(page, productName);
@@ -473,7 +476,7 @@ test.describe('Admin Order (EA04)', () => {
 
     // 受注編集画面でステータスを注文取消しへ変更する（workflow の cancel 遷移）
     await goOrderList(page);
-    await searchOrder(page, 'キャンセルテスト');
+    await searchOrder(page, ordererName);
     await expect(page.locator(searchResultMsg)).not.toContainText('検索結果：0件が該当しました');
     await page.locator('#search_result tbody tr:first-child a.action-edit').click();
     await page.waitForLoadState('load');
@@ -488,7 +491,7 @@ test.describe('Admin Order (EA04)', () => {
 
     // rollbackStock が走り在庫が戻る
     const stockAfterCancel = await getProductStock(page, productName);
-    expect(stockAfterCancel).toBeGreaterThan(stockAfterOrder);
+    expect(stockAfterCancel).toBe(stockBeforeOrder);
   });
 
   test('order_一括メール通知 (EA0402-UC02-T01)', async ({ page }) => {


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

在庫を戻す受注ステータス遷移（注文取消し）の検証を E2E に追加します。

- Closes #7016

issue #7016 で提案いただいた「代案として e2e で実行する」方針の実装です。本体側で挙げた対応（E2E spec の追加・「キャンセル遷移は PHPUnit の Web テストでは書けない」制約のドキュメント明記）は本 PR で完了します。発端となった coupon-plugin 側の E2E 導入はリポジトリが異なるため、別 issue として切り出します。

この経路は **PHPUnit の Web テストでは検証できません**。`OrderStateMachine` の cancel 遷移が
`StockReduceProcessor::rollback()` を呼び、その中で `ProductStock` に悲観ロック
（`PESSIMISTIC_WRITE`）を掛けるためです。

- テスト環境は `services_test.yaml` で `TransactionListener` を無効化している
- `dama/doctrine-test-bundle` はドライバ層でトランザクションを開くため、DBAL の
  `Connection::isTransactionActive()` は `false` を返す
- その結果 ORM 3 の `UnitOfWork::lock()` が `TransactionRequiredException` を投げる（500 になる）

issue で「代案として e2e で実行するのが良い」とご意見をいただいたので、その方針で実装しました。

## 方針(Policy)

**e2e 環境には `services_e2e.yaml` が無く、prod と同じく `TransactionListener` が登録されます。**
env ごとに実測しました。

```
$ bin/console debug:event-dispatcher kernel.request --env=e2e
  Eccube\EventListener\TransactionListener::onKernelRequest()
$ bin/console debug:event-dispatcher kernel.request --env=test
  （登録なし）
$ bin/console debug:event-dispatcher kernel.request --env=prod
  Eccube\EventListener\TransactionListener::onKernelRequest()
```

したがって E2E ではリクエスト単位で DBAL のトランザクションが開き、`lock()` は例外になりません。

## 実装に関する補足(Appendix)

`e2e/tests/admin-order.spec.ts` に 1 テストと在庫読み取りヘルパを追加しました。

- 受注登録 → 在庫が減る → 受注編集でステータスを `注文取消し` へ変更 → **在庫が戻る**、を通しで確認します
- 在庫は商品編集画面の `#admin_product_class_stock` から読みます（admin spec には DB fixture が無いため UI 経由）
- **在庫数は絶対値でアサートせず前後比較**（`toBeLessThan` / `toBeGreaterThan`）にしています。retry 時のデータ残留に耐えるためです
- 表示名は `キャンセル` ではなく **`注文取消し`**（`mtb_order_status` の id=3）です。最初 `キャンセル` で書いて `did not find some options` で落ちたので、実体に合わせました
- `admin-order` は `.github/workflows/e2e-test.yml` の `suite:` に既に含まれているため、**ワークフローの変更は不要**です

あわせて `eccube-e2e` Skill の「よくある間違い」に 1 行追記しました。
`eccube-phpunit` 側にも書きたい内容ですが、あちらは既に 12 項で `AGENTS.md` の上限（10 項）を
超えているため、追記せず E2E 側に寄せています。

## テスト（Test)

ローカルで対象テストのみ実行し、通ることを確認しました。

```
npx playwright test --project=setup --project=admin-tests admin-order.spec.ts \
  -g "注文取消しへ変更すると在庫が戻る"
→ 2 passed (18.1s)   # setup（管理者ログイン）＋ 本テスト
```

`npx tsc --noEmit` も通っています。

### ローカル実行時に踏んだ環境要因（本 PR の変更対象ではありません）

- 既定の `playwright.config.ts` は global `use` に `ignoreHTTPSErrors` を持たないため、自己署名証書の
  `https://127.0.0.1:4430` では起動直後に失敗します（`install-tests` プロジェクトのみ設定あり）
- かわりに `http://127.0.0.1:8080` で実行すると、dev 環境のセッション Cookie が
  `SameSite=None` + `Secure` のため http では破棄され、`InvalidCsrfTokenException` でログインできません
  （CI は `APP_ENV=e2e` で `packages/e2e/framework.yaml` が `cookie_secure: false` にするため http で通ります）
- dev の Web Debug Toolbar がログインボタンを覆い、click が POST に至らないケースもありました

いずれもローカル固有の話なので本 PR には含めていません。**必要なら別 PR で
global `use` に `ignoreHTTPSErrors` を入れる**ことは可能です（ご判断ください）。

## 相談（Discussion）

issue の方では、**発端となった coupon-plugin 側にも E2E を入れたい**旨を別途ご相談しています
（EC-CUBE/coupon-plugin には 4.2 / 4.4 とも E2E 資産がなく、sample-payment-plugin / stripe-payment-plugin に前例があります）。
本 PR は本体側のみです。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **テスト**
  - 注文取消し後、在庫がキャンセル前の数量から正確に1つ戻ることを確認します。
  - 商品一覧画面で在庫を確認し、注文者名で対象の受注を特定して一連の処理を検証します。

- **ドキュメント**
  - 件数や表示順に依存しない、安定した要素特定方法を追記しました。
  - 更新直後の値はキャッシュの影響を受けない画面で確認する方針を追加しました。
  - 悲観ロックを使用する処理はE2Eテストで検証する方針を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
