### PR TITLE
Web サーバー権限を診断する eccube:doctor:permissions の追加と、プラグインコマンドの終了コード修正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,29 @@ composer create-project ec-cube/ec-cube ec-cube "4.4.x-dev" --keep-vcs
 bin/console eccube:install
 ```
 
+#### Web サーバーと CLI の権限を分離した環境
+
+Web サーバー（`www-data`）と CLI（SSH ログインユーザー相当）の書き込み権限を分けた状態を再現するには、
+`docker-compose.permission-lanes.yml` を重ねる。`eccube:doctor:permissions` の動作確認に使う。
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.permission-lanes.yml up -d --wait
+curl -s -o /dev/null http://127.0.0.1:8080/   # セッションを生成し Web サーバーの uid を判定可能にする
+docker compose exec -u eccube ec-cube bin/console eccube:doctor:permissions
+```
+
+分離すると、`app/template` や `html/user_data` へ書き込む管理画面の機能（プラグイン導入・
+ページ/ブロック/メールテンプレート編集・CSS/JS 編集・ファイル管理）は動作しなくなる。
+CLI 側の代替導線は整備中のため、**日常の開発では重ねない**こと。
+
+既定モードと分離モードを切り替えるときは `var` ボリュームを作り直す。`var` 配下には旧 `www-data` の
+uid で作成されたディレクトリが残り、切り替え後の Web サーバーから書き込めなくなる
+（例: `var/cache/{env}/mcp-sessions`）。
+
+```bash
+docker compose ... down && docker volume rm <プロジェクト名>_var
+```
+
 ### テスト
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,16 +117,24 @@ curl -s -o /dev/null http://127.0.0.1:8080/   # セッションを生成し Web 
 docker compose exec -u eccube ec-cube bin/console eccube:doctor:permissions
 ```
 
+レーン W（`var`、`html/upload/**`、`app/keystore`）は `www-data` 所有とし、共有グループは作らない。
+CLI からレーン W を触る操作は Web サーバーのユーザーで実行する。本番の `sudo -u www-data` に相当する。
+
+```bash
+docker compose exec -u eccube   ec-cube bin/console eccube:page:apply ...   # レーン S を触る操作
+docker compose exec -u www-data ec-cube bin/console cache:clear             # レーン W を触る操作
+```
+
 分離すると、`app/template` や `html/user_data` へ書き込む管理画面の機能（プラグイン導入・
 ページ/ブロック/メールテンプレート編集・CSS/JS 編集・ファイル管理）は動作しなくなる。
 CLI 側の代替導線は整備中のため、**日常の開発では重ねない**こと。
 
-既定モードと分離モードを切り替えるときは `var` ボリュームを作り直す。`var` 配下には旧 `www-data` の
+既定モードと分離モードを切り替えるときはレーン W のボリュームを作り直す。切り替え前の `www-data` の
 uid で作成されたディレクトリが残り、切り替え後の Web サーバーから書き込めなくなる
 （例: `var/cache/{env}/mcp-sessions`）。
 
 ```bash
-docker compose ... down && docker volume rm <プロジェクト名>_var
+docker compose ... down -v
 ```
 
 ### テスト

--- a/docker-compose.permission-lanes.yml
+++ b/docker-compose.permission-lanes.yml
@@ -5,27 +5,37 @@ version: '3'
 #   docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.permission-lanes.yml up -d --wait
 #
 # 分離モードでは www-data は uid 33 のままとなり、CLI 用に別ユーザー (eccube) を作成する。
-# CLI はそのユーザーで実行する。
-#
-#   docker compose exec -u eccube ec-cube bin/console eccube:doctor:permissions
+# 共有グループは作らない。セキュリティポリシーで共有グループを作成できない環境があるため。
 #
 # 書き込み先は 2 つのレーンに分かれる。
 #
 #   レーン W (Web サーバーが書き込む)   var, html/upload/**, app/keystore
-#     → CLI ユーザー所有 + www-data グループ + setgid 付き 2775。両者が書き込める
+#     → www-data 所有。CLI から書き込む必要がある場合は Web サーバーのユーザーで実行する
 #   レーン S (CLI へ移せる)             上記以外 (app/template, html/user_data, app/Plugin, vendor, .env 等)
 #     → CLI ユーザー所有。www-data は読み取りのみ
+#
+# CLI の実行ユーザーは操作対象のレーンで決まる。
+#
+#   レーン S を触る   docker compose exec -u eccube   ec-cube bin/console ...
+#   レーン W を触る   docker compose exec -u www-data ec-cube bin/console cache:clear
+#                     (本番では sudo -u www-data bin/console cache:clear に相当する)
 #
 # 分離すると、レーン S へ書き込む管理画面の機能は動作しなくなる。
 # (プラグインの導入・有効化、ページ/ブロック/メールテンプレートの編集、CSS/JS の編集、
 #  ファイル管理、テンプレートのアップロード)
 # CLI 側の代替導線は整備中のため、日常の開発では本ファイルを重ねないこと。
 #
-# 既定モードと分離モードを切り替えるときは var ボリュームを作り直すこと。
-# var 配下には旧 www-data の uid で作成されたディレクトリが残り、切り替え後の Web サーバーから
+# 既定モードと分離モードを切り替えるときは、レーン W のボリュームを作り直すこと。
+# 切り替え前の www-data の uid で作成されたディレクトリが残り、切り替え後の Web サーバーから
 # 書き込めなくなる (例: var/cache/{env}/mcp-sessions)。
 #
-#   docker compose ... down && docker volume rm <プロジェクト名>_var
+#   docker compose ... down -v
+#
+# レーン W のディレクトリ (html/upload/**、app/keystore) はホスト側でも www-data の uid 所有になる。
+# 既定モードへ戻すときは所有者を元に戻すこと。
+#
+#   sudo chown -R $(id -u):$(id -g) html/upload app/keystore
+
 services:
   ec-cube:
     environment:

--- a/docker-compose.permission-lanes.yml
+++ b/docker-compose.permission-lanes.yml
@@ -1,0 +1,38 @@
+version: '3'
+
+# Web サーバー (www-data) と CLI (SSH ログインユーザー相当) の書き込み権限を分離する override。
+#
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.permission-lanes.yml up -d --wait
+#
+# 分離モードでは www-data は uid 33 のままとなり、CLI 用に別ユーザー (eccube) を作成する。
+# CLI はそのユーザーで実行する。
+#
+#   docker compose exec -u eccube ec-cube bin/console eccube:doctor:permissions
+#
+# 書き込み先は 2 つのレーンに分かれる。
+#
+#   レーン W (Web サーバーが書き込む)   var, html/upload/**, app/keystore
+#     → CLI ユーザー所有 + www-data グループ + setgid 付き 2775。両者が書き込める
+#   レーン S (CLI へ移せる)             上記以外 (app/template, html/user_data, app/Plugin, vendor, .env 等)
+#     → CLI ユーザー所有。www-data は読み取りのみ
+#
+# 分離すると、レーン S へ書き込む管理画面の機能は動作しなくなる。
+# (プラグインの導入・有効化、ページ/ブロック/メールテンプレートの編集、CSS/JS の編集、
+#  ファイル管理、テンプレートのアップロード)
+# CLI 側の代替導線は整備中のため、日常の開発では本ファイルを重ねないこと。
+#
+# 既定モードと分離モードを切り替えるときは var ボリュームを作り直すこと。
+# var 配下には旧 www-data の uid で作成されたディレクトリが残り、切り替え後の Web サーバーから
+# 書き込めなくなる (例: var/cache/{env}/mcp-sessions)。
+#
+#   docker compose ... down && docker volume rm <プロジェクト名>_var
+services:
+  ec-cube:
+    environment:
+      ECCUBE_PERMISSION_LANES: 1
+      # メンテナンスファイルの生成先。既定はプロジェクトルート直下だが、
+      # それだとルート自体を Web サーバーから書き込み可能にする必要があるため var/ 配下へ移す
+      ECCUBE_MAINTENANCE_FILE_PATH: /var/www/html/var/.maintenance
+      # レーン S へ書き込む管理画面の機能を 403 で止める場合は有効にする。
+      # 無効のままだと、それらの画面は書き込みエラーになる
+      # ECCUBE_RESTRICT_FILE_UPLOAD: 1

--- a/dockerbuild/docker-php-entrypoint
+++ b/dockerbuild/docker-php-entrypoint
@@ -1,11 +1,66 @@
 #!/bin/sh
 set -e
 
-if [ -n "${USER_ID}" ]; then
-    usermod -u ${USER_ID} -o www-data
-fi
-if [ -n "${GROUP_ID}" ]; then
-    groupmod -g ${GROUP_ID} www-data
+# ECCUBE_PERMISSION_LANES=1 のとき, Web サーバー (www-data) と CLI ユーザーを別のユーザーに分ける。
+# 未設定時は従来どおり www-data をホストユーザーへ合わせる (開発時のパーミッションエラーを避けるため)。
+PERMISSION_LANES="${ECCUBE_PERMISSION_LANES:-}"
+
+# レーン W: リクエスト処理中に Web サーバーが書き込むディレクトリ。
+# CLI ユーザー所有 + www-data グループ + setgid とし, 双方から書き込めるようにする。
+LANE_W_DIRS="var html/upload/save_image html/upload/temp_image html/upload/refund_request/save html/upload/refund_request/temp app/keystore"
+
+setup_split_users() {
+    # UID / GID はシェルが export しないことが多いため, 未指定なら
+    # bind mount されたファイルの所有者からホストユーザーを推定する。
+    cli_uid="${USER_ID:-$(stat -c %u "${APACHE_DOCUMENT_ROOT}/composer.json" 2>/dev/null || echo '')}"
+    cli_gid="${GROUP_ID:-$(stat -c %g "${APACHE_DOCUMENT_ROOT}/composer.json" 2>/dev/null || echo '')}"
+    # bind mount していない場合は www-data(33) や root(0) しか分からないため既定値へフォールバックする
+    case "${cli_uid}" in '' | 0 | 33) cli_uid=1000 ;; esac
+    case "${cli_gid}" in '' | 0 | 33) cli_gid=1000 ;; esac
+
+    if ! getent group "${cli_gid}" > /dev/null; then
+        groupadd -o -g "${cli_gid}" eccube
+    fi
+    if ! getent passwd "${cli_uid}" > /dev/null; then
+        useradd -o -u "${cli_uid}" -g "${cli_gid}" -m -d /home/eccube -s /bin/bash eccube
+    fi
+    cli_user="$(getent passwd "${cli_uid}" | cut -d: -f1)"
+
+    # レーン W をグループ経由で共有するため, CLI ユーザーを www-data グループへ入れる
+    usermod -aG www-data "${cli_user}"
+}
+
+apply_permission_lanes() {
+    # レーン S: CLI ユーザー所有. www-data は読み取りのみ.
+    # 初回起動時の composer install や installer-scripts は root で動くため, 毎回適用する
+    # (var はレーン W で扱い, node_modules は nodejs コンテナの管理下のため対象外).
+    find "${APACHE_DOCUMENT_ROOT}" -maxdepth 1 -mindepth 1 \
+        ! -name node_modules ! -name var \
+        -exec chown -R "${cli_uid}:${cli_gid}" {} +
+    chown "${cli_uid}:${cli_gid}" "${APACHE_DOCUMENT_ROOT}"
+
+    # レーン W: setgid でグループを継承させ, Web サーバーと CLI の双方から書き込めるようにする.
+    # Web サーバーが作成したファイルには触れない. 所有者を書き換えると Web サーバーの実行ユーザーを
+    # 判定する材料が失われ, パーミッションを揃えるとセッションファイルの 0600 まで緩めてしまうため.
+    # ファイルのパーミッションも変更しない. bind mount 越しに git 管理下の実行ビットが落ちるため
+    # (html/upload/save_image の同梱画像は 100755 で登録されている).
+    for dir in ${LANE_W_DIRS}; do
+        target="${APACHE_DOCUMENT_ROOT}/${dir}"
+        mkdir -p "${target}"
+        find "${target}" ! -user www-data -exec chown "${cli_uid}:www-data" {} +
+        find "${target}" -type d -exec chmod 2775 {} +
+    done
+}
+
+if [ "${PERMISSION_LANES}" = "1" ]; then
+    setup_split_users
+else
+    if [ -n "${USER_ID}" ]; then
+        usermod -u ${USER_ID} -o www-data
+    fi
+    if [ -n "${GROUP_ID}" ]; then
+        groupmod -g ${GROUP_ID} www-data
+    fi
 fi
 
 if [ ! -d /var/www/html/vendor/bin ]; then
@@ -15,7 +70,9 @@ if [ ! -d /var/www/html/vendor/bin ]; then
         --no-plugins \
         -d ${APACHE_DOCUMENT_ROOT}
     composer dumpautoload -o --apcu
-    chown -R www-data: vendor
+    if [ "${PERMISSION_LANES}" != "1" ]; then
+        chown -R www-data: vendor
+    fi
 fi
 
 bin/console doctrine:query:sql 'select * from dtb_base_info' > /dev/null 2>&1 || (
@@ -38,11 +95,17 @@ bin/console doctrine:query:sql 'select * from dtb_base_info' > /dev/null 2>&1 ||
             ;;
     esac
     composer run-script auto-scripts
-    find ${APACHE_DOCUMENT_ROOT} \( -path ${APACHE_DOCUMENT_ROOT}/vendor -prune \) -or -print0 \
-        | xargs -0 chown www-data:www-data
-    find ${APACHE_DOCUMENT_ROOT} \( -path ${APACHE_DOCUMENT_ROOT}/vendor -prune \) -or \( -type d -print0 \) \
-      | xargs -0 chmod g+s
+    if [ "${PERMISSION_LANES}" != "1" ]; then
+        find ${APACHE_DOCUMENT_ROOT} \( -path ${APACHE_DOCUMENT_ROOT}/vendor -prune \) -or -print0 \
+            | xargs -0 chown www-data:www-data
+        find ${APACHE_DOCUMENT_ROOT} \( -path ${APACHE_DOCUMENT_ROOT}/vendor -prune \) -or \( -type d -print0 \) \
+          | xargs -0 chmod g+s
+    fi
 )
+
+if [ "${PERMISSION_LANES}" = "1" ]; then
+    apply_permission_lanes
+fi
 
 echo "PassEnv APP_ENV APP_DEBUG TRUSTED_PROXIES TRUSTED_HOSTS" > /etc/apache2/conf-enabled/eccube_env.conf
 

--- a/dockerbuild/docker-php-entrypoint
+++ b/dockerbuild/docker-php-entrypoint
@@ -5,9 +5,10 @@ set -e
 # 未設定時は従来どおり www-data をホストユーザーへ合わせる (開発時のパーミッションエラーを避けるため)。
 PERMISSION_LANES="${ECCUBE_PERMISSION_LANES:-}"
 
-# レーン W: リクエスト処理中に Web サーバーが書き込むディレクトリ。
-# CLI ユーザー所有 + www-data グループ + setgid とし, 双方から書き込めるようにする。
-LANE_W_DIRS="var html/upload/save_image html/upload/temp_image html/upload/refund_request/save html/upload/refund_request/temp app/keystore"
+# レーン W: リクエスト処理中に Web サーバーが書き込むディレクトリ。www-data 所有とする。
+# CLI から書き込む必要がある場合は Web サーバーのユーザーで実行する (本番では sudo -u www-data)。
+# 共有グループは作らない。セキュリティポリシーで共有グループを作成できない環境があるため。
+LANE_W_DIRS="html/upload html/upload/save_image html/upload/temp_image html/upload/refund_request html/upload/refund_request/save html/upload/refund_request/temp app/keystore"
 
 setup_split_users() {
     # UID / GID はシェルが export しないことが多いため, 未指定なら
@@ -24,10 +25,6 @@ setup_split_users() {
     if ! getent passwd "${cli_uid}" > /dev/null; then
         useradd -o -u "${cli_uid}" -g "${cli_gid}" -m -d /home/eccube -s /bin/bash eccube
     fi
-    cli_user="$(getent passwd "${cli_uid}" | cut -d: -f1)"
-
-    # レーン W をグループ経由で共有するため, CLI ユーザーを www-data グループへ入れる
-    usermod -aG www-data "${cli_user}"
 }
 
 apply_permission_lanes() {
@@ -39,17 +36,19 @@ apply_permission_lanes() {
         -exec chown -R "${cli_uid}:${cli_gid}" {} +
     chown "${cli_uid}:${cli_gid}" "${APACHE_DOCUMENT_ROOT}"
 
-    # レーン W: setgid でグループを継承させ, Web サーバーと CLI の双方から書き込めるようにする.
-    # Web サーバーが作成したファイルには触れない. 所有者を書き換えると Web サーバーの実行ユーザーを
-    # 判定する材料が失われ, パーミッションを揃えるとセッションファイルの 0600 まで緩めてしまうため.
-    # ファイルのパーミッションも変更しない. bind mount 越しに git 管理下の実行ビットが落ちるため
-    # (html/upload/save_image の同梱画像は 100755 で登録されている).
+    # レーン W: ディレクトリだけを Web サーバー所有にする.
+    # 配布物 (html/upload/refund_request/.htaccess や既定画像) は CLI ユーザー所有のまま残す.
+    # 配下ごと chown すると, 本番の姿 (デプロイしたファイルは SSH ユーザー所有・Web は読み取りのみ) と
+    # ずれるうえ, bind mount 越しにホスト側の作業ツリーの所有者まで書き換えてしまうため.
     for dir in ${LANE_W_DIRS}; do
         target="${APACHE_DOCUMENT_ROOT}/${dir}"
         mkdir -p "${target}"
-        find "${target}" ! -user www-data -exec chown "${cli_uid}:www-data" {} +
-        find "${target}" -type d -exec chmod 2775 {} +
+        chown www-data:www-data "${target}"
     done
+
+    # var は名前付きボリュームで配布物を含まないため配下ごと Web サーバー所有にする.
+    # パーミッションは変更しない. 変更するとセッションファイルの 0600 を緩めてしまうため.
+    chown -R www-data:www-data "${APACHE_DOCUMENT_ROOT}/var"
 }
 
 if [ "${PERMISSION_LANES}" = "1" ]; then

--- a/src/Eccube/Command/DoctorPermissionsCommand.php
+++ b/src/Eccube/Command/DoctorPermissionsCommand.php
@@ -19,6 +19,7 @@ use Eccube\Service\Permission\DiagnosticReport;
 use Eccube\Service\Permission\FindingSeverity;
 use Eccube\Service\Permission\PermissionDiagnostic;
 use Eccube\Service\Permission\PermissionFinding;
+use Eccube\Service\Permission\UserIdentity;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -94,10 +95,19 @@ final class DoctorPermissionsCommand extends Command
             ));
         }
 
-        $io->text(sprintf('診断の実行ユーザー: uid=%d gid=%d', $report->cli->uid, $report->cli->gid));
+        if ($report->cli instanceof UserIdentity) {
+            $io->text(sprintf('診断の実行ユーザー: uid=%d gid=%d', $report->cli->uid, $report->cli->gid));
+        } else {
+            $io->warning([
+                '診断の実行ユーザーを特定できませんでした.',
+                'ext-posix が無効なため, 実効 uid / gid を取得できません.',
+                'レーン S を CLI から書き換えられるかどうかは判定していません.',
+            ]);
+        }
+
         $io->newLine();
 
-        if ($report->webServer !== null && $report->webServer->uid === $report->cli->uid) {
+        if ($report->webServer !== null && $report->cli instanceof UserIdentity && $report->webServer->uid === $report->cli->uid) {
             $io->note([
                 'Web サーバーと診断の実行ユーザーが同じ uid です.',
                 '共有ホスティング (suexec 等) で同一ユーザーとして動作している場合, 権限によるレーンの分離はできません.',

--- a/src/Eccube/Command/DoctorPermissionsCommand.php
+++ b/src/Eccube/Command/DoctorPermissionsCommand.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command;
+
+use Eccube\Service\Permission\DiagnosticReport;
+use Eccube\Service\Permission\FindingSeverity;
+use Eccube\Service\Permission\PermissionDiagnostic;
+use Eccube\Service\Permission\PermissionFinding;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * 書き込み先の権限レーンと, 実際の所有者・パーミッションの差分を出力する.
+ *
+ * 判定は所有者 uid / グループ gid / パーミッションビットからの推定であり,
+ * 補助グループ・ACL・SELinux は考慮しない.
+ */
+#[AsCommand(name: 'eccube:doctor:permissions', description: 'Web サーバーと CLI の書き込み権限を診断します.')]
+final class DoctorPermissionsCommand extends Command
+{
+    /**
+     * @var list<string>
+     */
+    private const FORMATS = ['table', 'json'];
+
+    public function __construct(private readonly PermissionDiagnostic $permissionDiagnostic)
+    {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, sprintf('出力形式 (%s)', implode('|', self::FORMATS)), 'table');
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $format = (string) $input->getOption('format');
+        if (!in_array($format, self::FORMATS, true)) {
+            $io->error(sprintf('--format は %s のいずれかで指定してください.', implode(' / ', self::FORMATS)));
+
+            return Command::INVALID;
+        }
+
+        $report = $this->permissionDiagnostic->run();
+
+        if ($format === 'json') {
+            $output->writeln((string) json_encode($report->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->renderTable($io, $report);
+        }
+
+        return $report->hasError() ? 1 : 0;
+    }
+
+    private function renderTable(SymfonyStyle $io, DiagnosticReport $report): void
+    {
+        $io->title('書き込み権限の診断');
+
+        if ($report->webServer === null) {
+            $io->warning([
+                'Web サーバーの実行ユーザーを特定できませんでした.',
+                'Web サーバーでのみ生成されるファイル (var/sessions/{env} 配下, html/upload 配下) が見つからないためです.',
+                'サイトへ一度アクセスしてから再実行するか, ps aux | grep -E \'php-fpm|httpd|apache2\' で確認してください.',
+            ]);
+        } else {
+            $io->text(sprintf(
+                'Web サーバーの実行ユーザー: uid=%d gid=%d (%s の所有者から判定)',
+                $report->webServer->uid,
+                $report->webServer->gid,
+                $report->webServer->source
+            ));
+        }
+
+        $io->text(sprintf('診断の実行ユーザー: uid=%d gid=%d', $report->cli->uid, $report->cli->gid));
+        $io->newLine();
+
+        if ($report->webServer !== null && $report->webServer->uid === $report->cli->uid) {
+            $io->note([
+                'Web サーバーと診断の実行ユーザーが同じ uid です.',
+                '共有ホスティング (suexec 等) で同一ユーザーとして動作している場合, 権限によるレーンの分離はできません.',
+                '別ユーザーで運用しているはずの環境では, 判定に使ったファイルが CLI で生成された可能性があります.',
+            ]);
+        }
+
+        $rows = [];
+        foreach ($report->findings as $finding) {
+            $rows[] = [
+                $this->decorate($finding->severity),
+                $finding->requirement->lane->value,
+                $finding->requirement->label,
+                $finding->ownership->exists ? sprintf('%d:%d', $finding->ownership->uid, $finding->ownership->gid) : '-',
+                $finding->ownership->exists ? $finding->ownership->permissionsString() : '-',
+                $finding->message,
+            ];
+        }
+
+        $io->table(['', 'レーン', 'パス', '所有者', '権限', '判定'], $rows);
+
+        $this->renderDetails($io, $report);
+
+        $io->text('判定は所有者 uid / グループ gid / パーミッションビットからの推定です. 補助グループ・ACL・SELinux は考慮していません.');
+        $io->newLine();
+
+        $summary = sprintf(
+            'OK: %d / WARN: %d / NG: %d',
+            $report->countBy(FindingSeverity::OK),
+            $report->countBy(FindingSeverity::WARN),
+            $report->countBy(FindingSeverity::NG)
+        );
+
+        if ($report->hasError()) {
+            $io->error($summary);
+        } else {
+            $io->success($summary);
+        }
+    }
+
+    private function renderDetails(SymfonyStyle $io, DiagnosticReport $report): void
+    {
+        foreach ($report->findings as $finding) {
+            if ($finding->severity === FindingSeverity::OK) {
+                continue;
+            }
+
+            $io->text(sprintf('%s %s — %s', $this->decorate($finding->severity), $finding->requirement->label, $finding->message));
+
+            foreach ($this->detailLines($finding) as $line) {
+                $io->text('    '.$line);
+            }
+        }
+
+        $io->newLine();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function detailLines(PermissionFinding $finding): array
+    {
+        $lines = [];
+
+        if ($finding->hint !== null) {
+            $lines[] = $finding->hint;
+        }
+
+        if ($finding->requirement->note !== null) {
+            $lines[] = $finding->requirement->note;
+        }
+
+        return $lines;
+    }
+
+    private function decorate(FindingSeverity $severity): string
+    {
+        return match ($severity) {
+            FindingSeverity::OK => '<info>[OK]</info>',
+            FindingSeverity::WARN => '<comment>[WARN]</comment>',
+            FindingSeverity::NG => '<error>[NG]</error>',
+        };
+    }
+}

--- a/src/Eccube/Command/PluginCommandTrait.php
+++ b/src/Eccube/Command/PluginCommandTrait.php
@@ -13,18 +13,28 @@
 
 namespace Eccube\Command;
 
+use Eccube\Common\EccubeConfig;
 use Eccube\Repository\PluginRepository;
 use Eccube\Service\PluginService;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Exception\ExceptionInterface as ProcessExceptionInterface;
 use Symfony\Component\Process\Process;
 use Symfony\Contracts\Service\Attribute\Required;
 
 trait PluginCommandTrait
 {
+    /**
+     * 本処理は完了したが, 手動での操作が必要な状態を表す終了コード.
+     *
+     * 1 (異常終了) と区別するために独自の値を使う. 2 は Symfony の Command::INVALID が使用済みのため避ける.
+     */
+    public const EXIT_MANUAL_ACTION_REQUIRED = 3;
+
     protected PluginService $pluginService;
 
     protected PluginRepository $pluginRepository;
+
+    protected EccubeConfig $eccubeConfig;
 
     #[Required]
     public function setPluginService(PluginService $pluginService): void
@@ -38,16 +48,38 @@ trait PluginCommandTrait
         $this->pluginRepository = $pluginRepository;
     }
 
-    protected function clearCache(SymfonyStyle $io): void
+    #[Required]
+    public function setEccubeConfig(EccubeConfig $eccubeConfig): void
+    {
+        $this->eccubeConfig = $eccubeConfig;
+    }
+
+    /**
+     * キャッシュを削除する.
+     *
+     * 失敗しても本処理は完了しているため例外にはせず, 手動で実行する手順を案内して false を返す.
+     *
+     * @return bool 削除できた場合 true
+     */
+    protected function clearCache(SymfonyStyle $io): bool
     {
         $command = ['bin/console', 'cache:clear', '--no-warmup'];
         try {
             $io->text(sprintf('<info>Run %s</info>...', implode(' ', $command)));
-            $process = new Process($command);
+            // cwd を明示しない場合, プロジェクトルート以外から実行すると bin/console を解決できない
+            $process = new Process($command, (string) $this->eccubeConfig->get('kernel.project_dir'));
             $process->mustRun();
             $io->text($process->getOutput());
-        } catch (ProcessFailedException $e) {
+
+            return true;
+        } catch (ProcessExceptionInterface $e) {
             $io->error($e->getMessage());
+            $io->warning(sprintf(
+                'キャッシュを削除できませんでした. 書き込み権限のあるユーザーで %s を実行してください.',
+                implode(' ', $command)
+            ));
+
+            return false;
         }
     }
 }

--- a/src/Eccube/Command/PluginCommandTrait.php
+++ b/src/Eccube/Command/PluginCommandTrait.php
@@ -68,6 +68,9 @@ trait PluginCommandTrait
             $io->text(sprintf('<info>Run %s</info>...', implode(' ', $command)));
             // cwd を明示しない場合, プロジェクトルート以外から実行すると bin/console を解決できない
             $process = new Process($command, (string) $this->eccubeConfig->get('kernel.project_dir'));
+            // Process の既定タイムアウトは 60 秒. 超過すると子プロセスが kill され,
+            // 削除が中途半端な状態のまま「削除できませんでした」と案内することになる
+            $process->setTimeout(null);
             $process->mustRun();
             $io->text($process->getOutput());
 

--- a/src/Eccube/Command/PluginDisableCommand.php
+++ b/src/Eccube/Command/PluginDisableCommand.php
@@ -53,10 +53,10 @@ class PluginDisableCommand extends Command
         }
 
         $this->pluginService->disable($plugin);
