### PR TITLE
docs(skills): 撤去済みの class_exists ラッパ指示を削除し「よくある間違い」を歯止めに合わせて短縮する

### DIFF
--- a/.claude/skills/eccube-contributing/SKILL.md
+++ b/.claude/skills/eccube-contributing/SKILL.md
@@ -65,7 +65,7 @@ PR では以下が GitHub Actions で走る。**同じものを手元で先に�
 - ❌ 機能追加なのにテスト無し / 既存テストを壊す → ✅ テストを伴わせ、関連テストを実行
 - ❌ マイナー互換を壊す変更（既存シグネチャ・フック・CSV 仕様の変更）を含める → ✅ 互換チェックリストを確認し、壊す場合は別途相談
 - ❌ PR テンプレートの節を空のまま提出 → ✅ 概要・方針・テスト範囲・互換性チェックを埋める
-- ❌ `@deprecated` な public API・定数の削除を `src/` と PHPUnit の grep だけで「呼び出し元なし」と判定 → ✅ `e2e/`（Playwright の globalSetup が実行する `setup-fixtures.php`）と `codeception/`（VAddy スキャンが `codecept -g vaddy` を実行）も走査対象に含め、全ツリー `git grep` で 0 件を確認する
+- ❌ `@deprecated` の削除可否を `src/` と PHPUnit の grep だけで判定 → ✅ `e2e/` と `codeception/` も実行される。全ツリー `git grep` で 0 件を確認する
 
 ## 実行・確認方法
 

--- a/.claude/skills/eccube-controller/SKILL.md
+++ b/.claude/skills/eccube-controller/SKILL.md
@@ -131,10 +131,10 @@ vendor/bin/php-cs-fixer fix                     # PSR-12 整形・ライセン�
 - ❌ 複数アクションに同じ処理をコピペ → ✅ Service の 1 メソッドに共通化
 - ❌ 具象クラス型ヒントで密結合 → ✅ インターフェース型ヒント＋コンストラクタ DI
 - ❌ 削除/Ajax 等の状態変更でトークン未検証 → ✅ `$this->isTokenValid()` を呼ぶ（GET 以外）
-- ❌ `$this->isTokenValid();`（戻り値を捨てた bare 呼び出し）を「CSRF 未検証」と誤読 → ✅ 無効時は `AccessDeniedHttpException` を投げ戻り値は常に true。bare 呼び出しで検証は成立し、`if (!isTokenValid())` の false 分岐はデッドコード
-- ❌ `#[Template]` 付きアクションの「エラー時に再描画される」を前提にレビュー判断 → ✅ `#[Template]` は配列を返したときのみ engage。Response/Redirect を返すパス（例: フォーム失敗で `redirectToRoute`）では描画されない
+- ❌ 戻り値を捨てた `isTokenValid();` を「CSRF 未検証」と誤読 → ✅ 無効時は例外を投げるので bare 呼び出しで検証は成立する。`if (!isTokenValid())` の false 分岐はデッドコード
+- ❌ `#[Template]` 付きアクションが常に再描画されると前提する → ✅ engage するのは配列を返したときだけ。Response/Redirect を返すパスでは描画されない
 - ❌ 管理アクションを `%eccube_admin_route%` 配下以外に置く → ✅ admin ファイアウォール配下に置く
-- ❌ 同一アクションで `executePurchaseFlow()` を複数回呼ぶとき 2 回目以降の `FlowResult` を無視する → ✅ 毎回 `hasError()`/`hasWarning()` の分岐を 1 回目と同じに揃える（共通化可）
+- ❌ `executePurchaseFlow()` を複数回呼んで 2 回目以降の `FlowResult` を無視する → ✅ 毎回 `hasError()`/`hasWarning()` を同じに分岐させる
 
 ---
 

