### PR TITLE
build(deps-dev): rector を 2.6.4 へ上げ, composer-based セットへ移行する (refs #7087)

### DIFF
--- a/codeception/_support/Page/Front/ProductDetailPage.php
+++ b/codeception/_support/Page/Front/ProductDetailPage.php
@@ -66,7 +66,7 @@ class ProductDetailPage extends AbstractFrontPage
         if (!is_null($category1)) {
             $this->tester->selectOption(['id' => 'classcategory_id1'], $category1);
             if (!is_null($category2)) {
-                $category2_id = current(array_keys($category2));
+                $category2_id = array_key_first($category2);
                 $this->tester->waitForElement(['xpath' => "//*[@id='classcategory_id2']/option[@value='{$category2_id}']"]);
                 $this->tester->selectOption(['id' => 'classcategory_id2'], $category2);
             }

--- a/codeception/_support/Page/Front/ProductListPage.php
+++ b/codeception/_support/Page/Front/ProductListPage.php
@@ -53,7 +53,7 @@ class ProductListPage extends AbstractFrontPage
         if (!is_null($category1)) {
             $this->tester->selectOption(['css' => "ul.ec-shelfGrid li.ec-shelfGrid__item:nth-child({$index}) form select[name='classcategory_id1']"], $category1);
             if (!is_null($category2)) {
-                $category2_id = current(array_keys($category2));
+                $category2_id = array_key_first($category2);
                 $this->tester->waitForElement(['xpath' => "//ul[@class='ec-shelfGrid']/li[@class='ec-shelfGrid__item'][{$index}]//select[@name='classcategory_id2']/option[@value='{$category2_id}']"]);
                 $this->tester->selectOption(['css' => "ul.ec-shelfGrid li.ec-shelfGrid__item:nth-child({$index}) form select[name='classcategory_id2']"], $category2);
             }

--- a/codeception/acceptance/_bootstrap.php
+++ b/codeception/acceptance/_bootstrap.php
@@ -285,9 +285,7 @@ $createProduct = (fn ($product_name = null, $product_class_num = 3) => createPro
 Fixtures::add('createProduct', $createProduct);
 
 $createCustomer = function ($email = null, $active = true) use ($container, $faker) {
-    if (is_null($email)) {
-        $email = microtime(true).'.'.$faker->safeEmail;
-    }
+    $email ??= microtime(true).'.'.$faker->safeEmail;
 
     return createCustomer($container, $email, $active);
 };

--- a/composer.lock
+++ b/composer.lock
@@ -14869,16 +14869,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.6.1",
+            "version": "2.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95"
+                "reference": "6ff008471683591224951526247b7a2b86980ba9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/b8e68f058bca43e01a2e1caa51ef022d6551ed95",
-                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/6ff008471683591224951526247b7a2b86980ba9",
+                "reference": "6ff008471683591224951526247b7a2b86980ba9",
                 "shasum": ""
             },
             "require": {
@@ -14917,7 +14917,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.6.1"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.4"
             },
             "funding": [
                 {
@@ -14925,7 +14925,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-03T17:30:34+00:00"
+            "time": "2026-08-27T09:20:34+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/rector.php
+++ b/rector.php
@@ -18,19 +18,15 @@ use Eccube\Rector\CodingStyle\NormalizePhpDocArrayGenericSpacingRector;
 use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
-use Rector\Doctrine\Bundle210\Rector\Class_\EventSubscriberInterfaceToAttributeRector;
 use Rector\Doctrine\Set\DoctrineSetList;
 use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
-use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\Symfony\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector;
 use Rector\Symfony\Set\SymfonySetList;
 use Rector\Symfony\Symfony34\Rector\Closure\ContainerGetNameToTypeInTestsRector;
 use Rector\Symfony\Symfony61\Rector\Class_\CommandConfigureToAttributeRector;
-use Rector\Symfony\Symfony61\Rector\Class_\CommandPropertyToAttributeRector;
 use Rector\ValueObject\PhpVersion;
 
 // この設定ファイルは Rector の CLI 実行専用。
@@ -60,10 +56,6 @@ return RectorConfig::configure()
                // Codeception 自動生成ファイル (codecept build で再生成されるため Rector の指摘は意味なし)
                __DIR__.'/codeception/_support/_generated',
                // 特定のルールを除外する場合
-               // 親の $entityManager 再宣言と step5 の接続専用 EM の取り違えを防ぐため
-               ControllerMethodInjectionToConstructorRector::class => [
-                   __DIR__.'/src/Eccube/Controller/Install/InstallController.php',
-               ],
                // Codeception の grabMultiple() 等は戻り値の要素が null になり得るため、
                // NullToStrictStringFuncCallArgRector が追加する (string) キャストを
                // RecastingRemovalRector が除去しないようにスキップする
@@ -109,10 +101,10 @@ return RectorConfig::configure()
            ])
            // 個別にルールを追加する場合はここに記述
            ->withRules([
-               CommandConfigureToAttributeRector::class, // Symfonyコマンドのconfigureメソッドをアトリビュートに変換する
-               CommandPropertyToAttributeRector::class, // Symfonyコマンドのプロパティをアトリビュートに変換する,
-               StaticDataProviderClassMethodRector::class, // PHPUnitのデータプロバイダを静的メソッドに変換する
-               EventSubscriberInterfaceToAttributeRector::class, // Doctrine EventSubscriberをAsDoctrineListenerアトリビュートに変換する
+               // 以下は composer-based セットに含まれるため withRules() では指定しない
+               // (二重登録になり rector 2.6.2 以降は警告が出る):
+               //   CommandConfigureToAttributeRector / CommandPropertyToAttributeRector
+               //   StaticDataProviderClassMethodRector / EventSubscriberInterfaceToAttributeRector
                AttributeArgumentsOrderRector::class, // すべての Attribute の引数をコンストラクタ引数順序に統一する
                NormalizePhpDocArrayGenericSpacingRector::class, // PHPDoc の配列ジェネリクス表記のカンマ後のスペースを統一する
            ])

--- a/rector.php
+++ b/rector.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 
 use Eccube\Rector\CodingStyle\AttributeArgumentsOrderRector;
 use Eccube\Rector\CodingStyle\NormalizePhpDocArrayGenericSpacingRector;
-use Rector\Caching\ValueObject\Storage\FileCacheStorage;
+use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\Doctrine\Bundle210\Rector\Class_\EventSubscriberInterfaceToAttributeRector;
@@ -56,9 +56,9 @@ return RectorConfig::configure()
            // スキップするパスやルールを指定
            ->withSkip([
                // 特定のファイルやディレクトリを除外する場合
-               __DIR__ . '/rector',
+               __DIR__.'/rector',
                // Codeception 自動生成ファイル (codecept build で再生成されるため Rector の指摘は意味なし)
-               __DIR__ . '/codeception/_support/_generated',
+               __DIR__.'/codeception/_support/_generated',
                // 特定のルールを除外する場合
                // 親の $entityManager 再宣言と step5 の接続専用 EM の取り違えを防ぐため
                ControllerMethodInjectionToConstructorRector::class => [
@@ -96,7 +96,11 @@ return RectorConfig::configure()
                ],
                // 8.3以上で対応可能
                AddTypeToConstRector::class, // [BC]定数に型を追加する PHP 8.3 以降で有効
-               RenameMethodRector::class, //addがaddCommandに変換されてしまうため一旦スキップ
+               RenameMethodRector::class, // addがaddCommandに変換されてしまうため一旦スキップ
+               // composer-based セットの設定では ContainerBuilder::addCompilerPass() に
+               // 第 2 引数 0 (int) を足すが, シグネチャは string $type なので TypeError になる。
+               // (例: addCompilerPass(new PluginPass(), 0, 0))
+               ArgumentAdderRector::class,
                // EccubeCliToolCommand の description は runtime (ツールの description) で組み立てるため、
                // #[AsCommand(description:)] へ移せない (属性は定数式のみ)。 このルールをスキップする。
                CommandConfigureToAttributeRector::class => [
@@ -116,20 +120,24 @@ return RectorConfig::configure()
            ->withSets([
                SetList::DEAD_CODE,
                LevelSetList::UP_TO_PHP_84, // PHPバージョンに合わせる
-               SymfonySetList::SYMFONY_74, // Symfonyのバージョンに合わせる (EC-CUBEのバージョンによって調整が必要)
+               // 各ルールが composer.json / installed.json を自分で見て,
+               // インストール済みバージョンに合うものだけ実行する。
+               // rector 2.6.2 でバージョン別のセット定数 (SYMFONY_74 等) は撤去された。
+               SymfonySetList::COMPOSER_BASED,
                SymfonySetList::SYMFONY_CODE_QUALITY,
                SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,
                DoctrineSetList::DOCTRINE_CODE_QUALITY,
-               DoctrineSetList::DOCTRINE_DBAL_30, // Doctrine DBALのバージョンに合わせる
+               DoctrineSetList::COMPOSER_BASED,
                DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES, // Doctrine Annotations を Attributes に変換
                PHPUnitSetList::PHPUNIT_CODE_QUALITY,
-               PHPUnitSetList::PHPUNIT_110, // PHPUnitのバージョンに合わせる
+               PHPUnitSetList::COMPOSER_BASED,
            ])
            // Symfony のコンテナ XML（EC-CUBE の構成に合わせて調整が必要な場合があります）
            ->withSymfonyContainerXml(__DIR__.'/var/cache/dev/Eccube_KernelDevDebugContainer.xml')
            // オプション: キャッシュ設定 (パフォーマンス向上のために推奨)
            ->withCache(
-               cacheClass: FileCacheStorage::class,
+               // cacheClass は既定が FileCacheStorage で, rector 2.6.3 では
+               // 指定しても無視される (MemoryCacheStorage が撤去された) ため渡さない。
                cacheDirectory: './var/rector_cache'
            )
            // オプション: import文の整理

--- a/src/Eccube/Command/ComposerInstallCommand.php
+++ b/src/Eccube/Command/ComposerInstallCommand.php
@@ -42,6 +42,6 @@ class ComposerInstallCommand extends Command
     {
         $this->composerService->execInstall($input->getOption('dry-run'), $output);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Eccube/Command/ComposerRemoveCommand.php
+++ b/src/Eccube/Command/ComposerRemoveCommand.php
@@ -59,7 +59,7 @@ class ComposerRemoveCommand extends Command
         } catch (\Exception $e) {
             $io->error($e->getMessage());
 
-            return 1;
+            return Command::FAILURE;
         }
     }
 }

--- a/src/Eccube/Command/ComposerRequireAlreadyInstalledPluginsCommand.php
+++ b/src/Eccube/Command/ComposerRequireAlreadyInstalledPluginsCommand.php
@@ -14,6 +14,7 @@
 namespace Eccube\Command;
 
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Order;
 use Eccube\Common\Constant;
 use Eccube\Repository\PluginRepository;
 use Eccube\Service\Composer\ComposerApiService;
@@ -50,9 +51,7 @@ class ComposerRequireAlreadyInstalledPluginsCommand extends Command
         $packageNames = [];
         $unSupportedPlugins = [];
 
-        $criteria = Criteria::create()
-            ->where(Criteria::expr()->notIn('source', ['', '0']))
-            ->orderBy(['code' => 'ASC']);
+        $criteria = Criteria::create()->where(Criteria::expr()->notIn('source', ['', '0']))->orderBy(['code' => Order::Ascending]);
         $Plugins = $this->pluginRepository->matching($criteria);
 
         foreach ($Plugins as $Plugin) {
@@ -71,7 +70,7 @@ class ComposerRequireAlreadyInstalledPluginsCommand extends Command
             ]);
             $question = new ConfirmationQuestion($message);
             if (!$this->io->askQuestion($question)) {
-                return 0;
+                return Command::SUCCESS;
             }
         }
 
@@ -79,6 +78,6 @@ class ComposerRequireAlreadyInstalledPluginsCommand extends Command
             $this->composerService->execRequire(implode(' ', $packageNames), $this->io);
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Eccube/Command/ComposerRequireCommand.php
+++ b/src/Eccube/Command/ComposerRequireCommand.php
@@ -51,6 +51,6 @@ class ComposerRequireCommand extends Command
 
         $this->composerService->execRequire($packageName, $output, $input->getOption('from'));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Eccube/Command/ComposerUpdateCommand.php
+++ b/src/Eccube/Command/ComposerUpdateCommand.php
@@ -38,6 +38,6 @@ class ComposerUpdateCommand extends Command
     {
         $this->composerService->execUpdate($input->getOption('dry-run'), $output);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Eccube/Command/DeleteCartsCommand.php
+++ b/src/Eccube/Command/DeleteCartsCommand.php
@@ -99,7 +99,7 @@ class DeleteCartsCommand extends Command
 
         $this->io->success('Delete carts successful.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     protected function deleteCarts(\DateTime $dateTime): void

--- a/src/Eccube/Command/GenerateDummyDataCommand.php
+++ b/src/Eccube/Command/GenerateDummyDataCommand.php
@@ -25,7 +25,18 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'eccube:fixtures:generate', description: 'Dummy data generator')]
+#[AsCommand(name: 'eccube:fixtures:generate', description: 'Dummy data generator', help: <<<'TXT'
+The <info>%command.name%</info> command generate of dummy data.
+
+  <info>php %command.full_name%</info>
+
+Generate of dummy data with images.
+
+  <info>php %command.full_name% --without-image</info>
+
+Generate of dummy data without images, use for options to faster.
+;
+TXT)]
 class GenerateDummyDataCommand extends Command
 {
     public function __construct(protected ?Generator $generator = null, protected ?EntityManagerInterface $entityManager = null, protected ?DeliveryRepository $deliveryRepository = null, protected ?ProductRepository $productRepository = null)
@@ -41,20 +52,7 @@ class GenerateDummyDataCommand extends Command
             ->addOption('without-image', null, InputOption::VALUE_NONE, 'Do not generate images.')
             ->addOption('products', null, InputOption::VALUE_REQUIRED, 'Number of Products.', 100)
             ->addOption('orders', null, InputOption::VALUE_REQUIRED, 'Number of Orders.', 10)
-            ->addOption('customers', null, InputOption::VALUE_REQUIRED, 'Number of Customers.', 100)
-            ->setHelp(<<<EOF
-The <info>%command.name%</info> command generate of dummy data.
-
-  <info>php %command.full_name%</info>
-
-Generate of dummy data with images.
-
-  <info>php %command.full_name% --without-image</info>
-
-Generate of dummy data without images, use for options to faster.
-;
-EOF
-            );
+            ->addOption('customers', null, InputOption::VALUE_REQUIRED, 'Number of Customers.', 100);
     }
 
     #[\Override]
@@ -186,6 +184,6 @@ EOF
         $output->writeln('');
         $output->writeln(sprintf('%s <info>success</info>', 'eccube:fixtures:generate'));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Eccube/Command/GenerateProxyCommand.php