-        $this->clearCache($io);
+        $cacheCleared = $this->clearCache($io);
 
         $io->success('Plugin Disabled.');
 
-        return 0;
+        return $cacheCleared ? 0 : self::EXIT_MANUAL_ACTION_REQUIRED;
     }
 }

--- a/src/Eccube/Command/PluginEnableCommand.php
+++ b/src/Eccube/Command/PluginEnableCommand.php
@@ -57,10 +57,10 @@ class PluginEnableCommand extends Command
         }
 
         $this->pluginService->enable($plugin);
-        $this->clearCache($io);
+        $cacheCleared = $this->clearCache($io);
 
         $io->success('Plugin Enabled.');
 
-        return 0;
+        return $cacheCleared ? 0 : self::EXIT_MANUAL_ACTION_REQUIRED;
     }
 }

--- a/src/Eccube/Command/PluginInstallCommand.php
+++ b/src/Eccube/Command/PluginInstallCommand.php
@@ -48,20 +48,21 @@ class PluginInstallCommand extends Command
             // PluginService::install() は install(string $path, int $source = 0, bool $notExists = false)
             // のため、$source を省略すると $ifNotExists が $source に入り --if-not-exists が効かない。
             // $source は管理画面のアーカイブアップロード (PluginController::install()) と同じ 0 を渡す。
-            if ($this->pluginService->install($path, 0, $ifNotExists)) {
-                $io->success('Installed.');
+            // install() は成功時に true を返すか例外を投げるため、戻り値では分岐しない。
+            $this->pluginService->install($path, 0, $ifNotExists);
+            $cacheCleared = $this->clearCache($io);
+            $io->success('Installed.');
 
-                return 0;
-            }
+            return $cacheCleared ? 0 : self::EXIT_MANUAL_ACTION_REQUIRED;
         }
 
         // 設置済ファイルからインストール
         if ($code) {
             $this->pluginService->installWithCode($code, $ifNotExists);
-            $this->clearCache($io);
+            $cacheCleared = $this->clearCache($io);
             $io->success('Installed.');
 
-            return 0;
+            return $cacheCleared ? 0 : self::EXIT_MANUAL_ACTION_REQUIRED;
         }
 
         $io->error('path or code is required.');

--- a/src/Eccube/Command/PluginSchemaUpdateCommand.php
+++ b/src/Eccube/Command/PluginSchemaUpdateCommand.php
@@ -48,10 +48,10 @@ class PluginSchemaUpdateCommand extends Command
 
         $config = $this->pluginService->readConfig($this->pluginService->calcPluginDir($code));
         $this->pluginService->generateProxyAndUpdateSchema($Plugin, $config);
-        $this->clearCache($io);
+        $cacheCleared = $this->clearCache($io);
 
         $io->success('Schema Updated.');
 
-        return 0;
+        return $cacheCleared ? 0 : self::EXIT_MANUAL_ACTION_REQUIRED;
     }
 }

--- a/src/Eccube/Command/PluginUninstallCommand.php
+++ b/src/Eccube/Command/PluginUninstallCommand.php
@@ -55,10 +55,10 @@ class PluginUninstallCommand extends Command
         }
 
         $this->pluginService->uninstall($plugin, $uninstallForce);
-        $this->clearCache($io);
+        $cacheCleared = $this->clearCache($io);
 
         $io->success('Uninstalled.');
 
-        return 0;
+        return $cacheCleared ? 0 : self::EXIT_MANUAL_ACTION_REQUIRED;
     }
 }

--- a/src/Eccube/Command/PluginUpdateCommand.php
+++ b/src/Eccube/Command/PluginUpdateCommand.php
@@ -49,10 +49,10 @@ class PluginUpdateCommand extends Command
 
         $config = $this->pluginService->readConfig($this->pluginService->calcPluginDir($code));
         $this->pluginService->updatePlugin($Plugin, $config);
-        $this->clearCache($io);
+        $cacheCleared = $this->clearCache($io);
 
         $io->success('Updated.');
 
-        return 0;
+        return $cacheCleared ? 0 : self::EXIT_MANUAL_ACTION_REQUIRED;
     }
 }

--- a/src/Eccube/Service/Permission/DiagnosticReport.php
+++ b/src/Eccube/Service/Permission/DiagnosticReport.php
@@ -23,12 +23,12 @@ final readonly class DiagnosticReport
     /**
      * @param list<PermissionFinding> $findings
      * @param UserIdentity|null       $webServer Web サーバーの実行ユーザー. 特定できなかった場合は null
-     * @param UserIdentity            $cli       診断を実行したユーザー
+     * @param UserIdentity|null       $cli       診断を実行したユーザー. 特定できなかった場合は null
      */
     public function __construct(
         public array $findings,
         public ?UserIdentity $webServer,
-        public UserIdentity $cli,
+        public ?UserIdentity $cli,
     ) {
     }
 
@@ -49,7 +49,7 @@ final readonly class DiagnosticReport
     {
         return [
             'web_server' => $this->webServer?->toArray(),
-            'cli' => $this->cli->toArray(),
+            'cli' => $this->cli?->toArray(),
             'summary' => [
                 'ok' => $this->countBy(FindingSeverity::OK),
                 'warn' => $this->countBy(FindingSeverity::WARN),

--- a/src/Eccube/Service/Permission/DiagnosticReport.php
+++ b/src/Eccube/Service/Permission/DiagnosticReport.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Permission;
+
+/**
+ * 診断の実行結果.
+ */
+final readonly class DiagnosticReport
+{
+    /**
+     * @param list<PermissionFinding> $findings
+     * @param UserIdentity|null       $webServer Web サーバーの実行ユーザー. 特定できなかった場合は null
+     * @param UserIdentity            $cli       診断を実行したユーザー
+     */
+    public function __construct(
+        public array $findings,
+        public ?UserIdentity $webServer,
+        public UserIdentity $cli,
+    ) {
+    }
+
+    public function hasError(): bool
+    {
+        return $this->countBy(FindingSeverity::NG) > 0;
+    }
+
+    public function countBy(FindingSeverity $severity): int
+    {
+        return count(array_filter($this->findings, static fn (PermissionFinding $finding) => $finding->severity === $severity));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'web_server' => $this->webServer?->toArray(),
+            'cli' => $this->cli->toArray(),
+            'summary' => [
+                'ok' => $this->countBy(FindingSeverity::OK),
+                'warn' => $this->countBy(FindingSeverity::WARN),
+                'ng' => $this->countBy(FindingSeverity::NG),
+            ],
+            'findings' => array_map(static fn (PermissionFinding $finding) => $finding->toArray(), $this->findings),
+        ];
+    }
+}

--- a/src/Eccube/Service/Permission/FindingSeverity.php
+++ b/src/Eccube/Service/Permission/FindingSeverity.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Permission;
+
+/**
+ * 診断結果の重大度.
+ */
+enum FindingSeverity: string
+{
+    /** 期待どおり. */
+    case OK = 'ok';
+
+    /** 判定できない, または運用上の注意が必要. */
+    case WARN = 'warn';
+
+    /** 期待と異なるため対応が必要. */
+    case NG = 'ng';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::OK => 'OK',
+            self::WARN => 'WARN',
+            self::NG => 'NG',
+        };
+    }
+}