--- a/.claude/skills/eccube-csv/SKILL.md
+++ b/.claude/skills/eccube-csv/SKILL.md
@@ -160,15 +160,14 @@ try {
 
 ## よくある間違い
 
-- ❌ コントローラ/サービスで `fgetcsv` / `fputcsv` を直書きする → ✅ `CsvImportService` / `CsvExportService::fputcsv()` に乗る
-- ❌ 文字コード・区切り文字をハードコードする（`'SJIS-win'`, `','` 直書き） → ✅ `EccubeConfig`（`eccube_csv_export_*` / `eccube_csv_import_*`）の設定値を使う
+- ❌ `fgetcsv` / `fputcsv` を直書きする → ✅ `CsvImportService` / `CsvExportService::fputcsv()` に乗る。直書きなら escape まで明示（省略は PHP 8.4 で非推奨）
+- ❌ 文字コード・区切り文字をハードコードする → ✅ `EccubeConfig` の `eccube_csv_export_*` / `eccube_csv_import_*` を使う
 - ❌ エクスポートで全件を配列に貯めて一括出力する → ✅ `StreamedResponse` ＋ `exportData()` のページング（100 件ずつ `em->clear()`）で逐次出力
 - ❌ 出力項目をコントローラに `if` で羅列する → ✅ `dtb_csv` 定義（`field_name` / `sort_no` / `enabled`）で表現し `getData()` に引かせる
 - ❌ インポートで自前エンコーディング判定や全行読み込みをする → ✅ `CsvImportService`（stream filter 自動適用・Iterator）に任せ 1 行ずつ処理
-- ❌ インポートをトランザクション無しで `flush()`／エラー時も一時ファイルを残す → ✅ `beginTransaction`〜`commit`/`rollback` で囲み、終了時に `removeUploadedFile()`
+- ❌ インポートをトランザクション無しで `flush()`／一時ファイルを残す → ✅ `beginTransaction`〜`commit`/`rollback` で囲み `removeUploadedFile()` する
 - ❌ 出力項目追加のためにコアの export 処理を改変する → ✅ `ADMIN_*_CSV_EXPORT*` イベントを購読して `ExportCsvRow` に列追加
-- ❌ `mtb_csv_type` へ `discriminator_type` を指定せず INSERT する（STI のため壊れる） → ✅ 種別追加時は discriminator を必ず指定（Skill `eccube-migration`）
-- ❌ 素の `fputcsv($fp, $row)` で escape 引数を省略（**PHP 8.4 で deprecation**：`the $escape parameter must be provided`）→ ✅ 第5引数まで明示（コアは `fputcsv(..., ',', '"', '\\')`）。そもそも `CsvExportService::fputcsv()` に乗れば吸収される
+- ❌ `mtb_csv_type` へ `discriminator_type` なしで INSERT する → ✅ STI なので必ず指定する（Skill `eccube-migration`）
 
 ## 実行・確認方法
 

--- a/.claude/skills/eccube-e2e/SKILL.md
+++ b/.claude/skills/eccube-e2e/SKILL.md
@@ -34,14 +34,14 @@ description: EC-CUBE 4.4 の E2E テスト（Playwright・`e2e/` 配下）を実
 
 ## よくある間違い
 
-- ❌ `waitForTimeout(固定ms)` で同期を取る → ✅ web-first assertion（`expect().toBeVisible()` / `waitForFunction()`）で「状態」を待つ。**例外**: yubinbango 郵便番号の自動入力など外部 JS 由来の待機のみ許容（理由をコメントで明記）。
+- ❌ `waitForTimeout(固定ms)` で同期を取る → ✅ web-first assertion で「状態」を待つ。外部 JS 由来の待機だけ例外とし、理由をコメントに書く。
 - ❌ `front-*` spec で管理者ログイン済みを前提にする → ✅ front は未認証 state。spec 内でログインするか admin 経由で会員作成する。
 - ❌ 固定件数で assert（`検索結果：1件が該当`）→ ✅ 正規表現（`/検索結果：\d+件が該当/`）。retry 時の重複データに強くする（`admin-product.spec.ts` 修正例）。
-- ❌ セレクタが複数要素にマッチ（strict mode violation）→ ✅ `.first()` か `data-*` 属性（例 `button[data-bs-target="#initializationConfirm"]`）で一意化する。
+- ❌ セレクタが複数要素にマッチ（strict mode violation）→ ✅ `.first()` か `data-*` 属性で一意化する。
 - ❌ テスト境界で管理者セッションが切れて 401 → ✅ `ensureAdminLoggedIn()` 等で再ログインしてから操作（`admin-basicinfo.spec.ts` 修正例）。
-- ❌ retry でプラグイン/データが残留し「既にインストール済み」で再失敗 → ✅ `beforeEach`/`afterEach` で cleanup（無効化→削除→ディレクトリ削除。`plugin-misc.spec.ts` 修正例）。
+- ❌ retry でプラグイン/データが残留し再失敗 → ✅ `beforeEach`/`afterEach` で cleanup（無効化 → 削除 → ディレクトリ削除）。
 - ❌ パスワードを見た目の文字数で作る → ✅ NFKC 正規化後で 15 文字以上か数える（min15。`[...str.normalize('NFKC')].length` で確認。#6488）。
-- ❌ 新規 `admin-*`/`front-*` spec を作ったのに CI で実行されない → ✅ `.github/workflows/e2e-test.yml` の `suite:` 配列にファイル名（接尾辞 `.spec.ts` 抜き）を追加する。
+- ❌ 新規 spec を作ったのに CI で実行されない → ✅ `e2e-test.yml` の `suite:` 配列にファイル名（`.spec.ts` 抜き）を追加する。
 
 ## 実行・確認方法
 

--- a/.claude/skills/eccube-entity/SKILL.md
+++ b/.claude/skills/eccube-entity/SKILL.md
@@ -17,10 +17,12 @@ description: EC-CUBE 4.4 の Doctrine エンティティを実装・改修する
 - プロパティ・getter / setter に型宣言を付ける。setter は `$this` を返す（fluent）。
   nullable は DB カラムの nullable と一致させる。
 
-## プロキシ拡張に対応するクラスラッパ
+## エンティティの骨格
 
-コアのエンティティは、プラグイン/カスタマイズによる trait 追加（プロキシ生成）に対応するため
-`if (!class_exists(X::class)) { ... }` で囲う。
+**`if (!class_exists(X::class)) { ... }` のクラスラッパは書かない。** プラグイン/カスタマイズによる
+trait 追加は、プロキシ生成（`app/proxy/entity` / `bin/console eccube:generate:proxies`）が担う。
+ラッパはその前段で使われていた名残で、`src/Eccube/Entity` からも `app/Customize/Entity` からも
+撤去済み（現在 0 件）。`EntityProxyService` はプロキシ生成時にこのブロックを除去する側に回っている。
 
 ```php
 namespace Eccube\Entity;
@@ -29,35 +31,33 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Eccube\Repository\ExampleRepository;
 
-if (!class_exists(Example::class)) {
-    #[ORM\Table(name: 'dtb_example')]
-    #[ORM\Index(columns: ['create_date'], name: 'dtb_example_create_date_idx')]
-    #[ORM\HasLifecycleCallbacks]
-    #[ORM\Entity(repositoryClass: ExampleRepository::class)]
-    class Example extends AbstractEntity
+#[ORM\Table(name: 'dtb_example')]
+#[ORM\Index(columns: ['create_date'], name: 'dtb_example_create_date_idx')]
+#[ORM\HasLifecycleCallbacks]
+#[ORM\Entity(repositoryClass: ExampleRepository::class)]
+class Example extends AbstractEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER, options: ['unsigned' => true])]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $name = null;
+
+    // getId() の戻り値が ?int（nullable）なのは、IDENTITY 採番のため
+    // 永続化（flush）されるまで ID が未採番（null）だから。意図的な nullable で、
+    // 「まだ DB に保存されていない新規エンティティ」を表現できる。
+    public function getId(): ?int
     {
-        #[ORM\Id]
-        #[ORM\Column(type: Types::INTEGER, options: ['unsigned' => true])]
-        #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-        private ?int $id = null;
+        return $this->id;
+    }
 
-        #[ORM\Column(length: 255, nullable: true)]
-        private ?string $name = null;
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
 
-        // getId() の戻り値が ?int（nullable）なのは、IDENTITY 採番のため
-        // 永続化（flush）されるまで ID が未採番（null）だから。意図的な nullable で、
-        // 「まだ DB に保存されていない新規エンティティ」を表現できる。
-        public function getId(): ?int
-        {
-            return $this->id;
-        }
-
-        public function setName(?string $name): self
-        {
-            $this->name = $name;
-
-            return $this;
-        }
+        return $this;
     }
 }
 ```
@@ -103,7 +103,6 @@ if (!class_exists(Example::class)) {
 - ❌ XML / アノテーションでマッピング → ✅ PHP8 属性
 - ❌ カラムを足したので ALTER マイグレーションを書く → ✅ 属性を足すだけ（`schema:update` が反映）。マイグレーションは INSERT・型変更等に限る
 - ❌ 在庫引当・採番・ポイント付与などの受注処理をエンティティに書く → ✅ PurchaseFlow / Service へ。エンティティは自身の状態から導く計算/判定まで
-- ❌ `class_exists` ラッパなしでコアエンティティを定義 → ✅ プロキシ拡張に対応するラッパで囲う
 - ❌ プロパティ/戻り値の型宣言省略 → ✅ 型を付け、PHPStan level 6 を通す
 - ❌ 金額 getter（`Order::getTotal()`・`OrderItem::getTotalPrice()` 等）の戻り値を int/float 扱い → ✅ DECIMAL は `?string`（getter は `string`）。型宣言・代入もこれに合わせる
 - ❌ 金額を float で四則演算（丸め誤差）→ ✅ `bcmath`（`bcadd` / `bcmul` / `bccomp`、スケール 2）で計算する

--- a/.claude/skills/eccube-entity/SKILL.md
+++ b/.claude/skills/eccube-entity/SKILL.md
@@ -104,7 +104,7 @@ class Example extends AbstractEntity
 - ❌ カラムを足したので ALTER マイグレーションを書く → ✅ 属性を足すだけ（`schema:update` が反映）。マイグレーションは INSERT・型変更等に限る
 - ❌ 在庫引当・採番・ポイント付与などの受注処理をエンティティに書く → ✅ PurchaseFlow / Service へ。エンティティは自身の状態から導く計算/判定まで
 - ❌ プロパティ/戻り値の型宣言省略 → ✅ 型を付け、PHPStan level 6 を通す
-- ❌ 金額 getter（`Order::getTotal()`・`OrderItem::getTotalPrice()` 等）の戻り値を int/float 扱い → ✅ DECIMAL は `?string`（getter は `string`）。型宣言・代入もこれに合わせる
+- ❌ 金額 getter の戻り値を int/float 扱い → ✅ DECIMAL は `?string`（getter は `string`）。型宣言・代入も合わせる
 - ❌ 金額を float で四則演算（丸め誤差）→ ✅ `bcmath`（`bcadd` / `bcmul` / `bccomp`、スケール 2）で計算する
-- ❌ `create_date` / `update_date` を自前の `#[ORM\PrePersist]`（＋`#[ORM\HasLifecycleCallbacks]`）でセット → ✅ コアの `SaveEventSubscriber`（グローバル Doctrine prePersist/preUpdate）が `method_exists` で `setCreateDate`/`setUpdateDate`/`setCreator` を自動セットする（`src/Eccube/Doctrine/EventSubscriber/SaveEventSubscriber.php`）。setter さえ生やせばよく、自前 PrePersist は二重実装になるので書かない
-- ❌ 他エンティティ（特にコアの `Product`/`Customer` 等、自分で制御できない親）への関連で親削除時の挙動を未決定 → ✅ FK は既定で削除を止める（RESTRICT 相当）。未指定だと**退会・商品削除が FK 違反で失敗**したり孤児化する。`onDelete`（`SET NULL`／`CASCADE`）を指定するか、Service・プラグイン disable 等で後始末する（コアは `onDelete` を限定使用し[95 JoinColumn 中 2 件]、多くは Service 側で関連を整理している）
+- ❌ `create_date` / `update_date` を自前の `#[ORM\PrePersist]` でセット → ✅ コアの `SaveEventSubscriber` が setter を検出して自動セットするので二重実装になる
+- ❌ 他エンティティへの関連で親削除時の挙動を未決定 → ✅ FK は既定で削除を止めるので、未指定だと親の削除が FK 違反で失敗する。`onDelete` を指定するか Service 側で後始末する（コアは大半が後者）

--- a/.claude/skills/eccube-mail/SKILL.md
+++ b/.claude/skills/eccube-mail/SKILL.md
@@ -164,7 +164,7 @@ HTML メールを足したいときは **同じディレクトリに `*.html.twi
 - ❌ プレーンテキストメール twig を素で書く / 通常の HTML エスケープをかける → ✅ `{% autoescape 'safe_textmail' %}` で囲む
 - ❌ HTML メール用に送信メソッドへ分岐を足す → ✅ 同名 `*.html.twig` を置けば `getHtmlTemplate()` が自動で multipart 化する
 - ❌ 送信失敗で例外を投げて受注処理を止める → ✅ `TransportExceptionInterface` を catch して `log_critical` で記録（既存の方針に合わせる）
-- ❌ `MailService` 内で `flush()` する／会員系メールを `MailHistory` に残そうとする → ✅ `save()`（persist）まで、`flush()` は呼び出し側。関連は `Order` のみで会員に紐づく口は無い
+- ❌ `MailService` 内で `flush()` する／会員系メールを `MailHistory` に残す → ✅ persist まで（`flush()` は呼び出し側）。関連は `Order` と `Creator`(Member) のみ
 - ❌ コアの `Resource/template/default/Mail/*.twig` を直接書き換える → ✅ `app/template/<コード>/Mail/` で上書きする
 - ❌ 送信前のイベント dispatch を省く → ✅ プラグインの差し替え口として `EccubeEvents::MAIL_*` を必ず発火する
 

--- a/.claude/skills/eccube-mail/SKILL.md
+++ b/.claude/skills/eccube-mail/SKILL.md
@@ -164,8 +164,7 @@ HTML メールを足したいときは **同じディレクトリに `*.html.twi
 - ❌ プレーンテキストメール twig を素で書く / 通常の HTML エスケープをかける → ✅ `{% autoescape 'safe_textmail' %}` で囲む
 - ❌ HTML メール用に送信メソッドへ分岐を足す → ✅ 同名 `*.html.twig` を置けば `getHtmlTemplate()` が自動で multipart 化する
 - ❌ 送信失敗で例外を投げて受注処理を止める → ✅ `TransportExceptionInterface` を catch して `log_critical` で記録（既存の方針に合わせる）
-- ❌ `MailHistory` を保存した後 `MailService` 内で `flush()` する → ✅ `save()`（persist）まで。`flush()` は呼び出し側
-- ❌ 会員系メールを `MailHistory` に残そうとする → ✅ `MailHistory` の関連は `Order` のみ。会員に紐づける口は無い（履歴対象は受注メール・出荷通知メール）
+- ❌ `MailService` 内で `flush()` する／会員系メールを `MailHistory` に残そうとする → ✅ `save()`（persist）まで、`flush()` は呼び出し側。関連は `Order` のみで会員に紐づく口は無い
 - ❌ コアの `Resource/template/default/Mail/*.twig` を直接書き換える → ✅ `app/template/<コード>/Mail/` で上書きする
 - ❌ 送信前のイベント dispatch を省く → ✅ プラグインの差し替え口として `EccubeEvents::MAIL_*` を必ず発火する
 

--- a/.claude/skills/eccube-phpunit/SKILL.md
+++ b/.claude/skills/eccube-phpunit/SKILL.md
@@ -108,14 +108,12 @@ public static function provideStatuses(): array
 - ❌ `new Client()` など HTTP クライアントの自前生成 → ✅ 親クラスの `$this->client`。
 - ❌ URL の文字列直書き（`'/products/list'`）→ ✅ `$this->generateUrl('product_list')`。
 - ❌ Entity の手組み → ✅ `createXxx()` フィクスチャヘルパ。
-- ❌ 支払方法のデフォルト/再選択テストで `find(1)` 等の ID 前提 → ✅ `Generator::createPayment()` で sort_no・利用条件を明示し `assertSame()` で再選択先を固定（フィクスチャ並び変更で偽陽性になり得る）。
+- ❌ 支払方法のテストで `find(1)` 等の ID 前提 → ✅ `Generator::createPayment()` で sort_no・利用条件を明示し `assertSame()` で固定する。
 - ❌ ステータス値のハードコーディング（`if ($status == 1)`）→ ✅ 定数（例: `OrderStatus::NEW`）を使う。
-- ❌ 回帰テストを追加して、修正を外すと落ちることを確認せずに完了とする → ✅ 修正を 1 つずつ外してどのテストが落ちるか実測する（落ちないテストはゲートにならない）。
-- ❌ PHP Warning が出ることを回帰の証拠にする → ✅ `phpunit.xml.dist` に `failOnWarning` が無いため Warning では落ちない。戻り値を assert で直接検証する。
+- ❌ 回帰テストがゲートになるか確かめない → ✅ 修正を外して落ちるか実測する。`failOnWarning` が無いので Warning では落ちず、戻り値を assert する。
 - ❌ 型宣言の省略 → ✅ 引数・戻り値に型を付け、PHPStan level 6 を通す。
-- ❌ `setUp()` で未宣言のプロパティに代入（`$this->Member = ...`）→ ✅ プロパティを必ず宣言する。PHP 8.2 の動的プロパティ deprecation が `failOnDeprecation`（`phpunit.xml.dist`）で CI red になる。
-- ❌ テストのプロパティを非 nullable で宣言（`protected array $Items = [];`）→ ✅ `protected ?array $Items = null;` と nullable にする。`EccubeTestCase::cleanUpProperties()` が tearDown で全プロパティに `null` を代入するため、非 nullable だと `TypeError` で全テストが落ちる（初期値が必要なら `setUp()` で代入する）。
-- ❌ HTML パートを持たないメールに `assertEmailHtmlBodyNotContains()` → ✅ `assertNull($Message->getHtmlBody())`。前者は `str_contains(null, …)` の deprecation を出し、かつ「HTML パートが無いので必ず通る」空振りアサーションになる。
+- ❌ テストのプロパティを未宣言で代入／非 nullable で宣言 → ✅ nullable で宣言する。未宣言は deprecation、非 nullable は `cleanUpProperties()` の null 代入で `TypeError`。
+- ❌ HTML パートを持たないメールに `assertEmailHtmlBodyNotContains()` → ✅ `assertNull($Message->getHtmlBody())`。前者は必ず通る空振りになる。
 
 ## 実行方法
 

--- a/.claude/skills/eccube-purchase-flow/SKILL.md
+++ b/.claude/skills/eccube-purchase-flow/SKILL.md
@@ -227,16 +227,14 @@ class SaleLimitOneValidator extends ItemValidator
 
 - ❌ 在庫引当・採番・ポイント付与・送料/値引き計算をコントローラや汎用 Service に直書き → ✅ 該当 Processor/Validator を拡張する
 - ❌ 検証なのに ItemHolderPreprocessor、明細付与なのに Validator、と取り違える → ✅ パイプライン表で役割に合うコンポーネントを選ぶ
-- ❌ abstract 基底の `execute()` を override / 自前で try-catch → ✅ `validate()`（protected）だけ override。`execute()` は `final`
-- ❌ `ProcessResult` を `new` する / `addError()` を探す → ✅ 例外（`throwInvalidItemException` / `InvalidItemException`）を投げ、基底に変換させる
-- ❌ ItemValidator で「購入を止めたい」のに止まらない → ✅ ItemValidator は**常に warning**。中断したい検証は `ItemHolderValidator`/`PostValidator` で warning なしの error にする
+- ❌ `final` な `execute()` の override・自前 try-catch・`ProcessResult` の `new` → ✅ `validate()` だけ override し `InvalidItemException` を投げる
+- ❌ ItemValidator で購入を止めようとする → ✅ ItemValidator は**常に warning**。中断したい検証は `ItemHolderValidator` / `PostValidator` の error にする
 - ❌ Preprocessor で明細を追加しっぱなし（再実行で多重化） → ✅ `setProcessorName(self::class)` で印を付け、毎回削除→再追加で冪等にする
 - ❌ 値引きで合計金額を超える明細を作る → ✅ 利用可能額まで丸めるかスキップし `ProcessResult::warn()` を返す
 - ❌ 金額を float / `+`・`*` で計算 → ✅ `bcadd`/`bcsub`/`bcmul`/`bccomp` を使う
 - ❌ `Cart` でも `getShippings()` / `getCustomer()` を呼ぶ → ✅ `instanceof Order` でガード（Cart には Shipping もポイントも無い）
 - ❌ PurchaseProcessor の `rollback()` を実装し忘れる → ✅ `prepare()` の逆操作（在庫戻し等）を必ず実装する
-- ❌ 属性方式で実行順を制御しようとする → ✅ 順序が要るなら YAML タグの `priority`（降順）で指定する
-- ❌ (A) YAML タグと (B) 属性を両方付ける → ✅ どちらか一方。コアは YAML、プラグイン/Customize は属性が定石
+- ❌ 属性で実行順を制御する／YAML タグと属性を両方付ける → ✅ 順序は YAML タグの `priority`（降順）。登録はどちらか一方（コアは YAML、プラグインは属性）
 
 ## 実行・確認方法
 

--- a/.claude/skills/eccube-purchase-flow/SKILL.md
+++ b/.claude/skills/eccube-purchase-flow/SKILL.md
@@ -234,7 +234,7 @@ class SaleLimitOneValidator extends ItemValidator
 - ❌ 金額を float / `+`・`*` で計算 → ✅ `bcadd`/`bcsub`/`bcmul`/`bccomp` を使う
 - ❌ `Cart` でも `getShippings()` / `getCustomer()` を呼ぶ → ✅ `instanceof Order` でガード（Cart には Shipping もポイントも無い）
 - ❌ PurchaseProcessor の `rollback()` を実装し忘れる → ✅ `prepare()` の逆操作（在庫戻し等）を必ず実装する
-- ❌ 属性で実行順を制御する／YAML タグと属性を両方付ける → ✅ 順序は YAML タグの `priority`（降順）。登録はどちらか一方（コアは YAML、プラグインは属性）
+- ❌ 属性で実行順を制御する／YAML タグと属性を両方付ける → ✅ 順序は YAML タグの `priority`（降順）。登録はどちらか一方（既定はコア=YAML / プラグイン=属性、順序が要るならプラグインも YAML）
 
 ## 実行・確認方法
 

--- a/.claude/skills/eccube-security/SKILL.md
+++ b/.claude/skills/eccube-security/SKILL.md
@@ -82,7 +82,7 @@ if ($this->isGranted('IS_AUTHENTICATED_FULLY')) { ... }
 
 - ❌ 管理アクションを `%eccube_admin_route%` 配下**以外**に置く → ✅ 配下に置き admin firewall の保護下にする
 - ❌ フォームを介さない POST/DELETE/Ajax で CSRF 未検証 → ✅ `$this->isTokenValid()` を呼ぶ（GET 以外）
-- ❌ Ajax 専用アクションで XHR 以外（直アクセス等）も受け付ける → ✅ CSRF 検証に加え **`$request->isXmlHttpRequest()`** を併用し XHR 由来に限定する（コア例: `NonMemberShoppingController` / `Admin/Content/MaintenanceController`）
+- ❌ Ajax 専用アクションで XHR 以外も受け付ける → ✅ CSRF 検証に加え **`$request->isXmlHttpRequest()`** を併用し XHR に限定する
 - ❌ フロントで `{id}` から取得したエンティティを所有権チェックせず編集/削除（**IDOR**）
   → ✅ `$this->getUser()` と突き合わせ、他人のリソースなら `AccessDeniedHttpException`
 - ❌ パスワード変更・退会など重要操作を `IS_AUTHENTICATED_REMEMBERED` で許可
@@ -90,8 +90,8 @@ if ($this->isGranted('IS_AUTHENTICATED_FULLY')) { ... }
 - ❌ 独自 Voter で「対象外」を `ACCESS_DENIED` で返す → ✅ 対象外は `ACCESS_ABSTAIN`（unanimous 戦略で誤拒否を防ぐ）
 - ❌ 自前でパスワードをハッシュ/平文比較 → ✅ `PasswordHasher` 経由に統一
 - ❌ ユーザー入力を Twig で `|raw` 出力 → ✅ エスケープを効かせる（Skill `eccube-twig-template`）
-- ❌ アップロード/ファイル操作を伴う管理ルートを新設したが `eccube_restrict_file_upload` の遮断対象を考慮しない → ✅ コアは `eccube_restrict_file_upload === '1'` のとき `eccube_restrict_file_upload_urls` のルートを `RestrictFileUploadListener` で遮断する。新規ルートを遮断対象に含めるべきか検討する
-- ❌ ユーザー指定のファイル名/パスをそのまま読み書き・配信（**ディレクトリトラバーサル**）→ ✅ `..` を拒否し `realpath()` で解決、許可ベースディレクトリ内かを `str_starts_with(realpath($target), realpath($baseDir))` で検証する（コアの `FileController::checkDir()` が手本。基準は `html/user_data` 等の jail ディレクトリ）
+- ❌ ファイル操作を伴う管理ルートを新設して `eccube_restrict_file_upload` を考慮しない → ✅ 遮断対象（`eccube_restrict_file_upload_urls`）に含めるべきか検討する
+- ❌ ユーザー指定のパスをそのまま読み書き（**ディレクトリトラバーサル**）→ ✅ `..` を拒否し `realpath()` で解決、許可ベース配下かを検証する（`FileController::checkDir()` が手本）
 
 ## 実行・確認方法
 

--- a/.claude/skills/eccube-twig-template/SKILL.md
+++ b/.claude/skills/eccube-twig-template/SKILL.md
@@ -97,7 +97,7 @@ public function onTemplateCart(TemplateEvent $event): void
 - ❌ 上書きを `app/template/` 直下に置く / `@admin` 名前空間を付け忘れる → ✅ 正しいサブディレクトリ・名前空間に置く
 - ❌ **管理画面テンプレートだから安全**と油断して `|raw` する → ✅ admin 配下も XSS シンク（過去の XSS 修正は管理画面テンプレートに多い）。DB/入力由来の値は admin でも必ずエスケープする
 - ❌ テンプレートイベントにエンティティ永続化など業務処理を書く → ✅ 見た目調整のみ。業務は対応するコントローライベントへ
-- ❌ inline `<script>` に素の `json_encode` で埋める → ✅ `</script>` で XSS になる。`JSON_HEX_TAG｜AMP｜APOS｜QUOT` を付ける
+- ❌ inline `<script>` に素の `json_encode` で埋める → ✅ `</script>` で XSS。`|json_encode_safe`（JSON-LD は `|json_ld`）を使う。属性値には不可
 
 ## 実行・確認方法
 

--- a/.claude/skills/eccube-twig-template/SKILL.md
+++ b/.claude/skills/eccube-twig-template/SKILL.md
@@ -97,7 +97,7 @@ public function onTemplateCart(TemplateEvent $event): void
 - ❌ 上書きを `app/template/` 直下に置く / `@admin` 名前空間を付け忘れる → ✅ 正しいサブディレクトリ・名前空間に置く
 - ❌ **管理画面テンプレートだから安全**と油断して `|raw` する → ✅ admin 配下も XSS シンク（過去の XSS 修正は管理画面テンプレートに多い）。DB/入力由来の値は admin でも必ずエスケープする
 - ❌ テンプレートイベントにエンティティ永続化など業務処理を書く → ✅ 見た目調整のみ。業務は対応するコントローライベントへ
-- ❌ inline `<script>`（JSON-LD `application/ld+json` 等）に動的値を文字列直書き／素の `json_encode` で埋める → ✅ 商品名・説明中の `</script>` や `"` で XSS・JSON 破壊になる。`json_encode($data, JSON_UNESCAPED_SLASHES｜JSON_HEX_TAG｜JSON_HEX_AMP｜JSON_HEX_APOS｜JSON_HEX_QUOT)` で `<`/`>`/`&` をエスケープする
+- ❌ inline `<script>` に素の `json_encode` で埋める → ✅ `</script>` で XSS になる。`JSON_HEX_TAG｜AMP｜APOS｜QUOT` を付ける
 
 ## 実行・確認方法
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,10 +267,16 @@ frontmatter の `description` がトリガ条件で、該当レイヤを触る�
 - **上限**: 1 Skill あたり 10 項・1 項 120 字程度に収める。超えたら**追記ではなく既存項への統合か削除**を選ぶ。
 - **頻度順**: 踏まれやすいものを上に置く。読み手の注意は前方に効くため、頻度順でないリストは下位が実質死ぬ。
 
-この歯止めは**追記するときに適用する**。本規則の導入時点で上限を超えている Skill
-（項数: `eccube-mail` 11 / `eccube-purchase-flow` 12、字数: `eccube-controller` `eccube-csv` `eccube-e2e`
-`eccube-entity` `eccube-phpunit` `eccube-purchase-flow` `eccube-security` `eccube-twig-template`）は、
-次にその節へ手を入れるときに統合・短縮する。既存の超過を理由に新規追記の歯止めを緩めない。
+この歯止めは**追記するときに適用する**。本規則の導入時点で超過していた Skill
+（項数 2 件・字数 8 件）は統合・短縮済みで、現在はすべて 10 項以内に収まっている。
+超過の有無は次で確認できる。
+
+```bash
+for f in .claude/skills/eccube-*/SKILL.md; do
+  sed -n '/よくある間違い/,/^## /p' "$f" | grep -E '^- ' \
+    | awk -v s="$(basename "$(dirname "$f")")" '{n++; if (length>m) m=length} END {if (n) printf "%-28s 項数=%-3s 最長=%s\n", s, n, m}'
+done
+```
 
 ## 主要エンティティ
 


### PR DESCRIPTION
## 概要

AI エージェント向けレイヤ規約 Skill の「よくある間違い」まわりを 2 点直します。ドキュメントのみの変更で、PHP コードは 1 行も触っていません。

1. **`eccube-entity` が、撤去済みの `class_exists` ラッパを指示し続けていた**（規約の誤り）
2. **`AGENTS.md` の歯止め（10 項・120 字程度）を超えている Skill が残っていた**（膨張）

## 1. 撤去済みの `class_exists` ラッパ指示を削除

コアのエンティティを `if (!class_exists(X::class)) { ... }` で囲む書き方は #6895 / #7051 で一括除去されましたが、**`eccube-entity/SKILL.md` は 3 箇所でこれを指示し続けていました**（セクション本文・コード例・「よくある間違い」1 項）。

実測です。

| 対象 | `class_exists` ラッパ |
|---|---|
| `src/Eccube/Entity/*.php` | **0 件** |
| `app/Customize/Entity/` | **0 件** |
| `EntityProxyService` | `removeClassExistsBlock()` で**除去する側**（`:67`, `:320`） |
| `eccube-entity/SKILL.md` | **3 箇所で「ラッパで囲う」と指示** |

この規約を読んで新しいエンティティを書くと、撤去したパターンが復活します。#6891 の再発防止ゲートが開いたままでした。

- セクション名を「プロキシ拡張に対応するクラスラッパ」から「エンティティの骨格」へ
- 冒頭で **「ラッパは書かない」** と明示し、trait 追加はプロキシ生成が担うこと・ラッパはその前段の名残であることを記載
- コード例からラッパを外してインデントを戻す（骨格の参考として例自体は残す）
- 「よくある間違い」から該当 1 項を削除

## 2. 「よくある間違い」を歯止めに合わせて統合・短縮

`AGENTS.md` は「1 Skill あたり 10 項・1 項 120 字程度」「超えたら**追記ではなく既存項への統合か削除**」と定めていますが、**規則の導入時点で超過していた Skill がそのまま残っていました**（項数 2 件・字数 8 件）。この状態だと、次に追記しようとしたときに「超過しているので足せない」で止まります。

短縮は `AGENTS.md` の一般化テストに合わせ、**一般則を残してファイルパス・コアクラスの列挙・経路の説明を落とす**方針です。クラス名は引きたくなる情報なので残しました。

**字数超過 24 項を短縮**（最長 343 字 → 132 字）。

**結論が同じ項を統合して項数超過を解消**しました。

| Skill | 項数 | 統合した内容 |
|---|---|---|
| `eccube-phpunit` | 12 → 10 | 回帰テストの検証 2 項 / テストのプロパティ宣言 2 項 |
| `eccube-purchase-flow` | 12 → 10 | 基底クラスの流儀 2 項 / 登録方式と実行順 2 項 |
| `eccube-mail` | 11 → 10 | `MailHistory` の扱い 2 項 |
| `eccube-csv` | 9 → 8 | CSV 関数の直書き 2 項 |

全体で **156 項 → 149 項**。現在はすべて 10 項以内・最長 132 字です。

### `AGENTS.md` 側

超過 Skill を名指ししていたリストを削除し、**現況を確認するコマンド**に置き換えました。リストは古くなりますが、コマンドなら常に現在値が出ます。

```bash
for f in .claude/skills/eccube-*/SKILL.md; do
  sed -n '/よくある間違い/,/^## /p' "$f" | grep -E '^- ' \
    | awk -v s="$(basename "$(dirname "$f")")" '{n++; if (length>m) m=length} END {if (n) printf "%-28s 項数=%-3s 最長=%s\n", s, n, m}'
done
```

## 確認したこと

- 上記コマンドで **全 Skill が 10 項以内**であることを確認
- `class_exists` の指示が他の Skill / `AGENTS.md` / `CLAUDE.md` に残っていないことを確認
- pre-push フック（rector `--dry-run` ＋ `phpstan analyse src/`）を通して push


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * 開発ガイドの「よくある間違い」を整理・簡潔化し、各機能の推奨手順や注意点を明確化しました。
  * エンティティ、CSV、E2E、セキュリティ、メール、テストなどのガイドラインを更新しました。
  * 非推奨 API の確認範囲、CSV のエスケープ、購入フローの登録ルールなどの説明を改善しました。
  * ガイド項目数の上限を確認するチェック手順を追加しました。
  * コードの動作に変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->