+++ b/src/Eccube/Command/GenerateProxyCommand.php
@@ -48,6 +48,6 @@ class GenerateProxyCommand extends Command
             $output
         );
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Eccube/Command/InstallerCommand.php
+++ b/src/Eccube/Command/InstallerCommand.php
@@ -272,13 +272,13 @@ class InstallerCommand extends Command
             } catch (ProcessFailedException $e) {
                 $this->io->error($e->getMessage());
 
-                return 1;
+                return Command::FAILURE;
             }
         }
 
         $this->io->success('EC-CUBE installation successful.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     protected function getDatabaseName(string $databaseUrl): string

--- a/src/Eccube/Command/LoadDataFixturesEccubeCommand.php
+++ b/src/Eccube/Command/LoadDataFixturesEccubeCommand.php
@@ -22,29 +22,22 @@ use Eccube\Doctrine\Common\CsvDataFixtures\Executor\DbalExecutor;
 use Eccube\Doctrine\Common\CsvDataFixtures\Loader;
 use Eccube\Entity\Member;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
-#[AsCommand(name: 'eccube:fixtures:load', description: 'Load data fixtures to your database.')]
+#[AsCommand(name: 'eccube:fixtures:load', description: 'Load data fixtures to your database.', help: <<<'TXT'
+The <info>%command.name%</info> command loads data fixtures from EC-CUBE.
+
+  <info>php %command.full_name%</info>
+TXT)]
 class LoadDataFixturesEccubeCommand extends DoctrineCommand
 {
     public function __construct(ManagerRegistry $registry, protected EccubeConfig $eccubeConfig, protected UserPasswordHasherInterface $passwordHasher)
     {
         parent::__construct($registry);
-    }
-
-    #[\Override]
-    protected function configure(): void
-    {
-        $this
-            ->setHelp(<<<EOF
-The <info>%command.name%</info> command loads data fixtures from EC-CUBE.
-
-  <info>php %command.full_name%</info>
-EOF
-            );
     }
 
     #[\Override]
@@ -134,6 +127,6 @@ EOF
 
         $output->writeln(sprintf('  <comment>></comment> <info>%s</info>', 'Finished Successful!'));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Eccube/Command/PluginDisableCommand.php
+++ b/src/Eccube/Command/PluginDisableCommand.php
@@ -42,14 +42,14 @@ class PluginDisableCommand extends Command
         if (empty($code)) {
             $io->error('code is required.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $plugin = $this->pluginRepository->findByCode($code);
         if (is_null($plugin)) {
             $io->error("Plugin `$code` is not found.");
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $this->pluginService->disable($plugin);
@@ -57,6 +57,6 @@ class PluginDisableCommand extends Command
 
         $io->success('Plugin Disabled.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Eccube/Command/PluginEnableCommand.php
+++ b/src/Eccube/Command/PluginEnableCommand.php
@@ -42,14 +42,14 @@ class PluginEnableCommand extends Command
         if (empty($code)) {
             $io->error('code is required.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $plugin = $this->pluginRepository->findByCode($code);
         if (is_null($plugin)) {
             $io->error("Plugin `$code` is not found.");
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if (!$plugin->isInitialized()) {
@@ -61,6 +61,6 @@ class PluginEnableCommand extends Command
 
         $io->success('Plugin Enabled.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Eccube/Command/PluginGenerateCommand.php
+++ b/src/Eccube/Command/PluginGenerateCommand.php
@@ -113,7 +113,7 @@ class PluginGenerateCommand extends Command
 
         $this->io->success(sprintf('Plugin was successfully created: %s %s %s', $name, $code, $version));
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function validateCode(mixed $code): string

--- a/src/Eccube/Command/PluginInstallCommand.php
+++ b/src/Eccube/Command/PluginInstallCommand.php
@@ -51,7 +51,7 @@ class PluginInstallCommand extends Command
             if ($this->pluginService->install($path, 0, $ifNotExists)) {
                 $io->success('Installed.');
 
-                return 0;
+                return Command::SUCCESS;
             }
         }
 
@@ -61,11 +61,11 @@ class PluginInstallCommand extends Command
             $this->clearCache($io);
             $io->success('Installed.');
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         $io->error('path or code is required.');
 
-        return 1;
+        return Command::FAILURE;
     }
 }

--- a/src/Eccube/Command/PluginSchemaUpdateCommand.php
+++ b/src/Eccube/Command/PluginSchemaUpdateCommand.php
@@ -43,7 +43,7 @@ class PluginSchemaUpdateCommand extends Command
         if (!$Plugin) {
             $io->error("No such plugin `{$code}`.");
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $config = $this->pluginService->readConfig($this->pluginService->calcPluginDir($code));
@@ -52,6 +52,6 @@ class PluginSchemaUpdateCommand extends Command
 
         $io->success('Schema Updated.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Eccube/Command/PluginUninstallCommand.php
+++ b/src/Eccube/Command/PluginUninstallCommand.php
@@ -44,14 +44,14 @@ class PluginUninstallCommand extends Command
         if (empty($code)) {
             $io->error('code is required.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $plugin = $this->pluginRepository->findByCode($code);
         if (is_null($plugin)) {
             $io->error("Plugin `$code` is not installed.");
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $this->pluginService->uninstall($plugin, $uninstallForce);
@@ -59,6 +59,6 @@ class PluginUninstallCommand extends Command
 
         $io->success('Uninstalled.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Eccube/Command/PluginUpdateCommand.php
+++ b/src/Eccube/Command/PluginUpdateCommand.php
@@ -44,7 +44,7 @@ class PluginUpdateCommand extends Command
         if (!$Plugin) {
             $io->error("No such plugin `{$code}`.");
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $config = $this->pluginService->readConfig($this->pluginService->calcPluginDir($code));
@@ -53,6 +53,6 @@ class PluginUpdateCommand extends Command
 
         $io->success('Updated.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Eccube/Controller/Admin/AdminController.php
+++ b/src/Eccube/Controller/Admin/AdminController.php
@@ -130,9 +130,7 @@ class AdminController extends AbstractController
 
         // 受注ステータスの一覧.
         $Criteria = new Criteria();
-        $Criteria
-            ->where($Criteria::expr()->notIn('id', $excludes))
-            ->orderBy(['sort_no' => 'ASC']);
+        $Criteria->where($Criteria::expr()->notIn('id', $excludes))->orderBy(['sort_no' => \Doctrine\Common\Collections\Order::Ascending]);
         $OrderStatuses = $this->orderStatusRepository->matching($Criteria);
 
         /**

--- a/src/Eccube/Controller/Admin/Content/FileController.php
+++ b/src/Eccube/Controller/Admin/Content/FileController.php
@@ -158,16 +158,8 @@ class FileController extends AbstractController
             ->add('create_file', TextType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Regex([
-                        'pattern' => '/[^[:alnum:]_.\\-]/',
-                        'match' => false,
-                        'message' => 'admin.content.file.folder_name_symbol_error',
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => "/^\.(.*)$/",
-                        'match' => false,
-                        'message' => 'admin.content.file.folder_name_period_error',
-                    ]),
+                    new Assert\Regex(pattern: '/[^[:alnum:]_.\\-]/', match: false, message: 'admin.content.file.folder_name_symbol_error'),
+                    new Assert\Regex(pattern: "/^\.(.*)$/", match: false, message: 'admin.content.file.folder_name_period_error'),
                 ],
             ])
             ->getForm();
@@ -273,9 +265,7 @@ class FileController extends AbstractController
             ->add('file', FileType::class, [
                 'multiple' => true,
                 'constraints' => [
-                    new Assert\NotBlank([
-                        'message' => 'admin.common.file_select_empty',
-                    ]),
+                    new Assert\NotBlank(message: 'admin.common.file_select_empty'),
                 ],
             ])
             ->add('create_file', TextType::class)

--- a/src/Eccube/Controller/Admin/Order/OrderController.php
+++ b/src/Eccube/Controller/Admin/Order/OrderController.php
@@ -471,10 +471,8 @@ class OrderController extends AbstractController
         $errors = $this->validator->validate(
             $trackingNumber,
             [
-                new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
-                new Assert\Regex(
-                    ['pattern' => '/^[0-9a-zA-Z-]+$/u', 'message' => trans('admin.order.tracking_number_error')]
-                ),
+                new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
+                new Assert\Regex(pattern: '/^[0-9a-zA-Z-]+$/u', message: trans('admin.order.tracking_number_error')),
             ]
         );
 

--- a/src/Eccube/Controller/Admin/Product/CsvImportController.php
+++ b/src/Eccube/Controller/Admin/Product/CsvImportController.php
@@ -322,7 +322,7 @@ class CsvImportController extends AbstractCsvImportController
                             if ($this->BaseInfo->isOptionProductDeliveryFee()) {
                                 if (isset($row[$headerByKey['delivery_fee']]) && StringUtil::isNotBlank($row[$headerByKey['delivery_fee']])) {
                                     $deliveryFee = str_replace(',', '', $row[$headerByKey['delivery_fee']]);
-                                    $errors = $this->validator->validate($deliveryFee, new GreaterThanOrEqual(['value' => 0]));
+                                    $errors = $this->validator->validate($deliveryFee, new GreaterThanOrEqual(value: 0));
                                     if ($errors->count() === 0) {
                                         $ProductClassOrg->setDeliveryFee($deliveryFee);
                                     } else {
@@ -336,7 +336,7 @@ class CsvImportController extends AbstractCsvImportController
                             if ($this->BaseInfo->isOptionProductTaxRule()) {
                                 if (isset($row[$headerByKey['tax_rate']]) && StringUtil::isNotBlank($row[$headerByKey['tax_rate']])) {
                                     $taxRate = $row[$headerByKey['tax_rate']];
-                                    $errors = $this->validator->validate($taxRate, new GreaterThanOrEqual(['value' => 0]));
+                                    $errors = $this->validator->validate($taxRate, new GreaterThanOrEqual(value: 0));
                                     if ($errors->count() === 0) {
                                         if ($ProductClassOrg->getTaxRule()) {
                                             // 商品別税率の設定があれば税率を更新
@@ -447,7 +447,7 @@ class CsvImportController extends AbstractCsvImportController
                                     if ($this->BaseInfo->isOptionProductDeliveryFee()) {
                                         if (isset($row[$headerByKey['delivery_fee']]) && StringUtil::isNotBlank($row[$headerByKey['delivery_fee']])) {
                                             $deliveryFee = str_replace(',', '', $row[$headerByKey['delivery_fee']]);
-                                            $errors = $this->validator->validate($deliveryFee, new GreaterThanOrEqual(['value' => 0]));
+                                            $errors = $this->validator->validate($deliveryFee, new GreaterThanOrEqual(value: 0));
                                             if ($errors->count() === 0) {
                                                 $pc->setDeliveryFee($deliveryFee);
                                             } else {
@@ -461,7 +461,7 @@ class CsvImportController extends AbstractCsvImportController
                                     if ($this->BaseInfo->isOptionProductTaxRule()) {
                                         if (isset($row[$headerByKey['tax_rate']]) && StringUtil::isNotBlank($row[$headerByKey['tax_rate']])) {
                                             $taxRate = $row[$headerByKey['tax_rate']];
-                                            $errors = $this->validator->validate($taxRate, new GreaterThanOrEqual(['value' => 0]));
+                                            $errors = $this->validator->validate($taxRate, new GreaterThanOrEqual(value: 0));
                                             if ($errors->count() === 0) {
                                                 if ($pc->getTaxRule()) {
                                                     // 商品別税率の設定があれば税率を更新
@@ -565,7 +565,7 @@ class CsvImportController extends AbstractCsvImportController
                                     if ($this->BaseInfo->isOptionProductDeliveryFee()) {
                                         if (isset($row[$headerByKey['delivery_fee']]) && StringUtil::isNotBlank($row[$headerByKey['delivery_fee']])) {
                                             $deliveryFee = str_replace(',', '', $row[$headerByKey['delivery_fee']]);
-                                            $errors = $this->validator->validate($deliveryFee, new GreaterThanOrEqual(['value' => 0]));
+                                            $errors = $this->validator->validate($deliveryFee, new GreaterThanOrEqual(value: 0));
                                             if ($errors->count() === 0) {
                                                 $ProductClass->setDeliveryFee($deliveryFee);
                                             } else {
@@ -579,7 +579,7 @@ class CsvImportController extends AbstractCsvImportController
                                     if ($this->BaseInfo->isOptionProductTaxRule()) {
                                         if (isset($row[$headerByKey['tax_rate']]) && StringUtil::isNotBlank($row[$headerByKey['tax_rate']])) {
                                             $taxRate = $row[$headerByKey['tax_rate']];
-                                            $errors = $this->validator->validate($taxRate, new GreaterThanOrEqual(['value' => 0]));
+                                            $errors = $this->validator->validate($taxRate, new GreaterThanOrEqual(value: 0));
                                             if ($errors->count() === 0) {
                                                 $TaxRule = $this->taxRuleRepository->newTaxRule();
                                                 $TaxRule->setTaxRate($taxRate);
@@ -1372,7 +1372,7 @@ class CsvImportController extends AbstractCsvImportController
 
         if (isset($row[$headerByKey['price01']]) && StringUtil::isNotBlank($row[$headerByKey['price01']])) {
             $price01 = str_replace(',', '', $row[$headerByKey['price01']]);
-            $errors = $this->validator->validate($price01, new GreaterThanOrEqual(['value' => 0]));
+            $errors = $this->validator->validate($price01, new GreaterThanOrEqual(value: 0));
             if ($errors->count() === 0) {
                 $ProductClass->setPrice01($price01);
             } else {
@@ -1383,7 +1383,7 @@ class CsvImportController extends AbstractCsvImportController
 
         if (isset($row[$headerByKey['price02']]) && StringUtil::isNotBlank($row[$headerByKey['price02']])) {
             $price02 = str_replace(',', '', $row[$headerByKey['price02']]);
-            $errors = $this->validator->validate($price02, new GreaterThanOrEqual(['value' => 0]));
+            $errors = $this->validator->validate($price02, new GreaterThanOrEqual(value: 0));
             if ($errors->count() === 0) {
                 $ProductClass->setPrice02($price02);
             } else {
@@ -1398,7 +1398,7 @@ class CsvImportController extends AbstractCsvImportController
         if ($this->BaseInfo->isOptionProductDeliveryFee()) {
             if (isset($row[$headerByKey['delivery_fee']]) && StringUtil::isNotBlank($row[$headerByKey['delivery_fee']])) {
                 $delivery_fee = str_replace(',', '', $row[$headerByKey['delivery_fee']]);
-                $errors = $this->validator->validate($delivery_fee, new GreaterThanOrEqual(['value' => 0]));
+                $errors = $this->validator->validate($delivery_fee, new GreaterThanOrEqual(value: 0));
                 if ($errors->count() === 0) {
                     $ProductClass->setDeliveryFee($delivery_fee);
                 } else {
@@ -1554,7 +1554,7 @@ class CsvImportController extends AbstractCsvImportController
         if (isset($row[$headerByKey['price01']])) {
             if ($row[$headerByKey['price01']] != '') {
                 $price01 = str_replace(',', '', $row[$headerByKey['price01']]);
-                $errors = $this->validator->validate($price01, new GreaterThanOrEqual(['value' => 0]));
+                $errors = $this->validator->validate($price01, new GreaterThanOrEqual(value: 0));
                 if ($errors->count() === 0) {
                     $ProductClass->setPrice01($price01);
                 } else {
@@ -1571,7 +1571,7 @@ class CsvImportController extends AbstractCsvImportController
             $this->addErrors($message);
         } else {
             $price02 = str_replace(',', '', $row[$headerByKey['price02']]);
-            $errors = $this->validator->validate($price02, new GreaterThanOrEqual(['value' => 0]));
+            $errors = $this->validator->validate($price02, new GreaterThanOrEqual(value: 0));
             if ($errors->count() === 0) {
                 $ProductClass->setPrice02($price02);
             } else {

--- a/src/Eccube/Controller/Admin/Setting/System/MasterdataController.php
+++ b/src/Eccube/Controller/Admin/Setting/System/MasterdataController.php
@@ -150,9 +150,7 @@ class MasterdataController extends AbstractController
                 foreach ($data['data'] as $key => $value) {
                     if ($value['id'] !== null && $value['name'] !== null) {
                         $entity = $repository->find($value['id']);
-                        if ($entity === null) {
-                            $entity = new $entityName();
-                        }
+                        $entity ??= new $entityName();
                         $entity->setId($value['id']);
                         $entity->setName($value['name']);
                         $entity->setSortNo($sortNo++);

--- a/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
+++ b/src/Eccube/Controller/Admin/Store/OwnerStoreController.php
@@ -217,9 +217,7 @@ class OwnerStoreController extends AbstractController
             [
                 new Assert\NotBlank(),
                 new Assert\Regex(
-                    [
-                        'pattern' => '/^[a-zA-Z0-9_]+$/',
-                    ]
+                    pattern: '/^[a-zA-Z0-9_]+$/'
                 ),
             ]
         );
@@ -308,9 +306,7 @@ class OwnerStoreController extends AbstractController
             [
                 new Assert\NotBlank(),
                 new Assert\Regex(
-                    [
-                        'pattern' => '/^[a-zA-Z0-9_]+$/',
-                    ]
+                    pattern: '/^[a-zA-Z0-9_]+$/'
                 ),
             ]
         );
@@ -326,9 +322,7 @@ class OwnerStoreController extends AbstractController
             [
                 new Assert\NotBlank(),
                 new Assert\Regex(
-                    [
-                        'pattern' => '/^[0-9.]+$/',
-                    ]
+                    pattern: '/^[0-9.]+$/'
                 ),
             ]
         );

--- a/src/Eccube/Controller/EntryController.php
+++ b/src/Eccube/Controller/EntryController.php
@@ -188,9 +188,7 @@ class EntryController extends AbstractController
             [
                 new Assert\NotBlank(),
                 new Assert\Regex(
-                    [
-                        'pattern' => '/^[a-zA-Z0-9]+$/',
-                    ]
+                    pattern: '/^[a-zA-Z0-9]+$/'
                 ),
             ]
         );

--- a/src/Eccube/Controller/ForgotController.php
+++ b/src/Eccube/Controller/ForgotController.php
@@ -151,9 +151,7 @@ class ForgotController extends AbstractController
             [
                 new Assert\NotBlank(),
                 new Assert\Regex(
-                    [
-                        'pattern' => '/^[a-zA-Z0-9]+$/',
-                    ]
+                    pattern: '/^[a-zA-Z0-9]+$/'
                 ),
             ]
         );

--- a/src/Eccube/Controller/Install/InstallController.php
+++ b/src/Eccube/Controller/Install/InstallController.php
@@ -285,10 +285,7 @@ class InstallController extends AbstractController
             $mailerUrl = $this->getParameter('eccube_mailer_dsn');
             $sessionData = array_merge($sessionData, $this->extractMailerUrl($mailerUrl));
         } else {
-            // 初期値設定
-            if (!isset($sessionData['admin_allow_hosts'])) {
-                $sessionData['admin_allow_hosts'] = '';
-            }
+            $sessionData['admin_allow_hosts'] ??= '';
             if (!isset($sessionData['smtp_host'])) {
                 $sessionData = array_merge($sessionData, $this->extractMailerUrl('smtp://localhost:25'));
             }
@@ -463,7 +460,7 @@ class InstallController extends AbstractController
         $forceSSL = isset($sessionData['admin_force_ssl']) && (bool) $sessionData['admin_force_ssl'];
         if ($forceSSL === false) {
             $forceSSL = '0';
-        } elseif ($forceSSL === true) {
+        } elseif ($forceSSL) {
             $forceSSL = '1';
         }
         $env = file_get_contents(__DIR__.'/../../../../.env.dist');
@@ -788,9 +785,7 @@ class InstallController extends AbstractController
             $options['smtp_host'] = 'smtp.gmail.com';
             $options['transport'] = 'smtp';
         }
-        if (!isset($options['smtp_port'])) {
-            $options['smtp_port'] = 'ssl' === $options['encryption'] ? 465 : 25;
-        }
+        $options['smtp_port'] ??= 'ssl' === $options['encryption'] ? 465 : 25;
         if (isset($options['smtp_username']) && !isset($options['auth_mode'])) {
             $options['auth_mode'] = 'plain';
         }

--- a/src/Eccube/Controller/NonMemberShoppingController.php
+++ b/src/Eccube/Controller/NonMemberShoppingController.php
@@ -223,10 +223,8 @@ class NonMemberShoppingController extends AbstractShoppingController
             $data['customer_name01'],
             [
                 new Assert\NotBlank(),
-                new Assert\Length(['max' => $this->eccubeConfig['eccube_name_len']]),
-                new Assert\Regex(
-                    ['pattern' => '/^[^\s ]+$/u', 'message' => 'form_error.not_contain_spaces']
-                ),
+                new Assert\Length(max: $this->eccubeConfig['eccube_name_len']),
+                new Assert\Regex(pattern: '/^[^\s ]+$/u', message: 'form_error.not_contain_spaces'),
             ]
         );
 
@@ -234,10 +232,8 @@ class NonMemberShoppingController extends AbstractShoppingController
             $data['customer_name02'],
             [
                 new Assert\NotBlank(),
-                new Assert\Length(['max' => $this->eccubeConfig['eccube_name_len']]),
-                new Assert\Regex(
-                    ['pattern' => '/^[^\s ]+$/u', 'message' => 'form_error.not_contain_spaces']
-                ),
+                new Assert\Length(max: $this->eccubeConfig['eccube_name_len']),
+                new Assert\Regex(pattern: '/^[^\s ]+$/u', message: 'form_error.not_contain_spaces'),
             ]
         );
 
@@ -250,8 +246,8 @@ class NonMemberShoppingController extends AbstractShoppingController
             $data['customer_kana01'],
             [
                 new Assert\NotBlank(),
-                new Assert\Length(['max' => $this->eccubeConfig['eccube_kana_len']]),
-                new Assert\Regex(['pattern' => '/^[ァ-ヶｦ-ﾟー]+$/u']),
+                new Assert\Length(max: $this->eccubeConfig['eccube_kana_len']),
+                new Assert\Regex(pattern: '/^[ァ-ヶｦ-ﾟー]+$/u'),
             ]
         );
         if (is_string($data['customer_kana02'])) {
@@ -263,14 +259,14 @@ class NonMemberShoppingController extends AbstractShoppingController
             $data['customer_kana02'],
             [
                 new Assert\NotBlank(),
-                new Assert\Length(['max' => $this->eccubeConfig['eccube_kana_len']]),
-                new Assert\Regex(['pattern' => '/^[ァ-ヶｦ-ﾟー]+$/u']),
+                new Assert\Length(max: $this->eccubeConfig['eccube_kana_len']),
+                new Assert\Regex(pattern: '/^[ァ-ヶｦ-ﾟー]+$/u'),
             ]);
 
         $errors[] = $this->validator->validate(
             $data['customer_company_name'],
             [
-                new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
             ]
         );
 
@@ -280,7 +276,7 @@ class NonMemberShoppingController extends AbstractShoppingController
                 new Assert\NotBlank(),
                 new Assert\Type(type: 'digit', message: 'form_error.numeric_only'),
                 new Assert\Length(
-                    ['max' => $this->eccubeConfig['eccube_tel_len_max']]
+                    max: $this->eccubeConfig['eccube_tel_len_max']
                 ),
             ]
         );
@@ -291,7 +287,7 @@ class NonMemberShoppingController extends AbstractShoppingController
                 new Assert\NotBlank(),
                 new Assert\Type(type: 'digit', message: 'form_error.numeric_only'),
                 new Assert\Length(
-                    ['max' => $this->eccubeConfig['eccube_postal_code']]
+                    max: $this->eccubeConfig['eccube_postal_code']
                 ),
             ]
         );
@@ -300,7 +296,7 @@ class NonMemberShoppingController extends AbstractShoppingController
             $data['customer_addr01'],
             [
                 new Assert\NotBlank(),
-                new Assert\Length(['max' => $this->eccubeConfig['eccube_address1_len']]),
+                new Assert\Length(max: $this->eccubeConfig['eccube_address1_len']),
             ]
         );
 
@@ -308,7 +304,7 @@ class NonMemberShoppingController extends AbstractShoppingController
             $data['customer_addr02'],
             [
                 new Assert\NotBlank(),
-                new Assert\Length(['max' => $this->eccubeConfig['eccube_address2_len']]),
+                new Assert\Length(max: $this->eccubeConfig['eccube_address2_len']),
             ]
         );
 

--- a/src/Eccube/DependencyInjection/Facade/LoggerFacade.php
+++ b/src/Eccube/DependencyInjection/Facade/LoggerFacade.php
@@ -33,9 +33,7 @@ class LoggerFacade
 
     public static function init(ContainerInterface $container, Logger $Logger): ?LoggerFacade
     {
-        if (null === self::$instance) {
-            self::$instance = new self($container, $Logger);
-        }
+        self::$instance ??= new self($container, $Logger);
 
         return self::$instance;
     }

--- a/src/Eccube/DependencyInjection/Facade/TranslatorFacade.php
+++ b/src/Eccube/DependencyInjection/Facade/TranslatorFacade.php
@@ -29,9 +29,7 @@ class TranslatorFacade
 
     public static function init(TranslatorInterface $Translator): ?TranslatorFacade
     {
-        if (null === self::$instance) {
-            self::$instance = new self($Translator);
-        }
+        self::$instance ??= new self($Translator);
 
         return self::$instance;
     }

--- a/src/Eccube/Doctrine/DBAL/Types/UTCDateTimeType.php
+++ b/src/Eccube/Doctrine/DBAL/Types/UTCDateTimeType.php
@@ -69,9 +69,7 @@ class UTCDateTimeType extends DateTimeType
 
     protected static function getUtcTimeZone(): \DateTimeZone
     {
-        if (is_null(self::$utc)) {
-            self::$utc = new \DateTimeZone('UTC');
-        }
+        self::$utc ??= new \DateTimeZone('UTC');
 
         return self::$utc;
     }

--- a/src/Eccube/Doctrine/DBAL/Types/UTCDateTimeTzType.php
+++ b/src/Eccube/Doctrine/DBAL/Types/UTCDateTimeTzType.php
@@ -69,9 +69,7 @@ class UTCDateTimeTzType extends DateTimeTzType
 
     protected static function getUtcTimeZone(): \DateTimeZone
     {
-        if (is_null(self::$utc)) {
-            self::$utc = new \DateTimeZone('UTC');
-        }
+        self::$utc ??= new \DateTimeZone('UTC');
 
         return self::$utc;
     }

--- a/src/Eccube/Entity/Category.php
+++ b/src/Eccube/Entity/Category.php
@@ -16,6 +16,7 @@ namespace Eccube\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Order;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping as ORM;
@@ -135,8 +136,7 @@ class Category extends AbstractEntity implements \Stringable
      */
     public function hasProductCategories(): bool
     {
-        $criteria = Criteria::create()
-        ->orderBy(['category_id' => Criteria::ASC])
+        $criteria = Criteria::create()->orderBy(['category_id' => Order::Ascending])
         ->setFirstResult(0)
         ->setMaxResults(1);
 

--- a/src/Eccube/Entity/Order.php
+++ b/src/Eccube/Entity/Order.php
@@ -1264,8 +1264,7 @@ class Order extends AbstractEntity implements PurchaseInterface, ItemHolderInter
      */
     public function getShippings(): Collection
     {
-        $criteria = Criteria::create()
-            ->orderBy(['name01' => Criteria::ASC, 'name02' => Criteria::ASC, 'id' => Criteria::ASC]);
+        $criteria = Criteria::create()->orderBy(['name01' => \Doctrine\Common\Collections\Order::Ascending, 'name02' => \Doctrine\Common\Collections\Order::Ascending, 'id' => \Doctrine\Common\Collections\Order::Ascending]);
 
         /** @var PersistentCollection<int,Shipping> $Shippings */
         $Shippings = $this->Shippings;

--- a/src/Eccube/Form/Type/AddCartType.php
+++ b/src/Eccube/Form/Type/AddCartType.php
@@ -64,7 +64,7 @@ class AddCartType extends AbstractType
                 'mapped' => false,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Regex(['pattern' => '/^\d+$/']),
+                    new Assert\Regex(pattern: '/^\d+$/'),
                 ], ])
             ->add(
                 $builder
@@ -88,10 +88,8 @@ class AddCartType extends AbstractType
                     ],
                     'constraints' => [
                         new Assert\NotBlank(),
-                        new Assert\GreaterThanOrEqual([
-                            'value' => 1,
-                        ]),
-                        new Assert\Regex(['pattern' => '/^\d+$/']),
+                        new Assert\GreaterThanOrEqual(value: 1),
+                        new Assert\Regex(pattern: '/^\d+$/'),
                     ],
                 ]);
             if ($Product->getProductClasses()) {
@@ -167,14 +165,5 @@ class AddCartType extends AbstractType
                 $child->vars['id'] .= $options['product']->getId();
             }
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'add_cart';
     }
 }

--- a/src/Eccube/Form/Type/AddressType.php
+++ b/src/Eccube/Form/Type/AddressType.php
@@ -101,7 +101,7 @@ class AddressType extends AbstractType
             'pref_options' => ['constraints' => [], 'attr' => ['class' => 'p-region-id']],
             'addr01_options' => [
                 'constraints' => [
-                    new Assert\Length(['max' => $this->config['eccube_address1_len']]),
+                    new Assert\Length(max: $this->config['eccube_address1_len']),
                 ],
                 'attr' => [
                     'class' => 'p-locality p-street-address',
@@ -110,7 +110,7 @@ class AddressType extends AbstractType
             ],
             'addr02_options' => [
                 'constraints' => [
-                    new Assert\Length(['max' => $this->config['eccube_address2_len']]),
+                    new Assert\Length(max: $this->config['eccube_address2_len']),
                 ],
                 'attr' => [
                     'class' => 'p-extended-address',
@@ -124,11 +124,5 @@ class AddressType extends AbstractType
             'inherit_data' => true,
             'trim' => true,
         ]);
-    }
-
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'address';
     }
 }

--- a/src/Eccube/Form/Type/AddressType.php
+++ b/src/Eccube/Form/Type/AddressType.php
@@ -61,9 +61,7 @@ class AddressType extends AbstractType
             ], $options['addr02_options']['constraints']);
         }
 
-        if (!isset($options['options']['error_bubbling'])) {
-            $options['options']['error_bubbling'] = $options['error_bubbling'];
-        }
+        $options['options']['error_bubbling'] ??= $options['error_bubbling'];
 
         $builder
             ->add($options['pref_name'], PrefType::class, array_merge_recursive($options['options'], $options['pref_options']))

--- a/src/Eccube/Form/Type/Admin/AuthenticationType.php
+++ b/src/Eccube/Form/Type/Admin/AuthenticationType.php
@@ -44,7 +44,7 @@ class AuthenticationType extends AbstractType
                 'label' => 'admin.store.setting.api_key',
                 'required' => false,
                 'constraints' => [
-                    new Assert\Regex(['pattern' => '/^[0-9a-zA-Z]+$/']),
+                    new Assert\Regex(pattern: '/^[0-9a-zA-Z]+$/'),
                 ],
             ])
             ->add('php_path', TextType::class,
@@ -52,9 +52,7 @@ class AuthenticationType extends AbstractType
                     'label' => 'admin.store.setting.php_path',
                     'required' => false,
                     'constraints' => [
-                        new Assert\Length([
-                            'max' => $this->eccubeConfig->get('eccube_smtext_len'),
-                        ]),
+                        new Assert\Length(max: $this->eccubeConfig->get('eccube_smtext_len')),
                     ],
                 ]);
     }

--- a/src/Eccube/Form/Type/Admin/AuthorityRoleType.php
+++ b/src/Eccube/Form/Type/Admin/AuthorityRoleType.php
@@ -46,10 +46,7 @@ class AuthorityRoleType extends AbstractType
             ->add('deny_url', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Regex([
-                        'pattern' => '/^\\/.*/',
-                        'message' => trans('admin.setting.system.authority.deny_url_is_invalid'),
-                    ]),
+                    new Regex(pattern: '/^\\/.*/', message: trans('admin.setting.system.authority.deny_url_is_invalid')),
                 ],
             ])
             ->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event): void {

--- a/src/Eccube/Form/Type/Admin/BlockType.php
+++ b/src/Eccube/Form/Type/Admin/BlockType.php
@@ -53,24 +53,16 @@ class BlockType extends AbstractType
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('file_name', TextType::class, [
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => '/^[0-9a-zA-Z\/_]+$/',
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => '/^(?!.*\/\/).+$/',
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
+                    new Assert\Regex(pattern: '/^[0-9a-zA-Z\/_]+$/'),
+                    new Assert\Regex(pattern: '/^(?!.*\/\/).+$/'),
                 ],
             ])
             ->add('block_html', TextareaType::class, [
@@ -123,14 +115,5 @@ class BlockType extends AbstractType
         $resolver->setDefaults([
             'data_class' => Block::class,
         ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'block';
     }
 }

--- a/src/Eccube/Form/Type/Admin/CalendarType.php
+++ b/src/Eccube/Form/Type/Admin/CalendarType.php
@@ -51,9 +51,7 @@ class CalendarType extends AbstractType
             ->add('title', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('holiday', DateType::class, [
@@ -63,10 +61,7 @@ class CalendarType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -84,10 +79,7 @@ class CalendarType extends AbstractType
             $errors = $this->validator->validate(
                 $Calendar->getHoliday(),
                 [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ]
             );
 
@@ -124,14 +116,5 @@ class CalendarType extends AbstractType
         $resolver->setDefaults([
             'data_class' => Calendar::class,
         ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'calendar';
     }
 }

--- a/src/Eccube/Form/Type/Admin/CategoryType.php
+++ b/src/Eccube/Form/Type/Admin/CategoryType.php
@@ -42,9 +42,7 @@ class CategoryType extends AbstractType
             ->add('name', TextType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
         ;

--- a/src/Eccube/Form/Type/Admin/ChangePasswordType.php
+++ b/src/Eccube/Form/Type/Admin/ChangePasswordType.php
@@ -45,19 +45,13 @@ class ChangePasswordType extends AbstractType
     {
         $changePasswordConstraints = [
             new Assert\NotBlank(),
-            new Assert\Length([
-                'min' => $this->eccubeConfig['eccube_password_min_len'],
-                'max' => $this->eccubeConfig['eccube_password_max_len'],
-            ]),
-            new Assert\Regex([
-                'pattern' => $this->eccubeConfig['eccube_password_pattern'],
-                'message' => 'form_error.password_pattern_invalid',
-            ]),
+            new Assert\Length(min: $this->eccubeConfig['eccube_password_min_len'], max: $this->eccubeConfig['eccube_password_max_len']),
+            new Assert\Regex(pattern: $this->eccubeConfig['eccube_password_pattern'], message: 'form_error.password_pattern_invalid'),
             new PasswordBlocklist(),
         ];
         // NIST SP 800-63B-4 対応の漏洩パスワードチェック. 閉域網等では config で無効化できる.
         if ($this->eccubeConfig['eccube_password_compromised_check']) {
-            $changePasswordConstraints[] = new Assert\NotCompromisedPassword(['skipOnError' => true]);
+            $changePasswordConstraints[] = new Assert\NotCompromisedPassword(skipOnError: true);
         }
 
         // 検証と保存を同一の正規化済み値で行うため, 検証前(PRE_SUBMIT)に新パスワードを NFKC 正規化する.

--- a/src/Eccube/Form/Type/Admin/ClassCategoryType.php
+++ b/src/Eccube/Form/Type/Admin/ClassCategoryType.php
@@ -40,18 +40,14 @@ class ClassCategoryType extends AbstractType
             ->add('name', TextType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('backend_name', TextType::class, [
                 'label' => 'classname.label.backend_name',
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('visible', ChoiceType::class, [

--- a/src/Eccube/Form/Type/Admin/ClassNameType.php
+++ b/src/Eccube/Form/Type/Admin/ClassNameType.php
@@ -44,17 +44,13 @@ class ClassNameType extends AbstractType
             ->add('name', TextType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('backend_name', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
         ;

--- a/src/Eccube/Form/Type/Admin/CsvImportType.php
+++ b/src/Eccube/Form/Type/Admin/CsvImportType.php
@@ -51,9 +51,7 @@ class CsvImportType extends AbstractType
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\File([
-                        'maxSize' => $this->csvMaxSize.'M',
-                    ]),
+                    new Assert\File(maxSize: $this->csvMaxSize.'M'),
                 ],
             ])
             ->add('is_split_csv', CheckboxType::class, [

--- a/src/Eccube/Form/Type/Admin/CustomerType.php
+++ b/src/Eccube/Form/Type/Admin/CustomerType.php
@@ -65,9 +65,7 @@ class CustomerType extends AbstractType
             ->add('company_name', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('postal_code', PostalType::class, [
@@ -84,9 +82,7 @@ class CustomerType extends AbstractType
                 'constraints' => [
                     new Assert\NotBlank(),
                     new Email(null, null, $this->eccubeConfig['eccube_rfc_email_check'] ? 'strict' : null),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_email_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_email_len']),
                 ],
                 'attr' => [
                     'placeholder' => 'common.mail_address_sample',
@@ -105,14 +101,8 @@ class CustomerType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\LessThanOrEqual([
-                        'value' => date('Y-m-d', strtotime('-1 day')),
-                        'message' => 'form_error.select_is_future_or_now_date',
-                    ]),
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\LessThanOrEqual(value: date('Y-m-d', strtotime('-1 day')), message: 'form_error.select_is_future_or_now_date'),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
             ])
             ->add('plain_password', RepeatedPasswordType::class)
@@ -129,18 +119,14 @@ class CustomerType extends AbstractType
                     'required' => false,
                     'constraints' => [
                         new Assert\NotBlank(),
-                        new Assert\Range([
-                            'min' => '-'.$this->eccubeConfig['eccube_price_max'],
-                            'max' => $this->eccubeConfig['eccube_price_max']]),
+                        new Assert\Range(min: '-'.$this->eccubeConfig['eccube_price_max'], max: $this->eccubeConfig['eccube_price_max']),
                     ],
                 ]
             )
             ->add('note', TextareaType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_ltext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
                 ],
             ]);
 

--- a/src/Eccube/Form/Type/Admin/DeliveryFeeType.php
+++ b/src/Eccube/Form/Type/Admin/DeliveryFeeType.php
@@ -46,13 +46,4 @@ class DeliveryFeeType extends AbstractType
             'data_class' => DeliveryFee::class,
         ]);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'delivery_fee';
-    }
 }

--- a/src/Eccube/Form/Type/Admin/DeliveryTimeType.php
+++ b/src/Eccube/Form/Type/Admin/DeliveryTimeType.php
@@ -78,13 +78,4 @@ class DeliveryTimeType extends AbstractType
                 ->orderBy('dt.sort_no', 'ASC'),
         ]);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'delivery_time';
-    }
 }

--- a/src/Eccube/Form/Type/Admin/DeliveryType.php
+++ b/src/Eccube/Form/Type/Admin/DeliveryType.php
@@ -46,20 +46,20 @@ class DeliveryType extends AbstractType
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('service_name', TextType::class, [
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('description', TextareaType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_ltext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
                 ],
             ])
             ->add('confirm_url', TextType::class, [
@@ -119,14 +119,5 @@ class DeliveryType extends AbstractType
         $resolver->setDefaults([
             'data_class' => Delivery::class,
         ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'delivery';
     }
 }

--- a/src/Eccube/Form/Type/Admin/LogType.php
+++ b/src/Eccube/Form/Type/Admin/LogType.php
@@ -73,7 +73,7 @@ class LogType extends AbstractType
                 ],
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Range(['min' => 1, 'max' => 50000]),
+                    new Assert\Range(min: 1, max: 50000),
                 ],
             ])
             ->add('log_level', ChoiceType::class, [
@@ -99,7 +99,7 @@ class LogType extends AbstractType
                     'placeholder' => 'admin.setting.system.log.keyword_placeholder',
                 ],
                 'constraints' => [
-                    new Assert\Length(['max' => 255]),
+                    new Assert\Length(max: 255),
                 ],
             ])
             ->add('download', SubmitType::class, [

--- a/src/Eccube/Form/Type/Admin/MailType.php
+++ b/src/Eccube/Form/Type/Admin/MailType.php
@@ -50,14 +50,14 @@ class MailType extends AbstractType
             ->add('name', TextType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('mail_subject', TextType::class, [
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('tpl_data', TextareaType::class, [
@@ -85,8 +85,8 @@ class MailType extends AbstractType
                 $form->add('file_name', TextType::class, [
                     'constraints' => [
                         new Assert\NotBlank(),
-                        new Assert\Regex(['pattern' => '/^[0-9a-z_-]+$/']),
-                        new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                        new Assert\Regex(pattern: '/^[0-9a-z_-]+$/'),
+                        new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                     ],
                 ]);
             }
@@ -116,14 +116,5 @@ class MailType extends AbstractType
         $resolver->setDefaults([
             'data_class' => MailTemplate::class,
         ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'mail';
     }
 }

--- a/src/Eccube/Form/Type/Admin/MainEditType.php
+++ b/src/Eccube/Form/Type/Admin/MainEditType.php
@@ -54,33 +54,23 @@ class MainEditType extends AbstractType
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('url', TextType::class, [
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => '/^([0-9a-zA-Z_\-]+\/?)+(?<!\/)$/',
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
+                    new Assert\Regex(pattern: '/^([0-9a-zA-Z_\-]+\/?)+(?<!\/)$/'),
                 ],
             ])
             ->add('file_name', TextType::class, [
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => '/^([0-9a-zA-Z_\-]+\/?)+$/',
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
+                    new Assert\Regex(pattern: '/^([0-9a-zA-Z_\-]+\/?)+$/'),
                 ],
             ])
             ->add('tpl_data', TextareaType::class, [
@@ -95,40 +85,30 @@ class MainEditType extends AbstractType
             ->add('author', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('description', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('keyword', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('meta_robots', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])->add('meta_tags', TextareaType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_ltext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
                 ],
             ])
             ->add('PcLayout', EntityType::class, [
@@ -267,14 +247,5 @@ class MainEditType extends AbstractType
         $resolver->setDefaults([
             'data_class' => Page::class,
         ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'main_edit';
     }
 }

--- a/src/Eccube/Form/Type/Admin/MasterdataDataType.php
+++ b/src/Eccube/Form/Type/Admin/MasterdataDataType.php
@@ -46,13 +46,8 @@ class MasterdataDataType extends AbstractType
             ->add('id', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_int_len'],
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => '/^\d+$/u',
-                        'message' => 'form_error.numeric_only',
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_int_len']),
+                    new Assert\Regex(pattern: '/^\d+$/u', message: 'form_error.numeric_only'),
                 ],
             ])
             ->add('name', TextType::class, [

--- a/src/Eccube/Form/Type/Admin/MemberType.php
+++ b/src/Eccube/Form/Type/Admin/MemberType.php
@@ -52,33 +52,27 @@ class MemberType extends AbstractType
         // 長さ・パターンに加えてブロックリスト・漏洩チェックもここで明示的に付与する.
         $passwordConstraints = [
             new Assert\NotBlank(),
-            new Assert\Length([
-                'min' => $this->eccubeConfig['eccube_password_min_len'],
-                'max' => $this->eccubeConfig['eccube_password_max_len'],
-            ]),
-            new Assert\Regex([
-                'pattern' => $this->eccubeConfig['eccube_password_pattern'],
-                'message' => 'form_error.password_pattern_invalid',
-            ]),
+            new Assert\Length(min: $this->eccubeConfig['eccube_password_min_len'], max: $this->eccubeConfig['eccube_password_max_len']),
+            new Assert\Regex(pattern: $this->eccubeConfig['eccube_password_pattern'], message: 'form_error.password_pattern_invalid'),
             new PasswordBlocklist(),
         ];
         // NIST SP 800-63B-4 対応の漏洩パスワードチェック. 閉域網等では config で無効化できる.
         if ($this->eccubeConfig['eccube_password_compromised_check']) {
-            $passwordConstraints[] = new Assert\NotCompromisedPassword(['skipOnError' => true]);
+            $passwordConstraints[] = new Assert\NotCompromisedPassword(skipOnError: true);
         }
 
         $builder
             ->add('name', TextType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('department', TextType::class, [
                 'required' => false,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('plain_password', RepeatedPasswordType::class, [
@@ -113,14 +107,8 @@ class MemberType extends AbstractType
 
             $options = [
                 'constraints' => [
-                    new Assert\Length([
-                        'min' => $this->eccubeConfig['eccube_id_min_len'],
-                        'max' => $this->eccubeConfig['eccube_id_max_len'],
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => '/^[[:graph:][:space:]]+$/i',
-                        'message' => 'form_error.graph_only',
-                    ]),
+                    new Assert\Length(min: $this->eccubeConfig['eccube_id_min_len'], max: $this->eccubeConfig['eccube_id_max_len']),
+                    new Assert\Regex(pattern: '/^[[:graph:][:space:]]+$/i', message: 'form_error.graph_only'),
                 ],
             ];
 

--- a/src/Eccube/Form/Type/Admin/NewsType.php
+++ b/src/Eccube/Form/Type/Admin/NewsType.php
@@ -47,24 +47,21 @@ class NewsType extends AbstractType
                 'with_seconds' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
             ])
             ->add('title', TextType::class, [
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_mtext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_mtext_len']),
                 ],
             ])
             ->add('url', TextType::class, [
                 'required' => false,
                 'constraints' => [
                     new Assert\Url(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_mtext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_mtext_len']),
                 ],
             ])
             ->add('link_method', CheckboxType::class, [
@@ -79,7 +76,7 @@ class NewsType extends AbstractType
                     'rows' => 8,
                 ],
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_ltext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
                 ],
             ])
             ->add('visible', ChoiceType::class, [

--- a/src/Eccube/Form/Type/Admin/OrderItemType.php
+++ b/src/Eccube/Form/Type/Admin/OrderItemType.php
@@ -298,15 +298,6 @@ class OrderItemType extends AbstractType
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'order_item';
-    }
-
     protected function addErrorsIfExists(FormInterface $form, ConstraintViolationListInterface $errors): void
     {
         if (count($errors) < 1) {

--- a/src/Eccube/Form/Type/Admin/OrderPdfType.php
+++ b/src/Eccube/Form/Type/Admin/OrderPdfType.php
@@ -64,10 +64,7 @@ class OrderPdfType extends AbstractType
                 'data' => new \DateTime(),
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'data-target' => '#'.$this->getBlockPrefix().'_issue_date',
@@ -79,7 +76,7 @@ class OrderPdfType extends AbstractType
                 'attr' => ['maxlength' => $config['eccube_stext_len']],
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $config['eccube_stext_len']]),
+                    new Assert\Length(max: $config['eccube_stext_len']),
                 ],
             ])
             ->add('download_kind', ChoiceType::class, [
@@ -98,7 +95,7 @@ class OrderPdfType extends AbstractType
                 'required' => false,
                 'attr' => ['maxlength' => $config['eccube_order_pdf_message_len']],
                 'constraints' => [
-                    new Assert\Length(['max' => $config['eccube_order_pdf_message_len']]),
+                    new Assert\Length(max: $config['eccube_order_pdf_message_len']),
                 ],
                 'trim' => false,
             ])
@@ -106,7 +103,7 @@ class OrderPdfType extends AbstractType
                 'required' => false,
                 'attr' => ['maxlength' => $config['eccube_order_pdf_message_len']],
                 'constraints' => [
-                    new Assert\Length(['max' => $config['eccube_order_pdf_message_len']]),
+                    new Assert\Length(max: $config['eccube_order_pdf_message_len']),
                 ],
                 'trim' => false,
             ])
@@ -114,7 +111,7 @@ class OrderPdfType extends AbstractType
                 'required' => false,
                 'attr' => ['maxlength' => $config['eccube_order_pdf_message_len']],
                 'constraints' => [
-                    new Assert\Length(['max' => $config['eccube_order_pdf_message_len']]),
+                    new Assert\Length(max: $config['eccube_order_pdf_message_len']),
                 ],
                 'trim' => false,
             ])
@@ -123,21 +120,21 @@ class OrderPdfType extends AbstractType
                 'required' => false,
                 'attr' => ['maxlength' => $config['eccube_stext_len']],
                 'constraints' => [
-                    new Assert\Length(['max' => $config['eccube_stext_len']]),
+                    new Assert\Length(max: $config['eccube_stext_len']),
                 ],
             ])
             ->add('note2', TextType::class, [
                 'required' => false,
                 'attr' => ['maxlength' => $config['eccube_stext_len']],
                 'constraints' => [
-                    new Assert\Length(['max' => $config['eccube_stext_len']]),
+                    new Assert\Length(max: $config['eccube_stext_len']),
                 ],
             ])
             ->add('note3', TextType::class, [
                 'required' => false,
                 'attr' => ['maxlength' => $config['eccube_stext_len']],
                 'constraints' => [
-                    new Assert\Length(['max' => $config['eccube_stext_len']]),
+                    new Assert\Length(max: $config['eccube_stext_len']),
                 ],
             ])
             ->add('default', CheckboxType::class, [

--- a/src/Eccube/Form/Type/Admin/OrderStatusSettingType.php
+++ b/src/Eccube/Form/Type/Admin/OrderStatusSettingType.php
@@ -45,21 +45,21 @@ class OrderStatusSettingType extends AbstractType
             ->add('name', TextType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('customer_order_status_name', TextType::class, [
                 'mapped' => false,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('color', ColorType::class, [
                 'mapped' => false,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('display_order_count', ToggleSwitchType::class, [

--- a/src/Eccube/Form/Type/Admin/OrderType.php
+++ b/src/Eccube/Form/Type/Admin/OrderType.php
@@ -172,10 +172,7 @@ class OrderType extends AbstractType
                 'widget' => 'single_text',
                 'with_seconds' => true,
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
             ])
             ->add('Payment', EntityType::class, [
@@ -236,15 +233,6 @@ class OrderType extends AbstractType
         $resolver->setDefaults([
             'data_class' => Order::class,
         ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'order';
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/PaymentRegisterType.php
+++ b/src/Eccube/Form/Type/Admin/PaymentRegisterType.php
@@ -49,7 +49,7 @@ class PaymentRegisterType extends AbstractType
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('rule_min', PriceType::class, [
@@ -62,10 +62,7 @@ class PaymentRegisterType extends AbstractType
                     // new Assert\Length(array(
                     //     'max' => $app['config']['int_len'],
                     // )),
-                    new Assert\Regex([
-                        'pattern' => "/^\d+$/u",
-                        'message' => 'form_error.numeric_only',
-                    ]),
+                    new Assert\Regex(pattern: "/^\d+$/u", message: 'form_error.numeric_only'),
                 ],
             ])
             ->add('rule_max', PriceType::class, [
@@ -108,14 +105,5 @@ class PaymentRegisterType extends AbstractType
         $resolver->setDefaults([
             'data_class' => Payment::class,
         ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'payment_register';
     }
 }

--- a/src/Eccube/Form/Type/Admin/PluginLocalInstallType.php
+++ b/src/Eccube/Form/Type/Admin/PluginLocalInstallType.php
@@ -35,20 +35,8 @@ class PluginLocalInstallType extends AbstractType
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\File([
-                        'mimeTypes' => ['application/zip', 'application/x-tar', 'application/x-gzip', 'application/gzip'],
-                        'mimeTypesMessage' => 'admin.store.template.invalid_upload_file',
-                    ]),
+                    new Assert\File(mimeTypes: ['application/zip', 'application/x-tar', 'application/x-gzip', 'application/gzip'], mimeTypesMessage: 'admin.store.template.invalid_upload_file'),
                 ],
             ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'plugin_local_install';
     }
 }

--- a/src/Eccube/Form/Type/Admin/PluginManagementType.php
+++ b/src/Eccube/Form/Type/Admin/PluginManagementType.php
@@ -44,22 +44,10 @@ class PluginManagementType extends AbstractType
                 'mapped' => false,
                 'required' => false,
                 'constraints' => [
-                    new Assert\NotBlank(['message' => 'ファイルを選択してください。']),
-                    new Assert\File([
-                        'mimeTypes' => ['application/zip', 'application/x-tar', 'application/x-gzip', 'application/gzip'],
-                        'mimeTypesMessage' => 'zipファイル、tarファイル、tar.gzファイルのいずれかをアップロードしてください。',
-                    ]),
+                    new Assert\NotBlank(message: 'ファイルを選択してください。'),
+                    new Assert\File(mimeTypes: ['application/zip', 'application/x-tar', 'application/x-gzip', 'application/gzip'], mimeTypesMessage: 'zipファイル、tarファイル、tar.gzファイルのいずれかをアップロードしてください。'),
                 ],
             ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'plugin_management';
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/ProductClassEditType.php
+++ b/src/Eccube/Form/Type/Admin/ProductClassEditType.php
@@ -64,9 +64,7 @@ class ProductClassEditType extends AbstractType
             ->add('code', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('stock', IntegerType::class, [
@@ -186,10 +184,7 @@ class ProductClassEditType extends AbstractType
 
             // 在庫数
             $errors = $this->validator->validate($data['stock'], [
-                new Assert\Regex([
-                    'pattern' => "/^\d+$/u",
-                    'message' => 'form_error.numeric_only',
-                ]),
+                new Assert\Regex(pattern: "/^\d+$/u", message: 'form_error.numeric_only'),
             ]);
             $this->addErrors('stock', $form, $errors);
 
@@ -200,16 +195,9 @@ class ProductClassEditType extends AbstractType
 
             // 販売制限数
             $errors = $this->validator->validate($data['sale_limit'], [
-                new Assert\Length([
-                    'max' => 10,
-                ]),
-                new Assert\GreaterThanOrEqual([
-                    'value' => 1,
-                ]),
-                new Assert\Regex([
-                    'pattern' => "/^\d+$/u",
-                    'message' => 'form_error.numeric_only',
-                ]),
+                new Assert\Length(max: 10),
+                new Assert\GreaterThanOrEqual(value: 1),
+                new Assert\Regex(pattern: "/^\d+$/u", message: 'form_error.numeric_only'),
             ]);
             $this->addErrors('sale_limit', $form, $errors);
 
@@ -222,11 +210,8 @@ class ProductClassEditType extends AbstractType
 
             // 税率
             $errors = $this->validator->validate($data['tax_rate'], [
-                new Assert\Range(['min' => 0, 'max' => 100]),
-                new Assert\Regex([
-                    'pattern' => "/^\d+(\.\d+)?$/",
-                    'message' => 'form_error.float_only',
-                ]),
+                new Assert\Range(min: 0, max: 100),
+                new Assert\Regex(pattern: "/^\d+(\.\d+)?$/", message: 'form_error.float_only'),
             ]);
             $this->addErrors('tax_rate', $form, $errors);
 

--- a/src/Eccube/Form/Type/Admin/ProductClassType.php
+++ b/src/Eccube/Form/Type/Admin/ProductClassType.php
@@ -53,18 +53,13 @@ class ProductClassType extends AbstractType
             ->add('code', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('stock', NumberType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Regex([
-                        'pattern' => "/^\d+$/u",
-                        'message' => 'form_error.numeric_only',
-                    ]),
+                    new Assert\Regex(pattern: "/^\d+$/u", message: 'form_error.numeric_only'),
                 ],
             ])
             ->add('stock_unlimited', CheckboxType::class, [
@@ -75,16 +70,9 @@ class ProductClassType extends AbstractType
             ->add('sale_limit', NumberType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => 10,
-                    ]),
-                    new Assert\GreaterThanOrEqual([
-                        'value' => 1,
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => "/^\d+$/u",
-                        'message' => 'form_error.numeric_only',
-                    ]),
+                    new Assert\Length(max: 10),
+                    new Assert\GreaterThanOrEqual(value: 1),
+                    new Assert\Regex(pattern: "/^\d+$/u", message: 'form_error.numeric_only'),
                 ],
             ])
             ->add('price01', PriceType::class, [
@@ -95,11 +83,8 @@ class ProductClassType extends AbstractType
             ->add('tax_rate', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Range(['min' => 0, 'max' => 100]),
-                    new Assert\Regex([
-                        'pattern' => "/^\d+(\.\d+)?$/",
-                        'message' => 'form_error.float_only',
-                    ]),
+                    new Assert\Range(min: 0, max: 100),
+                    new Assert\Regex(pattern: "/^\d+(\.\d+)?$/", message: 'form_error.float_only'),
                 ],
             ])
             ->add('delivery_fee', PriceType::class, [

--- a/src/Eccube/Form/Type/Admin/ProductTag.php
+++ b/src/Eccube/Form/Type/Admin/ProductTag.php
@@ -40,9 +40,7 @@ class ProductTag extends AbstractType
             ->add('name', TextType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ]);
     }

--- a/src/Eccube/Form/Type/Admin/ProductType.php
+++ b/src/Eccube/Form/Type/Admin/ProductType.php
@@ -64,7 +64,7 @@ class ProductType extends AbstractType
             ->add('name', TextType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('product_image', FileType::class, [
@@ -75,14 +75,14 @@ class ProductType extends AbstractType
             ->add('description_detail', TextareaType::class, [
                 'purify_html' => true,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_ltext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
                 ],
             ])
             ->add('description_list', TextareaType::class, [
                 'purify_html' => true,
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_ltext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
                 ],
             ])
             ->add('Category', ChoiceType::class, [
@@ -107,7 +107,7 @@ class ProductType extends AbstractType
             ->add('search_word', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_ltext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
                 ],
             ])
             // サブ情報
@@ -116,13 +116,13 @@ class ProductType extends AbstractType
                 'required' => false,
                 'constraints' => [
                     new TwigLint(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_lltext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_lltext_len']),
                 ],
             ])
             ->add('order_memo', TextareaType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_lltext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_lltext_len']),
                 ],
             ])
 
@@ -135,7 +135,7 @@ class ProductType extends AbstractType
             ->add('note', TextareaType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_ltext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
                 ],
             ])
 

--- a/src/Eccube/Form/Type/Admin/SearchCustomerType.php
+++ b/src/Eccube/Form/Type/Admin/SearchCustomerType.php
@@ -59,7 +59,7 @@ class SearchCustomerType extends AbstractType
                 'label' => 'admin.customer.multi_search_label',
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('customer_status', CustomerStatusType::class, [
@@ -94,10 +94,7 @@ class SearchCustomerType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -112,10 +109,7 @@ class SearchCustomerType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -135,35 +129,35 @@ class SearchCustomerType extends AbstractType
                 'label' => 'admin.order.purchase_product',
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('buy_total_start', PriceType::class, [
                 'label' => 'admin.order.purchase_price__start',
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_price_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_price_len']),
                 ],
             ])
             ->add('buy_total_end', PriceType::class, [
                 'label' => 'admin.order.purchase_price__end',
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_price_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_price_len']),
                 ],
             ])
             ->add('buy_times_start', IntegerType::class, [
                 'label' => 'admin.order.purchase_count__start',
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_int_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_int_len']),
                 ],
             ])
             ->add('buy_times_end', IntegerType::class, [
                 'label' => 'admin.order.purchase_count__end',
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_int_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_int_len']),
                 ],
             ])
             ->add('create_date_start', DateType::class, [
@@ -173,10 +167,7 @@ class SearchCustomerType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -190,10 +181,7 @@ class SearchCustomerType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -208,10 +196,7 @@ class SearchCustomerType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -225,10 +210,7 @@ class SearchCustomerType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -243,10 +225,7 @@ class SearchCustomerType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -260,10 +239,7 @@ class SearchCustomerType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -278,10 +254,7 @@ class SearchCustomerType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -295,10 +268,7 @@ class SearchCustomerType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -313,10 +283,7 @@ class SearchCustomerType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -330,10 +297,7 @@ class SearchCustomerType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -348,10 +312,7 @@ class SearchCustomerType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -365,10 +326,7 @@ class SearchCustomerType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',

--- a/src/Eccube/Form/Type/Admin/SearchLoginHistoryType.php
+++ b/src/Eccube/Form/Type/Admin/SearchLoginHistoryType.php
@@ -44,21 +44,21 @@ class SearchLoginHistoryType extends AbstractType
                 'label' => 'admin.setting.system.login_history.multi_search_label',
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('user_name', TextType::class, [
                 'label' => 'admin.setting.system.login_history.user_name',
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('client_ip', TextType::class, [
                 'label' => 'admin.setting.system.login_history.client_ip',
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('Status', LoginHistoryStatusType::class, [
@@ -73,10 +73,7 @@ class SearchLoginHistoryType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -90,10 +87,7 @@ class SearchLoginHistoryType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',

--- a/src/Eccube/Form/Type/Admin/SearchOrderType.php
+++ b/src/Eccube/Form/Type/Admin/SearchOrderType.php
@@ -52,7 +52,7 @@ class SearchOrderType extends AbstractType
                 'label' => 'admin.order.multi_search_label',
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('status', OrderStatusType::class, [
@@ -69,10 +69,7 @@ class SearchOrderType extends AbstractType
                     'label' => 'admin.order.orderer_kana',
                     'required' => false,
                     'constraints' => [
-                        new Assert\Regex([
-                            'pattern' => '/^[ァ-ヶｦ-ﾟー]+$/u',
-                            'message' => 'form_error.kana_only',
-                        ]),
+                        new Assert\Regex(pattern: '/^[ァ-ヶｦ-ﾟー]+$/u', message: 'form_error.kana_only'),
                     ],
                 ])
                 ->addEventSubscriber(new ConvertKanaListener('CV')
@@ -120,10 +117,7 @@ class SearchOrderType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -137,10 +131,7 @@ class SearchOrderType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -155,10 +146,7 @@ class SearchOrderType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -172,10 +160,7 @@ class SearchOrderType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -190,10 +175,7 @@ class SearchOrderType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -207,10 +189,7 @@ class SearchOrderType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -225,10 +204,7 @@ class SearchOrderType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -242,10 +218,7 @@ class SearchOrderType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -260,10 +233,7 @@ class SearchOrderType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -277,10 +247,7 @@ class SearchOrderType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -295,10 +262,7 @@ class SearchOrderType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -312,10 +276,7 @@ class SearchOrderType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -330,10 +291,7 @@ class SearchOrderType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -347,10 +305,7 @@ class SearchOrderType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -365,10 +320,7 @@ class SearchOrderType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -382,10 +334,7 @@ class SearchOrderType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',

--- a/src/Eccube/Form/Type/Admin/SearchProductType.php
+++ b/src/Eccube/Form/Type/Admin/SearchProductType.php
@@ -104,10 +104,7 @@ class SearchProductType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -121,10 +118,7 @@ class SearchProductType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -139,10 +133,7 @@ class SearchProductType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -156,10 +147,7 @@ class SearchProductType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -174,10 +162,7 @@ class SearchProductType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -191,10 +176,7 @@ class SearchProductType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -209,10 +191,7 @@ class SearchProductType extends AbstractType
                 'widget' => 'single_text',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',
@@ -226,10 +205,7 @@ class SearchProductType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
                 'attr' => [
                     'class' => 'datetimepicker-input',

--- a/src/Eccube/Form/Type/Admin/SearchRefundRequestType.php
+++ b/src/Eccube/Form/Type/Admin/SearchRefundRequestType.php
@@ -42,7 +42,7 @@ class SearchRefundRequestType extends AbstractType
                 'label' => 'admin.order.refund_request.multi_search_label',
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('status', RefundRequestStatusType::class, [

--- a/src/Eccube/Form/Type/Admin/SecurityType.php
+++ b/src/Eccube/Form/Type/Admin/SecurityType.php
@@ -60,41 +60,37 @@ class SecurityType extends AbstractType
             ->add('admin_route_dir', TextType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
-                    new Assert\Regex([
-                        'pattern' => '/\A\w+\z/',
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => "/^(?!($routes)$).*$/",
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
+                    new Assert\Regex(pattern: '/\A\w+\z/'),
+                    new Assert\Regex(pattern: "/^(?!($routes)$).*$/"),
                 ],
                 'data' => $this->eccubeConfig->get('eccube_admin_route'),
             ])
             ->add('front_allow_hosts', TextareaType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_ltext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
                 ],
                 'data' => $allowFrontHosts,
             ])
             ->add('front_deny_hosts', TextareaType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_ltext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
                 ],
                 'data' => $denyFrontHosts,
             ])
             ->add('admin_allow_hosts', TextareaType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_ltext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
                 ],
                 'data' => $allowHosts,
             ])
             ->add('admin_deny_hosts', TextareaType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_ltext_len']]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
                 ],
                 'data' => $denyHosts,
             ])
@@ -106,10 +102,8 @@ class SecurityType extends AbstractType
             ->add('trusted_hosts', TextType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
-                    new Assert\Regex([
-                        'pattern' => '/^[\x21-\x7e]+$/',
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
+                    new Assert\Regex(pattern: '/^[\x21-\x7e]+$/'),
                 ],
                 'data' => env('TRUSTED_HOSTS'),
             ])

--- a/src/Eccube/Form/Type/Admin/ShippingType.php
+++ b/src/Eccube/Form/Type/Admin/ShippingType.php
@@ -153,10 +153,7 @@ class ShippingType extends AbstractType
                 'input' => 'datetime',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
             ])
             ->add('shipping_date', DateTimeType::class, [
@@ -165,10 +162,7 @@ class ShippingType extends AbstractType
                 'widget' => 'single_text',
                 'with_seconds' => true,
                 'constraints' => [
-                    new Assert\Range([
-                        'min' => '0003-01-01',
-                        'minMessage' => 'form_error.out_of_range',
-                    ]),
+                    new Assert\Range(min: '0003-01-01', minMessage: 'form_error.out_of_range'),
                 ],
             ])
             ->add('tracking_number', TextType::class, [
@@ -325,14 +319,5 @@ class ShippingType extends AbstractType
         $resolver->setDefaults([
             'data_class' => Shipping::class,
         ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'shipping';
     }
 }

--- a/src/Eccube/Form/Type/Admin/ShopMasterType.php
+++ b/src/Eccube/Form/Type/Admin/ShopMasterType.php
@@ -56,29 +56,21 @@ class ShopMasterType extends AbstractType
             ->add('company_name', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('shop_name', TextType::class, [
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('shop_name_eng', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_mtext_len'],
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => '/^[[:graph:][:space:]]+$/i',
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_mtext_len']),
+                    new Assert\Regex(pattern: '/^[[:graph:][:space:]]+$/i'),
                 ],
             ])
             ->add('postal_code', PostalType::class, [
@@ -93,9 +85,7 @@ class ShopMasterType extends AbstractType
             ->add('business_hour', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('email01', EmailType::class, [
@@ -129,17 +119,13 @@ class ShopMasterType extends AbstractType
             ->add('good_traded', TextareaType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_ltext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
                 ],
             ])
             ->add('message', TextareaType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_ltext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_ltext_len']),
                 ],
             ])
             // 送料設定
@@ -150,10 +136,7 @@ class ShopMasterType extends AbstractType
             ->add('delivery_free_quantity', IntegerType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Regex([
-                        'pattern' => "/^\d+$/u",
-                        'message' => 'form_error.numeric_only',
-                    ]),
+                    new Assert\Regex(pattern: "/^\d+$/u", message: 'form_error.numeric_only'),
                 ],
             ])
             ->add('option_product_delivery_fee', ToggleSwitchType::class)
@@ -177,9 +160,7 @@ class ShopMasterType extends AbstractType
             ->add('invoice_registration_number', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             // 個別税率設定
@@ -191,35 +172,21 @@ class ShopMasterType extends AbstractType
             ->add('basic_point_rate', NumberType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Regex([
-                        'pattern' => "/^\d+$/u",
-                        'message' => 'form_error.numeric_only',
-                    ]),
-                    new Assert\Range([
-                        'min' => 0,
-                        'max' => 100,
-                    ]),
+                    new Assert\Regex(pattern: "/^\d+$/u", message: 'form_error.numeric_only'),
+                    new Assert\Range(min: 0, max: 100),
                 ],
             ])
             ->add('point_conversion_rate', NumberType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Regex([
-                        'pattern' => "/^\d+$/u",
-                        'message' => 'form_error.numeric_only',
-                    ]),
-                    new Assert\Range([
-                        'min' => 1,
-                        'max' => 100,
-                    ]),
+                    new Assert\Regex(pattern: "/^\d+$/u", message: 'form_error.numeric_only'),
+                    new Assert\Range(min: 1, max: 100),
                 ],
             ])
             ->add('ga_id', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             // エージェントコマース checkout の有効化フラグ (discovery / catalog は常時公開、checkout のみ制御)
@@ -243,12 +210,8 @@ class ShopMasterType extends AbstractType
                 ->create('company_kana', TextType::class, [
                     'required' => false,
                     'constraints' => [
-                        new Assert\Regex([
-                            'pattern' => '/^[ァ-ヶｦ-ﾟー]+$/u',
-                        ]),
-                        new Assert\Length([
-                            'max' => $this->eccubeConfig['eccube_stext_len'],
-                        ]),
+                        new Assert\Regex(pattern: '/^[ァ-ヶｦ-ﾟー]+$/u'),
+                        new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                     ],
                 ])
                 ->addEventSubscriber(new ConvertKanaListener('CV'))
@@ -259,12 +222,8 @@ class ShopMasterType extends AbstractType
                 ->create('shop_kana', TextType::class, [
                     'required' => false,
                     'constraints' => [
-                        new Assert\Length([
-                            'max' => $this->eccubeConfig['eccube_stext_len'],
-                        ]),
-                        new Assert\Regex([
-                            'pattern' => '/^[ァ-ヶｦ-ﾟー]+$/u',
-                        ]),
+                        new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
+                        new Assert\Regex(pattern: '/^[ァ-ヶｦ-ﾟー]+$/u'),
                     ],
                 ])
                 ->addEventSubscriber(new ConvertKanaListener('CV'))
@@ -280,14 +239,5 @@ class ShopMasterType extends AbstractType
         $resolver->setDefaults([
             'data_class' => BaseInfo::class,
         ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'shop_master';
     }
 }

--- a/src/Eccube/Form/Type/Admin/TagType.php
+++ b/src/Eccube/Form/Type/Admin/TagType.php
@@ -35,9 +35,7 @@ class TagType extends AbstractType
             ->add('name', TextType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
         ;

--- a/src/Eccube/Form/Type/Admin/TaxRuleType.php
+++ b/src/Eccube/Form/Type/Admin/TaxRuleType.php
@@ -48,11 +48,8 @@ class TaxRuleType extends AbstractType
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Range(['min' => 0]),
-                    new Assert\Regex([
-                        'pattern' => "/^\d+(\.\d+)?$/u",
-                        'message' => 'form_error.float_only',
-                    ]),
+                    new Assert\Range(min: 0),
+                    new Assert\Regex(pattern: "/^\d+(\.\d+)?$/u", message: 'form_error.float_only'),
                 ],
             ])
             ->add('rounding_type', RoundingTypeType::class, [
@@ -103,14 +100,5 @@ class TaxRuleType extends AbstractType
         $resolver->setDefaults([
             'data_class' => TaxRule::class,
         ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'tax_rule';
     }
 }

--- a/src/Eccube/Form/Type/Admin/TemplateType.php
+++ b/src/Eccube/Form/Type/Admin/TemplateType.php
@@ -41,32 +41,23 @@ class TemplateType extends AbstractType
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Regex([
-                        'pattern' => '/^[0-9a-zA-Z]+$/',
-                    ]),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Regex(pattern: '/^[0-9a-zA-Z]+$/'),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('name', TextType::class, [
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('file', FileType::class, [
                 'mapped' => false,
                 'required' => true,
                 'constraints' => [
-                    new Assert\NotBlank(['message' => trans('admin.common.select')]),
-                    new Assert\File([
-                        'mimeTypes' => ['application/zip', 'application/x-tar', 'application/x-gzip', 'application/gzip'],
-                        'mimeTypesMessage' => trans('admin.store.template.invalid_upload_file'),
-                    ]),
+                    new Assert\NotBlank(message: trans('admin.common.select')),
+                    new Assert\File(mimeTypes: ['application/zip', 'application/x-tar', 'application/x-gzip', 'application/gzip'], mimeTypesMessage: trans('admin.store.template.invalid_upload_file')),
                 ],
             ]);
     }

--- a/src/Eccube/Form/Type/Admin/TradeLawType.php
+++ b/src/Eccube/Form/Type/Admin/TradeLawType.php
@@ -41,18 +41,14 @@ class TradeLawType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('description', TextareaType::class, [
                 'required' => false,
                 'purify_html' => true,
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => 4000,
-                    ]),
+                    new Assert\Length(max: 4000),
                 ],
             ])
             ->add('displayOrderScreen', ToggleSwitchType::class, [

--- a/src/Eccube/Form/Type/Admin/TwoFactorAuthType.php
+++ b/src/Eccube/Form/Type/Admin/TwoFactorAuthType.php
@@ -36,10 +36,7 @@ class TwoFactorAuthType extends AbstractType
                     'required' => true,
                     'constraints' => [
                         new Assert\NotBlank(),
-                        new Assert\Length([
-                            'max' => 6,
-                            'min' => 6,
-                        ]),
+                        new Assert\Length(max: 6, min: 6),
                     ],
                     'attr' => [
                         'maxlength' => 6,

--- a/src/Eccube/Form/Type/Front/ContactType.php
+++ b/src/Eccube/Form/Type/Front/ContactType.php
@@ -68,19 +68,8 @@ class ContactType extends AbstractType
             ->add('contents', TextareaType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_lltext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_lltext_len']),
                 ],
             ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'contact';
     }
 }

--- a/src/Eccube/Form/Type/Front/CustomerAddressType.php
+++ b/src/Eccube/Form/Type/Front/CustomerAddressType.php
@@ -53,9 +53,7 @@ class CustomerAddressType extends AbstractType
                     'autocomplete' => 'organization',
                 ],
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('postal_code', PostalType::class)
@@ -74,14 +72,5 @@ class CustomerAddressType extends AbstractType
         $resolver->setDefaults([
             'data_class' => CustomerAddress::class,
         ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'customer_address';
     }
 }

--- a/src/Eccube/Form/Type/Front/CustomerLoginType.php
+++ b/src/Eccube/Form/Type/Front/CustomerLoginType.php
@@ -61,13 +61,4 @@ class CustomerLoginType extends AbstractType
             ],
         ]);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'customer_login';
-    }
 }