--- a/src/Eccube/Service/Permission/PathOwnership.php
+++ b/src/Eccube/Service/Permission/PathOwnership.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Permission;
+
+/**
+ * パスの所有者 uid / グループ gid / パーミッションビット.
+ *
+ * 指定ユーザーから書き込めるかどうかは is_writable() では判定できない.
+ * is_writable() が返すのは実行ユーザー (CLI 実行なら SSH ユーザー) から見た可否だけで,
+ * Web サーバーから書けるかどうかは分からないため, パーミッションビットから推定する.
+ * 補助グループ・ACL・SELinux までは判定できないため, 結果はあくまで推定として扱うこと.
+ */
+final readonly class PathOwnership
+{
+    public function __construct(
+        public string $path,
+        public bool $exists,
+        public int $uid,
+        public int $gid,
+        public int $permissions,
+        public bool $isDir,
+    ) {
+    }
+
+    public static function of(string $path): self
+    {
+        $stat = file_exists($path) ? stat($path) : false;
+
+        if ($stat === false) {
+            return new self($path, false, -1, -1, 0, false);
+        }
+
+        return new self($path, true, $stat['uid'], $stat['gid'], $stat['mode'] & 07777, is_dir($path));
+    }
+
+    public function isWritableBy(UserIdentity $user): bool
+    {
+        return $this->isAllowedFor($user, 0002, 0200, 0020);
+    }
+
+    public function isReadableBy(UserIdentity $user): bool
+    {
+        return $this->isAllowedFor($user, 0004, 0400, 0040);
+    }
+
+    public function permissionsString(): string
+    {
+        return sprintf('%04o', $this->permissions);
+    }
+
+    /**
+     * @param int $otherBit other のパーミッションビット
+     * @param int $ownerBit owner のパーミッションビット
+     * @param int $groupBit group のパーミッションビット
+     */
+    private function isAllowedFor(UserIdentity $user, int $otherBit, int $ownerBit, int $groupBit): bool
+    {
+        if (!$this->exists) {
+            return false;
+        }
+
+        // root はパーミッションビットに関わらずアクセスできる
+        if ($user->uid === 0) {
+            return true;
+        }
+
+        if (($this->permissions & $otherBit) !== 0) {
+            return true;
+        }
+
+        if ($user->uid === $this->uid && ($this->permissions & $ownerBit) !== 0) {
+            return true;
+        }
+
+        return $user->gid === $this->gid && ($this->permissions & $groupBit) !== 0;
+    }
+}

--- a/src/Eccube/Service/Permission/PathOwnership.php
+++ b/src/Eccube/Service/Permission/PathOwnership.php
@@ -21,7 +21,13 @@ namespace Eccube\Service\Permission;
  * 指定ユーザーから書き込めるかどうかは is_writable() では判定できない.
  * is_writable() が返すのは実行ユーザー (CLI 実行なら SSH ユーザー) から見た可否だけで,
  * Web サーバーから書けるかどうかは分からないため, パーミッションビットから推定する.
- * 補助グループ・ACL・SELinux までは判定できないため, 結果はあくまで推定として扱うこと.
+ *
+ * 判定は対象パス自身のビットだけで行う. 次のものは見ていないため, 結果はあくまで推定として扱うこと.
+ *
+ * - 補助グループ・ACL・SELinux
+ * - ディレクトリの実行 (x) ビット. エントリの作成・削除には w に加えて x が,
+ *   配下のファイルを開くには x が必要になる
+ * - 祖先ディレクトリの到達性. 親が 0700 なら, 子の所有者やビットに関わらず到達できない
  */
 final readonly class PathOwnership
 {
@@ -85,14 +91,14 @@ final readonly class PathOwnership
             return true;
         }
 
-        if (($this->permissions & $otherBit) !== 0) {
-            return true;
-        }
+        // POSIX は owner / group / other のうち 1 つのクラスだけを見る.
+        // 所有者が一致すれば, other が緩くても owner のビットで可否が決まる
+        $bit = match (true) {
+            $user->uid === $this->uid => $ownerBit,
+            $user->gid === $this->gid => $groupBit,
+            default => $otherBit,
+        };
 
-        if ($user->uid === $this->uid && ($this->permissions & $ownerBit) !== 0) {
-            return true;
-        }
-
-        return $user->gid === $this->gid && ($this->permissions & $groupBit) !== 0;
+        return ($this->permissions & $bit) !== 0;
     }
 }

--- a/src/Eccube/Service/Permission/PathOwnership.php
+++ b/src/Eccube/Service/Permission/PathOwnership.php
@@ -72,7 +72,9 @@ final readonly class PathOwnership
     }
 
     /**
-     * 到達を妨げている最も浅い祖先ディレクトリ. すべて通り抜けられる場合は null.
+     * 到達を妨げている祖先ディレクトリ. すべて通り抜けられる場合は null.
+     *
+     * 論理パスの祖先, 解決後の物理パスの祖先の順に, それぞれ浅い方から探す.
      */
     public function unreachableAncestorFor(UserIdentity $user): ?self
     {
@@ -138,11 +140,39 @@ final readonly class PathOwnership
     }
 
     /**
-     * ルート (/) から親ディレクトリまでを浅い順に返す.
+     * 通り抜ける必要がある祖先ディレクトリ.
+     *
+     * stat() はシンボリックリンクを解決するため, リンクを含むパスへ到達するには
+     * 論理パスの祖先 (リンク自体へ辿り着くまで) と, 解決後の物理パスの祖先の両方が必要になる.
+     * それぞれ浅い順に並べ, 重複は取り除く.
      *
      * @return list<string>
      */
     private static function ancestorPaths(string $path): array