--- a/src/Eccube/Form/Type/Front/EntryType.php
+++ b/src/Eccube/Form/Type/Front/EntryType.php
@@ -63,9 +63,7 @@ class EntryType extends AbstractType
                     'autocomplete' => 'organization',
                 ],
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('postal_code', PostalType::class)
@@ -82,10 +80,7 @@ class EntryType extends AbstractType
                 'widget' => 'choice',
                 'placeholder' => ['year' => '----', 'month' => '--', 'day' => '--'],
                 'constraints' => [
-                    new Assert\LessThanOrEqual([
-                        'value' => date('Y-m-d', strtotime('-1 day')),
-                        'message' => 'form_error.select_is_future_or_now_date',
-                    ]),
+                    new Assert\LessThanOrEqual(value: date('Y-m-d', strtotime('-1 day')), message: 'form_error.select_is_future_or_now_date'),
                 ],
             ])
             ->add('sex', SexType::class, [
@@ -131,15 +126,5 @@ class EntryType extends AbstractType
         $resolver->setDefaults([
             'data_class' => Customer::class,
         ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        // todo entry,mypageで共有されているので名前を変更する
-        return 'entry';
     }
 }

--- a/src/Eccube/Form/Type/Front/ForgotType.php
+++ b/src/Eccube/Form/Type/Front/ForgotType.php
@@ -51,13 +51,4 @@ class ForgotType extends AbstractType
             ],
         ]);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'forgot';
-    }
 }

--- a/src/Eccube/Form/Type/Front/NonMemberType.php
+++ b/src/Eccube/Form/Type/Front/NonMemberType.php
@@ -55,9 +55,7 @@ class NonMemberType extends AbstractType
                     'autocomplete' => 'organization',
                 ],
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('postal_code', PostalType::class, [

--- a/src/Eccube/Form/Type/Front/RefundRequestType.php
+++ b/src/Eccube/Form/Type/Front/RefundRequestType.php
@@ -60,16 +60,13 @@ class RefundRequestType extends AbstractType
                 'constraints' => [
                     new Assert\NotBlank(),
                     new Assert\GreaterThan(0),
-                    new Assert\LessThanOrEqual([
-                        'value' => $maxQuantity,
-                        'message' => 'form_error.refund_request.quantity_exceed',
-                    ]),
+                    new Assert\LessThanOrEqual(value: $maxQuantity, message: 'form_error.refund_request.quantity_exceed'),
                 ],
             ])
             ->add('reason', TextareaType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => 4000]),
+                    new Assert\Length(max: 4000),
                 ],
             ])
             ->add('files', FileType::class, [
@@ -77,17 +74,9 @@ class RefundRequestType extends AbstractType
                 'multiple' => true,
                 'required' => false,
                 'constraints' => [
-                    new Assert\Count([
-                        'max' => self::MAX_FILE_COUNT,
-                        'maxMessage' => 'form_error.refund_request.max_files',
-                    ]),
+                    new Assert\Count(max: self::MAX_FILE_COUNT, maxMessage: 'form_error.refund_request.max_files'),
                     new Assert\All([
-                        new Assert\File([
-                            'maxSize' => self::MAX_FILE_SIZE,
-                            'maxSizeMessage' => 'form_error.refund_request.file_size',
-                            'mimeTypes' => self::ALLOWED_MIME_TYPES,
-                            'mimeTypesMessage' => 'form_error.refund_request.file_type',
-                        ]),
+                        new Assert\File(maxSize: self::MAX_FILE_SIZE, maxSizeMessage: 'form_error.refund_request.file_size', mimeTypes: self::ALLOWED_MIME_TYPES, mimeTypesMessage: 'form_error.refund_request.file_type'),
                     ]),
                 ],
             ]);