+    {
+        $paths = self::parentPaths($path);
+
+        // open_basedir の制限下では警告が発生するため抑制する
+        $resolved = @realpath($path);
+        if ($resolved === false || $resolved === $path) {
+            return $paths;
+        }
+
+        foreach (self::parentPaths($resolved) as $parent) {
+            if (!in_array($parent, $paths, true)) {
+                $paths[] = $parent;
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * ルート (/) から親ディレクトリまでを浅い順に返す.
+     *
+     * @return list<string>
+     */
+    private static function parentPaths(string $path): array
     {
         $paths = [];
         $current = dirname($path);

--- a/src/Eccube/Service/Permission/PathOwnership.php
+++ b/src/Eccube/Service/Permission/PathOwnership.php
@@ -56,6 +56,14 @@ final readonly class PathOwnership
         return $this->isAllowedFor($user, 0004, 0400, 0040);
     }
 
+    /**
+     * 所有者・グループに関係なく, 任意のローカルユーザーから書き込めるか.
+     */
+    public function isWorldWritable(): bool
+    {
+        return $this->exists && ($this->permissions & 0002) !== 0;
+    }
+
     public function permissionsString(): string
     {
         return sprintf('%04o', $this->permissions);

--- a/src/Eccube/Service/Permission/PathOwnership.php
+++ b/src/Eccube/Service/Permission/PathOwnership.php
@@ -22,15 +22,15 @@ namespace Eccube\Service\Permission;
  * is_writable() が返すのは実行ユーザー (CLI 実行なら SSH ユーザー) から見た可否だけで,
  * Web サーバーから書けるかどうかは分からないため, パーミッションビットから推定する.
  *
- * 判定は対象パス自身のビットだけで行う. 次のものは見ていないため, 結果はあくまで推定として扱うこと.
- *
- * - 補助グループ・ACL・SELinux
- * - ディレクトリの実行 (x) ビット. エントリの作成・削除には w に加えて x が,
- *   配下のファイルを開くには x が必要になる
- * - 祖先ディレクトリの到達性. 親が 0700 なら, 子の所有者やビットに関わらず到達できない
+ * ディレクトリはエントリの作成・削除に w と x が, 配下のファイルを開くのに x が必要になるため,
+ * 自身のビットに加えて祖先ディレクトリの x も評価する.
+ * 補助グループ・ACL・SELinux までは判定できないため, 結果はあくまで推定として扱うこと.
  */
 final readonly class PathOwnership
 {
+    /**
+     * @param list<self> $ancestors 祖先ディレクトリ. ルート (/) から親ディレクトリまでを浅い順に並べる
+     */
     public function __construct(
         public string $path,
         public bool $exists,
@@ -38,28 +38,67 @@ final readonly class PathOwnership
         public int $gid,
         public int $permissions,
         public bool $isDir,
+        public array $ancestors = [],
     ) {
     }
 
     public static function of(string $path): self
     {
-        $stat = file_exists($path) ? stat($path) : false;
+        $ancestors = array_map(static fn (string $ancestor): self => self::statOf($ancestor), self::ancestorPaths($path));
 
-        if ($stat === false) {
-            return new self($path, false, -1, -1, 0, false);
-        }
-
-        return new self($path, true, $stat['uid'], $stat['gid'], $stat['mode'] & 07777, is_dir($path));
+        return self::statOf($path, $ancestors);
     }
 
     public function isWritableBy(UserIdentity $user): bool
     {
-        return $this->isAllowedFor($user, 0002, 0200, 0020);
+        // ディレクトリはエントリの作成・削除に x も必要
+        return $this->isAllowedFor($user, 0002, 0200, 0020)
+            && (!$this->isDir || $this->isTraversableBy($user));
     }
 
     public function isReadableBy(UserIdentity $user): bool
     {
-        return $this->isAllowedFor($user, 0004, 0400, 0040);
+        // ディレクトリは配下のファイルを開くために x も必要
+        return $this->isAllowedFor($user, 0004, 0400, 0040)
+            && (!$this->isDir || $this->isTraversableBy($user));
+    }
+
+    /**
+     * ディレクトリを通り抜けて配下へ到達できるか.
+     */
+    public function isTraversableBy(UserIdentity $user): bool
+    {
+        return $this->isAllowedFor($user, 0001, 0100, 0010);
+    }
+
+    /**
+     * 到達を妨げている最も浅い祖先ディレクトリ. すべて通り抜けられる場合は null.
+     */
+    public function unreachableAncestorFor(UserIdentity $user): ?self
+    {
+        foreach ($this->ancestors as $ancestor) {
+            if ($ancestor->exists && !$ancestor->isTraversableBy($user)) {
+                return $ancestor;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * 権限を確認できなかった祖先ディレクトリがあるか.
+     *
+     * open_basedir で上位ディレクトリを参照できない場合に発生する.
+     */
+    public function hasUnknownAncestor(): bool
+    {
+        foreach ($this->ancestors as $ancestor) {
+            if (!$ancestor->exists) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -73,6 +112,52 @@ final readonly class PathOwnership
     public function permissionsString(): string
     {
         return sprintf('%04o', $this->permissions);
+    }
+
+    /**
+     * @param list<self> $ancestors
+     */
+    private static function statOf(string $path, array $ancestors = []): self
+    {
+        // open_basedir の制限下では警告が発生するため抑制する. 参照できないことは exists=false で表す
+        $stat = @stat($path);
+
+        if ($stat === false) {
+            return new self($path, false, -1, -1, 0, false, $ancestors);
+        }
+
+        return new self(
+            $path,
+            true,
+            $stat['uid'],
+            $stat['gid'],
+            $stat['mode'] & 07777,
+            ($stat['mode'] & 0170000) === 0040000,
+            $ancestors
+        );
+    }
+
+    /**
+     * ルート (/) から親ディレクトリまでを浅い順に返す.
+     *
+     * @return list<string>
+     */
+    private static function ancestorPaths(string $path): array
+    {
+        $paths = [];
+        $current = dirname($path);
+
+        while (true) {
+            $paths[] = $current;
+            $parent = dirname($current);
+            if ($parent === $current) {
+                break;
+            }
+
+            $current = $parent;
+        }
+
+        return array_reverse($paths);
     }
 
     /**

--- a/src/Eccube/Service/Permission/PermissionDiagnostic.php
+++ b/src/Eccube/Service/Permission/PermissionDiagnostic.php
@@ -81,6 +81,36 @@ class PermissionDiagnostic
             );
         }
 
+        if ($ownership->hasUnknownAncestor()) {
+            return new PermissionFinding(
+                $requirement,
+                $ownership,
+                FindingSeverity::WARN,
+                '祖先ディレクトリの権限を確認できないため到達可否を判定できません',
+                'open_basedir 等で上位ディレクトリを参照できません.'
+            );
+        }
+
+        // 診断の実行ユーザーは対象パスを stat できている以上, 祖先も通り抜けられている.
+        // 判定が必要なのは Web サーバーだけ
+        $unreachable = $ownership->unreachableAncestorFor($webServer);
+        if ($unreachable instanceof PathOwnership) {
+            return new PermissionFinding(
+                $requirement,
+                $ownership,
+                FindingSeverity::NG,
+                'Web サーバーから到達できません',
+                sprintf(
+                    '祖先ディレクトリ %s (uid=%d gid=%d %s) に実行権限がないため, 配下へ到達できません. '
+                    .'実行権限を付与するか, 所有者を変更してください.',
+                    $unreachable->path,
+                    $unreachable->uid,
+                    $unreachable->gid,
+                    $unreachable->permissionsString()
+                )
+            );
+        }
+
         return $requirement->lane === WriteLane::WEB
             ? $this->evaluateWebLane($requirement, $ownership, $webServer)
             : $this->evaluateSshLane($requirement, $ownership, $webServer, $cli);
@@ -89,13 +119,12 @@ class PermissionDiagnostic
     private function evaluateWebLane(PermissionRequirement $requirement, PathOwnership $ownership, UserIdentity $webServer): PermissionFinding
     {
         if (!$ownership->isWritableBy($webServer)) {
-            return new PermissionFinding(
-                $requirement,
-                $ownership,
-                FindingSeverity::NG,
-                'Web サーバーから書き込めません',
-                sprintf('リクエスト処理中に書き込みが発生します. 所有者を uid=%d gid=%d へ変更するか, 書き込み権限を付与してください.', $webServer->uid, $webServer->gid)
-            );
+            $hint = sprintf('リクエスト処理中に書き込みが発生します. 所有者を uid=%d gid=%d へ変更するか, 書き込み権限を付与してください.', $webServer->uid, $webServer->gid);
+            if ($ownership->isDir) {
+                $hint .= ' ディレクトリはエントリの作成・削除に実行 (x) 権限も必要です.';
+            }
+
+            return new PermissionFinding($requirement, $ownership, FindingSeverity::NG, 'Web サーバーから書き込めません', $hint);
         }
 
         if ($ownership->isWorldWritable()) {
@@ -130,13 +159,12 @@ class PermissionDiagnostic
         }
 
         if (!$ownership->isReadableBy($webServer)) {
-            return new PermissionFinding(
-                $requirement,
-                $ownership,
-                FindingSeverity::NG,
-                'Web サーバーから読み取れません',
-                'このレーンは読み取り権限が必要です.'
-            );
+            $hint = 'このレーンは読み取り権限が必要です.';
+            if ($ownership->isDir) {
+                $hint .= ' ディレクトリは配下のファイルを開くために実行 (x) 権限も必要です.';
+            }
+
+            return new PermissionFinding($requirement, $ownership, FindingSeverity::NG, 'Web サーバーから読み取れません', $hint);
         }
 
         // CLI の実行ユーザーを特定できない環境では, CLI 側の書き込み可否は判定しない

--- a/src/Eccube/Service/Permission/PermissionDiagnostic.php
+++ b/src/Eccube/Service/Permission/PermissionDiagnostic.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Permission;
+
+/**
+ * 権限レーンの期待値と, 実際の所有者・パーミッションを突き合わせる.
+ */
+class PermissionDiagnostic
+{
+    public function __construct(
+        private readonly PermissionRequirementProvider $requirementProvider,
+        private readonly WebServerUserResolver $webServerUserResolver,
+    ) {
+    }
+
+    public function run(): DiagnosticReport
+    {
+        $webServer = $this->webServerUserResolver->resolve();
+        $cli = $this->webServerUserResolver->currentUser();
+
+        $findings = [];
+        foreach ($this->requirementProvider->requirements() as $requirement) {
+            $findings[] = $this->evaluate($requirement, PathOwnership::of($requirement->path), $webServer, $cli);
+        }
+
+        return new DiagnosticReport($findings, $webServer, $cli);
+    }
+
+    /**
+     * 1 件を判定する. ファイルシステムには触れず, 渡された所有者情報だけで判断する.
+     */
+    public function evaluate(
+        PermissionRequirement $requirement,
+        PathOwnership $ownership,
+        ?UserIdentity $webServer,
+        UserIdentity $cli,
+    ): PermissionFinding {
+        if (!$ownership->exists) {
+            if ($requirement->optional) {
+                return new PermissionFinding($requirement, $ownership, FindingSeverity::OK, '未作成 (必要になった時点で生成されます)');
+            }
+
+            return new PermissionFinding($requirement, $ownership, FindingSeverity::NG, '存在しません', '作成してください.');
+        }
+
+        if (!$webServer instanceof UserIdentity) {
+            return new PermissionFinding(
+                $requirement,
+                $ownership,
+                FindingSeverity::WARN,
+                'Web サーバーの実行ユーザーを特定できないため判定できません'
+            );
+        }
+
+        return $requirement->lane === WriteLane::WEB
+            ? $this->evaluateWebLane($requirement, $ownership, $webServer)
+            : $this->evaluateSshLane($requirement, $ownership, $webServer, $cli);
+    }
+
+    private function evaluateWebLane(PermissionRequirement $requirement, PathOwnership $ownership, UserIdentity $webServer): PermissionFinding
+    {
+        if (!$ownership->isWritableBy($webServer)) {
+            return new PermissionFinding(
+                $requirement,
+                $ownership,
+                FindingSeverity::NG,
+                'Web サーバーから書き込めません',
+                sprintf('リクエスト処理中に書き込みが発生します. 所有者を uid=%d gid=%d へ変更するか, 書き込み権限を付与してください.', $webServer->uid, $webServer->gid)
+            );
+        }
+
+        return new PermissionFinding($requirement, $ownership, FindingSeverity::OK, 'Web サーバーから書き込めます');
+    }
+
+    private function evaluateSshLane(
+        PermissionRequirement $requirement,
+        PathOwnership $ownership,
+        UserIdentity $webServer,
+        UserIdentity $cli,
+    ): PermissionFinding {
+        if ($ownership->isWritableBy($webServer)) {
+            return new PermissionFinding(
+                $requirement,
+                $ownership,
+                FindingSeverity::NG,
+                'Web サーバーから書き込み可能です (想定: 読み取りのみ)',
+                'CLI (SSH ログインユーザー) からのみ書き込める権限へ変更してください.'
+            );
+        }
+
+        if (!$ownership->isReadableBy($webServer)) {
+            return new PermissionFinding(
+                $requirement,
+                $ownership,
+                FindingSeverity::NG,
+                'Web サーバーから読み取れません',
+                'このレーンは読み取り権限が必要です.'
+            );
+        }
+
+        if (!$ownership->isWritableBy($cli)) {
+            return new PermissionFinding(
+                $requirement,
+                $ownership,
+                FindingSeverity::WARN,
+                'Web サーバーは読み取りのみですが, 診断の実行ユーザーからも書き込めません',
+                'このパスを書き換える CLI コマンドは, 書き込み権限を持つユーザーで実行してください.'
+            );
+        }
+
+        return new PermissionFinding($requirement, $ownership, FindingSeverity::OK, 'Web サーバーは読み取りのみです');
+    }
+}

--- a/src/Eccube/Service/Permission/PermissionDiagnostic.php
+++ b/src/Eccube/Service/Permission/PermissionDiagnostic.php
@@ -41,12 +41,15 @@ class PermissionDiagnostic
 
     /**
      * 1 件を判定する. ファイルシステムには触れず, 渡された所有者情報だけで判断する.
+     *
+     * @param UserIdentity|null $webServer Web サーバーの実行ユーザー. 特定できなかった場合は null
+     * @param UserIdentity|null $cli       診断の実行ユーザー. 特定できなかった場合は null
      */
     public function evaluate(
         PermissionRequirement $requirement,
         PathOwnership $ownership,
         ?UserIdentity $webServer,
-        UserIdentity $cli,
+        ?UserIdentity $cli,
     ): PermissionFinding {
         if (!$ownership->exists) {
             if ($requirement->optional) {
@@ -54,6 +57,19 @@ class PermissionDiagnostic
             }
 
             return new PermissionFinding($requirement, $ownership, FindingSeverity::NG, '存在しません', '作成してください.');
+        }
+
+        // 任意のローカルユーザーから書ける時点でレーン S の前提が崩れているため,
+        // Web サーバーの uid を特定できていなくても NG と判定できる
+        if ($requirement->lane === WriteLane::SSH && $ownership->isWorldWritable()) {
+            return new PermissionFinding(
+                $requirement,
+                $ownership,
+                FindingSeverity::NG,
+                '任意のローカルユーザーから書き込めます (想定: 読み取りのみ)',
+                'bin/console が umask(0000) を設定するため, CLI が作成したディレクトリは 0777 になります. '
+                .'other の書き込み権限を外してください.'
+            );
         }
 
         if (!$webServer instanceof UserIdentity) {
@@ -101,7 +117,7 @@ class PermissionDiagnostic
         PermissionRequirement $requirement,
         PathOwnership $ownership,
         UserIdentity $webServer,
-        UserIdentity $cli,
+        ?UserIdentity $cli,
     ): PermissionFinding {
         if ($ownership->isWritableBy($webServer)) {
             return new PermissionFinding(
@@ -123,7 +139,8 @@ class PermissionDiagnostic
             );
         }
 
-        if (!$ownership->isWritableBy($cli)) {
+        // CLI の実行ユーザーを特定できない環境では, CLI 側の書き込み可否は判定しない
+        if ($cli instanceof UserIdentity && !$ownership->isWritableBy($cli)) {
             return new PermissionFinding(
                 $requirement,
                 $ownership,

--- a/src/Eccube/Service/Permission/PermissionDiagnostic.php
+++ b/src/Eccube/Service/Permission/PermissionDiagnostic.php
@@ -88,8 +88,9 @@ class PermissionDiagnostic
                 $ownership,
                 FindingSeverity::WARN,
                 'Web サーバーから書き込めますが, 任意のローカルユーザーからも書き込めます',
-                'EC-CUBE は index.php と bin/console で umask(0000) を設定するため, アプリケーションが作成したディレクトリは 0777 になります. '
-                .'同一サーバーの他ユーザーから書き換えられるため, 共有サーバーでは所有者を Web サーバーに限定してください.'
+                'bin/console が umask(0000) を設定するため, CLI が作成したディレクトリは 0777 になります '
+                .'(dev では index.php も umask(0000) を設定するため Web からの作成も同様です). '
+                .'同一サーバーの他ユーザーから書き換えられます.'
             );
         }
 

--- a/src/Eccube/Service/Permission/PermissionDiagnostic.php
+++ b/src/Eccube/Service/Permission/PermissionDiagnostic.php
@@ -82,6 +82,17 @@ class PermissionDiagnostic
             );
         }
 
+        if ($ownership->isWorldWritable()) {
+            return new PermissionFinding(
+                $requirement,
+                $ownership,
+                FindingSeverity::WARN,
+                'Web サーバーから書き込めますが, 任意のローカルユーザーからも書き込めます',
+                'EC-CUBE は index.php と bin/console で umask(0000) を設定するため, アプリケーションが作成したディレクトリは 0777 になります. '
+                .'同一サーバーの他ユーザーから書き換えられるため, 共有サーバーでは所有者を Web サーバーに限定してください.'
+            );
+        }
+
         return new PermissionFinding($requirement, $ownership, FindingSeverity::OK, 'Web サーバーから書き込めます');
     }
 

--- a/src/Eccube/Service/Permission/PermissionFinding.php
+++ b/src/Eccube/Service/Permission/PermissionFinding.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Permission;
+
+/**
+ * 1 パスの診断結果.
+ */
+final readonly class PermissionFinding
+{
+    public function __construct(
+        public PermissionRequirement $requirement,
+        public PathOwnership $ownership,
+        public FindingSeverity $severity,
+        public string $message,
+        public ?string $hint = null,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'path' => $this->requirement->label,
+            'lane' => $this->requirement->lane->value,
+            'severity' => $this->severity->value,
+            'message' => $this->message,
+            'hint' => $this->hint,
+            'note' => $this->requirement->note,
+            'exists' => $this->ownership->exists,
+            'owner_uid' => $this->ownership->exists ? $this->ownership->uid : null,
+            'owner_gid' => $this->ownership->exists ? $this->ownership->gid : null,
+            'permissions' => $this->ownership->exists ? $this->ownership->permissionsString() : null,
+        ];
+    }
+}

--- a/src/Eccube/Service/Permission/PermissionRequirement.php
+++ b/src/Eccube/Service/Permission/PermissionRequirement.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Permission;
+
+/**
+ * 1 パスに対する権限の期待値.
+ */
+final readonly class PermissionRequirement
+{
+    /**
+     * @param string      $path     判定対象の絶対パス
+     * @param WriteLane   $lane     期待するレーン
+     * @param string      $label    表示用のプロジェクトルート相対パス
+     * @param bool        $optional 実行時に生成されるため, 未作成でも問題としない
+     * @param string|null $note     運用上の注意書き
+     */
+    public function __construct(
+        public string $path,
+        public WriteLane $lane,
+        public string $label,
+        public bool $optional = false,
+        public ?string $note = null,
+    ) {
+    }
+}

--- a/src/Eccube/Service/Permission/PermissionRequirementProvider.php
+++ b/src/Eccube/Service/Permission/PermissionRequirementProvider.php
@@ -33,7 +33,33 @@ class PermissionRequirementProvider
      */
     public function requirements(): array
     {
-        return [...$this->webLane(), ...$this->sshLane()];
+        $requirements = [];
+        foreach ([...$this->webLane(), ...$this->sshLane()] as $requirement) {
+            $registered = $requirements[$requirement->path] ?? null;
+            $requirements[$requirement->path] = $registered instanceof PermissionRequirement
+                ? $this->merge($registered, $requirement)
+                : $requirement;
+        }
+
+        return array_values($requirements);
+    }
+
+    /**
+     * 同じパスが複数の役割を持つ場合 (メンテナンスファイルの生成先が var/ を指す場合等) に 1 件へまとめる.
+     *
+     * レーンと表示名は先に定義したものを採用し, 注意書きは両方を残す. 一方でも必須なら必須として扱う.
+     */
+    private function merge(PermissionRequirement $registered, PermissionRequirement $duplicated): PermissionRequirement
+    {
+        $notes = array_filter([$registered->note, $duplicated->note]);
+
+        return new PermissionRequirement(
+            $registered->path,
+            $registered->lane,
+            $registered->label,
+            $registered->optional && $duplicated->optional,
+            $notes === [] ? null : implode(' ', $notes),
+        );
     }
 
     /**
@@ -103,7 +129,11 @@ class PermissionRequirementProvider
     private function create(string $path, WriteLane $lane, bool $optional = false, ?string $note = null): PermissionRequirement
     {
         $projectDir = $this->path('kernel.project_dir');
-        $label = str_starts_with($path, $projectDir.'/') ? substr($path, strlen($projectDir) + 1) : $path;
+        $label = match (true) {
+            $path === $projectDir => '.',
+            str_starts_with($path, $projectDir.'/') => substr($path, strlen($projectDir) + 1),
+            default => $path,
+        };
 
         return new PermissionRequirement($path, $lane, $label, $optional, $note);
     }

--- a/src/Eccube/Service/Permission/PermissionRequirementProvider.php
+++ b/src/Eccube/Service/Permission/PermissionRequirementProvider.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Permission;
+
+use Eccube\Common\EccubeConfig;
+
+/**
+ * 書き込み先を権限レーンへ分類した一覧を組み立てる.
+ *
+ * パスは設定パラメータから解決し, このクラスをレーン定義の唯一の置き場所とする.
+ */
+class PermissionRequirementProvider
+{
+    public function __construct(private readonly EccubeConfig $eccubeConfig)
+    {
+    }
+
+    /**
+     * @return list<PermissionRequirement>
+     */
+    public function requirements(): array
+    {
+        return [...$this->webLane(), ...$this->sshLane()];
+    }
+
+    /**
+     * リクエスト処理中に書き込みが発生するため, CLI へ移せないもの.
+     *
+     * @return list<PermissionRequirement>
+     */
+    private function webLane(): array
+    {
+        $projectDir = $this->path('kernel.project_dir');
+        $env = (string) $this->eccubeConfig->get('kernel.environment');
+
+        return [
+            $this->create($projectDir.'/var', WriteLane::WEB, true),
+            $this->create($this->path('kernel.cache_dir'), WriteLane::WEB, true),
+            $this->create($this->path('kernel.logs_dir'), WriteLane::WEB, true),
+            $this->create($projectDir.'/var/sessions/'.$env, WriteLane::WEB, true),
+            $this->create($this->path('eccube_save_image_dir'), WriteLane::WEB),
+            $this->create($this->path('eccube_temp_image_dir'), WriteLane::WEB),
+            $this->create($this->path('eccube_save_refund_request_file_dir'), WriteLane::WEB),
+            $this->create($this->path('eccube_temp_refund_request_file_dir'), WriteLane::WEB),
+            $this->create($projectDir.'/app/keystore', WriteLane::WEB, true, 'エージェントコマースの鍵を保存する. 未使用であれば作成されない.'),
+            $this->create(
+                dirname($this->path('eccube_content_maintenance_file_path')),
+                WriteLane::WEB,
+                false,
+                'メンテナンスファイル (ECCUBE_MAINTENANCE_FILE_PATH) の生成先. '
+                .'既定ではプロジェクトルート直下のため, ルートを Web サーバーから書き込み可能にする必要がある.'
+            ),
+        ];
+    }
+
+    /**
+     * CLI (SSH ログインユーザー) へ移せるもの. Web サーバーは読み取りのみでよい.
+     *
+     * @return list<PermissionRequirement>
+     */
+    private function sshLane(): array
+    {
+        $projectDir = $this->path('kernel.project_dir');
+
+        return [
+            $this->create($this->path('eccube_theme_app_dir'), WriteLane::SSH),
+            $this->create($this->path('eccube_html_dir').'/user_data', WriteLane::SSH),
+            $this->create($this->path('plugin_realdir'), WriteLane::SSH),
+            $this->create(
+                $this->path('plugin_data_realdir'),
+                WriteLane::SSH,
+                false,
+                'プラグインが実行時にデータを書き込む場合は, そのプラグインについて Web サーバーの書き込み権限が必要になる.'
+            ),
+            $this->create(
+                $projectDir.'/app/proxy',
+                WriteLane::SSH,
+                false,
+                'ReloadSafeAttributeDriver がリクエスト処理中に一時プロキシを生成するため, '
+                .'プラグイン操作を CLI へ寄せることが読み取り専用化の前提になる.'
+            ),
+            $this->create($this->path('eccube_html_plugin_dir'), WriteLane::SSH),
+            $this->create($projectDir.'/vendor', WriteLane::SSH),
+            $this->create($projectDir.'/composer.json', WriteLane::SSH),
+            $this->create($projectDir.'/composer.lock', WriteLane::SSH),
+            $this->create($projectDir.'/.env', WriteLane::SSH, true),
+        ];
+    }
+
+    private function create(string $path, WriteLane $lane, bool $optional = false, ?string $note = null): PermissionRequirement
+    {
+        $projectDir = $this->path('kernel.project_dir');
+        $label = str_starts_with($path, $projectDir.'/') ? substr($path, strlen($projectDir) + 1) : $path;
+
+        return new PermissionRequirement($path, $lane, $label, $optional, $note);
+    }
+
+    private function path(string $key): string
+    {
+        return rtrim(str_replace('\\', '/', (string) $this->eccubeConfig->get($key)), '/');
+    }
+}

--- a/src/Eccube/Service/Permission/PermissionRequirementProvider.php
+++ b/src/Eccube/Service/Permission/PermissionRequirementProvider.php
@@ -81,7 +81,13 @@ class PermissionRequirementProvider
             $this->create($this->path('eccube_temp_image_dir'), WriteLane::WEB),
             $this->create($this->path('eccube_save_refund_request_file_dir'), WriteLane::WEB),
             $this->create($this->path('eccube_temp_refund_request_file_dir'), WriteLane::WEB),
-            $this->create($projectDir.'/app/keystore', WriteLane::WEB, true, 'エージェントコマースの鍵を保存する. 未使用であれば作成されない.'),
+            $this->create(
+                $projectDir.'/app/keystore',
+                WriteLane::WEB,
+                true,
+                '秘密鍵の格納先. CLI で事前に配置し Web サーバーからは読み取りのみとするのが望ましい. '
+                .'実行時に鍵を生成する機能を使う場合のみ Web サーバーの書き込み権限が必要になる.'
+            ),
             $this->create(
                 dirname($this->path('eccube_content_maintenance_file_path')),
                 WriteLane::WEB,

--- a/src/Eccube/Service/Permission/UserIdentity.php
+++ b/src/Eccube/Service/Permission/UserIdentity.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Permission;
+
+/**
+ * 実行ユーザーの uid / gid.
+ *
+ * ext-posix は composer.json の require に含まれないため, ユーザー名は解決せず uid / gid のまま扱う.
+ */
+final readonly class UserIdentity
+{
+    /**
+     * @param string $source uid / gid をどこから判定したかを示す説明 (診断結果の根拠として表示する)
+     */
+    public function __construct(
+        public int $uid,
+        public int $gid,
+        public string $source,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'uid' => $this->uid,
+            'gid' => $this->gid,
+            'source' => $this->source,
+        ];
+    }
+}

--- a/src/Eccube/Service/Permission/WebServerUserResolver.php
+++ b/src/Eccube/Service/Permission/WebServerUserResolver.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Permission;
+
+use Eccube\Common\EccubeConfig;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Web サーバーの実行ユーザーを実測する.
+ *
+ * 実行ユーザー名は環境ごとに異なるため固定値を持たず, Web サーバーが生成したファイルの所有者から判定する.
+ * 判定材料は次の 2 種類に分ける.
+ *
+ * - Web サーバーでのみ生成されるもの: 所有者をそのまま採用する
+ * - bin/console でも生成されるもの (ログ): 診断の実行ユーザーと異なる場合のみ採用する.
+ *   同じ uid だった場合は「Web サーバーが同一ユーザー」なのか「CLI が書いたファイル」なのか区別できないため.
+ *
+ * 配布物を含むディレクトリ (html/upload/save_image) は, 同梱画像の所有者を拾ってしまうため判定に使わない.
+ */
+class WebServerUserResolver
+{
+    public function __construct(private readonly EccubeConfig $eccubeConfig)
+    {
+    }
+
+    public function resolve(): ?UserIdentity
+    {
+        $cli = $this->currentUser();
+
+        foreach ($this->candidates() as [$dir, $pattern, $webServerOnly]) {
+            $identity = $this->identityFromDir($dir, $pattern);
+            if (!$identity instanceof UserIdentity) {
+                continue;
+            }
+
+            if (!$webServerOnly && $identity->uid === $cli->uid) {
+                continue;
+            }
+
+            return $identity;
+        }
+
+        return null;
+    }
+
+    /**
+     * 診断を実行しているユーザー.
+     */
+    public function currentUser(): UserIdentity
+    {
+        $uid = getmyuid();
+        $gid = getmygid();
+
+        return new UserIdentity($uid === false ? -1 : $uid, $gid === false ? -1 : $gid, 'getmyuid()');
+    }
+
+    /**
+     * 判定に使うディレクトリ, 採用するファイル名のパターン, Web サーバーでのみ生成されるかどうか.
+     *
+     * @return list<array{string, string, bool}>
+     */
+    private function candidates(): array
+    {
+        $projectDir = (string) $this->eccubeConfig->get('kernel.project_dir');
+        $env = (string) $this->eccubeConfig->get('kernel.environment');
+
+        return [
+            // セッションファイルは Web リクエストでのみ生成される
+            [$projectDir.'/var/sessions/'.$env, '/^sess_/', true],
+            // アップロードされたファイル. 同梱されているのはドットファイルのみ
+            [(string) $this->eccubeConfig->get('eccube_temp_image_dir'), '/^[^.]/', true],
+            [(string) $this->eccubeConfig->get('eccube_temp_refund_request_file_dir'), '/^[^.]/', true],
+            [(string) $this->eccubeConfig->get('eccube_save_refund_request_file_dir'), '/^[^.]/', true],
+            // ログは bin/console 実行でも書き込まれる
+            [$this->eccubeConfig->get('kernel.logs_dir').'/'.$env, '/\.log$/', false],
+        ];
+    }
+
+    private function identityFromDir(string $dir, string $pattern): ?UserIdentity
+    {
+        if (!is_dir($dir)) {
+            return null;
+        }
+
+        $finder = Finder::create()->files()->in($dir)->depth(0)->name($pattern);
+
+        foreach ($finder as $file) {
+            $ownership = PathOwnership::of($file->getPathname());
+            if (!$ownership->exists) {
+                continue;
+            }
+
+            return new UserIdentity($ownership->uid, $ownership->gid, $file->getPathname());
+        }
+
+        return null;
+    }
+}

--- a/src/Eccube/Service/Permission/WebServerUserResolver.php
+++ b/src/Eccube/Service/Permission/WebServerUserResolver.php
@@ -28,6 +28,7 @@ use Symfony\Component\Finder\SplFileInfo;
  * - Web サーバーでのみ生成されるもの: 所有者をそのまま採用する
  * - bin/console でも生成されるもの (ログ): 診断の実行ユーザーと異なる場合のみ採用する.
  *   同じ uid だった場合は「Web サーバーが同一ユーザー」なのか「CLI が書いたファイル」なのか区別できないため.
+ *   診断の実行ユーザーを特定できない環境では区別できないため, 判定材料にしない.
  *
  * 配布物を含むディレクトリ (html/upload/save_image) は, 同梱画像の所有者を拾ってしまうため判定に使わない.
  */
@@ -47,7 +48,7 @@ class WebServerUserResolver
                 continue;
             }
 
-            if (!$webServerOnly && $identity->uid === $cli->uid) {
+            if (!$webServerOnly && (!$cli instanceof UserIdentity || $identity->uid === $cli->uid)) {
                 continue;
             }
 
@@ -58,14 +59,20 @@ class WebServerUserResolver
     }
 
     /**
-     * 診断を実行しているユーザー.
+     * 診断を実行しているプロセスの実効ユーザー. 特定できない場合は null.
+     *
+     * getmyuid() / getmygid() は実行プロセスではなくスクリプトファイルの所有者を返すため使わない.
+     * sudo -u www-data bin/console のように所有者と実行ユーザーが異なる場合に誤判定となる.
+     * ext-posix は composer.json の require に含まれず, disable_functions で無効化されることもあるため,
+     * 取得できない場合は判定不能として扱う.
      */
-    public function currentUser(): UserIdentity
+    public function currentUser(): ?UserIdentity
     {
-        $uid = getmyuid();
-        $gid = getmygid();
+        if (!function_exists('posix_geteuid') || !function_exists('posix_getegid')) {
+            return null;
+        }
 
-        return new UserIdentity($uid === false ? -1 : $uid, $gid === false ? -1 : $gid, 'getmyuid()');
+        return new UserIdentity(posix_geteuid(), posix_getegid(), 'posix_geteuid()');
     }
 
     /**

--- a/src/Eccube/Service/Permission/WebServerUserResolver.php
+++ b/src/Eccube/Service/Permission/WebServerUserResolver.php
@@ -17,6 +17,7 @@ namespace Eccube\Service\Permission;
 
 use Eccube\Common\EccubeConfig;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * Web サーバーの実行ユーザーを実測する.
@@ -98,6 +99,20 @@ class WebServerUserResolver
         // 過去の運用ミスで所有者が異なるファイルが残っている場合に備え, 最も新しいものを採用する
         $finder = Finder::create()->files()->in($dir)->depth(0)->name($pattern)->sortByModifiedTime();
 
+        try {
+            return $this->identityFromFinder($finder);
+        } catch (\UnexpectedValueException) {
+            // Web サーバー専用に絞ったディレクトリ (var/sessions を 0700 にする等) は一覧できない.
+            // 判定材料にできないだけなので, 次の候補へ移る
+            return null;
+        }
+    }
+
+    /**
+     * @param Finder<SplFileInfo> $finder
+     */
+    private function identityFromFinder(Finder $finder): ?UserIdentity
+    {
         $identity = null;
         foreach ($finder as $file) {
             $ownership = PathOwnership::of($file->getPathname());

--- a/src/Eccube/Service/Permission/WebServerUserResolver.php
+++ b/src/Eccube/Service/Permission/WebServerUserResolver.php
@@ -95,17 +95,19 @@ class WebServerUserResolver
             return null;
         }
 
-        $finder = Finder::create()->files()->in($dir)->depth(0)->name($pattern);
+        // 過去の運用ミスで所有者が異なるファイルが残っている場合に備え, 最も新しいものを採用する
+        $finder = Finder::create()->files()->in($dir)->depth(0)->name($pattern)->sortByModifiedTime();
 
+        $identity = null;
         foreach ($finder as $file) {
             $ownership = PathOwnership::of($file->getPathname());
             if (!$ownership->exists) {
                 continue;
             }
 
-            return new UserIdentity($ownership->uid, $ownership->gid, $file->getPathname());
+            $identity = new UserIdentity($ownership->uid, $ownership->gid, $file->getPathname());
         }
 
-        return null;
+        return $identity;
     }
 }

--- a/src/Eccube/Service/Permission/WriteLane.php
+++ b/src/Eccube/Service/Permission/WriteLane.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Permission;
+
+/**
+ * 書き込み先の権限レーン.
+ *
+ * Web サーバーへ与える書き込み権限を最小化するため, EC-CUBE が書き込む先を
+ * 「リクエスト処理中に書き込みが発生するもの」と「CLI (SSH ログインユーザー) へ移せるもの」に分類する.
+ */
+enum WriteLane: string
+{
+    /** Web サーバー所有. リクエスト処理中に書き込みが発生するため CLI へ移せない. */
+    case WEB = 'web';
+
+    /** SSH ユーザー所有. Web サーバーは読み取りのみ. */
+    case SSH = 'ssh';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::WEB => 'W (Web サーバー所有)',
+            self::SSH => 'S (SSH ユーザー所有)',
+        };
+    }
+}

--- a/tests/Eccube/Tests/Command/DoctorPermissionsCommandTest.php
+++ b/tests/Eccube/Tests/Command/DoctorPermissionsCommandTest.php
@@ -93,11 +93,32 @@ final class DoctorPermissionsCommandTest extends TestCase
 
     public function testUnknownWebServerUserIsReported(): void
     {
-        $report = new DiagnosticReport([], null, new UserIdentity(1000, 1000, 'getmyuid()'));
+        $report = new DiagnosticReport([], null, new UserIdentity(1000, 1000, 'posix_geteuid()'));
         $tester = $this->tester($report);
         $tester->execute([], ['decorated' => false]);
 
         $this->assertStringContainsString('特定できませんでした', $tester->getDisplay());
+    }
+
+    public function testUnknownCliUserIsReported(): void
+    {
+        $report = new DiagnosticReport([], new UserIdentity(33, 33, 'var/sessions/prod/sess_test'), null);
+        $tester = $this->tester($report);
+        $tester->execute([], ['decorated' => false]);
+
+        $this->assertStringContainsString('診断の実行ユーザーを特定できませんでした', $tester->getDisplay());
+    }
+
+    public function testUnknownCliUserIsNullInJson(): void
+    {
+        $report = new DiagnosticReport([], new UserIdentity(33, 33, 'var/sessions/prod/sess_test'), null);
+        $tester = $this->tester($report);
+        $tester->execute(['--format' => 'json']);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertNull($decoded['cli']);
     }
 
     private function tester(DiagnosticReport $report): CommandTester
@@ -122,7 +143,7 @@ final class DoctorPermissionsCommandTest extends TestCase
         return new DiagnosticReport(
             [$finding],
             new UserIdentity(33, 33, 'var/sessions/prod/sess_test'),
-            new UserIdentity(1000, 1000, 'getmyuid()')
+            new UserIdentity(1000, 1000, 'posix_geteuid()')
         );
     }
 }

--- a/tests/Eccube/Tests/Command/DoctorPermissionsCommandTest.php
+++ b/tests/Eccube/Tests/Command/DoctorPermissionsCommandTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Command;
+
+use Eccube\Command\DoctorPermissionsCommand;
+use Eccube\Service\Permission\DiagnosticReport;
+use Eccube\Service\Permission\FindingSeverity;
+use Eccube\Service\Permission\PathOwnership;
+use Eccube\Service\Permission\PermissionDiagnostic;
+use Eccube\Service\Permission\PermissionFinding;
+use Eccube\Service\Permission\PermissionRequirement;
+use Eccube\Service\Permission\UserIdentity;
+use Eccube\Service\Permission\WriteLane;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * 出力形式と終了コードを検証する.
+ *
+ * 実際の権限は環境ごとに異なるため, 診断結果は差し替えて検証する.
+ */
+final class DoctorPermissionsCommandTest extends TestCase
+{
+    public function testReturnsSuccessWhenNoErrorFound(): void
+    {
+        $tester = $this->tester($this->report(FindingSeverity::OK));
+
+        $this->assertSame(0, $tester->execute([]));
+    }
+
+    public function testReturnsFailureWhenErrorFound(): void
+    {
+        $tester = $this->tester($this->report(FindingSeverity::NG));
+
+        $this->assertSame(1, $tester->execute([]));
+    }
+
+    public function testWarningDoesNotFailTheCommand(): void
+    {
+        $tester = $this->tester($this->report(FindingSeverity::WARN));
+
+        $this->assertSame(0, $tester->execute([]));
+    }
+
+    public function testInvalidFormatIsRejected(): void
+    {
+        $tester = $this->tester($this->report(FindingSeverity::OK));
+
+        // 診断を実行する前にオプションを検証する
+        $this->assertSame(Command::INVALID, $tester->execute(['--format' => 'yaml']));
+    }
+
+    public function testJsonFormat(): void
+    {
+        $tester = $this->tester($this->report(FindingSeverity::NG));
+        $tester->execute(['--format' => 'json']);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(['uid' => 33, 'gid' => 33, 'source' => 'var/sessions/prod/sess_test'], $decoded['web_server']);
+        $this->assertSame(['ok' => 0, 'warn' => 0, 'ng' => 1], $decoded['summary']);
+        $this->assertSame('app/template', $decoded['findings'][0]['path']);
+        $this->assertSame('ssh', $decoded['findings'][0]['lane']);
+        $this->assertSame('ng', $decoded['findings'][0]['severity']);
+        $this->assertSame('0777', $decoded['findings'][0]['permissions']);
+    }
+
+    public function testTableFormatShowsPathAndHint(): void
+    {
+        $tester = $this->tester($this->report(FindingSeverity::NG));
+        $tester->execute([], ['decorated' => false]);
+        $display = $tester->getDisplay();
+
+        $this->assertStringContainsString('app/template', $display);
+        $this->assertStringContainsString('修正してください', $display);
+        $this->assertStringContainsString('uid=33', $display);
+    }
+
+    public function testUnknownWebServerUserIsReported(): void
+    {
+        $report = new DiagnosticReport([], null, new UserIdentity(1000, 1000, 'getmyuid()'));
+        $tester = $this->tester($report);
+        $tester->execute([], ['decorated' => false]);
+
+        $this->assertStringContainsString('特定できませんでした', $tester->getDisplay());
+    }
+
+    private function tester(DiagnosticReport $report): CommandTester
+    {
+        $diagnostic = $this->createMock(PermissionDiagnostic::class);
+        $diagnostic->method('run')->willReturn($report);
+
+        return new CommandTester(new DoctorPermissionsCommand($diagnostic));
+    }
+
+    private function report(FindingSeverity $severity): DiagnosticReport
+    {
+        $requirement = new PermissionRequirement('/path/app/template', WriteLane::SSH, 'app/template');
+        $finding = new PermissionFinding(
+            $requirement,
+            new PathOwnership('/path/app/template', true, 1000, 1000, 0777, true),
+            $severity,
+            'テスト用の判定',
+            '修正してください.'
+        );
+
+        return new DiagnosticReport(
+            [$finding],
+            new UserIdentity(33, 33, 'var/sessions/prod/sess_test'),
+            new UserIdentity(1000, 1000, 'getmyuid()')
+        );
+    }
+}

--- a/tests/Eccube/Tests/Command/PluginCommandTraitTest.php
+++ b/tests/Eccube/Tests/Command/PluginCommandTraitTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Command;
+
+use Eccube\Command\PluginCommandTrait;
+use Eccube\Command\PluginEnableCommand;
+use Eccube\Common\EccubeConfig;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * キャッシュ削除に失敗したときに, 成功として扱われないことを検証する.
+ *
+ * bin/console が存在しないディレクトリを cwd に渡して失敗を再現する.
+ */
+final class PluginCommandTraitTest extends TestCase
+{
+    public function testClearCacheReturnsFalseAndGuidesManualOperation(): void
+    {
+        $tester = new CommandTester($this->createProbeCommand(sys_get_temp_dir()));
+
+        $this->assertSame(PluginEnableCommand::EXIT_MANUAL_ACTION_REQUIRED, $tester->execute([], ['decorated' => false]));
+        $this->assertStringContainsString('bin/console cache:clear --no-warmup', $tester->getDisplay());
+    }
+
+    public function testManualActionExitCodeDoesNotCollideWithSymfonyReservedCodes(): void
+    {
+        // 定数はトレイトに定義しているため, 使用側のコマンドクラス経由で参照する
+        $this->assertSame(3, PluginEnableCommand::EXIT_MANUAL_ACTION_REQUIRED);
+        $this->assertNotSame(Command::SUCCESS, PluginEnableCommand::EXIT_MANUAL_ACTION_REQUIRED);
+        $this->assertNotSame(Command::FAILURE, PluginEnableCommand::EXIT_MANUAL_ACTION_REQUIRED);
+        $this->assertNotSame(Command::INVALID, PluginEnableCommand::EXIT_MANUAL_ACTION_REQUIRED);
+    }
+
+    private function createProbeCommand(string $projectDir): Command
+    {
+        $eccubeConfig = $this->createMock(EccubeConfig::class);
+        $eccubeConfig->method('get')->with('kernel.project_dir')->willReturn($projectDir);
+
+        $command = new class('eccube:tests:clear-cache') extends Command {
+            use PluginCommandTrait;
+
+            #[\Override]
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                return $this->clearCache(new SymfonyStyle($input, $output)) ? 0 : self::EXIT_MANUAL_ACTION_REQUIRED;
+            }
+        };
+        $command->setEccubeConfig($eccubeConfig);
+
+        return $command;
+    }
+}

--- a/tests/Eccube/Tests/Service/Permission/PathOwnershipTest.php
+++ b/tests/Eccube/Tests/Service/Permission/PathOwnershipTest.php
@@ -19,6 +19,7 @@ use Eccube\Service\Permission\PathOwnership;
 use Eccube\Service\Permission\UserIdentity;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * uid / gid / パーミッションビットからの書き込み・読み取り可否の推定を検証する.
@@ -133,7 +134,7 @@ final class PathOwnershipTest extends TestCase
             new PathOwnership('/project', true, 1000, 1000, 0711, true),
         ]);
 
-        $this->assertNull($ownership->unreachableAncestorFor(new UserIdentity(33, 33, 'test')));
+        $this->assertNotInstanceOf(PathOwnership::class, $ownership->unreachableAncestorFor(new UserIdentity(33, 33, 'test')));
     }
 
     public function testAncestorThatCannotBeStattedIsUnknown(): void
@@ -145,7 +146,30 @@ final class PathOwnershipTest extends TestCase
         ]);
 
         $this->assertTrue($ownership->hasUnknownAncestor());
-        $this->assertNull($ownership->unreachableAncestorFor(new UserIdentity(33, 33, 'test')));
+        $this->assertNotInstanceOf(PathOwnership::class, $ownership->unreachableAncestorFor(new UserIdentity(33, 33, 'test')));
+    }
+
+    public function testAncestorsIncludeTheResolvedPathOfASymlink(): void
+    {
+        // stat() はリンクを解決するため, 対象自身の権限はリンク先のものになる.
+        // リンク先の親を通り抜けられなければ到達できない
+        $root = sys_get_temp_dir().'/eccube-path-'.bin2hex(random_bytes(6));
+        $fs = new Filesystem();
+        $fs->mkdir($root.'/physical/target', 0755);
+        $fs->chmod($root.'/physical', 0700);
+        symlink($root.'/physical/target', $root.'/visible');
+
+        try {
+            $ownership = PathOwnership::of($root.'/visible');
+            $paths = array_map(static fn (PathOwnership $ancestor): string => $ancestor->path, $ownership->ancestors);
+
+            $this->assertContains($root, $paths, '論理パスの祖先を評価すること');
+            $this->assertContains($root.'/physical', $paths, 'リンク解決後の物理パスの祖先を評価すること');
+            $this->assertSame($root.'/physical', $ownership->unreachableAncestorFor(new UserIdentity(33, 33, 'test'))?->path);
+        } finally {
+            $fs->chmod($root.'/physical', 0755);
+            $fs->remove($root);
+        }
     }
 
     public function testOfCollectsAncestorsFromTheRoot(): void