@@ -104,14 +93,5 @@ class RefundRequestType extends AbstractType
             'max_quantity' => 1,
         ]);
         $resolver->setAllowedTypes('max_quantity', ['int', 'string']);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'refund_request';
     }
 }

--- a/src/Eccube/Form/Type/Front/ShoppingShippingType.php
+++ b/src/Eccube/Form/Type/Front/ShoppingShippingType.php
@@ -49,13 +49,4 @@ class ShoppingShippingType extends AbstractType
     {
         return CustomerAddressType::class;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'shopping_shipping';
-    }
 }

--- a/src/Eccube/Form/Type/Install/Step3Type.php
+++ b/src/Eccube/Form/Type/Install/Step3Type.php
@@ -48,19 +48,13 @@ class Step3Type extends AbstractType
     {
         $loginPassConstraints = [
             new Assert\NotBlank(),
-            new Assert\Length([
-                'min' => $this->eccubeConfig['eccube_password_min_len'],
-                'max' => $this->eccubeConfig['eccube_password_max_len'],
-            ]),
-            new Assert\Regex([
-                'pattern' => $this->eccubeConfig['eccube_password_pattern'],
-                'message' => 'form_error.password_pattern_invalid',
-            ]),
+            new Assert\Length(min: $this->eccubeConfig['eccube_password_min_len'], max: $this->eccubeConfig['eccube_password_max_len']),
+            new Assert\Regex(pattern: $this->eccubeConfig['eccube_password_pattern'], message: 'form_error.password_pattern_invalid'),
             new PasswordBlocklist(),
         ];
         // NIST SP 800-63B-4 対応の漏洩パスワードチェック. 閉域網等では config で無効化できる.
         if ($this->eccubeConfig['eccube_password_compromised_check']) {
-            $loginPassConstraints[] = new Assert\NotCompromisedPassword(['skipOnError' => true]);
+            $loginPassConstraints[] = new Assert\NotCompromisedPassword(skipOnError: true);
         }
 
         // 検証と保存を同一の正規化済み値で行うため, 検証前(PRE_SUBMIT)に login_pass を NFKC 正規化する.
@@ -77,9 +71,7 @@ class Step3Type extends AbstractType
                 'label' => trans('install.shop_name'),
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_stext_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_stext_len']),
                 ],
             ])
             ->add('email', EmailType::class, [
@@ -96,14 +88,8 @@ class Step3Type extends AbstractType
                 ]),
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'min' => $this->eccubeConfig['eccube_id_min_len'],
-                        'max' => $this->eccubeConfig['eccube_id_max_len'],
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => '/^[[:graph:][:space:]]+$/i',
-                        'message' => 'form_error.graph_only',
-                    ]),
+                    new Assert\Length(min: $this->eccubeConfig['eccube_id_min_len'], max: $this->eccubeConfig['eccube_id_max_len']),
+                    new Assert\Regex(pattern: '/^[[:graph:][:space:]]+$/i', message: 'form_error.graph_only'),
                 ],
             ])
             ->add('login_pass', PasswordType::class, [
@@ -120,12 +106,9 @@ class Step3Type extends AbstractType
                 ]),
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length([
-                        'min' => $this->eccubeConfig['eccube_id_min_len'],
-                        'max' => $this->eccubeConfig['eccube_id_max_len'],
-                    ]),
-                    new Assert\Regex(['pattern' => '/\A\w+\z/']),
-                    new Assert\NotEqualTo(['value' => 'admin', 'message' => 'form_error.admin_is_not_available']),
+                    new Assert\Length(min: $this->eccubeConfig['eccube_id_min_len'], max: $this->eccubeConfig['eccube_id_max_len']),
+                    new Assert\Regex(pattern: '/\A\w+\z/'),
+                    new Assert\NotEqualTo(value: 'admin', message: 'form_error.admin_is_not_available'),
                 ],
             ])
             ->add('admin_force_ssl', CheckboxType::class, [

--- a/src/Eccube/Form/Type/KanaType.php
+++ b/src/Eccube/Form/Type/KanaType.php
@@ -54,13 +54,8 @@ class KanaType extends AbstractType
                     'placeholder' => 'common.last_name_kana',
                 ],
                 'constraints' => [
-                    new Assert\Regex([
-                        'pattern' => '/^[ァ-ヶｦ-ﾟー]+$/u',
-                        'message' => 'form_error.kana_only',
-                    ]),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_kana_len'],
-                    ]),
+                    new Assert\Regex(pattern: '/^[ァ-ヶｦ-ﾟー]+$/u', message: 'form_error.kana_only'),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_kana_len']),
                 ],
             ],
             'firstname_options' => [
@@ -68,13 +63,8 @@ class KanaType extends AbstractType
                     'placeholder' => 'common.first_name_kana',
                 ],
                 'constraints' => [
-                    new Assert\Regex([
-                        'pattern' => '/^[ァ-ヶｦ-ﾟー]+$/u',
-                        'message' => 'form_error.kana_only',
-                    ]),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_kana_len'],
-                    ]),
+                    new Assert\Regex(pattern: '/^[ァ-ヶｦ-ﾟー]+$/u', message: 'form_error.kana_only'),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_kana_len']),
                 ],
             ],
         ]);
@@ -87,14 +77,5 @@ class KanaType extends AbstractType
     public function getParent(): ?string
     {
         return NameType::class;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'kana';
     }
 }

--- a/src/Eccube/Form/Type/Master/CategoryType.php
+++ b/src/Eccube/Form/Type/Master/CategoryType.php
@@ -41,10 +41,4 @@ class CategoryType extends AbstractType
     {
         return MasterType::class;
     }
-
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'category';
-    }
 }

--- a/src/Eccube/Form/Type/Master/CustomerStatusType.php
+++ b/src/Eccube/Form/Type/Master/CustomerStatusType.php
@@ -50,10 +50,4 @@ class CustomerStatusType extends AbstractType
     {
         return MasterType::class;
     }
-
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'customer_status';
-    }
 }

--- a/src/Eccube/Form/Type/Master/DeliveryDurationType.php
+++ b/src/Eccube/Form/Type/Master/DeliveryDurationType.php
@@ -45,15 +45,6 @@ class DeliveryDurationType extends AbstractType
      * {@inheritdoc}
      */
     #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'delivery_duration';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
     public function getParent(): ?string
     {
         return EntityType::class;

--- a/src/Eccube/Form/Type/Master/JobType.php
+++ b/src/Eccube/Form/Type/Master/JobType.php
@@ -36,15 +36,6 @@ class JobType extends AbstractType
      * {@inheritdoc}
      */
     #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'job';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
     public function getParent(): ?string
     {
         return MasterType::class;

--- a/src/Eccube/Form/Type/Master/LoginHistoryStatusType.php
+++ b/src/Eccube/Form/Type/Master/LoginHistoryStatusType.php
@@ -40,13 +40,4 @@ class LoginHistoryStatusType extends AbstractType
     {
         return MasterType::class;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'login_history_status';
-    }
 }

--- a/src/Eccube/Form/Type/Master/MailTemplateType.php
+++ b/src/Eccube/Form/Type/Master/MailTemplateType.php
@@ -43,15 +43,6 @@ class MailTemplateType extends AbstractType
      * {@inheritdoc}
      */
     #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'mail_template';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
     public function getParent(): string
     {
         return MasterType::class;

--- a/src/Eccube/Form/Type/Master/OrderStatusType.php
+++ b/src/Eccube/Form/Type/Master/OrderStatusType.php
@@ -68,15 +68,6 @@ class OrderStatusType extends AbstractType
      * {@inheritdoc}
      */
     #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'order_status';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
     public function getParent(): string
     {
         return MasterType::class;

--- a/src/Eccube/Form/Type/Master/PageMaxType.php
+++ b/src/Eccube/Form/Type/Master/PageMaxType.php
@@ -63,15 +63,6 @@ class PageMaxType extends AbstractType
      * {@inheritdoc}
      */
     #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'page_max';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
     public function getParent(): ?string
     {
         return MasterType::class;

--- a/src/Eccube/Form/Type/Master/PaymentType.php
+++ b/src/Eccube/Form/Type/Master/PaymentType.php
@@ -41,15 +41,6 @@ class PaymentType extends AbstractType
      * {@inheritdoc}
      */
     #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'payment';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
     public function getParent(): string
     {
         return MasterType::class;

--- a/src/Eccube/Form/Type/Master/PrefType.php
+++ b/src/Eccube/Form/Type/Master/PrefType.php
@@ -39,15 +39,6 @@ class PrefType extends AbstractType
      * {@inheritdoc}
      */
     #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'pref';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
     public function getParent(): string
     {
         return MasterType::class;

--- a/src/Eccube/Form/Type/Master/ProductListMaxType.php
+++ b/src/Eccube/Form/Type/Master/ProductListMaxType.php
@@ -54,15 +54,6 @@ class ProductListMaxType extends AbstractType
      * {@inheritdoc}
      */
     #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'product_list_max';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
     public function getParent(): ?string
     {
         return MasterType::class;

--- a/src/Eccube/Form/Type/Master/ProductListOrderByType.php
+++ b/src/Eccube/Form/Type/Master/ProductListOrderByType.php
@@ -54,15 +54,6 @@ class ProductListOrderByType extends AbstractType
      * {@inheritdoc}
      */
     #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'product_list_order_by';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
     public function getParent(): string
     {
         return MasterType::class;

--- a/src/Eccube/Form/Type/Master/ProductStatusType.php
+++ b/src/Eccube/Form/Type/Master/ProductStatusType.php
@@ -40,13 +40,4 @@ class ProductStatusType extends AbstractType
     {
         return MasterType::class;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'product_status';
-    }
 }

--- a/src/Eccube/Form/Type/Master/RefundRequestStatusType.php
+++ b/src/Eccube/Form/Type/Master/RefundRequestStatusType.php
@@ -35,15 +35,6 @@ class RefundRequestStatusType extends AbstractType
      * {@inheritdoc}
      */
     #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'refund_request_status';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
     public function getParent(): string
     {
         return MasterType::class;

--- a/src/Eccube/Form/Type/Master/SexType.php
+++ b/src/Eccube/Form/Type/Master/SexType.php
@@ -50,10 +50,4 @@ class SexType extends AbstractType
     {
         return MasterType::class;
     }
-
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'sex';
-    }
 }

--- a/src/Eccube/Form/Type/MasterType.php
+++ b/src/Eccube/Form/Type/MasterType.php
@@ -40,15 +40,6 @@ class MasterType extends AbstractType
      * {@inheritdoc}
      */
     #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'master';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
     public function getParent(): string
     {
         return EntityType::class;

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -53,9 +53,7 @@ class NameType extends AbstractType
             ], $options['firstname_options']['constraints']);
         }
 
-        if (!isset($options['options']['error_bubbling'])) {
-            $options['options']['error_bubbling'] = $options['error_bubbling'];
-        }
+        $options['options']['error_bubbling'] ??= $options['error_bubbling'];
 
         if (empty($options['lastname_name'])) {
             $options['lastname_name'] = $builder->getName().'01';

--- a/src/Eccube/Form/Type/NameType.php
+++ b/src/Eccube/Form/Type/NameType.php
@@ -99,13 +99,8 @@ class NameType extends AbstractType
                     'placeholder' => 'common.last_name',
                 ],
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_name_len'],
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => '/^[^\s ]+$/u',
-                        'message' => 'form_error.not_contain_spaces',
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_name_len']),
+                    new Assert\Regex(pattern: '/^[^\s ]+$/u', message: 'form_error.not_contain_spaces'),
                 ],
             ],
             'firstname_options' => [
@@ -113,13 +108,8 @@ class NameType extends AbstractType
                     'placeholder' => 'common.first_name',
                 ],
                 'constraints' => [
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_name_len'],
-                    ]),
-                    new Assert\Regex([
-                        'pattern' => '/^[^\s ]+$/u',
-                        'message' => 'form_error.not_contain_spaces',
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_name_len']),
+                    new Assert\Regex(pattern: '/^[^\s ]+$/u', message: 'form_error.not_contain_spaces'),
                 ],
             ],
             'lastname_name' => '',
@@ -128,14 +118,5 @@ class NameType extends AbstractType
             'inherit_data' => true,
             'trim' => true,
         ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'name';
     }
 }

--- a/src/Eccube/Form/Type/PhoneNumberType.php
+++ b/src/Eccube/Form/Type/PhoneNumberType.php
@@ -60,9 +60,7 @@ class PhoneNumberType extends AbstractType
                 $constraints[] = new Assert\NotBlank();
             }
 
-            $constraints[] = new Assert\Length([
-                'max' => $this->eccubeConfig['eccube_tel_len_max'],
-            ]);
+            $constraints[] = new Assert\Length(max: $this->eccubeConfig['eccube_tel_len_max']);
 
             $constraints[] = new Assert\Type(
                 type: 'digit',
@@ -87,14 +85,5 @@ class PhoneNumberType extends AbstractType
     public function getParent(): ?string
     {
         return TelType::class;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'phone_number';
     }
 }

--- a/src/Eccube/Form/Type/PostalType.php
+++ b/src/Eccube/Form/Type/PostalType.php
@@ -59,9 +59,7 @@ class PostalType extends AbstractType
                 $constraints[] = new Assert\NotBlank();
             }
 
-            $constraints[] = new Assert\Length([
-                'max' => $this->eccubeConfig['eccube_postal_code'],
-            ]);
+            $constraints[] = new Assert\Length(max: $this->eccubeConfig['eccube_postal_code']);
 
             $constraints[] = new Assert\Type(
                 type: 'digit',
@@ -88,14 +86,5 @@ class PostalType extends AbstractType
     public function getParent(): ?string
     {
         return TelType::class;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'postal';
     }
 }

--- a/src/Eccube/Form/Type/PriceType.php
+++ b/src/Eccube/Form/Type/PriceType.php
@@ -50,12 +50,9 @@ class PriceType extends AbstractType
             }
 
             if (isset($options['accept_minus']) && true === $options['accept_minus']) {
-                $constraints[] = new Range([
-                    'min' => $min,
-                    'max' => $max,
-                ]);
+                $constraints[] = new Range(min: $min, max: $max);
             } else {
-                $constraints[] = new Range(['min' => 0, 'max' => $max]);
+                $constraints[] = new Range(min: 0, max: $max);
             }
 
             return $constraints;
@@ -79,14 +76,5 @@ class PriceType extends AbstractType
     public function getParent(): ?string
     {
         return MoneyType::class;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'price';
     }
 }

--- a/src/Eccube/Form/Type/RepeatedEmailType.php
+++ b/src/Eccube/Form/Type/RepeatedEmailType.php
@@ -45,9 +45,7 @@ class RepeatedEmailType extends AbstractType
                 'constraints' => [
                     new Assert\NotBlank(),
                     new Email(null, null, $this->eccubeConfig['eccube_rfc_email_check'] ? 'strict' : null),
-                    new Assert\Length([
-                        'max' => $this->eccubeConfig['eccube_email_len'],
-                    ]),
+                    new Assert\Length(max: $this->eccubeConfig['eccube_email_len']),
                 ],
             ],
             'first_options' => [
@@ -73,14 +71,5 @@ class RepeatedEmailType extends AbstractType
     public function getParent(): ?string
     {
         return RepeatedType::class;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'repeated_email';
     }
 }

--- a/src/Eccube/Form/Type/RepeatedPasswordType.php
+++ b/src/Eccube/Form/Type/RepeatedPasswordType.php
@@ -69,19 +69,13 @@ class RepeatedPasswordType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $constraints = [
-            new Assert\Length([
-                'min' => $this->eccubeConfig['eccube_password_min_len'],
-                'max' => $this->eccubeConfig['eccube_password_max_len'],
-            ]),
-            new Assert\Regex([
-                'pattern' => $this->eccubeConfig['eccube_password_pattern'],
-                'message' => 'form_error.password_pattern_invalid',
-            ]),
+            new Assert\Length(min: $this->eccubeConfig['eccube_password_min_len'], max: $this->eccubeConfig['eccube_password_max_len']),
+            new Assert\Regex(pattern: $this->eccubeConfig['eccube_password_pattern'], message: 'form_error.password_pattern_invalid'),
             new PasswordBlocklist(),
         ];
         // NIST SP 800-63B-4 対応の漏洩パスワードチェック. 閉域網等では config で無効化できる.
         if ($this->eccubeConfig['eccube_password_compromised_check']) {
-            $constraints[] = new Assert\NotCompromisedPassword(['skipOnError' => true]);
+            $constraints[] = new Assert\NotCompromisedPassword(skipOnError: true);
         }
 
         $resolver->setDefaults([
@@ -117,14 +111,5 @@ class RepeatedPasswordType extends AbstractType
     public function getParent(): ?string
     {
         return RepeatedType::class;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'repeated_password';
     }
 }

--- a/src/Eccube/Form/Type/SearchProductBlockType.php
+++ b/src/Eccube/Form/Type/SearchProductBlockType.php
@@ -65,13 +65,4 @@ class SearchProductBlockType extends AbstractType
             'allow_extra_fields' => true,
         ]);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'search_product_block';
-    }
 }

--- a/src/Eccube/Form/Type/SearchProductType.php
+++ b/src/Eccube/Form/Type/SearchProductType.php
@@ -85,13 +85,4 @@ class SearchProductType extends AbstractType
             'allow_extra_fields' => true,
         ]);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'search_product';
-    }
 }

--- a/src/Eccube/Form/Type/ShippingMultipleItemType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleItemType.php
@@ -59,10 +59,8 @@ class ShippingMultipleItemType extends AbstractType
                 ],
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\GreaterThanOrEqual([
-                        'value' => 1,
-                    ]),
-                    new Assert\Regex(['pattern' => '/^\d+$/']),
+                    new Assert\GreaterThanOrEqual(value: 1),
+                    new Assert\Regex(pattern: '/^\d+$/'),
                 ],
             ])
             ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
@@ -131,14 +129,5 @@ class ShippingMultipleItemType extends AbstractType
                 }
                 $form['quantity']->setData($quantity);
             });
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'shipping_multiple_item';
     }
 }

--- a/src/Eccube/Form/Type/ShippingMultipleType.php
+++ b/src/Eccube/Form/Type/ShippingMultipleType.php
@@ -65,13 +65,4 @@ class ShippingMultipleType extends AbstractType
                     ]);
             });
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'shipping_multiple';
-    }
 }

--- a/src/Eccube/Form/Type/Shopping/OrderType.php
+++ b/src/Eccube/Form/Type/Shopping/OrderType.php
@@ -75,7 +75,7 @@ class OrderType extends AbstractType
         $builder->add('message', TextareaType::class, [
             'required' => false,
             'constraints' => [
-                new Length(['min' => 0, 'max' => 3000]),
+                new Length(min: 0, max: 3000),
             ],
         ])->add('Shippings', CollectionType::class, [
             'entry_type' => ShippingType::class,
@@ -89,11 +89,8 @@ class OrderType extends AbstractType
                 'required' => false,
                 'constraints' => [
                     new NotBlank(),
-                    new Regex([
-                        'pattern' => "/^\d+$/u",
-                        'message' => 'form_error.numeric_only',
-                    ]),
-                    new Length(['max' => 11]),
+                    new Regex(pattern: "/^\d+$/u", message: 'form_error.numeric_only'),
+                    new Length(max: 11),
                 ],
             ]);
         }
@@ -192,7 +189,7 @@ class OrderType extends AbstractType
             'multiple' => false,
             'placeholder' => false,
             'constraints' => [
-                new NotBlank(['message' => $message]),
+                new NotBlank(message: $message),
             ],
             'choices' => $choices,
             'data' => $data,

--- a/src/Eccube/Form/Type/ShoppingMultipleType.php
+++ b/src/Eccube/Form/Type/ShoppingMultipleType.php
@@ -68,13 +68,4 @@ class ShoppingMultipleType extends AbstractType
             'deliveryDurations' => [],
         ]);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getBlockPrefix(): string
-    {
-        return 'shopping_multiple';
-    }
 }