--- a/tests/Eccube/Tests/Service/Permission/PathOwnershipTest.php
+++ b/tests/Eccube/Tests/Service/Permission/PathOwnershipTest.php
@@ -81,14 +81,81 @@ final class PathOwnershipTest extends TestCase
      */
     public static function readableCases(): iterable
     {
-        yield 'owner with read bit' => [1000, 1000, 0400, 1000, 1000, true];
-        yield 'group with read bit' => [1000, 33, 0040, 33, 33, true];
-        yield 'other with read bit' => [1000, 1000, 0004, 33, 33, true];
+        yield 'owner with read bit' => [1000, 1000, 0500, 1000, 1000, true];
+        yield 'group with read bit' => [1000, 33, 0050, 33, 33, true];
+        yield 'other with read bit' => [1000, 1000, 0005, 33, 33, true];
         yield 'no read bit for other' => [1000, 1000, 0770, 33, 33, false];
 
         // 書き込みと同じく, 一致したクラスのビットだけで決まる
         yield 'owner class is used even when other is permissive' => [1000, 1000, 0004, 1000, 1000, false];
         yield 'group class is used even when other is permissive' => [1000, 33, 0004, 33, 33, false];
+    }
+
+    public function testDirectoryRequiresTheExecuteBit(): void
+    {
+        // エントリの作成・削除には w に加えて x が, 配下のファイルを開くには x が必要になる
+        $dir = new PathOwnership('/path', true, 1000, 1000, 0600, true);
+        $user = new UserIdentity(1000, 1000, 'test');
+
+        $this->assertFalse($dir->isWritableBy($user));
+        $this->assertFalse($dir->isReadableBy($user));
+        $this->assertFalse($dir->isTraversableBy($user));
+    }
+
+    public function testFileDoesNotRequireTheExecuteBit(): void
+    {
+        $file = new PathOwnership('/path/.env', true, 1000, 1000, 0600, false);
+        $user = new UserIdentity(1000, 1000, 'test');
+
+        $this->assertTrue($file->isWritableBy($user));
+        $this->assertTrue($file->isReadableBy($user));
+    }
+
+    public function testUnreachableAncestorIsTheShallowestOne(): void
+    {
+        $webServer = new UserIdentity(33, 33, 'test');
+        $ownership = new PathOwnership('/project/html/upload/temp_image', true, 33, 33, 0755, true, [
+            new PathOwnership('/', true, 0, 0, 0755, true),
+            new PathOwnership('/project', true, 1000, 1000, 0711, true),
+            new PathOwnership('/project/html', true, 1000, 1000, 0700, true),
+            new PathOwnership('/project/html/upload', true, 1000, 1000, 0700, true),
+        ]);
+
+        // 対象自身は Web サーバー所有 0755 でも, 祖先を通り抜けられなければ到達できない
+        $this->assertSame('/project/html', $ownership->unreachableAncestorFor($webServer)?->path);
+        $this->assertFalse($ownership->hasUnknownAncestor());
+    }
+
+    public function testReachableAncestorsReturnNull(): void
+    {
+        $ownership = new PathOwnership('/project/var', true, 33, 33, 0755, true, [
+            new PathOwnership('/', true, 0, 0, 0755, true),
+            new PathOwnership('/project', true, 1000, 1000, 0711, true),
+        ]);
+
+        $this->assertNull($ownership->unreachableAncestorFor(new UserIdentity(33, 33, 'test')));
+    }
+
+    public function testAncestorThatCannotBeStattedIsUnknown(): void
+    {
+        // open_basedir 等で参照できない祖先は, 通り抜けられないと断定しない
+        $ownership = new PathOwnership('/project/var', true, 33, 33, 0755, true, [
+            new PathOwnership('/', false, -1, -1, 0, false),
+            new PathOwnership('/project', true, 1000, 1000, 0711, true),
+        ]);
+
+        $this->assertTrue($ownership->hasUnknownAncestor());
+        $this->assertNull($ownership->unreachableAncestorFor(new UserIdentity(33, 33, 'test')));
+    }
+
+    public function testOfCollectsAncestorsFromTheRoot(): void
+    {
+        $ownership = PathOwnership::of(__FILE__);
+
+        $this->assertNotSame([], $ownership->ancestors);
+        $this->assertSame('/', $ownership->ancestors[0]->path);
+        $this->assertSame(__DIR__, $ownership->ancestors[array_key_last($ownership->ancestors)]->path);
+        $this->assertTrue($ownership->ancestors[0]->isDir);
     }
 
     public function testIsWorldWritable(): void

--- a/tests/Eccube/Tests/Service/Permission/PathOwnershipTest.php
+++ b/tests/Eccube/Tests/Service/Permission/PathOwnershipTest.php
@@ -156,16 +156,24 @@ final class PathOwnershipTest extends TestCase
         $root = sys_get_temp_dir().'/eccube-path-'.bin2hex(random_bytes(6));
         $fs = new Filesystem();
         $fs->mkdir($root.'/physical/target', 0755);
+        // mkdir() は umask の影響を受けるため, 判定に使うビットは chmod で明示する
+        $fs->chmod($root, 0755);
         $fs->chmod($root.'/physical', 0700);
         symlink($root.'/physical/target', $root.'/visible');
 
-        try {
-            $ownership = PathOwnership::of($root.'/visible');
-            $paths = array_map(static fn (PathOwnership $ancestor): string => $ancestor->path, $ownership->ancestors);
+        // 所有者と一致すると 0700 でも通り抜けられるため, テストを実行するユーザーとは別の uid / gid で判定する
+        $other = new UserIdentity((int) fileowner($root.'/physical') + 1, (int) filegroup($root.'/physical') + 1, 'test');
 
-            $this->assertContains($root, $paths, '論理パスの祖先を評価すること');
-            $this->assertContains($root.'/physical', $paths, 'リンク解決後の物理パスの祖先を評価すること');
-            $this->assertSame($root.'/physical', $ownership->unreachableAncestorFor(new UserIdentity(33, 33, 'test'))?->path);
+        try {
+            $ancestors = [];
+            foreach (PathOwnership::of($root.'/visible')->ancestors as $ancestor) {
+                $ancestors[$ancestor->path] = $ancestor;
+            }
+
+            $this->assertArrayHasKey($root, $ancestors, '論理パスの祖先を評価すること');
+            $this->assertArrayHasKey($root.'/physical', $ancestors, 'リンク解決後の物理パスの祖先を評価すること');
+            $this->assertTrue($ancestors[$root]->isTraversableBy($other));
+            $this->assertFalse($ancestors[$root.'/physical']->isTraversableBy($other), 'リンク先の親を通り抜けられない');
         } finally {
             $fs->chmod($root.'/physical', 0755);
             $fs->remove($root);

--- a/tests/Eccube/Tests/Service/Permission/PathOwnershipTest.php
+++ b/tests/Eccube/Tests/Service/Permission/PathOwnershipTest.php
@@ -53,6 +53,12 @@ final class PathOwnershipTest extends TestCase
         yield 'other with write bit' => [1000, 1000, 0007, 33, 33, true];
         yield 'other without write bit' => [1000, 1000, 0005, 33, 33, false];
 
+        // POSIX は owner / group / other のうち 1 つのクラスだけを見る.
+        // other が緩くても, 一致したクラスのビットで可否が決まる
+        yield 'owner class is used even when other is permissive' => [1000, 1000, 0006, 1000, 1000, false];
+        yield 'group class is used even when other is permissive' => [1000, 33, 0006, 33, 33, false];
+        yield 'owner class is used even when group is permissive' => [1000, 33, 0070, 1000, 33, false];
+
         // レーン S で守りたい形: SSH ユーザー所有 0755 は Web サーバーから書けない
         yield 'ssh owned 0755 is not writable by web server' => [1000, 1000, 0755, 33, 33, false];
         // group 書き込みを付けると Web サーバーから書けてしまう
@@ -79,6 +85,10 @@ final class PathOwnershipTest extends TestCase
         yield 'group with read bit' => [1000, 33, 0040, 33, 33, true];
         yield 'other with read bit' => [1000, 1000, 0004, 33, 33, true];
         yield 'no read bit for other' => [1000, 1000, 0770, 33, 33, false];
+
+        // 書き込みと同じく, 一致したクラスのビットだけで決まる
+        yield 'owner class is used even when other is permissive' => [1000, 1000, 0004, 1000, 1000, false];
+        yield 'group class is used even when other is permissive' => [1000, 33, 0004, 33, 33, false];
     }
 
     public function testIsWorldWritable(): void

--- a/tests/Eccube/Tests/Service/Permission/PathOwnershipTest.php
+++ b/tests/Eccube/Tests/Service/Permission/PathOwnershipTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Service\Permission;
+
+use Eccube\Service\Permission\PathOwnership;
+use Eccube\Service\Permission\UserIdentity;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * uid / gid / パーミッションビットからの書き込み・読み取り可否の推定を検証する.
+ *
+ * 実ファイルシステムには依存させない. chmod を使う検証は root で実行した場合に常に書き込み可能となり,
+ * Docker 開発環境と CI で結果が変わるため.
+ */
+final class PathOwnershipTest extends TestCase
+{
+    #[DataProvider(methodName: 'writableCases')]
+    public function testIsWritableBy(int $ownerUid, int $ownerGid, int $permissions, int $uid, int $gid, bool $expected): void
+    {
+        $ownership = new PathOwnership('/path', true, $ownerUid, $ownerGid, $permissions, true);
+
+        $this->assertSame($expected, $ownership->isWritableBy(new UserIdentity($uid, $gid, 'test')));
+    }
+
+    /**
+     * @return iterable<string, array{int, int, int, int, int, bool}>
+     */
+    public static function writableCases(): iterable
+    {
+        // 所有者一致
+        yield 'owner with write bit' => [1000, 1000, 0700, 1000, 1000, true];
+        yield 'owner without write bit' => [1000, 1000, 0500, 1000, 1000, false];
+
+        // グループ一致 (所有者は不一致)
+        yield 'group with write bit' => [1000, 33, 0070, 33, 33, true];
+        yield 'group without write bit' => [1000, 33, 0050, 33, 33, false];
+
+        // other
+        yield 'other with write bit' => [1000, 1000, 0007, 33, 33, true];
+        yield 'other without write bit' => [1000, 1000, 0005, 33, 33, false];
+
+        // レーン S で守りたい形: SSH ユーザー所有 0755 は Web サーバーから書けない
+        yield 'ssh owned 0755 is not writable by web server' => [1000, 1000, 0755, 33, 33, false];
+        // group 書き込みを付けると Web サーバーから書けてしまう
+        yield 'ssh owned 0775 with shared group is writable by web server' => [1000, 33, 0775, 33, 33, true];
+
+        // root はパーミッションビットに関わらず書き込める
+        yield 'root ignores permission bits' => [1000, 1000, 0000, 0, 0, true];
+    }
+
+    #[DataProvider(methodName: 'readableCases')]
+    public function testIsReadableBy(int $ownerUid, int $ownerGid, int $permissions, int $uid, int $gid, bool $expected): void
+    {
+        $ownership = new PathOwnership('/path', true, $ownerUid, $ownerGid, $permissions, true);
+
+        $this->assertSame($expected, $ownership->isReadableBy(new UserIdentity($uid, $gid, 'test')));
+    }
+
+    /**
+     * @return iterable<string, array{int, int, int, int, int, bool}>
+     */
+    public static function readableCases(): iterable
+    {
+        yield 'owner with read bit' => [1000, 1000, 0400, 1000, 1000, true];
+        yield 'group with read bit' => [1000, 33, 0040, 33, 33, true];
+        yield 'other with read bit' => [1000, 1000, 0004, 33, 33, true];
+        yield 'no read bit for other' => [1000, 1000, 0770, 33, 33, false];
+    }
+
+    public function testNotExistsIsNeitherWritableNorReadable(): void
+    {
+        $ownership = new PathOwnership('/path', false, -1, -1, 0, false);
+        $user = new UserIdentity(0, 0, 'test');
+
+        $this->assertFalse($ownership->isWritableBy($user));
+        $this->assertFalse($ownership->isReadableBy($user));
+    }
+
+    public function testOfReturnsNotExistsForMissingPath(): void
+    {
+        $ownership = PathOwnership::of(__DIR__.'/no-such-path');
+
+        $this->assertFalse($ownership->exists);
+    }
+
+    public function testOfReadsOwnershipOfExistingPath(): void
+    {
+        $ownership = PathOwnership::of(__FILE__);
+
+        $this->assertTrue($ownership->exists);
+        $this->assertFalse($ownership->isDir);
+        $this->assertSame(fileowner(__FILE__), $ownership->uid);
+        $this->assertMatchesRegularExpression('/\A\d{4}\z/', $ownership->permissionsString());
+    }
+}

--- a/tests/Eccube/Tests/Service/Permission/PathOwnershipTest.php
+++ b/tests/Eccube/Tests/Service/Permission/PathOwnershipTest.php
@@ -81,6 +81,13 @@ final class PathOwnershipTest extends TestCase
         yield 'no read bit for other' => [1000, 1000, 0770, 33, 33, false];
     }
 
+    public function testIsWorldWritable(): void
+    {
+        $this->assertTrue((new PathOwnership('/path', true, 33, 33, 0777, true))->isWorldWritable());
+        $this->assertFalse((new PathOwnership('/path', true, 33, 33, 0775, true))->isWorldWritable());
+        $this->assertFalse((new PathOwnership('/path', false, -1, -1, 0, false))->isWorldWritable());
+    }
+
     public function testNotExistsIsNeitherWritableNorReadable(): void
     {
         $ownership = new PathOwnership('/path', false, -1, -1, 0, false);

--- a/tests/Eccube/Tests/Service/Permission/PermissionDiagnosticTest.php
+++ b/tests/Eccube/Tests/Service/Permission/PermissionDiagnosticTest.php
@@ -70,10 +70,20 @@ final class PermissionDiagnosticTest extends TestCase
 
     public function testSshLaneIsNgWhenWebServerCanWrite(): void
     {
-        // other に書き込みビットがあると Web サーバーから書けてしまう
-        $finding = $this->evaluate(WriteLane::SSH, self::SSH_UID, self::SSH_UID, 0757);
+        // Web サーバーと共有するグループに書き込みビットがあると書けてしまう
+        $finding = $this->evaluate(WriteLane::SSH, self::SSH_UID, self::WEB_UID, 0775);
 
         $this->assertSame(FindingSeverity::NG, $finding->severity);
+        $this->assertSame('Web サーバーから書き込み可能です (想定: 読み取りのみ)', $finding->message);
+    }
+
+    public function testSshLaneIsNgWhenWorldWritable(): void
+    {
+        // umask(0000) の影響で CLI が 0777 で作成したディレクトリ
+        $finding = $this->evaluate(WriteLane::SSH, self::SSH_UID, self::SSH_UID, 0777);
+
+        $this->assertSame(FindingSeverity::NG, $finding->severity);
+        $this->assertSame('任意のローカルユーザーから書き込めます (想定: 読み取りのみ)', $finding->message);
     }
 
     public function testSshLaneIsNgWhenWebServerCannotRead(): void
@@ -89,6 +99,20 @@ final class PermissionDiagnosticTest extends TestCase
         $finding = $this->evaluate(WriteLane::SSH, 1001, 1001, 0755);
 
         $this->assertSame(FindingSeverity::WARN, $finding->severity);
+    }
+
+    public function testSshLaneSkipsTheCliCheckWhenCurrentUserIsUnknown(): void
+    {
+        // ext-posix が無効で実行ユーザーを特定できない場合, CLI 側の書き込み可否は判定しない
+        $requirement = new PermissionRequirement('/path', WriteLane::SSH, 'app/template');
+        $finding = $this->diagnostic()->evaluate(
+            $requirement,
+            new PathOwnership('/path', true, 1001, 1001, 0755, true),
+            $this->webServer(),
+            null
+        );
+
+        $this->assertSame(FindingSeverity::OK, $finding->severity);
     }
 
     public function testMissingOptionalPathIsOk(): void
@@ -122,13 +146,27 @@ final class PermissionDiagnosticTest extends TestCase
         $requirement = new PermissionRequirement('/path', WriteLane::SSH, 'app/template');
         $finding = $this->diagnostic()->evaluate(
             $requirement,
+            new PathOwnership('/path', true, self::SSH_UID, self::SSH_UID, 0750, true),
+            null,
+            $this->cli()
+        );
+
+        // Web サーバーの uid が分からなければ, 読み取れるかどうかも書けるかどうかも判定できない
+        $this->assertSame(FindingSeverity::WARN, $finding->severity);
+    }
+
+    public function testWorldWritableSshLaneIsNgEvenWhenWebServerUserIsUnknown(): void
+    {
+        $requirement = new PermissionRequirement('/path', WriteLane::SSH, 'app/template');
+        $finding = $this->diagnostic()->evaluate(
+            $requirement,
             new PathOwnership('/path', true, self::SSH_UID, self::SSH_UID, 0777, true),
             null,
             $this->cli()
         );
 
-        // 0777 は誰でも書けるが, Web サーバーの uid が分からない以上 NG とは断定しない
-        $this->assertSame(FindingSeverity::WARN, $finding->severity);
+        // 任意のローカルユーザーから書ける以上, Web サーバーの uid を問わずレーン S の前提が崩れている
+        $this->assertSame(FindingSeverity::NG, $finding->severity);
     }
 
     private function evaluate(WriteLane $lane, int $ownerUid, int $ownerGid, int $permissions): PermissionFinding
@@ -158,6 +196,6 @@ final class PermissionDiagnosticTest extends TestCase
 
     private function cli(): UserIdentity
     {
-        return new UserIdentity(self::SSH_UID, self::SSH_UID, 'getmyuid()');
+        return new UserIdentity(self::SSH_UID, self::SSH_UID, 'posix_geteuid()');
     }
 }

--- a/tests/Eccube/Tests/Service/Permission/PermissionDiagnosticTest.php
+++ b/tests/Eccube/Tests/Service/Permission/PermissionDiagnosticTest.php
@@ -115,6 +115,52 @@ final class PermissionDiagnosticTest extends TestCase
         $this->assertSame(FindingSeverity::OK, $finding->severity);
     }
 