--- a/src/Eccube/Form/Validator/TwigLintValidator.php
+++ b/src/Eccube/Form/Validator/TwigLintValidator.php
@@ -35,10 +35,7 @@ class TwigLintValidator extends ConstraintValidator
     #[\Override]
     public function validate($value, Constraint $constraint): void
     {
-        // valueがnullの場合は "Template is not defined"のエラーが投げられるので, 空文字でチェックする.
-        if (is_null($value)) {
-            $value = '';
-        }
+        $value ??= '';
 
         $realLoader = $this->twig->getLoader();
         try {

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -368,7 +368,7 @@ class Kernel extends BaseKernel
     {
         // see https://github.com/EC-CUBE/ec-cube/issues/4727
         // キャッシュクリアなど、コード内でコマンドを利用している場合に2回実行されてしまう
-        if (true === $this->booted) {
+        if ($this->booted) {
             return;
         }
 

--- a/src/Eccube/Plugin/AbstractPluginManager.php
+++ b/src/Eccube/Plugin/AbstractPluginManager.php
@@ -43,9 +43,7 @@ abstract class AbstractPluginManager
      */
     public function migration(Connection $connection, string $pluginCode, ?string $version = null, ?string $migrationFilePath = null): void
     {
-        if (null === $migrationFilePath) {
-            $migrationFilePath = __DIR__.'/../../../app/Plugin/'.$pluginCode.'/DoctrineMigrations';
-        }
+        $migrationFilePath ??= __DIR__.'/../../../app/Plugin/'.$pluginCode.'/DoctrineMigrations';
 
         if (null == $version) {
             $version = 'latest';

--- a/src/Eccube/Security/Core/User/CustomerProvider.php
+++ b/src/Eccube/Security/Core/User/CustomerProvider.php
@@ -55,11 +55,9 @@ class CustomerProvider implements UserProviderInterface, PasswordUpgraderInterfa
 
     /**
      * Whether this provider supports the given user class.
-     *
-     * @param string $class
      */
     #[\Override]
-    public function supportsClass($class): bool
+    public function supportsClass(string $class): bool
     {
         return Customer::class === $class || is_subclass_of($class, Customer::class);
     }

--- a/src/Eccube/Security/Core/User/MemberProvider.php
+++ b/src/Eccube/Security/Core/User/MemberProvider.php
@@ -55,11 +55,9 @@ class MemberProvider implements UserProviderInterface, PasswordUpgraderInterface
 
     /**
      * Whether this provider supports the given user class.
-     *
-     * @param string $class
      */
     #[\Override]
-    public function supportsClass($class): bool
+    public function supportsClass(string $class): bool
     {
         return Member::class === $class || is_subclass_of($class, Member::class);
     }

--- a/src/Eccube/Service/CsvExportService.php
+++ b/src/Eccube/Service/CsvExportService.php
@@ -268,9 +268,7 @@ class CsvExportService
      */
     public function fputcsv(array $row): void
     {
-        if (is_null($this->convertEncodingCallBack)) {
-            $this->convertEncodingCallBack = $this->getConvertEncodingCallback();
-        }
+        $this->convertEncodingCallBack ??= $this->getConvertEncodingCallback();
 
         // 出力開始時(exportHeader/exportData)に解決済み. 単体で fputcsv だけ呼ぶ場合は都度解決する.
         $sanitizeFormulas = $this->sanitizeFormulas ?? $this->baseInfoRepository->get()->isOptionSanitizeCsvFormulas();

--- a/src/Eccube/Service/EntityProxyService.php
+++ b/src/Eccube/Service/EntityProxyService.php
@@ -46,9 +46,7 @@ class EntityProxyService
      */
     public function generate(array $includesDirs, array $excludeDirs, string $outputDir, ?OutputInterface $output = null): array
     {
-        if (is_null($output)) {
-            $output = new ConsoleOutput();
-        }
+        $output ??= new ConsoleOutput();
 
         $generatedFiles = [];
 

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -659,9 +659,7 @@ class PluginService
      */
     private function regenerateProxy(Plugin $plugin, bool $temporary, ?string $outputDir = null, bool $uninstall = false): array
     {
-        if (is_null($outputDir)) {
-            $outputDir = $this->projectRoot.'/app/proxy/entity';
-        }
+        $outputDir ??= $this->projectRoot.'/app/proxy/entity';
         @mkdir($outputDir);
 
         if ($temporary) {

--- a/src/Eccube/Service/PurchaseFlow/Processor/AddPointProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/AddPointProcessor.php
@@ -60,9 +60,7 @@ class AddPointProcessor extends ItemHolderPostValidator
             function ($carry, ItemInterface $item) use ($basicPointRate) {
                 $pointRate = $item->getPointRate() ?: null;
 
-                if ($pointRate === null) {
-                    $pointRate = $basicPointRate;
-                }
+                $pointRate ??= $basicPointRate;
 
                 // TODO: ポイントは税抜き分しか割引されない、ポイント明細は税抜きのままでいいのか？
                 $point = '0';

--- a/src/Eccube/Twig/Extension/CartServiceExtension.php
+++ b/src/Eccube/Twig/Extension/CartServiceExtension.php
@@ -15,26 +15,15 @@ namespace Eccube\Twig\Extension;
 
 use Eccube\Entity\Cart;
 use Eccube\Service\CartService;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
+use Twig\Attribute\AsTwigFunction;
 
-class CartServiceExtension extends AbstractExtension
+class CartServiceExtension
 {
     public function __construct(protected CartService $cartService)
     {
     }
 
-    #[\Override]
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('get_cart', $this->get_cart(...), ['is_safe' => ['all']]),
-            new TwigFunction('get_all_carts', $this->get_all_carts(...), ['is_safe' => ['all']]),
-            new TwigFunction('get_carts_total_price', $this->get_carts_total_price(...), ['is_safe' => ['all']]),
-            new TwigFunction('get_carts_total_quantity', $this->get_carts_total_quantity(...), ['is_safe' => ['all']]),
-        ];
-    }
-
+    #[AsTwigFunction(name: 'get_cart', isSafe: ['all'])]
     public function get_cart(): ?Cart
     {
         return $this->cartService->getCart();
@@ -43,11 +32,13 @@ class CartServiceExtension extends AbstractExtension
     /**
      * @return Cart[]
      */
+    #[AsTwigFunction(name: 'get_all_carts', isSafe: ['all'])]
     public function get_all_carts(): array
     {
         return $this->cartService->getCarts();
     }
 
+    #[AsTwigFunction(name: 'get_carts_total_price', isSafe: ['all'])]
     public function get_carts_total_price(): string
     {
         $Carts = $this->cartService->getCarts();
@@ -55,6 +46,7 @@ class CartServiceExtension extends AbstractExtension
         return array_reduce($Carts, fn (string $total, Cart $Cart) => bcadd($total, $Cart->getTotalPrice()), '0');
     }
 
+    #[AsTwigFunction(name: 'get_carts_total_quantity', isSafe: ['all'])]
     public function get_carts_total_quantity(): string
     {
         $Carts = $this->cartService->getCarts();

--- a/src/Eccube/Twig/Extension/CookieConsentExtension.php
+++ b/src/Eccube/Twig/Extension/CookieConsentExtension.php
@@ -15,8 +15,7 @@ namespace Eccube\Twig\Extension;
 
 use Eccube\Service\CookieConsentService;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
+use Twig\Attribute\AsTwigFunction;
 
 /**
  * クッキー同意機能のTwig拡張。
@@ -24,7 +23,7 @@ use Twig\TwigFunction;
  * 設定ページ等のキャッシュ対象外ページや、利用側が任意に同意状態を参照する用途で利用する。
  * フルページキャッシュ／CDN 配下のページでは、利用者ごとの同意状態に依存する出し分けに使わないこと。
  */
-class CookieConsentExtension extends AbstractExtension
+class CookieConsentExtension
 {
     public function __construct(
         private readonly CookieConsentService $cookieConsentService,
@@ -33,25 +32,11 @@ class CookieConsentExtension extends AbstractExtension
     }
 
     /**
-     * {@inheritdoc}
-     *
-     * @return TwigFunction[]
-     */
-    #[\Override]
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('is_cookie_consent_given', $this->isConsentGiven(...)),
-            new TwigFunction('is_cookie_consent_accepted', $this->isConsentAccepted(...)),
-            new TwigFunction('get_cookie_consent_status', $this->getConsentStatus(...)),
-        ];
-    }
-
-    /**
      * 同意が得られているか（同意または拒否のいずれか）をチェックする。
      *
      * @return bool true: 同意/拒否のいずれかが選択済み、false: 未設定
      */
+    #[AsTwigFunction(name: 'is_cookie_consent_given')]
     public function isConsentGiven(): bool
     {
         $request = $this->requestStack->getCurrentRequest();
@@ -67,6 +52,7 @@ class CookieConsentExtension extends AbstractExtension
      *
      * @return bool true: 同意済み、false: 拒否または未設定
      */
+    #[AsTwigFunction(name: 'is_cookie_consent_accepted')]
     public function isConsentAccepted(): bool
     {
         $request = $this->requestStack->getCurrentRequest();
@@ -82,6 +68,7 @@ class CookieConsentExtension extends AbstractExtension
      *
      * @return string|null 'accepted'|'rejected'|null
      */
+    #[AsTwigFunction(name: 'get_cookie_consent_status')]
     public function getConsentStatus(): ?string
     {
         $request = $this->requestStack->getCurrentRequest();

--- a/src/Eccube/Twig/Extension/CsrfExtension.php
+++ b/src/Eccube/Twig/Extension/CsrfExtension.php
@@ -15,10 +15,9 @@ namespace Eccube\Twig\Extension;
 
 use Eccube\Common\Constant;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
+use Twig\Attribute\AsTwigFunction;
 
-class CsrfExtension extends AbstractExtension
+class CsrfExtension
 {
     /**
      * CsrfExtension constructor.
@@ -27,17 +26,7 @@ class CsrfExtension extends AbstractExtension
     {
     }
 
-    /**
-     * @return array<int, TwigFunction>
-     */
-    #[\Override]
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('csrf_token_for_anchor', $this->getCsrfTokenForAnchor(...), ['is_safe' => ['all']]),
-        ];
-    }
-
+    #[AsTwigFunction(name: 'csrf_token_for_anchor', isSafe: ['all'])]
     public function getCsrfTokenForAnchor(): string
     {
         $token = $this->tokenManager->getToken(Constant::TOKEN_NAME)->getValue();

--- a/src/Eccube/Twig/Extension/EccubeExtension.php
+++ b/src/Eccube/Twig/Extension/EccubeExtension.php
@@ -344,9 +344,7 @@ class EccubeExtension extends AbstractExtension
      */
     public function getCurrencySymbol(?string $currency = null): bool|string
     {
-        if ($currency === null) {
-            $currency = $this->eccubeConfig->get('currency');
-        }
+        $currency ??= $this->eccubeConfig->get('currency');
 
         return Currencies::getSymbol($currency);
     }

--- a/src/Eccube/Twig/Extension/IntlExtension.php
+++ b/src/Eccube/Twig/Extension/IntlExtension.php
@@ -13,32 +13,18 @@
 
 namespace Eccube\Twig\Extension;
 
+use Twig\Attribute\AsTwigFilter;
 use Twig\Environment;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFilter;
 
-class IntlExtension extends AbstractExtension
+class IntlExtension
 {
-    /**
-     * {@inheritdoc}
-     */
-    #[\Override]
-    public function getFilters(): array
-    {
-        return [
-            new TwigFilter('date_day', $this->date_day(...), ['needs_environment' => true]),
-            new TwigFilter('date_min', $this->date_min(...), ['needs_environment' => true]),
-            new TwigFilter('date_sec', $this->date_sec(...), ['needs_environment' => true]),
-            new TwigFilter('date_day_with_weekday', $this->date_day_with_weekday(...), ['needs_environment' => true]),
-        ];
-    }
-
     /**
      * format_datetime('medium', 'none')のショートカット.
      *
      * 2015/08/28のように、日までのフォーマットで表示します(localeがjaの場合).
      * null,空文字に対して利用した場合は、空文字を返却します.
      */
+    #[AsTwigFilter(name: 'date_day', needsEnvironment: true)]
     public function date_day(Environment $env, \DateTimeInterface|string|null $date): bool|string
     {
         if (!$date) {
@@ -54,6 +40,7 @@ class IntlExtension extends AbstractExtension
      * 2015/08/28 16:13のように、分までのフォーマットで表示します(localeがjaの場合).
      * null,空文字に対して利用した場合は、空文字を返却します.
      */
+    #[AsTwigFilter(name: 'date_min', needsEnvironment: true)]
     public function date_min(Environment $env, \DateTimeInterface|string|null $date): bool|string
     {
         if (!$date) {
@@ -69,6 +56,7 @@ class IntlExtension extends AbstractExtension
      * 2015/08/28 16:13:05(localeがjaの場合).
      * null,空文字に対して利用した場合は、空文字を返却します.
      */
+    #[AsTwigFilter(name: 'date_sec', needsEnvironment: true)]
     public function date_sec(Environment $env, \DateTimeInterface|string|null $date): bool|string
     {
         if (!$date) {
@@ -78,6 +66,7 @@ class IntlExtension extends AbstractExtension
         return (new \Twig\Extra\Intl\IntlExtension())->formatDateTime($env, $date, 'medium', 'medium');
     }
 
+    #[AsTwigFilter(name: 'date_day_with_weekday', needsEnvironment: true)]
     public function date_day_with_weekday(Environment $env, \DateTimeInterface|string|null $date): bool|string
     {
         if (!$date) {

--- a/src/Eccube/Twig/Extension/TaxExtension.php
+++ b/src/Eccube/Twig/Extension/TaxExtension.php
@@ -15,10 +15,9 @@ namespace Eccube\Twig\Extension;
 
 use Eccube\Entity\OrderItem;
 use Eccube\Repository\TaxRuleRepository;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
+use Twig\Attribute\AsTwigFunction;
 
-class TaxExtension extends AbstractExtension
+class TaxExtension
 {
     /**
      * TaxExtension constructor.
@@ -28,23 +27,11 @@ class TaxExtension extends AbstractExtension
     }
 
     /**
-     * Returns a list of functions to add to the existing list.
-     *
-     * @return TwigFunction[] An array of functions
-     */
-    #[\Override]
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('is_reduced_tax_rate', $this->isReducedTaxRate(...)),
-        ];
-    }
-
-    /**
      * 明細が軽減税率対象かどうかを返す.
      *
      * 受注作成時点での標準税率と比較し, 異なれば軽減税率として判定する.
      */
+    #[AsTwigFunction(name: 'is_reduced_tax_rate')]
     public function isReducedTaxRate(OrderItem $OrderItem): bool
     {
         $Order = $OrderItem->getOrder();

--- a/src/Eccube/Twig/Extension/TwigIncludeExtension.php
+++ b/src/Eccube/Twig/Extension/TwigIncludeExtension.php
@@ -13,24 +13,14 @@
 
 namespace Eccube\Twig\Extension;
 
+use Twig\Attribute\AsTwigFunction;
 use Twig\Environment;
-use Twig\Extension\AbstractExtension;
 use Twig\TemplateWrapper;
-use Twig\TwigFunction;
 
-class TwigIncludeExtension extends AbstractExtension
+class TwigIncludeExtension
 {
     public function __construct(protected Environment $twig)
     {
-    }
-
-    #[\Override]
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('include_dispatch', $this->include_dispatch(...),
-                ['needs_context' => true, 'is_safe' => ['all']]),
-        ];
     }
 
     /**
@@ -42,6 +32,7 @@ class TwigIncludeExtension extends AbstractExtension
      *
      * @return string レンダリング結果
      */
+    #[AsTwigFunction(name: 'include_dispatch', needsContext: true, isSafe: ['all'])]
     public function include_dispatch(array $context, string|TemplateWrapper $template, array $variables = []): string
     {
         if (!empty($variables)) {

--- a/tests/Eccube/Tests/DependencyInjection/Compiler/AutoConfigurationTagPassTest.php
+++ b/tests/Eccube/Tests/DependencyInjection/Compiler/AutoConfigurationTagPassTest.php
@@ -34,7 +34,7 @@ final class AutoConfigurationTagPassTest extends EccubeTestCase
         $this->assertFalse($definition->hasTag('doctrine.event_subscriber'));
 
         $container->addCompilerPass(new AutoConfigurationTagPass());
-        $container->compile();
+        $container->compile(true);
 
         $definition = $container->getDefinition(Subscriber::class);
         $this->assertTrue($definition->hasTag('doctrine.event_subscriber'));
@@ -50,7 +50,7 @@ final class AutoConfigurationTagPassTest extends EccubeTestCase
         $this->assertFalse($child->hasTag('eccube_rate_limiter'));
 
         $container->addCompilerPass(new AutoConfigurationTagPass());
-        $container->compile();
+        $container->compile(true);
 
         $this->assertTrue($child->hasTag('eccube_rate_limiter'));
     }

--- a/tests/Eccube/Tests/DependencyInjection/Compiler/NavCompilerPassTest.php
+++ b/tests/Eccube/Tests/DependencyInjection/Compiler/NavCompilerPassTest.php
@@ -31,7 +31,7 @@ final class NavCompilerPassTest extends EccubeTestCase
         $container = $this->createContainer();
 
         $container->addCompilerPass(new NavCompilerPass());
-        $container->compile();
+        $container->compile(true);
 
         $eccubeNav = $container->getParameter('eccube_nav');
 
@@ -57,7 +57,7 @@ final class NavCompilerPassTest extends EccubeTestCase
             ->addTag(NavCompilerPass::NAV_TAG);
 
         $container->addCompilerPass(new NavCompilerPass());
-        $container->compile();
+        $container->compile(true);
 
         $eccubeNav = $container->getParameter('eccube_nav');
 
@@ -85,7 +85,7 @@ final class NavCompilerPassTest extends EccubeTestCase
             ->addTag(NavCompilerPass::NAV_TAG);
 
         $container->addCompilerPass(new NavCompilerPass());
-        $container->compile();
+        $container->compile(true);
 
         $eccubeNav = $container->getParameter('eccube_nav');
 

--- a/tests/Eccube/Tests/DependencyInjection/Compiler/PluginPassTest.php
+++ b/tests/Eccube/Tests/DependencyInjection/Compiler/PluginPassTest.php
@@ -39,7 +39,7 @@ final class PluginPassTest extends TestCase
     {
         $this->containerBuilder->setParameter('eccube.plugins.disabled', []);
         $this->containerBuilder->addCompilerPass(new PluginPass());
-        $this->containerBuilder->compile();
+        $this->containerBuilder->compile(false);
 
         $def = $this->containerBuilder->getDefinition(\Plugin\Sample\TestClass::class);
         $this->assertTrue($def->hasTag('test_tag'));
@@ -52,7 +52,7 @@ final class PluginPassTest extends TestCase
     {
         $this->containerBuilder->setParameter('eccube.plugins.disabled', ['Sample']);
         $this->containerBuilder->addCompilerPass(new PluginPass());
-        $this->containerBuilder->compile();
+        $this->containerBuilder->compile(false);
 
         $def = $this->containerBuilder->getDefinition(\Plugin\Sample\TestClass::class);
 

--- a/tests/Eccube/Tests/DependencyInjection/Compiler/QueryCustomizerPassTest.php
+++ b/tests/Eccube/Tests/DependencyInjection/Compiler/QueryCustomizerPassTest.php
@@ -34,7 +34,7 @@ final class QueryCustomizerPassTest extends TestCase
             ->addTag(QueryCustomizerPass::QUERY_CUSTOMIZER_TAG);
 
         $container->addCompilerPass(new QueryCustomizerPass());
-        $container->compile();
+        $container->compile(true);
 
         // Queriesにカスタマイザが追加されていることを確認
         $queries = $container->get(Queries::class);

--- a/tests/Eccube/Tests/DependencyInjection/Compiler/TwigExtensionPassTest.php
+++ b/tests/Eccube/Tests/DependencyInjection/Compiler/TwigExtensionPassTest.php
@@ -53,7 +53,7 @@ final class TwigExtensionPassTest extends TestCase
     {
         $this->containerBuilder->setParameter('kernel.debug', false);
         $this->containerBuilder->addCompilerPass(new TwigExtensionPass());
-        $this->containerBuilder->compile();
+        $this->containerBuilder->compile(false);
 
         /** @var Environment $twig */
         $twig = $this->containerBuilder->get(Environment::class);

--- a/tests/Eccube/Tests/Doctrine/Common/CsvDataFixtures/LoaderTest.php
+++ b/tests/Eccube/Tests/Doctrine/Common/CsvDataFixtures/LoaderTest.php
@@ -59,7 +59,7 @@ final class LoaderTest extends EccubeTestCase
             ->files();
         $fixtures = $this->loader->loadFromIterator($finder->getIterator());
 
-        $this->assertTrue(is_array($fixtures));
+        $this->assertIsArray($fixtures);
         $this->assertInstanceOf(CsvFixture::class, $fixtures[0]);
 
         $this->expected = iterator_count($finder->getIterator());
@@ -76,7 +76,7 @@ final class LoaderTest extends EccubeTestCase
 
         $fixtures = $this->loader->loadFromDirectory($this->dir);
 
-        $this->assertTrue(is_array($fixtures));
+        $this->assertIsArray($fixtures);
         $this->assertInstanceOf(CsvFixture::class, $fixtures[0]);
 
         $this->expected = iterator_count($finder->getIterator());

--- a/tests/Eccube/Tests/Doctrine/TimeZone/TimeZoneTest.php
+++ b/tests/Eccube/Tests/Doctrine/TimeZone/TimeZoneTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Eccube\Tests\Doctrine;
 
+use Doctrine\DBAL\Exception;
 use Eccube\Entity\Product;
 use Eccube\Repository\ProductRepository;
 use Eccube\Tests\EccubeTestCase;
@@ -26,7 +27,7 @@ final class TimeZoneTest extends EccubeTestCase
     /**
      * {@inheritdoc}
      *
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws Exception
      */
     protected function setUp(): void
     {

--- a/tests/Eccube/Tests/Entity/AbstractEntityTest.php
+++ b/tests/Eccube/Tests/Entity/AbstractEntityTest.php
@@ -38,13 +38,13 @@ final class AbstractEntityTest extends EccubeTestCase
             'field3' => 3,
         ];
         $this->objEntity = new TestEntity($arrProps);
-        $this->assertTrue(is_object($this->objEntity));
+        $this->assertIsObject($this->objEntity);
     }
 
     public function testNewInstanceEmptyParams()
     {
         $this->objEntity = new TestEntity();
-        $this->assertTrue(is_object($this->objEntity));
+        $this->assertIsObject($this->objEntity);
     }
 
     public function testToArray()

--- a/tests/Eccube/Tests/Entity/TaxRuleTest.php
+++ b/tests/Eccube/Tests/Entity/TaxRuleTest.php
@@ -117,9 +117,7 @@ final class TaxRuleTest extends EccubeTestCase
      */
     private function createTaxRule(string $taxRate, int $sortNo = 0, ?\DateTime $applyDate = null, ?ProductClass $ProductClass = null, ?Product $Product = null): TaxRule
     {
-        if ($applyDate === null) {
-            $applyDate = new \DateTime();
-        }
+        $applyDate ??= new \DateTime();
         $TaxRule = new TaxRule();
         $TaxRule
             ->setTaxRate($taxRate)

--- a/tests/Eccube/Tests/EventListener/Mcp/AuthFailureAuditListenerTest.php
+++ b/tests/Eccube/Tests/EventListener/Mcp/AuthFailureAuditListenerTest.php
@@ -17,6 +17,7 @@ namespace Eccube\Tests\EventListener\Mcp;
 
 use Eccube\EventListener\Mcp\AuthFailureAuditListener;
 use Eccube\Service\Mcp\McpAuditLogger;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\AbstractLogger;
 use Psr\Log\NullLogger;
@@ -83,6 +84,7 @@ final class AuthFailureAuditListenerTest extends TestCase
         $this->assertSame([], $recorder->records, 'mcp 以外のパスの 401 は記録しない');
     }
 
+    #[DoesNotPerformAssertions]
     public function testAuditFailureDoesNotBreakResponse(): void
     {
         $throwingAudit = new McpAuditLogger(
@@ -101,8 +103,6 @@ final class AuthFailureAuditListenerTest extends TestCase
 
         // 監査が throw しても例外が伝播しない (401 応答を壊さない)
         $listener->onKernelResponse($this->responseEvent('/admin/mcp', Response::HTTP_UNAUTHORIZED));
-
-        $this->addToAssertionCount(1);
     }
 
     private function buildListener(AbstractLogger $recorder): AuthFailureAuditListener

--- a/tests/Eccube/Tests/Fixture/Generator.php
+++ b/tests/Eccube/Tests/Fixture/Generator.php
@@ -313,9 +313,7 @@ class Generator
         $ProductCodesGenerated = [];
 
         $Product = new Product();
-        if (is_null($product_name)) {
-            $product_name = $faker->realText($faker->numberBetween(10, 50));
-        }
+        $product_name ??= $faker->realText($faker->numberBetween(10, 50));
         $Product
             ->setName($product_name)
             ->setCreator($Member)
@@ -536,9 +534,7 @@ class Generator
         $quantity = $faker->numberBetween(1, 10);
         $Pref = $this->entityManager->find(Pref::class, $faker->numberBetween(1, 47));
         $Payments = $this->paymentRepository->findAll();
-        if ($statusTypeId === null) {
-            $statusTypeId = OrderStatus::PROCESSING;
-        }
+        $statusTypeId ??= OrderStatus::PROCESSING;
         $OrderStatus = $this->entityManager->find(OrderStatus::class, $statusTypeId);
         $Order = new Order($OrderStatus);
         $Order->setCustomer($Customer);

--- a/tests/Eccube/Tests/Repository/CalendarRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/CalendarRepositoryTest.php
@@ -57,9 +57,7 @@ final class CalendarRepositoryTest extends EccubeTestCase
     public function createCalendar(string $title = 'title', ?\DateTime $holiday = null): Calendar
     {
         $Calendar = new Calendar();
-        if (is_null($holiday)) {
-            $holiday = $this->DateTimeNow;
-        }
+        $holiday ??= $this->DateTimeNow;
         $Calendar->setTitle($title)
             ->setHoliday($holiday);
         $this->entityManager->persist($Calendar);

--- a/tests/Eccube/Tests/Repository/CategoryRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/CategoryRepositoryTest.php
@@ -18,6 +18,7 @@ namespace Eccube\Tests\Repository;
 use Eccube\Entity\Category;
 use Eccube\Repository\CategoryRepository;
 use Eccube\Tests\EccubeTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 /**
  * CategoryRepository test cases.
@@ -229,6 +230,7 @@ final class CategoryRepositoryTest extends EccubeTestCase
         $this->assertNotInstanceOf(Category::class, $Category);
     }
 
+    #[DoesNotPerformAssertions]
     public function testDeleteFail()
     {
         // 商品をカテゴリに紐付けて作成.
@@ -240,7 +242,6 @@ final class CategoryRepositoryTest extends EccubeTestCase
             $this->categoryRepository->delete($Category);
             $this->fail();
         } catch (\Exception) {
-            $this->addToAssertionCount(1);
         }
     }
 }

--- a/tests/Eccube/Tests/Repository/ClassCategoryRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/ClassCategoryRepositoryTest.php
@@ -22,6 +22,7 @@ use Eccube\Repository\ClassCategoryRepository;
 use Eccube\Repository\ClassNameRepository;
 use Eccube\Repository\ProductClassRepository;
 use Eccube\Tests\EccubeTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 /**
  * ClassCategoryRepository test cases.
@@ -176,6 +177,7 @@ final class ClassCategoryRepositoryTest extends EccubeTestCase
         $this->assertNotInstanceOf(ClassCategory::class, $this->entityManager->find(ClassCategory::class, $ClassCategoryId));
     }
 
+    #[DoesNotPerformAssertions]
     public function testDeleteWithException()
     {
         $Product = $this->createProduct();
@@ -191,7 +193,6 @@ final class ClassCategoryRepositoryTest extends EccubeTestCase
                 $this->classCategoryRepository->delete($ClassCategory1);
                 $this->fail();
             } catch (\Exception) {
-                $this->addToAssertionCount(1);
             }
         }
     }

--- a/tests/Eccube/Tests/Repository/ClassNameRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/ClassNameRepositoryTest.php
@@ -23,6 +23,7 @@ use Eccube\Repository\ClassCategoryRepository;
 use Eccube\Repository\ClassNameRepository;
 use Eccube\Repository\ProductClassRepository;
 use Eccube\Tests\EccubeTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 /**
  * ClassNameRepository test cases.
@@ -142,6 +143,7 @@ final class ClassNameRepositoryTest extends EccubeTestCase
         $this->assertNotInstanceOf(ClassName::class, $this->entityManager->find(ClassName::class, $ClassNameId));
     }
 
+    #[DoesNotPerformAssertions]
     public function testDeleteWithException()
     {
         $ClassName = new ClassName();
@@ -162,7 +164,6 @@ final class ClassNameRepositoryTest extends EccubeTestCase
             $this->classNameRepository->delete($ClassName);
             $this->fail();
         } catch (\Exception) {
-            $this->addToAssertionCount(1);
         }
     }
 }

--- a/tests/Eccube/Tests/Repository/PaymentRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/PaymentRepositoryTest.php
@@ -235,7 +235,7 @@ final class PaymentRepositoryTest extends EccubeTestCase
     {
         $Results = $this->paymentRepository->findAllArray();
 
-        $this->assertTrue(is_array($Results));
+        $this->assertIsArray($Results);
 
         $this->expected = '銀行振込';
         $this->actual = $Results[3]['method'];
@@ -257,7 +257,7 @@ final class PaymentRepositoryTest extends EccubeTestCase
         $this->actual = count($payments);
         $this->verify();
 
-        $this->assertTrue(is_array($payments[0]));
+        $this->assertIsArray($payments[0]);
     }
 
     public function testFindPaymentsAsObjects()
@@ -275,6 +275,6 @@ final class PaymentRepositoryTest extends EccubeTestCase
         $this->actual = count($payments);
         $this->verify();
 
-        $this->assertTrue(is_object($payments[0]));
+        $this->assertIsObject($payments[0]);
     }
 }

--- a/tests/Eccube/Tests/Repository/TaxRuleRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/TaxRuleRepositoryTest.php
@@ -86,9 +86,7 @@ final class TaxRuleRepositoryTest extends EccubeTestCase
         $TaxRule = new TaxRule();
         $RoundingType = $this->entityManager->find(RoundingType::class, 1);
         $Member = $this->memberRepository->find(2);
-        if (is_null($apply_date)) {
-            $apply_date = $this->DateTimeNow;
-        }
+        $apply_date ??= $this->DateTimeNow;
         $TaxRule->setTaxRate((string) $tax_rate)
             ->setApplyDate($apply_date)
             ->setRoundingType($RoundingType)

--- a/tests/Eccube/Tests/Service/AgentCommerce/Conformance/AcpCheckoutConformanceTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/Conformance/AcpCheckoutConformanceTest.php
@@ -22,6 +22,7 @@ use Eccube\Repository\CheckoutSessionRepository;
 use Eccube\Repository\Master\CheckoutSessionStatusRepository;
 use Eccube\Service\AgentCommerce\Acp\AcpMessageMapper;
 use Eccube\Tests\EccubeTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -230,6 +231,7 @@ final class AcpCheckoutConformanceTest extends EccubeTestCase
      *
      * @see https://github.com/agentic-commerce-protocol/agentic-commerce-protocol ACP openapi.agentic_checkout_webhook.yaml
      */
+    #[DoesNotPerformAssertions]
     public function testWebhookDispatchDeferred(): void
     {
         $this->markTestIncomplete('Webhook の outbound 送出 (order_create/order_update) は後続 PR で実装する (署名基盤 AcpMessageSigner は本 PR に存在)。');

--- a/tests/Eccube/Tests/Service/AgentCommerce/Conformance/AcpFeedConformanceTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/Conformance/AcpFeedConformanceTest.php
@@ -20,6 +20,7 @@ use Eccube\Service\AgentCommerce\Catalog\AgentCatalogItemDto;
 use Eccube\Service\AgentCommerce\Catalog\AgentCatalogVariantDto;
 use Eccube\Service\AgentCommerce\Catalog\AvailabilityStatus;
 use JsonSchema\Validator;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -225,6 +226,7 @@ final class AcpFeedConformanceTest extends TestCase
      *
      * @see https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/blob/main/spec/2026-04-17/openapi/openapi.feed.yaml
      */
+    #[DoesNotPerformAssertions]
     public function testFeedPushTransportRequirementsAreDeferredToLayer9(): void
     {
         self::markTestIncomplete('Feed push transport (POST /feeds, PATCH /feeds/{id}/products, outbound Bearer api_key, idempotency) は国内 GA 前で活用不可のため Layer 9 (ACP push) で検証する。');

--- a/tests/Eccube/Tests/Service/AgentCommerce/Conformance/AgentCheckoutCoreConformanceTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/Conformance/AgentCheckoutCoreConformanceTest.php
@@ -20,6 +20,7 @@ use Eccube\Entity\Master\CheckoutSessionStatus;
 use Eccube\Entity\Order;
 use Eccube\Service\AgentCommerce\CheckoutSession\AgentCheckoutMessageLevel;
 use Eccube\Service\AgentCommerce\Payment\PaymentOutcomeStatus;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -119,6 +120,7 @@ final class AgentCheckoutCoreConformanceTest extends TestCase
      * プロトコル系 (HTTP 4xx/5xx) とビジネス系 (HTTP 200 + messages[]) の 2 系統への
      * 実際の HTTP 変換は checkout controller (#6776/#6574) の責務であり中核の対象外.
      */
+    #[DoesNotPerformAssertions]
     public function testTwoTierHttpMappingIsDeferredToControllerLayer(): void
     {
         self::markTestIncomplete('HTTP ステータスと messages[] への 2 系統変換は ACP/UCP checkout controller (#6776/#6574) で検証する。');
@@ -128,6 +130,7 @@ final class AgentCheckoutCoreConformanceTest extends TestCase
      * リプレイ (Idempotency-Key) で副作用を再実行しない不変条件は、controller/middleware の
      * 冪等性処理に依存するため中核では未実装.
      */
+    #[DoesNotPerformAssertions]
     public function testIdempotentReplayIsDeferredToControllerLayer(): void
     {
         self::markTestIncomplete('Idempotency-Key によるリプレイ抑止は checkout controller (#6776/#6574) で検証する。');

--- a/tests/Eccube/Tests/Service/AgentCommerce/Conformance/AgentCommerceBaseConformanceTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/Conformance/AgentCommerceBaseConformanceTest.php
@@ -18,6 +18,7 @@ namespace Eccube\Tests\Service\AgentCommerce\Conformance;
 use Eccube\Service\AgentCommerce\MinorUnitConverter;
 use Eccube\Service\AgentCommerce\Security\KeyStoreInterface;
 use Eccube\Service\AgentCommerce\Security\UcpMessageSigner;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -89,6 +90,7 @@ final class AgentCommerceBaseConformanceTest extends TestCase
      * business errors as HTTP 200 + messages[]) is enforced at the controller
      * layer, which is out of scope for the common base.
      */
+    #[DoesNotPerformAssertions]
     public function testTwoTierErrorModelIsDeferredToControllerLayer(): void
     {
         self::markTestIncomplete('Two-tier error model (HTTP errors vs messages[]) is verified in the ACP/UCP checkout controller tracks, not in the common base.');

--- a/tests/Eccube/Tests/Service/AgentCommerce/Conformance/UcpCatalogConformanceTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/Conformance/UcpCatalogConformanceTest.php
@@ -20,6 +20,7 @@ use Eccube\Service\AgentCommerce\Catalog\AgentCatalogVariantDto;
 use Eccube\Service\AgentCommerce\Catalog\AvailabilityStatus;
 use Eccube\Service\AgentCommerce\Catalog\Ucp\UcpCatalogProductSerializer;
 use Eccube\Service\AgentCommerce\Catalog\Ucp\UcpCatalogResponseBuilder;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -175,6 +176,7 @@ final class UcpCatalogConformanceTest extends TestCase
      *
      * @see https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/catalog/rest.md#L591
      */
+    #[DoesNotPerformAssertions]
     public function testCursorPaginationDefaultLimitIsVerifiedAtControllerLayer(): void
     {
         self::markTestIncomplete('MUST: REST transport supports cursor-based pagination with a default limit of 10. pagination cursor の生成・default limit はコントローラ (UcpCatalogController) の Web テスト (Layer 3) で検証する。');
@@ -186,6 +188,7 @@ final class UcpCatalogConformanceTest extends TestCase
      *
      * @see https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/catalog/rest.md#L592
      */
+    #[DoesNotPerformAssertions]
     public function testLookupHttpStatusSemanticsAreVerifiedAtControllerLayer(): void
     {
         self::markTestIncomplete('MUST: lookup は HTTP 200 を返し未知 ID は返却件数減で表現、batch 超過は HTTP 400 + request_too_large。HTTP ステータスを伴うためコントローラ (Layer 3) で検証する。');

--- a/tests/Eccube/Tests/Service/AgentCommerce/Conformance/UcpCheckoutConformanceTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/Conformance/UcpCheckoutConformanceTest.php
@@ -25,6 +25,7 @@ use Eccube\Service\AgentCommerce\Idempotency\AgentCheckoutIdempotencyStore;
 use Eccube\Service\AgentCommerce\Ucp\UcpMessageMapper;
 use Eccube\Service\AgentCommerce\Ucp\UcpStatusMapper;
 use Eccube\Tests\EccubeTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 /**
  * Layer 0: UCP Checkout 仕様適合性 (規範要件 1:1 トレース).
@@ -116,6 +117,7 @@ final class UcpCheckoutConformanceTest extends EccubeTestCase
      *
      * @see https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/checkout.md (continue_url MUST be absolute HTTPS when requires_escalation)
      */
+    #[DoesNotPerformAssertions]
     public function testContinueUrlMustBeAbsoluteHttpsOnEscalation(): void
     {
         $this->markTestIncomplete('requires_escalation の永続化と continue_url 生成は MVP では未実装 (escalation は recoverable で代替)。');
@@ -126,6 +128,7 @@ final class UcpCheckoutConformanceTest extends EccubeTestCase
      *
      * @see https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/checkout.md (confirmation email after completion)
      */
+    #[DoesNotPerformAssertions]
     public function testCompleteSendsConfirmationEmail(): void
     {
         $this->markTestIncomplete('確認メール送信は shopping flow / MailService 連携で別途検証する (本 Layer では未トレース)。');
@@ -136,6 +139,7 @@ final class UcpCheckoutConformanceTest extends EccubeTestCase
      *
      * @see https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/checkout-rest.md (all endpoints over TLS 1.3+)
      */
+    #[DoesNotPerformAssertions]
     public function testAllEndpointsRequireHttps(): void
     {
         $this->markTestIncomplete('HTTPS 強制はトランスポート層 (デプロイ構成) の責務であり、アプリ層ではトレースしない。');

--- a/tests/Eccube/Tests/Service/AgentCommerce/Conformance/UcpDiscoveryConformanceTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/Conformance/UcpDiscoveryConformanceTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Eccube\Tests\Service\AgentCommerce\Conformance;
 
 use Eccube\Service\AgentCommerce\Discovery\UcpProfileBuilder;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -97,6 +98,7 @@ final class UcpDiscoveryConformanceTest extends TestCase
      *
      * @see https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/overview.md#L360
      */
+    #[DoesNotPerformAssertions]
     public function testServicesAndPaymentHandlersRegistriesArePresentEvenWhenEmpty(): void
     {
         self::markTestIncomplete('MUST: services と payment_handlers MUST be present even when empty. profile 全体の組み立ては UcpProfileBuilder のコンテナ依存 (BaseInfo/UrlGenerator) を要するため、空オブジェクト保証はコンテナ駆動の discovery Web テスト (Layer 3\') で検証する。');
@@ -126,6 +128,7 @@ final class UcpDiscoveryConformanceTest extends TestCase
      *
      * @see https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/overview.md#L1090
      */
+    #[DoesNotPerformAssertions]
     public function testProfileDeliveryHttpsNoRedirectAndCacheControlAreVerifiedAtWebLayer(): void
     {
         self::markTestIncomplete('MUST: profile served over HTTPS, MUST NOT use 3xx redirects, Cache-Control MUST be "public, max-age>=60" (not private/no-store/no-cache). これらの配信ヘッダ要件は discovery コントローラの Web テスト (Layer 3\') で検証する。');

--- a/tests/Eccube/Tests/Service/AgentCommerce/Schema/UcpCatalogSchemaContractTest.php
+++ b/tests/Eccube/Tests/Service/AgentCommerce/Schema/UcpCatalogSchemaContractTest.php
@@ -22,6 +22,7 @@ use Eccube\Service\AgentCommerce\Catalog\AgentCatalogVariantDto;
 use Eccube\Service\AgentCommerce\Catalog\AvailabilityStatus;
 use Eccube\Service\AgentCommerce\Catalog\Ucp\UcpCatalogProductSerializer;
 use Eccube\Service\AgentCommerce\Catalog\Ucp\UcpCatalogResponseBuilder;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -76,6 +77,7 @@ final class UcpCatalogSchemaContractTest extends TestCase
         );
     }
 
+    #[DoesNotPerformAssertions]
     public function testLookupResponseMatchesUcpSchema(): void
     {
         // lookup_response の variants は lookup_variant を要求し、これは input_correlation[]

--- a/tests/Eccube/Tests/Service/CookieConsentLogServiceTest.php
+++ b/tests/Eccube/Tests/Service/CookieConsentLogServiceTest.php
@@ -19,6 +19,7 @@ use Eccube\Service\CookieConsentLogService;
 use Eccube\Service\CookieConsentService;
 use Eccube\Tests\EccubeTestCase;
 use Monolog\Handler\TestHandler;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 /**
  * CookieConsentLogServiceのテスト
@@ -115,6 +116,7 @@ final class CookieConsentLogServiceTest extends EccubeTestCase
     /**
      * ログ出力が失敗しても例外を投げず処理を継続する（ベストエフォート）ことを確認する。
      */
+    #[DoesNotPerformAssertions]
     public function testSaveLogIsBestEffortAndDoesNotThrow()
     {
         // 必須キーを欠いた不完全なデータでも例外を投げないこと
@@ -122,7 +124,5 @@ final class CookieConsentLogServiceTest extends EccubeTestCase
         $invalid = ['consent_status' => 'accepted'];
 
         $this->service->saveLog($invalid);
-
-        $this->addToAssertionCount(1);
     }
 }

--- a/tests/Eccube/Tests/Service/Mcp/McpAuditLoggerTest.php
+++ b/tests/Eccube/Tests/Service/Mcp/McpAuditLoggerTest.php
@@ -89,8 +89,7 @@ final class McpAuditLoggerTest extends TestCase
     public function testRequestIdIsStableWithinSameRequest(): void
     {
         $logger = $this->captureLogger();
-        $stack = new RequestStack();
-        $stack->push(new Request());
+        $stack = new RequestStack([new Request()]);
         $auditLogger = new McpAuditLogger($logger, $stack);
 
         $auditLogger->logToolCall('a', [], AuditResult::Success, 1.0);

--- a/tests/Eccube/Tests/Twig/Extension/CookieConsentExtensionTest.php
+++ b/tests/Eccube/Tests/Twig/Extension/CookieConsentExtensionTest.php
@@ -32,8 +32,7 @@ final class CookieConsentExtensionTest extends EccubeTestCase
         if ($cookieValue !== null) {
             $request->cookies->set(CookieConsentService::COOKIE_NAME, $cookieValue);
         }
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         return new CookieConsentExtension(new CookieConsentService(), $requestStack);
     }

--- a/tests/Eccube/Tests/Twig/Extension/IntlExtensionTest.php
+++ b/tests/Eccube/Tests/Twig/Extension/IntlExtensionTest.php
@@ -18,8 +18,10 @@ namespace Eccube\Tests\Twig\Extension;
 use Eccube\Twig\Extension\IntlExtension;
 use PHPUnit\Framework\TestCase;
 use Twig\Environment;
+use Twig\Extension\AttributeExtension;
 use Twig\Extension\CoreExtension;
 use Twig\Loader\ArrayLoader;
+use Twig\RuntimeLoader\FactoryRuntimeLoader;
 
 final class IntlExtensionTest extends TestCase
 {
@@ -33,7 +35,13 @@ final class IntlExtensionTest extends TestCase
 
         $this->twig = new Environment($loader);
         $this->twig->getExtension(CoreExtension::class)->setTimezone('Asia/Tokyo');
-        $this->twig->addExtension(new IntlExtension());
+        // IntlExtension は #[AsTwigFilter] で定義するため, 素の Environment では
+        // AttributeExtension とランタイムローダの組で登録する（コンテナ経由の登録は
+        // TwigBundle が twig.attribute_extension として自動で行う）。
+        $this->twig->addExtension(new AttributeExtension(IntlExtension::class));
+        $this->twig->addRuntimeLoader(new FactoryRuntimeLoader([
+            IntlExtension::class => static fn (): IntlExtension => new IntlExtension(),
+        ]));
     }
 
     public function testDateDay()

--- a/tests/Eccube/Tests/Web/AgentCommerce/AcpCheckoutControllerTest.php
+++ b/tests/Eccube/Tests/Web/AgentCommerce/AcpCheckoutControllerTest.php
@@ -69,10 +69,7 @@ final class AcpCheckoutControllerTest extends EccubeTestCase
         if ($auth) {
             $headers['HTTP_AUTHORIZATION'] = 'Bearer '.self::TOKEN;
         }
-        // Idempotency-Key は POST で必須。明示指定が無ければ一意キーを自動付与する。
-        if (!isset($server['HTTP_Idempotency-Key'])) {
-            $server['HTTP_Idempotency-Key'] = 'idem-'.bin2hex(random_bytes(8));
-        }
+        $server['HTTP_Idempotency-Key'] ??= 'idem-'.bin2hex(random_bytes(8));
 
         $this->client->request(Request::METHOD_POST, $uri, [], [], array_merge($headers, $server), (string) json_encode($body));
 

--- a/tests/Eccube/Tests/Web/Block/NewItemTest.php
+++ b/tests/Eccube/Tests/Web/Block/NewItemTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Eccube\Tests\Web\Block;
 
+use Doctrine\DBAL\Exception;
 use Eccube\Tests\Web\AbstractWebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -23,7 +24,7 @@ final class NewItemTest extends AbstractWebTestCase
     /**
      * {@inheritdoc}
      *
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws Exception
      */
     protected function setUp(): void
     {

--- a/tests/Eccube/Tests/Web/CartValidationTest.php
+++ b/tests/Eccube/Tests/Web/CartValidationTest.php
@@ -2344,7 +2344,7 @@ final class CartValidationTest extends AbstractWebTestCase
         // THEN
         // check message error (expect not contain)
         $message = $crawler->filter('#cart_box__body')->text();
-        $this->assertNotContains('この商品は同時に購入することはできません。', $message);
+        $this->assertStringNotContainsString('この商品は同時に購入することはできません。', $message);
     }
 
     protected function scenarioCartIn(Customer $Customer, ProductClass $ProductClass, int $num = 1): mixed

--- a/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
+++ b/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
@@ -59,8 +59,7 @@ final class InstallControllerTest extends AbstractWebTestCase
         $cacheUtil = static::getContainer()->get(CacheUtil::class);
         $request = new Request();
         $request->setSession(new Session(new MockArraySessionStorage()));
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
         $this->session = new EccubeSession($requestStack);
         $this->controller = new InstallController($passwordHasher, $cacheUtil);
         $this->controller->setFormFactory($formFactory);

--- a/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
+++ b/tests/Eccube/Tests/Web/Install/InstallControllerTest.php
@@ -85,7 +85,7 @@ final class InstallControllerTest extends AbstractWebTestCase
     public function testStep1()
     {
         $this->actual = $this->controller->step1($this->createStub(Request::class));
-        $this->assertTrue(is_array($this->actual));
+        $this->assertIsArray($this->actual);
         $this->assertInstanceOf(FormView::class, $this->actual['form']);
     }
 
@@ -102,7 +102,7 @@ final class InstallControllerTest extends AbstractWebTestCase
     {
         $entityManager = static::getContainer()->get(EntityManagerInterface::class);
         $this->actual = $this->controller->step3($this->createStub(Request::class), $entityManager);
-        $this->assertTrue(is_array($this->actual));
+        $this->assertIsArray($this->actual);
         $this->assertInstanceOf(FormView::class, $this->actual['form']);
         $this->assertInstanceOf(Request::class, $this->actual['request']);
     }
@@ -110,7 +110,7 @@ final class InstallControllerTest extends AbstractWebTestCase
     public function testStep4()
     {
         $this->actual = $this->controller->step4($this->createStub(Request::class));
-        $this->assertTrue(is_array($this->actual));
+        $this->assertIsArray($this->actual);
         $this->assertInstanceOf(FormView::class, $this->actual['form']);
     }
 


### PR DESCRIPTION
## 概要

`rector/rector` を 2.6.1 → 2.6.4 へ上げ、**この更新が要求する変更をまとめて入れます**。

[#7087](https://github.com/EC-CUBE/ec-cube/pull/7087)（php-dev-tools グループ）の `rector / Rector` が赤いのは、この更新に含まれる rector の破壊的変更で `rector.php` が起動できなくなるためです。**直す場所は lock ではなく本体の設定とコード側**なので、rector 分だけを本 PR に切り出しました。本 PR がマージされれば #7087 は rebase で rector が落ち、残り 4 件（phpstan 2.2.10 / symfony/browser-kit / dom-crawler / phpunit-bridge）の更新になります。

```
[ERROR] Undefined constant Rector\Symfony\Set\SymfonySetList::SYMFONY_74
```

## 何が壊れるか

2.6.2 の「every extension package now ships a single composer-based set」で、**バージョン別のセット定数が撤去されました**。

| SetList | 2.6.1 | 2.6.4 |
|---|---|---|
| `SymfonySetList` | 38 | **5**（`SYMFONY_25`〜`SYMFONY_81` の 33 個が消滅） |
| `DoctrineSetList` | 21 | **7** |
| `PHPUnitSetList` | 15 | **5** |

`rector.php` が参照していた撤去済みの定数は 3 つです。rector は最初の未定義定数で即座に落ちるため、CI のログには 1 つしか出ません。

- `SymfonySetList::SYMFONY_74` → `SymfonySetList::COMPOSER_BASED`
- `DoctrineSetList::DOCTRINE_DBAL_30` → `DoctrineSetList::COMPOSER_BASED`
- `PHPUnitSetList::PHPUNIT_110` → `PHPUnitSetList::COMPOSER_BASED`

`COMPOSER_BASED` は 2.6.1 にも存在するため、置き換え自体は現行版でも動きます。各ルールが `composer.json` / `installed.json` を見て、インストール済みバージョンに合うものだけ実行します。

## 置き換えは等価ではありません（実測）

キャッシュを消した **1283 ファイル走査**での計測です。

| 条件 | 変更提案 |
|---|---|
| rector 2.6.1・変更前の設定 | **0 ファイル** |
| rector 2.6.1・`COMPOSER_BASED` × 3 | **126 ファイル / 13 ルール** |
| rector 2.6.4・`COMPOSER_BASED` × 3（上記適用後） | **さらに 44 ファイル / 9 ルール** |

後者 44 件は composer-based 移行とは独立で、**2.6.2〜2.6.4 で追加・変更されたルール**の分です。

これらを `withSkip()` で先送りにすると、「コード側に理由がある既存の例外」と「まだ直していないもの」が同じリストに混ざって読めなくなるため、**すべて適用しました**。

## コミットの構成

対象ルールは `COMPOSER_BASED` を入れないと発火しないため、**コード変更を先・設定変更を後**にしています。1〜4 は現行 rector から見ると対象ルールが眠っているので指摘ゼロ、5 の時点では既にコードが片付いているので dry-run 0 件。**各コミットが単体で緑**になります。

| # | コミット | 対象 | 内容 |
|---|---|---|---|
| 1 | `refactor(command)` | 17 | `return 0/1` → `Command::SUCCESS/FAILURE`、`setHelp()` → `#[AsCommand(help:)]` |
| 2 | `refactor(twig)` | 6+1 | `getFunctions()/getFilters()` → `#[AsTwigFunction]/#[AsTwigFilter]` |
| 3 | `refactor` | 14 | `Criteria::ASC` → `Order::Ascending`、`compile()` の引数明示ほか |
| 4 | `refactor(form)` | 91 | Validator 制約を名前付き引数へ（254 箇所）、既定と同じ `getBlockPrefix()` の削除（52 クラス） |
| 5 | `build(rector)` | 1 | 3 定数を `COMPOSER_BASED` へ |
| 6 | `build(deps-dev)` | 45 | **rector 2.6.4 への更新と、それが要求する 44 ファイルの追従** |
| 7 | `build(rector)` | 1 | 2.6.4 が警告する死んだ skip と二重登録の掃除 |

コミット 6 の内訳は次のとおりです。

| ルール | 件数 | 内容 |
|---|---|---|
| `IfToNullCoalescingAssignRector` | 21 | `if (!isset($x)) { $x = y; }` → `$x ??= y` |
| `AddDoesNotPerformAssertionToNonAssertingTestRector` | 13 | アサーションを持たないテストに `#[DoesNotPerformAssertions]` |
| `AssertTrueFalseToSpecificMethodRector` | 4 | `assertTrue(x === y)` 等を専用アサーションへ |
| `SimplifyBoolIdenticalTrueRector` / `ArrayKeysToArrayKeyFirstLastRector` / `RemoveUselessParamTagRector` / `AddParamTypeDeclarationRector` | 各 2 | 真偽比較の簡約、`array_key_first`、冗長な `@param`、引数型の付与 |
| `SpecificAssertContainsRector` | 1 | `assertContains` の絞り込み |

## 確認したこと

- **`rector process --dry-run` が 1283 ファイルで 0 件**（rector 2.6.4・キャッシュ削除後）
- `phpstan analyse src/` → **No errors**
- `php-cs-fixer` → 変更ファイルすべて違反なし
- `tests/Eccube/Tests/Form` → **741 tests / 788 assertions OK**
- `tests/Eccube/Tests/DependencyInjection` → **33 tests OK**
- 変更ファイルすべて `php -l` 通過（45 件）
- `tests/Eccube/Tests/Repository` / `Entity` / `EventListener` は `origin/4.4` と比較して**エラー 164 件が同数、失敗は 18 → 15 件**（手元 DB の残存データ由来。悪化はありません）
- `tests/Eccube/Tests/Twig` / `tests/Eccube/Tests/Command` は変更前後で**失敗件数・失敗テストが完全に一致**（`origin/4.4` を直接 checkout して比較）。手元 DB の残存データ由来で、本 PR とは無関係

### 型付与とテスト属性は個別に確認しました

- `AddParamTypeDeclarationRector` が触るのは `CustomerProvider` / `MemberProvider` の `supportsClass($class)` で、`UserProviderInterface::supportsClass(string $class): bool` と一致する型を付けるだけです
- `#[DoesNotPerformAssertions]` が付いた 18 メソッドは、いずれも本体にアサーションがありません（`markTestIncomplete()` のみのもの、例外を投げないことだけを見るものなど）。`UcpCatalogSchemaContractTest::testLookupResponseMatchesUcpSchema` は `markTestIncomplete()` のみで属性が冗長ですが、外すと次の rector 実行で再付与されるため残しています

### Twig の属性化は実機で登録を確認

`AbstractExtension` の継承をやめるため登録経路が変わります。TwigBundle 7.4 が `AsTwigFilter` / `AsTwigFunction` を `registerAttributeForAutoconfiguration` で `twig.attribute_extension` として自動登録するので、サービス定義の変更は不要でした。

- `debug:container --tag=twig.attribute_extension` に 6 クラスが並ぶ
- `debug:twig` に 14 件のフィルタ/関数がすべて出る
- `parent::getFunctions()` / `parent::getFilters()` を呼ぶ箇所は `src` / `app` / `tests` に無い

明示タグを持つ `EccubeBlockExtension` は対象外です。素の `Environment` を使う `IntlExtensionTest` だけ、`AttributeExtension` ＋ `FactoryRuntimeLoader` で登録するよう追従させています。

### `getBlockPrefix()` の削除は値が変わりません

削除対象は戻り値が Symfony の既定と一致するものだけです（例: `AddCartType` の `'add_cart'` はクラス名から同じ値が算出される）。プラグインが `getBlockPrefix()` を呼んでも `AbstractType` の実装に落ちるため、参照側も壊れません。

## `ArgumentAdderRector` を skip しています

composer-based セットの設定では `ContainerBuilder::addCompilerPass()` に第 2 引数 `0`（int）を足しますが、シグネチャは `string $type` なので **TypeError** になります。

```
TypeError: ContainerBuilder::addCompilerPass(): Argument #2 ($type) must be of type string, int given
```

このルールが本リポジトリで生む変更はこの 3 箇所だけなので、`RenameMethodRector` と同じ形で理由付きの skip にしました。`src/Eccube/Kernel.php` の呼び出しは影響を受けていません。

## 2.6.4 が出す警告も潰しました（コミット 7）

exit code は 0 のままですが、設定が現行版と食い違っていることを示しているため合わせて掃除しました。

- **`ControllerMethodInjectionToConstructorRector` が非推奨になり、どのセットにも登録されなくなりました**（`This skipped rule is never registered`）。`withSkip()` のエントリごと削除しています。`InstallController` を除外する意図は、ルール自体が動かなくなったので不要です
- **次の 4 ルールは composer-based セットに含まれるため、`withRules()` での指定が二重登録になります**（`Remove them from withRules() to avoid duplications`）。`withRules()` から外しました。セット経由で有効なままであることは `--only` で確認済みです（2.6.2 以降は未登録ルールを `--only` に渡すとエラーになる）
  - `CommandConfigureToAttributeRector` / `CommandPropertyToAttributeRector`
  - `StaticDataProviderClassMethodRector` / `EventSubscriberInterfaceToAttributeRector`

`CommandConfigureToAttributeRector` の `EccubeCliToolCommand` 向け skip は、セット側で有効なままなので維持しています。

掃除後の dry-run は **1283 ファイルで 0 件・警告なし**です。

## あわせて

`withCache()` の `cacheClass` を渡すのをやめました。既定が `FileCacheStorage` で、2.6.4 では指定しても無視されます（`MemoryCacheStorage` が撤去され「always use FileCacheStorage」になった）。

refs #7087


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 各種コマンドの終了結果が明確になり、成功・失敗を正確に判定できるようになりました。
  * ダミーデータ生成やデータ投入コマンドのヘルプ表示を整理しました。
  * フォーム入力の検証設定を見直しました。入力条件やエラーメッセージに変更はありません。
  * Twigの関数・フィルター登録方式を整理しました。表示や操作への影響はありません。

* **テスト**
  * 自動テストを更新し、各機能の安定性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->