+    public function testUnreachablePathIsNg(): void
+    {
+        // 対象自身は Web サーバー所有 0755 でも, 親が 0700 なら到達できない
+        $requirement = new PermissionRequirement('/project/html/upload/temp_image', WriteLane::WEB, 'html/upload/temp_image');
+        $finding = $this->diagnostic()->evaluate(
+            $requirement,
+            new PathOwnership('/project/html/upload/temp_image', true, self::WEB_UID, self::WEB_UID, 0755, true, [
+                new PathOwnership('/project', true, self::SSH_UID, self::SSH_UID, 0755, true),
+                new PathOwnership('/project/html', true, self::SSH_UID, self::SSH_UID, 0755, true),
+                new PathOwnership('/project/html/upload', true, self::SSH_UID, self::SSH_UID, 0700, true),
+            ]),
+            $this->webServer(),
+            $this->cli()
+        );
+
+        $this->assertSame(FindingSeverity::NG, $finding->severity);
+        $this->assertSame('Web サーバーから到達できません', $finding->message);
+        $this->assertStringContainsString('/project/html/upload', (string) $finding->hint);
+    }
+
+    public function testUnknownAncestorIsWarn(): void
+    {
+        $requirement = new PermissionRequirement('/project/var', WriteLane::WEB, 'var');
+        $finding = $this->diagnostic()->evaluate(
+            $requirement,
+            new PathOwnership('/project/var', true, self::WEB_UID, self::WEB_UID, 0755, true, [
+                new PathOwnership('/', false, -1, -1, 0, false),
+            ]),
+            $this->webServer(),
+            $this->cli()
+        );
+
+        $this->assertSame(FindingSeverity::WARN, $finding->severity);
+        $this->assertStringContainsString('open_basedir', (string) $finding->hint);
+    }
+
+    public function testDirectoryWithoutExecuteBitIsNg(): void
+    {
+        // レーン S の 0644 は一覧できても配下のファイルを開けない
+        $finding = $this->evaluate(WriteLane::SSH, self::SSH_UID, self::SSH_UID, 0644);
+
+        $this->assertSame(FindingSeverity::NG, $finding->severity);
+        $this->assertSame('Web サーバーから読み取れません', $finding->message);
+        $this->assertStringContainsString('実行 (x) 権限', (string) $finding->hint);
+    }
+
     public function testMissingOptionalPathIsOk(): void
     {
         $requirement = new PermissionRequirement('/path', WriteLane::WEB, 'var/cache/prod', true);

--- a/tests/Eccube/Tests/Service/Permission/PermissionDiagnosticTest.php
+++ b/tests/Eccube/Tests/Service/Permission/PermissionDiagnosticTest.php
@@ -42,6 +42,16 @@ final class PermissionDiagnosticTest extends TestCase
         $this->assertSame(FindingSeverity::OK, $finding->severity);
     }
 
+    public function testWebLaneWarnsWhenWorldWritable(): void
+    {
+        // umask(0000) の影響でアプリケーションが 0777 で作成したディレクトリ.
+        // Web サーバーからは書けるが, 任意のローカルユーザーからも書ける
+        $finding = $this->evaluate(WriteLane::WEB, self::WEB_UID, self::WEB_UID, 0777);
+
+        $this->assertSame(FindingSeverity::WARN, $finding->severity);
+        $this->assertStringContainsString('umask(0000)', (string) $finding->hint);
+    }
+
     public function testWebLaneIsNgWhenWebServerCannotWrite(): void
     {
         // SSH ユーザー所有 0755 は Web サーバーから書き込めない

--- a/tests/Eccube/Tests/Service/Permission/PermissionDiagnosticTest.php
+++ b/tests/Eccube/Tests/Service/Permission/PermissionDiagnosticTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Service\Permission;
+
+use Eccube\Service\Permission\FindingSeverity;
+use Eccube\Service\Permission\PathOwnership;
+use Eccube\Service\Permission\PermissionDiagnostic;
+use Eccube\Service\Permission\PermissionFinding;
+use Eccube\Service\Permission\PermissionRequirement;
+use Eccube\Service\Permission\UserIdentity;
+use Eccube\Service\Permission\WriteLane;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * レーンごとの判定を検証する.
+ *
+ * evaluate() はファイルシステムに触れないため, 依存を持つコンストラクタを通さずに検証する.
+ */
+final class PermissionDiagnosticTest extends TestCase
+{
+    private const WEB_UID = 33;
+    private const SSH_UID = 1000;
+
+    public function testWebLaneIsOkWhenWebServerCanWrite(): void
+    {
+        // Web サーバー所有 0755
+        $finding = $this->evaluate(WriteLane::WEB, self::WEB_UID, self::WEB_UID, 0755);
+
+        $this->assertSame(FindingSeverity::OK, $finding->severity);
+    }
+
+    public function testWebLaneIsNgWhenWebServerCannotWrite(): void
+    {
+        // SSH ユーザー所有 0755 は Web サーバーから書き込めない
+        $finding = $this->evaluate(WriteLane::WEB, self::SSH_UID, self::SSH_UID, 0755);
+
+        $this->assertSame(FindingSeverity::NG, $finding->severity);
+        $this->assertNotNull($finding->hint);
+    }
+
+    public function testSshLaneIsOkWhenWebServerCanOnlyRead(): void
+    {
+        $finding = $this->evaluate(WriteLane::SSH, self::SSH_UID, self::SSH_UID, 0755);
+
+        $this->assertSame(FindingSeverity::OK, $finding->severity);
+    }
+
+    public function testSshLaneIsNgWhenWebServerCanWrite(): void
+    {
+        // other に書き込みビットがあると Web サーバーから書けてしまう
+        $finding = $this->evaluate(WriteLane::SSH, self::SSH_UID, self::SSH_UID, 0757);
+
+        $this->assertSame(FindingSeverity::NG, $finding->severity);
+    }
+
+    public function testSshLaneIsNgWhenWebServerCannotRead(): void
+    {
+        $finding = $this->evaluate(WriteLane::SSH, self::SSH_UID, self::SSH_UID, 0700);
+
+        $this->assertSame(FindingSeverity::NG, $finding->severity);
+    }
+
+    public function testSshLaneWarnsWhenDiagnosingUserCannotWrite(): void
+    {
+        // 別の SSH ユーザー所有: Web サーバーは読み取りのみだが, 診断の実行ユーザーからも書き込めない
+        $finding = $this->evaluate(WriteLane::SSH, 1001, 1001, 0755);
+
+        $this->assertSame(FindingSeverity::WARN, $finding->severity);
+    }
+
+    public function testMissingOptionalPathIsOk(): void
+    {
+        $requirement = new PermissionRequirement('/path', WriteLane::WEB, 'var/cache/prod', true);
+        $finding = $this->diagnostic()->evaluate(
+            $requirement,
+            new PathOwnership('/path', false, -1, -1, 0, false),
+            $this->webServer(),
+            $this->cli()
+        );
+
+        $this->assertSame(FindingSeverity::OK, $finding->severity);
+    }
+
+    public function testMissingRequiredPathIsNg(): void
+    {
+        $requirement = new PermissionRequirement('/path', WriteLane::WEB, 'html/upload/save_image');
+        $finding = $this->diagnostic()->evaluate(
+            $requirement,
+            new PathOwnership('/path', false, -1, -1, 0, false),
+            $this->webServer(),
+            $this->cli()
+        );
+
+        $this->assertSame(FindingSeverity::NG, $finding->severity);
+    }
+
+    public function testUnknownWebServerUserIsWarn(): void
+    {
+        $requirement = new PermissionRequirement('/path', WriteLane::SSH, 'app/template');
+        $finding = $this->diagnostic()->evaluate(
+            $requirement,
+            new PathOwnership('/path', true, self::SSH_UID, self::SSH_UID, 0777, true),
+            null,
+            $this->cli()
+        );
+
+        // 0777 は誰でも書けるが, Web サーバーの uid が分からない以上 NG とは断定しない
+        $this->assertSame(FindingSeverity::WARN, $finding->severity);
+    }
+
+    private function evaluate(WriteLane $lane, int $ownerUid, int $ownerGid, int $permissions): PermissionFinding
+    {
+        $requirement = new PermissionRequirement('/path', $lane, 'path/for/test');
+
+        return $this->diagnostic()->evaluate(
+            $requirement,
+            new PathOwnership('/path', true, $ownerUid, $ownerGid, $permissions, true),
+            $this->webServer(),
+            $this->cli()
+        );
+    }
+
+    private function diagnostic(): PermissionDiagnostic
+    {
+        /** @var PermissionDiagnostic $diagnostic */
+        $diagnostic = (new \ReflectionClass(PermissionDiagnostic::class))->newInstanceWithoutConstructor();
+
+        return $diagnostic;
+    }
+
+    private function webServer(): UserIdentity
+    {
+        return new UserIdentity(self::WEB_UID, self::WEB_UID, 'var/sessions/prod/sess_test');
+    }
+
+    private function cli(): UserIdentity
+    {
+        return new UserIdentity(self::SSH_UID, self::SSH_UID, 'getmyuid()');
+    }
+}

--- a/tests/Eccube/Tests/Service/Permission/PermissionRequirementProviderTest.php
+++ b/tests/Eccube/Tests/Service/Permission/PermissionRequirementProviderTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Service\Permission;
+
+use Eccube\Common\EccubeConfig;
+use Eccube\Service\Permission\PermissionRequirement;
+use Eccube\Service\Permission\PermissionRequirementProvider;
+use Eccube\Service\Permission\WriteLane;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * レーン定義の組み立てを検証する.
+ */
+final class PermissionRequirementProviderTest extends TestCase
+{
+    private const PROJECT_DIR = '/var/www/html';
+
+    public function testLanesAreAssigned(): void
+    {
+        $requirements = $this->requirementsByLabel();
+
+        $this->assertSame(WriteLane::WEB, $requirements['var/cache/prod']->lane);
+        $this->assertSame(WriteLane::WEB, $requirements['html/upload/save_image']->lane);
+        $this->assertSame(WriteLane::SSH, $requirements['app/template']->lane);
+        $this->assertSame(WriteLane::SSH, $requirements['html/user_data']->lane);
+        $this->assertSame(WriteLane::SSH, $requirements['composer.json']->lane);
+    }
+
+    public function testRuntimeGeneratedPathsAreOptional(): void
+    {
+        $requirements = $this->requirementsByLabel();
+
+        $this->assertTrue($requirements['var/cache/prod']->optional);
+        $this->assertFalse($requirements['html/upload/save_image']->optional);
+    }
+
+    public function testMaintenanceFileDirectoryIsMergedWhenItPointsToAnExistingRequirement(): void
+    {
+        // ECCUBE_MAINTENANCE_FILE_PATH を var/ 配下へ移した場合, var の重複行を作らない
+        $requirements = $this->requirementsByLabel(self::PROJECT_DIR.'/var/.maintenance');
+
+        $this->assertArrayHasKey('var', $requirements);
+        $this->assertStringContainsString('メンテナンスファイル', (string) $requirements['var']->note);
+        // 一方が必須なら必須として扱う
+        $this->assertFalse($requirements['var']->optional);
+    }
+
+    public function testMaintenanceFileDirectoryIsListedSeparatelyWhenItIsTheProjectRoot(): void
+    {
+        // 既定はプロジェクトルート直下のため, ルート自体がレーン W の対象になる
+        $requirements = $this->requirementsByLabel();
+
+        $this->assertArrayHasKey('.', $requirements);
+        $this->assertSame(WriteLane::WEB, $requirements['.']->lane);
+        $this->assertSame(self::PROJECT_DIR, $requirements['.']->path);
+    }
+
+    public function testPathsAreUnique(): void
+    {
+        $paths = array_map(
+            static fn (PermissionRequirement $requirement) => $requirement->path,
+            $this->provider()->requirements()
+        );
+
+        $this->assertSame(array_unique($paths), $paths);
+    }
+
+    /**
+     * @return array<string, PermissionRequirement>
+     */
+    private function requirementsByLabel(?string $maintenanceFilePath = null): array
+    {
+        $requirements = [];
+        foreach ($this->provider($maintenanceFilePath)->requirements() as $requirement) {
+            $requirements[$requirement->label] = $requirement;
+        }
+
+        return $requirements;
+    }
+
+    private function provider(?string $maintenanceFilePath = null): PermissionRequirementProvider
+    {
+        $values = [
+            'kernel.project_dir' => self::PROJECT_DIR,
+            'kernel.environment' => 'prod',
+            'kernel.cache_dir' => self::PROJECT_DIR.'/var/cache/prod',
+            'kernel.logs_dir' => self::PROJECT_DIR.'/var/log',
+            'eccube_save_image_dir' => self::PROJECT_DIR.'/html/upload/save_image',
+            'eccube_temp_image_dir' => self::PROJECT_DIR.'/html/upload/temp_image',
+            'eccube_save_refund_request_file_dir' => self::PROJECT_DIR.'/html/upload/refund_request/save',
+            'eccube_temp_refund_request_file_dir' => self::PROJECT_DIR.'/html/upload/refund_request/temp',
+            'eccube_content_maintenance_file_path' => $maintenanceFilePath ?? self::PROJECT_DIR.'/.maintenance',
+            'eccube_theme_app_dir' => self::PROJECT_DIR.'/app/template',
+            'eccube_html_dir' => self::PROJECT_DIR.'/html',
+            'eccube_html_plugin_dir' => self::PROJECT_DIR.'/html/plugin',
+            'plugin_realdir' => self::PROJECT_DIR.'/app/Plugin',
+            'plugin_data_realdir' => self::PROJECT_DIR.'/app/PluginData',
+        ];
+
+        $eccubeConfig = $this->createMock(EccubeConfig::class);
+        $eccubeConfig->method('get')->willReturnCallback(static fn (string $key): mixed => $values[$key] ?? null);
+
+        return new PermissionRequirementProvider($eccubeConfig);
+    }
+}

--- a/tests/Eccube/Tests/Service/Permission/WebServerUserResolverTest.php
+++ b/tests/Eccube/Tests/Service/Permission/WebServerUserResolverTest.php
@@ -86,6 +86,29 @@ final class WebServerUserResolverTest extends TestCase
         $this->assertStringContainsString('uploaded.jpg', (string) $identity->source);
     }
 
+    public function testUnreadableDirectoryFallsBackToTheNextCandidate(): void
+    {
+        if (getmyuid() === 0) {
+            // root はパーミッションビットを無視するため, この検証は成立しない
+            $this->markTestSkipped('root では読み取り不可のディレクトリを再現できません.');
+        }
+
+        // Web サーバー専用に絞った var/sessions (0700 等) は一覧できない。
+        // 例外にせず次の候補へ移ることを確認する
+        $this->fs->dumpFile($this->projectDir.'/var/sessions/prod/sess_0123456789', '');
+        $this->fs->chmod($this->projectDir.'/var/sessions/prod', 0000);
+        $this->fs->dumpFile($this->projectDir.'/html/upload/temp_image/uploaded.jpg', '');
+
+        try {
+            $identity = $this->resolver()->resolve();
+        } finally {
+            $this->fs->chmod($this->projectDir.'/var/sessions/prod', 0755);
+        }
+
+        $this->assertInstanceOf(UserIdentity::class, $identity);
+        $this->assertStringContainsString('uploaded.jpg', $identity->source);
+    }
+
     public function testCurrentUserIsResolvedFromTheProcess(): void
     {
         $cli = $this->resolver()->currentUser();

--- a/tests/Eccube/Tests/Service/Permission/WebServerUserResolverTest.php
+++ b/tests/Eccube/Tests/Service/Permission/WebServerUserResolverTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Service\Permission;
+
+use Eccube\Common\EccubeConfig;
+use Eccube\Service\Permission\UserIdentity;
+use Eccube\Service\Permission\WebServerUserResolver;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Web サーバーの実行ユーザーの判定を検証する.
+ *
+ * テストが生成するファイルの所有者は診断の実行ユーザーと同じになるため,
+ * 「Web サーバーでのみ生成されるもの」と「CLI でも生成されるもの」の扱いの違いを検証できる.
+ */
+final class WebServerUserResolverTest extends TestCase
+{
+    private string $projectDir;
+
+    private Filesystem $fs;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fs = new Filesystem();
+        $this->projectDir = sys_get_temp_dir().'/eccube-permission-'.bin2hex(random_bytes(6));
+        $this->fs->mkdir($this->projectDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fs->remove($this->projectDir);
+        parent::tearDown();
+    }
+
+    public function testReturnsNullWhenNoCandidateExists(): void
+    {
+        $this->assertNotInstanceOf(UserIdentity::class, $this->resolver()->resolve());
+    }
+
+    public function testSessionFileIsUsedEvenWhenOwnerIsTheCurrentUser(): void
+    {
+        // セッションファイルは Web リクエストでのみ生成されるため, 実行ユーザーと同じ uid でも採用する
+        $this->fs->dumpFile($this->projectDir.'/var/sessions/prod/sess_0123456789', '');
+
+        $identity = $this->resolver()->resolve();
+
+        $this->assertInstanceOf(UserIdentity::class, $identity);
+        $this->assertSame(getmyuid(), $identity->uid);
+        $this->assertStringContainsString('sess_0123456789', $identity->source);
+    }
+
+    public function testLogFileOwnedByTheCurrentUserIsIgnored(): void
+    {
+        // ログは bin/console 実行でも書き込まれるため, 実行ユーザーと同じ uid では判定材料にならない
+        $this->fs->dumpFile($this->projectDir.'/var/log/prod/site.log', '');
+
+        $this->assertNotInstanceOf(UserIdentity::class, $this->resolver()->resolve());
+    }
+
+    public function testUploadedFileIsUsedButDotFileIsIgnored(): void
+    {
+        $this->fs->dumpFile($this->projectDir.'/html/upload/temp_image/.gitkeep', '');
+
+        $this->assertNotInstanceOf(UserIdentity::class, $this->resolver()->resolve());
+
+        $this->fs->dumpFile($this->projectDir.'/html/upload/temp_image/uploaded.jpg', '');
+
+        $identity = $this->resolver()->resolve();
+
+        $this->assertInstanceOf(UserIdentity::class, $identity);
+        $this->assertStringContainsString('uploaded.jpg', (string) $identity->source);
+    }
+
+    public function testCurrentUserIsResolvedFromTheProcess(): void
+    {
+        $cli = $this->resolver()->currentUser();
+
+        $this->assertSame(getmyuid(), $cli->uid);
+        $this->assertSame(getmygid(), $cli->gid);
+    }
+
+    private function resolver(): WebServerUserResolver
+    {
+        $values = [
+            'kernel.project_dir' => $this->projectDir,
+            'kernel.environment' => 'prod',
+            'kernel.logs_dir' => $this->projectDir.'/var/log',
+            'eccube_temp_image_dir' => $this->projectDir.'/html/upload/temp_image',
+            'eccube_temp_refund_request_file_dir' => $this->projectDir.'/html/upload/refund_request/temp',
+            'eccube_save_refund_request_file_dir' => $this->projectDir.'/html/upload/refund_request/save',
+        ];
+
+        $eccubeConfig = $this->createMock(EccubeConfig::class);
+        $eccubeConfig->method('get')->willReturnCallback(static fn (string $key): mixed => $values[$key] ?? null);
+
+        return new WebServerUserResolver($eccubeConfig);
+    }
+}

--- a/tests/Eccube/Tests/Service/Permission/WebServerUserResolverTest.php
+++ b/tests/Eccube/Tests/Service/Permission/WebServerUserResolverTest.php
@@ -26,6 +26,9 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * テストが生成するファイルの所有者は診断の実行ユーザーと同じになるため,
  * 「Web サーバーでのみ生成されるもの」と「CLI でも生成されるもの」の扱いの違いを検証できる.
+ *
+ * ext-posix が無効な環境では実効 uid / gid を取得できず currentUser() が null を返すため,
+ * 実効ユーザーに依存する検証はスキップする.
  */
 final class WebServerUserResolverTest extends TestCase
 {
@@ -35,6 +38,10 @@ final class WebServerUserResolverTest extends TestCase
 
     protected function setUp(): void
     {
+        if (!function_exists('posix_geteuid')) {
+            self::markTestSkipped('ext-posix が無効な環境では実効 uid / gid を検証できません.');
+        }
+
         parent::setUp();
         $this->fs = new Filesystem();
         $this->projectDir = sys_get_temp_dir().'/eccube-permission-'.bin2hex(random_bytes(6));
@@ -60,7 +67,7 @@ final class WebServerUserResolverTest extends TestCase
         $identity = $this->resolver()->resolve();
 
         $this->assertInstanceOf(UserIdentity::class, $identity);
-        $this->assertSame(getmyuid(), $identity->uid);
+        $this->assertSame(posix_geteuid(), $identity->uid);
         $this->assertStringContainsString('sess_0123456789', $identity->source);
     }
 
@@ -88,7 +95,7 @@ final class WebServerUserResolverTest extends TestCase
 
     public function testUnreadableDirectoryFallsBackToTheNextCandidate(): void
     {
-        if (getmyuid() === 0) {
+        if (posix_geteuid() === 0) {
             // root はパーミッションビットを無視するため, この検証は成立しない
             $this->markTestSkipped('root では読み取り不可のディレクトリを再現できません.');
         }
@@ -109,12 +116,17 @@ final class WebServerUserResolverTest extends TestCase
         $this->assertStringContainsString('uploaded.jpg', $identity->source);
     }
 
-    public function testCurrentUserIsResolvedFromTheProcess(): void
+    public function testCurrentUserIsTheEffectiveUserOfTheProcess(): void
     {
+        // getmyuid() はスクリプトファイルの所有者を返すため契約にできない.
+        // プロセスが生成したファイルの所有者 (= 実効 uid) と一致することを確認する
+        $this->fs->dumpFile($this->projectDir.'/var/created-by-this-process', '');
+
         $cli = $this->resolver()->currentUser();
 
-        $this->assertSame(getmyuid(), $cli->uid);
-        $this->assertSame(getmygid(), $cli->gid);
+        $this->assertInstanceOf(UserIdentity::class, $cli);
+        $this->assertSame(fileowner($this->projectDir.'/var/created-by-this-process'), $cli->uid);
+        $this->assertSame(posix_getegid(), $cli->gid);
     }
 
     private function resolver(): WebServerUserResolver


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Refs #7072 の Phase 1 です。

EC-CUBE はリポジトリのほぼ全体に Web サーバーの書き込み権限がある前提で動作するため、[公式ドキュメント](https://doc4.ec-cube.net/permission)に沿って権限を厳格化すると管理画面の多くの機能が動作しなくなります。#7072 では、書き込みを CLI (SSH ログインユーザー権限) へ移すことで Web サーバーには最小限の書き込み権限しか与えずに運用できる状態を目指しています。

本 PR はその第一歩として、**現状を診断できるようにする**ものです。挙動を変える変更は含みません (プラグインコマンドの終了コードを除く、後述)。

1. 書き込み先を「リクエスト処理中に書き込みが発生するもの (レーン W)」と「CLI へ移せるもの (レーン S)」に分類し、実際の所有者・パーミッションとの差分を出力する `eccube:doctor:permissions` を追加
2. `eccube:plugin:*` がキャッシュ削除の失敗を成功として扱っていた問題を修正

## 方針(Policy)

### 判定に `is_writable()` は使わない

`is_writable()` が返すのは実行ユーザー (CLI 実行なら SSH ユーザー) から見た可否だけで、Web サーバーから書けるかどうかは分かりません。所有者 uid・グループ gid・パーミッションビットから推定しています。

補助グループ・ACL・SELinux までは判定できないため、出力には推定である旨を明記しています。

### Web サーバーの実行ユーザーは実測する

実行ユーザー名は環境ごとに異なるためコード中に固定値を持たせず、Web サーバーが生成したファイルの所有者から判定します。判定材料は 2 種類に分けています。

- **Web サーバーでのみ生成されるもの** (`var/sessions/{env}/sess_*`、`html/upload/temp_image`、`html/upload/refund_request/{save,temp}`) — 所有者をそのまま採用
- **`bin/console` でも生成されるログ** — 診断の実行ユーザーと uid が異なる場合のみ採用。同じ uid では「Web サーバーが同一ユーザー」なのか「CLI が書いたファイル」なのか区別できないため

`html/upload/save_image` は配布画像 (`no_image_product.png`、`sand-*.png` 等) を含み、その所有者を拾って誤検出するため判定には使いません。

`var/sessions/{env}` を Web サーバー専用 (`0700`) に絞ると CLI からは一覧できないため、その場合は例外にせず次の候補へフォールバックします。

判定できない場合は NG とせず「判定不能」として警告し、確認方法を案内します。

`ext-posix` は `composer.json` の require に含まれていないため、`posix_getpwuid()` は使わず uid を数値で表示します。

### レーン定義の置き場所

`PermissionRequirementProvider` をレーン定義の唯一の置き場所としています。#7072 の後続フェーズで `InstallController::$eccubeDirs` をここへ寄せることを想定しています。

### 終了コード 3 の追加

`PluginCommandTrait::clearCache()` は失敗を `$io->error()` で表示するだけで戻り値を持たず、このトレイトを使う 6 コマンド (`eccube:plugin:enable` / `disable` / `install` / `uninstall` / `update` / `schema-update`) はいずれも直後に `return 0` していたため、**書き込み権限が無くキャッシュを削除できない環境でも成功として扱われていました**。

本処理自体は完了しているため異常終了 (1) にはせず、「完了したが手動操作が必要」を表す終了コード **3** と手動実行の案内を返します。`2` は Symfony の `Command::INVALID` が使用済みのため避けました。

## 実装に関する補足(Appendix)

### 追加したクラス

| ファイル | 役割 |
|---|---|
| `Service/Permission/WriteLane.php` | レーンの enum (WEB / SSH) |
| `Service/Permission/PermissionRequirementProvider.php` | レーン定義 |
| `Service/Permission/WebServerUserResolver.php` | Web サーバー uid / gid の実測 |
| `Service/Permission/PermissionDiagnostic.php` | 突合。`evaluate()` はファイルシステムに触れない |
| `Service/Permission/{PathOwnership,UserIdentity,PermissionRequirement,PermissionFinding,DiagnosticReport,FindingSeverity}.php` | VO・enum |
| `Command/DoctorPermissionsCommand.php` | コマンド本体 (入出力と終了コードのみ) |
| `docker-compose.permission-lanes.yml` | 権限を分離した docker 環境 (後述) |

### 出力

既定は人間向けのテーブル、`--format=json` で機械可読です。終了コードは `0` = 問題なし / `1` = 要対応の NG あり / `2` = オプション不正 (`Command::INVALID`)。

```
$ bin/console eccube:doctor:permissions

 Web サーバーの実行ユーザー: uid=33 gid=33 (var/sessions/prod/sess_xxxx の所有者から判定)
 診断の実行ユーザー: uid=1000 gid=1000

  [OK]     web   var/cache/prod      33:33       0755   Web サーバーから書き込めます
  [WARN]   web   var/log             33:33       0777   Web サーバーから書き込めますが, 任意のローカルユーザーからも書き込めます
  [OK]     web   var/sessions/prod   -           -      未作成 (必要になった時点で生成されます)
  [NG]     ssh   app/template        1000:1000   0775   Web サーバーから書き込み可能です (想定: 読み取りのみ)
```

レーン W が `o+w` の場合は WARN を出します。`bin/console` が無条件に `umask(0000)` を設定するため、CLI が作成したディレクトリは `0777` になり、同一サーバーの他ユーザーから書き換えられます (dev では `index.php` も `umask(0000)` を設定するため Web からの作成も同様です)。

Web サーバーと診断の実行ユーザーが同じ uid だった場合は、共有ホスティング (suexec 等) では権限によるレーン分離ができない旨を注記します。

### 権限を分離した docker 環境

診断結果を実環境で確認できるよう、Web サーバー (`www-data`) と CLI を別ユーザーで動かす compose の override を追加しています。

```bash
docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.permission-lanes.yml up -d --wait
curl -s -o /dev/null http://127.0.0.1:8080/   # セッションを生成し Web サーバーの uid を判定可能にする
docker compose exec -u eccube ec-cube bin/console eccube:doctor:permissions
```

**既定モードは変更していません。** override を指定しなければ、従来どおり `www-data` をホストユーザーへ合わせるため開発時のパーミッションエラーは起きません。

分離モードでは `www-data` を uid 33 のままとし、CLI 用のユーザーを別に作成します。**共有グループは作りません** (セキュリティポリシー上、共有グループを作成できない環境があるため)。

- レーン W (`var`、`html/upload/**`、`app/keystore`) — **`www-data` 所有**
- レーン S (上記以外) — CLI ユーザー所有。`www-data` は読み取りのみ
- `ECCUBE_MAINTENANCE_FILE_PATH` を `var/` 配下へ移す。既定のプロジェクトルート直下のままだと、ルート自体を Web サーバーから書き込み可能にする必要があるため

CLI の実行ユーザーは操作対象のレーンで決まります。本番の `sudo -u www-data` に相当します。

```bash
docker compose exec -u eccube   ec-cube bin/console eccube:page:apply ...   # レーン S を触る操作
docker compose exec -u www-data ec-cube bin/console cache:clear             # レーン W を触る操作
```

レーン W は**ディレクトリだけ**を `www-data` 所有にします。配下ごと `chown` すると、本番の姿 (デプロイしたファイルは SSH ユーザー所有・Web は読み取りのみ) とずれるうえ、`html/upload/refund_request/.htaccess` のような配布物の所有者まで書き換えてしまうためです。パーミッションは変更しません。変更するとセッションファイルの `0600` を緩め、bind mount 越しに git 管理下の実行ビットも落ちます。

分離すると、レーン S へ書き込む管理画面の機能 (プラグイン導入・ページ/ブロック/メールテンプレート編集・CSS/JS 編集・ファイル管理) は動作しなくなります。これは #7072 が目指す状態そのもので、CLI 側の代替導線が入るまでは日常の開発では重ねない前提です。

### あわせて修正した点

- `PluginCommandTrait` の `Process` に cwd を渡していないため、プロジェクトルート以外から実行すると `bin/console` を解決できずキャッシュ削除に失敗していた
- `eccube:plugin:install` の `--path` 経路だけキャッシュを削除していなかった。`PluginService::install()` は成功時に `true` を返すか例外を投げるため、戻り値による分岐もあわせて整理

## テスト（Test)

`tests/Eccube/Tests/Service/Permission/` と `tests/Eccube/Tests/Command/` に 47 テストを追加しています (DB 不要)。

- `PathOwnershipTest` — uid / gid / パーミッションビットからの可否推定と world-writable の判定
- `PermissionDiagnosticTest` — レーンごとの判定 (OK / WARN / NG の分岐)
- `PermissionRequirementProviderTest` — レーン定義の組み立てとパスの一意性
- `WebServerUserResolverTest` — 判定材料の採否と、一覧できないディレクトリでのフォールバック
- `DoctorPermissionsCommandTest` — 出力形式と終了コード
- `PluginCommandTraitTest` — キャッシュ削除失敗時に終了コード 3 を返すこと

`chmod` を使う検証は root 実行時に常に成功してしまい Docker 開発環境と CI で結果が変わるため、判定ロジックはファイルシステムに触れない純粋メソッドに切り出して検証し、どうしても `chmod` が必要なものは root ではスキップしています。

ローカルでの確認:

```
vendor/bin/php-cs-fixer fix --dry-run --diff   → 0 件
vendor/bin/phpstan analyse src (level 6)       → No errors
vendor/bin/rector process --dry-run            → 差分なし
vendor/bin/phpunit <上記6ファイル>              → OK (47 tests, 82 assertions)
```

分離した docker 環境での確認 (PHP 8.2 / SQLite / `APP_ENV=dev`):

```
id www-data → uid=33(www-data)  gid=33(www-data)  groups=33(www-data)
id eccube   → uid=1000(eccube) gid=1000(eccube) groups=1000(eccube)   ← 共有グループなし

html/upload/refund_request            ディレクトリ  33:33      ← Web サーバー所有
html/upload/refund_request/.htaccess  配布物        1000:1000  ← SSH ユーザー所有 (Web は読み取りのみ)

docker compose exec -u eccube ec-cube bin/console eccube:doctor:permissions
  → Web サーバーの実行ユーザー: uid=33 gid=33 (var/sessions/dev/sess_xxxx の所有者から判定)
    OK: 16 / WARN: 3 / NG: 0   終了コード 0

docker compose exec -u www-data ec-cube touch app/template/x           → Permission denied (レーン S)
docker compose exec -u www-data ec-cube touch html/user_data/x         → Permission denied (レーン S)
docker compose exec -u www-data ec-cube touch vendor/x                 → Permission denied (レーン S)
docker compose exec -u www-data ec-cube touch html/upload/save_image/x → 成功              (レーン W)

curl http://127.0.0.1:8080/ , /admin/login → いずれも 200 (cache:clear 後も同じ)
```

WARN 3 件は `var/cache/{env}`・`var/log`・`var/sessions/{env}` が `0777` になっているものです。`bin/console` の `umask(0000)` により、アプリケーションが作成したディレクトリは誰でも書き込める状態になります。**この状態ではレーン W の分離は成立しません**。本 PR は現状を検出できるようにするところまでで、`umask(0000)` の扱いは #7072 の Phase 2 (#7100) で解決しています。

既定モード (override なし) でも `/` と `/admin/login` が 200 を返すこと、`www-data` がホストユーザーの uid になること、Web サーバーと診断の実行ユーザーが同じ uid である旨の注記が出ることを確認しています。

なお、既定モードと分離モードを切り替えるときは、レーン W のボリュームと所有者の作り直しが必要です。切り替え前の `www-data` の uid で作成されたディレクトリ (`var/cache/{env}/mcp-sessions` 等) が残り、切り替え後の Web サーバーから書き込めなくなります。compose ファイルと `AGENTS.md` に記載しています。

## 相談（Discussion）

- 終了コード `3` (完了したが手動操作が必要) という値の妥当性についてご意見をいただきたいです。`2` は `Command::INVALID` が使用済みのため避けています。
- レーン S の判定対象に `.env` を含めています。存在しない場合は「未作成」として扱っています。
- レーン W が `0777` になる件 (`umask(0000)`) は本 PR では検出のみに留めています。#7100 (Phase 2) で `index.php` / `bin/console` の無条件呼び出しを削除し、**環境変数 `ECCUBE_UMASK` (8 進数表記) による任意設定**へ変更済みです。未設定なら OS / PHP-FPM の既定に従い、`0000` を設定すると 4.3 以前の挙動 (ディレクトリ 0777 / ファイル 0666) に戻せます。本 PR に前倒しで含めるべきかご意見をいただきたいです。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更はありません
  - **`eccube:plugin:*` の終了コードが変わります**。キャッシュ削除に失敗した場合、これまで `0` を返していたものが `3` を返します。成功時の挙動は変わりません。これらのコマンドを cron や CI から実行している環境では、これまで気付けなかった失敗が検出されるようになります (本 PR の目的です)。
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
  - `PluginCommandTrait::clearCache()` の戻り値を `void` から `bool` へ変更していますが、`protected` メソッドであり引数・データ型の削除には該当しません。
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - WebサーバーとCLIの書き込み権限を分離する運用モードを追加しました。
  - `eccube:doctor:permissions` で権限状態を表形式またはJSON形式で確認できます。
  - Docker Composeの設定例と、分離環境の構築・確認手順を追加しました。

- **改善**
  - プラグイン操作後のキャッシュ削除に失敗した場合、手動対応が必要であることを終了コードと警告で通知します。

- **テスト**
  - 権限診断、ユーザー判定、各種プラグイン操作の動作検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
