### PR TITLE
feat: ページ・ブロック・メールテンプレートを CLI から操作できるようにする

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -57,5 +57,11 @@ ECCUBE_AUTH_MAGIC=<change.me>
 #ECCUBE_2FA_COOKIE_NAME=eccube_2fa
 #ECCUBE_2FA_EXPIRE=14
 #ECCUBE_RESTRICT_FILE_UPLOAD=0
+# umask for files and directories created by the application (octal notation).
+# Leave it unset to follow the OS / PHP-FPM default (recommended).
+# Set 0000 to restore the 4.3 behavior (directories 0777 / files 0666) when the web server
+# and the CLI run as different users and both need to write the same files.
+# Note that it also makes them writable by any other local user on the same server.
+#ECCUBE_UMASK=
 
 ###< APPLICATION CONFIG ###

--- a/.env.dist
+++ b/.env.dist
@@ -64,4 +64,9 @@ ECCUBE_AUTH_MAGIC=<change.me>
 # Note that it also makes them writable by any other local user on the same server.
 #ECCUBE_UMASK=
 
+## CLI 実行時にログをファイル (var/log) へ書き込むかどうか。 未設定なら書き込む。
+## Web サーバーと CLI で var/log の書き込み権限を分離した構成では 0 を設定する。
+## CLI のログはコンソール出力のみになるため、 cron 等で記録が必要な場合はリダイレクトする。
+#ECCUBE_CLI_LOG_TO_FILE=1
+
 ###< APPLICATION CONFIG ###

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -191,7 +191,7 @@ jobs:
         run: |
           rm -r app/Plugin/*
           git checkout app/Plugin
-          rm -r var/cache
+          rm -rf var/cache var/build var/runtime
           echo "session.save_path=$PWD/var/sessions/test" > php.ini
           echo "memory_limit=512M" >> php.ini
           php -c php.ini vendor/bin/phpunit --group plugin-service

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -22,14 +22,15 @@ case "${ECCUBE_HOOK_RUNNER:-auto}" in
 esac
 [ -n "$RUN" ] && echo "pre-push: running in Docker ($SVC)" || echo "pre-push: running on host"
 
-# rector.php は dev の Symfony コンテナ XML (var/cache/dev/Eccube_KernelDevDebugContainer.xml) を
+# rector.php は dev の Symfony コンテナ XML (var/build/dev/Eccube_KernelDevDebugContainer.xml) を
 # 参照する。fresh clone / cache:clear 直後など XML が無い cold 状態だと rector が全ファイルで
 # read error → exit 非ゼロになり push がブロックされる。無ければ dev キャッシュを生成しておく。
-# （cache:warmup では XML が再生成されないため cache:clear を使う）
-CONTAINER_XML="var/cache/dev/Eccube_KernelDevDebugContainer.xml"
+# XML (debug.container.dump) はデバッグ用コンテナのコンパイル時にのみ出力されるため、
+# .env で APP_DEBUG=0 の環境でも生成されるよう APP_DEBUG=1 を明示する。
+CONTAINER_XML="var/build/dev/Eccube_KernelDevDebugContainer.xml"
 if ! $RUN test -f "$CONTAINER_XML"; then
-  echo "pre-push: dev container XML 不在のため cache:clear --env=dev で生成"
-  if ! $RUN bin/console cache:clear --env=dev; then
+  echo "pre-push: dev container XML 不在のため cache:clear (dev/debug) で生成"
+  if ! $RUN env APP_ENV=dev APP_DEBUG=1 bin/console cache:clear; then
     echo "FAIL: cache:clear（dev コンテナ XML を生成できませんでした）"
     exit 1
   fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,13 +117,22 @@ curl -s -o /dev/null http://127.0.0.1:8080/   # セッションを生成し Web 
 docker compose exec -u eccube ec-cube bin/console eccube:doctor:permissions
 ```
 
-レーン W（`var`、`html/upload/**`、`app/keystore`）は `www-data` 所有とし、共有グループは作らない。
-CLI からレーン W を触る操作は Web サーバーのユーザーで実行する。本番の `sudo -u www-data` に相当する。
+レーン W（`var/runtime`、`var/sessions`、`var/log`、`html/upload/**`、`app/keystore`）は `www-data` 所有とし、
+共有グループは作らない。CLI からレーン W を触る操作は Web サーバーのユーザーで実行する。
+本番の `sudo -u www-data` に相当する。
 
 ```bash
-docker compose exec -u eccube   ec-cube bin/console eccube:page:apply ...   # レーン S を触る操作
-docker compose exec -u www-data ec-cube bin/console cache:clear             # レーン W を触る操作
+docker compose exec -u eccube   ec-cube bin/console eccube:cache:build        # レーン S を触る操作
+docker compose exec -u www-data ec-cube bin/console cache:pool:clear --all    # レーン W を触る操作
 ```
+
+`cache:clear` は `var/build` と `var/cache` の双方へ書き込むため、分離モードでは使用できない。
+コンパイル済みコンテナとテンプレートの再生成は `eccube:cache:build` を使う。
+
+アプリケーションが作成するファイルの umask は環境変数 `ECCUBE_UMASK`（8 進数表記）で設定する。
+未設定なら OS / PHP-FPM の既定に従う（推奨）。Web サーバーと CLI が別ユーザーで、かつ双方が同じ
+ファイルへ書き込む必要がある環境では `0000` を設定すると 4.3 以前と同じ挙動（ディレクトリ 0777 /
+ファイル 0666）に戻せるが、同一サーバーの他ユーザーからも書き換え可能になる。
 
 分離すると、`app/template` や `html/user_data` へ書き込む管理画面の機能（プラグイン導入・
 ページ/ブロック/メールテンプレート編集・CSS/JS 編集・ファイル管理）は動作しなくなる。
@@ -131,7 +140,7 @@ CLI 側の代替導線は整備中のため、**日常の開発では重ねな�
 
 既定モードと分離モードを切り替えるときはレーン W のボリュームを作り直す。切り替え前の `www-data` の
 uid で作成されたディレクトリが残り、切り替え後の Web サーバーから書き込めなくなる
-（例: `var/cache/{env}/mcp-sessions`）。
+（例: `var/runtime/{env}/mcp-sessions`）。
 
 ```bash
 docker compose ... down -v
@@ -179,9 +188,14 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose
 
 ### キャッシュ / データベース
 
+キャッシュは 3 つのディレクトリに分かれる。`var/build/{env}`（コンパイル済みコンテナ・ルーティング・
+メタデータ・prod の twig）と `var/cache/{env}`（ビルド時のみ使用）は CLI が生成し、
+`var/runtime/{env}`（cache pool・翻訳・htmlpurifier・twig のフォールバック等）はリクエスト処理中に生成される。
+
 ```bash
-bin/console cache:clear
-bin/console cache:warmup
+bin/console eccube:cache:build   # var/build を再生成（テンプレートの事前コンパイルを含む）
+bin/console cache:pool:clear --all   # 実行時キャッシュ（cache pool）を削除
+bin/console cache:clear          # 従来どおり全体を削除（build と cache の双方に書き込み権限が必要）
 
 # スキーマは Entity 属性が源泉。アップデートは 2 段構え:
 bin/console doctrine:schema:update --dump-sql        # 属性差分の SQL プレビュー

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,20 @@ docker compose exec -u www-data ec-cube bin/console cache:pool:clear --all    # 
 
 分離すると、`app/template` や `html/user_data` へ書き込む管理画面の機能（プラグイン導入・
 ページ/ブロック/メールテンプレート編集・CSS/JS 編集・ファイル管理）は動作しなくなる。
-CLI 側の代替導線は整備中のため、**日常の開発では重ねない**こと。
+ページ・ブロック・メールテンプレートは下記の CLI が代替導線になる。CSS/JS 編集とファイル管理は
+未整備のため、**日常の開発では重ねない**こと。
+
+```bash
+# DB レコードと twig ファイルを対で扱う（apply は upsert で冪等。--dry-run / --format=json に対応）
+bin/console eccube:page:list|show|apply|remove
+bin/console eccube:block:list|show|apply|remove
+bin/console eccube:mail-template:list|show|apply
+cat guide.twig | bin/console eccube:page:apply --url=guide --name=ご利用ガイド --body=-
+```
+
+入力値の検証は管理画面と同じ FormType を通すため、重複チェックや twig の構文チェックも同じものが効く。
+`apply` / `remove` は build ディレクトリへ書き込めない場合、本処理を完了させたうえで終了コード `3` と
+`eccube:cache:build` の案内を返す。
 
 既定モードと分離モードを切り替えるときはレーン W のボリュームを作り直す。切り替え前の `www-data` の
 uid で作成されたディレクトリが残り、切り替え後の Web サーバーから書き込めなくなる

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,11 @@ Web サーバー（`www-data`）と CLI（SSH ログインユーザー相当）�
 `docker-compose.permission-lanes.yml` を重ねる。`eccube:doctor:permissions` の動作確認に使う。
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.permission-lanes.yml up -d --wait
+# --build は必須。 公開イメージ (ghcr) には dockerbuild/docker-php-entrypoint のレーン分離が
+# 含まれないため、 pull されたイメージのままだと www-data がホストユーザーへリマップされ分離されない。
+# DB は SQLite だと var/eccube.db を CLI から書けないため、 DB サーバーを重ねる。
+docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml \
+  -f docker-compose.permission-lanes.yml up -d --build --wait
 curl -s -o /dev/null http://127.0.0.1:8080/   # セッションを生成し Web サーバーの uid を判定可能にする
 docker compose exec -u eccube ec-cube bin/console eccube:doctor:permissions
 ```
@@ -128,6 +132,11 @@ docker compose exec -u www-data ec-cube bin/console cache:pool:clear --all    # 
 
 `cache:clear` は `var/build` と `var/cache` の双方へ書き込むため、分離モードでは使用できない。
 コンパイル済みコンテナとテンプレートの再生成は `eccube:cache:build` を使う。
+
+`var/log` はレーン W のため、CLI からはログファイルへ書き込めない。ログの出力に失敗すると本来のエラーが
+ログ書き込みエラーへすり替わるため、分離した構成では `ECCUBE_CLI_LOG_TO_FILE=0` を設定し、CLI のログを
+コンソール出力に寄せる（記録が必要な場合はリダイレクトする）。未設定なら従来どおりファイルへ書く。
+`docker-compose.permission-lanes.yml` では既に設定済み。
 
 アプリケーションが作成するファイルの umask は環境変数 `ECCUBE_UMASK`（8 進数表記）で設定する。
 未設定なら OS / PHP-FPM の既定に従う（推奨）。Web サーバーと CLI が別ユーザーで、かつ双方が同じ

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,11 +150,17 @@ docker compose exec -u www-data ec-cube bin/console cache:pool:clear --all    # 
 ページ・ブロック・メールテンプレートは下記の CLI が代替導線になる。CSS/JS 編集とファイル管理は
 未整備のため、**日常の開発では重ねない**こと。
 
+DB レコードと twig ファイルを対で扱う。`apply` は upsert で冪等。`--dry-run` / `--format=json` に対応。
+
+| 対象 | サブコマンド |
+|---|---|
+| `bin/console eccube:page:*` | `list` / `show` / `apply` / `remove` |
+| `bin/console eccube:block:*` | `list` / `show` / `apply` / `remove` |
+| `bin/console eccube:mail-template:*` | `list` / `show` / `apply` |
+
 ```bash
-# DB レコードと twig ファイルを対で扱う（apply は upsert で冪等。--dry-run / --format=json に対応）
-bin/console eccube:page:list|show|apply|remove
-bin/console eccube:block:list|show|apply|remove
-bin/console eccube:mail-template:list|show|apply
+bin/console eccube:page:list
+bin/console eccube:page:show --route=guide > guide.twig
 cat guide.twig | bin/console eccube:page:apply --route=guide --name=ご利用ガイド --body=-
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ docker compose exec -u www-data ec-cube bin/console cache:pool:clear --all    # 
 bin/console eccube:page:list|show|apply|remove
 bin/console eccube:block:list|show|apply|remove
 bin/console eccube:mail-template:list|show|apply
-cat guide.twig | bin/console eccube:page:apply --url=guide --name=ご利用ガイド --body=-
+cat guide.twig | bin/console eccube:page:apply --route=guide --name=ご利用ガイド --body=-
 ```
 
 入力値の検証は管理画面と同じ FormType を通すため、重複チェックや twig の構文チェックも同じものが効く。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,9 +121,11 @@ curl -s -o /dev/null http://127.0.0.1:8080/   # セッションを生成し Web 
 docker compose exec -u eccube ec-cube bin/console eccube:doctor:permissions
 ```
 
-レーン W（`var/runtime`、`var/sessions`、`var/log`、`html/upload/**`、`app/keystore`）は `www-data` 所有とし、
+レーン W（`var/runtime`、`var/sessions`、`var/log`、`html/upload/**`）は `www-data` 所有とし、
 共有グループは作らない。CLI からレーン W を触る操作は Web サーバーのユーザーで実行する。
 本番の `sudo -u www-data` に相当する。
+`app/keystore` はレーン S。秘密鍵はデプロイ成果物で、Web サーバーから書き込めると署名鍵の
+差し替えを許すため読み取りのみとする（実行時に鍵を生成する機能を使う場合は事前に配置しておく）。
 
 ```bash
 docker compose exec -u eccube   ec-cube bin/console eccube:cache:build        # レーン S を触る操作
@@ -198,8 +200,9 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose
 ### キャッシュ / データベース
 
 キャッシュは 3 つのディレクトリに分かれる。`var/build/{env}`（コンパイル済みコンテナ・ルーティング・
-メタデータ・prod の twig）と `var/cache/{env}`（ビルド時のみ使用）は CLI が生成し、
-`var/runtime/{env}`（cache pool・翻訳・htmlpurifier・twig のフォールバック等）はリクエスト処理中に生成される。
+メタデータ・prod の twig）と `var/cache/{env}`（翻訳カタログ・htmlpurifier）は CLI が生成し、
+リクエスト処理中は読み取りのみ。`var/runtime/{env}`（cache pool・mcp-sessions・事前コンパイル漏れの
+twig のフォールバック等）はリクエスト処理中に生成される。
 
 ```bash
 bin/console eccube:cache:build   # var/build を再生成（テンプレートの事前コンパイルを含む）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,9 @@ docker compose exec -u eccube   ec-cube bin/console eccube:cache:build        # 
 docker compose exec -u www-data ec-cube bin/console cache:pool:clear --all    # レーン W を触る操作
 ```
 
-`cache:clear` は `var/build` と `var/cache` の双方へ書き込むため、分離モードでは使用できない。
+`cache:clear` は `var/build` と `var/cache` の双方へ書き込む。3 分割ではどちらもレーン S のため
+CLI ユーザーなら成功する（Web サーバーのユーザーでは失敗する）。ただし `--no-warmup` を付けると
+コンパイル済みコンテナが再生成されず、次のリクエストで Web サーバーが 500 になる。
 コンパイル済みコンテナとテンプレートの再生成は `eccube:cache:build` を使う。
 
 `var/log` はレーン W のため、CLI からはログファイルへ書き込めない。ログの出力に失敗すると本来のエラーが

--- a/app/config/eccube/packages/dev/web_profiler.yaml
+++ b/app/config/eccube/packages/dev/web_profiler.yaml
@@ -6,3 +6,5 @@ framework:
     profiler:
         only_exceptions: false
         collect_serializer_data: true
+        # プロファイラはリクエスト処理中に書き込まれるため, ランタイムディレクトリへ置く.
+        dsn: 'file:%eccube_runtime_dir%/profiler'

--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -21,6 +21,12 @@ parameters:
     env(ECCUBE_2FA_COOKIE_NAME): 'eccube_2fa'
     env(ECCUBE_2FA_EXPIRE): '14'
     env(ECCUBE_RESTRICT_FILE_UPLOAD): '0'
+    # アプリケーションが作成するファイル・ディレクトリの umask (8 進数表記).
+    # 空の場合は OS / PHP-FPM の既定に従う (推奨).
+    # Web サーバーと CLI が別ユーザーで, かつ双方が同じファイルへ書き込む必要がある環境では
+    # '0000' を設定すると 4.3 以前と同じ挙動 (ディレクトリ 0777 / ファイル 0666) になるが,
+    # 同一サーバーの他ユーザーからも書き換え可能になる.
+    env(ECCUBE_UMASK): ''
 
     # EC-CUBE parameter
     eccube_database_url: '%env(DATABASE_URL)%'
@@ -38,6 +44,13 @@ parameters:
     eccube_auth_magic: '%env(ECCUBE_AUTH_MAGIC)%'
     eccube_auth_type: HMAC
     eccube_password_hash_algos: SHA256
+    # リクエスト処理中に Web サーバーが書き込むディレクトリ.
+    # kernel.cache_dir / kernel.build_dir は eccube:cache:build (CLI) が生成するため,
+    # 実行時に生成されるキャッシュ・一時ファイルはすべてここへ集約する (Eccube\Kernel::getRuntimeDir()).
+    eccube_runtime_dir: '%kernel.project_dir%/var/runtime/%kernel.environment%'
+    # 実際の適用は index.php / bin/console の apply_umask() が行う (コンテナ生成より前のため).
+    # ここでは診断・参照用にパラメータとして公開する.
+    eccube_umask: '%env(ECCUBE_UMASK)%'
     eccube_theme_app_dir: '%kernel.project_dir%/app/template'
     eccube_theme_src_dir: '%kernel.project_dir%/src/Eccube/Resource/template'
     eccube_theme_user_data_dir: '%eccube_theme_app_dir%/user_data'
@@ -60,7 +73,7 @@ parameters:
     # 本保存領域(eccube_save_refund_request_file_dir)の配下に置かない。配信検証のプレフィックス一致で一時ファイルが到達可能になるのを防ぐため、兄弟ディレクトリ(temp)に分離する
     eccube_temp_refund_request_file_dir: '%kernel.project_dir%/html/upload/refund_request/temp'
     eccube_csv_size: 5                 # post_max_size, upload_max_filesize に任せればよい？
-    eccube_csv_temp_realdir: '%kernel.cache_dir%/%kernel.environment%/eccube' # upload_tmp_dir に任せればよい？
+    eccube_csv_temp_realdir: '%eccube_runtime_dir%/eccube' # upload_tmp_dir に任せればよい？
     eccube_csv_split_lines: 100
     eccube_default_password: 'abc*********123'
     eccube_deliv_addr_max: 20

--- a/app/config/eccube/packages/framework.yaml
+++ b/app/config/eccube/packages/framework.yaml
@@ -3,9 +3,6 @@ framework:
     default_locale: '%locale%'
     translator:
       fallback: ['%locale%']
-      # 翻訳カタログはリクエスト処理中にも生成されるため, ランタイムディレクトリへ置く.
-      # (既定は %kernel.cache_dir%/translations)
-      cache_dir: '%eccube_runtime_dir%/translations'
     csrf_protection: { enabled: true }
     http_method_override: true
     trusted_hosts: ~

--- a/app/config/eccube/packages/framework.yaml
+++ b/app/config/eccube/packages/framework.yaml
@@ -3,6 +3,9 @@ framework:
     default_locale: '%locale%'
     translator:
       fallback: ['%locale%']
+      # 翻訳カタログはリクエスト処理中にも生成されるため, ランタイムディレクトリへ置く.
+      # (既定は %kernel.cache_dir%/translations)
+      cache_dir: '%eccube_runtime_dir%/translations'
     csrf_protection: { enabled: true }
     http_method_override: true
     trusted_hosts: ~
@@ -52,6 +55,9 @@ framework:
         # to avoid collisions when multiple apps share the same cache backend (e.g. a Redis server)
         # See https://symfony.com/doc/current/reference/configuration/framework.html#prefix-seed
         prefix_seed: ec-cube
+        # cache pool はリクエスト処理中に書き込まれるため, ランタイムディレクトリへ置く.
+        # cache.system 側は設定できないため RuntimeCacheDirPass で差し替える.
+        directory: '%eccube_runtime_dir%/pools/app'
     # Lock factory. flock store works on shared hosting without external infra.
     # Used by Agent Commerce (UCP Catalog) cache stampede prevention.
     lock: flock

--- a/app/config/eccube/packages/html_purifier.yaml
+++ b/app/config/eccube/packages/html_purifier.yaml
@@ -1,0 +1,8 @@
+exercise_html_purifier:
+    # HTMLPurifier のシリアライザキャッシュはリクエスト処理中に生成されるため,
+    # ランタイムディレクトリへ置く (既定は %kernel.cache_dir%/htmlpurifier).
+    #
+    # HTMLPurifier は Cache.SerializerPermissions で明示的に chmod するため umask の影響を受けず,
+    # 先に生成したユーザー以外は書き込めない. kernel.cache_dir を CLI ユーザー所有にすると
+    # Web サーバーから Permission denied になるため, 分離が必須となる.
+    default_cache_serializer_path: '%eccube_runtime_dir%/htmlpurifier'

--- a/app/config/eccube/packages/html_purifier.yaml
+++ b/app/config/eccube/packages/html_purifier.yaml
@@ -1,8 +1,0 @@
-exercise_html_purifier:
-    # HTMLPurifier のシリアライザキャッシュはリクエスト処理中に生成されるため,
-    # ランタイムディレクトリへ置く (既定は %kernel.cache_dir%/htmlpurifier).
-    #
-    # HTMLPurifier は Cache.SerializerPermissions で明示的に chmod するため umask の影響を受けず,
-    # 先に生成したユーザー以外は書き込めない. kernel.cache_dir を CLI ユーザー所有にすると
-    # Web サーバーから Permission denied になるため, 分離が必須となる.
-    default_cache_serializer_path: '%eccube_runtime_dir%/htmlpurifier'

--- a/app/config/eccube/packages/install/web_profiler.yaml
+++ b/app/config/eccube/packages/install/web_profiler.yaml
@@ -3,4 +3,7 @@ web_profiler:
     intercept_redirects: false
 
 framework:
-    profiler: { only_exceptions: false }
+    profiler:
+        only_exceptions: false
+        # プロファイラはリクエスト処理中に書き込まれるため, ランタイムディレクトリへ置く.
+        dsn: 'file:%eccube_runtime_dir%/profiler'

--- a/app/config/eccube/packages/mcp.yaml
+++ b/app/config/eccube/packages/mcp.yaml
@@ -9,3 +9,6 @@ mcp:
         path: '/%eccube_admin_route%/mcp'
         session:
             store: file
+            # MCP セッションはリクエスト処理中に書き込まれるため, ランタイムディレクトリへ置く.
+            # (既定は %kernel.cache_dir%/mcp-sessions)
+            directory: '%eccube_runtime_dir%/mcp-sessions'

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -11,6 +11,9 @@ parameters:
     env(ECCUBE_MCP_ALLOWED_ORIGINS): ''
     # MCP 監査ログ (mcp.log) の保管日数 (rotating_file の世代数)。 設計 §4.2
     env(ECCUBE_MCP_LOG_RETENTION_DAYS): '90'
+    # CLI 実行時もログをファイルへ書くか。 Web サーバーと CLI で var/log の書き込み権限を
+    # 分離した構成では 0 を設定し、 CLI のログはコンソール出力 (必要ならリダイレクト) に寄せる。
+    env(ECCUBE_CLI_LOG_TO_FILE): '1'
     locale: '%env(ECCUBE_LOCALE)%'
     timezone: '%env(ECCUBE_TIMEZONE)%'
     currency: '%env(ECCUBE_CURRENCY)%'

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -404,7 +404,7 @@ services:
     # Agent Commerce: UCP Catalog (pull / REST) (#6794)
     Eccube\Service\AgentCommerce\Catalog\Ucp\UcpCatalogCache:
         arguments:
-            $cacheDir: '%kernel.cache_dir%'
+            $cacheDir: '%eccube_runtime_dir%'
 
     # Agent Commerce: UCP Discovery (/.well-known/ucp) (#6794 / #6777)
     # payment_handlers は決済ハンドラプラグインが tagged service で寄与する (既定は空 {}).

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -303,6 +303,11 @@ services:
         arguments:
             $container: !tagged_locator { tag: 'cache.pool.clearer' }
 
+    # cache:clear で %eccube_runtime_dir%/pools を削除する (kernel.cache_clearer は autoconfigure で付与).
+    Eccube\Util\RuntimeCachePoolClearer:
+        arguments:
+            $runtimeDir: '%eccube_runtime_dir%'
+
     Eccube\Asset\FilemtimeVersionStrategy:
         arguments:
             - '%eccube_html_dir%/user_data'

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -311,6 +311,13 @@ services:
         arguments:
             $runtimeDir: '%eccube_runtime_dir%'
 
+    # cache:clear の後始末 (コンパイル済みコンテナの再生成・実行時 cache pool の削除) を案内する
+    Eccube\EventListener\RuntimeCachePoolClearListener:
+        arguments:
+            $buildDir: '%kernel.build_dir%'
+            $cacheDir: '%kernel.cache_dir%'
+            $containerClass: '%kernel.container_class%'
+
     Eccube\Asset\FilemtimeVersionStrategy:
         arguments:
             - '%eccube_html_dir%/user_data'

--- a/bin/console
+++ b/bin/console
@@ -7,7 +7,6 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\ErrorHandler\Debug;
 
-umask(0000);
 set_time_limit(0);
 
 require __DIR__.'/../vendor/autoload.php';
@@ -35,6 +34,9 @@ if (!isset($_SERVER['APP_ENV'])) {
         (new Dotenv())->overload(__DIR__.'/../.env.install');
     }
 }
+
+// umask はコンテナ生成より前に決める必要があるため, 環境変数 ECCUBE_UMASK から読み込む.
+apply_umask();
 
 $input = new ArgvInput();
 $env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev');

--- a/docker-compose.permission-lanes.yml
+++ b/docker-compose.permission-lanes.yml
@@ -2,7 +2,12 @@ version: '3'
 
 # Web サーバー (www-data) と CLI (SSH ログインユーザー相当) の書き込み権限を分離する override。
 #
-#   docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.permission-lanes.yml up -d --wait
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml \
+#     -f docker-compose.permission-lanes.yml up -d --build --wait
+#
+# --build は必須。公開イメージ (ghcr) には本リポジトリの dockerbuild/docker-php-entrypoint が
+# 含まれないため、pull されたイメージのままでは www-data がホストユーザーへリマップされ分離されない。
+# DB サーバーを重ねるのは、既定の SQLite (var/eccube.db) が var 配下にあり CLI から書き込めないため。
 #
 # 分離モードでは www-data は uid 33 のままとなり、CLI 用に別ユーザー (eccube) を作成する。
 # 共有グループは作らない。セキュリティポリシーで共有グループを作成できない環境があるため。
@@ -48,6 +53,10 @@ services:
       # それだとルート自体を Web サーバーから書き込み可能にする必要があるため
       # レーン W の var/runtime 配下へ移す (管理画面から生成されるため Web サーバーの書き込み権限が要る)
       ECCUBE_MAINTENANCE_FILE_PATH: /var/www/html/var/runtime/.maintenance
+      # var/log はレーン W (www-data 所有) のため CLI からは書き込めない。
+      # ログ出力の失敗で本来のエラーが隠れるのを防ぐため、CLI ではファイルへ書かない。
+      # (Web リクエストのログは従来どおりファイルへ出力される)
+      ECCUBE_CLI_LOG_TO_FILE: 0
       # レーン S へ書き込む管理画面の機能を 403 で止める場合は有効にする。
       # 無効のままだと、それらの画面は書き込みエラーになる
       # ECCUBE_RESTRICT_FILE_UPLOAD: 1

--- a/docker-compose.permission-lanes.yml
+++ b/docker-compose.permission-lanes.yml
@@ -7,7 +7,10 @@ version: '3'
 #
 # --build は必須。公開イメージ (ghcr) には本リポジトリの dockerbuild/docker-php-entrypoint が
 # 含まれないため、pull されたイメージのままでは www-data がホストユーザーへリマップされ分離されない。
-# DB サーバーを重ねるのは、既定の SQLite (var/eccube.db) が var 配下にあり CLI から書き込めないため。
+#
+# DB は PostgreSQL または MySQL が必須。既定の SQLite はデータベースファイルが var 配下に置かれ、
+# Web サーバーと CLI の双方が書き込む必要があるため、権限を分離すると成立しない
+# (エントリポイントが起動時に検査し、SQLite なら起動を中止する)。
 #
 # 分離モードでは www-data は uid 33 のままとなり、CLI 用に別ユーザー (eccube) を作成する。
 # 共有グループは作らない。セキュリティポリシーで共有グループを作成できない環境があるため。
@@ -49,6 +52,12 @@ services:
   ec-cube:
     environment:
       ECCUBE_PERMISSION_LANES: 1
+      # 分離モードは prod で動かす。dev (APP_DEBUG=1) はリクエスト処理中にコンテナを再生成するため、
+      # Kernel::buildContainer() が var/cache と var/build (レーン S = CLI 所有) への書き込みを要求し、
+      # 「Unable to write in the "cache" directory」で 500 になる。
+      # prod は debug=false でコンテナを再生成しないため、eccube:cache:build の生成物を読むだけで動く。
+      APP_ENV: prod
+      APP_DEBUG: 0
       # メンテナンスファイルの生成先。既定はプロジェクトルート直下だが、
       # それだとルート自体を Web サーバーから書き込み可能にする必要があるため
       # レーン W の var/runtime 配下へ移す (管理画面から生成されるため Web サーバーの書き込み権限が要る)

--- a/docker-compose.permission-lanes.yml
+++ b/docker-compose.permission-lanes.yml
@@ -9,16 +9,20 @@ version: '3'
 #
 # 書き込み先は 2 つのレーンに分かれる。
 #
-#   レーン W (Web サーバーが書き込む)   var, html/upload/**, app/keystore
+#   レーン W (Web サーバーが書き込む)   var/runtime, var/sessions, var/log, html/upload/**, app/keystore
 #     → www-data 所有。CLI から書き込む必要がある場合は Web サーバーのユーザーで実行する
-#   レーン S (CLI へ移せる)             上記以外 (app/template, html/user_data, app/Plugin, vendor, .env 等)
+#   レーン S (CLI へ移せる)             上記以外 (var/build, var/cache, app/template, html/user_data,
+#                                       app/Plugin, vendor, .env 等)
 #     → CLI ユーザー所有。www-data は読み取りのみ
 #
 # CLI の実行ユーザーは操作対象のレーンで決まる。
 #
-#   レーン S を触る   docker compose exec -u eccube   ec-cube bin/console ...
-#   レーン W を触る   docker compose exec -u www-data ec-cube bin/console cache:clear
-#                     (本番では sudo -u www-data bin/console cache:clear に相当する)
+#   レーン S を触る   docker compose exec -u eccube   ec-cube bin/console eccube:cache:build
+#   レーン W を触る   docker compose exec -u www-data ec-cube bin/console cache:pool:clear --all
+#                     (本番では sudo -u www-data bin/console ... に相当する)
+#
+# cache:clear は var/build と var/cache の双方へ書き込むため、分離モードでは使用できない。
+# コンパイル済みコンテナとテンプレートの再生成は eccube:cache:build を使う。
 #
 # 分離すると、レーン S へ書き込む管理画面の機能は動作しなくなる。
 # (プラグインの導入・有効化、ページ/ブロック/メールテンプレートの編集、CSS/JS の編集、
@@ -27,7 +31,7 @@ version: '3'
 #
 # 既定モードと分離モードを切り替えるときは、レーン W のボリュームを作り直すこと。
 # 切り替え前の www-data の uid で作成されたディレクトリが残り、切り替え後の Web サーバーから
-# 書き込めなくなる (例: var/cache/{env}/mcp-sessions)。
+# 書き込めなくなる (例: var/runtime/{env}/mcp-sessions)。
 #
 #   docker compose ... down -v
 #
@@ -41,8 +45,9 @@ services:
     environment:
       ECCUBE_PERMISSION_LANES: 1
       # メンテナンスファイルの生成先。既定はプロジェクトルート直下だが、
-      # それだとルート自体を Web サーバーから書き込み可能にする必要があるため var/ 配下へ移す
-      ECCUBE_MAINTENANCE_FILE_PATH: /var/www/html/var/.maintenance
+      # それだとルート自体を Web サーバーから書き込み可能にする必要があるため
+      # レーン W の var/runtime 配下へ移す (管理画面から生成されるため Web サーバーの書き込み権限が要る)
+      ECCUBE_MAINTENANCE_FILE_PATH: /var/www/html/var/runtime/.maintenance
       # レーン S へ書き込む管理画面の機能を 403 で止める場合は有効にする。
       # 無効のままだと、それらの画面は書き込みエラーになる
       # ECCUBE_RESTRICT_FILE_UPLOAD: 1

--- a/docker-compose.permission-lanes.yml
+++ b/docker-compose.permission-lanes.yml
@@ -17,11 +17,15 @@ version: '3'
 #
 # 書き込み先は 2 つのレーンに分かれる。
 #
-#   レーン W (Web サーバーが書き込む)   var/runtime, var/sessions, var/log, html/upload/**, app/keystore
+#   レーン W (Web サーバーが書き込む)   var/runtime, var/sessions, var/log, html/upload/**
 #     → www-data 所有。CLI から書き込む必要がある場合は Web サーバーのユーザーで実行する
 #   レーン S (CLI へ移せる)             上記以外 (var/build, var/cache, app/template, html/user_data,
-#                                       app/Plugin, vendor, .env 等)
+#                                       app/Plugin, app/keystore, vendor, .env 等)
 #     → CLI ユーザー所有。www-data は読み取りのみ
+#
+# app/keystore はレーン S。秘密鍵はデプロイ成果物であり、Web サーバーから書き込めると
+# 署名鍵の差し替えを許すため読み取りのみとする。実行時に鍵を生成する機能
+# (AcpMessageSigner / UcpMessageSigner) を使う場合は、鍵を事前に配置しておくこと。
 #
 # CLI の実行ユーザーは操作対象のレーンで決まる。
 #
@@ -43,10 +47,10 @@ version: '3'
 #
 #   docker compose ... down -v
 #
-# レーン W のディレクトリ (html/upload/**、app/keystore) はホスト側でも www-data の uid 所有になる。
+# レーン W のディレクトリ (html/upload/**) はホスト側でも www-data の uid 所有になる。
 # 既定モードへ戻すときは所有者を元に戻すこと。
 #
-#   sudo chown -R $(id -u):$(id -g) html/upload app/keystore
+#   sudo chown -R $(id -u):$(id -g) html/upload
 
 services:
   ec-cube:

--- a/dockerbuild/docker-php-entrypoint
+++ b/dockerbuild/docker-php-entrypoint
@@ -8,7 +8,9 @@ PERMISSION_LANES="${ECCUBE_PERMISSION_LANES:-}"
 # レーン W: リクエスト処理中に Web サーバーが書き込むディレクトリ。www-data 所有とする。
 # CLI から書き込む必要がある場合は Web サーバーのユーザーで実行する (本番では sudo -u www-data)。
 # 共有グループは作らない。セキュリティポリシーで共有グループを作成できない環境があるため。
-LANE_W_DIRS="html/upload html/upload/save_image html/upload/temp_image html/upload/refund_request html/upload/refund_request/save html/upload/refund_request/temp app/keystore"
+# app/keystore はレーン S (CLI が鍵を配置し Web サーバーは読み取りのみ)。
+# 実行時に鍵を生成する機能を使う場合のみ Web サーバーの書き込み権限が必要になる。
+LANE_W_DIRS="html/upload html/upload/save_image html/upload/temp_image html/upload/refund_request html/upload/refund_request/save html/upload/refund_request/temp"
 
 # var 配下のレーン分け。
 # var/runtime (実行時キャッシュ)・var/sessions・var/log はリクエスト処理中に書き込まれる。

--- a/dockerbuild/docker-php-entrypoint
+++ b/dockerbuild/docker-php-entrypoint
@@ -16,6 +16,27 @@ LANE_W_DIRS="html/upload html/upload/save_image html/upload/temp_image html/uplo
 LANE_W_VAR_DIRS="var/runtime var/sessions var/log"
 LANE_S_VAR_DIRS="var/build var/cache"
 
+# 分離モードでは SQLite を使えない。データベースファイルは var 配下 (レーン W) に置かれ、
+# Web サーバーと CLI の双方が書き込む必要があるため、権限を分けると成立しないため。
+require_database_server() {
+    case "${DATABASE_URL:-}" in
+        postgres://* | postgresql://* | pgsql://* | mysql://*)
+            return 0
+            ;;
+        '')
+            echo "ECCUBE_PERMISSION_LANES=1 では DATABASE_URL の指定が必要です (PostgreSQL または MySQL)。" >&2
+            echo "docker-compose.pgsql.yml または docker-compose.mysql.yml を重ねてください。" >&2
+            exit 1
+            ;;
+        *)
+            # 値そのものは資格情報を含むためスキームのみ表示する
+            echo "ECCUBE_PERMISSION_LANES=1 では PostgreSQL または MySQL が必要です (指定されたスキーム: ${DATABASE_URL%%:*})。" >&2
+            echo "SQLite はデータベースファイルを Web サーバーと CLI の双方が書き込むため、権限を分離できません。" >&2
+            exit 1
+            ;;
+    esac
+}
+
 setup_split_users() {
     # UID / GID はシェルが export しないことが多いため, 未指定なら
     # bind mount されたファイルの所有者からホストユーザーを推定する。
@@ -69,6 +90,7 @@ apply_permission_lanes() {
 }
 
 if [ "${PERMISSION_LANES}" = "1" ]; then
+    require_database_server
     setup_split_users
 else
     if [ -n "${USER_ID}" ]; then
@@ -123,7 +145,10 @@ if [ "${PERMISSION_LANES}" = "1" ]; then
     apply_permission_lanes
 fi
 
-echo "PassEnv APP_ENV APP_DEBUG TRUSTED_PROXIES TRUSTED_HOSTS" > /etc/apache2/conf-enabled/eccube_env.conf
+# compose 等で与えた環境変数を Web サーバー (mod_php) 側にも渡す。
+# DATABASE_URL が渡らないと Web だけ .env の値 (既定は SQLite) を読み、
+# CLI と Web で接続先が食い違う。
+echo "PassEnv APP_ENV APP_DEBUG TRUSTED_PROXIES TRUSTED_HOSTS DATABASE_URL DATABASE_SERVER_VERSION DATABASE_CHARSET MAILER_DSN" > /etc/apache2/conf-enabled/eccube_env.conf
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then

--- a/dockerbuild/docker-php-entrypoint
+++ b/dockerbuild/docker-php-entrypoint
@@ -10,6 +10,12 @@ PERMISSION_LANES="${ECCUBE_PERMISSION_LANES:-}"
 # 共有グループは作らない。セキュリティポリシーで共有グループを作成できない環境があるため。
 LANE_W_DIRS="html/upload html/upload/save_image html/upload/temp_image html/upload/refund_request html/upload/refund_request/save html/upload/refund_request/temp app/keystore"
 
+# var 配下のレーン分け。
+# var/runtime (実行時キャッシュ)・var/sessions・var/log はリクエスト処理中に書き込まれる。
+# var/build (コンパイル済みコンテナ・テンプレート)・var/cache は eccube:cache:build が生成する。
+LANE_W_VAR_DIRS="var/runtime var/sessions var/log"
+LANE_S_VAR_DIRS="var/build var/cache"
+
 setup_split_users() {
     # UID / GID はシェルが export しないことが多いため, 未指定なら
     # bind mount されたファイルの所有者からホストユーザーを推定する。
@@ -46,9 +52,20 @@ apply_permission_lanes() {
         chown www-data:www-data "${target}"
     done
 
-    # var は名前付きボリュームで配布物を含まないため配下ごと Web サーバー所有にする.
+    # var は名前付きボリュームで配布物を含まないため, 配下をレーンごとに所有者を分ける.
     # パーミッションは変更しない. 変更するとセッションファイルの 0600 を緩めてしまうため.
-    chown -R www-data:www-data "${APACHE_DOCUMENT_ROOT}/var"
+    # var 自体は CLI ユーザー所有にする (eccube:cache:build が var/build を作り直せるように).
+    chown "${cli_uid}:${cli_gid}" "${APACHE_DOCUMENT_ROOT}/var"
+    for dir in ${LANE_S_VAR_DIRS}; do
+        target="${APACHE_DOCUMENT_ROOT}/${dir}"
+        mkdir -p "${target}"
+        chown -R "${cli_uid}:${cli_gid}" "${target}"
+    done
+    for dir in ${LANE_W_VAR_DIRS}; do
+        target="${APACHE_DOCUMENT_ROOT}/${dir}"
+        mkdir -p "${target}"
+        chown -R www-data:www-data "${target}"
+    done
 }
 
 if [ "${PERMISSION_LANES}" = "1" ]; then

--- a/dockerbuild/docker-php-entrypoint
+++ b/dockerbuild/docker-php-entrypoint
@@ -22,7 +22,7 @@ LANE_S_VAR_DIRS="var/build var/cache"
 # Web サーバーと CLI の双方が書き込む必要があるため、権限を分けると成立しないため。
 require_database_server() {
     case "${DATABASE_URL:-}" in
-        postgres://* | postgresql://* | pgsql://* | mysql://*)
+        postgres://* | postgresql://* | pgsql://* | mysql://* | mysql2://*)
             return 0
             ;;
         '')

--- a/dockerbuild/docker-php-entrypoint
+++ b/dockerbuild/docker-php-entrypoint
@@ -20,9 +20,14 @@ LANE_S_VAR_DIRS="var/build var/cache"
 
 # 分離モードでは SQLite を使えない。データベースファイルは var 配下 (レーン W) に置かれ、
 # Web サーバーと CLI の双方が書き込む必要があるため、権限を分けると成立しないため。
+#
+# スキームは DsnParser が解釈できるものを列挙する。別名 (postgres 等) は
+# ConnectionFactory::DEFAULT_SCHEME_MAP で driver へ変換され、マップに無いものは
+# scheme の - を _ に置換して driver 名として扱われる (pdo-pgsql -> pdo_pgsql)。
 require_database_server() {
     case "${DATABASE_URL:-}" in
-        postgres://* | postgresql://* | pgsql://* | mysql://* | mysql2://*)
+        postgres://* | postgresql://* | pgsql://* | pdo-pgsql://* | \
+        mysql://* | mysql2://* | pdo-mysql://* | mysqli://*)
             return 0
             ;;
         '')

--- a/dockerbuild/docker-php-entrypoint
+++ b/dockerbuild/docker-php-entrypoint
@@ -54,6 +54,27 @@ setup_split_users() {
     if ! getent passwd "${cli_uid}" > /dev/null; then
         useradd -o -u "${cli_uid}" -g "${cli_gid}" -m -d /home/eccube -s /bin/bash eccube
     fi
+
+    # 既存の uid を再利用した場合は名前が eccube とは限らないため実際の名前を引く
+    cli_user="$(getent passwd "${cli_uid}" | cut -d: -f1)"
+}
+
+# レーン S のビルド生成物を CLI ユーザーで作っておく。
+#
+# BuildDirCacheWarmerPass が twig.template_cache_warmer のタグを外すため, composer install の
+# cache:warmup ではテンプレートが事前コンパイルされず, 初回起動時点の var/build/{env}/twig は空になる。
+# その状態で Web サーバーがページを描画すると, コンパイル結果がレーン W の var/runtime/{env}/twig へ
+# 書かれる。レーン W は CLI ユーザーから削除できないため, 以降 eccube:cache:build が
+# 削除できない旨の警告を出し続けることになる。アクセスを受ける前にここで作っておく。
+build_lane_s_cache() {
+    if runuser -u "${cli_user}" -- bin/console eccube:cache:build; then
+        return 0
+    fi
+
+    # 失敗しても起動は続ける (実行時キャッシュへフォールバックして動作するため)。
+    # 原因を潰さないと上記の警告が出続けるので, 気づけるように明示する。
+    echo "警告: eccube:cache:build に失敗しました。" >&2
+    echo "      アクセスを受ける前に ${cli_user} で bin/console eccube:cache:build を実行してください。" >&2
 }
 
 apply_permission_lanes() {
@@ -145,6 +166,8 @@ bin/console doctrine:query:sql 'select * from dtb_base_info' > /dev/null 2>&1 ||
 
 if [ "${PERMISSION_LANES}" = "1" ]; then
     apply_permission_lanes
+    # 所有者を分けた後に実行する。先に実行すると root 所有の生成物が残り, chown -R が必要になる。
+    build_lane_s_cache
 fi
 
 # compose 等で与えた環境変数を Web サーバー (mod_php) 側にも渡す。

--- a/index.php
+++ b/index.php
@@ -47,14 +47,15 @@ if (!isset($_SERVER['APP_ENV'])) {
     // putenv は使わない（スレッド安全性のため）ので、env() 関数（$_ENV / $_SERVER 優先）と整合する。
     boot_env(__DIR__.'/.env', false);
 }
+// umask はコンテナ生成より前に決める必要があるため, 環境変数 ECCUBE_UMASK から読み込む.
+apply_umask();
+
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
 
 $env = isset($_SERVER['APP_ENV']) ? $_SERVER['APP_ENV'] : 'dev';
 $debug = isset($_SERVER['APP_DEBUG']) ? $_SERVER['APP_DEBUG'] : ('prod' !== $env);
 
 if ($debug) {
-    umask(0000);
-
     Debug::enable();
 }
 

--- a/llms.txt
+++ b/llms.txt
@@ -166,6 +166,19 @@ bin/console cache:pool:clear --all  # Clear the runtime cache pools
 bin/console cache:clear             # Clear everything (needs write access to build and cache)
 ```
 
+### Content Management
+
+Pages, blocks and mail templates pair a database record with a Twig file, so they are managed
+through dedicated commands rather than by copying files. `apply` is an idempotent upsert and
+supports `--dry-run` and `--format=json`; `--body=-` reads the template from stdin.
+
+```bash
+bin/console eccube:page:list|show|apply|remove
+bin/console eccube:block:list|show|apply|remove
+bin/console eccube:mail-template:list|show|apply
+cat guide.twig | bin/console eccube:page:apply --url=guide --name=Guide --body=-
+```
+
 ## Community
 
 - [GitHub Repository](https://github.com/EC-CUBE/ec-cube)

--- a/llms.txt
+++ b/llms.txt
@@ -156,9 +156,14 @@ npm run build   # Build Sass and JavaScript
 
 ### Cache Management
 
+EC-CUBE splits generated files into three directories: `var/build/{env}` (compiled container,
+routing, metadata, precompiled templates) and `var/cache/{env}` are produced by the CLI, while
+`var/runtime/{env}` (cache pools, translations, HTMLPurifier, Twig fallback) is written at request time.
+
 ```bash
-bin/console cache:clear
-bin/console cache:warmup
+bin/console eccube:cache:build      # Rebuild var/build (includes template precompilation)
+bin/console cache:pool:clear --all  # Clear the runtime cache pools
+bin/console cache:clear             # Clear everything (needs write access to build and cache)
 ```
 
 ## Community

--- a/llms.txt
+++ b/llms.txt
@@ -176,7 +176,7 @@ supports `--dry-run` and `--format=json`; `--body=-` reads the template from std
 bin/console eccube:page:list|show|apply|remove
 bin/console eccube:block:list|show|apply|remove
 bin/console eccube:mail-template:list|show|apply
-cat guide.twig | bin/console eccube:page:apply --url=guide --name=Guide --body=-
+cat guide.twig | bin/console eccube:page:apply --route=guide --name=Guide --body=-
 ```
 
 ## Community

--- a/llms.txt
+++ b/llms.txt
@@ -157,8 +157,9 @@ npm run build   # Build Sass and JavaScript
 ### Cache Management
 
 EC-CUBE splits generated files into three directories: `var/build/{env}` (compiled container,
-routing, metadata, precompiled templates) and `var/cache/{env}` are produced by the CLI, while
-`var/runtime/{env}` (cache pools, translations, HTMLPurifier, Twig fallback) is written at request time.
+routing, metadata, precompiled templates) and `var/cache/{env}` (translation catalogues,
+HTMLPurifier) are produced by the CLI and only read while serving requests, whereas
+`var/runtime/{env}` (cache pools, MCP sessions, Twig fallback) is written at request time.
 
 ```bash
 bin/console eccube:cache:build      # Rebuild var/build (includes template precompilation)

--- a/llms.txt
+++ b/llms.txt
@@ -173,10 +173,12 @@ Pages, blocks and mail templates pair a database record with a Twig file, so the
 through dedicated commands rather than by copying files. `apply` is an idempotent upsert and
 supports `--dry-run` and `--format=json`; `--body=-` reads the template from stdin.
 
+`eccube:page:*` and `eccube:block:*` provide `list`, `show`, `apply` and `remove`;
+`eccube:mail-template:*` provides `list`, `show` and `apply`.
+
 ```bash
-bin/console eccube:page:list|show|apply|remove
-bin/console eccube:block:list|show|apply|remove
-bin/console eccube:mail-template:list|show|apply
+bin/console eccube:page:list
+bin/console eccube:page:show --route=guide > guide.twig
 cat guide.twig | bin/console eccube:page:apply --route=guide --name=Guide --body=-
 ```
 

--- a/rector.php
+++ b/rector.php
@@ -126,7 +126,8 @@ return RectorConfig::configure()
                PHPUnitSetList::PHPUNIT_110, // PHPUnitのバージョンに合わせる
            ])
            // Symfony のコンテナ XML（EC-CUBE の構成に合わせて調整が必要な場合があります）
-           ->withSymfonyContainerXml(__DIR__.'/var/cache/dev/Eccube_KernelDevDebugContainer.xml')
+           // debug.container.dump は kernel.build_dir 配下に出力される
+           ->withSymfonyContainerXml(__DIR__.'/var/build/dev/Eccube_KernelDevDebugContainer.xml')
            // オプション: キャッシュ設定 (パフォーマンス向上のために推奨)
            ->withCache(
                cacheClass: FileCacheStorage::class,

--- a/src/Eccube/Cache/WriteFailsafeFilesystemAdapter.php
+++ b/src/Eccube/Cache/WriteFailsafeFilesystemAdapter.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Cache;
+
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+
+/**
+ * 書き込めない場合に保存を諦める FilesystemAdapter.
+ *
+ * @see WriteFailsafeTrait 理由
+ */
+final class WriteFailsafeFilesystemAdapter extends FilesystemAdapter
+{
+    use WriteFailsafeTrait;
+
+    public function __construct(string $namespace = '', int $defaultLifetime = 0, ?string $directory = null, ?MarshallerInterface $marshaller = null)
+    {
+        parent::__construct($namespace, $defaultLifetime, $directory, $marshaller);
+
+        $this->initWriteFailsafe($directory);
+    }
+}

--- a/src/Eccube/Cache/WriteFailsafePhpFilesAdapter.php
+++ b/src/Eccube/Cache/WriteFailsafePhpFilesAdapter.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Cache;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
+
+/**
+ * 書き込めない場合に保存を諦める PhpFilesAdapter.
+ *
+ * @see WriteFailsafeTrait 理由
+ */
+final class WriteFailsafePhpFilesAdapter extends PhpFilesAdapter
+{
+    use WriteFailsafeTrait;
+
+    public function __construct(string $namespace = '', int $defaultLifetime = 0, ?string $directory = null, bool $appendOnly = false)
+    {
+        parent::__construct($namespace, $defaultLifetime, $directory, $appendOnly);
+
+        $this->initWriteFailsafe($directory);
+    }
+
+    /**
+     * cache.system 用のファクトリ.
+     *
+     * 書き込める場合は Symfony の既定 (AbstractAdapter::createSystemCache) をそのまま使う.
+     * 書き込めない場合のみ本アダプタへ差し替える.
+     */
+    #[\Override]
+    public static function createSystemCache(string $namespace, int $defaultLifetime, string $version, string $directory, ?LoggerInterface $logger = null): AdapterInterface
+    {
+        $path = $directory;
+        while (!file_exists($path)) {
+            $parent = \dirname($path);
+            if ($parent === $path) {
+                break;
+            }
+            $path = $parent;
+        }
+
+        if (is_writable($path)) {
+            return AbstractAdapter::createSystemCache($namespace, $defaultLifetime, $version, $directory, $logger);
+        }
+
+        // 書き込めない構成では APCu との ChainAdapter は組まない.
+        // (CLI では apc.enable_cli が無効な環境が大半で, 既定でも PhpFilesAdapter 単体になる)
+        $adapter = new self($namespace, $defaultLifetime, $directory, true);
+        if (null !== $logger) {
+            $adapter->setLogger($logger);
+        }
+
+        return $adapter;
+    }
+}

--- a/src/Eccube/Cache/WriteFailsafeTrait.php
+++ b/src/Eccube/Cache/WriteFailsafeTrait.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Cache;
+
+/**
+ * 書き込めないキャッシュ領域への保存を諦める.
+ *
+ * 権限を分離した構成では, 実行時キャッシュ (%eccube_runtime_dir%/pools) は Web サーバー所有
+ * (レーン W) になるため CLI からは書き込めない. Symfony のアダプタは保存に失敗するたびに
+ * 警告を記録するため, CLI を実行するたびに大量の警告が並ぶ.
+ *
+ * 保存できないことは権限で決まっており実行時には解消できないため, 書き込みは行わない.
+ * 読み取りは従来どおり委譲するので, Web サーバーが生成したキャッシュは利用できる.
+ * キャッシュの生成・削除は権限のあるユーザー (sudo -u www-data) 側で行う.
+ */
+trait WriteFailsafeTrait
+{
+    private bool $cacheWritable = true;
+
+    /**
+     * @param string|null $directory キャッシュの出力先 (null なら PHP の一時ディレクトリ)
+     */
+    private function initWriteFailsafe(?string $directory): void
+    {
+        if (null === $directory) {
+            return;
+        }
+
+        // 未作成のことがあるため, 存在する直近の親ディレクトリで判定する
+        $path = $directory;
+        while (!file_exists($path)) {
+            $parent = \dirname($path);
+            if ($parent === $path) {
+                break;
+            }
+            $path = $parent;
+        }
+
+        $this->cacheWritable = is_writable($path);
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     *
+     * @return array<int, string>|bool
+     */
+    #[\Override]
+    protected function doSave(array $values, int $lifetime): array|bool
+    {
+        return $this->cacheWritable ? parent::doSave($values, $lifetime) : true;
+    }
+}

--- a/src/Eccube/Command/CacheBuildCommand.php
+++ b/src/Eccube/Command/CacheBuildCommand.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\TwigBundle\CacheWarmer\TemplateCacheWarmer;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\RebootableInterface;
+
+/**
+ * ビルドディレクトリ (kernel.build_dir) のみを再生成する.
+ *
+ * cache:clear は kernel.build_dir と kernel.cache_dir の双方に加え, 実行時キャッシュも
+ * 作り直そうとするため, Web サーバーと CLI で所有者を分けた構成では使用できない
+ * (CacheClearCommand.php の is_writable() 検査). 本コマンドは CacheClearCommand と同じ
+ * 「別名のディレクトリへ warmup してから rename で差し替える」手順を build 側だけに適用し,
+ * %eccube_runtime_dir% (Web サーバー所有) には触れない.
+ */
+#[AsCommand(name: 'eccube:cache:build', description: 'コンパイル済みコンテナとテンプレートを生成します.')]
+final class CacheBuildCommand extends Command
+{
+    /**
+     * 書き込み権限が不足しており, 手動での対応が必要.
+     *
+     * PluginCommandTrait::EXIT_MANUAL_ACTION_REQUIRED と同じ意味づけの終了コード.
+     * (2 は Symfony の Command::INVALID が使用済みのため避ける)
+     */
+    public const EXIT_MANUAL_ACTION_REQUIRED = 3;
+
+    private readonly Filesystem $filesystem;
+
+    public function __construct(?Filesystem $filesystem = null)
+    {
+        parent::__construct();
+
+        $this->filesystem = $filesystem ?? new Filesystem();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('no-twig', null, InputOption::VALUE_NONE, 'テンプレートの事前コンパイルを省略します.')
+            ->setHelp(<<<'EOF'
+                <info>%command.name%</info> は kernel.build_dir のみを再生成します.
+
+                  <info>php %command.full_name% --env=prod --no-debug</info>
+
+                実行時キャッシュ (%eccube_runtime_dir%) は削除しません.
+                Web サーバーが生成したキャッシュを削除するには, Web サーバーのユーザーで
+                <info>bin/console cache:pool:clear --all</info> を実行するか, 管理画面のキャッシュ管理を使用してください.
+                EOF
+            );
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $application = $this->getApplication();
+        if (!$application instanceof Application) {
+            $io->error('このコマンドは bin/console から実行してください.');
+
+            return self::FAILURE;
+        }
+
+        $kernel = $application->getKernel();
+        if (!$kernel instanceof RebootableInterface) {
+            $io->error(sprintf('%s は RebootableInterface を実装していないため再生成できません.', $kernel::class));
+
+            return self::FAILURE;
+        }
+
+        $container = $kernel->getContainer();
+        $realBuildDir = (string) $container->getParameter('kernel.build_dir');
+        $realCacheDir = (string) $container->getParameter('kernel.cache_dir');
+
+        if (($unwritable = $this->findUnwritable([$realBuildDir, $realCacheDir])) !== null) {
+            $this->reportUnwritable($io, $unwritable);
+
+            return self::EXIT_MANUAL_ACTION_REQUIRED;
+        }
+
+        $io->comment(sprintf(
+            'ビルドディレクトリを再生成します (環境: <info>%s</info>, デバッグ: <info>%s</info>)',
+            $kernel->getEnvironment(),
+            var_export($kernel->isDebug(), true)
+        ));
+
+        // 現在のコンテナのディレクトリ名は再起動前にしか取得できない.
+        $containerDir = basename(dirname((string) (new \ReflectionObject($container))->getFileName()));
+
+        // warmup 先はシリアライズされたリソース内のパス長を変えないよう, 実体と同じ長さにする.
+        $warmupDir = substr($realBuildDir, 0, -1).(str_ends_with($realBuildDir, '_') ? '-' : '_');
+        $oldBuildDir = substr($realBuildDir, 0, -1).(str_ends_with($realBuildDir, '~') ? '+' : '~');
+        $this->filesystem->remove([$warmupDir, $oldBuildDir]);
+        $this->filesystem->mkdir($warmupDir);
+
+        // 再起動するとコンテナは作り直されるため, 既存のディスパッチャは使えなくなる.
+        $application->setDispatcher(new EventDispatcher());
+        $kernel->reboot($warmupDir);
+
+        // 事前コンパイルより先に実行する. dev では twig の出力先が %eccube_runtime_dir%/twig に
+        // なるため, 後から削除すると warmup の結果まで消えてしまう.
+        $this->clearStaleRuntimeCache($io, (string) $container->getParameter('eccube_runtime_dir'));
+
+        if (!$input->getOption('no-twig')) {
+            $this->warmUpTemplates($kernel, $realCacheDir, $warmupDir, $io);
+        }
+
+        $this->replaceWarmupPaths($warmupDir, $realBuildDir);
+
+        if (!$this->filesystem->exists($warmupDir.'/'.$containerDir)) {
+            $this->filesystem->rename($realBuildDir.'/'.$containerDir, $warmupDir.'/'.$containerDir);
+            touch($warmupDir.'/'.$containerDir.'.legacy');
+        }
+
+        $this->filesystem->rename($realBuildDir, $oldBuildDir);
+        // 差し替えの最中に別プロセスが再構築した中途半端な成果物は捨てる.
+        $this->filesystem->remove($realBuildDir);
+        $this->filesystem->rename($warmupDir, $realBuildDir);
+        $this->filesystem->remove($oldBuildDir);
+
+        $io->success(sprintf('"%s" 環境のビルドディレクトリを生成しました.', $kernel->getEnvironment()));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param list<string> $dirs
+     */
+    private function findUnwritable(array $dirs): ?string
+    {
+        foreach ($dirs as $dir) {
+            if (!is_dir($dir)) {
+                if (!@mkdir($dir, 0755, true) && !is_dir($dir)) {
+                    return $dir;
+                }
+
+                continue;
+            }
+
+            if (!is_writable($dir)) {
+                return $dir;
+            }
+        }
+
+        return null;
+    }
+
+    private function reportUnwritable(SymfonyStyle $io, string $dir): void
+    {
+        $io->error(sprintf('%s へ書き込めません.', $dir));
+        $io->text([
+            'ビルドディレクトリの生成には kernel.build_dir と kernel.cache_dir の双方への書き込み権限が必要です.',
+            '所有者を確認するには次を実行してください.',
+            '',
+            '    bin/console eccube:doctor:permissions',
+        ]);
+    }
+
+    private function warmUpTemplates(KernelInterface $kernel, string $realCacheDir, string $warmupDir, SymfonyStyle $io): void
+    {
+        // BuildDirCacheWarmerPass が kernel.cache_warmer タグを外しているため, ここで明示的に実行する.
+        $container = $kernel->getContainer();
+        if (!$container->has('twig.template_cache_warmer')) {
+            return;
+        }
+
+        $warmer = $container->get('twig.template_cache_warmer');
+        if (!$warmer instanceof TemplateCacheWarmer) {
+            return;
+        }
+
+        $io->comment('テンプレートを事前コンパイルしています...');
+        $warmer->warmUp($realCacheDir, $warmupDir);
+    }
+
+    /**
+     * warmup 先のパスを実体のパスへ書き換える.
+     */
+    private function replaceWarmupPaths(string $warmupDir, string $realBuildDir): void
+    {
+        $search = [$warmupDir, str_replace('/', '\\/', $warmupDir), str_replace('\\', '\\\\', $warmupDir)];
+        $replace = str_replace('\\', '/', $realBuildDir);
+
+        foreach (Finder::create()->files()->in($warmupDir) as $file) {
+            $path = (string) $file;
+            $content = str_replace($search, $replace, $this->filesystem->readFile($path), $count);
+            if ($count) {
+                file_put_contents($path, $content);
+            }
+        }
+    }
+
+    /**
+     * 実行時キャッシュのうち, ビルド結果と食い違いうるものを削除する.
+     *
+     * 権限を分離した構成では Web サーバー所有のため削除できない. その場合は案内に留める.
+     */
+    private function clearStaleRuntimeCache(SymfonyStyle $io, string $runtimeDir): void
+    {
+        $stale = array_filter(
+            array_map(static fn (string $name): string => $runtimeDir.'/'.$name, ['twig', 'translations', 'htmlpurifier']),
+            is_dir(...)
+        );
+
+        if ($stale === []) {
+            return;
+        }
+
+        if (!is_writable($runtimeDir)) {
+            $io->warning([
+                sprintf('%s へ書き込めないため, 実行時キャッシュを削除できませんでした.', $runtimeDir),
+                'Web サーバーのユーザーで次を実行するか, 管理画面のキャッシュ管理から削除してください.',
+                '    bin/console cache:pool:clear --all',
+            ]);
+
+            return;
+        }
+
+        $this->filesystem->remove($stale);
+        $io->comment('古い実行時キャッシュを削除しました.');
+    }
+}

--- a/src/Eccube/Command/CacheBuildCommand.php
+++ b/src/Eccube/Command/CacheBuildCommand.php
@@ -217,18 +217,14 @@ final class CacheBuildCommand extends Command
     }
 
     /**
-     * 実行時キャッシュのうち, ビルド結果と食い違いうるものを削除する.
+     * ビルド結果と食い違いうる実行時キャッシュ (事前コンパイル漏れのテンプレート) を削除する.
      *
      * 権限を分離した構成では Web サーバー所有のため削除できない. その場合は案内に留める.
      */
     private function clearStaleRuntimeCache(SymfonyStyle $io, string $runtimeDir): void
     {
-        $stale = array_filter(
-            array_map(static fn (string $name): string => $runtimeDir.'/'.$name, ['twig', 'translations', 'htmlpurifier']),
-            is_dir(...)
-        );
-
-        if ($stale === []) {
+        $stale = $runtimeDir.'/twig';
+        if (!is_dir($stale)) {
             return;
         }
 

--- a/src/Eccube/Command/CacheBuildCommand.php
+++ b/src/Eccube/Command/CacheBuildCommand.php
@@ -98,7 +98,9 @@ final class CacheBuildCommand extends Command
         $realBuildDir = (string) $container->getParameter('kernel.build_dir');
         $realCacheDir = (string) $container->getParameter('kernel.cache_dir');
 
-        if (($unwritable = $this->findUnwritable([$realBuildDir, $realCacheDir])) !== null) {
+        // ビルドディレクトリは warmup 用の別名を同じ親へ作り, 最後に rename で差し替えるため,
+        // 親ディレクトリにも書き込み権限が要る (親を検査しないと mkdir/rename が例外になる).
+        if (($unwritable = $this->findUnwritable([dirname($realBuildDir), $realBuildDir, $realCacheDir])) !== null) {
             $this->reportUnwritable($io, $unwritable);
 
             return self::EXIT_MANUAL_ACTION_REQUIRED;
@@ -175,7 +177,7 @@ final class CacheBuildCommand extends Command
     {
         $io->error(sprintf('%s へ書き込めません.', $dir));
         $io->text([
-            'ビルドディレクトリの生成には kernel.build_dir と kernel.cache_dir の双方への書き込み権限が必要です.',
+            'ビルドディレクトリの生成には kernel.build_dir (とその親ディレクトリ) と kernel.cache_dir への書き込み権限が必要です.',
             '所有者を確認するには次を実行してください.',
             '',
             '    bin/console eccube:doctor:permissions',

--- a/src/Eccube/Command/CacheBuildCommand.php
+++ b/src/Eccube/Command/CacheBuildCommand.php
@@ -229,10 +229,14 @@ final class CacheBuildCommand extends Command
         }
 
         if (!is_writable($runtimeDir)) {
+            // cache:pool:clear は cache pool だけが対象で, このディレクトリには触れない.
+            // 削除できるのは管理画面のキャッシュ管理 (CacheUtil::clearRuntimeCache) か,
+            // Web サーバーのユーザーによる直接削除のいずれか.
             $io->warning([
-                sprintf('%s へ書き込めないため, 実行時キャッシュを削除できませんでした.', $runtimeDir),
-                'Web サーバーのユーザーで次を実行するか, 管理画面のキャッシュ管理から削除してください.',
-                '    bin/console cache:pool:clear --all',
+                sprintf('%s を削除できないため, 事前コンパイル漏れのテンプレートに古い内容が残ります.', $stale),
+                '管理画面のキャッシュ管理から削除するか, Web サーバーのユーザーで次を実行してください'
+                .' (bin/console cache:pool:clear は cache pool のみが対象で, このディレクトリは削除しません).',
+                sprintf('    rm -rf %s', $stale),
             ]);
 
             return;

--- a/src/Eccube/Command/CacheBuildCommand.php
+++ b/src/Eccube/Command/CacheBuildCommand.php
@@ -213,7 +213,9 @@ final class CacheBuildCommand extends Command
             $path = (string) $file;
             $content = str_replace($search, $replace, $this->filesystem->readFile($path), $count);
             if ($count) {
-                file_put_contents($path, $content);
+                // 書き込みに失敗したら中断する. 見逃すと不完全な成果物を
+                // ビルドディレクトリへ昇格させたまま成功として終わってしまう.
+                $this->filesystem->dumpFile($path, $content);
             }
         }
     }

--- a/src/Eccube/Command/Content/BlockApplyCommand.php
+++ b/src/Eccube/Command/Content/BlockApplyCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command\Content;
+
+use Eccube\Entity\Master\DeviceType;
+use Eccube\Exception\ContentValidationException;
+use Eccube\Service\Content\BlockContentService;
+use Eccube\Service\Content\ContentStatus;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * ブロック (dtb_block + twig) をファイル名を鍵に登録・更新する.
+ */
+#[AsCommand(name: 'eccube:block:apply', description: 'ブロックを登録・更新します.')]
+final class BlockApplyCommand extends Command
+{
+    use ContentCommandTrait;
+
+    public function __construct(private readonly BlockContentService $blockContentService)
+    {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('file-name', null, InputOption::VALUE_REQUIRED, '対象ブロックのファイル名 (登録・更新の鍵)')
+            ->addOption('name', null, InputOption::VALUE_REQUIRED, 'ブロック名')
+            ->addOption('device-type', null, InputOption::VALUE_REQUIRED, 'デバイス種別 ID', (string) DeviceType::DEVICE_TYPE_PC);
+        $this->addWriteOptions();
+        $this->setHelp(<<<'EOF'
+            <info>%command.name%</info> は dtb_block とテンプレートファイルを対で登録・更新します.
+
+              <info>cat campaign.twig | php %command.full_name% --file-name=campaign --name=キャンペーン --body=-</info>
+            EOF
+        );
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $format = (string) $input->getOption('format');
+        if (!$this->isValidFormat($format)) {
+            $this->invalidFormat($io);
+
+            return Command::INVALID;
+        }
+
+        $fileName = $input->getOption('file-name');
+        if (null === $fileName || '' === $fileName) {
+            $io->error('--file-name を指定してください.');
+
+            return Command::INVALID;
+        }
+
+        try {
+            $body = $this->readBody($input);
+        } catch (\InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return Command::INVALID;
+        }
+
+        $payload = [
+            'file_name' => (string) $fileName,
+            'device_type' => (int) $input->getOption('device-type'),
+        ];
+        if (null !== $body) {
+            $payload['body'] = $body;
+        }
+        if (null !== $input->getOption('name')) {
+            $payload['name'] = (string) $input->getOption('name');
+        }
+
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        try {
+            $result = $this->blockContentService->apply($payload, $dryRun);
+        } catch (\InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return Command::INVALID;
+        } catch (ContentValidationException $e) {
+            $io->error(array_merge([sprintf('ブロックを保存できません: %s', (string) $fileName)], $e->getErrors()));
+
+            return 1;
+        }
+
+        $this->renderResult($io, $output, $format, $result, $dryRun);
+
+        if ($dryRun || ContentStatus::Unchanged === $result->status || $input->getOption('no-cache-clear')) {
+            return 0;
+        }
+
+        return $this->clearContentCache($io) ? 0 : self::EXIT_MANUAL_ACTION_REQUIRED;
+    }
+}

--- a/src/Eccube/Command/Content/BlockApplyCommand.php
+++ b/src/Eccube/Command/Content/BlockApplyCommand.php
@@ -17,6 +17,7 @@ namespace Eccube\Command\Content;
 
 use Eccube\Entity\Master\DeviceType;
 use Eccube\Exception\ContentValidationException;
+use Eccube\Exception\ContentWriteException;
 use Eccube\Service\Content\BlockContentService;
 use Eccube\Service\Content\ContentStatus;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -105,6 +106,8 @@ final class BlockApplyCommand extends Command
             $io->error(array_merge([sprintf('ブロックを保存できません: %s', (string) $fileName)], $e->getErrors()));
 
             return 1;
+        } catch (ContentWriteException $e) {
+            return $this->reportWriteFailure($io, sprintf('ブロックを保存できません: %s', (string) $fileName), $e);
         }
 
         $this->renderResult($io, $output, $format, $result, $dryRun);

--- a/src/Eccube/Command/Content/BlockListCommand.php
+++ b/src/Eccube/Command/Content/BlockListCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command\Content;
+
+use Eccube\Entity\Block;
+use Eccube\Entity\Master\DeviceType;
+use Eccube\Repository\BlockRepository;
+use Eccube\Service\Content\BlockContentService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'eccube:block:list', description: 'ブロックの一覧を表示します.')]
+final class BlockListCommand extends Command
+{
+    use ContentCommandTrait;
+
+    public function __construct(
+        private readonly BlockRepository $blockRepository,
+        private readonly BlockContentService $blockContentService,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this->addOption('device-type', null, InputOption::VALUE_REQUIRED, 'デバイス種別 ID', (string) DeviceType::DEVICE_TYPE_PC);
+        $this->addFormatOption();
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $format = (string) $input->getOption('format');
+        if (!$this->isValidFormat($format)) {
+            $this->invalidFormat($io);
+
+            return Command::INVALID;
+        }
+
+        try {
+            $DeviceType = $this->blockContentService->getDeviceType((int) $input->getOption('device-type'));
+        } catch (\InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return Command::INVALID;
+        }
+
+        $rows = [];
+        /** @var Block $Block */
+        foreach ($this->blockRepository->getList($DeviceType) as $Block) {
+            $rows[] = [
+                'id' => $Block->getId(),
+                'name' => (string) $Block->getName(),
+                'file_name' => (string) $Block->getFileName(),
+                'deletable' => $Block->isDeletable(),
+                'path' => $this->blockContentService->getFilePath($Block),
+            ];
+        }
+
+        if ('json' === $format) {
+            $output->writeln((string) json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return 0;
+        }
+
+        $io->table(
+            ['ID', 'ブロック名', 'ファイル名', '削除可'],
+            array_map(static fn (array $row): array => [
+                $row['id'],
+                $row['name'],
+                $row['file_name'],
+                $row['deletable'] ? 'yes' : 'no',
+            ], $rows)
+        );
+
+        return 0;
+    }
+}

--- a/src/Eccube/Command/Content/BlockRemoveCommand.php
+++ b/src/Eccube/Command/Content/BlockRemoveCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command\Content;
+
+use Eccube\Entity\Block;
+use Eccube\Entity\Master\DeviceType;
+use Eccube\Service\Content\BlockContentService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * ブロック (dtb_block + twig) を削除する.
+ *
+ * 管理画面と同じく, 削除可能なブロックのみ削除できる.
+ */
+#[AsCommand(name: 'eccube:block:remove', description: 'ブロックを削除します.')]
+final class BlockRemoveCommand extends Command
+{
+    use ContentCommandTrait;
+
+    public function __construct(private readonly BlockContentService $blockContentService)
+    {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('file-name', null, InputOption::VALUE_REQUIRED, '対象ブロックのファイル名')
+            ->addOption('device-type', null, InputOption::VALUE_REQUIRED, 'デバイス種別 ID', (string) DeviceType::DEVICE_TYPE_PC)
+            ->addOption('force', 'f', InputOption::VALUE_NONE, '確認せずに削除する')
+            ->addOption('no-cache-clear', null, InputOption::VALUE_NONE, 'キャッシュの削除を省略する');
+        $this->addFormatOption();
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $format = (string) $input->getOption('format');
+        if (!$this->isValidFormat($format)) {
+            $this->invalidFormat($io);
+
+            return Command::INVALID;
+        }
+
+        $fileName = $input->getOption('file-name');
+        if (null === $fileName || '' === $fileName) {
+            $io->error('--file-name を指定してください.');
+
+            return Command::INVALID;
+        }
+
+        try {
+            $DeviceType = $this->blockContentService->getDeviceType((int) $input->getOption('device-type'));
+        } catch (\InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return Command::INVALID;
+        }
+
+        $Block = $this->blockContentService->findByFileName((string) $fileName, $DeviceType);
+        if (!$Block instanceof Block) {
+            $io->error(sprintf('ブロックが見つかりません: %s', (string) $fileName));
+
+            return 1;
+        }
+
+        if (!$Block->isDeletable()) {
+            $io->error(sprintf('削除できないブロックです: %s', (string) $fileName));
+
+            return 1;
+        }
+
+        if (!$input->getOption('force') && !$io->confirm(sprintf('%s を削除しますか?', (string) $fileName), false)) {
+            $io->text('中止しました.');
+
+            return 1;
+        }
+
+        $result = $this->blockContentService->remove($Block);
+
+        $this->renderResult($io, $output, $format, $result, false);
+
+        if ($input->getOption('no-cache-clear')) {
+            return 0;
+        }
+
+        return $this->clearContentCache($io) ? 0 : self::EXIT_MANUAL_ACTION_REQUIRED;
+    }
+}

--- a/src/Eccube/Command/Content/BlockRemoveCommand.php
+++ b/src/Eccube/Command/Content/BlockRemoveCommand.php
@@ -17,6 +17,7 @@ namespace Eccube\Command\Content;
 
 use Eccube\Entity\Block;
 use Eccube\Entity\Master\DeviceType;
+use Eccube\Exception\ContentWriteException;
 use Eccube\Service\Content\BlockContentService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -97,7 +98,11 @@ final class BlockRemoveCommand extends Command
             return 1;
         }
 
-        $result = $this->blockContentService->remove($Block);
+        try {
+            $result = $this->blockContentService->remove($Block);
+        } catch (ContentWriteException $e) {
+            return $this->reportWriteFailure($io, sprintf('ブロックを削除できません: %s', $Block->getFileName()), $e);
+        }
 
         $this->renderResult($io, $output, $format, $result, false);
 

--- a/src/Eccube/Command/Content/BlockShowCommand.php
+++ b/src/Eccube/Command/Content/BlockShowCommand.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command\Content;
+
+use Eccube\Entity\Block;
+use Eccube\Entity\Master\DeviceType;
+use Eccube\Service\Content\BlockContentService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'eccube:block:show', description: 'ブロックのテンプレートを出力します.')]
+final class BlockShowCommand extends Command
+{
+    use ContentCommandTrait;
+
+    public function __construct(private readonly BlockContentService $blockContentService)
+    {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('file-name', null, InputOption::VALUE_REQUIRED, '対象ブロックのファイル名')
+            ->addOption('device-type', null, InputOption::VALUE_REQUIRED, 'デバイス種別 ID', (string) DeviceType::DEVICE_TYPE_PC);
+        $this->addFormatOption();
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $format = (string) $input->getOption('format');
+        if (!$this->isValidFormat($format)) {
+            $this->invalidFormat($io);
+
+            return Command::INVALID;
+        }
+
+        $fileName = $input->getOption('file-name');
+        if (null === $fileName || '' === $fileName) {
+            $io->error('--file-name を指定してください.');
+
+            return Command::INVALID;
+        }
+
+        try {
+            $DeviceType = $this->blockContentService->getDeviceType((int) $input->getOption('device-type'));
+        } catch (\InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return Command::INVALID;
+        }
+
+        $Block = $this->blockContentService->findByFileName((string) $fileName, $DeviceType);
+        if (!$Block instanceof Block) {
+            $io->error(sprintf('ブロックが見つかりません: %s', (string) $fileName));
+
+            return 1;
+        }
+
+        $body = $this->blockContentService->readTemplate($Block);
+
+        if ('json' === $format) {
+            $output->writeln((string) json_encode([
+                'id' => $Block->getId(),
+                'name' => $Block->getName(),
+                'file_name' => $Block->getFileName(),
+                'device_type_id' => $Block->getDeviceType()->getId(),
+                'deletable' => $Block->isDeletable(),
+                'path' => $this->blockContentService->getFilePath($Block),
+                'body' => $body,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return 0;
+        }
+
+        $output->write($body);
+
+        return 0;
+    }
+}

--- a/src/Eccube/Command/Content/ContentCommandTrait.php
+++ b/src/Eccube/Command/Content/ContentCommandTrait.php
@@ -148,19 +148,36 @@ trait ContentCommandTrait
         $buildTwigDir = $buildDir.'/twig';
         $buildTwigWritable = !is_dir($buildTwigDir) || is_writable($buildDir);
 
+        // 実行時の cache pool は Web サーバー所有のため, 権限を分離した構成では CLI から削除できない.
+        // 削除の可否は実行前に判定する (cache:pool:clear は失敗しても例外にならない).
+        $poolDir = rtrim((string) $this->eccubeConfig->get('eccube_runtime_dir'), '/').'/pools';
+        $poolClearable = !is_dir($poolDir) || is_writable($poolDir);
+
         $this->cacheUtil->clearTwigCache();
         $this->cacheUtil->clearDoctrineCache();
+
+        $cleared = true;
 
         if (!$buildTwigWritable) {
             $io->warning([
                 sprintf('%s を削除できないため, 更新したテンプレートが反映されません.', $buildTwigDir),
                 '書き込み権限のあるユーザーで bin/console eccube:cache:build を実行してください.',
             ]);
-
-            return false;
+            $cleared = false;
         }
 
-        return true;
+        if (!$poolClearable) {
+            $io->warning([
+                sprintf('%s を削除できないため, Doctrine のキャッシュに古い内容が残ります.', $poolDir),
+                sprintf(
+                    'Web サーバーのユーザーで bin/console cache:pool:clear %s を実行してください.',
+                    CacheUtil::DOCTRINE_APP_CACHE_KEY
+                ),
+            ]);
+            $cleared = false;
+        }
+
+        return $cleared;
     }
 
     protected function renderResult(SymfonyStyle $io, OutputInterface $output, string $format, ContentResult $result, bool $dryRun): void

--- a/src/Eccube/Command/Content/ContentCommandTrait.php
+++ b/src/Eccube/Command/Content/ContentCommandTrait.php
@@ -144,13 +144,17 @@ trait ContentCommandTrait
      */
     protected function clearContentCache(SymfonyStyle $io): bool
     {
+        // 削除の可否は実行前に判定する. 権限が無い場合, 削除処理は例外にはならず
+        // 単に対象が残る (CacheUtil::clearTwigCache / cache:pool:clear).
         $buildDir = rtrim((string) $this->eccubeConfig->get('kernel.build_dir'), '/');
+        $runtimeDir = rtrim((string) $this->eccubeConfig->get('eccube_runtime_dir'), '/');
         $buildTwigDir = $buildDir.'/twig';
-        $buildTwigWritable = !is_dir($buildTwigDir) || is_writable($buildDir);
+        $runtimeTwigDir = $runtimeDir.'/twig';
+        $poolDir = $runtimeDir.'/pools';
 
-        // 実行時の cache pool は Web サーバー所有のため, 権限を分離した構成では CLI から削除できない.
-        // 削除の可否は実行前に判定する (cache:pool:clear は失敗しても例外にならない).
-        $poolDir = rtrim((string) $this->eccubeConfig->get('eccube_runtime_dir'), '/').'/pools';
+        $buildTwigClearable = !is_dir($buildTwigDir) || is_writable($buildDir);
+        // ディレクトリの削除には親ディレクトリの書き込み権限が必要になる
+        $runtimeTwigClearable = !is_dir($runtimeTwigDir) || is_writable($runtimeDir);
         $poolClearable = !is_dir($poolDir) || is_writable($poolDir);
 
         $this->cacheUtil->clearTwigCache();
@@ -158,7 +162,7 @@ trait ContentCommandTrait
 
         $cleared = true;
 
-        if (!$buildTwigWritable) {
+        if (!$buildTwigClearable) {
             $io->warning([
                 sprintf('%s を削除できないため, 更新したテンプレートが反映されません.', $buildTwigDir),
                 '書き込み権限のあるユーザーで bin/console eccube:cache:build を実行してください.',
@@ -166,11 +170,12 @@ trait ContentCommandTrait
             $cleared = false;
         }
 
-        if (!$poolClearable) {
+        // 実行時キャッシュは Web サーバー所有 (レーン W) のため, CLI からは削除できない.
+        if (!$runtimeTwigClearable || !$poolClearable) {
             $io->warning([
-                sprintf('%s を削除できないため, Doctrine のキャッシュに古い内容が残ります.', $poolDir),
+                sprintf('%s を削除できないため, 実行時キャッシュに古い内容が残ります.', $runtimeDir),
                 sprintf(
-                    'Web サーバーのユーザーで bin/console cache:pool:clear %s を実行してください.',
+                    'Web サーバーのユーザーで bin/console cache:pool:clear %s を実行するか, 管理画面のキャッシュ管理から削除してください.',
                     CacheUtil::DOCTRINE_APP_CACHE_KEY
                 ),
             ]);

--- a/src/Eccube/Command/Content/ContentCommandTrait.php
+++ b/src/Eccube/Command/Content/ContentCommandTrait.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command\Content;
+
+use Eccube\Common\EccubeConfig;
+use Eccube\Service\Content\ContentResult;
+use Eccube\Service\Content\ContentStatus;
+use Eccube\Util\CacheUtil;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\StreamableInputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Contracts\Service\Attribute\Required;
+
+/**
+ * コンテンツ操作コマンドの共通処理.
+ *
+ * 入出力 (stdin / --format / --dry-run) と終了コード, キャッシュの削除を担う.
+ */
+trait ContentCommandTrait
+{
+    /**
+     * 本処理は完了したが, 手動での操作が必要な状態を表す終了コード.
+     *
+     * PluginCommandTrait::EXIT_MANUAL_ACTION_REQUIRED と同じ意味づけ.
+     * (2 は Symfony の Command::INVALID が使用済みのため避ける)
+     */
+    public const EXIT_MANUAL_ACTION_REQUIRED = 3;
+
+    /**
+     * @var list<string>
+     */
+    private const FORMATS = ['table', 'json'];
+
+    /**
+     * 差分表示の上限行数.
+     */
+    private const DIFF_MAX_LINES = 100;
+
+    protected CacheUtil $cacheUtil;
+
+    protected EccubeConfig $eccubeConfig;
+
+    #[Required]
+    public function setCacheUtil(CacheUtil $cacheUtil): void
+    {
+        $this->cacheUtil = $cacheUtil;
+    }
+
+    #[Required]
+    public function setEccubeConfig(EccubeConfig $eccubeConfig): void
+    {
+        $this->eccubeConfig = $eccubeConfig;
+    }
+
+    protected function addFormatOption(): void
+    {
+        $this->addOption('format', null, InputOption::VALUE_REQUIRED, sprintf('出力形式 (%s)', implode('|', self::FORMATS)), 'table');
+    }
+
+    /**
+     * 本文の入力と, 副作用を制御するオプションを追加する.
+     */
+    protected function addWriteOptions(): void
+    {
+        $this
+            ->addOption('body', null, InputOption::VALUE_REQUIRED, '本文. "-" を指定すると標準入力から読み込む')
+            ->addOption('body-file', null, InputOption::VALUE_REQUIRED, '本文を読み込むファイルのパス')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, '変更内容を表示するだけで適用しない')
+            ->addOption('no-cache-clear', null, InputOption::VALUE_NONE, 'キャッシュの削除を省略する');
+        $this->addFormatOption();
+    }
+
+    protected function isValidFormat(string $format): bool
+    {
+        return in_array($format, self::FORMATS, true);
+    }
+
+    protected function invalidFormat(SymfonyStyle $io): void
+    {
+        $io->error(sprintf('--format は %s のいずれかで指定してください.', implode(' / ', self::FORMATS)));
+    }
+
+    /**
+     * --body / --body-file から本文を取得する.
+     *
+     * どちらも指定されていない場合は null を返す (現在の内容を維持する).
+     *
+     * @throws \InvalidArgumentException 両方が指定された場合, またはファイルを読めない場合
+     */
+    protected function readBody(InputInterface $input, string $bodyOption = 'body', string $fileOption = 'body-file'): ?string
+    {
+        $body = $input->getOption($bodyOption);
+        $file = $input->getOption($fileOption);
+
+        if (null !== $body && null !== $file) {
+            throw new \InvalidArgumentException(sprintf('--%s と --%s は同時に指定できません.', $bodyOption, $fileOption));
+        }
+
+        if (null !== $file) {
+            if (!is_file((string) $file) || !is_readable((string) $file)) {
+                throw new \InvalidArgumentException(sprintf('ファイルを読み込めません: %s', (string) $file));
+            }
+
+            return (string) file_get_contents((string) $file);
+        }
+
+        if ('-' === $body) {
+            return $this->readStdin($input);
+        }
+
+        return null === $body ? null : (string) $body;
+    }
+
+    private function readStdin(InputInterface $input): string
+    {
+        $stream = $input instanceof StreamableInputInterface ? $input->getStream() : null;
+        $stream ??= \STDIN;
+
+        return (string) stream_get_contents($stream);
+    }
+
+    /**
+     * テンプレートの更新を反映するためキャッシュを削除する.
+     *
+     * 権限を分離した構成では build ディレクトリを CLI から削除できないため,
+     * その場合は本処理を完了させたうえで手動実行を案内する.
+     *
+     * @return bool すべて削除できた場合 true
+     */
+    protected function clearContentCache(SymfonyStyle $io): bool
+    {
+        $buildDir = rtrim((string) $this->eccubeConfig->get('kernel.build_dir'), '/');
+        $buildTwigDir = $buildDir.'/twig';
+        $buildTwigWritable = !is_dir($buildTwigDir) || is_writable($buildDir);
+
+        $this->cacheUtil->clearTwigCache();
+        $this->cacheUtil->clearDoctrineCache();
+
+        if (!$buildTwigWritable) {
+            $io->warning([
+                sprintf('%s を削除できないため, 更新したテンプレートが反映されません.', $buildTwigDir),
+                '書き込み権限のあるユーザーで bin/console eccube:cache:build を実行してください.',
+            ]);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function renderResult(SymfonyStyle $io, OutputInterface $output, string $format, ContentResult $result, bool $dryRun): void
+    {
+        if ('json' === $format) {
+            $output->writeln((string) json_encode(
+                ['dry_run' => $dryRun] + $result->toArray(),
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+            ));
+
+            return;
+        }
+
+        foreach ($result->fieldChanges as $field => [$before, $after]) {
+            $io->writeln(sprintf('  %s: %s -> %s', $field, self::inline($before), self::inline($after)));
+        }
+        foreach ($result->fileChanges as $path => [$before, $after]) {
+            $this->renderFileDiff($io, $path, $before, $after);
+        }
+        foreach ($result->removedPaths as $path) {
+            $io->writeln(sprintf('  removed: %s', $path));
+        }
+
+        $message = sprintf('%s: %s', $result->status->value, $result->identifier);
+        if ($dryRun) {
+            $io->note($message.' (dry-run のため適用していません)');
+
+            return;
+        }
+
+        if (ContentStatus::Unchanged === $result->status) {
+            $io->text($message);
+
+            return;
+        }
+
+        $io->success($message);
+    }
+
+    /**
+     * 変更前後の差分を表示する.
+     *
+     * 先頭・末尾の一致行を除いた範囲のみを出力する簡易差分.
+     */
+    private function renderFileDiff(SymfonyStyle $io, string $path, string $before, string $after): void
+    {
+        $io->writeln(sprintf('--- %s', $path));
+
+        $beforeLines = '' === $before ? [] : explode("\n", $before);
+        $afterLines = '' === $after ? [] : explode("\n", $after);
+
+        $start = 0;
+        while ($start < count($beforeLines) && $start < count($afterLines) && $beforeLines[$start] === $afterLines[$start]) {
+            ++$start;
+        }
+        $endBefore = count($beforeLines) - 1;
+        $endAfter = count($afterLines) - 1;
+        while ($endBefore >= $start && $endAfter >= $start && $beforeLines[$endBefore] === $afterLines[$endAfter]) {
+            --$endBefore;
+            --$endAfter;
+        }
+
+        $lines = [];
+        for ($i = $start; $i <= $endBefore; ++$i) {
+            $lines[] = '<fg=red>- '.$beforeLines[$i].'</>';
+        }
+        for ($i = $start; $i <= $endAfter; ++$i) {
+            $lines[] = '<fg=green>+ '.$afterLines[$i].'</>';
+        }
+
+        $total = count($lines);
+        foreach (array_slice($lines, 0, self::DIFF_MAX_LINES) as $line) {
+            $io->writeln($line);
+        }
+        if ($total > self::DIFF_MAX_LINES) {
+            $io->writeln(sprintf('  ... (他 %d 行)', $total - self::DIFF_MAX_LINES));
+        }
+    }
+
+    private static function inline(string $value): string
+    {
+        $value = str_replace("\n", ' ', $value);
+
+        return mb_strlen($value) > 60 ? mb_substr($value, 0, 60).'...' : $value;
+    }
+}

--- a/src/Eccube/Command/Content/ContentCommandTrait.php
+++ b/src/Eccube/Command/Content/ContentCommandTrait.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Eccube\Command\Content;
 
 use Eccube\Common\EccubeConfig;
+use Eccube\Exception\ContentWriteException;
 use Eccube\Service\Content\ContentResult;
 use Eccube\Service\Content\ContentStatus;
 use Eccube\Util\CacheUtil;
@@ -93,6 +94,25 @@ trait ContentCommandTrait
     protected function invalidFormat(SymfonyStyle $io): void
     {
         $io->error(sprintf('--format は %s のいずれかで指定してください.', implode(' / ', self::FORMATS)));
+    }
+
+    /**
+     * テンプレートファイルの操作に失敗したことを, 対処方法を添えて表示する.
+     *
+     * 権限を分離した構成では app/template は CLI ユーザーの所有 (レーン S) となり,
+     * Web サーバーのユーザーで実行すると書き込みだけが失敗する. 実行ユーザーの誤りが
+     * 最も多い原因のため, 確認手段を案内する.
+     */
+    protected function reportWriteFailure(SymfonyStyle $io, string $summary, ContentWriteException $e): int
+    {
+        $io->error([
+            $summary,
+            $e->getMessage(),
+            'テンプレートの配置先 (レーン S) を所有するユーザーで実行してください.'
+            .' 期待値と実際の所有者は bin/console eccube:doctor:permissions で確認できます.',
+        ]);
+
+        return 1;
     }
 
     /**

--- a/src/Eccube/Command/Content/ContentCommandTrait.php
+++ b/src/Eccube/Command/Content/ContentCommandTrait.php
@@ -191,9 +191,21 @@ trait ContentCommandTrait
         }
 
         // 実行時キャッシュは Web サーバー所有 (レーン W) のため, CLI からは削除できない.
-        if (!$runtimeTwigClearable || !$poolClearable) {
+        // twig と cache pool で削除の手段が違うため, 案内も分ける.
+        if (!$runtimeTwigClearable) {
+            // cache:pool:clear は cache pool だけが対象で, このディレクトリには触れない.
             $io->warning([
-                sprintf('%s を削除できないため, 実行時キャッシュに古い内容が残ります.', $runtimeDir),
+                sprintf('%s を削除できないため, 更新したテンプレートが反映されないことがあります.', $runtimeTwigDir),
+                '管理画面のキャッシュ管理から削除するか, Web サーバーのユーザーで次を実行してください'
+                .' (bin/console cache:pool:clear は cache pool のみが対象で, このディレクトリは削除しません).',
+                sprintf('    rm -rf %s', $runtimeTwigDir),
+            ]);
+            $cleared = false;
+        }
+
+        if (!$poolClearable) {
+            $io->warning([
+                sprintf('%s を削除できないため, 実行時キャッシュに古い内容が残ります.', $poolDir),
                 sprintf(
                     'Web サーバーのユーザーで bin/console cache:pool:clear %s を実行するか, 管理画面のキャッシュ管理から削除してください.',
                     CacheUtil::DOCTRINE_APP_CACHE_KEY

--- a/src/Eccube/Command/Content/ContentCommandTrait.php
+++ b/src/Eccube/Command/Content/ContentCommandTrait.php
@@ -136,7 +136,14 @@ trait ContentCommandTrait
                 throw new \InvalidArgumentException(sprintf('ファイルを読み込めません: %s', (string) $file));
             }
 
-            return (string) file_get_contents((string) $file);
+            // 失敗時の false を空文字列へ丸めない. 丸めるとテンプレートを空で上書きしてしまう
+            // (メールテンプレートは MailType に NotBlank が無いため検証でも止まらない).
+            $contents = file_get_contents((string) $file);
+            if (false === $contents) {
+                throw new \InvalidArgumentException(sprintf('ファイルを読み込めません: %s', (string) $file));
+            }
+
+            return $contents;
         }
 
         if ('-' === $body) {
@@ -146,12 +153,21 @@ trait ContentCommandTrait
         return null === $body ? null : (string) $body;
     }
 
+    /**
+     * @throws \InvalidArgumentException 標準入力を読めない場合
+     */
     private function readStdin(InputInterface $input): string
     {
         $stream = $input instanceof StreamableInputInterface ? $input->getStream() : null;
         $stream ??= \STDIN;
 
-        return (string) stream_get_contents($stream);
+        // readBody() と同じ理由で false を空文字列へ丸めない
+        $contents = stream_get_contents($stream);
+        if (false === $contents) {
+            throw new \InvalidArgumentException('標準入力を読み込めません.');
+        }
+
+        return $contents;
     }
 
     /**

--- a/src/Eccube/Command/Content/MailTemplateApplyCommand.php
+++ b/src/Eccube/Command/Content/MailTemplateApplyCommand.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command\Content;
+
+use Eccube\Exception\ContentValidationException;
+use Eccube\Service\Content\ContentStatus;
+use Eccube\Service\Content\MailTemplateContentService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * メールテンプレート (dtb_mail_template + twig) を登録・更新する.
+ *
+ * ファイル名は新規登録時のみ指定できる (管理画面と同じ制約).
+ */
+#[AsCommand(name: 'eccube:mail-template:apply', description: 'メールテンプレートを登録・更新します.')]
+final class MailTemplateApplyCommand extends Command
+{
+    use ContentCommandTrait;
+
+    public function __construct(private readonly MailTemplateContentService $mailTemplateContentService)
+    {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('file-name', null, InputOption::VALUE_REQUIRED, '対象テンプレートのファイル名 (登録・更新の鍵)')
+            ->addOption('id', null, InputOption::VALUE_REQUIRED, '対象テンプレートの ID')
+            ->addOption('name', null, InputOption::VALUE_REQUIRED, 'テンプレート名')
+            ->addOption('subject', null, InputOption::VALUE_REQUIRED, 'メールの件名')
+            ->addOption('html-body', null, InputOption::VALUE_REQUIRED, 'HTML パートの本文. "-" を指定すると標準入力から読み込む')
+            ->addOption('html-body-file', null, InputOption::VALUE_REQUIRED, 'HTML パートの本文を読み込むファイルのパス')
+            ->addOption('remove-html', null, InputOption::VALUE_NONE, 'HTML パートを削除する');
+        $this->addWriteOptions();
+        $this->setHelp(<<<'EOF'
+            <info>%command.name%</info> は dtb_mail_template とテンプレートファイルを対で登録・更新します.
+
+              <info>cat order.twig | php %command.full_name% --file-name=order --body=-</info>
+
+            HTML パートは --html-body / --html-body-file で指定し, --remove-html で削除します.
+            いずれも指定しない場合は現在の内容を維持します.
+            EOF
+        );
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $format = (string) $input->getOption('format');
+        if (!$this->isValidFormat($format)) {
+            $this->invalidFormat($io);
+
+            return Command::INVALID;
+        }
+
+        $fileName = $input->getOption('file-name');
+        $id = $input->getOption('id');
+        if (null === $fileName && null === $id) {
+            $io->error('--file-name または --id を指定してください.');
+
+            return Command::INVALID;
+        }
+
+        $removeHtml = (bool) $input->getOption('remove-html');
+
+        try {
+            $body = $this->readBody($input);
+            $htmlBody = $this->readBody($input, 'html-body', 'html-body-file');
+        } catch (\InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return Command::INVALID;
+        }
+
+        if ($removeHtml && null !== $htmlBody) {
+            $io->error('--remove-html と --html-body / --html-body-file は同時に指定できません.');
+
+            return Command::INVALID;
+        }
+
+        $payload = [];
+        if (null !== $fileName) {
+            $payload['file_name'] = (string) $fileName;
+        }
+        if (null !== $id) {
+            $payload['id'] = (int) $id;
+        }
+        if (null !== $body) {
+            $payload['body'] = $body;
+        }
+        if (null !== $htmlBody) {
+            $payload['html_body'] = $htmlBody;
+        }
+        if ($removeHtml) {
+            $payload['remove_html'] = true;
+        }
+        foreach (['name', 'subject'] as $option) {
+            $value = $input->getOption($option);
+            if (null !== $value) {
+                $payload[$option] = (string) $value;
+            }
+        }
+
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        try {
+            $result = $this->mailTemplateContentService->apply($payload, $dryRun);
+        } catch (ContentValidationException $e) {
+            $io->error(array_merge([sprintf('メールテンプレートを保存できません: %s', (string) ($fileName ?? $id))], $e->getErrors()));
+
+            return 1;
+        }
+
+        $this->renderResult($io, $output, $format, $result, $dryRun);
+
+        if ($dryRun || ContentStatus::Unchanged === $result->status || $input->getOption('no-cache-clear')) {
+            return 0;
+        }
+
+        return $this->clearContentCache($io) ? 0 : self::EXIT_MANUAL_ACTION_REQUIRED;
+    }
+}

--- a/src/Eccube/Command/Content/MailTemplateApplyCommand.php
+++ b/src/Eccube/Command/Content/MailTemplateApplyCommand.php
@@ -86,6 +86,14 @@ final class MailTemplateApplyCommand extends Command
 
         $removeHtml = (bool) $input->getOption('remove-html');
 
+        // 標準入力は一度しか読めない. 双方に "-" を指定すると 2 回目は EOF となり,
+        // HTML パートを空文字列 (= パートなし) で上書きしてしまう.
+        if ('-' === $input->getOption('body') && '-' === $input->getOption('html-body')) {
+            $io->error('--body と --html-body の両方に "-" は指定できません. 一方は --body-file / --html-body-file を使用してください.');
+
+            return Command::INVALID;
+        }
+
         try {
             $body = $this->readBody($input);
             $htmlBody = $this->readBody($input, 'html-body', 'html-body-file');

--- a/src/Eccube/Command/Content/MailTemplateApplyCommand.php
+++ b/src/Eccube/Command/Content/MailTemplateApplyCommand.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Eccube\Command\Content;
 
 use Eccube\Exception\ContentValidationException;
+use Eccube\Exception\ContentWriteException;
 use Eccube\Service\Content\ContentStatus;
 use Eccube\Service\Content\MailTemplateContentService;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -131,6 +132,8 @@ final class MailTemplateApplyCommand extends Command
             $io->error(array_merge([sprintf('メールテンプレートを保存できません: %s', (string) ($fileName ?? $id))], $e->getErrors()));
 
             return 1;
+        } catch (ContentWriteException $e) {
+            return $this->reportWriteFailure($io, sprintf('メールテンプレートを保存できません: %s', (string) ($fileName ?? $id)), $e);
         }
 
         $this->renderResult($io, $output, $format, $result, $dryRun);

--- a/src/Eccube/Command/Content/MailTemplateListCommand.php
+++ b/src/Eccube/Command/Content/MailTemplateListCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command\Content;
+
+use Eccube\Entity\MailTemplate;
+use Eccube\Repository\MailTemplateRepository;
+use Eccube\Service\Content\MailTemplateContentService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'eccube:mail-template:list', description: 'メールテンプレートの一覧を表示します.')]
+final class MailTemplateListCommand extends Command
+{
+    use ContentCommandTrait;
+
+    public function __construct(
+        private readonly MailTemplateRepository $mailTemplateRepository,
+        private readonly MailTemplateContentService $mailTemplateContentService,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this->addFormatOption();
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $format = (string) $input->getOption('format');
+        if (!$this->isValidFormat($format)) {
+            $this->invalidFormat($io);
+
+            return Command::INVALID;
+        }
+
+        $rows = [];
+        /** @var MailTemplate $Mail */
+        foreach ($this->mailTemplateRepository->findBy([], ['id' => 'ASC']) as $Mail) {
+            $rows[] = [
+                'id' => $Mail->getId(),
+                'name' => (string) $Mail->getName(),
+                'file_name' => (string) $Mail->getFileName(),
+                'mail_subject' => (string) $Mail->getMailSubject(),
+                'path' => $this->mailTemplateContentService->getFilePath($Mail),
+            ];
+        }
+
+        if ('json' === $format) {
+            $output->writeln((string) json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return 0;
+        }
+
+        $io->table(
+            ['ID', 'テンプレート名', 'ファイル名', '件名'],
+            array_map(static fn (array $row): array => [
+                $row['id'],
+                $row['name'],
+                $row['file_name'],
+                $row['mail_subject'],
+            ], $rows)
+        );
+
+        return 0;
+    }
+}

--- a/src/Eccube/Command/Content/MailTemplateShowCommand.php
+++ b/src/Eccube/Command/Content/MailTemplateShowCommand.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command\Content;
+
+use Eccube\Entity\MailTemplate;
+use Eccube\Repository\MailTemplateRepository;
+use Eccube\Service\Content\MailTemplateContentService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'eccube:mail-template:show', description: 'メールテンプレートを出力します.')]
+final class MailTemplateShowCommand extends Command
+{
+    use ContentCommandTrait;
+
+    public function __construct(
+        private readonly MailTemplateRepository $mailTemplateRepository,
+        private readonly MailTemplateContentService $mailTemplateContentService,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('file-name', null, InputOption::VALUE_REQUIRED, '対象テンプレートのファイル名 (例: order または Mail/order.twig)')
+            ->addOption('id', null, InputOption::VALUE_REQUIRED, '対象テンプレートの ID')
+            ->addOption('html', null, InputOption::VALUE_NONE, 'HTML パートを出力する');
+        $this->addFormatOption();
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $format = (string) $input->getOption('format');
+        if (!$this->isValidFormat($format)) {
+            $this->invalidFormat($io);
+
+            return Command::INVALID;
+        }
+
+        $fileName = $input->getOption('file-name');
+        $id = $input->getOption('id');
+        if (null === $fileName && null === $id) {
+            $io->error('--file-name または --id を指定してください.');
+
+            return Command::INVALID;
+        }
+
+        $Mail = null === $id
+            ? $this->mailTemplateContentService->findByFileName((string) $fileName)
+            : $this->mailTemplateRepository->find((int) $id);
+
+        if (!$Mail instanceof MailTemplate) {
+            $io->error(sprintf('メールテンプレートが見つかりません: %s', (string) ($fileName ?? $id)));
+
+            return 1;
+        }
+
+        $body = $this->mailTemplateContentService->readTemplate($Mail);
+        $htmlBody = $this->mailTemplateContentService->readHtmlTemplate($Mail);
+
+        if ('json' === $format) {
+            $output->writeln((string) json_encode([
+                'id' => $Mail->getId(),
+                'name' => (string) $Mail->getName(),
+                'file_name' => (string) $Mail->getFileName(),
+                'mail_subject' => (string) $Mail->getMailSubject(),
+                'deletable' => $Mail->isDeletable(),
+                'path' => $this->mailTemplateContentService->getFilePath($Mail),
+                'html_path' => $this->mailTemplateContentService->getHtmlFilePath($Mail),
+                'body' => $body,
+                'html_body' => $htmlBody,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return 0;
+        }
+
+        if ($input->getOption('html')) {
+            if (null === $htmlBody) {
+                $io->error(sprintf('HTML パートがありません: %s', (string) $Mail->getFileName()));
+
+                return 1;
+            }
+
+            $output->write($htmlBody);
+
+            return 0;
+        }
+
+        $output->write($body);
+
+        return 0;
+    }
+}

--- a/src/Eccube/Command/Content/PageApplyCommand.php
+++ b/src/Eccube/Command/Content/PageApplyCommand.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command\Content;
+
+use Eccube\Exception\ContentValidationException;
+use Eccube\Service\Content\ContentStatus;
+use Eccube\Service\Content\PageContentService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * ページ (dtb_page + twig) を URL を鍵に登録・更新する.
+ *
+ * 指定しなかった項目は既存の値を維持するため, 同じ入力を複数回適用しても結果は変わらない.
+ */
+#[AsCommand(name: 'eccube:page:apply', description: 'ページを登録・更新します.')]
+final class PageApplyCommand extends Command
+{
+    use ContentCommandTrait;
+
+    /**
+     * オプション名 => payload のキー.
+     *
+     * @var array<string, string>
+     */
+    private const FIELD_OPTIONS = [
+        'name' => 'name',
+        'file-name' => 'file_name',
+        'author' => 'author',
+        'description' => 'description',
+        'keyword' => 'keyword',
+        'meta-robots' => 'meta_robots',
+        'meta-tags' => 'meta_tags',
+        'pc-layout' => 'pc_layout',
+        'sp-layout' => 'sp_layout',
+    ];
+
+    public function __construct(private readonly PageContentService $pageContentService)
+    {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('url', null, InputOption::VALUE_REQUIRED, '対象ページの URL (登録・更新の鍵)')
+            ->addOption('name', null, InputOption::VALUE_REQUIRED, 'ページ名')
+            ->addOption('file-name', null, InputOption::VALUE_REQUIRED, 'テンプレートのファイル名 (新規登録時の既定は URL と同じ)')
+            ->addOption('author', null, InputOption::VALUE_REQUIRED, 'author')
+            ->addOption('description', null, InputOption::VALUE_REQUIRED, 'description')
+            ->addOption('keyword', null, InputOption::VALUE_REQUIRED, 'keyword')
+            ->addOption('meta-robots', null, InputOption::VALUE_REQUIRED, 'meta robots')
+            ->addOption('meta-tags', null, InputOption::VALUE_REQUIRED, 'meta tags')
+            ->addOption('pc-layout', null, InputOption::VALUE_REQUIRED, 'PC レイアウトの ID (空文字で解除)')
+            ->addOption('sp-layout', null, InputOption::VALUE_REQUIRED, 'SP レイアウトの ID (空文字で解除)');
+        $this->addWriteOptions();
+        $this->setHelp(<<<'EOF'
+            <info>%command.name%</info> は dtb_page とテンプレートファイルを対で登録・更新します.
+
+              <info>cat guide.twig | php %command.full_name% --url=guide --name=ご利用ガイド --body=-</info>
+              <info>php %command.full_name% --url=guide --body-file=guide.twig --dry-run</info>
+
+            既定ページ (EDIT_TYPE_DEFAULT 以上) は URL とファイル名を変更できません.
+            EOF
+        );
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $format = (string) $input->getOption('format');
+        if (!$this->isValidFormat($format)) {
+            $this->invalidFormat($io);
+
+            return Command::INVALID;
+        }
+
+        $url = $input->getOption('url');
+        if (null === $url || '' === $url) {
+            $io->error('--url を指定してください.');
+
+            return Command::INVALID;
+        }
+
+        try {
+            $body = $this->readBody($input);
+        } catch (\InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return Command::INVALID;
+        }
+
+        $payload = ['url' => (string) $url];
+        if (null !== $body) {
+            $payload['body'] = $body;
+        }
+        foreach (self::FIELD_OPTIONS as $option => $key) {
+            $value = $input->getOption($option);
+            if (null !== $value) {
+                $payload[$key] = (string) $value;
+            }
+        }
+
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        try {
+            /** @var array{url: string} $payload */
+            $result = $this->pageContentService->apply($payload, $dryRun);
+        } catch (ContentValidationException $e) {
+            $io->error(array_merge([sprintf('ページを保存できません: %s', (string) $url)], $e->getErrors()));
+
+            return 1;
+        }
+
+        $this->renderResult($io, $output, $format, $result, $dryRun);
+
+        if ($dryRun || ContentStatus::Unchanged === $result->status || $input->getOption('no-cache-clear')) {
+            return 0;
+        }
+
+        return $this->clearContentCache($io) ? 0 : self::EXIT_MANUAL_ACTION_REQUIRED;
+    }
+}

--- a/src/Eccube/Command/Content/PageApplyCommand.php
+++ b/src/Eccube/Command/Content/PageApplyCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * ページ (dtb_page + twig) を URL を鍵に登録・更新する.
+ * ページ (dtb_page + twig) をルーティング名を鍵に登録・更新する.
  *
  * 指定しなかった項目は既存の値を維持するため, 同じ入力を複数回適用しても結果は変わらない.
  */
@@ -62,9 +62,9 @@ final class PageApplyCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('url', null, InputOption::VALUE_REQUIRED, '対象ページの URL (登録・更新の鍵)')
+            ->addOption('route', null, InputOption::VALUE_REQUIRED, '対象ページのルーティング名 (登録・更新の鍵. 例: product_list)')
             ->addOption('name', null, InputOption::VALUE_REQUIRED, 'ページ名')
-            ->addOption('file-name', null, InputOption::VALUE_REQUIRED, 'テンプレートのファイル名 (新規登録時の既定は URL と同じ)')
+            ->addOption('file-name', null, InputOption::VALUE_REQUIRED, 'テンプレートのファイル名 (新規登録時の既定はルーティング名と同じ)')
             ->addOption('author', null, InputOption::VALUE_REQUIRED, 'author')
             ->addOption('description', null, InputOption::VALUE_REQUIRED, 'description')
             ->addOption('keyword', null, InputOption::VALUE_REQUIRED, 'keyword')
@@ -76,10 +76,11 @@ final class PageApplyCommand extends Command
         $this->setHelp(<<<'EOF'
             <info>%command.name%</info> は dtb_page とテンプレートファイルを対で登録・更新します.
 
-              <info>cat guide.twig | php %command.full_name% --url=guide --name=ご利用ガイド --body=-</info>
-              <info>php %command.full_name% --url=guide --body-file=guide.twig --dry-run</info>
+              <info>cat guide.twig | php %command.full_name% --route=guide --name=ご利用ガイド --body=-</info>
+              <info>php %command.full_name% --route=guide --body-file=guide.twig --dry-run</info>
 
-            既定ページ (EDIT_TYPE_DEFAULT 以上) は URL とファイル名を変更できません.
+            --route は dtb_page.url に保存されるルート名です (管理画面のページ管理の「ルーティング名」列).
+            既定ページ (EDIT_TYPE_DEFAULT 以上) はルーティング名とファイル名を変更できません.
             EOF
         );
     }
@@ -96,9 +97,9 @@ final class PageApplyCommand extends Command
             return Command::INVALID;
         }
 
-        $url = $input->getOption('url');
-        if (null === $url || '' === $url) {
-            $io->error('--url を指定してください.');
+        $route = $input->getOption('route');
+        if (null === $route || '' === $route) {
+            $io->error('--route を指定してください.');
 
             return Command::INVALID;
         }
@@ -111,7 +112,7 @@ final class PageApplyCommand extends Command
             return Command::INVALID;
         }
 
-        $payload = ['url' => (string) $url];
+        $payload = ['route' => (string) $route];
         if (null !== $body) {
             $payload['body'] = $body;
         }
@@ -125,14 +126,14 @@ final class PageApplyCommand extends Command
         $dryRun = (bool) $input->getOption('dry-run');
 
         try {
-            /** @var array{url: string} $payload */
+            /** @var array{route: string} $payload */
             $result = $this->pageContentService->apply($payload, $dryRun);
         } catch (ContentValidationException $e) {
-            $io->error(array_merge([sprintf('ページを保存できません: %s', (string) $url)], $e->getErrors()));
+            $io->error(array_merge([sprintf('ページを保存できません: %s', (string) $route)], $e->getErrors()));
 
             return 1;
         } catch (ContentWriteException $e) {
-            return $this->reportWriteFailure($io, sprintf('ページを保存できません: %s', (string) $url), $e);
+            return $this->reportWriteFailure($io, sprintf('ページを保存できません: %s', (string) $route), $e);
         }
 
         $this->renderResult($io, $output, $format, $result, $dryRun);

--- a/src/Eccube/Command/Content/PageApplyCommand.php
+++ b/src/Eccube/Command/Content/PageApplyCommand.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Eccube\Command\Content;
 
 use Eccube\Exception\ContentValidationException;
+use Eccube\Exception\ContentWriteException;
 use Eccube\Service\Content\ContentStatus;
 use Eccube\Service\Content\PageContentService;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -130,6 +131,8 @@ final class PageApplyCommand extends Command
             $io->error(array_merge([sprintf('ページを保存できません: %s', (string) $url)], $e->getErrors()));
 
             return 1;
+        } catch (ContentWriteException $e) {
+            return $this->reportWriteFailure($io, sprintf('ページを保存できません: %s', (string) $url), $e);
         }
 
         $this->renderResult($io, $output, $format, $result, $dryRun);

--- a/src/Eccube/Command/Content/PageListCommand.php
+++ b/src/Eccube/Command/Content/PageListCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command\Content;
+
+use Eccube\Entity\Page;
+use Eccube\Repository\PageRepository;
+use Eccube\Service\Content\PageContentService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'eccube:page:list', description: 'ページの一覧を表示します.')]
+final class PageListCommand extends Command
+{
+    use ContentCommandTrait;
+
+    public function __construct(
+        private readonly PageRepository $pageRepository,
+        private readonly PageContentService $pageContentService,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this->addFormatOption();
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $format = (string) $input->getOption('format');
+        if (!$this->isValidFormat($format)) {
+            $this->invalidFormat($io);
+
+            return Command::INVALID;
+        }
+
+        $rows = [];
+        /** @var Page $Page */
+        foreach ($this->pageRepository->getPageList() as $Page) {
+            $rows[] = [
+                'id' => $Page->getId(),
+                'url' => (string) $Page->getUrl(),
+                'name' => (string) $Page->getName(),
+                'file_name' => (string) $Page->getFileName(),
+                'editable' => $this->pageContentService->isUserDataPage($Page),
+                'path' => $this->pageContentService->getFilePath($Page),
+            ];
+        }
+
+        if ('json' === $format) {
+            $output->writeln((string) json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return 0;
+        }
+
+        $io->table(
+            ['ID', 'URL', 'ページ名', 'ファイル名', '編集可'],
+            array_map(static fn (array $row): array => [
+                $row['id'],
+                $row['url'],
+                $row['name'],
+                $row['file_name'],
+                $row['editable'] ? 'yes' : 'no',
+            ], $rows)
+        );
+
+        return 0;
+    }
+}

--- a/src/Eccube/Command/Content/PageListCommand.php
+++ b/src/Eccube/Command/Content/PageListCommand.php
@@ -59,7 +59,7 @@ final class PageListCommand extends Command
         foreach ($this->pageRepository->getPageList() as $Page) {
             $rows[] = [
                 'id' => $Page->getId(),
-                'url' => (string) $Page->getUrl(),
+                'route' => (string) $Page->getUrl(),
                 'name' => (string) $Page->getName(),
                 'file_name' => (string) $Page->getFileName(),
                 'editable' => $this->pageContentService->isUserDataPage($Page),
@@ -74,10 +74,10 @@ final class PageListCommand extends Command
         }
 
         $io->table(
-            ['ID', 'URL', 'ページ名', 'ファイル名', '編集可'],
+            ['ID', 'ルーティング名', 'ページ名', 'ファイル名', '編集可'],
             array_map(static fn (array $row): array => [
                 $row['id'],
-                $row['url'],
+                $row['route'],
                 $row['name'],
                 $row['file_name'],
                 $row['editable'] ? 'yes' : 'no',

--- a/src/Eccube/Command/Content/PageRemoveCommand.php
+++ b/src/Eccube/Command/Content/PageRemoveCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command\Content;
+
+use Eccube\Entity\Page;
+use Eccube\Service\Content\PageContentService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * ページ (dtb_page + twig) を削除する.
+ *
+ * 管理画面と同じく, ユーザーが作成したページ (EDIT_TYPE_USER) のみ削除できる.
+ */
+#[AsCommand(name: 'eccube:page:remove', description: 'ページを削除します.')]
+final class PageRemoveCommand extends Command
+{
+    use ContentCommandTrait;
+
+    public function __construct(private readonly PageContentService $pageContentService)
+    {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('url', null, InputOption::VALUE_REQUIRED, '対象ページの URL')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, '確認せずに削除する')
+            ->addOption('no-cache-clear', null, InputOption::VALUE_NONE, 'キャッシュの削除を省略する');
+        $this->addFormatOption();
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $format = (string) $input->getOption('format');
+        if (!$this->isValidFormat($format)) {
+            $this->invalidFormat($io);
+
+            return Command::INVALID;
+        }
+
+        $url = $input->getOption('url');
+        if (null === $url || '' === $url) {
+            $io->error('--url を指定してください.');
+
+            return Command::INVALID;
+        }
+
+        $Page = $this->pageContentService->findByUrl((string) $url);
+        if (!$Page instanceof Page) {
+            $io->error(sprintf('ページが見つかりません: %s', (string) $url));
+
+            return 1;
+        }
+
+        if (Page::EDIT_TYPE_USER !== $Page->getEditType()) {
+            $io->error(sprintf('既定ページのため削除できません: %s', (string) $url));
+
+            return 1;
+        }
+
+        if (!$input->getOption('force') && !$io->confirm(sprintf('%s を削除しますか?', (string) $url), false)) {
+            $io->text('中止しました.');
+
+            return 1;
+        }
+
+        $result = $this->pageContentService->remove($Page);
+
+        $this->renderResult($io, $output, $format, $result, false);
+
+        if ($input->getOption('no-cache-clear')) {
+            return 0;
+        }
+
+        return $this->clearContentCache($io) ? 0 : self::EXIT_MANUAL_ACTION_REQUIRED;
+    }
+}

--- a/src/Eccube/Command/Content/PageRemoveCommand.php
+++ b/src/Eccube/Command/Content/PageRemoveCommand.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Eccube\Command\Content;
 
 use Eccube\Entity\Page;
+use Eccube\Exception\ContentWriteException;
 use Eccube\Service\Content\PageContentService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -87,7 +88,11 @@ final class PageRemoveCommand extends Command
             return 1;
         }
 
-        $result = $this->pageContentService->remove($Page);
+        try {
+            $result = $this->pageContentService->remove($Page);
+        } catch (ContentWriteException $e) {
+            return $this->reportWriteFailure($io, sprintf('ページを削除できません: %s', (string) $Page->getUrl()), $e);
+        }
 
         $this->renderResult($io, $output, $format, $result, false);
 

--- a/src/Eccube/Command/Content/PageRemoveCommand.php
+++ b/src/Eccube/Command/Content/PageRemoveCommand.php
@@ -44,7 +44,7 @@ final class PageRemoveCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('url', null, InputOption::VALUE_REQUIRED, '対象ページの URL')
+            ->addOption('route', null, InputOption::VALUE_REQUIRED, '対象ページのルーティング名 (例: product_list)')
             ->addOption('force', 'f', InputOption::VALUE_NONE, '確認せずに削除する')
             ->addOption('no-cache-clear', null, InputOption::VALUE_NONE, 'キャッシュの削除を省略する');
         $this->addFormatOption();
@@ -62,27 +62,27 @@ final class PageRemoveCommand extends Command
             return Command::INVALID;
         }
 
-        $url = $input->getOption('url');
-        if (null === $url || '' === $url) {
-            $io->error('--url を指定してください.');
+        $route = $input->getOption('route');
+        if (null === $route || '' === $route) {
+            $io->error('--route を指定してください.');
 
             return Command::INVALID;
         }
 
-        $Page = $this->pageContentService->findByUrl((string) $url);
+        $Page = $this->pageContentService->findByRoute((string) $route);
         if (!$Page instanceof Page) {
-            $io->error(sprintf('ページが見つかりません: %s', (string) $url));
+            $io->error(sprintf('ページが見つかりません: %s', (string) $route));
 
             return 1;
         }
 
         if (Page::EDIT_TYPE_USER !== $Page->getEditType()) {
-            $io->error(sprintf('既定ページのため削除できません: %s', (string) $url));
+            $io->error(sprintf('既定ページのため削除できません: %s', (string) $route));
 
             return 1;
         }
 
-        if (!$input->getOption('force') && !$io->confirm(sprintf('%s を削除しますか?', (string) $url), false)) {
+        if (!$input->getOption('force') && !$io->confirm(sprintf('%s を削除しますか?', (string) $route), false)) {
             $io->text('中止しました.');
 
             return 1;

--- a/src/Eccube/Command/Content/PageShowCommand.php
+++ b/src/Eccube/Command/Content/PageShowCommand.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command\Content;
+
+use Eccube\Entity\Page;
+use Eccube\Repository\PageRepository;
+use Eccube\Service\Content\PageContentService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * apply の逆操作. 既定ではテンプレートの本文だけを標準出力へ書き出す.
+ */
+#[AsCommand(name: 'eccube:page:show', description: 'ページのテンプレートを出力します.')]
+final class PageShowCommand extends Command
+{
+    use ContentCommandTrait;
+
+    public function __construct(
+        private readonly PageRepository $pageRepository,
+        private readonly PageContentService $pageContentService,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('url', null, InputOption::VALUE_REQUIRED, '対象ページの URL')
+            ->addOption('id', null, InputOption::VALUE_REQUIRED, '対象ページの ID');
+        $this->addFormatOption();
+        $this->setHelp(<<<'EOF'
+            <info>%command.name%</info> は apply の逆操作です.
+
+              <info>php %command.full_name% --url=guide > guide.twig</info>
+            EOF
+        );
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $format = (string) $input->getOption('format');
+        if (!$this->isValidFormat($format)) {
+            $this->invalidFormat($io);
+
+            return Command::INVALID;
+        }
+
+        $url = $input->getOption('url');
+        $id = $input->getOption('id');
+        if (null === $url && null === $id) {
+            $io->error('--url または --id を指定してください.');
+
+            return Command::INVALID;
+        }
+
+        $Page = null === $id
+            ? $this->pageContentService->findByUrl((string) $url)
+            : $this->pageRepository->find((int) $id);
+
+        if (!$Page instanceof Page) {
+            $io->error(sprintf('ページが見つかりません: %s', (string) ($url ?? $id)));
+
+            return 1;
+        }
+
+        $body = $this->pageContentService->readTemplate($Page);
+
+        if ('json' === $format) {
+            $output->writeln((string) json_encode([
+                'id' => $Page->getId(),
+                'url' => (string) $Page->getUrl(),
+                'name' => (string) $Page->getName(),
+                'file_name' => (string) $Page->getFileName(),
+                'author' => $Page->getAuthor(),
+                'description' => $Page->getDescription(),
+                'keyword' => $Page->getKeyword(),
+                'meta_robots' => $Page->getMetaRobots(),
+                'meta_tags' => $Page->getMetaTags(),
+                'layouts' => array_map(static fn ($Layout): array => [
+                    'id' => $Layout->getId(),
+                    'name' => $Layout->getName(),
+                    'device_type_id' => $Layout->getDeviceType()->getId(),
+                ], $Page->getLayouts()),
+                'path' => $this->pageContentService->getFilePath($Page),
+                'body' => $body,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return 0;
+        }
+
+        $output->write($body);
+
+        return 0;
+    }
+}

--- a/src/Eccube/Command/Content/PageShowCommand.php
+++ b/src/Eccube/Command/Content/PageShowCommand.php
@@ -44,13 +44,13 @@ final class PageShowCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('url', null, InputOption::VALUE_REQUIRED, '対象ページの URL')
+            ->addOption('route', null, InputOption::VALUE_REQUIRED, '対象ページのルーティング名 (例: product_list)')
             ->addOption('id', null, InputOption::VALUE_REQUIRED, '対象ページの ID');
         $this->addFormatOption();
         $this->setHelp(<<<'EOF'
             <info>%command.name%</info> は apply の逆操作です.
 
-              <info>php %command.full_name% --url=guide > guide.twig</info>
+              <info>php %command.full_name% --route=guide > guide.twig</info>
             EOF
         );
     }
@@ -67,20 +67,20 @@ final class PageShowCommand extends Command
             return Command::INVALID;
         }
 
-        $url = $input->getOption('url');
+        $route = $input->getOption('route');
         $id = $input->getOption('id');
-        if (null === $url && null === $id) {
-            $io->error('--url または --id を指定してください.');
+        if (null === $route && null === $id) {
+            $io->error('--route または --id を指定してください.');
 
             return Command::INVALID;
         }
 
         $Page = null === $id
-            ? $this->pageContentService->findByUrl((string) $url)
+            ? $this->pageContentService->findByRoute((string) $route)
             : $this->pageRepository->find((int) $id);
 
         if (!$Page instanceof Page) {
-            $io->error(sprintf('ページが見つかりません: %s', (string) ($url ?? $id)));
+            $io->error(sprintf('ページが見つかりません: %s', (string) ($route ?? $id)));
 
             return 1;
         }
@@ -90,7 +90,7 @@ final class PageShowCommand extends Command
         if ('json' === $format) {
             $output->writeln((string) json_encode([
                 'id' => $Page->getId(),
-                'url' => (string) $Page->getUrl(),
+                'route' => (string) $Page->getUrl(),
                 'name' => (string) $Page->getName(),
                 'file_name' => (string) $Page->getFileName(),
                 'author' => $Page->getAuthor(),

--- a/src/Eccube/Controller/Admin/Content/BlockController.php
+++ b/src/Eccube/Controller/Admin/Content/BlockController.php
@@ -21,10 +21,9 @@ use Eccube\Event\EventArgs;
 use Eccube\Form\Type\Admin\BlockType;
 use Eccube\Repository\BlockRepository;
 use Eccube\Repository\Master\DeviceTypeRepository;
+use Eccube\Service\Content\BlockContentService;
 use Eccube\Util\CacheUtil;
-use Eccube\Util\StringUtil;
 use Symfony\Bridge\Twig\Attribute\Template;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -34,7 +33,7 @@ use Twig\Error\LoaderError;
 
 class BlockController extends AbstractController
 {
-    public function __construct(protected BlockRepository $blockRepository, protected DeviceTypeRepository $deviceTypeRepository, private readonly Environment $twig, private readonly Filesystem $fs, private readonly CacheUtil $cacheUtil)
+    public function __construct(protected BlockRepository $blockRepository, protected DeviceTypeRepository $deviceTypeRepository, private readonly Environment $twig, private readonly CacheUtil $cacheUtil, private readonly BlockContentService $blockContentService)
     {
     }
 
@@ -129,26 +128,8 @@ class BlockController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $Block = $form->getData();
-            $this->entityManager->persist($Block);
-            $this->entityManager->flush();
-
-            $dir = sprintf('%s/app/template/%s/Block',
-                $this->getParameter('kernel.project_dir'),
-                $this->getParameter('eccube.theme'));
-
-            $file = $dir.'/'.$Block->getFileName().'.twig';
-
-            $source = $form->get('block_html')->getData();
-            $source = StringUtil::convertLineFeed($source);
-            $this->fs->dumpFile($file, $source);
-
-            // 更新でファイル名を変更した場合、以前のファイルを削除
-            if (null !== $previousFileName && $Block->getFileName() !== $previousFileName) {
-                $old = $dir.'/'.$previousFileName.'.twig';
-                if ($this->fs->exists($old)) {
-                    $this->fs->remove($old);
-                }
-            }
+            // DB 登録とテンプレートファイルの生成は Service に委譲する
+            $this->blockContentService->save($Block, (string) $form->get('block_html')->getData(), $previousFileName);
 
             // キャッシュの削除
             $this->cacheUtil->clearTwigCache();
@@ -182,18 +163,7 @@ class BlockController extends AbstractController
 
         // ユーザーが作ったブロックのみ削除する
         if ($Block->isDeletable()) {
-            $dir = sprintf('%s/app/template/%s/Block',
-                $this->getParameter('kernel.project_dir'),
-                $this->getParameter('eccube.theme'));
-
-            $file = $dir.'/'.$Block->getFileName().'.twig';
-
-            if ($this->fs->exists($file)) {
-                $this->fs->remove($file);
-            }
-
-            $this->entityManager->remove($Block);
-            $this->entityManager->flush();
+            $this->blockContentService->remove($Block);
 
             $event = new EventArgs(
                 [

--- a/src/Eccube/Controller/Admin/Content/CacheController.php
+++ b/src/Eccube/Controller/Admin/Content/CacheController.php
@@ -45,7 +45,12 @@ class CacheController extends AbstractController
 
             $this->addFlash('eccube.admin.disable_maintenance', '');
 
-            $this->addSuccess('admin.common.delete_complete', 'admin');
+            if ($this->cacheUtil->canClearBuildCache()) {
+                $this->addSuccess('admin.common.delete_complete', 'admin');
+            } else {
+                // ビルドディレクトリへ書き込めない構成では実行時キャッシュのみ削除される.
+                $this->addWarning('admin.content.cache_build_dir_not_writable', 'admin');
+            }
         }
 
         return [

--- a/src/Eccube/Controller/Admin/Content/PageController.php
+++ b/src/Eccube/Controller/Admin/Content/PageController.php
@@ -15,17 +15,15 @@ namespace Eccube\Controller\Admin\Content;
 
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\Page;
-use Eccube\Entity\PageLayout;
 use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
 use Eccube\Form\Type\Admin\MainEditType;
 use Eccube\Repository\Master\DeviceTypeRepository;
 use Eccube\Repository\PageLayoutRepository;
 use Eccube\Repository\PageRepository;
+use Eccube\Service\Content\PageContentService;
 use Eccube\Util\CacheUtil;
-use Eccube\Util\StringUtil;
 use Symfony\Bridge\Twig\Attribute\Template;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -36,7 +34,7 @@ class PageController extends AbstractController
     /**
      * PageController constructor.
      */
-    public function __construct(protected PageRepository $pageRepository, protected PageLayoutRepository $pageLayoutRepository, protected DeviceTypeRepository $deviceTypeRepository, private readonly Environment $twig, private readonly CacheUtil $cacheUtil)
+    public function __construct(protected PageRepository $pageRepository, protected PageLayoutRepository $pageLayoutRepository, protected DeviceTypeRepository $deviceTypeRepository, private readonly Environment $twig, private readonly CacheUtil $cacheUtil, private readonly PageContentService $pageContentService)
     {
     }
 
@@ -133,65 +131,16 @@ class PageController extends AbstractController
                     ->setFileName($PrevPage->getFileName())
                     ->setName($Page->getName());
             }
-            // DB登録
-            $this->entityManager->persist($Page);
-            $this->entityManager->flush();
-
-            // ファイル生成・更新
-            if ($isUserDataPage) {
-                $templatePath = $this->getParameter('eccube_theme_user_data_dir');
-            } else {
-                $templatePath = $this->getParameter('eccube_theme_front_dir');
-            }
-            $filePath = $templatePath.'/'.$Page->getFileName().'.twig';
-
-            $fs = new Filesystem();
-            $pageData = $form->get('tpl_data')->getData();
-            $pageData = StringUtil::convertLineFeed($pageData);
-            $fs->dumpFile($filePath, $pageData);
-
-            // 更新でファイル名を変更した場合、以前のファイルを削除
-            if ($Page->getFileName() != $fileName && !is_null($fileName)) {
-                $oldFilePath = $templatePath.'/'.$fileName.'.twig';
-                if ($fs->exists($oldFilePath)) {
-                    $fs->remove($oldFilePath);
-                }
-            }
-
-            foreach ($Page->getPageLayouts() as $PageLayout) {
-                $Page->removePageLayout($PageLayout);
-                $this->entityManager->remove($PageLayout);
-                $this->entityManager->flush();
-            }
-
-            $Layout = $form['PcLayout']->getData();
-            $LastPageLayout = $this->pageLayoutRepository->findOneBy([], ['sort_no' => 'DESC']);
-            $sortNo = $LastPageLayout->getSortNo();
-
-            if ($Layout) {
-                $PageLayout = new PageLayout();
-                $PageLayout->setLayoutId($Layout->getId());
-                $PageLayout->setLayout($Layout);
-                $PageLayout->setPageId($Page->getId());
-                $PageLayout->setSortNo($sortNo++);
-                $PageLayout->setPage($Page);
-
-                $this->entityManager->persist($PageLayout);
-                $this->entityManager->flush();
-            }
-
-            $Layout = $form['SpLayout']->getData();
-            if ($Layout) {
-                $PageLayout = new PageLayout();
-                $PageLayout->setLayoutId($Layout->getId());
-                $PageLayout->setLayout($Layout);
-                $PageLayout->setPageId($Page->getId());
-                $PageLayout->setSortNo($sortNo++);
-                $PageLayout->setPage($Page);
-
-                $this->entityManager->persist($PageLayout);
-                $this->entityManager->flush();
-            }
+            // DB 登録とテンプレートファイルの生成は Service に委譲する
+            $result = $this->pageContentService->save(
+                $Page,
+                (string) $form->get('tpl_data')->getData(),
+                $form['PcLayout']->getData(),
+                $form['SpLayout']->getData(),
+                $fileName
+            );
+            $templatePath = $this->pageContentService->getTemplateDir($Page);
+            $filePath = (string) $result->path();
 
             $event = new EventArgs(
                 [
@@ -254,14 +203,7 @@ class PageController extends AbstractController
 
         // ユーザーが作ったページのみ削除する
         if ($Page->getEditType() == Page::EDIT_TYPE_USER) {
-            $templatePath = $this->getParameter('eccube_theme_user_data_dir');
-            $file = $templatePath.'/'.$Page->getFileName().'.twig';
-            $fs = new Filesystem();
-            if ($fs->exists($file)) {
-                $fs->remove($file);
-            }
-            $this->entityManager->remove($Page);
-            $this->entityManager->flush();
+            $this->pageContentService->remove($Page);
 
             $event = new EventArgs(
                 [

--- a/src/Eccube/Controller/Admin/Setting/Shop/MailController.php
+++ b/src/Eccube/Controller/Admin/Setting/Shop/MailController.php
@@ -19,10 +19,9 @@ use Eccube\Event\EccubeEvents;
 use Eccube\Event\EventArgs;
 use Eccube\Form\Type\Admin\MailType;
 use Eccube\Repository\MailTemplateRepository;
+use Eccube\Service\Content\MailTemplateContentService;
 use Eccube\Util\CacheUtil;
-use Eccube\Util\StringUtil;
 use Symfony\Bridge\Twig\Attribute\Template;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -38,7 +37,7 @@ class MailController extends AbstractController
     /**
      * MailController constructor.
      */
-    public function __construct(protected MailTemplateRepository $mailTemplateRepository, private readonly Environment $twig, private readonly CacheUtil $cacheUtil)
+    public function __construct(protected MailTemplateRepository $mailTemplateRepository, private readonly Environment $twig, private readonly CacheUtil $cacheUtil, private readonly MailTemplateContentService $mailTemplateContentService)
     {
     }
 
@@ -95,32 +94,17 @@ class MailController extends AbstractController
             if ($form->isSubmitted() && $form->isValid()) {
                 $Mail = $form->getData();
                 $Mail->setDeletable(true);
-                $this->entityManager->persist($Mail);
-                $this->entityManager->flush();
 
-                // ファイル生成・更新
-                $templatePath = $this->getParameter('eccube_theme_front_dir');
-                $filePath = $templatePath.'/'.$Mail->getFileName();
-
-                $fs = new Filesystem();
-                $mailData = $form->get('tpl_data')->getData();
-                $mailData = StringUtil::convertLineFeed($mailData);
-                $fs->dumpFile($filePath, $mailData);
-
-                // HTMLファイル用
+                // DB 登録とテンプレートファイルの生成は Service に委譲する.
+                // HTML 本文が null の場合は HTML パートのファイルを削除する.
                 $htmlMailData = $form->get('html_tpl_data')->getData();
-                $htmlFileName = $this->getHtmlFileName($Mail->getFileName());
-
-                if (!is_null($htmlMailData)) {
-                    $htmlMailData = StringUtil::convertLineFeed($htmlMailData);
-                    $fs->dumpFile($templatePath.'/'.$htmlFileName, $htmlMailData);
-                } else {
-                    // 空登録の場合は削除
-                    $htmlFilePath = $templatePath.'/'.$htmlFileName;
-                    if ($this->validateFilePath($htmlFilePath) && is_file($htmlFilePath)) {
-                        $fs->remove($htmlFilePath);
-                    }
-                }
+                $result = $this->mailTemplateContentService->save(
+                    $Mail,
+                    (string) $form->get('tpl_data')->getData(),
+                    null === $htmlMailData ? null : (string) $htmlMailData
+                );
+                $templatePath = $this->mailTemplateContentService->getTemplateDir();
+                $filePath = (string) $result->path();
 
                 $event = new EventArgs(
                     [
@@ -186,19 +170,7 @@ class MailController extends AbstractController
 
         log_info('メールテンプレート削除開始', [$Mail->getId()]);
 
-        $this->entityManager->remove($Mail);
-        $this->entityManager->flush();
-
-        $fs = new Filesystem();
-        $templatePath = $this->getParameter('eccube_theme_front_dir');
-        $filePath = $templatePath.'/'.$Mail->getFileName();
-        if ($this->validateFilePath($filePath) && is_file($filePath)) {
-            $fs->remove($filePath);
-        }
-        $htmlFilePath = $templatePath.'/'.$this->getHtmlFileName($Mail->getFileName());
-        if ($this->validateFilePath($htmlFilePath) && is_file($htmlFilePath)) {
-            $fs->remove($htmlFilePath);
-        }
+        $this->mailTemplateContentService->remove($Mail);
 
         $this->addSuccess('admin.common.delete_complete', 'admin');
 
@@ -212,11 +184,7 @@ class MailController extends AbstractController
      */
     protected function getHtmlFileName(string $fileName): string
     {
-        // HTMLテンプレートファイルの取得
-        $targetTemplate = pathinfo($fileName);
-        $suffix = '.html';
-
-        return $targetTemplate['dirname'].DIRECTORY_SEPARATOR.$targetTemplate['filename'].$suffix.'.'.$targetTemplate['extension'];
+        return $this->mailTemplateContentService->getHtmlFileName($fileName);
     }
 
     /**
@@ -224,9 +192,6 @@ class MailController extends AbstractController
      */
     protected function validateFilePath(string $path): bool
     {
-        $templatePath = realpath($this->getParameter('eccube_theme_front_dir'));
-        $path = realpath($path);
-
-        return \str_starts_with($path, $templatePath);
+        return $this->mailTemplateContentService->isInsideTemplateDir($path);
     }
 }

--- a/src/Eccube/Controller/InstallPluginController.php
+++ b/src/Eccube/Controller/InstallPluginController.php
@@ -192,8 +192,16 @@ class InstallPluginController extends InstallController
         // KernelEvents::TERMINATE で強制的にキャッシュを削除する
         // see https://github.com/EC-CUBE/ec-cube/issues/5498#issuecomment-1205904083
         $this->eventDispatcher->addListener(KernelEvents::TERMINATE, function (): void {
+            $projectDir = $this->getParameter('kernel.project_dir');
+            $env = env('APP_ENV', 'prod');
             $fs = new Filesystem();
-            $fs->remove($this->getParameter('kernel.project_dir').'/var/cache/'.env('APP_ENV', 'prod'));
+            // ビルド生成物 (var/build) と実行時キャッシュ (var/runtime) は別ディレクトリのため,
+            // インストール直後のプラグインを反映するには双方を削除する必要がある.
+            $fs->remove([
+                $projectDir.'/var/cache/'.$env,
+                $projectDir.'/var/build/'.$env,
+                $projectDir.'/var/runtime/'.$env,
+            ]);
         });
     }
 }

--- a/src/Eccube/DependencyInjection/Compiler/BuildDirCacheWarmerPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/BuildDirCacheWarmerPass.php
@@ -17,50 +17,31 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * コンテナ再構築に伴う自動 warmup を, ビルドディレクトリへ書くものだけに絞る.
+ * テンプレートの一括事前コンパイルを eccube:cache:build のときだけ実行するようにする.
  *
  * kernel.cache_dir と kernel.build_dir が別パスになると, Kernel::initializeContainer() が
  * コンテナ再構築のたびに CacheWarmerAggregate::enableOptionalWarmers() を呼ぶ
- * (vendor/symfony/http-kernel/Kernel.php). その結果, 次の 2 つの問題が起きる.
+ * (vendor/symfony/http-kernel/Kernel.php). その結果, 本来デプロイ時にだけ実行したい
+ * 全テンプレートのコンパイルが composer install や Web リクエスト起因の再構築でも走り,
+ * ピークメモリが 87.5MiB から 219MiB へ跳ね上がる (実測).
  *
- * 1. %eccube_runtime_dir% へ書く warmer が CLI から実行される.
- *    ランタイムディレクトリは Web サーバー所有のため, 権限を分離した構成では
- *    eccube:cache:build が Permission denied で失敗する.
- * 2. 全テンプレートのコンパイルがデプロイ時以外でも走り, composer install 時の
- *    ピークメモリが 87.5MiB から 219MiB へ跳ね上がる (実測).
+ * kernel.cache_warmer タグを外して自動実行の対象から除き, eccube:cache:build が
+ * 明示的に呼び出す. 事前コンパイルされなかったテンプレートは, 従来どおり
+ * リクエスト処理中に twig.template_cache.runtime_cache へコンパイルされる.
  *
- * いずれも「リクエスト処理中に生成されるキャッシュ」であり, 事前生成しなくても
- * 初回アクセス時に Web サーバーが生成する. そのため kernel.cache_warmer タグを外し,
- * 自動 warmup の対象から除く. テンプレートの事前コンパイルだけは eccube:cache:build が
- * 明示的に呼び出すため, サービスを public にしておく.
+ * 他の warmer は外さない. 翻訳カタログや HTMLPurifier のシリアライザキャッシュは
+ * ソースから導かれるビルド生成物で, kernel.cache_dir 配下へ出力される
+ * (リクエスト処理中は読み取りのみ). とくに HTMLPurifier は基底ディレクトリを
+ * 自分では作らず警告を出すため (DefinitionCache/Serializer::_prepareDir()),
+ * warmer を外すとテンプレートの描画が失敗する.
  */
 class BuildDirCacheWarmerPass implements CompilerPassInterface
 {
     public const TWIG_WARMER_ID = 'twig.template_cache_warmer';
 
-    /**
-     * %eccube_runtime_dir% 配下へ書き込む warmer.
-     *
-     * - translation.warmer: Translator::warmUp() は引数の cacheDir ではなく
-     *   framework.translator.cache_dir へ書く (Translator.php:95-114)
-     * - exercise_html_purifier.cache_warmer.serializer: 設定値 (default_cache_serializer_path) へ書く
-     *
-     * @var list<string>
-     */
-    private const RUNTIME_WARMER_IDS = [
-        'translation.warmer',
-        'exercise_html_purifier.cache_warmer.serializer',
-    ];
-
     #[\Override]
     public function process(ContainerBuilder $container): void
     {
-        foreach (self::RUNTIME_WARMER_IDS as $id) {
-            if ($container->hasDefinition($id)) {
-                $container->getDefinition($id)->clearTag('kernel.cache_warmer');
-            }
-        }
-
         if (!$container->hasDefinition(self::TWIG_WARMER_ID)) {
             return;
         }

--- a/src/Eccube/DependencyInjection/Compiler/BuildDirCacheWarmerPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/BuildDirCacheWarmerPass.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * コンテナ再構築に伴う自動 warmup を, ビルドディレクトリへ書くものだけに絞る.
+ *
+ * kernel.cache_dir と kernel.build_dir が別パスになると, Kernel::initializeContainer() が
+ * コンテナ再構築のたびに CacheWarmerAggregate::enableOptionalWarmers() を呼ぶ
+ * (vendor/symfony/http-kernel/Kernel.php). その結果, 次の 2 つの問題が起きる.
+ *
+ * 1. %eccube_runtime_dir% へ書く warmer が CLI から実行される.
+ *    ランタイムディレクトリは Web サーバー所有のため, 権限を分離した構成では
+ *    eccube:cache:build が Permission denied で失敗する.
+ * 2. 全テンプレートのコンパイルがデプロイ時以外でも走り, composer install 時の
+ *    ピークメモリが 87.5MiB から 219MiB へ跳ね上がる (実測).
+ *
+ * いずれも「リクエスト処理中に生成されるキャッシュ」であり, 事前生成しなくても
+ * 初回アクセス時に Web サーバーが生成する. そのため kernel.cache_warmer タグを外し,
+ * 自動 warmup の対象から除く. テンプレートの事前コンパイルだけは eccube:cache:build が
+ * 明示的に呼び出すため, サービスを public にしておく.
+ */
+class BuildDirCacheWarmerPass implements CompilerPassInterface
+{
+    public const TWIG_WARMER_ID = 'twig.template_cache_warmer';
+
+    /**
+     * %eccube_runtime_dir% 配下へ書き込む warmer.
+     *
+     * - translation.warmer: Translator::warmUp() は引数の cacheDir ではなく
+     *   framework.translator.cache_dir へ書く (Translator.php:95-114)
+     * - exercise_html_purifier.cache_warmer.serializer: 設定値 (default_cache_serializer_path) へ書く
+     *
+     * @var list<string>
+     */
+    private const RUNTIME_WARMER_IDS = [
+        'translation.warmer',
+        'exercise_html_purifier.cache_warmer.serializer',
+    ];
+
+    #[\Override]
+    public function process(ContainerBuilder $container): void
+    {
+        foreach (self::RUNTIME_WARMER_IDS as $id) {
+            if ($container->hasDefinition($id)) {
+                $container->getDefinition($id)->clearTag('kernel.cache_warmer');
+            }
+        }
+
+        if (!$container->hasDefinition(self::TWIG_WARMER_ID)) {
+            return;
+        }
+
+        $container->getDefinition(self::TWIG_WARMER_ID)
+            ->clearTag('kernel.cache_warmer')
+            // eccube:cache:build が再起動後のコンテナから取得するため public にする.
+            ->setPublic(true);
+    }
+}

--- a/src/Eccube/DependencyInjection/Compiler/CliFileLogHandlerPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/CliFileLogHandlerPass.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\DependencyInjection\Compiler;
+
+use Eccube\Log\CliSuppressibleHandler;
+use Monolog\Handler\StreamHandler;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * ファイルへ書き込む monolog のハンドラを CliSuppressibleHandler でラップする.
+ *
+ * 権限を分離した構成では var/log が Web サーバー所有 (レーン W) になり, CLI からは
+ * 書き込めない. ECCUBE_CLI_LOG_TO_FILE=0 のとき, CLI 実行時だけファイルへの書き込みを
+ * 止められるようにする.
+ *
+ * コンパイル済みコンテナは Web と CLI で共有するため, ここで実行経路を判定することはできない.
+ * 判定はハンドラ側 (実行時) で行い, 本パスはラップのみを担う.
+ *
+ * 対象は StreamHandler を継承したハンドラ (rotating_file / stream) に限る.
+ * ConsoleHandler や FingersCrossedHandler はファイルを開かないため対象外だが,
+ * FingersCrossedHandler が委譲する先 (main_rotating_file 等) はラップされるため,
+ * バッファされたレコードの書き出しも抑止される.
+ */
+class CliFileLogHandlerPass implements CompilerPassInterface
+{
+    private const HANDLER_ID_PREFIX = 'monolog.handler.';
+
+    private const INNER_ID_SUFFIX = '.cli_suppressible.inner';
+
+    #[\Override]
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (!str_starts_with($id, self::HANDLER_ID_PREFIX)) {
+                continue;
+            }
+            if (str_ends_with($id, self::INNER_ID_SUFFIX)) {
+                continue;
+            }
+
+            $class = $definition->getClass();
+            if (null === $class) {
+                continue;
+            }
+
+            $class = (string) $container->getParameterBag()->resolveValue($class);
+            if (!is_a($class, StreamHandler::class, true)) {
+                continue;
+            }
+
+            $innerId = $id.self::INNER_ID_SUFFIX;
+            $container->setDefinition($innerId, $definition);
+            $container->setDefinition($id, new Definition(CliSuppressibleHandler::class, [
+                new Reference($innerId),
+                '%env(bool:ECCUBE_CLI_LOG_TO_FILE)%',
+            ]));
+        }
+    }
+}

--- a/src/Eccube/DependencyInjection/Compiler/RuntimeCacheDirPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/RuntimeCacheDirPass.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * リクエスト処理中に書き込まれるキャッシュの出力先を %eccube_runtime_dir% へ寄せる.
+ *
+ * kernel.cache_dir / kernel.build_dir は eccube:cache:build (CLI) が生成するディレクトリで,
+ * Web サーバーからは読み取り専用で運用できるようにする. そのため, サービス定義に
+ * %kernel.cache_dir% がハードコードされていて設定で変更できないものをここで差し替える.
+ *
+ * 設定で変更できるもの (framework.translator.cache_dir, exercise_html_purifier の
+ * default_cache_serializer_path, mcp.http.session.directory 等) は yaml 側で指定する.
+ */
+class RuntimeCacheDirPass implements CompilerPassInterface
+{
+    #[\Override]
+    public function process(ContainerBuilder $container): void
+    {
+        $runtimeDir = (string) $container->getParameter('eccube_runtime_dir');
+
+        // cache.adapter.system のディレクトリは framework.cache.directory の対象外で,
+        // cache.php:87 が %kernel.cache_dir%/pools/system をハードコードしている.
+        // (cache.app 側は framework.cache.directory の既定値が %kernel.share_dir% 起点のため
+        //  Kernel::getShareDir() の変更で追従する)
+        if ($container->hasDefinition('cache.adapter.system')) {
+            $container->getDefinition('cache.adapter.system')
+                ->replaceArgument(3, $runtimeDir.'/pools/system');
+        }
+
+        $this->moveTwigCache($container, $runtimeDir);
+    }
+
+    /**
+     * twig のコンパイル結果のうち, リクエスト処理中に書き込まれる側を移す.
+     *
+     * - prod: twig.template_cache.runtime_cache (build に無いテンプレートのフォールバック先)
+     * - dev : auto_reload が有効なため 3 層構成にならず, twig サービスの cache オプションが
+     *         %kernel.cache_dir%/twig という文字列になる (TwigExtension.php:172-177)
+     */
+    private function moveTwigCache(ContainerBuilder $container, string $runtimeDir): void
+    {
+        if ($container->hasDefinition('twig.template_cache.runtime_cache')) {
+            $container->getDefinition('twig.template_cache.runtime_cache')
+                ->replaceArgument(0, $runtimeDir.'/twig');
+        }
+
+        if (!$container->hasDefinition('twig')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('twig');
+        $options = $definition->getArgument(1);
+        if (!is_array($options) || !isset($options['cache']) || !is_string($options['cache'])) {
+            return;
+        }
+
+        $options['cache'] = $runtimeDir.'/twig';
+        $definition->replaceArgument(1, $options);
+    }
+}

--- a/src/Eccube/DependencyInjection/Compiler/RuntimeCachePoolFailsafePass.php
+++ b/src/Eccube/DependencyInjection/Compiler/RuntimeCachePoolFailsafePass.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\DependencyInjection\Compiler;
+
+use Eccube\Cache\WriteFailsafeFilesystemAdapter;
+use Eccube\Cache\WriteFailsafePhpFilesAdapter;
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * ファイルへ書き込む cache pool を, 書き込めない場合に保存を諦める実装へ差し替える.
+ *
+ * 実行時キャッシュ (%eccube_runtime_dir%/pools) は Web サーバー所有 (レーン W) のため
+ * CLI からは書き込めない. 既定のアダプタは保存に失敗するたびに警告を記録するので,
+ * CLI を実行するたびに大量の警告が並ぶ.
+ *
+ * 書き込めるかどうかは実行時にしか分からない (コンパイル済みコンテナは Web と CLI で共有する)
+ * ため, 判定はアダプタ側で行う. 本パスは差し替えのみを担う.
+ */
+class RuntimeCachePoolFailsafePass implements CompilerPassInterface
+{
+    #[\Override]
+    public function process(ContainerBuilder $container): void
+    {
+        foreach (array_keys($container->findTaggedServiceIds('cache.pool')) as $id) {
+            if (!$container->hasDefinition($id)) {
+                continue;
+            }
+
+            $definition = $container->getDefinition($id);
+
+            if ($this->isSystemCacheFactory($definition)) {
+                $definition->setFactory([WriteFailsafePhpFilesAdapter::class, 'createSystemCache']);
+                continue;
+            }
+
+            if (FilesystemAdapter::class === $this->resolveClass($container, $definition)) {
+                $definition->setClass(WriteFailsafeFilesystemAdapter::class);
+            }
+        }
+    }
+
+    private function isSystemCacheFactory(Definition $definition): bool
+    {
+        $factory = $definition->getFactory();
+
+        return \is_array($factory)
+            && AbstractAdapter::class === $factory[0]
+            && 'createSystemCache' === $factory[1];
+    }
+
+    /**
+     * ChildDefinition はクラスを持たないことがあるため, 親をたどって解決する.
+     */
+    private function resolveClass(ContainerBuilder $container, Definition $definition): ?string
+    {
+        $class = $definition->getClass();
+        while (null === $class && $definition instanceof ChildDefinition) {
+            $parent = $definition->getParent();
+            if (!$container->hasDefinition($parent)) {
+                return null;
+            }
+            $definition = $container->getDefinition($parent);
+            $class = $definition->getClass();
+        }
+
+        return null === $class ? null : (string) $container->getParameterBag()->resolveValue($class);
+    }
+}

--- a/src/Eccube/EventListener/RuntimeCachePoolClearListener.php
+++ b/src/Eccube/EventListener/RuntimeCachePoolClearListener.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace Eccube\EventListener;
 
+use Eccube\Service\Permission\PathOwnership;
+use Eccube\Service\Permission\WebServerUserResolver;
 use Eccube\Util\CacheUtil;
 use Eccube\Util\RuntimeCachePoolClearer;
 use Symfony\Component\Console\ConsoleEvents;
@@ -23,22 +25,33 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * cache:clear が実行時 cache pool を削除できなかったことを通知する.
+ * cache:clear の後始末が必要なことを通知する.
  *
- * 権限を分離した構成では, cache:clear をレーン S の所有者 (CLI ユーザー) で実行すると
- * ビルド生成物は削除できる一方, レーン W のランタイムディレクトリにある cache pool は削除できない.
- * RuntimeCachePoolClearer はここで例外を投げると cache:clear 全体が失敗するため中断しないが,
- * そのままでは "Cache was successfully cleared" と表示され, 消えていないことが利用者に伝わらない.
+ * 権限を分離した構成では cache:clear が 2 つの後始末を残す. どちらも cache:clear 自体は
+ * 成功として終わるため, 案内しないと気づけない.
+ *
+ * 1. コンパイル済みコンテナの消失 — cache:clear はビルドディレクトリも削除する
+ *    (CacheClearCommand.php の $useBuildDir 分岐). --no-warmup を付けると再生成されないため,
+ *    次回起動時に Kernel::buildContainer() がコンテナを作り直そうとし, レーン S (var/cache) へ
+ *    書き込めない Web サーバーは "Unable to write in the "cache" directory" で 500 になる.
+ *    復旧できるのは CLI ユーザーの eccube:cache:build だけなので最優先で案内する.
+ * 2. 実行時 cache pool の残存 — レーン W のランタイムディレクトリは CLI ユーザーから削除できない.
+ *    RuntimeCachePoolClearer は例外を投げず (投げると cache:clear 全体が失敗する) 結果だけを残す.
  *
  * eccube:cache:build や eccube:page:apply とは異なり, 終了コードは変更しない.
  * cache:clear は composer.json の auto-scripts (cache:clear --no-warmup) から実行され,
  * 非ゼロを返すと composer install がスクリプト失敗として中断する (実測で [KO] になる).
- * cache:clear 自体が担うビルド生成物の削除は成功しているため, 残りの操作は警告で案内する.
+ * auto-scripts は直後に cache:warmup でコンテナを再生成するため, 1 の状態は残らない.
  */
 class RuntimeCachePoolClearListener implements EventSubscriberInterface
 {
-    public function __construct(private readonly RuntimeCachePoolClearer $runtimeCachePoolClearer)
-    {
+    public function __construct(
+        private readonly RuntimeCachePoolClearer $runtimeCachePoolClearer,
+        private readonly WebServerUserResolver $webServerUserResolver,
+        private readonly string $buildDir,
+        private readonly string $cacheDir,
+        private readonly string $containerClass,
+    ) {
     }
 
     #[\Override]
@@ -60,17 +73,57 @@ class RuntimeCachePoolClearListener implements EventSubscriberInterface
             return;
         }
 
+        $io = new SymfonyStyle($event->getInput(), $event->getOutput());
+
+        // コンテナが無い状態は Web サーバーが起動できないため, pool の案内より先に出す.
+        if ($this->needsManualRebuild()) {
+            $io->warning([
+                sprintf('%s にコンパイル済みコンテナがありません.', $this->buildDir),
+                'ビルドディレクトリへ書き込めるユーザーで bin/console eccube:cache:build を実行してください.'
+                .' 実行するまで Web サーバーはアプリケーションを起動できず, Web サーバーのユーザーで実行する'
+                .' bin/console も同じ理由で失敗します.',
+            ]);
+        }
+
         $unclearedPath = $this->runtimeCachePoolClearer->getUnclearedPath();
         if (null === $unclearedPath) {
             return;
         }
 
-        (new SymfonyStyle($event->getInput(), $event->getOutput()))->warning([
+        $io->warning([
             sprintf('%s を削除できないため, 実行時キャッシュに古い内容が残ります.', $unclearedPath),
             sprintf(
                 'Web サーバーのユーザーで bin/console cache:pool:clear --all または bin/console cache:pool:clear %s を実行するか, 管理画面のキャッシュ管理から削除してください.',
                 CacheUtil::DOCTRINE_APP_CACHE_KEY
             ),
         ]);
+    }
+
+    /**
+     * コンパイル済みコンテナが無く, かつ Web サーバーからは作り直せない状態か.
+     *
+     * 権限を分離していない構成では Web サーバー自身がコンテナを再生成できるため案内は不要.
+     * Web サーバーの実行ユーザーを特定できない場合も, 誤った警告を出さないよう黙る
+     * (判定材料が要るときは eccube:doctor:permissions が別途案内する).
+     */
+    private function needsManualRebuild(): bool
+    {
+        if (is_file(rtrim($this->buildDir, '/').'/'.$this->containerClass.'.php')) {
+            return false;
+        }
+
+        $webServerUser = $this->webServerUserResolver->resolve();
+        if (null === $webServerUser) {
+            return false;
+        }
+
+        // Kernel::buildContainer() は cache と build の双方へ書き込めることを要求する.
+        foreach ([$this->cacheDir, $this->buildDir] as $dir) {
+            if (!PathOwnership::of($dir)->isWritableBy($webServerUser)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Eccube/EventListener/RuntimeCachePoolClearListener.php
+++ b/src/Eccube/EventListener/RuntimeCachePoolClearListener.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\EventListener;
+
+use Eccube\Util\CacheUtil;
+use Eccube\Util\RuntimeCachePoolClearer;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * cache:clear が実行時 cache pool を削除できなかったことを通知する.
+ *
+ * 権限を分離した構成では, cache:clear をレーン S の所有者 (CLI ユーザー) で実行すると
+ * ビルド生成物は削除できる一方, レーン W のランタイムディレクトリにある cache pool は削除できない.
+ * RuntimeCachePoolClearer はここで例外を投げると cache:clear 全体が失敗するため中断しないが,
+ * そのままでは "Cache was successfully cleared" と表示され, 消えていないことが利用者に伝わらない.
+ *
+ * eccube:cache:build や eccube:page:apply とは異なり, 終了コードは変更しない.
+ * cache:clear は composer.json の auto-scripts (cache:clear --no-warmup) から実行され,
+ * 非ゼロを返すと composer install がスクリプト失敗として中断する (実測で [KO] になる).
+ * cache:clear 自体が担うビルド生成物の削除は成功しているため, 残りの操作は警告で案内する.
+ */
+class RuntimeCachePoolClearListener implements EventSubscriberInterface
+{
+    public function __construct(private readonly RuntimeCachePoolClearer $runtimeCachePoolClearer)
+    {
+    }
+
+    #[\Override]
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ConsoleEvents::TERMINATE => ['onConsoleTerminate'],
+        ];
+    }
+
+    public function onConsoleTerminate(ConsoleTerminateEvent $event): void
+    {
+        if ('cache:clear' !== $event->getCommand()?->getName()) {
+            return;
+        }
+
+        // 本処理自体が失敗している場合は, そちらのエラーを埋もれさせないため何も表示しない.
+        if (0 !== $event->getExitCode()) {
+            return;
+        }
+
+        $unclearedPath = $this->runtimeCachePoolClearer->getUnclearedPath();
+        if (null === $unclearedPath) {
+            return;
+        }
+
+        (new SymfonyStyle($event->getInput(), $event->getOutput()))->warning([
+            sprintf('%s を削除できないため, 実行時キャッシュに古い内容が残ります.', $unclearedPath),
+            sprintf(
+                'Web サーバーのユーザーで bin/console cache:pool:clear --all または bin/console cache:pool:clear %s を実行するか, 管理画面のキャッシュ管理から削除してください.',
+                CacheUtil::DOCTRINE_APP_CACHE_KEY
+            ),
+        ]);
+    }
+}

--- a/src/Eccube/EventListener/RuntimeCachePoolClearListener.php
+++ b/src/Eccube/EventListener/RuntimeCachePoolClearListener.php
@@ -119,7 +119,12 @@ class RuntimeCachePoolClearListener implements EventSubscriberInterface
 
         // Kernel::buildContainer() は cache と build の双方へ書き込めることを要求する.
         foreach ([$this->cacheDir, $this->buildDir] as $dir) {
-            if (!PathOwnership::of($dir)->isWritableBy($webServerUser)) {
+            $ownership = PathOwnership::of($dir);
+            // isWritableBy() が見るのは対象自身のビットだけなので, 祖先の到達可否は別に確かめる.
+            if ($ownership->unreachableAncestorFor($webServerUser) instanceof PathOwnership) {
+                return true;
+            }
+            if (!$ownership->isWritableBy($webServerUser)) {
                 return true;
             }
         }

--- a/src/Eccube/Exception/ContentValidationException.php
+++ b/src/Eccube/Exception/ContentValidationException.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Exception;
+
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * コンテンツ操作の入力値が不正なときに送出する.
+ *
+ * 検証は管理画面と同じ FormType を submit して行うため, エラーの内容も管理画面と一致する.
+ */
+class ContentValidationException extends \RuntimeException
+{
+    /**
+     * @param list<string> $errors フィールド名付きのエラーメッセージ
+     */
+    public function __construct(private readonly array $errors, string $message = 'Validation failed.')
+    {
+        parent::__construct($message);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @param FormInterface<mixed> $form
+     */
+    public static function fromForm(FormInterface $form): self
+    {
+        $errors = [];
+        foreach ($form->getErrors(true) as $error) {
+            $origin = $error->getOrigin();
+            $name = $origin instanceof FormInterface ? $origin->getName() : '';
+            $errors[] = '' === $name || $form->getName() === $name
+                ? $error->getMessage()
+                : sprintf('%s: %s', $name, $error->getMessage());
+        }
+
+        return new self($errors);
+    }
+}

--- a/src/Eccube/Exception/ContentWriteException.php
+++ b/src/Eccube/Exception/ContentWriteException.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Exception;
+
+/**
+ * DB レコードと対になるテンプレートファイルの読み書きに失敗した.
+ *
+ * 権限を分離した構成では app/template を CLI ユーザーが所有し Web サーバーからは書き込めないため,
+ * 実行ユーザーを誤るとファイル操作だけが失敗する. 生の IOException を伝播させると呼び出し側で
+ * スタックトレースがそのまま表示され, 対処方法 (実行ユーザーの変更) が分からないため, 専用の
+ * 例外へ変換して案内できるようにする.
+ */
+class ContentWriteException extends \RuntimeException
+{
+    public function __construct(private readonly string $path, string $message, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+
+    /**
+     * 操作に失敗したファイルのパス.
+     */
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public static function forWrite(string $path, \Throwable $previous): self
+    {
+        return new self(
+            $path,
+            sprintf('%s へ書き込めません. 書き込み権限のあるユーザーで実行してください.', $path),
+            $previous
+        );
+    }
+
+    public static function forRemove(string $path, \Throwable $previous): self
+    {
+        return new self(
+            $path,
+            sprintf('%s を削除できません. 書き込み権限のあるユーザーで実行してください.', $path),
+            $previous
+        );
+    }
+}

--- a/src/Eccube/Form/Type/Admin/LogType.php
+++ b/src/Eccube/Form/Type/Admin/LogType.php
@@ -49,7 +49,7 @@ class LogType extends AbstractType
 
         // ログディレクトリが存在しない場合は作成（Monolog StreamHandlerと同様の実装）
         if (!is_dir($dirs)) {
-            mkdir($dirs, 0777, true);
+            mkdir($dirs, 0755, true);
         }
 
         foreach ($finder->in($dirs) as $file) {

--- a/src/Eccube/Form/Type/Admin/LogType.php
+++ b/src/Eccube/Form/Type/Admin/LogType.php
@@ -48,8 +48,11 @@ class LogType extends AbstractType
         $dirs = $this->kernel->getLogDir().DIRECTORY_SEPARATOR.$this->kernel->getEnvironment();
 
         // ログディレクトリが存在しない場合は作成（Monolog StreamHandlerと同様の実装）
+        // モードを 0777 のままにするのは, 実効値を ECCUBE_UMASK に委ねるため.
+        // 0755 を直接指定すると ECCUBE_UMASK=0000 を設定しても 0777 にならず,
+        // Web サーバーと CLI が別ユーザーで同じログへ書き込む構成が成立しなくなる.
         if (!is_dir($dirs)) {
-            mkdir($dirs, 0755, true);
+            mkdir($dirs, 0777, true);
         }
 
         foreach ($finder->in($dirs) as $file) {

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -17,6 +17,7 @@ use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappi
 use Eccube\Common\EccubeNav;
 use Eccube\Common\EccubeTwigBlock;
 use Eccube\DependencyInjection\Compiler\AutoConfigurationTagPass;
+use Eccube\DependencyInjection\Compiler\BuildDirCacheWarmerPass;
 use Eccube\DependencyInjection\Compiler\McpAuditLoggerChannelLockPass;
 use Eccube\DependencyInjection\Compiler\McpCliCommandPass;
 use Eccube\DependencyInjection\Compiler\McpScopeEnforcementPass;
@@ -25,6 +26,7 @@ use Eccube\DependencyInjection\Compiler\PaymentMethodPass;
 use Eccube\DependencyInjection\Compiler\PluginPass;
 use Eccube\DependencyInjection\Compiler\PurchaseFlowPass;
 use Eccube\DependencyInjection\Compiler\QueryCustomizerPass;
+use Eccube\DependencyInjection\Compiler\RuntimeCacheDirPass;
 use Eccube\DependencyInjection\Compiler\StripAutoMappedEntityPathsPass;
 use Eccube\DependencyInjection\Compiler\StripReportFieldsArgPass;
 use Eccube\DependencyInjection\Compiler\TwigBlockPass;
@@ -70,10 +72,51 @@ class Kernel extends BaseKernel
         $this->loadEntityProxies();
     }
 
+    /**
+     * ビルド時にのみ書き込まれるディレクトリ.
+     *
+     * getBuildDir() と別パスであることが, twig の 3 層キャッシュ
+     * (readonly_cache + runtime_cache) が有効になる条件のため, 統合してはならない.
+     * see TwigExtension::load() の `$cacheDir === $buildDir` 判定.
+     */
     #[\Override]
     public function getCacheDir(): string
     {
         return $this->getProjectDir().'/var/cache/'.$this->environment;
+    }
+
+    /**
+     * コンパイル済みコンテナ・ルーティング・メタデータ・twig(prod) の出力先.
+     *
+     * getCacheDir() と分離することで, Web サーバーからは読み取り専用で運用できる.
+     * 生成は eccube:cache:build (CLI) が行う.
+     */
+    #[\Override]
+    public function getBuildDir(): string
+    {
+        return $this->getProjectDir().'/var/build/'.$this->environment;
+    }
+
+    /**
+     * リクエスト処理中に Web サーバーが書き込むディレクトリ.
+     *
+     * cache pool・翻訳・htmlpurifier・twig のランタイムキャッシュ等,
+     * 実行時に生成されるものはすべてここへ集約する.
+     * getCacheDir() / getBuildDir() を Web サーバーから書けない構成にするための受け皿.
+     */
+    public function getRuntimeDir(): string
+    {
+        return $this->getProjectDir().'/var/runtime/'.$this->environment;
+    }
+
+    /**
+     * HttpCache のストア (share_dir/http_cache) はリクエスト処理中に書き込まれるため,
+     * ランタイムディレクトリへ向ける.
+     */
+    #[\Override]
+    public function getShareDir(): ?string
+    {
+        return $this->getRuntimeDir();
     }
 
     #[\Override]
@@ -252,6 +295,12 @@ class Kernel extends BaseKernel
 
         // twigのurl,path関数を差し替え
         $container->addCompilerPass(new TwigExtensionPass());
+
+        // リクエスト処理中に書き込まれるキャッシュを %eccube_runtime_dir% へ寄せる.
+        $container->addCompilerPass(new RuntimeCacheDirPass());
+
+        // 自動 warmup をビルドディレクトリへ書くものだけに絞る.
+        $container->addCompilerPass(new BuildDirCacheWarmerPass());
 
         // クエリカスタマイズの拡張.
         $container->registerForAutoconfiguration(QueryCustomizer::class)

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -18,6 +18,7 @@ use Eccube\Common\EccubeNav;
 use Eccube\Common\EccubeTwigBlock;
 use Eccube\DependencyInjection\Compiler\AutoConfigurationTagPass;
 use Eccube\DependencyInjection\Compiler\BuildDirCacheWarmerPass;
+use Eccube\DependencyInjection\Compiler\CliFileLogHandlerPass;
 use Eccube\DependencyInjection\Compiler\McpAuditLoggerChannelLockPass;
 use Eccube\DependencyInjection\Compiler\McpCliCommandPass;
 use Eccube\DependencyInjection\Compiler\McpScopeEnforcementPass;
@@ -301,6 +302,9 @@ class Kernel extends BaseKernel
 
         // 自動 warmup をビルドディレクトリへ書くものだけに絞る.
         $container->addCompilerPass(new BuildDirCacheWarmerPass());
+
+        // CLI からファイルへログを書けない構成 (var/log が Web サーバー所有) に対応する.
+        $container->addCompilerPass(new CliFileLogHandlerPass());
 
         // クエリカスタマイズの拡張.
         $container->registerForAutoconfiguration(QueryCustomizer::class)

--- a/src/Eccube/Kernel.php
+++ b/src/Eccube/Kernel.php
@@ -28,6 +28,7 @@ use Eccube\DependencyInjection\Compiler\PluginPass;
 use Eccube\DependencyInjection\Compiler\PurchaseFlowPass;
 use Eccube\DependencyInjection\Compiler\QueryCustomizerPass;
 use Eccube\DependencyInjection\Compiler\RuntimeCacheDirPass;
+use Eccube\DependencyInjection\Compiler\RuntimeCachePoolFailsafePass;
 use Eccube\DependencyInjection\Compiler\StripAutoMappedEntityPathsPass;
 use Eccube\DependencyInjection\Compiler\StripReportFieldsArgPass;
 use Eccube\DependencyInjection\Compiler\TwigBlockPass;
@@ -305,6 +306,9 @@ class Kernel extends BaseKernel
 
         // CLI からファイルへログを書けない構成 (var/log が Web サーバー所有) に対応する.
         $container->addCompilerPass(new CliFileLogHandlerPass());
+
+        // 書き込めない実行時キャッシュ (var/runtime が Web サーバー所有) に対応する.
+        $container->addCompilerPass(new RuntimeCachePoolFailsafePass());
 
         // クエリカスタマイズの拡張.
         $container->registerForAutoconfiguration(QueryCustomizer::class)

--- a/src/Eccube/Log/CliSuppressibleHandler.php
+++ b/src/Eccube/Log/CliSuppressibleHandler.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Log;
+
+use Monolog\Handler\HandlerInterface;
+use Monolog\Handler\HandlerWrapper;
+use Monolog\LogRecord;
+
+/**
+ * CLI 実行時にファイルへの書き込みを抑止するハンドラ.
+ *
+ * Web サーバーと CLI で書き込み権限を分離すると, var/log は Web サーバー所有 (レーン W) に
+ * なるため CLI からは書き込めない. ログの出力に失敗すると本来のエラーがログ書き込みエラーへ
+ * すり替わり, 原因の特定が難しくなる.
+ *
+ * 本ハンドラは委譲先を呼ばないことで, ファイルのオープン (ディレクトリの作成を含む) 自体を
+ * 発生させない. Monolog のストリームは書き込み時に遅延オープンされるため, handle() を
+ * 通さなければ権限エラーは起きない.
+ *
+ * CLI のログはコンソールハンドラ (標準出力) へ出るため, cron 等で記録を残す場合は
+ * リダイレクトする.
+ *
+ * @see \Eccube\DependencyInjection\Compiler\CliFileLogHandlerPass 適用箇所
+ */
+class CliSuppressibleHandler extends HandlerWrapper
+{
+    private readonly bool $enabled;
+
+    /**
+     * @param bool $logToFileInCli CLI 実行時もファイルへ書き込むか (ECCUBE_CLI_LOG_TO_FILE)
+     */
+    public function __construct(HandlerInterface $handler, bool $logToFileInCli)
+    {
+        parent::__construct($handler);
+
+        $this->enabled = $logToFileInCli || \PHP_SAPI !== 'cli';
+    }
+
+    #[\Override]
+    public function isHandling(LogRecord $record): bool
+    {
+        return $this->enabled && parent::isHandling($record);
+    }
+
+    #[\Override]
+    public function handle(LogRecord $record): bool
+    {
+        return $this->enabled && parent::handle($record);
+    }
+
+    /**
+     * @param array<int, LogRecord> $records
+     */
+    #[\Override]
+    public function handleBatch(array $records): void
+    {
+        if ($this->enabled) {
+            parent::handleBatch($records);
+        }
+    }
+}

--- a/src/Eccube/Resource/functions/env.php
+++ b/src/Eccube/Resource/functions/env.php
@@ -39,6 +39,35 @@ function boot_env(string $path, bool $overrideExistingVars = false): void
 }
 
 /**
+ * ECCUBE_UMASK が設定されている場合に umask を適用する.
+ *
+ * umask はコンテナを生成するより前に決める必要があるため, コンテナのパラメータではなく
+ * 環境変数から読み込む (app/config/eccube/packages/eccube.yaml の eccube_umask で既定値を宣言している).
+ *
+ * 未設定の場合は OS / PHP-FPM の既定 umask に従う. Web サーバーと CLI が別ユーザーで,
+ * かつ双方が同じファイルへ書き込む必要がある環境では '0000' を設定すると, 生成される
+ * ディレクトリが 0777, ファイルが 0666 になり相互に書き込めるようになる (4.3 以前の既定).
+ * ただし同一サーバーの他ユーザーからも書き換え可能になるため, 権限を分離できる環境では
+ * 設定しないこと.
+ *
+ * 値は 8 進数表記の文字列 (例: '0022', '0000'). 解釈できない値は無視する.
+ */
+function apply_umask(): void
+{
+    $value = env('ECCUBE_UMASK');
+    if ($value === null || $value === '') {
+        return;
+    }
+
+    $value = (string) $value;
+    if (!preg_match('/\A0?[0-7]{1,4}\z/', $value)) {
+        return;
+    }
+
+    umask((int) octdec($value));
+}
+
+/**
  * Gets the value of an environment variable. Supports boolean, null and empty values.
  *
  * Symfony Dotenv は putenv() をデフォルトで使用しないため（スレッドセーフではないため）、

--- a/src/Eccube/Resource/locale/messages.en.yaml
+++ b/src/Eccube/Resource/locale/messages.en.yaml
@@ -1177,6 +1177,7 @@ admin.content.block_source_code: Codes
 admin.content.cache__card_title: Caches
 admin.content.cache_message: If you replaced the Twig file on the production server with FTP etc, the UI will not be updated unless you delete the Twig cache.
 admin.content.cache_delete: Delete Cache
+admin.content.cache_build_dir_not_writable: Only the runtime cache was deleted. Run "bin/console eccube:cache:build" from the CLI to rebuild the compiled container and templates.
 admin.content.news.publish_date: Published on
 admin.content.news.display_status: Display Status
 admin.content.news.display_status__show: Displayed

--- a/src/Eccube/Resource/locale/messages.ja.yaml
+++ b/src/Eccube/Resource/locale/messages.ja.yaml
@@ -1176,6 +1176,7 @@ admin.content.block_source_code: コード
 admin.content.cache__card_title: キャッシュ管理
 admin.content.cache_message: 本番環境にFTPなどでTwigファイルをアップロードして入れ替えた場合、画面を反映させるにはTwigキャッシュを削除する必要があります。
 admin.content.cache_delete: キャッシュ削除
+admin.content.cache_build_dir_not_writable: 実行時キャッシュのみ削除しました。コンパイル済みコンテナとテンプレートを更新するには、CLI で bin/console eccube:cache:build を実行してください。
 admin.content.news.publish_date: 公開日時
 admin.content.news.display_status: 公開状態
 admin.content.news.display_status__show: 公開

--- a/src/Eccube/Service/AgentCommerce/Catalog/Ucp/UcpCatalogCache.php
+++ b/src/Eccube/Service/AgentCommerce/Catalog/Ucp/UcpCatalogCache.php
@@ -23,7 +23,7 @@ use Symfony\Component\Lock\LockFactory;
  *
  * UCP Catalog は POST RPC のため ETag は使えず、リクエストボディの hash をキャッシュキー
  * とする。共有レンサバ前提のため symfony/cache の FilesystemAdapter を既定とする
- * (var/cache/<env>/agent-commerce/catalog 配下)。
+ * (var/runtime/<env>/agent-commerce/catalog 配下)。
  *
  * キャッシュミス時の再生成スタンピードを防ぐため symfony/lock の LockFactory で
  * 鍵ごとに排他し、ロック取得失敗時はブロックして待機する (取得後に再度キャッシュ確認)。

--- a/src/Eccube/Service/Content/BlockContentService.php
+++ b/src/Eccube/Service/Content/BlockContentService.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Content;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Common\EccubeConfig;
+use Eccube\Entity\Block;
+use Eccube\Entity\Master\DeviceType;
+use Eccube\Exception\ContentValidationException;
+use Eccube\Form\Type\Admin\BlockType;
+use Eccube\Repository\BlockRepository;
+use Eccube\Repository\Master\DeviceTypeRepository;
+use Eccube\Util\StringUtil;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Form\FormFactoryInterface;
+use Twig\Environment;
+use Twig\Error\LoaderError;
+
+/**
+ * ブロック (dtb_block と app/template/{theme}/Block 配下の twig) を対で扱う.
+ *
+ * 管理画面 (BlockController) と CLI (eccube:block:*) の双方から使用する.
+ */
+class BlockContentService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly BlockRepository $blockRepository,
+        private readonly DeviceTypeRepository $deviceTypeRepository,
+        private readonly FormFactoryInterface $formFactory,
+        private readonly Environment $twig,
+        private readonly Filesystem $filesystem,
+        private readonly EccubeConfig $eccubeConfig,
+    ) {
+    }
+
+    public function getTemplateDir(): string
+    {
+        return $this->eccubeConfig->get('eccube_theme_front_dir').'/Block';
+    }
+
+    public function getFilePath(Block $Block): string
+    {
+        return $this->getTemplateDir().'/'.$Block->getFileName().'.twig';
+    }
+
+    public function findByFileName(string $fileName, DeviceType $DeviceType): ?Block
+    {
+        return $this->blockRepository->findOneBy([
+            'file_name' => $fileName,
+            'DeviceType' => $DeviceType,
+        ]);
+    }
+
+    public function getDeviceType(int $id = DeviceType::DEVICE_TYPE_PC): DeviceType
+    {
+        $DeviceType = $this->deviceTypeRepository->find($id);
+        if (null === $DeviceType) {
+            throw new \InvalidArgumentException(sprintf('DeviceType "%d" is not found.', $id));
+        }
+
+        return $DeviceType;
+    }
+
+    /**
+     * テンプレートの本文を取得する.
+     *
+     * 書き込み先のファイルがあればそれを読み, 無い場合は twig のローダ経由で
+     * コアのテンプレートへフォールバックする (PageContentService::readTemplate と同じ理由).
+     */
+    public function readTemplate(Block $Block): string
+    {
+        $filePath = $this->getFilePath($Block);
+        if (is_file($filePath)) {
+            return (string) file_get_contents($filePath);
+        }
+
+        try {
+            return $this->twig->getLoader()
+                ->getSourceContext('Block/'.$Block->getFileName().'.twig')
+                ->getCode();
+        } catch (LoaderError) {
+            return '';
+        }
+    }
+
+    /**
+     * ファイル名を鍵にブロックを登録・更新する (upsert).
+     *
+     * @param array{file_name: string, name?: string, body?: string, device_type?: int} $payload
+     *
+     * @throws ContentValidationException  入力値が不正な場合
+     * @throws \InvalidArgumentException   デバイス種別が存在しない場合
+     */
+    public function apply(array $payload, bool $dryRun = false): ContentResult
+    {
+        $fileName = $payload['file_name'];
+        $DeviceType = $this->getDeviceType($payload['device_type'] ?? DeviceType::DEVICE_TYPE_PC);
+
+        $Block = $this->findByFileName($fileName, $DeviceType);
+        $isNew = null === $Block;
+        if (null === $Block) {
+            $Block = $this->blockRepository->newBlock($DeviceType);
+        }
+
+        // 新規登録時は比較対象が無い (未設定のゲッタは null を返すため呼び出さない)
+        $before = $isNew ? [] : $this->snapshot($Block);
+        $beforeBody = $isNew ? '' : StringUtil::convertLineFeed($this->readTemplate($Block));
+
+        $data = [
+            'file_name' => $fileName,
+            'block_html' => $payload['body'] ?? $beforeBody,
+            'DeviceType' => (string) $DeviceType->getId(),
+        ];
+        if (array_key_exists('name', $payload)) {
+            $data['name'] = (string) $payload['name'];
+        }
+        if (!$isNew) {
+            $data['id'] = (string) $Block->getId();
+        }
+
+        $form = $this->formFactory->create(BlockType::class, $Block, ['csrf_protection' => false]);
+        $form->submit($data, false);
+
+        if (!$form->isValid()) {
+            throw ContentValidationException::fromForm($form);
+        }
+
+        $body = StringUtil::convertLineFeed((string) $form->get('block_html')->getData());
+        $fieldChanges = self::diffFields($before, $this->snapshot($Block));
+        $fileChanges = $beforeBody === $body ? [] : [$this->getFilePath($Block) => [$beforeBody, $body]];
+
+        if ($dryRun) {
+            if (!$isNew) {
+                $this->entityManager->refresh($Block);
+            }
+
+            return new ContentResult(
+                $isNew ? ContentStatus::Created : ([] === $fieldChanges && [] === $fileChanges ? ContentStatus::Unchanged : ContentStatus::Updated),
+                $Block->getId(),
+                $fileName,
+                [],
+                [],
+                $fieldChanges,
+                $fileChanges
+            );
+        }
+
+        if (!$isNew && [] === $fieldChanges && [] === $fileChanges) {
+            return new ContentResult(ContentStatus::Unchanged, $Block->getId(), $fileName);
+        }
+
+        return $this->save($Block, $body, null)->withChanges($fieldChanges, $fileChanges);
+    }
+
+    /**
+     * ブロックを永続化し, テンプレートファイルを書き出す.
+     */
+    public function save(Block $Block, string $body, ?string $previousFileName): ContentResult
+    {
+        $isNew = null === $Block->getId();
+
+        $this->entityManager->persist($Block);
+        $this->entityManager->flush();
+
+        $dir = $this->getTemplateDir();
+        $filePath = $dir.'/'.$Block->getFileName().'.twig';
+        $this->filesystem->dumpFile($filePath, StringUtil::convertLineFeed($body));
+
+        $removedPaths = [];
+        // 更新でファイル名を変更した場合, 以前のファイルを削除する
+        if (null !== $previousFileName && $Block->getFileName() !== $previousFileName) {
+            $oldFilePath = $dir.'/'.$previousFileName.'.twig';
+            if ($this->filesystem->exists($oldFilePath)) {
+                $this->filesystem->remove($oldFilePath);
+                $removedPaths[] = $oldFilePath;
+            }
+        }
+
+        return new ContentResult(
+            $isNew ? ContentStatus::Created : ContentStatus::Updated,
+            $Block->getId(),
+            $Block->getFileName(),
+            [$filePath],
+            $removedPaths
+        );
+    }
+
+    /**
+     * ブロックとテンプレートファイルを削除する.
+     *
+     * ユーザーが作成したブロック (deletable) のみ削除できる.
+     */
+    public function remove(Block $Block): ContentResult
+    {
+        if (!$Block->isDeletable()) {
+            throw new \LogicException(sprintf('Block "%s" is not removable.', $Block->getFileName()));
+        }
+
+        $id = $Block->getId();
+        $fileName = $Block->getFileName();
+        $filePath = $this->getFilePath($Block);
+
+        $removedPaths = [];
+        if ($this->filesystem->exists($filePath)) {
+            $this->filesystem->remove($filePath);
+            $removedPaths[] = $filePath;
+        }
+
+        $this->entityManager->remove($Block);
+        $this->entityManager->flush();
+
+        return new ContentResult(ContentStatus::Removed, $id, $fileName, [], $removedPaths);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function snapshot(Block $Block): array
+    {
+        return [
+            'name' => $Block->getName(),
+            'file_name' => $Block->getFileName(),
+        ];
+    }
+
+    /**
+     * @param array<string, string> $before
+     * @param array<string, string> $after
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    private static function diffFields(array $before, array $after): array
+    {
+        $changes = [];
+        foreach ($after as $field => $value) {
+            $previous = $before[$field] ?? '';
+            if ($previous !== $value) {
+                $changes[$field] = [$previous, $value];
+            }
+        }
+
+        return $changes;
+    }
+}

--- a/src/Eccube/Service/Content/BlockContentService.php
+++ b/src/Eccube/Service/Content/BlockContentService.php
@@ -20,10 +20,12 @@ use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Block;
 use Eccube\Entity\Master\DeviceType;
 use Eccube\Exception\ContentValidationException;
+use Eccube\Exception\ContentWriteException;
 use Eccube\Form\Type\Admin\BlockType;
 use Eccube\Repository\BlockRepository;
 use Eccube\Repository\Master\DeviceTypeRepository;
 use Eccube\Util\StringUtil;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Form\FormFactoryInterface;
 use Twig\Environment;
@@ -103,6 +105,7 @@ class BlockContentService
      * @param array{file_name: string, name?: string, body?: string, device_type?: int} $payload
      *
      * @throws ContentValidationException  入力値が不正な場合
+     * @throws ContentWriteException       テンプレートファイルを書き出せない場合
      * @throws \InvalidArgumentException   デバイス種別が存在しない場合
      */
     public function apply(array $payload, bool $dryRun = false): ContentResult
@@ -168,41 +171,62 @@ class BlockContentService
 
     /**
      * ブロックを永続化し, テンプレートファイルを書き出す.
+     *
+     * DB とファイルはトランザクションで対にする. 先にコミットするとテンプレートの書き出しに
+     * 失敗したときレコードだけが残り, そのブロックを配置したページの表示が 500 になる.
+     *
+     * @throws ContentWriteException テンプレートファイルを書き出せない場合
      */
     public function save(Block $Block, string $body, ?string $previousFileName): ContentResult
     {
         $isNew = null === $Block->getId();
 
-        $this->entityManager->persist($Block);
-        $this->entityManager->flush();
+        return $this->entityManager->wrapInTransaction(function () use ($Block, $body, $previousFileName, $isNew): ContentResult {
+            $this->entityManager->persist($Block);
+            $this->entityManager->flush();
 
-        $dir = $this->getTemplateDir();
-        $filePath = $dir.'/'.$Block->getFileName().'.twig';
-        $this->filesystem->dumpFile($filePath, StringUtil::convertLineFeed($body));
+            $dir = $this->getTemplateDir();
+            $filePath = $dir.'/'.$Block->getFileName().'.twig';
 
-        $removedPaths = [];
-        // 更新でファイル名を変更した場合, 以前のファイルを削除する
-        if (null !== $previousFileName && $Block->getFileName() !== $previousFileName) {
-            $oldFilePath = $dir.'/'.$previousFileName.'.twig';
-            if ($this->filesystem->exists($oldFilePath)) {
-                $this->filesystem->remove($oldFilePath);
-                $removedPaths[] = $oldFilePath;
+            try {
+                $this->filesystem->dumpFile($filePath, StringUtil::convertLineFeed($body));
+            } catch (IOException $e) {
+                throw ContentWriteException::forWrite($filePath, $e);
             }
-        }
 
-        return new ContentResult(
-            $isNew ? ContentStatus::Created : ContentStatus::Updated,
-            $Block->getId(),
-            $Block->getFileName(),
-            [$filePath],
-            $removedPaths
-        );
+            $removedPaths = [];
+            // 更新でファイル名を変更した場合, 以前のファイルを削除する
+            if (null !== $previousFileName && $Block->getFileName() !== $previousFileName) {
+                $oldFilePath = $dir.'/'.$previousFileName.'.twig';
+                if ($this->filesystem->exists($oldFilePath)) {
+                    try {
+                        $this->filesystem->remove($oldFilePath);
+                    } catch (IOException $e) {
+                        throw ContentWriteException::forRemove($oldFilePath, $e);
+                    }
+                    $removedPaths[] = $oldFilePath;
+                }
+            }
+
+            return new ContentResult(
+                $isNew ? ContentStatus::Created : ContentStatus::Updated,
+                $Block->getId(),
+                $Block->getFileName(),
+                [$filePath],
+                $removedPaths
+            );
+        });
     }
 
     /**
      * ブロックとテンプレートファイルを削除する.
      *
      * ユーザーが作成したブロック (deletable) のみ削除できる.
+     *
+     * ファイルを先に削除する. 削除に失敗した場合は DB を更新せずに中断するため,
+     * レコードとファイルの対は保たれる.
+     *
+     * @throws ContentWriteException テンプレートファイルを削除できない場合
      */
     public function remove(Block $Block): ContentResult
     {
@@ -216,7 +240,11 @@ class BlockContentService
 
         $removedPaths = [];
         if ($this->filesystem->exists($filePath)) {
-            $this->filesystem->remove($filePath);
+            try {
+                $this->filesystem->remove($filePath);
+            } catch (IOException $e) {
+                throw ContentWriteException::forRemove($filePath, $e);
+            }
             $removedPaths[] = $filePath;
         }
 

--- a/src/Eccube/Service/Content/ContentResult.php
+++ b/src/Eccube/Service/Content/ContentResult.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Content;
+
+/**
+ * コンテンツ操作 (DB レコード + twig ファイル) の結果.
+ *
+ * --dry-run と --format=json の出力源を兼ねるため, 変更内容は
+ * フィールド単位 ($fieldChanges) とファイル単位 ($fileChanges) に分けて保持する.
+ */
+final readonly class ContentResult
+{
+    /**
+     * @param list<string>                            $writtenPaths 書き込んだファイル
+     * @param list<string>                            $removedPaths 削除したファイル
+     * @param array<string, array{0: string, 1: string}> $fieldChanges フィールド名 => [変更前, 変更後]
+     * @param array<string, array{0: string, 1: string}> $fileChanges  ファイルパス => [変更前, 変更後]
+     */
+    public function __construct(
+        public ContentStatus $status,
+        public ?int $id,
+        public string $identifier,
+        public array $writtenPaths = [],
+        public array $removedPaths = [],
+        public array $fieldChanges = [],
+        public array $fileChanges = [],
+    ) {
+    }
+
+    /**
+     * @param array<string, array{0: string, 1: string}> $fieldChanges
+     * @param array<string, array{0: string, 1: string}> $fileChanges
+     */
+    public function withChanges(array $fieldChanges, array $fileChanges): self
+    {
+        return new self(
+            $this->status,
+            $this->id,
+            $this->identifier,
+            $this->writtenPaths,
+            $this->removedPaths,
+            $fieldChanges,
+            $fileChanges
+        );
+    }
+
+    public function path(): ?string
+    {
+        return $this->writtenPaths[0] ?? null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status->value,
+            'id' => $this->id,
+            'identifier' => $this->identifier,
+            'written_paths' => $this->writtenPaths,
+            'removed_paths' => $this->removedPaths,
+            'field_changes' => $this->fieldChanges,
+            'file_changes' => array_keys($this->fileChanges),
+        ];
+    }
+}

--- a/src/Eccube/Service/Content/ContentStatus.php
+++ b/src/Eccube/Service/Content/ContentStatus.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Content;
+
+/**
+ * コンテンツ操作の結果種別.
+ *
+ * apply() は冪等に設計しているため, 同じ入力を複数回適用したときは Unchanged になる.
+ */
+enum ContentStatus: string
+{
+    case Created = 'created';
+    case Updated = 'updated';
+    case Unchanged = 'unchanged';
+    case Removed = 'removed';
+}

--- a/src/Eccube/Service/Content/MailTemplateContentService.php
+++ b/src/Eccube/Service/Content/MailTemplateContentService.php
@@ -1,0 +1,328 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Content;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Common\EccubeConfig;
+use Eccube\Entity\MailTemplate;
+use Eccube\Exception\ContentValidationException;
+use Eccube\Form\Type\Admin\MailType;
+use Eccube\Repository\MailTemplateRepository;
+use Eccube\Util\StringUtil;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Form\FormFactoryInterface;
+use Twig\Environment;
+use Twig\Error\LoaderError;
+
+/**
+ * メールテンプレート (dtb_mail_template と app/template/{theme}/Mail 配下の twig) を対で扱う.
+ *
+ * 管理画面 (MailController) と CLI (eccube:mail-template:*) の双方から使用する.
+ * dtb_mail_template.file_name は "Mail/xxx.twig" 形式で保持する.
+ */
+class MailTemplateContentService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MailTemplateRepository $mailTemplateRepository,
+        private readonly FormFactoryInterface $formFactory,
+        private readonly Environment $twig,
+        private readonly Filesystem $filesystem,
+        private readonly EccubeConfig $eccubeConfig,
+    ) {
+    }
+
+    public function getTemplateDir(): string
+    {
+        return (string) $this->eccubeConfig->get('eccube_theme_front_dir');
+    }
+
+    public function getFilePath(MailTemplate $Mail): string
+    {
+        return $this->getTemplateDir().'/'.$Mail->getFileName();
+    }
+
+    public function getHtmlFilePath(MailTemplate $Mail): string
+    {
+        return $this->getTemplateDir().'/'.$this->getHtmlFileName((string) $Mail->getFileName());
+    }
+
+    /**
+     * HTML 用テンプレート名を取得する.
+     */
+    public function getHtmlFileName(string $fileName): string
+    {
+        $targetTemplate = pathinfo($fileName);
+        $suffix = '.html';
+
+        return $targetTemplate['dirname'].DIRECTORY_SEPARATOR.$targetTemplate['filename'].$suffix.'.'.$targetTemplate['extension'];
+    }
+
+    /**
+     * テンプレートディレクトリ配下のパスかどうかを検証する.
+     */
+    public function isInsideTemplateDir(string $path): bool
+    {
+        $templatePath = realpath($this->getTemplateDir());
+        $path = realpath($path);
+
+        return false !== $path && false !== $templatePath && str_starts_with($path, $templatePath);
+    }
+
+    /**
+     * "xxx" / "Mail/xxx.twig" のいずれの表記でもテンプレートを取得する.
+     */
+    public function findByFileName(string $fileName): ?MailTemplate
+    {
+        return $this->mailTemplateRepository->findOneBy(['file_name' => $this->normalizeFileName($fileName)]);
+    }
+
+    public function normalizeFileName(string $fileName): string
+    {
+        return str_contains($fileName, '/') ? $fileName : 'Mail/'.$fileName.'.twig';
+    }
+
+    public function readTemplate(MailTemplate $Mail): string
+    {
+        return (string) $this->read($this->getFilePath($Mail), (string) $Mail->getFileName());
+    }
+
+    /**
+     * HTML パートの本文を取得する. HTML パートが無い場合は null を返す.
+     */
+    public function readHtmlTemplate(MailTemplate $Mail): ?string
+    {
+        return $this->read($this->getHtmlFilePath($Mail), $this->getHtmlFileName((string) $Mail->getFileName()));
+    }
+
+    /**
+     * ファイル名または ID を鍵にメールテンプレートを登録・更新する (upsert).
+     *
+     * @param array{file_name?: string, id?: int, name?: string, subject?: string, body?: string, html_body?: string, remove_html?: bool} $payload
+     *
+     * @throws ContentValidationException
+     */
+    public function apply(array $payload, bool $dryRun = false): ContentResult
+    {
+        $Mail = $this->resolveTarget($payload);
+        $isNew = null === $Mail;
+        if (null === $Mail) {
+            $Mail = new MailTemplate();
+            // 管理画面から登録したテンプレートと同様に削除可能にする
+            $Mail->setDeletable(true);
+        }
+
+        // 新規登録時は比較対象が無い (未設定のゲッタは null を返すため呼び出さない)
+        $before = $isNew ? [] : $this->snapshot($Mail);
+        $beforeBody = $isNew ? '' : StringUtil::convertLineFeed($this->readTemplate($Mail));
+        $beforeHtmlBody = $isNew ? null : $this->readHtmlTemplate($Mail);
+
+        $removeHtml = (bool) ($payload['remove_html'] ?? false);
+        $htmlBody = $removeHtml ? null : ($payload['html_body'] ?? $beforeHtmlBody);
+
+        $data = [
+            'tpl_data' => $payload['body'] ?? $beforeBody,
+            // 空の HTML 本文は「HTML パートなし」として扱う (管理画面と同じ)
+            'html_tpl_data' => $htmlBody,
+        ];
+        foreach (['name' => 'name', 'subject' => 'mail_subject'] as $key => $field) {
+            if (array_key_exists($key, $payload)) {
+                $data[$field] = (string) $payload[$key];
+            }
+        }
+        if ($isNew && isset($payload['file_name'])) {
+            // 新規登録時のみファイル名を指定できる (MailType が Mail/xxx.twig へ変換する)
+            $data['file_name'] = $this->toBaseName($payload['file_name']);
+        }
+
+        $form = $this->formFactory->create(MailType::class, $Mail, ['csrf_protection' => false]);
+        $form->submit($data, false);
+
+        if (!$form->isValid()) {
+            throw ContentValidationException::fromForm($form);
+        }
+
+        $body = StringUtil::convertLineFeed((string) $form->get('tpl_data')->getData());
+        $newHtmlBody = $form->get('html_tpl_data')->getData();
+        $newHtmlBody = null === $newHtmlBody ? null : StringUtil::convertLineFeed((string) $newHtmlBody);
+
+        $fieldChanges = self::diffFields($before, $this->snapshot($Mail));
+        $fileChanges = [];
+        if ($beforeBody !== $body) {
+            $fileChanges[$this->getFilePath($Mail)] = [$beforeBody, $body];
+        }
+        if ($beforeHtmlBody !== $newHtmlBody) {
+            $fileChanges[$this->getHtmlFilePath($Mail)] = [(string) $beforeHtmlBody, (string) $newHtmlBody];
+        }
+
+        if ($dryRun) {
+            if (!$isNew) {
+                $this->entityManager->refresh($Mail);
+            }
+
+            return new ContentResult(
+                $isNew ? ContentStatus::Created : ([] === $fieldChanges && [] === $fileChanges ? ContentStatus::Unchanged : ContentStatus::Updated),
+                $Mail->getId(),
+                (string) $Mail->getFileName(),
+                [],
+                [],
+                $fieldChanges,
+                $fileChanges
+            );
+        }
+
+        if (!$isNew && [] === $fieldChanges && [] === $fileChanges) {
+            return new ContentResult(ContentStatus::Unchanged, $Mail->getId(), (string) $Mail->getFileName());
+        }
+
+        return $this->save($Mail, $body, $newHtmlBody)->withChanges($fieldChanges, $fileChanges);
+    }
+
+    /**
+     * メールテンプレートを永続化し, テンプレートファイルを書き出す.
+     *
+     * $htmlBody に null を渡すと HTML パートのファイルを削除する (管理画面と同じ挙動).
+     */
+    public function save(MailTemplate $Mail, string $body, ?string $htmlBody): ContentResult
+    {
+        $isNew = null === $Mail->getId();
+
+        $this->entityManager->persist($Mail);
+        $this->entityManager->flush();
+
+        $filePath = $this->getFilePath($Mail);
+        $this->filesystem->dumpFile($filePath, StringUtil::convertLineFeed($body));
+
+        $writtenPaths = [$filePath];
+        $removedPaths = [];
+        $htmlFilePath = $this->getHtmlFilePath($Mail);
+
+        if (null !== $htmlBody) {
+            $this->filesystem->dumpFile($htmlFilePath, StringUtil::convertLineFeed($htmlBody));
+            $writtenPaths[] = $htmlFilePath;
+        } elseif ($this->isInsideTemplateDir($htmlFilePath) && is_file($htmlFilePath)) {
+            $this->filesystem->remove($htmlFilePath);
+            $removedPaths[] = $htmlFilePath;
+        }
+
+        return new ContentResult(
+            $isNew ? ContentStatus::Created : ContentStatus::Updated,
+            $Mail->getId(),
+            (string) $Mail->getFileName(),
+            $writtenPaths,
+            $removedPaths
+        );
+    }
+
+    /**
+     * メールテンプレートとテンプレートファイルを削除する.
+     */
+    public function remove(MailTemplate $Mail): ContentResult
+    {
+        if (!$Mail->isDeletable()) {
+            throw new \LogicException(sprintf('MailTemplate "%s" is not removable.', (string) $Mail->getFileName()));
+        }
+
+        $id = $Mail->getId();
+        $fileName = (string) $Mail->getFileName();
+        $filePath = $this->getFilePath($Mail);
+        $htmlFilePath = $this->getHtmlFilePath($Mail);
+
+        $this->entityManager->remove($Mail);
+        $this->entityManager->flush();
+
+        $removedPaths = [];
+        foreach ([$filePath, $htmlFilePath] as $path) {
+            if ($this->isInsideTemplateDir($path) && is_file($path)) {
+                $this->filesystem->remove($path);
+                $removedPaths[] = $path;
+            }
+        }
+
+        return new ContentResult(ContentStatus::Removed, $id, $fileName, [], $removedPaths);
+    }
+
+    /**
+     * @param array{file_name?: string, id?: int} $payload
+     */
+    private function resolveTarget(array $payload): ?MailTemplate
+    {
+        if (isset($payload['id'])) {
+            return $this->mailTemplateRepository->find($payload['id']);
+        }
+
+        return isset($payload['file_name']) ? $this->findByFileName($payload['file_name']) : null;
+    }
+
+    /**
+     * 書き込み先のファイルがあればそれを読み, 無い場合は twig のローダ経由で
+     * コアのテンプレートへフォールバックする.
+     *
+     * twig のローダはテンプレートの探索結果をプロセス内でキャッシュするため,
+     * 直前に書き出したファイルを読み落とさないようファイルを優先する.
+     */
+    private function read(string $filePath, string $twigName): ?string
+    {
+        if (is_file($filePath)) {
+            return (string) file_get_contents($filePath);
+        }
+
+        try {
+            return $this->twig->getLoader()->getSourceContext($twigName)->getCode();
+        } catch (LoaderError) {
+            return null;
+        }
+    }
+
+    /**
+     * "Mail/xxx.twig" 形式で渡された場合に基底名 (xxx) を返す.
+     */
+    private function toBaseName(string $fileName): string
+    {
+        return str_contains($fileName, '/') ? pathinfo($fileName, PATHINFO_FILENAME) : $fileName;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function snapshot(MailTemplate $Mail): array
+    {
+        return [
+            'name' => (string) $Mail->getName(),
+            'file_name' => (string) $Mail->getFileName(),
+            'mail_subject' => (string) $Mail->getMailSubject(),
+        ];
+    }
+
+    /**
+     * @param array<string, string> $before
+     * @param array<string, string> $after
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    private static function diffFields(array $before, array $after): array
+    {
+        $changes = [];
+        foreach ($after as $field => $value) {
+            $previous = $before[$field] ?? '';
+            if ($previous !== $value) {
+                $changes[$field] = [$previous, $value];
+            }
+        }
+
+        return $changes;
+    }
+}

--- a/src/Eccube/Service/Content/MailTemplateContentService.php
+++ b/src/Eccube/Service/Content/MailTemplateContentService.php
@@ -131,7 +131,9 @@ class MailTemplateContentService
         // 新規登録時は比較対象が無い (未設定のゲッタは null を返すため呼び出さない)
         $before = $isNew ? [] : $this->snapshot($Mail);
         $beforeBody = $isNew ? '' : StringUtil::convertLineFeed($this->readTemplate($Mail));
-        $beforeHtmlBody = $isNew ? null : $this->readHtmlTemplate($Mail);
+        // 比較相手 ($newHtmlBody) は正規化されるため, ここでも揃えないと
+        // CRLF のファイルが毎回 Updated になり apply() の冪等性が壊れる.
+        $beforeHtmlBody = $isNew ? null : self::normalizeHtmlBody($this->readHtmlTemplate($Mail));
 
         $removeHtml = (bool) ($payload['remove_html'] ?? false);
         $htmlBody = $removeHtml ? null : ($payload['html_body'] ?? $beforeHtmlBody);
@@ -251,7 +253,21 @@ class MailTemplateContentService
     }
 
     /**
+     * HTML パートの改行を正規化する. 「HTML パートなし」を表す null はそのまま返す.
+     */
+    private static function normalizeHtmlBody(?string $htmlBody): ?string
+    {
+        return null === $htmlBody ? null : StringUtil::convertLineFeed($htmlBody);
+    }
+
+    /**
      * メールテンプレートとテンプレートファイルを削除する.
+     *
+     * ファイルを先に削除する. 逆順にするとレコードだけが消えてテンプレートが残り, 削除に失敗した
+     * テンプレートが一覧から消える. ファイルの削除に失敗した場合は DB を更新せずに中断するため,
+     * レコードとファイルの対は保たれる (PageContentService::remove() と同じ理由).
+     *
+     * @throws ContentWriteException テンプレートファイルを削除できない場合
      */
     public function remove(MailTemplate $Mail): ContentResult
     {
@@ -264,9 +280,6 @@ class MailTemplateContentService
         $filePath = $this->getFilePath($Mail);
         $htmlFilePath = $this->getHtmlFilePath($Mail);
 
-        $this->entityManager->remove($Mail);
-        $this->entityManager->flush();
-
         $removedPaths = [];
         foreach ([$filePath, $htmlFilePath] as $path) {
             if ($this->isInsideTemplateDir($path) && is_file($path)) {
@@ -278,6 +291,9 @@ class MailTemplateContentService
                 $removedPaths[] = $path;
             }
         }
+
+        $this->entityManager->remove($Mail);
+        $this->entityManager->flush();
 
         return new ContentResult(ContentStatus::Removed, $id, $fileName, [], $removedPaths);
     }

--- a/src/Eccube/Service/Content/MailTemplateContentService.php
+++ b/src/Eccube/Service/Content/MailTemplateContentService.php
@@ -19,9 +19,11 @@ use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Common\EccubeConfig;
 use Eccube\Entity\MailTemplate;
 use Eccube\Exception\ContentValidationException;
+use Eccube\Exception\ContentWriteException;
 use Eccube\Form\Type\Admin\MailType;
 use Eccube\Repository\MailTemplateRepository;
 use Eccube\Util\StringUtil;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Form\FormFactoryInterface;
 use Twig\Environment;
@@ -114,6 +116,7 @@ class MailTemplateContentService
      * @param array{file_name?: string, id?: int, name?: string, subject?: string, body?: string, html_body?: string, remove_html?: bool} $payload
      *
      * @throws ContentValidationException
+     * @throws ContentWriteException      テンプレートファイルを書き出せない場合
      */
     public function apply(array $payload, bool $dryRun = false): ContentResult
     {
@@ -195,36 +198,56 @@ class MailTemplateContentService
      * メールテンプレートを永続化し, テンプレートファイルを書き出す.
      *
      * $htmlBody に null を渡すと HTML パートのファイルを削除する (管理画面と同じ挙動).
+     *
+     * DB とファイルはトランザクションで対にする. 先にコミットするとテンプレートの書き出しに
+     * 失敗したとき, 件名だけが更新され本文が古いままという食い違いが残る.
+     *
+     * @throws ContentWriteException テンプレートファイルを書き出せない場合
      */
     public function save(MailTemplate $Mail, string $body, ?string $htmlBody): ContentResult
     {
         $isNew = null === $Mail->getId();
 
-        $this->entityManager->persist($Mail);
-        $this->entityManager->flush();
+        return $this->entityManager->wrapInTransaction(function () use ($Mail, $body, $htmlBody, $isNew): ContentResult {
+            $this->entityManager->persist($Mail);
+            $this->entityManager->flush();
 
-        $filePath = $this->getFilePath($Mail);
-        $this->filesystem->dumpFile($filePath, StringUtil::convertLineFeed($body));
+            $filePath = $this->getFilePath($Mail);
 
-        $writtenPaths = [$filePath];
-        $removedPaths = [];
-        $htmlFilePath = $this->getHtmlFilePath($Mail);
+            try {
+                $this->filesystem->dumpFile($filePath, StringUtil::convertLineFeed($body));
+            } catch (IOException $e) {
+                throw ContentWriteException::forWrite($filePath, $e);
+            }
 
-        if (null !== $htmlBody) {
-            $this->filesystem->dumpFile($htmlFilePath, StringUtil::convertLineFeed($htmlBody));
-            $writtenPaths[] = $htmlFilePath;
-        } elseif ($this->isInsideTemplateDir($htmlFilePath) && is_file($htmlFilePath)) {
-            $this->filesystem->remove($htmlFilePath);
-            $removedPaths[] = $htmlFilePath;
-        }
+            $writtenPaths = [$filePath];
+            $removedPaths = [];
+            $htmlFilePath = $this->getHtmlFilePath($Mail);
 
-        return new ContentResult(
-            $isNew ? ContentStatus::Created : ContentStatus::Updated,
-            $Mail->getId(),
-            (string) $Mail->getFileName(),
-            $writtenPaths,
-            $removedPaths
-        );
+            if (null !== $htmlBody) {
+                try {
+                    $this->filesystem->dumpFile($htmlFilePath, StringUtil::convertLineFeed($htmlBody));
+                } catch (IOException $e) {
+                    throw ContentWriteException::forWrite($htmlFilePath, $e);
+                }
+                $writtenPaths[] = $htmlFilePath;
+            } elseif ($this->isInsideTemplateDir($htmlFilePath) && is_file($htmlFilePath)) {
+                try {
+                    $this->filesystem->remove($htmlFilePath);
+                } catch (IOException $e) {
+                    throw ContentWriteException::forRemove($htmlFilePath, $e);
+                }
+                $removedPaths[] = $htmlFilePath;
+            }
+
+            return new ContentResult(
+                $isNew ? ContentStatus::Created : ContentStatus::Updated,
+                $Mail->getId(),
+                (string) $Mail->getFileName(),
+                $writtenPaths,
+                $removedPaths
+            );
+        });
     }
 
     /**
@@ -247,7 +270,11 @@ class MailTemplateContentService
         $removedPaths = [];
         foreach ([$filePath, $htmlFilePath] as $path) {
             if ($this->isInsideTemplateDir($path) && is_file($path)) {
-                $this->filesystem->remove($path);
+                try {
+                    $this->filesystem->remove($path);
+                } catch (IOException $e) {
+                    throw ContentWriteException::forRemove($path, $e);
+                }
                 $removedPaths[] = $path;
             }
         }

--- a/src/Eccube/Service/Content/PageContentService.php
+++ b/src/Eccube/Service/Content/PageContentService.php
@@ -1,0 +1,371 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Content;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Common\EccubeConfig;
+use Eccube\Entity\Layout;
+use Eccube\Entity\Master\DeviceType;
+use Eccube\Entity\Page;
+use Eccube\Entity\PageLayout;
+use Eccube\Exception\ContentValidationException;
+use Eccube\Form\Type\Admin\MainEditType;
+use Eccube\Repository\PageLayoutRepository;
+use Eccube\Repository\PageRepository;
+use Eccube\Util\StringUtil;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Form\FormFactoryInterface;
+use Twig\Environment;
+use Twig\Error\LoaderError;
+
+/**
+ * ページ (dtb_page と app/template 配下の twig) を対で扱う.
+ *
+ * 管理画面 (PageController) と CLI (eccube:page:*) の双方から使用する.
+ * 入力値の検証は管理画面と同じ MainEditType を submit して行うため,
+ * URL / ファイル名の重複チェックや TwigLint も同じものが効く.
+ */
+class PageContentService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly PageRepository $pageRepository,
+        private readonly PageLayoutRepository $pageLayoutRepository,
+        private readonly FormFactoryInterface $formFactory,
+        private readonly Environment $twig,
+        private readonly Filesystem $filesystem,
+        private readonly EccubeConfig $eccubeConfig,
+    ) {
+    }
+
+    public function findByUrl(string $url): ?Page
+    {
+        return $this->pageRepository->findOneBy(['url' => $url]);
+    }
+
+    /**
+     * ユーザーが作成したページか.
+     *
+     * 既定ページ (EDIT_TYPE_DEFAULT 以上) は URL・ファイル名を変更できず,
+     * テンプレートの配置先も user_data ではなくテーマのディレクトリになる.
+     */
+    public function isUserDataPage(Page $Page): bool
+    {
+        return $Page->getEditType() < Page::EDIT_TYPE_DEFAULT;
+    }
+
+    public function getTemplateDir(Page $Page): string
+    {
+        return $this->isUserDataPage($Page)
+            ? (string) $this->eccubeConfig->get('eccube_theme_user_data_dir')
+            : (string) $this->eccubeConfig->get('eccube_theme_front_dir');
+    }
+
+    public function getFilePath(Page $Page): string
+    {
+        return $this->getTemplateDir($Page).'/'.$Page->getFileName().'.twig';
+    }
+
+    /**
+     * テンプレートの本文を取得する.
+     *
+     * 書き込み先のファイルがあればそれを読む. 無い場合は管理画面の編集欄と同じ経路
+     * (twig のローダ) へフォールバックし, コアのテンプレートを取得する.
+     * twig のローダはテンプレートの探索結果をプロセス内でキャッシュするため,
+     * 直前に書き出したファイルを読み落とさないようファイルを優先する.
+     */
+    public function readTemplate(Page $Page): string
+    {
+        $filePath = $this->getFilePath($Page);
+        if (is_file($filePath)) {
+            return (string) file_get_contents($filePath);
+        }
+
+        $namespace = $this->isUserDataPage($Page) ? '@user_data/' : '';
+
+        try {
+            return $this->twig->getLoader()
+                ->getSourceContext($namespace.$Page->getFileName().'.twig')
+                ->getCode();
+        } catch (LoaderError) {
+            return '';
+        }
+    }
+
+    /**
+     * URL を鍵にページを登録・更新する (upsert).
+     *
+     * 指定しなかった項目は既存の値を維持するため, 同じ入力を複数回適用しても結果は変わらない.
+     *
+     * @param array{url: string, name?: string, file_name?: string, body?: string, author?: string, description?: string, keyword?: string, meta_robots?: string, meta_tags?: string, pc_layout?: string|int|null, sp_layout?: string|int|null} $payload
+     *
+     * @throws ContentValidationException
+     */
+    public function apply(array $payload, bool $dryRun = false): ContentResult
+    {
+        $url = $payload['url'];
+        $Page = $this->findByUrl($url);
+        $isNew = null === $Page;
+        if (null === $Page) {
+            $Page = $this->pageRepository->newPage();
+        }
+
+        $previousFileName = $Page->getFileName();
+        // 新規登録時は比較対象が無い (未設定のゲッタは null を返すため呼び出さない)
+        $before = $isNew ? [] : $this->snapshot($Page);
+        $beforeBody = $isNew ? '' : StringUtil::convertLineFeed($this->readTemplate($Page));
+
+        $form = $this->formFactory->create(MainEditType::class, $Page, ['csrf_protection' => false]);
+        $form->submit($this->toFormData($payload, $Page, $isNew, $beforeBody), false);
+
+        if (!$form->isValid()) {
+            throw ContentValidationException::fromForm($form);
+        }
+
+        $body = StringUtil::convertLineFeed((string) $form->get('tpl_data')->getData());
+        /** @var Layout|null $PcLayout */
+        $PcLayout = $form['PcLayout']->getData();
+        /** @var Layout|null $SpLayout */
+        $SpLayout = $form['SpLayout']->getData();
+
+        $fieldChanges = self::diffFields($before, $this->snapshot($Page, $PcLayout, $SpLayout));
+        $filePath = $this->getFilePath($Page);
+        $fileChanges = $beforeBody === $body && $previousFileName === $Page->getFileName()
+            ? []
+            : [$filePath => [$beforeBody, $body]];
+
+        if ($dryRun) {
+            if (!$isNew) {
+                // submit で書き換えたエンティティを DB の内容へ戻す (dry-run は永続化しない)
+                $this->entityManager->refresh($Page);
+            }
+
+            return new ContentResult(
+                $this->resolveStatus($isNew, $fieldChanges, $fileChanges),
+                $Page->getId(),
+                $url,
+                [],
+                [],
+                $fieldChanges,
+                $fileChanges
+            );
+        }
+
+        if (!$isNew && [] === $fieldChanges && [] === $fileChanges) {
+            return new ContentResult(ContentStatus::Unchanged, $Page->getId(), $url);
+        }
+
+        return $this->save($Page, $body, $PcLayout, $SpLayout, $isNew ? null : $previousFileName)
+            ->withChanges($fieldChanges, $fileChanges);
+    }
+
+    /**
+     * ページを永続化し, テンプレートファイルを書き出す.
+     *
+     * 検証済みのエンティティを受け取る前提のため, 管理画面からは
+     * $form->isValid() を通過した後に呼び出す.
+     */
+    public function save(Page $Page, string $body, ?Layout $PcLayout, ?Layout $SpLayout, ?string $previousFileName): ContentResult
+    {
+        $isNew = null === $Page->getId();
+
+        $this->entityManager->persist($Page);
+        $this->entityManager->flush();
+
+        $templateDir = $this->getTemplateDir($Page);
+        $filePath = $templateDir.'/'.$Page->getFileName().'.twig';
+        $this->filesystem->dumpFile($filePath, StringUtil::convertLineFeed($body));
+
+        $removedPaths = [];
+        // 更新でファイル名を変更した場合, 以前のファイルを削除する
+        if (null !== $previousFileName && $Page->getFileName() !== $previousFileName) {
+            $oldFilePath = $templateDir.'/'.$previousFileName.'.twig';
+            if ($this->filesystem->exists($oldFilePath)) {
+                $this->filesystem->remove($oldFilePath);
+                $removedPaths[] = $oldFilePath;
+            }
+        }
+
+        $this->replaceLayouts($Page, $PcLayout, $SpLayout);
+
+        return new ContentResult(
+            $isNew ? ContentStatus::Created : ContentStatus::Updated,
+            $Page->getId(),
+            (string) $Page->getUrl(),
+            [$filePath],
+            $removedPaths
+        );
+    }
+
+    /**
+     * ページとテンプレートファイルを削除する.
+     *
+     * ユーザーが作成したページ (EDIT_TYPE_USER) のみ削除できる.
+     */
+    public function remove(Page $Page): ContentResult
+    {
+        if (Page::EDIT_TYPE_USER !== $Page->getEditType()) {
+            throw new \LogicException(sprintf('Page "%s" is not removable.', (string) $Page->getUrl()));
+        }
+
+        $id = $Page->getId();
+        $url = (string) $Page->getUrl();
+        $filePath = $this->getFilePath($Page);
+
+        $removedPaths = [];
+        if ($this->filesystem->exists($filePath)) {
+            $this->filesystem->remove($filePath);
+            $removedPaths[] = $filePath;
+        }
+
+        $this->entityManager->remove($Page);
+        $this->entityManager->flush();
+
+        return new ContentResult(ContentStatus::Removed, $id, $url, [], $removedPaths);
+    }
+
+    /**
+     * ページに紐づくレイアウトを貼り替える.
+     */
+    private function replaceLayouts(Page $Page, ?Layout $PcLayout, ?Layout $SpLayout): void
+    {
+        foreach ($Page->getPageLayouts() as $PageLayout) {
+            $Page->removePageLayout($PageLayout);
+            $this->entityManager->remove($PageLayout);
+            $this->entityManager->flush();
+        }
+
+        $LastPageLayout = $this->pageLayoutRepository->findOneBy([], ['sort_no' => 'DESC']);
+        $sortNo = null === $LastPageLayout ? 0 : $LastPageLayout->getSortNo();
+
+        foreach ([$PcLayout, $SpLayout] as $Layout) {
+            if (null === $Layout) {
+                continue;
+            }
+
+            $PageLayout = new PageLayout();
+            $PageLayout->setLayoutId($Layout->getId());
+            $PageLayout->setLayout($Layout);
+            $PageLayout->setPageId($Page->getId());
+            $PageLayout->setSortNo($sortNo++);
+            $PageLayout->setPage($Page);
+
+            $this->entityManager->persist($PageLayout);
+            $this->entityManager->flush();
+        }
+    }
+
+    /**
+     * @param array<string, string|int|null> $payload
+     *
+     * @return array<string, string>
+     */
+    private function toFormData(array $payload, Page $Page, bool $isNew, string $currentBody): array
+    {
+        // 本文は常に送信する (未指定なら現在の内容を維持する)
+        $data = ['tpl_data' => (string) ($payload['body'] ?? $currentBody)];
+
+        $fields = ['name', 'author', 'description', 'keyword', 'meta_robots', 'meta_tags'];
+        // 既定ページは URL・ファイル名を変更できない (管理画面と同じ制約)
+        if ($this->isUserDataPage($Page)) {
+            $fields[] = 'file_name';
+        }
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $payload)) {
+                $data[$field] = (string) $payload[$field];
+            }
+        }
+
+        if ($isNew) {
+            $data['url'] = (string) $payload['url'];
+            $data['file_name'] ??= (string) $payload['url'];
+        }
+
+        foreach (['pc_layout' => 'PcLayout', 'sp_layout' => 'SpLayout'] as $key => $field) {
+            if (array_key_exists($key, $payload)) {
+                $data[$field] = null === $payload[$key] ? '' : (string) $payload[$key];
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function snapshot(Page $Page, ?Layout $PcLayout = null, ?Layout $SpLayout = null): array
+    {
+        $snapshot = [
+            'name' => (string) $Page->getName(),
+            'url' => (string) $Page->getUrl(),
+            'file_name' => (string) $Page->getFileName(),
+            'author' => (string) $Page->getAuthor(),
+            'description' => (string) $Page->getDescription(),
+            'keyword' => (string) $Page->getKeyword(),
+            'meta_robots' => (string) $Page->getMetaRobots(),
+            'meta_tags' => (string) $Page->getMetaTags(),
+        ];
+
+        if (null === $PcLayout && null === $SpLayout) {
+            // 変更前のスナップショット: 紐づいているレイアウトから取得する
+            $snapshot['PcLayout'] = '';
+            $snapshot['SpLayout'] = '';
+            foreach ($Page->getLayouts() as $Layout) {
+                $field = DeviceType::DEVICE_TYPE_PC === $Layout->getDeviceType()->getId() ? 'PcLayout' : 'SpLayout';
+                $snapshot[$field] = (string) $Layout->getId();
+            }
+
+            return $snapshot;
+        }
+
+        $snapshot['PcLayout'] = null === $PcLayout ? '' : (string) $PcLayout->getId();
+        $snapshot['SpLayout'] = null === $SpLayout ? '' : (string) $SpLayout->getId();
+
+        return $snapshot;
+    }
+
+    /**
+     * @param array<string, string> $before
+     * @param array<string, string> $after
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    private static function diffFields(array $before, array $after): array
+    {
+        $changes = [];
+        foreach ($after as $field => $value) {
+            $previous = $before[$field] ?? '';
+            if ($previous !== $value) {
+                $changes[$field] = [$previous, $value];
+            }
+        }
+
+        return $changes;
+    }
+
+    /**
+     * @param array<string, array{0: string, 1: string}> $fieldChanges
+     * @param array<string, array{0: string, 1: string}> $fileChanges
+     */
+    private function resolveStatus(bool $isNew, array $fieldChanges, array $fileChanges): ContentStatus
+    {
+        if ($isNew) {
+            return ContentStatus::Created;
+        }
+
+        return [] === $fieldChanges && [] === $fileChanges ? ContentStatus::Unchanged : ContentStatus::Updated;
+    }
+}

--- a/src/Eccube/Service/Content/PageContentService.php
+++ b/src/Eccube/Service/Content/PageContentService.php
@@ -38,7 +38,7 @@ use Twig\Error\LoaderError;
  *
  * 管理画面 (PageController) と CLI (eccube:page:*) の双方から使用する.
  * 入力値の検証は管理画面と同じ MainEditType を submit して行うため,
- * URL / ファイル名の重複チェックや TwigLint も同じものが効く.
+ * ルーティング名 / ファイル名の重複チェックや TwigLint も同じものが効く.
  */
 class PageContentService
 {
@@ -53,15 +53,21 @@ class PageContentService
     ) {
     }
 
-    public function findByUrl(string $url): ?Page
+    /**
+     * ルーティング名 (dtb_page.url) を鍵にページを取得する.
+     *
+     * dtb_page.url が保持するのは実際の URL ではなくルート名 (例: product_list) で,
+     * 管理画面のページ管理も同じ値を「ルーティング名」列に表示する.
+     */
+    public function findByRoute(string $route): ?Page
     {
-        return $this->pageRepository->findOneBy(['url' => $url]);
+        return $this->pageRepository->findOneBy(['url' => $route]);
     }
 
     /**
      * ユーザーが作成したページか.
      *
-     * 既定ページ (EDIT_TYPE_DEFAULT 以上) は URL・ファイル名を変更できず,
+     * 既定ページ (EDIT_TYPE_DEFAULT 以上) はルーティング名・ファイル名を変更できず,
      * テンプレートの配置先も user_data ではなくテーマのディレクトリになる.
      */
     public function isUserDataPage(Page $Page): bool
@@ -108,19 +114,19 @@ class PageContentService
     }
 
     /**
-     * URL を鍵にページを登録・更新する (upsert).
+     * ルーティング名を鍵にページを登録・更新する (upsert).
      *
      * 指定しなかった項目は既存の値を維持するため, 同じ入力を複数回適用しても結果は変わらない.
      *
-     * @param array{url: string, name?: string, file_name?: string, body?: string, author?: string, description?: string, keyword?: string, meta_robots?: string, meta_tags?: string, pc_layout?: string|int|null, sp_layout?: string|int|null} $payload
+     * @param array{route: string, name?: string, file_name?: string, body?: string, author?: string, description?: string, keyword?: string, meta_robots?: string, meta_tags?: string, pc_layout?: string|int|null, sp_layout?: string|int|null} $payload
      *
      * @throws ContentValidationException
      * @throws ContentWriteException      テンプレートファイルを書き出せない場合
      */
     public function apply(array $payload, bool $dryRun = false): ContentResult
     {
-        $url = $payload['url'];
-        $Page = $this->findByUrl($url);
+        $route = $payload['route'];
+        $Page = $this->findByRoute($route);
         $isNew = null === $Page;
         if (null === $Page) {
             $Page = $this->pageRepository->newPage();
@@ -159,7 +165,7 @@ class PageContentService
             return new ContentResult(
                 $this->resolveStatus($isNew, $fieldChanges, $fileChanges),
                 $Page->getId(),
-                $url,
+                $route,
                 [],
                 [],
                 $fieldChanges,
@@ -168,7 +174,7 @@ class PageContentService
         }
 
         if (!$isNew && [] === $fieldChanges && [] === $fileChanges) {
-            return new ContentResult(ContentStatus::Unchanged, $Page->getId(), $url);
+            return new ContentResult(ContentStatus::Unchanged, $Page->getId(), $route);
         }
 
         return $this->save($Page, $body, $PcLayout, $SpLayout, $isNew ? null : $previousFileName)
@@ -248,7 +254,7 @@ class PageContentService
         }
 
         $id = $Page->getId();
-        $url = (string) $Page->getUrl();
+        $route = (string) $Page->getUrl();
         $filePath = $this->getFilePath($Page);
 
         $removedPaths = [];
@@ -264,7 +270,7 @@ class PageContentService
         $this->entityManager->remove($Page);
         $this->entityManager->flush();
 
-        return new ContentResult(ContentStatus::Removed, $id, $url, [], $removedPaths);
+        return new ContentResult(ContentStatus::Removed, $id, $route, [], $removedPaths);
     }
 
     /**
@@ -309,7 +315,7 @@ class PageContentService
         $data = ['tpl_data' => (string) ($payload['body'] ?? $currentBody)];
 
         $fields = ['name', 'author', 'description', 'keyword', 'meta_robots', 'meta_tags'];
-        // 既定ページは URL・ファイル名を変更できない (管理画面と同じ制約)
+        // 既定ページはルーティング名・ファイル名を変更できない (管理画面と同じ制約)
         if ($this->isUserDataPage($Page)) {
             $fields[] = 'file_name';
         }
@@ -320,8 +326,9 @@ class PageContentService
         }
 
         if ($isNew) {
-            $data['url'] = (string) $payload['url'];
-            $data['file_name'] ??= (string) $payload['url'];
+            // フォーム側の項目名は dtb_page の列に合わせて url のまま
+            $data['url'] = (string) $payload['route'];
+            $data['file_name'] ??= (string) $payload['route'];
         }
 
         foreach (['pc_layout' => 'PcLayout', 'sp_layout' => 'SpLayout'] as $key => $field) {
@@ -340,7 +347,7 @@ class PageContentService
     {
         $snapshot = [
             'name' => (string) $Page->getName(),
-            'url' => (string) $Page->getUrl(),
+            'route' => (string) $Page->getUrl(),
             'file_name' => (string) $Page->getFileName(),
             'author' => (string) $Page->getAuthor(),
             'description' => (string) $Page->getDescription(),

--- a/src/Eccube/Service/Content/PageContentService.php
+++ b/src/Eccube/Service/Content/PageContentService.php
@@ -134,7 +134,7 @@ class PageContentService
 
         $previousFileName = $Page->getFileName();
         // 新規登録時は比較対象が無い (未設定のゲッタは null を返すため呼び出さない)
-        $before = $isNew ? [] : $this->snapshot($Page);
+        $before = $isNew ? [] : $this->snapshotOfCurrentLayouts($Page);
         $beforeBody = $isNew ? '' : StringUtil::convertLineFeed($this->readTemplate($Page));
 
         $form = $this->formFactory->create(MainEditType::class, $Page, ['csrf_protection' => false]);
@@ -150,7 +150,7 @@ class PageContentService
         /** @var Layout|null $SpLayout */
         $SpLayout = $form['SpLayout']->getData();
 
-        $fieldChanges = self::diffFields($before, $this->snapshot($Page, $PcLayout, $SpLayout));
+        $fieldChanges = self::diffFields($before, $this->snapshotWithLayouts($Page, $PcLayout, $SpLayout));
         $filePath = $this->getFilePath($Page);
         $fileChanges = $beforeBody === $body && $previousFileName === $Page->getFileName()
             ? []
@@ -341,11 +341,44 @@ class PageContentService
     }
 
     /**
+     * 変更前のスナップショット. レイアウトは現在紐づいているものから取得する.
+     *
      * @return array<string, string>
      */
-    private function snapshot(Page $Page, ?Layout $PcLayout = null, ?Layout $SpLayout = null): array
+    private function snapshotOfCurrentLayouts(Page $Page): array
     {
-        $snapshot = [
+        $snapshot = $this->snapshotFields($Page) + ['PcLayout' => '', 'SpLayout' => ''];
+        foreach ($Page->getLayouts() as $Layout) {
+            $field = DeviceType::DEVICE_TYPE_PC === $Layout->getDeviceType()->getId() ? 'PcLayout' : 'SpLayout';
+            $snapshot[$field] = (string) $Layout->getId();
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * 変更後のスナップショット. 引数のレイアウトをそのまま反映する.
+     *
+     * 引数の null 有無で変更前と変更後を区別してはいけない. 両方のレイアウトを外す操作では
+     * 双方が null になり, 現在の値を読み直すと差分が出ず Unchanged で早期 return してしまう
+     * (レイアウトが外れない).
+     *
+     * @return array<string, string>
+     */
+    private function snapshotWithLayouts(Page $Page, ?Layout $PcLayout, ?Layout $SpLayout): array
+    {
+        return $this->snapshotFields($Page) + [
+            'PcLayout' => null === $PcLayout ? '' : (string) $PcLayout->getId(),
+            'SpLayout' => null === $SpLayout ? '' : (string) $SpLayout->getId(),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function snapshotFields(Page $Page): array
+    {
+        return [
             'name' => (string) $Page->getName(),
             'route' => (string) $Page->getUrl(),
             'file_name' => (string) $Page->getFileName(),
@@ -355,23 +388,6 @@ class PageContentService
             'meta_robots' => (string) $Page->getMetaRobots(),
             'meta_tags' => (string) $Page->getMetaTags(),
         ];
-
-        if (null === $PcLayout && null === $SpLayout) {
-            // 変更前のスナップショット: 紐づいているレイアウトから取得する
-            $snapshot['PcLayout'] = '';
-            $snapshot['SpLayout'] = '';
-            foreach ($Page->getLayouts() as $Layout) {
-                $field = DeviceType::DEVICE_TYPE_PC === $Layout->getDeviceType()->getId() ? 'PcLayout' : 'SpLayout';
-                $snapshot[$field] = (string) $Layout->getId();
-            }
-
-            return $snapshot;
-        }
-
-        $snapshot['PcLayout'] = null === $PcLayout ? '' : (string) $PcLayout->getId();
-        $snapshot['SpLayout'] = null === $SpLayout ? '' : (string) $SpLayout->getId();
-
-        return $snapshot;
     }
 
     /**

--- a/src/Eccube/Service/Content/PageContentService.php
+++ b/src/Eccube/Service/Content/PageContentService.php
@@ -22,10 +22,12 @@ use Eccube\Entity\Master\DeviceType;
 use Eccube\Entity\Page;
 use Eccube\Entity\PageLayout;
 use Eccube\Exception\ContentValidationException;
+use Eccube\Exception\ContentWriteException;
 use Eccube\Form\Type\Admin\MainEditType;
 use Eccube\Repository\PageLayoutRepository;
 use Eccube\Repository\PageRepository;
 use Eccube\Util\StringUtil;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Form\FormFactoryInterface;
 use Twig\Environment;
@@ -113,6 +115,7 @@ class PageContentService
      * @param array{url: string, name?: string, file_name?: string, body?: string, author?: string, description?: string, keyword?: string, meta_robots?: string, meta_tags?: string, pc_layout?: string|int|null, sp_layout?: string|int|null} $payload
      *
      * @throws ContentValidationException
+     * @throws ContentWriteException      テンプレートファイルを書き出せない場合
      */
     public function apply(array $payload, bool $dryRun = false): ContentResult
     {
@@ -177,43 +180,66 @@ class PageContentService
      *
      * 検証済みのエンティティを受け取る前提のため, 管理画面からは
      * $form->isValid() を通過した後に呼び出す.
+     *
+     * DB とファイルはトランザクションで対にする. 先にコミットするとテンプレートの書き出しに
+     * 失敗したときレコードだけが残り, そのページの表示が 500 になる. 権限を分離した構成では
+     * app/template への書き込みだけが失敗し得るため, ロールバックして整合を保つ.
+     *
+     * @throws ContentWriteException テンプレートファイルを書き出せない場合
      */
     public function save(Page $Page, string $body, ?Layout $PcLayout, ?Layout $SpLayout, ?string $previousFileName): ContentResult
     {
         $isNew = null === $Page->getId();
 
-        $this->entityManager->persist($Page);
-        $this->entityManager->flush();
+        return $this->entityManager->wrapInTransaction(function () use ($Page, $body, $PcLayout, $SpLayout, $previousFileName, $isNew): ContentResult {
+            $this->entityManager->persist($Page);
+            $this->entityManager->flush();
 
-        $templateDir = $this->getTemplateDir($Page);
-        $filePath = $templateDir.'/'.$Page->getFileName().'.twig';
-        $this->filesystem->dumpFile($filePath, StringUtil::convertLineFeed($body));
+            $templateDir = $this->getTemplateDir($Page);
+            $filePath = $templateDir.'/'.$Page->getFileName().'.twig';
 
-        $removedPaths = [];
-        // 更新でファイル名を変更した場合, 以前のファイルを削除する
-        if (null !== $previousFileName && $Page->getFileName() !== $previousFileName) {
-            $oldFilePath = $templateDir.'/'.$previousFileName.'.twig';
-            if ($this->filesystem->exists($oldFilePath)) {
-                $this->filesystem->remove($oldFilePath);
-                $removedPaths[] = $oldFilePath;
+            try {
+                $this->filesystem->dumpFile($filePath, StringUtil::convertLineFeed($body));
+            } catch (IOException $e) {
+                throw ContentWriteException::forWrite($filePath, $e);
             }
-        }
 
-        $this->replaceLayouts($Page, $PcLayout, $SpLayout);
+            $removedPaths = [];
+            // 更新でファイル名を変更した場合, 以前のファイルを削除する
+            if (null !== $previousFileName && $Page->getFileName() !== $previousFileName) {
+                $oldFilePath = $templateDir.'/'.$previousFileName.'.twig';
+                if ($this->filesystem->exists($oldFilePath)) {
+                    try {
+                        $this->filesystem->remove($oldFilePath);
+                    } catch (IOException $e) {
+                        throw ContentWriteException::forRemove($oldFilePath, $e);
+                    }
+                    $removedPaths[] = $oldFilePath;
+                }
+            }
 
-        return new ContentResult(
-            $isNew ? ContentStatus::Created : ContentStatus::Updated,
-            $Page->getId(),
-            (string) $Page->getUrl(),
-            [$filePath],
-            $removedPaths
-        );
+            $this->replaceLayouts($Page, $PcLayout, $SpLayout);
+
+            return new ContentResult(
+                $isNew ? ContentStatus::Created : ContentStatus::Updated,
+                $Page->getId(),
+                (string) $Page->getUrl(),
+                [$filePath],
+                $removedPaths
+            );
+        });
     }
 
     /**
      * ページとテンプレートファイルを削除する.
      *
      * ユーザーが作成したページ (EDIT_TYPE_USER) のみ削除できる.
+     *
+     * ファイルを先に削除する. 逆順にするとレコードだけが消えてテンプレートが残り, 削除に失敗した
+     * ページが表示できないまま一覧から消える. ファイルの削除に失敗した場合は DB を更新せずに
+     * 中断するため, レコードとファイルの対は保たれる.
+     *
+     * @throws ContentWriteException テンプレートファイルを削除できない場合
      */
     public function remove(Page $Page): ContentResult
     {
@@ -227,7 +253,11 @@ class PageContentService
 
         $removedPaths = [];
         if ($this->filesystem->exists($filePath)) {
-            $this->filesystem->remove($filePath);
+            try {
+                $this->filesystem->remove($filePath);
+            } catch (IOException $e) {
+                throw ContentWriteException::forRemove($filePath, $e);
+            }
             $removedPaths[] = $filePath;
         }
 

--- a/src/Eccube/Service/EntityProxyService.php
+++ b/src/Eccube/Service/EntityProxyService.php
@@ -84,7 +84,7 @@ class EntityProxyService
             // baseDir e.g. /src/Eccube/Entity and /app/Plugin/PluginCode/Entity
             $baseDir = str_replace($projectDir, '', str_replace($baseName, '', $fileName));
             if (!file_exists($outputDir.$baseDir)) {
-                mkdir($outputDir.$baseDir, 0777, true);
+                mkdir($outputDir.$baseDir, 0755, true);
             }
 
             $file = ltrim(str_replace($projectDir, '', $fileName), '/');

--- a/src/Eccube/Service/Permission/PathOwnership.php
+++ b/src/Eccube/Service/Permission/PathOwnership.php
@@ -23,7 +23,8 @@ namespace Eccube\Service\Permission;
  * Web サーバーから書けるかどうかは分からないため, パーミッションビットから推定する.
  *
  * ディレクトリはエントリの作成・削除に w と x が, 配下のファイルを開くのに x が必要になるため,
- * 自身のビットに加えて祖先ディレクトリの x も評価する.
+ * isWritableBy() / isReadableBy() は自身の x も評価する. ただし見るのは自身のビットだけで,
+ * 祖先ディレクトリを通り抜けられるかは unreachableAncestorFor() で別に確かめる必要がある.
  * 補助グループ・ACL・SELinux までは判定できないため, 結果はあくまで推定として扱うこと.
  */
 final readonly class PathOwnership

--- a/src/Eccube/Service/Permission/PermissionDiagnostic.php
+++ b/src/Eccube/Service/Permission/PermissionDiagnostic.php
@@ -36,7 +36,55 @@ class PermissionDiagnostic
             $findings[] = $this->evaluate($requirement, PathOwnership::of($requirement->path), $webServer, $cli);
         }
 
+        $warmupFallback = $this->detectWarmupFallback();
+        if ($warmupFallback instanceof PermissionFinding) {
+            $findings[] = $warmupFallback;
+        }
+
         return new DiagnosticReport($findings, $webServer, $cli);
+    }
+
+    /**
+     * 事前コンパイル漏れのテンプレートがリクエスト処理中にコンパイルされていないか調べる.
+     */
+    private function detectWarmupFallback(): ?PermissionFinding
+    {
+        $requirement = $this->requirementProvider->warmupFallbackRequirement();
+        if (!$requirement instanceof PermissionRequirement || !is_dir($requirement->path)) {
+            return null;
+        }
+
+        if (!$this->hasCompiledTemplate($requirement->path)) {
+            return null;
+        }
+
+        return new PermissionFinding(
+            $requirement,
+            PathOwnership::of($requirement->path),
+            FindingSeverity::WARN,
+            '事前コンパイルされていないテンプレートがリクエスト処理中にコンパイルされています',
+            'bin/console eccube:cache:build を実行してください. '
+            .'ビルドディレクトリを読み取り専用で運用する場合, ここに生成物が増え続けます.'
+        );
+    }
+
+    private function hasCompiledTemplate(string $dir): bool
+    {
+        try {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+            );
+            foreach ($iterator as $file) {
+                if ($file instanceof \SplFileInfo && $file->isFile() && $file->getExtension() === 'php') {
+                    return true;
+                }
+            }
+        } catch (\UnexpectedValueException) {
+            // 読み取りできないディレクトリは判定不能として扱う.
+            return false;
+        }
+
+        return false;
     }
 
     /**
@@ -88,9 +136,9 @@ class PermissionDiagnostic
                 $ownership,
                 FindingSeverity::WARN,
                 'Web サーバーから書き込めますが, 任意のローカルユーザーからも書き込めます',
-                'bin/console が umask(0000) を設定するため, CLI が作成したディレクトリは 0777 になります '
-                .'(dev では index.php も umask(0000) を設定するため Web からの作成も同様です). '
-                .'同一サーバーの他ユーザーから書き換えられます.'
+                'ECCUBE_UMASK に 0000 を設定していると, アプリケーションが作成するディレクトリは 0777, '
+                .'ファイルは 0666 になります. 同一サーバーの他ユーザーから書き換えられるため, '
+                .'権限を分離できる環境では ECCUBE_UMASK を空にしてください.'
             );
         }
 

--- a/src/Eccube/Service/Permission/PermissionDiagnostic.php
+++ b/src/Eccube/Service/Permission/PermissionDiagnostic.php
@@ -115,7 +115,8 @@ class PermissionDiagnostic
                 $ownership,
                 FindingSeverity::NG,
                 '任意のローカルユーザーから書き込めます (想定: 読み取りのみ)',
-                'bin/console が umask(0000) を設定するため, CLI が作成したディレクトリは 0777 になります. '
+                'ECCUBE_UMASK に 0000 を設定していると, アプリケーションが作成するディレクトリは 0777, '
+                .'ファイルは 0666 になります. 権限を分離できる環境では ECCUBE_UMASK を空にしたうえで, '
                 .'other の書き込み権限を外してください.'
             );
         }

--- a/src/Eccube/Service/Permission/PermissionRequirementProvider.php
+++ b/src/Eccube/Service/Permission/PermissionRequirementProvider.php
@@ -45,6 +45,29 @@ class PermissionRequirementProvider
     }
 
     /**
+     * 事前コンパイルされなかったテンプレートのフォールバック先.
+     *
+     * prod では twig が [build_dir/twig (読み取り専用), runtime_dir/twig] の 2 層構成になり,
+     * build 側に無いテンプレートだけがリクエスト処理中に runtime 側へコンパイルされる.
+     * ここに生成物があれば eccube:cache:build の warmup 漏れを意味する.
+     *
+     * dev は auto_reload が有効で 2 層構成にならず, runtime 側が通常の出力先になるため対象外.
+     */
+    public function warmupFallbackRequirement(): ?PermissionRequirement
+    {
+        if ($this->eccubeConfig->get('kernel.debug')) {
+            return null;
+        }
+
+        return $this->create(
+            $this->path('eccube_runtime_dir').'/twig',
+            WriteLane::WEB,
+            true,
+            'ビルドディレクトリに無いテンプレートのフォールバック先.'
+        );
+    }
+
+    /**
      * 同じパスが複数の役割を持つ場合 (メンテナンスファイルの生成先が var/ を指す場合等) に 1 件へまとめる.
      *
      * レーンと表示名は先に定義したものを採用し, 注意書きは両方を残す. 一方でも必須なら必須として扱う.
@@ -74,7 +97,7 @@ class PermissionRequirementProvider
 
         return [
             $this->create($projectDir.'/var', WriteLane::WEB, true),
-            $this->create($this->path('kernel.cache_dir'), WriteLane::WEB, true),
+            $this->create($this->path('eccube_runtime_dir'), WriteLane::WEB, true),
             $this->create($this->path('kernel.logs_dir'), WriteLane::WEB, true),
             $this->create($projectDir.'/var/sessions/'.$env, WriteLane::WEB, true),
             $this->create($this->path('eccube_save_image_dir'), WriteLane::WEB),
@@ -128,6 +151,19 @@ class PermissionRequirementProvider
             $this->create($projectDir.'/vendor', WriteLane::SSH),
             $this->create($projectDir.'/composer.json', WriteLane::SSH),
             $this->create($projectDir.'/composer.lock', WriteLane::SSH),
+            $this->create(
+                $this->path('kernel.build_dir'),
+                WriteLane::SSH,
+                true,
+                'コンパイル済みコンテナ・ルーティング・事前コンパイル済みテンプレートの出力先. '
+                .'生成は bin/console eccube:cache:build で行う.'
+            ),
+            $this->create(
+                $this->path('kernel.cache_dir'),
+                WriteLane::SSH,
+                true,
+                'ビルド時にのみ使用する. 実行時のキャッシュは eccube_runtime_dir 側に生成される.'
+            ),
             $this->create($projectDir.'/.env', WriteLane::SSH, true),
         ];
     }

--- a/src/Eccube/Service/Permission/PermissionRequirementProvider.php
+++ b/src/Eccube/Service/Permission/PermissionRequirementProvider.php
@@ -96,7 +96,6 @@ class PermissionRequirementProvider
         $env = (string) $this->eccubeConfig->get('kernel.environment');
 
         return [
-            $this->create($projectDir.'/var', WriteLane::WEB, true),
             $this->create($this->path('eccube_runtime_dir'), WriteLane::WEB, true),
             $this->create($this->path('kernel.logs_dir'), WriteLane::WEB, true),
             $this->create($projectDir.'/var/sessions/'.$env, WriteLane::WEB, true),
@@ -104,13 +103,6 @@ class PermissionRequirementProvider
             $this->create($this->path('eccube_temp_image_dir'), WriteLane::WEB),
             $this->create($this->path('eccube_save_refund_request_file_dir'), WriteLane::WEB),
             $this->create($this->path('eccube_temp_refund_request_file_dir'), WriteLane::WEB),
-            $this->create(
-                $projectDir.'/app/keystore',
-                WriteLane::WEB,
-                true,
-                '秘密鍵の格納先. CLI で事前に配置し Web サーバーからは読み取りのみとするのが望ましい. '
-                .'実行時に鍵を生成する機能を使う場合のみ Web サーバーの書き込み権限が必要になる.'
-            ),
             $this->create(
                 dirname($this->path('eccube_content_maintenance_file_path')),
                 WriteLane::WEB,
@@ -131,6 +123,20 @@ class PermissionRequirementProvider
         $projectDir = $this->path('kernel.project_dir');
 
         return [
+            $this->create(
+                $projectDir.'/var',
+                WriteLane::SSH,
+                true,
+                'Web サーバーが書き込むのは配下の var/runtime・var/sessions・var/log で, '
+                .'var 自体へは書き込まない. Web サーバーからは通過 (r-x) できればよい.'
+            ),
+            $this->create(
+                $projectDir.'/app/keystore',
+                WriteLane::SSH,
+                true,
+                '秘密鍵の格納先. CLI で事前に配置し Web サーバーからは読み取りのみとする. '
+                .'実行時に鍵を生成する機能 (AcpMessageSigner) を使う場合のみ Web サーバーの書き込み権限が必要になる.'
+            ),
             $this->create($this->path('eccube_theme_app_dir'), WriteLane::SSH),
             $this->create($this->path('eccube_html_dir').'/user_data', WriteLane::SSH),
             $this->create($this->path('plugin_realdir'), WriteLane::SSH),

--- a/src/Eccube/Service/Permission/PermissionRequirementProvider.php
+++ b/src/Eccube/Service/Permission/PermissionRequirementProvider.php
@@ -168,7 +168,8 @@ class PermissionRequirementProvider
                 $this->path('kernel.cache_dir'),
                 WriteLane::SSH,
                 true,
-                'ビルド時にのみ使用する. 実行時のキャッシュは eccube_runtime_dir 側に生成される.'
+                '翻訳カタログ・htmlpurifier の出力先. CLI が生成し, リクエスト処理中は読み取りのみ. '
+                .'リクエスト処理中に書き込まれるキャッシュは eccube_runtime_dir 側に生成される.'
             ),
             $this->create($projectDir.'/.env', WriteLane::SSH, true),
         ];

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -346,12 +346,14 @@ class PluginService
      */
     public function createTempDir(): string
     {
-        // アーカイブの展開先はリクエスト処理中にも作られるため, ランタイムディレクトリへ置く.
-        $tempDir = $this->eccubeConfig->get('eccube_runtime_dir').'/Plugin';
-        @mkdir($tempDir, 0755, true);
-        $d = ($tempDir.'/'.sha1(StringUtil::random(16)));
+        // アーカイブの検査用の一時領域. 本来の配置先へは元アーカイブから展開し直すため,
+        // ここから移動することはない (install() / update() を参照).
+        // OS の一時ディレクトリを使うことで, Web サーバーと CLI で書き込み権限を分離した構成でも
+        // 同じ経路が使える (/tmp は 1777 で, どちらのユーザーも自分のディレクトリを作成できる).
+        $d = sys_get_temp_dir().'/eccube_plugin_'.sha1(StringUtil::random(16));
 
-        if (!mkdir($d, 0755)) {
+        // 他のユーザーから展開後のファイルを読まれないよう, 所有者のみに制限する.
+        if (!mkdir($d, 0700)) {
             throw new PluginException(trans('admin.store.plugin.mkdir.error', ['%dir_name%' => $d]));
         }
 

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -348,12 +348,25 @@ class PluginService
     {
         // アーカイブの検査用の一時領域. 本来の配置先へは元アーカイブから展開し直すため,
         // ここから移動することはない (install() / update() を参照).
-        // OS の一時ディレクトリを使うことで, Web サーバーと CLI で書き込み権限を分離した構成でも
-        // 同じ経路が使える (/tmp は 1777 で, どちらのユーザーも自分のディレクトリを作成できる).
-        $d = sys_get_temp_dir().'/eccube_plugin_'.sha1(StringUtil::random(16));
+        if (\PHP_SAPI === 'cli') {
+            // ランタイムディレクトリは Web サーバー所有 (レーン W) になり得るため, CLI からは
+            // OS の一時ディレクトリを使う (/tmp は 1777 で, どのユーザーも自分の領域を作れる).
+            // 他のユーザーから展開後のファイルを読まれないよう, 所有者のみに制限する.
+            $d = sys_get_temp_dir().'/eccube_plugin_'.sha1(StringUtil::random(16));
 
-        // 他のユーザーから展開後のファイルを読まれないよう, 所有者のみに制限する.
-        if (!mkdir($d, 0700)) {
+            if (!mkdir($d, 0700)) {
+                throw new PluginException(trans('admin.store.plugin.mkdir.error', ['%dir_name%' => $d]));
+            }
+
+            return $d;
+        }
+
+        // リクエスト処理中に作られる分はランタイムディレクトリへ置く.
+        $tempDir = $this->eccubeConfig->get('eccube_runtime_dir').'/Plugin';
+        @mkdir($tempDir, 0755, true);
+        $d = ($tempDir.'/'.sha1(StringUtil::random(16)));
+
+        if (!mkdir($d, 0755)) {
             throw new PluginException(trans('admin.store.plugin.mkdir.error', ['%dir_name%' => $d]));
         }
 

--- a/src/Eccube/Service/PluginService.php
+++ b/src/Eccube/Service/PluginService.php
@@ -55,11 +55,6 @@ class PluginService
     private readonly string $projectRoot;
 
     /**
-     * @var string %kernel.environment%
-     */
-    private readonly string $environment;
-
-    /**
      * PluginService constructor.
      */
     public function __construct(
@@ -75,7 +70,6 @@ class PluginService
         private readonly PluginContext $pluginContext,
     ) {
         $this->projectRoot = $this->eccubeConfig->get('kernel.project_dir');
-        $this->environment = $this->eccubeConfig->get('kernel.environment');
     }
 
     /**
@@ -352,11 +346,12 @@ class PluginService
      */
     public function createTempDir(): string
     {
-        $tempDir = $this->projectRoot.'/var/cache/'.$this->environment.'/Plugin';
-        @mkdir($tempDir);
+        // アーカイブの展開先はリクエスト処理中にも作られるため, ランタイムディレクトリへ置く.
+        $tempDir = $this->eccubeConfig->get('eccube_runtime_dir').'/Plugin';
+        @mkdir($tempDir, 0755, true);
         $d = ($tempDir.'/'.sha1(StringUtil::random(16)));
 
-        if (!mkdir($d, 0777)) {
+        if (!mkdir($d, 0755)) {
             throw new PluginException(trans('admin.store.plugin.mkdir.error', ['%dir_name%' => $d]));
         }
 

--- a/src/Eccube/Util/CacheUtil.php
+++ b/src/Eccube/Util/CacheUtil.php
@@ -13,7 +13,9 @@
 
 namespace Eccube\Util;
 
+use Eccube\Common\EccubeConfig;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -36,8 +38,26 @@ class CacheUtil implements EventSubscriberInterface
     /**
      * CacheUtil constructor.
      */
-    public function __construct(protected KernelInterface $kernel, private readonly ContainerInterface $container)
+    public function __construct(
+        protected KernelInterface $kernel,
+        private readonly ContainerInterface $container,
+        private readonly EccubeConfig $eccubeConfig,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * cache:clear を実行できるか (= ビルド生成物を Web サーバーから作り直せるか).
+     *
+     * cache:clear は kernel.build_dir と kernel.cache_dir の双方へ書き込むため
+     * (CacheClearCommand.php の is_writable() 検査), 権限を分離した構成では失敗する.
+     * その場合はリクエスト処理中に生成されるキャッシュのみを削除し, ビルド生成物の
+     * 再生成は CLI の eccube:cache:build に委ねる.
+     */
+    public function canClearBuildCache(): bool
     {
+        return is_writable((string) $this->eccubeConfig->get('kernel.build_dir'))
+            && is_writable((string) $this->eccubeConfig->get('kernel.cache_dir'));
     }
 
     /**
@@ -55,6 +75,12 @@ class CacheUtil implements EventSubscriberInterface
     {
         if ($this->clearCacheAfterResponse === false) {
             return '';
+        }
+
+        // 別の環境を指定された場合 (インストーラが prod を対象にする等) は, 現在の環境の
+        // ディレクトリを見ても判定にならないため, 従来どおり cache:clear を試みる.
+        if ($this->clearCacheAfterResponse === null && !$this->canClearBuildCache()) {
+            return $this->clearRuntimeCache();
         }
 
         $console = new Application($this->kernel);
@@ -133,9 +159,52 @@ class CacheUtil implements EventSubscriberInterface
      */
     public function clearTwigCache(): void
     {
-        $cacheDir = $this->kernel->getCacheDir().'/twig';
         $fs = new Filesystem();
-        $fs->remove($cacheDir);
+        $fs->remove($this->runtimePath('twig'));
+
+        // prod では事前コンパイル済みのテンプレート (kernel.build_dir/twig) が読み取り専用キャッシュ
+        // として優先されるため, そちらを消さないと更新したテンプレートが反映されない.
+        // 権限を分離した構成では削除できないため, その場合は eccube:cache:build の再実行が必要になる.
+        $buildDir = rtrim((string) $this->eccubeConfig->get('kernel.build_dir'), '/');
+        if (is_dir($buildDir.'/twig') && is_writable($buildDir)) {
+            $fs->remove($buildDir.'/twig');
+        }
+    }
+
+    /**
+     * リクエスト処理中に生成されるキャッシュのみを削除します.
+     *
+     * ビルド生成物 (コンパイル済みコンテナ・ルーティング・事前コンパイル済みテンプレート) は
+     * kernel.build_dir にあり Web サーバーから書き込めないため, ここでは削除しない.
+     */
+    public function clearRuntimeCache(): string
+    {
+        /** @var Psr6CacheClearer $poolClearer */
+        $poolClearer = $this->container->get('cache.global_clearer');
+        $poolClearer->clear((string) $this->eccubeConfig->get('eccube_runtime_dir'));
+
+        $fs = new Filesystem();
+        $fs->remove([
+            $this->runtimePath('twig'),
+            $this->runtimePath('translations'),
+            $this->runtimePath('htmlpurifier'),
+        ]);
+
+        if (function_exists('opcache_reset')) {
+            opcache_reset();
+        }
+
+        $message = 'ビルドディレクトリへ書き込めないため, 実行時キャッシュのみ削除しました.'
+            .' コンパイル済みコンテナとテンプレートを更新するには CLI で'
+            .' bin/console eccube:cache:build を実行してください.';
+        $this->logger->warning($message);
+
+        return $message;
+    }
+
+    private function runtimePath(string $name): string
+    {
+        return rtrim((string) $this->eccubeConfig->get('eccube_runtime_dir'), '/').'/'.$name;
     }
 
     /**

--- a/src/Eccube/Util/CacheUtil.php
+++ b/src/Eccube/Util/CacheUtil.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
@@ -159,15 +160,35 @@ class CacheUtil implements EventSubscriberInterface
      */
     public function clearTwigCache(): void
     {
-        $fs = new Filesystem();
-        $fs->remove($this->runtimePath('twig'));
+        // 実行時キャッシュは Web サーバー所有 (レーン W) になり得るため, CLI からは削除できない.
+        // 権限が無い場合に例外を投げると, キャッシュ削除の失敗が本処理の失敗として現れてしまう.
+        $this->removeIfPossible($this->runtimePath('twig'));
 
         // prod では事前コンパイル済みのテンプレート (kernel.build_dir/twig) が読み取り専用キャッシュ
         // として優先されるため, そちらを消さないと更新したテンプレートが反映されない.
         // 権限を分離した構成では削除できないため, その場合は eccube:cache:build の再実行が必要になる.
         $buildDir = rtrim((string) $this->eccubeConfig->get('kernel.build_dir'), '/');
-        if (is_dir($buildDir.'/twig') && is_writable($buildDir)) {
-            $fs->remove($buildDir.'/twig');
+        if (is_writable($buildDir)) {
+            $this->removeIfPossible($buildDir.'/twig');
+        }
+    }
+
+    /**
+     * 削除できる場合のみ削除する.
+     *
+     * 権限を分離した構成では, 実行するユーザーによって削除できないディレクトリがある.
+     * 削除できたかどうかは呼び出し側が判定できる (is_dir) ため, ここでは例外にしない.
+     */
+    private function removeIfPossible(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        try {
+            (new Filesystem())->remove($dir);
+        } catch (IOException) {
+            // 権限が無い場合は残す. 削除は権限のあるユーザー (Web サーバー) 側に委ねる.
         }
     }
 
@@ -185,8 +206,7 @@ class CacheUtil implements EventSubscriberInterface
 
         // 翻訳カタログや HTMLPurifier のキャッシュは kernel.cache_dir 配下のビルド生成物のため,
         // ここでは触れない (再生成は eccube:cache:build が行う).
-        $fs = new Filesystem();
-        $fs->remove($this->runtimePath('twig'));
+        $this->removeIfPossible($this->runtimePath('twig'));
 
         if (function_exists('opcache_reset')) {
             opcache_reset();

--- a/src/Eccube/Util/CacheUtil.php
+++ b/src/Eccube/Util/CacheUtil.php
@@ -183,12 +183,10 @@ class CacheUtil implements EventSubscriberInterface
         $poolClearer = $this->container->get('cache.global_clearer');
         $poolClearer->clear((string) $this->eccubeConfig->get('eccube_runtime_dir'));
 
+        // 翻訳カタログや HTMLPurifier のキャッシュは kernel.cache_dir 配下のビルド生成物のため,
+        // ここでは触れない (再生成は eccube:cache:build が行う).
         $fs = new Filesystem();
-        $fs->remove([
-            $this->runtimePath('twig'),
-            $this->runtimePath('translations'),
-            $this->runtimePath('htmlpurifier'),
-        ]);
+        $fs->remove($this->runtimePath('twig'));
 
         if (function_exists('opcache_reset')) {
             opcache_reset();

--- a/src/Eccube/Util/RuntimeCachePoolClearer.php
+++ b/src/Eccube/Util/RuntimeCachePoolClearer.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Util;
+
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
+
+/**
+ * cache:clear で %eccube_runtime_dir%/pools を削除する.
+ *
+ * cache:clear は kernel.cache_dir と kernel.build_dir を物理削除するだけで, cache pool を
+ * 論理的にはクリアしない (cache.global_clearer / cache.system_clearer は kernel.cache_clearer
+ * タグを持たないため, ChainCacheClearer には 1 件も登録されない). cache pool が
+ * kernel.cache_dir 配下にあった頃は, ディレクトリごと消えることで結果的にクリアされていた.
+ *
+ * cache pool をランタイムディレクトリへ移したことでこの副作用が失われ, cache:clear の後も
+ * 古い内容が残るようになった. とくに Doctrine のメタデータキャッシュが残ると, プラグインの
+ * 更新でエンティティに追加されたカラムがスキーマ差分に現れなくなる.
+ *
+ * 従来と同じ範囲 (ファイルシステム上の pool) だけを削除する. Redis 等の外部ストアを
+ * 使用している場合の挙動は変えない.
+ */
+final readonly class RuntimeCachePoolClearer implements CacheClearerInterface
+{
+    public function __construct(private string $runtimeDir)
+    {
+    }
+
+    #[\Override]
+    public function clear(string $cacheDir): void
+    {
+        $pools = rtrim($this->runtimeDir, '/').'/pools';
+        if (!is_dir($pools)) {
+            return;
+        }
+
+        try {
+            (new Filesystem())->remove($pools);
+        } catch (IOException) {
+            // 権限を分離した構成ではランタイムディレクトリは Web サーバー所有のため削除できない.
+            // その場合の実行時キャッシュの削除は cache:pool:clear (Web サーバーのユーザー) に委ねる.
+        }
+    }
+}

--- a/src/Eccube/Util/RuntimeCachePoolClearer.php
+++ b/src/Eccube/Util/RuntimeCachePoolClearer.php
@@ -34,15 +34,27 @@ use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
  * 従来と同じ範囲 (ファイルシステム上の pool) だけを削除する. Redis 等の外部ストアを
  * 使用している場合の挙動は変えない.
  */
-final readonly class RuntimeCachePoolClearer implements CacheClearerInterface
+final class RuntimeCachePoolClearer implements CacheClearerInterface
 {
-    public function __construct(private string $runtimeDir)
+    /**
+     * 削除できずに残った pool ディレクトリ. 削除できた場合と対象が無い場合は null.
+     *
+     * 権限を分離した構成ではランタイムディレクトリが Web サーバー所有のため, CLI ユーザーの
+     * cache:clear からは削除できない. 例外にすると cache:clear がビルド生成物の削除まで含めて
+     * 失敗するため, ここでは中断せずに結果を残し, 呼び出し側 (RuntimeCachePoolClearListener) が
+     * 未削除であることと対処方法を通知する.
+     */
+    private ?string $unclearedPath = null;
+
+    public function __construct(private readonly string $runtimeDir)
     {
     }
 
     #[\Override]
     public function clear(string $cacheDir): void
     {
+        $this->unclearedPath = null;
+
         $pools = rtrim($this->runtimeDir, '/').'/pools';
         if (!is_dir($pools)) {
             return;
@@ -51,8 +63,17 @@ final readonly class RuntimeCachePoolClearer implements CacheClearerInterface
         try {
             (new Filesystem())->remove($pools);
         } catch (IOException) {
-            // 権限を分離した構成ではランタイムディレクトリは Web サーバー所有のため削除できない.
-            // その場合の実行時キャッシュの削除は cache:pool:clear (Web サーバーのユーザー) に委ねる.
+            // 実行時キャッシュの削除は cache:pool:clear (Web サーバーのユーザー) に委ねる.
+            // Filesystem::remove() は一部でも削除できないと例外を投げるため, ここで残存を検知できる.
+            $this->unclearedPath = $pools;
         }
+    }
+
+    /**
+     * 直前の clear() で削除できずに残った pool ディレクトリを返す.
+     */
+    public function getUnclearedPath(): ?string
+    {
+        return $this->unclearedPath;
     }
 }

--- a/tests/Eccube/Tests/Cache/WriteFailsafeFilesystemAdapterTest.php
+++ b/tests/Eccube/Tests/Cache/WriteFailsafeFilesystemAdapterTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Cache;
+
+use Eccube\Cache\WriteFailsafeFilesystemAdapter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class WriteFailsafeFilesystemAdapterTest extends TestCase
+{
+    private string $workDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->workDir = sys_get_temp_dir().'/eccube-cache-failsafe-'.bin2hex(random_bytes(6));
+        mkdir($this->workDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->workDir)) {
+            chmod($this->workDir, 0755);
+        }
+        (new Filesystem())->remove($this->workDir);
+        parent::tearDown();
+    }
+
+    public function testSavesWhenDirectoryIsWritable(): void
+    {
+        $adapter = new WriteFailsafeFilesystemAdapter('ns', 0, $this->workDir);
+
+        $item = $adapter->getItem('key');
+        $item->set('value');
+
+        $this->assertTrue($adapter->save($item));
+        $this->assertSame('value', $adapter->getItem('key')->get());
+    }
+
+    /**
+     * 書き込めない場合でも例外にせず, 保存できたものとして扱う (警告も記録しない).
+     */
+    public function testGivesUpSavingWhenDirectoryIsNotWritable(): void
+    {
+        $this->skipWhenRunningAsRoot();
+
+        // 先に書き込み可能な状態でキャッシュを作り, その後で書き込み不可にする
+        $writable = new WriteFailsafeFilesystemAdapter('ns', 0, $this->workDir);
+        $item = $writable->getItem('warm');
+        $item->set('warmed');
+        $writable->save($item);
+
+        chmod($this->workDir, 0555);
+
+        $adapter = new WriteFailsafeFilesystemAdapter('ns', 0, $this->workDir);
+        $newItem = $adapter->getItem('cold');
+        $newItem->set('value');
+
+        $this->assertTrue($adapter->save($newItem), '保存できなくても失敗として扱わない');
+        $this->assertFalse($adapter->getItem('cold')->isHit(), '実際には保存されない');
+        // 読み取りは従来どおり行える
+        $this->assertSame('warmed', $adapter->getItem('warm')->get());
+    }
+
+    /**
+     * 未作成のディレクトリは, 存在する直近の親で判定する (初回起動時に書き込みを諦めない).
+     */
+    public function testTreatsMissingDirectoryAsWritableWhenParentIsWritable(): void
+    {
+        $adapter = new WriteFailsafeFilesystemAdapter('ns', 0, $this->workDir.'/not-yet/created');
+
+        $item = $adapter->getItem('key');
+        $item->set('value');
+
+        $this->assertTrue($adapter->save($item));
+        $this->assertSame('value', $adapter->getItem('key')->get());
+    }
+
+    private function skipWhenRunningAsRoot(): void
+    {
+        if (getmyuid() === 0) {
+            $this->markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
+        }
+    }
+}

--- a/tests/Eccube/Tests/Cache/WriteFailsafeFilesystemAdapterTest.php
+++ b/tests/Eccube/Tests/Cache/WriteFailsafeFilesystemAdapterTest.php
@@ -16,11 +16,14 @@ declare(strict_types=1);
 namespace Eccube\Tests\Cache;
 
 use Eccube\Cache\WriteFailsafeFilesystemAdapter;
+use Eccube\Tests\EffectiveUserTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 final class WriteFailsafeFilesystemAdapterTest extends TestCase
 {
+    use EffectiveUserTrait;
+
     private string $workDir;
 
     protected function setUp(): void
@@ -91,8 +94,6 @@ final class WriteFailsafeFilesystemAdapterTest extends TestCase
 
     private function skipWhenRunningAsRoot(): void
     {
-        if (getmyuid() === 0) {
-            $this->markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
-        }
+        $this->skipIfRoot();
     }
 }

--- a/tests/Eccube/Tests/Command/CacheBuildCommandTest.php
+++ b/tests/Eccube/Tests/Command/CacheBuildCommandTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Command;
+
+use Eccube\Command\CacheBuildCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\RebootableInterface;
+
+/**
+ * 書き込み権限が不足しているときの振る舞いを検証する.
+ *
+ * 実際のビルドはコンテナの再構築を伴うためここでは扱わない.
+ */
+final class CacheBuildCommandTest extends TestCase
+{
+    private string $workDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->workDir = sys_get_temp_dir().'/eccube-cache-build-'.bin2hex(random_bytes(6));
+        mkdir($this->workDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        // 読み取り専用にしたディレクトリを消せるよう権限を戻す
+        foreach (['build', 'cache'] as $name) {
+            if (is_dir($this->workDir.'/'.$name)) {
+                chmod($this->workDir.'/'.$name, 0755);
+            }
+        }
+        (new Filesystem())->remove($this->workDir);
+        parent::tearDown();
+    }
+
+    public function testReturnsManualActionRequiredWhenBuildDirIsNotWritable(): void
+    {
+        $this->skipWhenRunningAsRoot();
+
+        $buildDir = $this->workDir.'/build';
+        $cacheDir = $this->workDir.'/cache';
+        mkdir($buildDir, 0555);
+        mkdir($cacheDir, 0755);
+
+        $tester = $this->tester($buildDir, $cacheDir);
+
+        $this->assertSame(CacheBuildCommand::EXIT_MANUAL_ACTION_REQUIRED, $tester->execute([]));
+        $this->assertStringContainsString($buildDir, $tester->getDisplay());
+        $this->assertStringContainsString('eccube:doctor:permissions', $tester->getDisplay());
+    }
+
+    /**
+     * cache ディレクトリの書き込み権限も必要になる (Kernel::buildContainer() の検査).
+     */
+    public function testReturnsManualActionRequiredWhenCacheDirIsNotWritable(): void
+    {
+        $this->skipWhenRunningAsRoot();
+
+        $buildDir = $this->workDir.'/build';
+        $cacheDir = $this->workDir.'/cache';
+        mkdir($buildDir, 0755);
+        mkdir($cacheDir, 0555);
+
+        $tester = $this->tester($buildDir, $cacheDir);
+
+        $this->assertSame(CacheBuildCommand::EXIT_MANUAL_ACTION_REQUIRED, $tester->execute([]));
+        $this->assertStringContainsString($cacheDir, $tester->getDisplay());
+    }
+
+    private function skipWhenRunningAsRoot(): void
+    {
+        if (getmyuid() === 0) {
+            $this->markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
+        }
+    }
+
+    private function tester(string $buildDir, string $cacheDir): CommandTester
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('getParameter')->willReturnCallback(static fn (string $key): mixed => match ($key) {
+            'kernel.build_dir' => $buildDir,
+            'kernel.cache_dir' => $cacheDir,
+            'eccube_runtime_dir' => $cacheDir.'/../runtime',
+            default => null,
+        });
+
+        $kernel = $this->createMockForIntersectionOfInterfaces([KernelInterface::class, RebootableInterface::class]);
+        $kernel->method('getContainer')->willReturn($container);
+        $kernel->method('getEnvironment')->willReturn('prod');
+        $kernel->method('isDebug')->willReturn(false);
+        // 検査で弾かれるため再構築は行われない
+        $kernel->expects($this->never())->method('reboot');
+
+        $command = new CacheBuildCommand();
+        $command->setApplication(new Application($kernel));
+
+        return new CommandTester($command);
+    }
+}

--- a/tests/Eccube/Tests/Command/CacheBuildCommandTest.php
+++ b/tests/Eccube/Tests/Command/CacheBuildCommandTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Eccube\Tests\Command;
 
 use Eccube\Command\CacheBuildCommand;
+use Eccube\Tests\EffectiveUserTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -31,6 +32,8 @@ use Symfony\Component\HttpKernel\RebootableInterface;
  */
 final class CacheBuildCommandTest extends TestCase
 {
+    use EffectiveUserTrait;
+
     private string $workDir;
 
     protected function setUp(): void
@@ -43,9 +46,13 @@ final class CacheBuildCommandTest extends TestCase
     protected function tearDown(): void
     {
         // 読み取り専用にしたディレクトリを消せるよう権限を戻す
-        foreach (['build', 'cache'] as $name) {
-            if (is_dir($this->workDir.'/'.$name)) {
-                chmod($this->workDir.'/'.$name, 0755);
+        $entries = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->workDir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+        foreach ($entries as $entry) {
+            if ($entry instanceof \SplFileInfo && $entry->isDir()) {
+                chmod($entry->getPathname(), 0755);
             }
         }
         (new Filesystem())->remove($this->workDir);
@@ -54,7 +61,7 @@ final class CacheBuildCommandTest extends TestCase
 
     public function testReturnsManualActionRequiredWhenBuildDirIsNotWritable(): void
     {
-        $this->skipWhenRunningAsRoot();
+        $this->skipIfRoot();
 
         $buildDir = $this->workDir.'/build';
         $cacheDir = $this->workDir.'/cache';
@@ -73,7 +80,7 @@ final class CacheBuildCommandTest extends TestCase
      */
     public function testReturnsManualActionRequiredWhenCacheDirIsNotWritable(): void
     {
-        $this->skipWhenRunningAsRoot();
+        $this->skipIfRoot();
 
         $buildDir = $this->workDir.'/build';
         $cacheDir = $this->workDir.'/cache';
@@ -86,11 +93,28 @@ final class CacheBuildCommandTest extends TestCase
         $this->assertStringContainsString($cacheDir, $tester->getDisplay());
     }
 
-    private function skipWhenRunningAsRoot(): void
+    /**
+     * ビルドディレクトリの親にも書き込み権限が必要になる.
+     *
+     * warmup 先を同じ親に別名で作り, 最後に rename で差し替えるため, ビルドディレクトリ自体へ
+     * 書き込めても親へ書き込めなければ差し替えられない. 事前に検査しないと mkdir が例外になり,
+     * 権限の案内を出せないまま終わる.
+     */
+    public function testReturnsManualActionRequiredWhenBuildDirParentIsNotWritable(): void
     {
-        if (getmyuid() === 0) {
-            $this->markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
-        }
+        $this->skipIfRoot();
+
+        $parent = $this->workDir.'/lane-s';
+        $buildDir = $parent.'/build';
+        $cacheDir = $this->workDir.'/cache';
+        mkdir($buildDir, 0755, true);
+        mkdir($cacheDir, 0755);
+        chmod($parent, 0555);
+
+        $tester = $this->tester($buildDir, $cacheDir);
+
+        $this->assertSame(CacheBuildCommand::EXIT_MANUAL_ACTION_REQUIRED, $tester->execute([]));
+        $this->assertStringContainsString($parent, $tester->getDisplay());
     }
 
     private function tester(string $buildDir, string $cacheDir): CommandTester

--- a/tests/Eccube/Tests/Command/Content/BlockCommandTest.php
+++ b/tests/Eccube/Tests/Command/Content/BlockCommandTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Command\Content;
+
+use Eccube\Command\Content\BlockApplyCommand;
+use Eccube\Command\Content\BlockListCommand;
+use Eccube\Command\Content\BlockRemoveCommand;
+use Eccube\Command\Content\BlockShowCommand;
+use Eccube\Entity\Block;
+use Eccube\Entity\Master\DeviceType;
+use Eccube\Service\Content\BlockContentService;
+use Eccube\Tests\EccubeTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class BlockCommandTest extends EccubeTestCase
+{
+    private ?BlockContentService $blockContentService = null;
+
+    /**
+     * @var list<string>|null
+     */
+    private ?array $createdFiles = null;
+
+    private ?string $fileName = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->blockContentService = self::getContainer()->get(BlockContentService::class);
+        $this->createdFiles = [];
+        $this->fileName = 'test_block_'.bin2hex(random_bytes(4));
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdFiles ?? [] as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function testApplyCreatesBlock(): void
+    {
+        $tester = $this->apply([
+            '--file-name' => $this->fileName,
+            '--name' => 'テストブロック',
+            '--body' => '<p>created</p>',
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $Block = $this->findBlock();
+        $this->assertInstanceOf(Block::class, $Block);
+        $this->assertSame('<p>created</p>', file_get_contents($this->blockContentService->getFilePath($Block)));
+    }
+
+    public function testApplyReturnsInvalidWithoutFileName(): void
+    {
+        $tester = $this->apply(['--name' => 'テストブロック']);
+
+        $this->assertSame(Command::INVALID, $tester->getStatusCode());
+    }
+
+    public function testApplyReturnsInvalidWithUnknownDeviceType(): void
+    {
+        $tester = $this->apply([
+            '--file-name' => $this->fileName,
+            '--name' => 'テストブロック',
+            '--body' => '<p>x</p>',
+            '--device-type' => '9999',
+        ]);
+
+        $this->assertSame(Command::INVALID, $tester->getStatusCode());
+    }
+
+    public function testShowOutputsTemplate(): void
+    {
+        $this->apply(['--file-name' => $this->fileName, '--name' => 'テストブロック', '--body' => '<p>shown</p>']);
+
+        $tester = new CommandTester(self::getContainer()->get(BlockShowCommand::class));
+        $tester->execute(['--file-name' => $this->fileName]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertSame('<p>shown</p>', $tester->getDisplay());
+    }
+
+    public function testListContainsCreatedBlock(): void
+    {
+        $this->apply(['--file-name' => $this->fileName, '--name' => 'テストブロック', '--body' => '<p>x</p>']);
+
+        $tester = new CommandTester(self::getContainer()->get(BlockListCommand::class));
+        $tester->execute(['--format' => 'json']);
+
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $fileNames = array_column((array) json_decode($tester->getDisplay(), true), 'file_name');
+        $this->assertContains($this->fileName, $fileNames);
+    }
+
+    public function testRemoveDeletesBlock(): void
+    {
+        $this->apply(['--file-name' => $this->fileName, '--name' => 'テストブロック', '--body' => '<p>x</p>']);
+
+        $tester = new CommandTester(self::getContainer()->get(BlockRemoveCommand::class));
+        $tester->execute(['--file-name' => $this->fileName, '--force' => true, '--no-cache-clear' => true]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertNotInstanceOf(Block::class, $this->findBlock());
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     */
+    private function apply(array $input): CommandTester
+    {
+        $tester = new CommandTester(self::getContainer()->get(BlockApplyCommand::class));
+        $tester->execute($input + ['--no-cache-clear' => true]);
+
+        $Block = $this->findBlock();
+        if ($Block instanceof Block) {
+            $this->createdFiles[] = $this->blockContentService->getFilePath($Block);
+        }
+
+        return $tester;
+    }
+
+    private function findBlock(): ?Block
+    {
+        return $this->blockContentService->findByFileName(
+            (string) $this->fileName,
+            $this->blockContentService->getDeviceType(DeviceType::DEVICE_TYPE_PC)
+        );
+    }
+}

--- a/tests/Eccube/Tests/Command/Content/MailTemplateCommandTest.php
+++ b/tests/Eccube/Tests/Command/Content/MailTemplateCommandTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Command\Content;
+
+use Eccube\Command\Content\MailTemplateApplyCommand;
+use Eccube\Command\Content\MailTemplateListCommand;
+use Eccube\Command\Content\MailTemplateShowCommand;
+use Eccube\Entity\MailTemplate;
+use Eccube\Service\Content\MailTemplateContentService;
+use Eccube\Tests\EccubeTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class MailTemplateCommandTest extends EccubeTestCase
+{
+    private ?MailTemplateContentService $mailTemplateContentService = null;
+
+    /**
+     * @var list<string>|null
+     */
+    private ?array $createdFiles = null;
+
+    private ?string $fileName = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mailTemplateContentService = self::getContainer()->get(MailTemplateContentService::class);
+        $this->createdFiles = [];
+        $this->fileName = 'test_mail_'.bin2hex(random_bytes(4));
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdFiles ?? [] as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function testApplyCreatesTemplate(): void
+    {
+        $tester = $this->apply([
+            '--file-name' => $this->fileName,
+            '--name' => 'テストメール',
+            '--subject' => '件名',
+            '--body' => 'created body',
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $Mail = $this->mailTemplateContentService->findByFileName((string) $this->fileName);
+        $this->assertInstanceOf(MailTemplate::class, $Mail);
+        $this->assertSame('created body', file_get_contents($this->mailTemplateContentService->getFilePath($Mail)));
+    }
+
+    public function testApplyReturnsInvalidWithoutTarget(): void
+    {
+        $tester = $this->apply(['--name' => 'テストメール']);
+
+        $this->assertSame(Command::INVALID, $tester->getStatusCode());
+    }
+
+    public function testApplyRejectsConflictingHtmlOptions(): void
+    {
+        $tester = $this->apply([
+            '--file-name' => $this->fileName,
+            '--html-body' => '<p>html</p>',
+            '--remove-html' => true,
+        ]);
+
+        $this->assertSame(Command::INVALID, $tester->getStatusCode());
+    }
+
+    public function testShowOutputsHtmlPart(): void
+    {
+        $this->apply([
+            '--file-name' => $this->fileName,
+            '--name' => 'テストメール',
+            '--subject' => '件名',
+            '--body' => 'body',
+        ]);
+        $this->apply(['--file-name' => $this->fileName, '--html-body' => '<p>html</p>']);
+
+        $Mail = $this->mailTemplateContentService->findByFileName((string) $this->fileName);
+        $this->assertInstanceOf(MailTemplate::class, $Mail);
+        $this->createdFiles[] = $this->mailTemplateContentService->getHtmlFilePath($Mail);
+
+        $tester = new CommandTester(self::getContainer()->get(MailTemplateShowCommand::class));
+        $tester->execute(['--file-name' => $this->fileName, '--html' => true]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertSame('<p>html</p>', $tester->getDisplay());
+    }
+
+    public function testShowReturnsErrorWhenHtmlPartIsMissing(): void
+    {
+        $this->apply([
+            '--file-name' => $this->fileName,
+            '--name' => 'テストメール',
+            '--subject' => '件名',
+            '--body' => 'body',
+        ]);
+
+        $tester = new CommandTester(self::getContainer()->get(MailTemplateShowCommand::class));
+        $tester->execute(['--file-name' => $this->fileName, '--html' => true]);
+
+        $this->assertSame(1, $tester->getStatusCode());
+    }
+
+    public function testListContainsCreatedTemplate(): void
+    {
+        $this->apply([
+            '--file-name' => $this->fileName,
+            '--name' => 'テストメール',
+            '--subject' => '件名',
+            '--body' => 'body',
+        ]);
+
+        $tester = new CommandTester(self::getContainer()->get(MailTemplateListCommand::class));
+        $tester->execute(['--format' => 'json']);
+
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $fileNames = array_column((array) json_decode($tester->getDisplay(), true), 'file_name');
+        $this->assertContains('Mail/'.$this->fileName.'.twig', $fileNames);
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     */
+    private function apply(array $input): CommandTester
+    {
+        $tester = new CommandTester(self::getContainer()->get(MailTemplateApplyCommand::class));
+        $tester->execute($input + ['--no-cache-clear' => true]);
+
+        $Mail = $this->mailTemplateContentService->findByFileName((string) $this->fileName);
+        if ($Mail instanceof MailTemplate) {
+            $this->createdFiles[] = $this->mailTemplateContentService->getFilePath($Mail);
+        }
+
+        return $tester;
+    }
+}

--- a/tests/Eccube/Tests/Command/Content/PageCommandTest.php
+++ b/tests/Eccube/Tests/Command/Content/PageCommandTest.php
@@ -163,6 +163,48 @@ final class PageCommandTest extends EccubeTestCase
         $this->assertSame(0, $tester->getStatusCode());
     }
 
+    /**
+     * 実行時の cache pool を削除できない場合 (権限を分離した構成) は,
+     * 本処理を完了させたうえで終了コード 3 と手動実行の案内を返す.
+     */
+    public function testApplyReturnsManualActionRequiredWhenCacheIsNotClearable(): void
+    {
+        if (function_exists('posix_geteuid') && 0 === posix_geteuid()) {
+            $this->markTestSkipped('root では権限による書き込み不可を再現できない');
+        }
+
+        $poolDir = rtrim((string) self::getContainer()->getParameter('eccube_runtime_dir'), '/').'/pools';
+        if (!is_dir($poolDir)) {
+            mkdir($poolDir, 0775, true);
+        }
+        chmod($poolDir, 0555);
+
+        if (is_writable($poolDir)) {
+            chmod($poolDir, 0775);
+            $this->markTestSkipped('ディレクトリを書き込み不可にできない環境');
+        }
+
+        try {
+            $tester = new CommandTester(self::getContainer()->get(PageApplyCommand::class));
+            $tester->execute([
+                '--url' => $this->url,
+                '--name' => 'テストページ',
+                '--body' => 'body',
+            ]);
+
+            $Page = $this->pageContentService->findByUrl((string) $this->url);
+            if ($Page instanceof Page) {
+                $this->createdFiles[] = $this->pageContentService->getFilePath($Page);
+            }
+
+            $this->assertSame(3, $tester->getStatusCode());
+            $this->assertInstanceOf(Page::class, $Page, '本処理は完了している');
+            $this->assertStringContainsString('cache:pool:clear', $tester->getDisplay());
+        } finally {
+            chmod($poolDir, 0775);
+        }
+    }
+
     public function testShowOutputsTemplate(): void
     {
         $this->apply(['--url' => $this->url, '--name' => 'テストページ', '--body' => 'shown body']);

--- a/tests/Eccube/Tests/Command/Content/PageCommandTest.php
+++ b/tests/Eccube/Tests/Command/Content/PageCommandTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Command\Content;
+
+use Eccube\Command\Content\PageApplyCommand;
+use Eccube\Command\Content\PageListCommand;
+use Eccube\Command\Content\PageRemoveCommand;
+use Eccube\Command\Content\PageShowCommand;
+use Eccube\Entity\Page;
+use Eccube\Service\Content\PageContentService;
+use Eccube\Tests\EccubeTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class PageCommandTest extends EccubeTestCase
+{
+    private ?PageContentService $pageContentService = null;
+
+    /**
+     * @var list<string>|null
+     */
+    private ?array $createdFiles = null;
+
+    private ?string $url = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->pageContentService = self::getContainer()->get(PageContentService::class);
+        $this->createdFiles = [];
+        $this->url = 'test_page_'.bin2hex(random_bytes(4));
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdFiles ?? [] as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function testApplyCreatesPage(): void
+    {
+        $tester = $this->apply([
+            '--url' => $this->url,
+            '--name' => 'テストページ',
+            '--body' => 'created body',
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('created', $tester->getDisplay());
+
+        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $this->assertInstanceOf(Page::class, $Page);
+        $this->assertSame('created body', file_get_contents($this->pageContentService->getFilePath($Page)));
+    }
+
+    public function testApplyReadsBodyFromStdin(): void
+    {
+        $tester = $this->apply([
+            '--url' => $this->url,
+            '--name' => 'テストページ',
+            '--body' => '-',
+        ], ['body from stdin']);
+
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $this->assertInstanceOf(Page::class, $Page);
+        $this->assertSame('body from stdin', trim((string) file_get_contents($this->pageContentService->getFilePath($Page))));
+    }
+
+    public function testApplyDryRunDoesNotCreatePage(): void
+    {
+        $tester = $this->apply([
+            '--url' => $this->url,
+            '--name' => 'テストページ',
+            '--body' => 'body',
+            '--dry-run' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('dry-run', $tester->getDisplay());
+        $this->assertNotInstanceOf(Page::class, $this->pageContentService->findByUrl((string) $this->url));
+    }
+
+    public function testApplyOutputsJson(): void
+    {
+        $tester = $this->apply([
+            '--url' => $this->url,
+            '--name' => 'テストページ',
+            '--body' => 'body',
+            '--format' => 'json',
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $decoded = json_decode($tester->getDisplay(), true);
+        $this->assertIsArray($decoded);
+        $this->assertSame('created', $decoded['status']);
+        $this->assertSame($this->url, $decoded['identifier']);
+    }
+
+    public function testApplyReturnsInvalidWithoutUrl(): void
+    {
+        $tester = $this->apply(['--name' => 'テストページ']);
+
+        $this->assertSame(Command::INVALID, $tester->getStatusCode());
+    }
+
+    public function testApplyReturnsInvalidWithUnknownFormat(): void
+    {
+        $tester = $this->apply(['--url' => $this->url, '--format' => 'yaml']);
+
+        $this->assertSame(Command::INVALID, $tester->getStatusCode());
+    }
+
+    public function testApplyFailsWithInvalidTwig(): void
+    {
+        $tester = $this->apply([
+            '--url' => $this->url,
+            '--name' => 'テストページ',
+            '--body' => '{% block foo %}',
+        ]);
+
+        $this->assertSame(1, $tester->getStatusCode());
+        $this->assertNotInstanceOf(Page::class, $this->pageContentService->findByUrl((string) $this->url));
+    }
+
+    /**
+     * キャッシュ削除まで含めて実行する (トレイトの #[Required] 注入が効いていることの確認を兼ねる).
+     */
+    public function testApplyClearsCache(): void
+    {
+        $tester = new CommandTester(self::getContainer()->get(PageApplyCommand::class));
+        $tester->execute([
+            '--url' => $this->url,
+            '--name' => 'テストページ',
+            '--body' => 'body',
+        ]);
+
+        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        if ($Page instanceof Page) {
+            $this->createdFiles[] = $this->pageContentService->getFilePath($Page);
+        }
+
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
+    public function testShowOutputsTemplate(): void
+    {
+        $this->apply(['--url' => $this->url, '--name' => 'テストページ', '--body' => 'shown body']);
+
+        $tester = new CommandTester(self::getContainer()->get(PageShowCommand::class));
+        $tester->execute(['--url' => $this->url]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertSame('shown body', $tester->getDisplay());
+    }
+
+    public function testShowReturnsErrorWhenNotFound(): void
+    {
+        $tester = new CommandTester(self::getContainer()->get(PageShowCommand::class));
+        $tester->execute(['--url' => 'not_found_page']);
+
+        $this->assertSame(1, $tester->getStatusCode());
+    }
+
+    public function testListContainsCreatedPage(): void
+    {
+        $this->apply(['--url' => $this->url, '--name' => 'テストページ', '--body' => 'body']);
+
+        $tester = new CommandTester(self::getContainer()->get(PageListCommand::class));
+        $tester->execute(['--format' => 'json']);
+
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $urls = array_column((array) json_decode($tester->getDisplay(), true), 'url');
+        $this->assertContains($this->url, $urls);
+    }
+
+    public function testRemoveDeletesPage(): void
+    {
+        $this->apply(['--url' => $this->url, '--name' => 'テストページ', '--body' => 'body']);
+
+        $tester = new CommandTester(self::getContainer()->get(PageRemoveCommand::class));
+        $tester->execute(['--url' => $this->url, '--force' => true, '--no-cache-clear' => true]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertNotInstanceOf(Page::class, $this->pageContentService->findByUrl((string) $this->url));
+    }
+
+    public function testRemoveIsAbortedWithoutConfirmation(): void
+    {
+        $this->apply(['--url' => $this->url, '--name' => 'テストページ', '--body' => 'body']);
+
+        $tester = new CommandTester(self::getContainer()->get(PageRemoveCommand::class));
+        $tester->setInputs(['no']);
+        $tester->execute(['--url' => $this->url, '--no-cache-clear' => true]);
+
+        $this->assertSame(1, $tester->getStatusCode());
+        $this->assertInstanceOf(Page::class, $this->pageContentService->findByUrl((string) $this->url));
+    }
+
+    public function testRemoveRejectsDefaultPage(): void
+    {
+        $Page = $this->entityManager->getRepository(Page::class)->findOneBy(['edit_type' => Page::EDIT_TYPE_DEFAULT]);
+        $this->assertInstanceOf(Page::class, $Page);
+
+        $tester = new CommandTester(self::getContainer()->get(PageRemoveCommand::class));
+        $tester->execute(['--url' => $Page->getUrl(), '--force' => true, '--no-cache-clear' => true]);
+
+        $this->assertSame(1, $tester->getStatusCode());
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     * @param list<string>         $stdin
+     */
+    private function apply(array $input, array $stdin = []): CommandTester
+    {
+        $tester = new CommandTester(self::getContainer()->get(PageApplyCommand::class));
+        if ([] !== $stdin) {
+            $tester->setInputs($stdin);
+        }
+        $tester->execute($input + ['--no-cache-clear' => true]);
+
+        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        if ($Page instanceof Page) {
+            $this->createdFiles[] = $this->pageContentService->getFilePath($Page);
+        }
+
+        return $tester;
+    }
+}

--- a/tests/Eccube/Tests/Command/Content/PageCommandTest.php
+++ b/tests/Eccube/Tests/Command/Content/PageCommandTest.php
@@ -22,11 +22,14 @@ use Eccube\Command\Content\PageShowCommand;
 use Eccube\Entity\Page;
 use Eccube\Service\Content\PageContentService;
 use Eccube\Tests\EccubeTestCase;
+use Eccube\Tests\EffectiveUserTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
 final class PageCommandTest extends EccubeTestCase
 {
+    use EffectiveUserTrait;
+
     private ?PageContentService $pageContentService = null;
 
     /**
@@ -151,9 +154,7 @@ final class PageCommandTest extends EccubeTestCase
      */
     public function testApplyReportsWriteFailureWithGuidance(): void
     {
-        if (0 === getmyuid()) {
-            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
-        }
+        $this->skipIfRoot();
 
         $Page = new Page();
         $Page->setEditType(Page::EDIT_TYPE_USER);
@@ -212,9 +213,7 @@ final class PageCommandTest extends EccubeTestCase
      */
     public function testApplyReturnsManualActionRequiredWhenCacheIsNotClearable(): void
     {
-        if (function_exists('posix_geteuid') && 0 === posix_geteuid()) {
-            $this->markTestSkipped('root では権限による書き込み不可を再現できない');
-        }
+        $this->skipIfRoot();
 
         $poolDir = rtrim((string) self::getContainer()->getParameter('eccube_runtime_dir'), '/').'/pools';
         if (!is_dir($poolDir)) {

--- a/tests/Eccube/Tests/Command/Content/PageCommandTest.php
+++ b/tests/Eccube/Tests/Command/Content/PageCommandTest.php
@@ -144,6 +144,49 @@ final class PageCommandTest extends EccubeTestCase
     }
 
     /**
+     * テンプレートを書き出せない場合は, 生の例外ではなく対処方法を表示して終了する.
+     *
+     * 権限を分離した構成では実行ユーザーを誤ると書き込みだけが失敗するため,
+     * 確認手段 (eccube:doctor:permissions) を案内する.
+     */
+    public function testApplyReportsWriteFailureWithGuidance(): void
+    {
+        if (0 === getmyuid()) {
+            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
+        }
+
+        $Page = new Page();
+        $Page->setEditType(Page::EDIT_TYPE_USER);
+        $templateDir = $this->pageContentService->getTemplateDir($Page);
+        $originalPerms = fileperms($templateDir) & 0777;
+
+        chmod($templateDir, 0555);
+
+        try {
+            $tester = $this->apply([
+                '--url' => $this->url,
+                '--name' => 'テストページ',
+                '--body' => 'body',
+            ]);
+        } finally {
+            chmod($templateDir, $originalPerms);
+        }
+
+        $this->assertSame(1, $tester->getStatusCode());
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('ページを保存できません', $display);
+        $this->assertStringContainsString('eccube:doctor:permissions', $display);
+
+        $this->entityManager->clear();
+        $this->assertNotInstanceOf(
+            Page::class,
+            $this->pageContentService->findByUrl((string) $this->url),
+            '書き出せなかったページのレコードが残ってはいけない'
+        );
+    }
+
+    /**
      * キャッシュ削除まで含めて実行する (トレイトの #[Required] 注入が効いていることの確認を兼ねる).
      */
     public function testApplyClearsCache(): void

--- a/tests/Eccube/Tests/Command/Content/PageCommandTest.php
+++ b/tests/Eccube/Tests/Command/Content/PageCommandTest.php
@@ -219,10 +219,12 @@ final class PageCommandTest extends EccubeTestCase
         if (!is_dir($poolDir)) {
             mkdir($poolDir, 0775, true);
         }
+        // 検証後に元へ戻す. 固定値で戻すと元の権限を書き換えたまま終わる
+        $originalMode = fileperms($poolDir) & 0777;
         chmod($poolDir, 0555);
 
         if (is_writable($poolDir)) {
-            chmod($poolDir, 0775);
+            chmod($poolDir, $originalMode);
             $this->markTestSkipped('ディレクトリを書き込み不可にできない環境');
         }
 
@@ -243,7 +245,7 @@ final class PageCommandTest extends EccubeTestCase
             $this->assertInstanceOf(Page::class, $Page, '本処理は完了している');
             $this->assertStringContainsString('cache:pool:clear', $tester->getDisplay());
         } finally {
-            chmod($poolDir, 0775);
+            chmod($poolDir, $originalMode);
         }
     }
 

--- a/tests/Eccube/Tests/Command/Content/PageCommandTest.php
+++ b/tests/Eccube/Tests/Command/Content/PageCommandTest.php
@@ -34,14 +34,14 @@ final class PageCommandTest extends EccubeTestCase
      */
     private ?array $createdFiles = null;
 
-    private ?string $url = null;
+    private ?string $route = null;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->pageContentService = self::getContainer()->get(PageContentService::class);
         $this->createdFiles = [];
-        $this->url = 'test_page_'.bin2hex(random_bytes(4));
+        $this->route = 'test_page_'.bin2hex(random_bytes(4));
     }
 
     protected function tearDown(): void
@@ -58,7 +58,7 @@ final class PageCommandTest extends EccubeTestCase
     public function testApplyCreatesPage(): void
     {
         $tester = $this->apply([
-            '--url' => $this->url,
+            '--route' => $this->route,
             '--name' => 'テストページ',
             '--body' => 'created body',
         ]);
@@ -66,7 +66,7 @@ final class PageCommandTest extends EccubeTestCase
         $this->assertSame(0, $tester->getStatusCode());
         $this->assertStringContainsString('created', $tester->getDisplay());
 
-        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $Page = $this->pageContentService->findByRoute((string) $this->route);
         $this->assertInstanceOf(Page::class, $Page);
         $this->assertSame('created body', file_get_contents($this->pageContentService->getFilePath($Page)));
     }
@@ -74,14 +74,14 @@ final class PageCommandTest extends EccubeTestCase
     public function testApplyReadsBodyFromStdin(): void
     {
         $tester = $this->apply([
-            '--url' => $this->url,
+            '--route' => $this->route,
             '--name' => 'テストページ',
             '--body' => '-',
         ], ['body from stdin']);
 
         $this->assertSame(0, $tester->getStatusCode());
 
-        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $Page = $this->pageContentService->findByRoute((string) $this->route);
         $this->assertInstanceOf(Page::class, $Page);
         $this->assertSame('body from stdin', trim((string) file_get_contents($this->pageContentService->getFilePath($Page))));
     }
@@ -89,7 +89,7 @@ final class PageCommandTest extends EccubeTestCase
     public function testApplyDryRunDoesNotCreatePage(): void
     {
         $tester = $this->apply([
-            '--url' => $this->url,
+            '--route' => $this->route,
             '--name' => 'テストページ',
             '--body' => 'body',
             '--dry-run' => true,
@@ -97,13 +97,13 @@ final class PageCommandTest extends EccubeTestCase
 
         $this->assertSame(0, $tester->getStatusCode());
         $this->assertStringContainsString('dry-run', $tester->getDisplay());
-        $this->assertNotInstanceOf(Page::class, $this->pageContentService->findByUrl((string) $this->url));
+        $this->assertNotInstanceOf(Page::class, $this->pageContentService->findByRoute((string) $this->route));
     }
 
     public function testApplyOutputsJson(): void
     {
         $tester = $this->apply([
-            '--url' => $this->url,
+            '--route' => $this->route,
             '--name' => 'テストページ',
             '--body' => 'body',
             '--format' => 'json',
@@ -114,10 +114,10 @@ final class PageCommandTest extends EccubeTestCase
         $decoded = json_decode($tester->getDisplay(), true);
         $this->assertIsArray($decoded);
         $this->assertSame('created', $decoded['status']);
-        $this->assertSame($this->url, $decoded['identifier']);
+        $this->assertSame($this->route, $decoded['identifier']);
     }
 
-    public function testApplyReturnsInvalidWithoutUrl(): void
+    public function testApplyReturnsInvalidWithoutRoute(): void
     {
         $tester = $this->apply(['--name' => 'テストページ']);
 
@@ -126,7 +126,7 @@ final class PageCommandTest extends EccubeTestCase
 
     public function testApplyReturnsInvalidWithUnknownFormat(): void
     {
-        $tester = $this->apply(['--url' => $this->url, '--format' => 'yaml']);
+        $tester = $this->apply(['--route' => $this->route, '--format' => 'yaml']);
 
         $this->assertSame(Command::INVALID, $tester->getStatusCode());
     }
@@ -134,13 +134,13 @@ final class PageCommandTest extends EccubeTestCase
     public function testApplyFailsWithInvalidTwig(): void
     {
         $tester = $this->apply([
-            '--url' => $this->url,
+            '--route' => $this->route,
             '--name' => 'テストページ',
             '--body' => '{% block foo %}',
         ]);
 
         $this->assertSame(1, $tester->getStatusCode());
-        $this->assertNotInstanceOf(Page::class, $this->pageContentService->findByUrl((string) $this->url));
+        $this->assertNotInstanceOf(Page::class, $this->pageContentService->findByRoute((string) $this->route));
     }
 
     /**
@@ -164,7 +164,7 @@ final class PageCommandTest extends EccubeTestCase
 
         try {
             $tester = $this->apply([
-                '--url' => $this->url,
+                '--route' => $this->route,
                 '--name' => 'テストページ',
                 '--body' => 'body',
             ]);
@@ -181,7 +181,7 @@ final class PageCommandTest extends EccubeTestCase
         $this->entityManager->clear();
         $this->assertNotInstanceOf(
             Page::class,
-            $this->pageContentService->findByUrl((string) $this->url),
+            $this->pageContentService->findByRoute((string) $this->route),
             '書き出せなかったページのレコードが残ってはいけない'
         );
     }
@@ -193,12 +193,12 @@ final class PageCommandTest extends EccubeTestCase
     {
         $tester = new CommandTester(self::getContainer()->get(PageApplyCommand::class));
         $tester->execute([
-            '--url' => $this->url,
+            '--route' => $this->route,
             '--name' => 'テストページ',
             '--body' => 'body',
         ]);
 
-        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $Page = $this->pageContentService->findByRoute((string) $this->route);
         if ($Page instanceof Page) {
             $this->createdFiles[] = $this->pageContentService->getFilePath($Page);
         }
@@ -230,12 +230,12 @@ final class PageCommandTest extends EccubeTestCase
         try {
             $tester = new CommandTester(self::getContainer()->get(PageApplyCommand::class));
             $tester->execute([
-                '--url' => $this->url,
+                '--route' => $this->route,
                 '--name' => 'テストページ',
                 '--body' => 'body',
             ]);
 
-            $Page = $this->pageContentService->findByUrl((string) $this->url);
+            $Page = $this->pageContentService->findByRoute((string) $this->route);
             if ($Page instanceof Page) {
                 $this->createdFiles[] = $this->pageContentService->getFilePath($Page);
             }
@@ -250,10 +250,10 @@ final class PageCommandTest extends EccubeTestCase
 
     public function testShowOutputsTemplate(): void
     {
-        $this->apply(['--url' => $this->url, '--name' => 'テストページ', '--body' => 'shown body']);
+        $this->apply(['--route' => $this->route, '--name' => 'テストページ', '--body' => 'shown body']);
 
         $tester = new CommandTester(self::getContainer()->get(PageShowCommand::class));
-        $tester->execute(['--url' => $this->url]);
+        $tester->execute(['--route' => $this->route]);
 
         $this->assertSame(0, $tester->getStatusCode());
         $this->assertSame('shown body', $tester->getDisplay());
@@ -262,45 +262,45 @@ final class PageCommandTest extends EccubeTestCase
     public function testShowReturnsErrorWhenNotFound(): void
     {
         $tester = new CommandTester(self::getContainer()->get(PageShowCommand::class));
-        $tester->execute(['--url' => 'not_found_page']);
+        $tester->execute(['--route' => 'not_found_page']);
 
         $this->assertSame(1, $tester->getStatusCode());
     }
 
     public function testListContainsCreatedPage(): void
     {
-        $this->apply(['--url' => $this->url, '--name' => 'テストページ', '--body' => 'body']);
+        $this->apply(['--route' => $this->route, '--name' => 'テストページ', '--body' => 'body']);
 
         $tester = new CommandTester(self::getContainer()->get(PageListCommand::class));
         $tester->execute(['--format' => 'json']);
 
         $this->assertSame(0, $tester->getStatusCode());
 
-        $urls = array_column((array) json_decode($tester->getDisplay(), true), 'url');
-        $this->assertContains($this->url, $urls);
+        $routes = array_column((array) json_decode($tester->getDisplay(), true), 'route');
+        $this->assertContains($this->route, $routes);
     }
 
     public function testRemoveDeletesPage(): void
     {
-        $this->apply(['--url' => $this->url, '--name' => 'テストページ', '--body' => 'body']);
+        $this->apply(['--route' => $this->route, '--name' => 'テストページ', '--body' => 'body']);
 
         $tester = new CommandTester(self::getContainer()->get(PageRemoveCommand::class));
-        $tester->execute(['--url' => $this->url, '--force' => true, '--no-cache-clear' => true]);
+        $tester->execute(['--route' => $this->route, '--force' => true, '--no-cache-clear' => true]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertNotInstanceOf(Page::class, $this->pageContentService->findByUrl((string) $this->url));
+        $this->assertNotInstanceOf(Page::class, $this->pageContentService->findByRoute((string) $this->route));
     }
 
     public function testRemoveIsAbortedWithoutConfirmation(): void
     {
-        $this->apply(['--url' => $this->url, '--name' => 'テストページ', '--body' => 'body']);
+        $this->apply(['--route' => $this->route, '--name' => 'テストページ', '--body' => 'body']);
 
         $tester = new CommandTester(self::getContainer()->get(PageRemoveCommand::class));
         $tester->setInputs(['no']);
-        $tester->execute(['--url' => $this->url, '--no-cache-clear' => true]);
+        $tester->execute(['--route' => $this->route, '--no-cache-clear' => true]);
 
         $this->assertSame(1, $tester->getStatusCode());
-        $this->assertInstanceOf(Page::class, $this->pageContentService->findByUrl((string) $this->url));
+        $this->assertInstanceOf(Page::class, $this->pageContentService->findByRoute((string) $this->route));
     }
 
     public function testRemoveRejectsDefaultPage(): void
@@ -309,7 +309,7 @@ final class PageCommandTest extends EccubeTestCase
         $this->assertInstanceOf(Page::class, $Page);
 
         $tester = new CommandTester(self::getContainer()->get(PageRemoveCommand::class));
-        $tester->execute(['--url' => $Page->getUrl(), '--force' => true, '--no-cache-clear' => true]);
+        $tester->execute(['--route' => $Page->getUrl(), '--force' => true, '--no-cache-clear' => true]);
 
         $this->assertSame(1, $tester->getStatusCode());
     }
@@ -326,7 +326,7 @@ final class PageCommandTest extends EccubeTestCase
         }
         $tester->execute($input + ['--no-cache-clear' => true]);
 
-        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $Page = $this->pageContentService->findByRoute((string) $this->route);
         if ($Page instanceof Page) {
             $this->createdFiles[] = $this->pageContentService->getFilePath($Page);
         }

--- a/tests/Eccube/Tests/DependencyInjection/Compiler/CliFileLogHandlerPassTest.php
+++ b/tests/Eccube/Tests/DependencyInjection/Compiler/CliFileLogHandlerPassTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\DependencyInjection\Compiler;
+
+use Eccube\DependencyInjection\Compiler\CliFileLogHandlerPass;
+use Eccube\Log\CliSuppressibleHandler;
+use Monolog\Handler\RotatingFileHandler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Monolog\Handler\ConsoleHandler;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class CliFileLogHandlerPassTest extends TestCase
+{
+    public function testWrapsFileHandler(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('monolog.handler.main', new Definition(RotatingFileHandler::class, [
+            '/var/www/html/var/log/prod/site.log',
+            10,
+        ]));
+
+        (new CliFileLogHandlerPass())->process($container);
+
+        $wrapper = $container->getDefinition('monolog.handler.main');
+        $this->assertSame(CliSuppressibleHandler::class, $wrapper->getClass());
+        $this->assertSame('%env(bool:ECCUBE_CLI_LOG_TO_FILE)%', $wrapper->getArgument(1));
+
+        $inner = $container->getDefinition('monolog.handler.main.cli_suppressible.inner');
+        $this->assertSame(RotatingFileHandler::class, $inner->getClass());
+        $this->assertSame('/var/www/html/var/log/prod/site.log', $inner->getArgument(0));
+    }
+
+    public function testDoesNotWrapNonFileHandler(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('monolog.handler.console', new Definition(ConsoleHandler::class));
+
+        (new CliFileLogHandlerPass())->process($container);
+
+        $this->assertSame(ConsoleHandler::class, $container->getDefinition('monolog.handler.console')->getClass());
+        $this->assertFalse($container->hasDefinition('monolog.handler.console.cli_suppressible.inner'));
+    }
+
+    public function testIsIdempotent(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('monolog.handler.main', new Definition(RotatingFileHandler::class, ['/tmp/site.log']));
+
+        $pass = new CliFileLogHandlerPass();
+        $pass->process($container);
+        $pass->process($container);
+
+        $this->assertSame(CliSuppressibleHandler::class, $container->getDefinition('monolog.handler.main')->getClass());
+        $this->assertSame(
+            RotatingFileHandler::class,
+            $container->getDefinition('monolog.handler.main.cli_suppressible.inner')->getClass()
+        );
+        $this->assertFalse(
+            $container->hasDefinition('monolog.handler.main.cli_suppressible.inner.cli_suppressible.inner'),
+            '二重にラップしない'
+        );
+    }
+}

--- a/tests/Eccube/Tests/DependencyInjection/Compiler/RuntimeCachePoolFailsafePassTest.php
+++ b/tests/Eccube/Tests/DependencyInjection/Compiler/RuntimeCachePoolFailsafePassTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\DependencyInjection\Compiler;
+
+use Eccube\Cache\WriteFailsafeFilesystemAdapter;
+use Eccube\Cache\WriteFailsafePhpFilesAdapter;
+use Eccube\DependencyInjection\Compiler\RuntimeCachePoolFailsafePass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class RuntimeCachePoolFailsafePassTest extends TestCase
+{
+    public function testReplacesFilesystemAdapterPool(): void
+    {
+        $container = new ContainerBuilder();
+        $definition = new Definition(FilesystemAdapter::class, ['ns', 0, '/var/www/html/var/runtime/prod/pools/app']);
+        $definition->addTag('cache.pool');
+        $container->setDefinition('cache.app', $definition);
+
+        (new RuntimeCachePoolFailsafePass())->process($container);
+
+        $this->assertSame(WriteFailsafeFilesystemAdapter::class, $container->getDefinition('cache.app')->getClass());
+    }
+
+    public function testReplacesSystemCacheFactory(): void
+    {
+        $container = new ContainerBuilder();
+        $definition = new Definition(FilesystemAdapter::class);
+        $definition->setFactory([AbstractAdapter::class, 'createSystemCache']);
+        $definition->addTag('cache.pool');
+        $container->setDefinition('cache.system', $definition);
+
+        (new RuntimeCachePoolFailsafePass())->process($container);
+
+        $factory = $container->getDefinition('cache.system')->getFactory();
+
+        $this->assertIsArray($factory);
+        $this->assertSame(WriteFailsafePhpFilesAdapter::class, $factory[0]);
+        $this->assertSame('createSystemCache', $factory[1]);
+    }
+
+    /**
+     * ChildDefinition はクラスを持たないため, 親をたどって判定する.
+     */
+    public function testResolvesClassThroughParentDefinition(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('cache.adapter.filesystem', new Definition(FilesystemAdapter::class));
+        $child = new ChildDefinition('cache.adapter.filesystem');
+        $child->addTag('cache.pool');
+        $container->setDefinition('doctrine.app_cache_pool', $child);
+
+        (new RuntimeCachePoolFailsafePass())->process($container);
+
+        $this->assertSame(
+            WriteFailsafeFilesystemAdapter::class,
+            $container->getDefinition('doctrine.app_cache_pool')->getClass()
+        );
+    }
+
+    public function testKeepsOtherAdapters(): void
+    {
+        $container = new ContainerBuilder();
+        $definition = new Definition(ArrayAdapter::class);
+        $definition->addTag('cache.pool');
+        $container->setDefinition('cache.array', $definition);
+
+        (new RuntimeCachePoolFailsafePass())->process($container);
+
+        $this->assertSame(ArrayAdapter::class, $container->getDefinition('cache.array')->getClass());
+    }
+}

--- a/tests/Eccube/Tests/EffectiveUserTrait.php
+++ b/tests/Eccube/Tests/EffectiveUserTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests;
+
+/**
+ * 権限による書き込み不可を再現するテストのためのヘルパ.
+ *
+ * root はパーミッションビットを無視するため, 書き込み不可を前提としたテストは成立しない.
+ * 実効 uid の判定に getmyuid() は使えない. 返るのは実行プロセスではなく
+ * スクリプトファイルの所有者で, root で非 root 所有の作業ツリーを実行した場合
+ * (bind mount した checkout を root のコンテナで動かす等) に root を検出できない.
+ *
+ * @see \Eccube\Service\Permission\WebServerUserResolver
+ */
+trait EffectiveUserTrait
+{
+    /**
+     * root で実行している場合にテストをスキップする.
+     *
+     * ext-posix が無い環境では実効 uid を確認できないため, 同じくスキップする
+     * (root かどうか分からないまま検証すると偽陽性・偽陰性のどちらも起こりうる).
+     */
+    protected function skipIfRoot(): void
+    {
+        if (!function_exists('posix_geteuid')) {
+            self::markTestSkipped('ext-posix が無いため実効 uid を確認できません.');
+        }
+
+        if (0 === posix_geteuid()) {
+            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
+        }
+    }
+}

--- a/tests/Eccube/Tests/EventListener/RuntimeCachePoolClearListenerTest.php
+++ b/tests/Eccube/Tests/EventListener/RuntimeCachePoolClearListenerTest.php
@@ -141,6 +141,11 @@ final class RuntimeCachePoolClearListenerTest extends TestCase
 
         $display = $this->dispatch('cache:clear', 0, $this->foreignUser())['display'];
 
+        // strpos() は見つからないと false を返し, 比較では 0 として扱われる. 案内が
+        // 欠けていても順序の検証だけは通ってしまうため, 先に双方の存在を確かめる
+        $this->assertStringContainsString('eccube:cache:build', $display);
+        $this->assertStringContainsString('cache:pool:clear', $display);
+
         $this->assertLessThan(
             strpos($display, 'cache:pool:clear'),
             strpos($display, 'eccube:cache:build'),

--- a/tests/Eccube/Tests/EventListener/RuntimeCachePoolClearListenerTest.php
+++ b/tests/Eccube/Tests/EventListener/RuntimeCachePoolClearListenerTest.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 namespace Eccube\Tests\EventListener;
 
 use Eccube\EventListener\RuntimeCachePoolClearListener;
+use Eccube\Service\Permission\UserIdentity;
+use Eccube\Service\Permission\WebServerUserResolver;
 use Eccube\Util\RuntimeCachePoolClearer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
@@ -29,13 +31,22 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class RuntimeCachePoolClearListenerTest extends TestCase
 {
+    private const CONTAINER_CLASS = 'Eccube_KernelProdContainer';
+
     private string $runtimeDir;
+
+    private string $buildDir;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->runtimeDir = sys_get_temp_dir().'/eccube-pool-listener-'.bin2hex(random_bytes(6));
+        $base = sys_get_temp_dir().'/eccube-pool-listener-'.bin2hex(random_bytes(6));
+        $this->runtimeDir = $base.'/runtime';
+        $this->buildDir = $base.'/build';
         mkdir($this->runtimeDir, 0755, true);
+        mkdir($this->buildDir, 0755, true);
+        // 既定はコンパイル済みコンテナがある状態 (cache:clear を warmup 込みで実行した後)
+        file_put_contents($this->buildDir.'/'.self::CONTAINER_CLASS.'.php', '<?php');
     }
 
     protected function tearDown(): void
@@ -43,8 +54,90 @@ final class RuntimeCachePoolClearListenerTest extends TestCase
         if (is_dir($this->runtimeDir)) {
             chmod($this->runtimeDir, 0755);
         }
-        (new Filesystem())->remove($this->runtimeDir);
+        (new Filesystem())->remove(\dirname($this->runtimeDir));
         parent::tearDown();
+    }
+
+    /**
+     * --no-warmup を付けるとビルドディレクトリからコンパイル済みコンテナが消える.
+     *
+     * 権限を分離した構成では Web サーバーが作り直せず 500 になる. 復旧できるのは
+     * CLI ユーザーの eccube:cache:build だけなので, cache pool の案内より先に伝える.
+     */
+    public function testWarnsWhenWebServerCannotRebuildContainer(): void
+    {
+        unlink($this->buildDir.'/'.self::CONTAINER_CLASS.'.php');
+
+        $output = $this->dispatch('cache:clear', 0, $this->foreignUser());
+
+        $this->assertStringContainsString($this->buildDir, $output['display']);
+        $this->assertStringContainsString('eccube:cache:build', $output['display']);
+    }
+
+    /**
+     * 権限を分離していない構成では Web サーバー自身が作り直せるため案内しない.
+     */
+    public function testStaysSilentWhenWebServerCanRebuildContainer(): void
+    {
+        unlink($this->buildDir.'/'.self::CONTAINER_CLASS.'.php');
+
+        $output = $this->dispatch('cache:clear', 0, $this->currentUser());
+
+        $this->assertStringNotContainsString('eccube:cache:build', $output['display']);
+    }
+
+    /**
+     * Web サーバーの実行ユーザーを特定できない場合は, 誤った警告を出さない.
+     */
+    public function testStaysSilentWhenWebServerUserIsUnknown(): void
+    {
+        unlink($this->buildDir.'/'.self::CONTAINER_CLASS.'.php');
+
+        $output = $this->dispatch('cache:clear', 0);
+
+        $this->assertStringNotContainsString('eccube:cache:build', $output['display']);
+    }
+
+    public function testStaysSilentWhenCompiledContainerExists(): void
+    {
+        $output = $this->dispatch('cache:clear', 0, $this->foreignUser());
+
+        $this->assertStringNotContainsString('eccube:cache:build', $output['display']);
+    }
+
+    /**
+     * コンテナが無い場合は, ビルドの案内を cache pool の案内より先に出す.
+     */
+    public function testContainerWarningComesFirst(): void
+    {
+        if (0 === getmyuid()) {
+            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
+        }
+
+        unlink($this->buildDir.'/'.self::CONTAINER_CLASS.'.php');
+        mkdir($this->runtimeDir.'/pools/system', 0755, true);
+        chmod($this->runtimeDir, 0555);
+
+        $display = $this->dispatch('cache:clear', 0, $this->foreignUser())['display'];
+
+        $this->assertLessThan(
+            strpos($display, 'cache:pool:clear'),
+            strpos($display, 'eccube:cache:build'),
+            'Web サーバーを復旧させる操作を先に案内する'
+        );
+    }
+
+    /**
+     * ビルドディレクトリを所有せず, other にも書き込み権が無いユーザー.
+     */
+    private function foreignUser(): UserIdentity
+    {
+        return new UserIdentity(fileowner($this->buildDir) + 4242, filegroup($this->buildDir) + 4242, 'test');
+    }
+
+    private function currentUser(): UserIdentity
+    {
+        return new UserIdentity((int) fileowner($this->buildDir), (int) filegroup($this->buildDir), 'test');
     }
 
     public function testWarnsWhenPoolsCouldNotBeCleared(): void
@@ -128,15 +221,19 @@ final class RuntimeCachePoolClearListenerTest extends TestCase
     /**
      * @return array{exitCode: int, display: string}
      */
-    private function dispatch(string $commandName, int $exitCode): array
+    private function dispatch(string $commandName, int $exitCode, ?UserIdentity $webServerUser = null): array
     {
         $clearer = new RuntimeCachePoolClearer($this->runtimeDir);
         $clearer->clear($this->runtimeDir);
 
+        $resolver = $this->createMock(WebServerUserResolver::class);
+        $resolver->method('resolve')->willReturn($webServerUser);
+
         $output = new BufferedOutput();
         $event = new ConsoleTerminateEvent(new Command($commandName), new ArrayInput([]), $output, $exitCode);
 
-        (new RuntimeCachePoolClearListener($clearer))->onConsoleTerminate($event);
+        (new RuntimeCachePoolClearListener($clearer, $resolver, $this->buildDir, $this->buildDir, self::CONTAINER_CLASS))
+            ->onConsoleTerminate($event);
 
         return ['exitCode' => $event->getExitCode(), 'display' => $output->fetch()];
     }

--- a/tests/Eccube/Tests/EventListener/RuntimeCachePoolClearListenerTest.php
+++ b/tests/Eccube/Tests/EventListener/RuntimeCachePoolClearListenerTest.php
@@ -18,6 +18,7 @@ namespace Eccube\Tests\EventListener;
 use Eccube\EventListener\RuntimeCachePoolClearListener;
 use Eccube\Service\Permission\UserIdentity;
 use Eccube\Service\Permission\WebServerUserResolver;
+use Eccube\Tests\EffectiveUserTrait;
 use Eccube\Util\RuntimeCachePoolClearer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
@@ -31,6 +32,8 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class RuntimeCachePoolClearListenerTest extends TestCase
 {
+    use EffectiveUserTrait;
+
     private const CONTAINER_CLASS = 'Eccube_KernelProdContainer';
 
     private string $runtimeDir;
@@ -98,6 +101,26 @@ final class RuntimeCachePoolClearListenerTest extends TestCase
         $this->assertStringNotContainsString('eccube:cache:build', $output['display']);
     }
 
+    /**
+     * 祖先ディレクトリを通り抜けられない場合も, Web サーバーはコンテナを作り直せない.
+     *
+     * PathOwnership::isWritableBy() が見るのは対象自身のビットだけなので,
+     * ビルドディレクトリが誰でも書ける状態でも, 親を通れなければ到達できない.
+     */
+    public function testWarnsWhenWebServerCannotTraverseAncestor(): void
+    {
+        $this->skipIfRoot();
+
+        unlink($this->buildDir.'/'.self::CONTAINER_CLASS.'.php');
+        chmod($this->buildDir, 0777);
+        // 親は所有者だけが通り抜けられる
+        chmod(\dirname($this->buildDir), 0700);
+
+        $output = $this->dispatch('cache:clear', 0, $this->foreignUser());
+
+        $this->assertStringContainsString('eccube:cache:build', $output['display']);
+    }
+
     public function testStaysSilentWhenCompiledContainerExists(): void
     {
         $output = $this->dispatch('cache:clear', 0, $this->foreignUser());
@@ -110,9 +133,7 @@ final class RuntimeCachePoolClearListenerTest extends TestCase
      */
     public function testContainerWarningComesFirst(): void
     {
-        if (0 === getmyuid()) {
-            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
-        }
+        $this->skipIfRoot();
 
         unlink($this->buildDir.'/'.self::CONTAINER_CLASS.'.php');
         mkdir($this->runtimeDir.'/pools/system', 0755, true);
@@ -142,9 +163,7 @@ final class RuntimeCachePoolClearListenerTest extends TestCase
 
     public function testWarnsWhenPoolsCouldNotBeCleared(): void
     {
-        if (0 === getmyuid()) {
-            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
-        }
+        $this->skipIfRoot();
 
         mkdir($this->runtimeDir.'/pools/system', 0755, true);
         chmod($this->runtimeDir, 0555);
@@ -163,9 +182,7 @@ final class RuntimeCachePoolClearListenerTest extends TestCase
      */
     public function testKeepsSuccessExitCodeForComposerScripts(): void
     {
-        if (0 === getmyuid()) {
-            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
-        }
+        $this->skipIfRoot();
 
         mkdir($this->runtimeDir.'/pools/system', 0755, true);
         chmod($this->runtimeDir, 0555);
@@ -187,9 +204,7 @@ final class RuntimeCachePoolClearListenerTest extends TestCase
 
     public function testIgnoresOtherCommands(): void
     {
-        if (0 === getmyuid()) {
-            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
-        }
+        $this->skipIfRoot();
 
         mkdir($this->runtimeDir.'/pools/system', 0755, true);
         chmod($this->runtimeDir, 0555);
@@ -205,9 +220,7 @@ final class RuntimeCachePoolClearListenerTest extends TestCase
      */
     public function testStaysSilentWhenCommandAlreadyFailed(): void
     {
-        if (0 === getmyuid()) {
-            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
-        }
+        $this->skipIfRoot();
 
         mkdir($this->runtimeDir.'/pools/system', 0755, true);
         chmod($this->runtimeDir, 0555);

--- a/tests/Eccube/Tests/EventListener/RuntimeCachePoolClearListenerTest.php
+++ b/tests/Eccube/Tests/EventListener/RuntimeCachePoolClearListenerTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\EventListener;
+
+use Eccube\EventListener\RuntimeCachePoolClearListener;
+use Eccube\Util\RuntimeCachePoolClearer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * cache:clear が実行時 cache pool を削除できなかったことを通知する.
+ */
+final class RuntimeCachePoolClearListenerTest extends TestCase
+{
+    private string $runtimeDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->runtimeDir = sys_get_temp_dir().'/eccube-pool-listener-'.bin2hex(random_bytes(6));
+        mkdir($this->runtimeDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->runtimeDir)) {
+            chmod($this->runtimeDir, 0755);
+        }
+        (new Filesystem())->remove($this->runtimeDir);
+        parent::tearDown();
+    }
+
+    public function testWarnsWhenPoolsCouldNotBeCleared(): void
+    {
+        if (0 === getmyuid()) {
+            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
+        }
+
+        mkdir($this->runtimeDir.'/pools/system', 0755, true);
+        chmod($this->runtimeDir, 0555);
+
+        $output = $this->dispatch('cache:clear', 0);
+
+        $this->assertStringContainsString($this->runtimeDir.'/pools', $output['display']);
+        $this->assertStringContainsString('cache:pool:clear', $output['display']);
+    }
+
+    /**
+     * 終了コードは変更しない.
+     *
+     * cache:clear は composer.json の auto-scripts から実行されるため, 非ゼロを返すと
+     * 分離した構成で composer install がスクリプト失敗として中断してしまう.
+     */
+    public function testKeepsSuccessExitCodeForComposerScripts(): void
+    {
+        if (0 === getmyuid()) {
+            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
+        }
+
+        mkdir($this->runtimeDir.'/pools/system', 0755, true);
+        chmod($this->runtimeDir, 0555);
+
+        $output = $this->dispatch('cache:clear', 0);
+
+        $this->assertSame(0, $output['exitCode']);
+    }
+
+    public function testKeepsSuccessWhenPoolsAreCleared(): void
+    {
+        mkdir($this->runtimeDir.'/pools/system', 0755, true);
+
+        $output = $this->dispatch('cache:clear', 0);
+
+        $this->assertSame(0, $output['exitCode']);
+        $this->assertSame('', trim($output['display']));
+    }
+
+    public function testIgnoresOtherCommands(): void
+    {
+        if (0 === getmyuid()) {
+            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
+        }
+
+        mkdir($this->runtimeDir.'/pools/system', 0755, true);
+        chmod($this->runtimeDir, 0555);
+
+        $output = $this->dispatch('cache:warmup', 0);
+
+        $this->assertSame(0, $output['exitCode']);
+        $this->assertSame('', trim($output['display']));
+    }
+
+    /**
+     * 本処理が失敗している場合は, そちらのエラーを埋もれさせないため何も表示しない.
+     */
+    public function testStaysSilentWhenCommandAlreadyFailed(): void
+    {
+        if (0 === getmyuid()) {
+            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
+        }
+
+        mkdir($this->runtimeDir.'/pools/system', 0755, true);
+        chmod($this->runtimeDir, 0555);
+
+        $output = $this->dispatch('cache:clear', 1);
+
+        $this->assertSame(1, $output['exitCode']);
+        $this->assertSame('', trim($output['display']));
+    }
+
+    /**
+     * @return array{exitCode: int, display: string}
+     */
+    private function dispatch(string $commandName, int $exitCode): array
+    {
+        $clearer = new RuntimeCachePoolClearer($this->runtimeDir);
+        $clearer->clear($this->runtimeDir);
+
+        $output = new BufferedOutput();
+        $event = new ConsoleTerminateEvent(new Command($commandName), new ArrayInput([]), $output, $exitCode);
+
+        (new RuntimeCachePoolClearListener($clearer))->onConsoleTerminate($event);
+
+        return ['exitCode' => $event->getExitCode(), 'display' => $output->fetch()];
+    }
+}

--- a/tests/Eccube/Tests/Functions/ApplyUmaskTest.php
+++ b/tests/Eccube/Tests/Functions/ApplyUmaskTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Functions;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ECCUBE_UMASK による umask の適用を検証する.
+ */
+final class ApplyUmaskTest extends TestCase
+{
+    private int $originalUmask;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalUmask = umask();
+        unset($_ENV['ECCUBE_UMASK'], $_SERVER['ECCUBE_UMASK']);
+        putenv('ECCUBE_UMASK');
+    }
+
+    protected function tearDown(): void
+    {
+        umask($this->originalUmask);
+        unset($_ENV['ECCUBE_UMASK'], $_SERVER['ECCUBE_UMASK']);
+        putenv('ECCUBE_UMASK');
+        parent::tearDown();
+    }
+
+    public function testUnsetKeepsCurrentUmask(): void
+    {
+        umask(0022);
+
+        apply_umask();
+
+        $this->assertSame(0022, umask());
+    }
+
+    public function testEmptyValueKeepsCurrentUmask(): void
+    {
+        umask(0022);
+        $_ENV['ECCUBE_UMASK'] = '';
+
+        apply_umask();
+
+        $this->assertSame(0022, umask());
+    }
+
+    /**
+     * 互換のため 4.3 以前と同じ挙動 (ディレクトリ 0777 / ファイル 0666) に戻せること.
+     */
+    public function testZeroUmaskIsApplied(): void
+    {
+        umask(0022);
+        $_ENV['ECCUBE_UMASK'] = '0000';
+
+        apply_umask();
+
+        $this->assertSame(0000, umask());
+    }
+
+    public function testOctalValueIsApplied(): void
+    {
+        umask(0000);
+        $_ENV['ECCUBE_UMASK'] = '0027';
+
+        apply_umask();
+
+        $this->assertSame(0027, umask());
+    }
+
+    /**
+     * env() は先頭に 0 の無い数値を int として返すため, その経路も 8 進数として解釈すること.
+     */
+    public function testValueWithoutLeadingZeroIsTreatedAsOctal(): void
+    {
+        umask(0000);
+        $_ENV['ECCUBE_UMASK'] = '22';
+
+        apply_umask();
+
+        $this->assertSame(0022, umask());
+    }
+
+    public function testInvalidValueIsIgnored(): void
+    {
+        umask(0022);
+        $_ENV['ECCUBE_UMASK'] = '0999';
+
+        apply_umask();
+
+        $this->assertSame(0022, umask());
+    }
+}

--- a/tests/Eccube/Tests/Log/CliSuppressibleHandlerTest.php
+++ b/tests/Eccube/Tests/Log/CliSuppressibleHandlerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Log;
+
+use Eccube\Log\CliSuppressibleHandler;
+use Monolog\Handler\TestHandler;
+use Monolog\Level;
+use Monolog\LogRecord;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * テストは CLI で実行されるため, PHP_SAPI === 'cli' の経路を検証する.
+ */
+final class CliSuppressibleHandlerTest extends TestCase
+{
+    public function testSuppressesRecordInCli(): void
+    {
+        $inner = new TestHandler();
+        $handler = new CliSuppressibleHandler($inner, false);
+
+        $this->assertFalse($handler->isHandling($this->record()));
+        $this->assertFalse($handler->handle($this->record()));
+        $this->assertSame([], $inner->getRecords(), '委譲先を呼ばないためファイルは開かれない');
+    }
+
+    public function testDelegatesWhenEnabled(): void
+    {
+        // bubble = false のハンドラは handle() で true を返す. 委譲先の戻り値を
+        // そのまま返していることを確認する (バブリングの挙動を変えない).
+        $inner = new TestHandler(Level::Debug, false);
+        $handler = new CliSuppressibleHandler($inner, true);
+
+        $this->assertTrue($handler->isHandling($this->record()));
+        $this->assertTrue($handler->handle($this->record()));
+        $this->assertCount(1, $inner->getRecords());
+    }
+
+    public function testSuppressesBatchInCli(): void
+    {
+        $inner = new TestHandler();
+        $handler = new CliSuppressibleHandler($inner, false);
+
+        $handler->handleBatch([$this->record(), $this->record()]);
+
+        $this->assertSame([], $inner->getRecords());
+    }
+
+    public function testDelegatesBatchWhenEnabled(): void
+    {
+        $inner = new TestHandler();
+        $handler = new CliSuppressibleHandler($inner, true);
+
+        $handler->handleBatch([$this->record(), $this->record()]);
+
+        $this->assertCount(2, $inner->getRecords());
+    }
+
+    private function record(): LogRecord
+    {
+        return new LogRecord(new \DateTimeImmutable(), 'app', Level::Warning, 'message');
+    }
+}

--- a/tests/Eccube/Tests/Service/Content/BlockContentServiceTest.php
+++ b/tests/Eccube/Tests/Service/Content/BlockContentServiceTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Service\Content;
+
+use Eccube\Entity\Block;
+use Eccube\Entity\Master\DeviceType;
+use Eccube\Exception\ContentValidationException;
+use Eccube\Service\Content\BlockContentService;
+use Eccube\Service\Content\ContentResult;
+use Eccube\Service\Content\ContentStatus;
+use Eccube\Tests\EccubeTestCase;
+
+final class BlockContentServiceTest extends EccubeTestCase
+{
+    private ?BlockContentService $blockContentService = null;
+
+    /**
+     * @var list<string>|null
+     */
+    private ?array $createdFiles = null;
+
+    private ?string $fileName = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->blockContentService = self::getContainer()->get(BlockContentService::class);
+        $this->createdFiles = [];
+        $this->fileName = 'test_block_'.bin2hex(random_bytes(4));
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdFiles ?? [] as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function testApplyCreatesBlockAndTemplate(): void
+    {
+        $result = $this->apply(['name' => 'テストブロック', 'body' => '<p>created</p>']);
+
+        $this->assertSame(ContentStatus::Created, $result->status);
+
+        $Block = $this->findBlock();
+        $this->assertInstanceOf(Block::class, $Block);
+        $this->assertSame('テストブロック', $Block->getName());
+        $this->assertTrue($Block->isDeletable());
+        $this->assertSame('<p>created</p>', file_get_contents((string) $result->path()));
+    }
+
+    public function testApplyIsIdempotent(): void
+    {
+        $this->apply(['name' => 'テストブロック', 'body' => '<p>same</p>']);
+        $result = $this->apply(['name' => 'テストブロック', 'body' => '<p>same</p>']);
+
+        $this->assertSame(ContentStatus::Unchanged, $result->status);
+        $this->assertSame([], $result->writtenPaths);
+    }
+
+    public function testApplyDryRunDoesNotWrite(): void
+    {
+        $created = $this->apply(['name' => 'テストブロック', 'body' => '<p>body</p>']);
+        $path = (string) $created->path();
+
+        $result = $this->apply(['body' => '<p>changed</p>'], true);
+
+        $this->assertSame(ContentStatus::Updated, $result->status);
+        $this->assertSame('<p>body</p>', file_get_contents($path));
+    }
+
+    public function testApplyRejectsInvalidTwig(): void
+    {
+        $this->expectException(ContentValidationException::class);
+
+        $this->apply(['name' => 'テストブロック', 'body' => '{% block foo %}']);
+    }
+
+    public function testRemoveDeletesBlockAndTemplate(): void
+    {
+        $created = $this->apply(['name' => 'テストブロック', 'body' => '<p>body</p>']);
+        $path = (string) $created->path();
+
+        $Block = $this->findBlock();
+        $this->assertInstanceOf(Block::class, $Block);
+
+        $result = $this->blockContentService->remove($Block);
+
+        $this->assertSame(ContentStatus::Removed, $result->status);
+        $this->assertFileDoesNotExist($path);
+        $this->assertNotInstanceOf(Block::class, $this->findBlock());
+    }
+
+    public function testRemoveRejectsUndeletableBlock(): void
+    {
+        $created = $this->apply(['name' => 'テストブロック', 'body' => '<p>body</p>']);
+        $this->createdFiles[] = (string) $created->path();
+
+        $Block = $this->findBlock();
+        $this->assertInstanceOf(Block::class, $Block);
+        $Block->setDeletable(false);
+
+        $this->expectException(\LogicException::class);
+
+        $this->blockContentService->remove($Block);
+    }
+
+    /**
+     * @param array<string, string> $payload
+     */
+    private function apply(array $payload, bool $dryRun = false): ContentResult
+    {
+        /** @var array{file_name: string} $payload */
+        $payload = ['file_name' => (string) $this->fileName] + $payload;
+        $result = $this->blockContentService->apply($payload, $dryRun);
+
+        foreach ($result->writtenPaths as $path) {
+            $this->createdFiles[] = $path;
+        }
+
+        return $result;
+    }
+
+    private function findBlock(): ?Block
+    {
+        return $this->blockContentService->findByFileName(
+            (string) $this->fileName,
+            $this->blockContentService->getDeviceType(DeviceType::DEVICE_TYPE_PC)
+        );
+    }
+}

--- a/tests/Eccube/Tests/Service/Content/MailTemplateContentServiceTest.php
+++ b/tests/Eccube/Tests/Service/Content/MailTemplateContentServiceTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Service\Content;
+
+use Eccube\Entity\MailTemplate;
+use Eccube\Exception\ContentValidationException;
+use Eccube\Service\Content\ContentResult;
+use Eccube\Service\Content\ContentStatus;
+use Eccube\Service\Content\MailTemplateContentService;
+use Eccube\Tests\EccubeTestCase;
+
+final class MailTemplateContentServiceTest extends EccubeTestCase
+{
+    private ?MailTemplateContentService $mailTemplateContentService = null;
+
+    /**
+     * @var list<string>|null
+     */
+    private ?array $createdFiles = null;
+
+    private ?string $fileName = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mailTemplateContentService = self::getContainer()->get(MailTemplateContentService::class);
+        $this->createdFiles = [];
+        $this->fileName = 'test_mail_'.bin2hex(random_bytes(4));
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdFiles ?? [] as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function testApplyCreatesTemplate(): void
+    {
+        $result = $this->apply(['name' => 'テストメール', 'subject' => '件名', 'body' => 'created body']);
+
+        $this->assertSame(ContentStatus::Created, $result->status);
+
+        $Mail = $this->mailTemplateContentService->findByFileName((string) $this->fileName);
+        $this->assertInstanceOf(MailTemplate::class, $Mail);
+        $this->assertSame('Mail/'.$this->fileName.'.twig', $Mail->getFileName(), 'ファイル名は Mail/xxx.twig へ変換される');
+        $this->assertTrue($Mail->isDeletable());
+        $this->assertSame('created body', file_get_contents((string) $result->path()));
+    }
+
+    public function testApplyIsIdempotent(): void
+    {
+        $this->apply(['name' => 'テストメール', 'subject' => '件名', 'body' => 'same body']);
+        $result = $this->apply(['body' => 'same body']);
+
+        $this->assertSame(ContentStatus::Unchanged, $result->status);
+    }
+
+    public function testApplyWritesAndRemovesHtmlPart(): void
+    {
+        $this->apply(['name' => 'テストメール', 'subject' => '件名', 'body' => 'body']);
+
+        $result = $this->apply(['html_body' => '<p>html</p>']);
+        $htmlPath = $result->writtenPaths[1] ?? '';
+        $this->createdFiles[] = $htmlPath;
+
+        $this->assertSame(ContentStatus::Updated, $result->status);
+        $this->assertSame('<p>html</p>', file_get_contents($htmlPath));
+
+        $removed = $this->apply(['remove_html' => true]);
+
+        $this->assertSame([$htmlPath], $removed->removedPaths);
+        $this->assertFileDoesNotExist($htmlPath);
+    }
+
+    public function testApplyKeepsHtmlPartWhenNotSpecified(): void
+    {
+        $this->apply(['name' => 'テストメール', 'subject' => '件名', 'body' => 'body']);
+        $result = $this->apply(['html_body' => '<p>html</p>']);
+        $htmlPath = $result->writtenPaths[1] ?? '';
+        $this->createdFiles[] = $htmlPath;
+
+        $this->apply(['body' => 'updated body']);
+
+        $this->assertFileExists($htmlPath, 'HTML パートを指定しない場合は現在の内容を維持する');
+    }
+
+    public function testApplyRejectsInvalidTwig(): void
+    {
+        $this->expectException(ContentValidationException::class);
+
+        $this->apply(['name' => 'テストメール', 'subject' => '件名', 'body' => '{% block foo %}']);
+    }
+
+    public function testRemoveDeletesTemplate(): void
+    {
+        $created = $this->apply(['name' => 'テストメール', 'subject' => '件名', 'body' => 'body']);
+        $path = (string) $created->path();
+
+        $Mail = $this->mailTemplateContentService->findByFileName((string) $this->fileName);
+        $this->assertInstanceOf(MailTemplate::class, $Mail);
+
+        $result = $this->mailTemplateContentService->remove($Mail);
+
+        $this->assertSame(ContentStatus::Removed, $result->status);
+        $this->assertFileDoesNotExist($path);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function apply(array $payload, bool $dryRun = false): ContentResult
+    {
+        $payload = ['file_name' => (string) $this->fileName] + $payload;
+        $result = $this->mailTemplateContentService->apply($payload, $dryRun);
+
+        foreach ($result->writtenPaths as $path) {
+            $this->createdFiles[] = $path;
+        }
+
+        return $result;
+    }
+}

--- a/tests/Eccube/Tests/Service/Content/MailTemplateContentServiceTest.php
+++ b/tests/Eccube/Tests/Service/Content/MailTemplateContentServiceTest.php
@@ -17,13 +17,17 @@ namespace Eccube\Tests\Service\Content;
 
 use Eccube\Entity\MailTemplate;
 use Eccube\Exception\ContentValidationException;
+use Eccube\Exception\ContentWriteException;
 use Eccube\Service\Content\ContentResult;
 use Eccube\Service\Content\ContentStatus;
 use Eccube\Service\Content\MailTemplateContentService;
 use Eccube\Tests\EccubeTestCase;
+use Eccube\Tests\EffectiveUserTrait;
 
 final class MailTemplateContentServiceTest extends EccubeTestCase
 {
+    use EffectiveUserTrait;
+
     private ?MailTemplateContentService $mailTemplateContentService = null;
 
     /**
@@ -121,6 +125,42 @@ final class MailTemplateContentServiceTest extends EccubeTestCase
 
         $this->assertSame(ContentStatus::Removed, $result->status);
         $this->assertFileDoesNotExist($path);
+    }
+
+    /**
+     * テンプレートファイルを削除できない場合はレコードも残す.
+     *
+     * 逆順にするとレコードだけが消えてテンプレートが残り, 削除に失敗したテンプレートが
+     * 一覧から消える.
+     */
+    public function testRemoveKeepsRecordWhenTemplateIsNotRemovable(): void
+    {
+        $this->skipIfRoot();
+
+        $created = $this->apply(['name' => 'テストメール', 'subject' => '件名', 'body' => 'body']);
+        $path = (string) $created->path();
+        $dir = \dirname($path);
+        $originalMode = fileperms($dir) & 0777;
+
+        $Mail = $this->mailTemplateContentService->findByFileName((string) $this->fileName);
+        $this->assertInstanceOf(MailTemplate::class, $Mail);
+
+        chmod($dir, 0555);
+        try {
+            $this->mailTemplateContentService->remove($Mail);
+            self::fail('書き込めないディレクトリのテンプレートは削除できない');
+        } catch (ContentWriteException $e) {
+            $this->assertStringContainsString($path, $e->getPath());
+        } finally {
+            chmod($dir, $originalMode);
+        }
+
+        $this->entityManager->clear();
+        $this->assertInstanceOf(
+            MailTemplate::class,
+            $this->mailTemplateContentService->findByFileName((string) $this->fileName),
+            'ファイルを削除できないときはレコードも残す'
+        );
     }
 
     /**

--- a/tests/Eccube/Tests/Service/Content/PageContentServiceTest.php
+++ b/tests/Eccube/Tests/Service/Content/PageContentServiceTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Service\Content;
+
+use Eccube\Entity\Layout;
+use Eccube\Entity\Master\DeviceType;
+use Eccube\Entity\Page;
+use Eccube\Exception\ContentValidationException;
+use Eccube\Service\Content\ContentResult;
+use Eccube\Service\Content\ContentStatus;
+use Eccube\Service\Content\PageContentService;
+use Eccube\Tests\EccubeTestCase;
+
+final class PageContentServiceTest extends EccubeTestCase
+{
+    private ?PageContentService $pageContentService = null;
+
+    /**
+     * @var list<string>|null
+     */
+    private ?array $createdFiles = null;
+
+    private ?string $url = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->pageContentService = self::getContainer()->get(PageContentService::class);
+        $this->createdFiles = [];
+        $this->url = 'test_page_'.bin2hex(random_bytes(4));
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdFiles ?? [] as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function testApplyCreatesPageAndTemplate(): void
+    {
+        $result = $this->apply(['name' => 'テストページ', 'body' => 'created body']);
+
+        $this->assertSame(ContentStatus::Created, $result->status);
+        $this->assertNotNull($result->id);
+
+        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $this->assertInstanceOf(Page::class, $Page);
+        $this->assertSame('テストページ', $Page->getName());
+        $this->assertSame($this->url, $Page->getFileName(), 'ファイル名を省略した場合は URL を既定値にする');
+        $this->assertSame('created body', file_get_contents((string) $result->path()));
+    }
+
+    public function testApplyIsIdempotent(): void
+    {
+        $this->apply(['name' => 'テストページ', 'body' => 'same body']);
+        $result = $this->apply(['name' => 'テストページ', 'body' => 'same body']);
+
+        $this->assertSame(ContentStatus::Unchanged, $result->status);
+        $this->assertSame([], $result->writtenPaths, '変更が無い場合はファイルを書き換えない');
+    }
+
+    public function testApplyKeepsUnspecifiedValues(): void
+    {
+        $this->apply(['name' => 'テストページ', 'body' => 'first body', 'author' => '作者']);
+        $result = $this->apply(['body' => 'second body']);
+
+        $this->assertSame(ContentStatus::Updated, $result->status);
+
+        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $this->assertInstanceOf(Page::class, $Page);
+        $this->assertSame('テストページ', $Page->getName());
+        $this->assertSame('作者', $Page->getAuthor());
+        $this->assertSame('second body', file_get_contents((string) $result->path()));
+    }
+
+    public function testApplyDryRunDoesNotWrite(): void
+    {
+        $created = $this->apply(['name' => 'テストページ', 'body' => 'body']);
+        $path = (string) $created->path();
+
+        $result = $this->apply(['body' => 'changed body'], true);
+
+        $this->assertSame(ContentStatus::Updated, $result->status);
+        $this->assertSame([], $result->writtenPaths);
+        $this->assertArrayHasKey($path, $result->fileChanges);
+        $this->assertSame('body', file_get_contents($path), 'dry-run はファイルを書き換えない');
+
+        $this->entityManager->clear();
+        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $this->assertInstanceOf(Page::class, $Page);
+        $this->assertSame('テストページ', $Page->getName());
+    }
+
+    public function testApplyRejectsInvalidTwig(): void
+    {
+        $this->expectException(ContentValidationException::class);
+
+        $this->apply(['name' => 'テストページ', 'body' => '{% block foo %}']);
+    }
+
+    public function testApplyRejectsDuplicatedFileName(): void
+    {
+        $this->apply(['name' => 'テストページ', 'body' => 'body']);
+
+        $other = 'test_page_'.bin2hex(random_bytes(4));
+
+        try {
+            $this->pageContentService->apply([
+                'url' => $other,
+                'name' => '別のページ',
+                'file_name' => (string) $this->url,
+                'body' => 'body',
+            ]);
+            self::fail('重複したファイル名は登録できない');
+        } catch (ContentValidationException $e) {
+            $this->assertNotSame([], $e->getErrors());
+        }
+    }
+
+    public function testApplyRenamesTemplateFile(): void
+    {
+        $created = $this->apply(['name' => 'テストページ', 'body' => 'body']);
+        $oldPath = (string) $created->path();
+
+        $newFileName = $this->url.'_renamed';
+        $result = $this->apply(['file_name' => $newFileName]);
+        $this->createdFiles[] = (string) $result->path();
+
+        $this->assertSame(ContentStatus::Updated, $result->status);
+        $this->assertSame([$oldPath], $result->removedPaths, '旧ファイルを削除する');
+        $this->assertFileDoesNotExist($oldPath);
+        $this->assertSame('body', file_get_contents((string) $result->path()));
+    }
+
+    public function testApplyLinksLayout(): void
+    {
+        $Layout = $this->findLayout();
+
+        $this->apply(['name' => 'テストページ', 'body' => 'body', 'pc_layout' => (string) $Layout->getId()]);
+
+        // PageLayout は Page のコレクションへ追加せず永続化するため, 読み直して確認する
+        $this->entityManager->clear();
+        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $this->assertInstanceOf(Page::class, $Page);
+        $this->assertSame([$Layout->getId()], array_map(static fn (Layout $L): ?int => $L->getId(), $Page->getLayouts()));
+    }
+
+    public function testRemoveDeletesPageAndTemplate(): void
+    {
+        $created = $this->apply(['name' => 'テストページ', 'body' => 'body']);
+        $path = (string) $created->path();
+
+        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $this->assertInstanceOf(Page::class, $Page);
+
+        $result = $this->pageContentService->remove($Page);
+
+        $this->assertSame(ContentStatus::Removed, $result->status);
+        $this->assertFileDoesNotExist($path);
+        $this->assertNotInstanceOf(Page::class, $this->pageContentService->findByUrl((string) $this->url));
+    }
+
+    public function testRemoveRejectsDefaultPage(): void
+    {
+        $Page = $this->entityManager->getRepository(Page::class)->findOneBy(['edit_type' => Page::EDIT_TYPE_DEFAULT]);
+        $this->assertInstanceOf(Page::class, $Page);
+
+        $this->expectException(\LogicException::class);
+
+        $this->pageContentService->remove($Page);
+    }
+
+    public function testApplyKeepsFileNameOfDefaultPage(): void
+    {
+        $Page = $this->entityManager->getRepository(Page::class)->findOneBy(['edit_type' => Page::EDIT_TYPE_DEFAULT]);
+        $this->assertInstanceOf(Page::class, $Page);
+        $fileName = (string) $Page->getFileName();
+        $body = $this->pageContentService->readTemplate($Page);
+
+        $result = $this->pageContentService->apply([
+            'url' => (string) $Page->getUrl(),
+            'file_name' => 'must_be_ignored',
+            'body' => $body,
+        ], true);
+
+        $this->assertArrayNotHasKey('file_name', $result->fieldChanges, '既定ページのファイル名は変更できない');
+        $this->assertSame($fileName, $Page->getFileName());
+    }
+
+    /**
+     * @param array<string, string> $payload
+     */
+    private function apply(array $payload, bool $dryRun = false): ContentResult
+    {
+        /** @var array{url: string} $payload */
+        $payload = ['url' => (string) $this->url] + $payload;
+        $result = $this->pageContentService->apply($payload, $dryRun);
+
+        foreach ($result->writtenPaths as $path) {
+            $this->createdFiles[] = $path;
+        }
+
+        return $result;
+    }
+
+    private function findLayout(): Layout
+    {
+        $DeviceType = $this->entityManager->getRepository(DeviceType::class)->find(DeviceType::DEVICE_TYPE_PC);
+        $Layout = $this->entityManager->getRepository(Layout::class)->findOneBy(['DeviceType' => $DeviceType], ['id' => 'DESC']);
+        $this->assertInstanceOf(Layout::class, $Layout);
+
+        return $Layout;
+    }
+}

--- a/tests/Eccube/Tests/Service/Content/PageContentServiceTest.php
+++ b/tests/Eccube/Tests/Service/Content/PageContentServiceTest.php
@@ -202,6 +202,30 @@ final class PageContentServiceTest extends EccubeTestCase
         $this->assertSame([$Layout->getId()], array_map(static fn (Layout $L): ?int => $L->getId(), $Page->getLayouts()));
     }
 
+    /**
+     * 両方のレイアウトを外す操作で, 変更後のスナップショットが現在の値を読み直さないこと.
+     *
+     * 読み直すと差分が出ず Unchanged で早期 return し, レイアウトが外れないまま終わる.
+     */
+    public function testApplyUnlinksBothLayouts(): void
+    {
+        $Layout = $this->findLayout();
+        $this->apply(['name' => 'テストページ', 'body' => 'body', 'pc_layout' => (string) $Layout->getId()]);
+
+        // PageLayout は Page のコレクションへ追加せず永続化するため, CLI の 2 回目の実行と
+        // 同じ状態 (DB から読み直したエンティティ) にしてから解除する
+        $this->entityManager->clear();
+
+        $result = $this->apply(['pc_layout' => '', 'sp_layout' => '']);
+
+        $this->assertSame(ContentStatus::Updated, $result->status, 'レイアウトの解除は変更として扱う');
+
+        $this->entityManager->clear();
+        $Page = $this->pageContentService->findByRoute((string) $this->route);
+        $this->assertInstanceOf(Page::class, $Page);
+        $this->assertSame([], $Page->getLayouts());
+    }
+
     public function testRemoveDeletesPageAndTemplate(): void
     {
         $created = $this->apply(['name' => 'テストページ', 'body' => 'body']);

--- a/tests/Eccube/Tests/Service/Content/PageContentServiceTest.php
+++ b/tests/Eccube/Tests/Service/Content/PageContentServiceTest.php
@@ -24,9 +24,12 @@ use Eccube\Service\Content\ContentResult;
 use Eccube\Service\Content\ContentStatus;
 use Eccube\Service\Content\PageContentService;
 use Eccube\Tests\EccubeTestCase;
+use Eccube\Tests\EffectiveUserTrait;
 
 final class PageContentServiceTest extends EccubeTestCase
 {
+    use EffectiveUserTrait;
+
     private ?PageContentService $pageContentService = null;
 
     /**
@@ -125,9 +128,7 @@ final class PageContentServiceTest extends EccubeTestCase
      */
     public function testApplyRollsBackWhenTemplateIsNotWritable(): void
     {
-        if (0 === getmyuid()) {
-            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
-        }
+        $this->skipIfRoot();
 
         $Page = new Page();
         $Page->setEditType(Page::EDIT_TYPE_USER);

--- a/tests/Eccube/Tests/Service/Content/PageContentServiceTest.php
+++ b/tests/Eccube/Tests/Service/Content/PageContentServiceTest.php
@@ -34,14 +34,14 @@ final class PageContentServiceTest extends EccubeTestCase
      */
     private ?array $createdFiles = null;
 
-    private ?string $url = null;
+    private ?string $route = null;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->pageContentService = self::getContainer()->get(PageContentService::class);
         $this->createdFiles = [];
-        $this->url = 'test_page_'.bin2hex(random_bytes(4));
+        $this->route = 'test_page_'.bin2hex(random_bytes(4));
     }
 
     protected function tearDown(): void
@@ -62,10 +62,10 @@ final class PageContentServiceTest extends EccubeTestCase
         $this->assertSame(ContentStatus::Created, $result->status);
         $this->assertNotNull($result->id);
 
-        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $Page = $this->pageContentService->findByRoute((string) $this->route);
         $this->assertInstanceOf(Page::class, $Page);
         $this->assertSame('テストページ', $Page->getName());
-        $this->assertSame($this->url, $Page->getFileName(), 'ファイル名を省略した場合は URL を既定値にする');
+        $this->assertSame($this->route, $Page->getFileName(), 'ファイル名を省略した場合はルーティング名を既定値にする');
         $this->assertSame('created body', file_get_contents((string) $result->path()));
     }
 
@@ -85,7 +85,7 @@ final class PageContentServiceTest extends EccubeTestCase
 
         $this->assertSame(ContentStatus::Updated, $result->status);
 
-        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $Page = $this->pageContentService->findByRoute((string) $this->route);
         $this->assertInstanceOf(Page::class, $Page);
         $this->assertSame('テストページ', $Page->getName());
         $this->assertSame('作者', $Page->getAuthor());
@@ -105,7 +105,7 @@ final class PageContentServiceTest extends EccubeTestCase
         $this->assertSame('body', file_get_contents($path), 'dry-run はファイルを書き換えない');
 
         $this->entityManager->clear();
-        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $Page = $this->pageContentService->findByRoute((string) $this->route);
         $this->assertInstanceOf(Page::class, $Page);
         $this->assertSame('テストページ', $Page->getName());
     }
@@ -140,7 +140,7 @@ final class PageContentServiceTest extends EccubeTestCase
             $this->apply(['name' => 'テストページ', 'body' => 'body']);
             self::fail('書き込めない場合は ContentWriteException を投げる');
         } catch (ContentWriteException $e) {
-            $this->assertStringContainsString((string) $this->url, $e->getPath());
+            $this->assertStringContainsString((string) $this->route, $e->getPath());
         } finally {
             chmod($templateDir, $originalPerms);
         }
@@ -149,7 +149,7 @@ final class PageContentServiceTest extends EccubeTestCase
 
         $this->assertNotInstanceOf(
             Page::class,
-            $this->pageContentService->findByUrl((string) $this->url),
+            $this->pageContentService->findByRoute((string) $this->route),
             'テンプレートを書き出せなかったページのレコードが残ってはいけない'
         );
     }
@@ -162,9 +162,9 @@ final class PageContentServiceTest extends EccubeTestCase
 
         try {
             $this->pageContentService->apply([
-                'url' => $other,
+                'route' => $other,
                 'name' => '別のページ',
-                'file_name' => (string) $this->url,
+                'file_name' => (string) $this->route,
                 'body' => 'body',
             ]);
             self::fail('重複したファイル名は登録できない');
@@ -178,7 +178,7 @@ final class PageContentServiceTest extends EccubeTestCase
         $created = $this->apply(['name' => 'テストページ', 'body' => 'body']);
         $oldPath = (string) $created->path();
 
-        $newFileName = $this->url.'_renamed';
+        $newFileName = $this->route.'_renamed';
         $result = $this->apply(['file_name' => $newFileName]);
         $this->createdFiles[] = (string) $result->path();
 
@@ -196,7 +196,7 @@ final class PageContentServiceTest extends EccubeTestCase
 
         // PageLayout は Page のコレクションへ追加せず永続化するため, 読み直して確認する
         $this->entityManager->clear();
-        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $Page = $this->pageContentService->findByRoute((string) $this->route);
         $this->assertInstanceOf(Page::class, $Page);
         $this->assertSame([$Layout->getId()], array_map(static fn (Layout $L): ?int => $L->getId(), $Page->getLayouts()));
     }
@@ -206,14 +206,14 @@ final class PageContentServiceTest extends EccubeTestCase
         $created = $this->apply(['name' => 'テストページ', 'body' => 'body']);
         $path = (string) $created->path();
 
-        $Page = $this->pageContentService->findByUrl((string) $this->url);
+        $Page = $this->pageContentService->findByRoute((string) $this->route);
         $this->assertInstanceOf(Page::class, $Page);
 
         $result = $this->pageContentService->remove($Page);
 
         $this->assertSame(ContentStatus::Removed, $result->status);
         $this->assertFileDoesNotExist($path);
-        $this->assertNotInstanceOf(Page::class, $this->pageContentService->findByUrl((string) $this->url));
+        $this->assertNotInstanceOf(Page::class, $this->pageContentService->findByRoute((string) $this->route));
     }
 
     public function testRemoveRejectsDefaultPage(): void
@@ -234,7 +234,7 @@ final class PageContentServiceTest extends EccubeTestCase
         $body = $this->pageContentService->readTemplate($Page);
 
         $result = $this->pageContentService->apply([
-            'url' => (string) $Page->getUrl(),
+            'route' => (string) $Page->getUrl(),
             'file_name' => 'must_be_ignored',
             'body' => $body,
         ], true);
@@ -248,8 +248,8 @@ final class PageContentServiceTest extends EccubeTestCase
      */
     private function apply(array $payload, bool $dryRun = false): ContentResult
     {
-        /** @var array{url: string} $payload */
-        $payload = ['url' => (string) $this->url] + $payload;
+        /** @var array{route: string} $payload */
+        $payload = ['route' => (string) $this->route] + $payload;
         $result = $this->pageContentService->apply($payload, $dryRun);
 
         foreach ($result->writtenPaths as $path) {

--- a/tests/Eccube/Tests/Service/Content/PageContentServiceTest.php
+++ b/tests/Eccube/Tests/Service/Content/PageContentServiceTest.php
@@ -19,6 +19,7 @@ use Eccube\Entity\Layout;
 use Eccube\Entity\Master\DeviceType;
 use Eccube\Entity\Page;
 use Eccube\Exception\ContentValidationException;
+use Eccube\Exception\ContentWriteException;
 use Eccube\Service\Content\ContentResult;
 use Eccube\Service\Content\ContentStatus;
 use Eccube\Service\Content\PageContentService;
@@ -114,6 +115,43 @@ final class PageContentServiceTest extends EccubeTestCase
         $this->expectException(ContentValidationException::class);
 
         $this->apply(['name' => 'テストページ', 'body' => '{% block foo %}']);
+    }
+
+    /**
+     * テンプレートを書き出せない場合は DB もロールバックする.
+     *
+     * 先にコミットするとレコードだけが残り, テンプレートの無いページとして
+     * フロントの表示が 500 になる. 権限を分離した構成では書き出しだけが失敗し得る.
+     */
+    public function testApplyRollsBackWhenTemplateIsNotWritable(): void
+    {
+        if (0 === getmyuid()) {
+            self::markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
+        }
+
+        $Page = new Page();
+        $Page->setEditType(Page::EDIT_TYPE_USER);
+        $templateDir = $this->pageContentService->getTemplateDir($Page);
+        $originalPerms = fileperms($templateDir) & 0777;
+
+        chmod($templateDir, 0555);
+
+        try {
+            $this->apply(['name' => 'テストページ', 'body' => 'body']);
+            self::fail('書き込めない場合は ContentWriteException を投げる');
+        } catch (ContentWriteException $e) {
+            $this->assertStringContainsString((string) $this->url, $e->getPath());
+        } finally {
+            chmod($templateDir, $originalPerms);
+        }
+
+        $this->entityManager->clear();
+
+        $this->assertNotInstanceOf(
+            Page::class,
+            $this->pageContentService->findByUrl((string) $this->url),
+            'テンプレートを書き出せなかったページのレコードが残ってはいけない'
+        );
     }
 
     public function testApplyRejectsDuplicatedFileName(): void

--- a/tests/Eccube/Tests/Service/Permission/PermissionDiagnosticTest.php
+++ b/tests/Eccube/Tests/Service/Permission/PermissionDiagnosticTest.php
@@ -44,12 +44,12 @@ final class PermissionDiagnosticTest extends TestCase
 
     public function testWebLaneWarnsWhenWorldWritable(): void
     {
-        // umask(0000) の影響でアプリケーションが 0777 で作成したディレクトリ.
+        // ECCUBE_UMASK=0000 の影響でアプリケーションが 0777 で作成したディレクトリ.
         // Web サーバーからは書けるが, 任意のローカルユーザーからも書ける
         $finding = $this->evaluate(WriteLane::WEB, self::WEB_UID, self::WEB_UID, 0777);
 
         $this->assertSame(FindingSeverity::WARN, $finding->severity);
-        $this->assertStringContainsString('umask(0000)', (string) $finding->hint);
+        $this->assertStringContainsString('ECCUBE_UMASK', (string) $finding->hint);
     }
 
     public function testWebLaneIsNgWhenWebServerCannotWrite(): void

--- a/tests/Eccube/Tests/Service/Permission/PermissionRequirementProviderTest.php
+++ b/tests/Eccube/Tests/Service/Permission/PermissionRequirementProviderTest.php
@@ -32,8 +32,11 @@ final class PermissionRequirementProviderTest extends TestCase
     {
         $requirements = $this->requirementsByLabel();
 
-        $this->assertSame(WriteLane::WEB, $requirements['var/cache/prod']->lane);
+        $this->assertSame(WriteLane::WEB, $requirements['var/runtime/prod']->lane);
         $this->assertSame(WriteLane::WEB, $requirements['html/upload/save_image']->lane);
+        // ビルド生成物は CLI が生成するためレーン S
+        $this->assertSame(WriteLane::SSH, $requirements['var/build/prod']->lane);
+        $this->assertSame(WriteLane::SSH, $requirements['var/cache/prod']->lane);
         $this->assertSame(WriteLane::SSH, $requirements['app/template']->lane);
         $this->assertSame(WriteLane::SSH, $requirements['html/user_data']->lane);
         $this->assertSame(WriteLane::SSH, $requirements['composer.json']->lane);
@@ -43,7 +46,8 @@ final class PermissionRequirementProviderTest extends TestCase
     {
         $requirements = $this->requirementsByLabel();
 
-        $this->assertTrue($requirements['var/cache/prod']->optional);
+        $this->assertTrue($requirements['var/runtime/prod']->optional);
+        $this->assertTrue($requirements['var/build/prod']->optional);
         $this->assertFalse($requirements['html/upload/save_image']->optional);
     }
 
@@ -66,6 +70,23 @@ final class PermissionRequirementProviderTest extends TestCase
         $this->assertArrayHasKey('.', $requirements);
         $this->assertSame(WriteLane::WEB, $requirements['.']->lane);
         $this->assertSame(self::PROJECT_DIR, $requirements['.']->path);
+    }
+
+    public function testWarmupFallbackIsTheRuntimeTwigDirectory(): void
+    {
+        $requirement = $this->provider()->warmupFallbackRequirement();
+
+        $this->assertInstanceOf(PermissionRequirement::class, $requirement);
+        $this->assertSame(self::PROJECT_DIR.'/var/runtime/prod/twig', $requirement->path);
+        $this->assertSame(WriteLane::WEB, $requirement->lane);
+    }
+
+    /**
+     * dev は auto_reload により twig が 2 層構成にならないため, 生成物があっても warmup 漏れではない.
+     */
+    public function testWarmupFallbackIsNotDetectedInDebugMode(): void
+    {
+        $this->assertNotInstanceOf(PermissionRequirement::class, $this->provider(null, true)->warmupFallbackRequirement());
     }
 
     public function testPathsAreUnique(): void
@@ -91,12 +112,15 @@ final class PermissionRequirementProviderTest extends TestCase
         return $requirements;
     }
 
-    private function provider(?string $maintenanceFilePath = null): PermissionRequirementProvider
+    private function provider(?string $maintenanceFilePath = null, bool $debug = false): PermissionRequirementProvider
     {
         $values = [
             'kernel.project_dir' => self::PROJECT_DIR,
             'kernel.environment' => 'prod',
+            'kernel.debug' => $debug,
             'kernel.cache_dir' => self::PROJECT_DIR.'/var/cache/prod',
+            'kernel.build_dir' => self::PROJECT_DIR.'/var/build/prod',
+            'eccube_runtime_dir' => self::PROJECT_DIR.'/var/runtime/prod',
             'kernel.logs_dir' => self::PROJECT_DIR.'/var/log',
             'eccube_save_image_dir' => self::PROJECT_DIR.'/html/upload/save_image',
             'eccube_temp_image_dir' => self::PROJECT_DIR.'/html/upload/temp_image',

--- a/tests/Eccube/Tests/Service/Permission/PermissionRequirementProviderTest.php
+++ b/tests/Eccube/Tests/Service/Permission/PermissionRequirementProviderTest.php
@@ -40,6 +40,11 @@ final class PermissionRequirementProviderTest extends TestCase
         $this->assertSame(WriteLane::SSH, $requirements['app/template']->lane);
         $this->assertSame(WriteLane::SSH, $requirements['html/user_data']->lane);
         $this->assertSame(WriteLane::SSH, $requirements['composer.json']->lane);
+        // var 自体は CLI 所有. Web サーバーが書き込むのは配下の runtime / sessions / log で,
+        // var へは通過 (r-x) できればよい
+        $this->assertSame(WriteLane::SSH, $requirements['var']->lane);
+        // 秘密鍵は CLI で配置し Web サーバーは読み取りのみ
+        $this->assertSame(WriteLane::SSH, $requirements['app/keystore']->lane);
     }
 
     public function testRuntimeGeneratedPathsAreOptional(): void
@@ -60,6 +65,8 @@ final class PermissionRequirementProviderTest extends TestCase
         $this->assertStringContainsString('メンテナンスファイル', (string) $requirements['var']->note);
         // 一方が必須なら必須として扱う
         $this->assertFalse($requirements['var']->optional);
+        // Web サーバーの書き込みが必要な役割が加わるため, レーン W が優先される
+        $this->assertSame(WriteLane::WEB, $requirements['var']->lane);
     }
 
     public function testMaintenanceFileDirectoryIsListedSeparatelyWhenItIsTheProjectRoot(): void

--- a/tests/Eccube/Tests/Service/Permission/WebServerUserResolverTest.php
+++ b/tests/Eccube/Tests/Service/Permission/WebServerUserResolverTest.php
@@ -38,7 +38,7 @@ final class WebServerUserResolverTest extends TestCase
 
     protected function setUp(): void
     {
-        if (!function_exists('posix_geteuid')) {
+        if (!function_exists('posix_geteuid') || !function_exists('posix_getegid')) {
             self::markTestSkipped('ext-posix が無効な環境では実効 uid / gid を検証できません.');
         }
 

--- a/tests/Eccube/Tests/Service/Permission/WebServerUserResolverTest.php
+++ b/tests/Eccube/Tests/Service/Permission/WebServerUserResolverTest.php
@@ -50,7 +50,12 @@ final class WebServerUserResolverTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->fs->remove($this->projectDir);
+        // setUp() が markTestSkipped() で中断した場合も tearDown() は実行されるため,
+        // 未初期化のプロパティを参照しないようにする (参照するとスキップに加えてエラーになる).
+        if (isset($this->fs)) {
+            $this->fs->remove($this->projectDir);
+        }
+
         parent::tearDown();
     }
 

--- a/tests/Eccube/Tests/Service/PluginServiceTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceTest.php
@@ -105,10 +105,11 @@ final class PluginServiceTest extends AbstractServiceTestCase
 
     // テスト用のダミープラグインを配置する
     /**
-     * アーカイブの検査用の一時領域は OS の一時ディレクトリに作る.
+     * CLI 実行時, アーカイブの検査用の一時領域は OS の一時ディレクトリに作る.
      *
      * var/runtime (Web サーバー所有) に作ると, Web サーバーと CLI で書き込み権限を
      * 分離した構成でプラグイン操作が CLI から行えなくなるため.
+     * (テストは CLI で実行されるため, この経路を通る)
      */
     public function testCreateTempDirUsesSystemTempDir(): void
     {

--- a/tests/Eccube/Tests/Service/PluginServiceTest.php
+++ b/tests/Eccube/Tests/Service/PluginServiceTest.php
@@ -104,6 +104,25 @@ final class PluginServiceTest extends AbstractServiceTestCase
      */
 
     // テスト用のダミープラグインを配置する
+    /**
+     * アーカイブの検査用の一時領域は OS の一時ディレクトリに作る.
+     *
+     * var/runtime (Web サーバー所有) に作ると, Web サーバーと CLI で書き込み権限を
+     * 分離した構成でプラグイン操作が CLI から行えなくなるため.
+     */
+    public function testCreateTempDirUsesSystemTempDir(): void
+    {
+        $dir = $this->service->createTempDir();
+
+        try {
+            $this->assertDirectoryExists($dir);
+            $this->assertStringStartsWith(realpath(sys_get_temp_dir()), (string) realpath($dir));
+            $this->assertSame('0700', substr(sprintf('%o', fileperms($dir)), -4), '所有者のみに制限する');
+        } finally {
+            rmdir($dir);
+        }
+    }
+
     private function createTempDir()
     {
         $t = sys_get_temp_dir().'/plugintest.'.sha1((string) mt_rand());

--- a/tests/Eccube/Tests/Util/CacheUtilTest.php
+++ b/tests/Eccube/Tests/Util/CacheUtilTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Util;
+
+use Eccube\Common\EccubeConfig;
+use Eccube\Util\CacheUtil;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * ビルドディレクトリへ書き込めるかどうかによる分岐を検証する.
+ */
+final class CacheUtilTest extends TestCase
+{
+    private string $workDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->workDir = sys_get_temp_dir().'/eccube-cache-util-'.bin2hex(random_bytes(6));
+        foreach (['build', 'cache', 'runtime'] as $name) {
+            mkdir($this->workDir.'/'.$name, 0755, true);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['build', 'cache', 'runtime'] as $name) {
+            if (is_dir($this->workDir.'/'.$name)) {
+                chmod($this->workDir.'/'.$name, 0755);
+            }
+        }
+        (new Filesystem())->remove($this->workDir);
+        parent::tearDown();
+    }
+
+    public function testCanClearBuildCacheWhenBothDirectoriesAreWritable(): void
+    {
+        $this->assertTrue($this->cacheUtil()->canClearBuildCache());
+    }
+
+    public function testCannotClearBuildCacheWhenBuildDirIsReadOnly(): void
+    {
+        $this->skipWhenRunningAsRoot();
+        chmod($this->workDir.'/build', 0555);
+
+        $this->assertFalse($this->cacheUtil()->canClearBuildCache());
+    }
+
+    /**
+     * cache:clear は build と cache の双方へ書き込むため, どちらか一方でも書けなければ実行できない.
+     */
+    public function testCannotClearBuildCacheWhenCacheDirIsReadOnly(): void
+    {
+        $this->skipWhenRunningAsRoot();
+        chmod($this->workDir.'/cache', 0555);
+
+        $this->assertFalse($this->cacheUtil()->canClearBuildCache());
+    }
+
+    /**
+     * 実行時キャッシュの削除はランタイムディレクトリだけを対象とし, ビルド生成物は残す.
+     */
+    public function testClearRuntimeCacheRemovesOnlyRuntimeArtifacts(): void
+    {
+        $runtimeDir = $this->workDir.'/runtime';
+        foreach (['twig', 'translations', 'htmlpurifier', 'mcp-sessions'] as $name) {
+            mkdir($runtimeDir.'/'.$name, 0755, true);
+        }
+        mkdir($this->workDir.'/build/twig', 0755, true);
+
+        $message = $this->cacheUtil()->clearRuntimeCache();
+
+        $this->assertDirectoryDoesNotExist($runtimeDir.'/twig');
+        $this->assertDirectoryDoesNotExist($runtimeDir.'/translations');
+        $this->assertDirectoryDoesNotExist($runtimeDir.'/htmlpurifier');
+        // キャッシュではないものは削除しない
+        $this->assertDirectoryExists($runtimeDir.'/mcp-sessions');
+        // ビルド生成物には触れない
+        $this->assertDirectoryExists($this->workDir.'/build/twig');
+        $this->assertStringContainsString('eccube:cache:build', $message);
+    }
+
+    /**
+     * prod では build 側の読み取り専用キャッシュが優先されるため, 双方を削除しないと
+     * 管理画面で更新したテンプレートが反映されない.
+     */
+    public function testClearTwigCacheRemovesBothRuntimeAndBuildCaches(): void
+    {
+        mkdir($this->workDir.'/runtime/twig', 0755, true);
+        mkdir($this->workDir.'/build/twig', 0755, true);
+
+        $this->cacheUtil()->clearTwigCache();
+
+        $this->assertDirectoryDoesNotExist($this->workDir.'/runtime/twig');
+        $this->assertDirectoryDoesNotExist($this->workDir.'/build/twig');
+    }
+
+    /**
+     * ビルドディレクトリへ書き込めない構成では build 側は残る (eccube:cache:build に委ねる).
+     */
+    public function testClearTwigCacheKeepsBuildCacheWhenBuildDirIsReadOnly(): void
+    {
+        $this->skipWhenRunningAsRoot();
+        mkdir($this->workDir.'/runtime/twig', 0755, true);
+        mkdir($this->workDir.'/build/twig', 0755, true);
+        chmod($this->workDir.'/build', 0555);
+
+        $this->cacheUtil()->clearTwigCache();
+
+        $this->assertDirectoryDoesNotExist($this->workDir.'/runtime/twig');
+        $this->assertDirectoryExists($this->workDir.'/build/twig');
+    }
+
+    private function skipWhenRunningAsRoot(): void
+    {
+        if (getmyuid() === 0) {
+            $this->markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
+        }
+    }
+
+    private function cacheUtil(): CacheUtil
+    {
+        $eccubeConfig = $this->createMock(EccubeConfig::class);
+        $eccubeConfig->method('get')->willReturnCallback(fn (string $key): mixed => match ($key) {
+            'kernel.build_dir' => $this->workDir.'/build',
+            'kernel.cache_dir' => $this->workDir.'/cache',
+            'eccube_runtime_dir' => $this->workDir.'/runtime',
+            default => null,
+        });
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->with('cache.global_clearer')->willReturn(new Psr6CacheClearer());
+
+        return new CacheUtil(
+            $this->createStub(KernelInterface::class),
+            $container,
+            $eccubeConfig,
+            $this->createStub(LoggerInterface::class),
+        );
+    }
+}

--- a/tests/Eccube/Tests/Util/CacheUtilTest.php
+++ b/tests/Eccube/Tests/Util/CacheUtilTest.php
@@ -81,20 +81,20 @@ final class CacheUtilTest extends TestCase
     public function testClearRuntimeCacheRemovesOnlyRuntimeArtifacts(): void
     {
         $runtimeDir = $this->workDir.'/runtime';
-        foreach (['twig', 'translations', 'htmlpurifier', 'mcp-sessions'] as $name) {
+        foreach (['twig', 'mcp-sessions'] as $name) {
             mkdir($runtimeDir.'/'.$name, 0755, true);
         }
         mkdir($this->workDir.'/build/twig', 0755, true);
+        mkdir($this->workDir.'/cache/htmlpurifier', 0755, true);
 
         $message = $this->cacheUtil()->clearRuntimeCache();
 
         $this->assertDirectoryDoesNotExist($runtimeDir.'/twig');
-        $this->assertDirectoryDoesNotExist($runtimeDir.'/translations');
-        $this->assertDirectoryDoesNotExist($runtimeDir.'/htmlpurifier');
         // キャッシュではないものは削除しない
         $this->assertDirectoryExists($runtimeDir.'/mcp-sessions');
         // ビルド生成物には触れない
         $this->assertDirectoryExists($this->workDir.'/build/twig');
+        $this->assertDirectoryExists($this->workDir.'/cache/htmlpurifier');
         $this->assertStringContainsString('eccube:cache:build', $message);
     }
 

--- a/tests/Eccube/Tests/Util/CacheUtilTest.php
+++ b/tests/Eccube/Tests/Util/CacheUtilTest.php
@@ -129,6 +129,24 @@ final class CacheUtilTest extends TestCase
         $this->assertDirectoryExists($this->workDir.'/build/twig');
     }
 
+    /**
+     * 実行時キャッシュは Web サーバー所有 (レーン W) になり得るため, CLI から削除できないことがある.
+     * その場合に例外を投げると, キャッシュ削除の失敗が本処理の失敗として現れてしまう.
+     */
+    public function testClearTwigCacheKeepsRuntimeCacheWhenRuntimeDirIsReadOnly(): void
+    {
+        $this->skipWhenRunningAsRoot();
+        mkdir($this->workDir.'/runtime/twig', 0755, true);
+        mkdir($this->workDir.'/build/twig', 0755, true);
+        chmod($this->workDir.'/runtime', 0555);
+
+        $this->cacheUtil()->clearTwigCache();
+
+        $this->assertDirectoryExists($this->workDir.'/runtime/twig');
+        // 削除できる側 (build) は削除する
+        $this->assertDirectoryDoesNotExist($this->workDir.'/build/twig');
+    }
+
     private function skipWhenRunningAsRoot(): void
     {
         if (getmyuid() === 0) {

--- a/tests/Eccube/Tests/Util/CacheUtilTest.php
+++ b/tests/Eccube/Tests/Util/CacheUtilTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Eccube\Tests\Util;
 
 use Eccube\Common\EccubeConfig;
+use Eccube\Tests\EffectiveUserTrait;
 use Eccube\Util\CacheUtil;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -29,6 +30,8 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 final class CacheUtilTest extends TestCase
 {
+    use EffectiveUserTrait;
+
     private string $workDir;
 
     protected function setUp(): void
@@ -149,9 +152,7 @@ final class CacheUtilTest extends TestCase
 
     private function skipWhenRunningAsRoot(): void
     {
-        if (getmyuid() === 0) {
-            $this->markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
-        }
+        $this->skipIfRoot();
     }
 
     private function cacheUtil(): CacheUtil

--- a/tests/Eccube/Tests/Util/RuntimeCachePoolClearerTest.php
+++ b/tests/Eccube/Tests/Util/RuntimeCachePoolClearerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Util;
+
+use Eccube\Util\RuntimeCachePoolClearer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * cache:clear でランタイムディレクトリの cache pool が削除されることを検証する.
+ */
+final class RuntimeCachePoolClearerTest extends TestCase
+{
+    private string $runtimeDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->runtimeDir = sys_get_temp_dir().'/eccube-runtime-pool-'.bin2hex(random_bytes(6));
+        mkdir($this->runtimeDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->runtimeDir)) {
+            chmod($this->runtimeDir, 0755);
+        }
+        (new Filesystem())->remove($this->runtimeDir);
+        parent::tearDown();
+    }
+
+    public function testPoolsAreRemoved(): void
+    {
+        mkdir($this->runtimeDir.'/pools/system', 0755, true);
+        file_put_contents($this->runtimeDir.'/pools/system/entry.php', '<?php return [];');
+
+        (new RuntimeCachePoolClearer($this->runtimeDir))->clear($this->runtimeDir);
+
+        $this->assertDirectoryDoesNotExist($this->runtimeDir.'/pools');
+    }
+
+    /**
+     * pool 以外のランタイムキャッシュ (セッションや一時領域) は削除しない.
+     */
+    public function testOtherRuntimeDirectoriesAreKept(): void
+    {
+        mkdir($this->runtimeDir.'/pools/app', 0755, true);
+        mkdir($this->runtimeDir.'/mcp-sessions', 0755, true);
+        mkdir($this->runtimeDir.'/twig', 0755, true);
+
+        (new RuntimeCachePoolClearer($this->runtimeDir))->clear($this->runtimeDir);
+
+        $this->assertDirectoryDoesNotExist($this->runtimeDir.'/pools');
+        $this->assertDirectoryExists($this->runtimeDir.'/mcp-sessions');
+        $this->assertDirectoryExists($this->runtimeDir.'/twig');
+    }
+
+    public function testMissingPoolsDirectoryIsIgnored(): void
+    {
+        (new RuntimeCachePoolClearer($this->runtimeDir))->clear($this->runtimeDir);
+
+        $this->assertDirectoryExists($this->runtimeDir);
+    }
+
+    /**
+     * 権限を分離した構成ではランタイムディレクトリは Web サーバー所有のため削除できない.
+     * cache:clear 全体を失敗させず, 実行時キャッシュの削除は cache:pool:clear に委ねる.
+     */
+    public function testUnwritableDirectoryDoesNotThrow(): void
+    {
+        if (getmyuid() === 0) {
+            $this->markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
+        }
+
+        mkdir($this->runtimeDir.'/pools/system', 0755, true);
+        chmod($this->runtimeDir, 0555);
+
+        (new RuntimeCachePoolClearer($this->runtimeDir))->clear($this->runtimeDir);
+
+        $this->assertDirectoryExists($this->runtimeDir.'/pools');
+    }
+}

--- a/tests/Eccube/Tests/Util/RuntimeCachePoolClearerTest.php
+++ b/tests/Eccube/Tests/Util/RuntimeCachePoolClearerTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Eccube\Tests\Util;
 
+use Eccube\Tests\EffectiveUserTrait;
 use Eccube\Util\RuntimeCachePoolClearer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
@@ -24,6 +25,8 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class RuntimeCachePoolClearerTest extends TestCase
 {
+    use EffectiveUserTrait;
+
     private string $runtimeDir;
 
     protected function setUp(): void
@@ -85,9 +88,7 @@ final class RuntimeCachePoolClearerTest extends TestCase
      */
     public function testUnwritableDirectoryDoesNotThrow(): void
     {
-        if (getmyuid() === 0) {
-            $this->markTestSkipped('root は書き込み権限の検査を通過するため検証できません.');
-        }
+        $this->skipIfRoot();
 
         mkdir($this->runtimeDir.'/pools/system', 0755, true);
         chmod($this->runtimeDir, 0555);

--- a/tests/Eccube/Tests/Util/RuntimeCachePoolClearerTest.php
+++ b/tests/Eccube/Tests/Util/RuntimeCachePoolClearerTest.php
@@ -47,9 +47,11 @@ final class RuntimeCachePoolClearerTest extends TestCase
         mkdir($this->runtimeDir.'/pools/system', 0755, true);
         file_put_contents($this->runtimeDir.'/pools/system/entry.php', '<?php return [];');
 
-        (new RuntimeCachePoolClearer($this->runtimeDir))->clear($this->runtimeDir);
+        $clearer = new RuntimeCachePoolClearer($this->runtimeDir);
+        $clearer->clear($this->runtimeDir);
 
         $this->assertDirectoryDoesNotExist($this->runtimeDir.'/pools');
+        $this->assertNull($clearer->getUnclearedPath(), '削除できた場合は未削除として報告しない');
     }
 
     /**
@@ -70,9 +72,11 @@ final class RuntimeCachePoolClearerTest extends TestCase
 
     public function testMissingPoolsDirectoryIsIgnored(): void
     {
-        (new RuntimeCachePoolClearer($this->runtimeDir))->clear($this->runtimeDir);
+        $clearer = new RuntimeCachePoolClearer($this->runtimeDir);
+        $clearer->clear($this->runtimeDir);
 
         $this->assertDirectoryExists($this->runtimeDir);
+        $this->assertNull($clearer->getUnclearedPath(), '対象が無い場合は未削除として報告しない');
     }
 
     /**
@@ -88,8 +92,14 @@ final class RuntimeCachePoolClearerTest extends TestCase
         mkdir($this->runtimeDir.'/pools/system', 0755, true);
         chmod($this->runtimeDir, 0555);
 
-        (new RuntimeCachePoolClearer($this->runtimeDir))->clear($this->runtimeDir);
+        $clearer = new RuntimeCachePoolClearer($this->runtimeDir);
+        $clearer->clear($this->runtimeDir);
 
         $this->assertDirectoryExists($this->runtimeDir.'/pools');
+        $this->assertSame(
+            $this->runtimeDir.'/pools',
+            $clearer->getUnclearedPath(),
+            '削除できなかったことを呼び出し側へ伝える (cache:clear が成功と表示しないようにするため)'
+        );
     }
 }

--- a/tests/Eccube/Tests/Web/Admin/Content/CacheControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Content/CacheControllerTest.php
@@ -17,6 +17,7 @@ namespace Eccube\Tests\Web\Admin\Content;
 
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 
 #[Group('cache-clear')]
@@ -31,14 +32,30 @@ final class CacheControllerTest extends AbstractAdminWebTestCase
         $this->assertTrue($client->getResponse()->isSuccessful());
     }
 
+    /**
+     * キャッシュ管理画面から, kernel.cache_dir と実行時 cache pool の双方が削除されること.
+     *
+     * 検証対象のファイルは必ず作ってから実行する. 存在しないパスへ置くと
+     * assertFileDoesNotExist が素通りし, 何も検証しないテストになる.
+     *
+     * kernel.build_dir は検証しない. CacheClearCommand は「コンテナが本リクエスト中に
+     * 生成された」場合 (REQUEST_TIME <= filemtime(containerFile)) はビルドディレクトリを
+     * 差し替えないため, 直前の状態によって結果が変わる.
+     */
     public function testRoutingAdminContentCachePost()
     {
         $client = $this->client;
 
         $url = $this->generateUrl('admin_content_cache');
 
-        $cacheDir = static::getContainer()->getParameter('kernel.cache_dir');
-        file_put_contents($cacheDir.'/twig/sample', 'test');
+        $fs = new Filesystem();
+        $cacheDir = rtrim((string) static::getContainer()->getParameter('kernel.cache_dir'), '/');
+        // cache pool は var/cache 配下ではなく実行時ディレクトリにあるため, cache:clear の
+        // ディレクトリ削除では消えない (RuntimeCachePoolClearer が削除する)
+        $poolDir = rtrim((string) static::getContainer()->getParameter('eccube_runtime_dir'), '/').'/pools';
+
+        $fs->dumpFile($cacheDir.'/sample', 'test');
+        $fs->dumpFile($poolDir.'/sample', 'test');
 
         $client->request(Request::METHOD_POST, $url, [
             'form' => [
@@ -47,6 +64,7 @@ final class CacheControllerTest extends AbstractAdminWebTestCase
         ]);
 
         $this->assertTrue($client->getResponse()->isSuccessful());
-        $this->assertFileDoesNotExist($cacheDir.'/twig/sample', 'sampleは削除済');
+        $this->assertFileDoesNotExist($cacheDir.'/sample', 'kernel.cache_dir は削除済');
+        $this->assertFileDoesNotExist($poolDir.'/sample', '実行時 cache pool は削除済');
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Refs #7072 の **Phase 3a** です（実装計画: https://github.com/EC-CUBE/ec-cube/issues/7072#issuecomment-5535347643 ）。

ページ・ブロック・メールテンプレートを CLI から操作できるようにします。これらは **DB レコードと twig ファイルが対**になっており（`persist` / `flush` の直後に `dumpFile`）、`scp` や `git pull` でファイルを配 るだけでは機能しません。そのため両者を一体で扱うコマンドを追加し、Web サーバーに `app/template` への書き込み権限を与えなくても運用できるようにします。

| コマンド | 対象 |
|---|---|
| `eccube:page:list` / `show` / `apply` / `remove` | `dtb_page` ＋ `app/template/user_data/*.twig`（既定ページはテーマ配下） |
| `eccube:block:list` / `show` / `apply` / `remove` | `dtb_block` ＋ `app/template/{theme}/Block/*.twig` |
| `eccube:mail-template:list` / `show` / `apply` | `dtb_mail_template` ＋ `app/template/{theme}/Mail/*.twig`（HTML パート含む） |

```bash
cat guide.twig | bin/console eccube:page:apply --route=guide --name=ご利用ガイド --body=-
bin/console eccube:page:show --route=guide > guide.twig      # apply の逆操作
bin/console eccube:page:apply --route=guide --body-file=guide.twig --dry-run
```

> [!NOTE]
> `eccube:page:*` の鍵は **`--route`（ルーティング名）**です。`dtb_page.url` が保持しているのは実際の URL ではなくルート名（例: `product_list`）で、管理画面のページ管理も同じ値を「ルーティング名」列に表示しています（「URL」列は router から解決したパスを表示する別の値）。オプション名・`eccube:page:list` の見出し・JSON のキーはこの管理画面の見出しに揃えました。DB の列名とフォームの項目名（`MainEditType` の `url`）は変更していません。
>
> ```
>  ---- ---------------- ---------------- --------------- --------
>   ID   ルーティング名   ページ名         ファイル名      編集可
>  ---- ---------------- ---------------- --------------- --------
>   2    product_list     商品一覧ページ   Product/list    no
> ```

> [!NOTE]
> **Depends on #7100（Phase 2）→ #7098（Phase 1）**。本 PR のブランチは #7100 のブランチの上に積んでいるため、差分には #7098 / #7100 のコミットも含まれます。**レビュー対象は次の 9 コミット**です。
>
> - `feat: ページ・ブロック・メールテンプレートを CLI から操作できるようにする`
> - `fix: 実行時 cache pool を削除できない場合も終了コード 3 を返す`
> - `fix: 削除できない実行時キャッシュも終了コード 3 の対象にする`
> - `fix: pre-push フックが参照する dev コンテナ XML のパスを build ディレクトリへ追従させる`（#7100 の追従漏れ。下記「実装に関する補足」参照）
> - `fix(content): テンプレートを書き出せないとき DB をロールバックする`
> - `fix(content): 実行時 twig キャッシュの案内で cache:pool:clear を示さない`
> - `refactor: eccube:page:* の --url を --route へ改名する`
> - `test: コンテンツ CLI のテストも root 判定を実効 uid で行う`
> - `fix(content): レビュー指摘 (CodeRabbit #7105) の修正`
>
> #7100 のマージ後に 4.4 へ rebase します。

## 方針(Policy)

**管理画面と CLI で実装を二重化しない**ことを最優先にしました。現状は「コントローラが DB と twig の対を直接書く」構造のため、CLI を素朴に足すと同じ処理が 2 実装になり、必ず乖離します。次の 3 層に分離しています。

```
Command層  src/Eccube/Command/Content/    入出力（stdin / --format / --dry-run / 終了コード）
   ↓
Service層  src/Eccube/Service/Content/    DB レコードと twig ファイルの対を扱う
   ↓
Form層     既存の MainEditType / BlockType / MailType を submit して検証を再利用
```

- **検証は管理画面と同じ FormType を `submit()` して再利用します**。ルーティング名・ファイル名の重複チェック、`TwigLint` による twig の構文チェック、文字数制限が CLI でも同じように効きます。これらの FormType は `EntityManager` / `Repository` / `EccubeConfig` にしか依存しておらず HTTP 非依存のため、CLI からそのまま利用できます（着手前に PoC で確認しました）。
- **管理画面のコントローラも同じ Service へ委譲**します（`PageController` / `BlockController` / `MailController`）。管理画面の振る舞いは変えていません。
- `apply` は **upsert で冪等**です。指定しなかった項目は既存の値を維持し、内容が同一なら `unchanged` を返してファイルの mtime も更新しません（デプロイ側の差分検出を壊さないため）。

## 実装に関する補足(Appendix)

**終了コード**

| コード | 意味 |
|---|---|
| `0` | 正常終了 |
| `1` | 対象が見つからない / 入力値が不正（バリデーションエラー） |
| `2` | オプションが不正（`Command::INVALID`） |
| `3` | 本処理は完了したが手動操作が必要（`eccube:cache:build` の実行が必要） |

`3` は #7098 / #7100 で導入した `EXIT_MANUAL_ACTION_REQUIRED` と同じ意味づけです。権限を分離した構成では `var/build/{env}/twig` を CLI から削除できず、更新したテンプレートが反映されないため、本処理を完了させたうえで `eccube:cache:build` の実行を案内します。

**テンプレート本文の読み取り順**

書き込み先のファイルを優先して読み、無い場合のみ twig のローダへフォールバックします（コアのテンプレートを取得するため）。twig の `FilesystemLoader` はテンプレートの探索結果をプロセス内でキャッシュするため、ローダだけに頼ると **直前に書き出したファイルを読み落とし**ます。実際に「HTML パートを追加した直後に本文だけを更新すると HTML パートが消える」という不具合が出たため、ファイルを優先しています。

**管理画面と同じ制約**

- ページの削除はユーザーが作成したページ（`EDIT_TYPE_USER`）のみ、ブロックの削除は `deletable` のみ
- 既定ページ（`EDIT_TYPE_DEFAULT` 以上）はルーティング名・ファイル名を変更できない
- メールテンプレートのファイル名は新規登録時のみ指定でき、`Mail/xxx.twig` へ変換される
- ファイル名は FormType の正規表現（`.` を許可しない）で検証されるため、`--file-name=../../evil` のようなパストラバーサルは管理画面と同様に拒否されます

**HTML パートの扱い**

管理画面は「HTML 本文が空なら削除」ですが、CLI では誤削除を避けるため `--remove-html` を明示したときだけ削除します。`--html-body` を指定しなければ現在の内容を維持します。

**`.husky/pre-push` の修正について**

#7100 で `debug.container.dump` の出力先が `var/cache/dev` から `var/build/dev` へ移った際、`rector.php` は追従済みでしたが `.husky/pre-push` が旧パスを見たままでした。その結果 push のたびに XML 不在と判定して `cache:clear` が走り、さらに `.env` で `APP_DEBUG=0` の環境ではデバッグ用コンテナがコンパイルされず XML も生成されないため、rector が全ファイルで read error となり push がブロックされます（本 PR の作業中に踏みました）。Phase 2 の追従漏れですが、本ブランチが #7100 の上に積んでいるためここで直しています。

**スコープ外（Phase 3b で対応）**

`eccube:asset:*`（CSS/JS）・`eccube:user-data:*`（`html/user_data`）・`eccube:env:*` は別 PR にします。`eccube:mail-template:remove` は管理画面にも削除導線がないため実装していません。

## テスト（Test)

新規テスト 52 件を追加しています。

- `tests/Eccube/Tests/Service/Content/` — upsert の created / updated / unchanged、重複ファイル名の拒否、不正な twig の拒否、ファイル名変更時の旧ファイル削除、レイアウトの紐付け、削除可否の保護、dry-run が書き込まないこと、HTML パートの追加・維持・削除、テンプレートを書き出せないときの DB ロールバック
- `tests/Eccube/Tests/Command/Content/` — `CommandTester` による `--dry-run` / `--format=json` / 標準入力（`--body=-`）/ 終了コード `0`・`1`・`2`・`3` / 確認なしの削除中止 / 書き込み失敗時の案内表示

既存の Web テスト（`PageControllerTest` / `BlockControllerTest` / `MailControllerTest` 計 21 件）は**無変更のまま通ります**。これがコントローラ委譲の回帰ネットです。

ローカルで CI と同じゲートを通しています。

```
vendor/bin/php-cs-fixer fix --dry-run --diff   # Fixed 0 of 1383 files
vendor/bin/phpstan analyse src                 # No errors (level 6)
vendor/bin/rector process --dry-run            # Rector is done!
vendor/bin/phpunit tests/Eccube/Tests/Service/Content tests/Eccube/Tests/Command/Content \
  tests/Eccube/Tests/Web/Admin/Content/PageControllerTest.php \
  tests/Eccube/Tests/Web/Admin/Content/BlockControllerTest.php \
  tests/Eccube/Tests/Web/Admin/Setting/Shop/MailControllerTest.php   # OK (73 tests, 180 assertions)
```

### 権限を分離した環境での動作確認

`docker-compose.permission-lanes.yml` を重ねた環境で下記の全手順を実行し、期待どおりの結果を確認しました（WSL2 + Docker Desktop / Docker Engine 29.6.1 / Compose v5.3.0）。手動で追試する場合の手順としてそのまま使えます。

#### 1. 起動

`--build` は必須です（公開イメージには本リポジトリの `dockerbuild/docker-php-entrypoint` が含まれず、`www-data` がホストユーザーへリマップされて分離されません）。既定の SQLite はデータベースファイルを Web と CLI の双方が書くため使えず、DB サーバーを重ねます。

```bash
docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml \
  -f docker-compose.permission-lanes.yml up -d --build --wait

# テンプレートを事前コンパイルする（アクセスを受ける前に実行する。理由は下記）
docker compose exec -u eccube ec-cube bin/console eccube:cache:build

# Web サーバーの uid を判定できるようにセッションを生成する
curl -s -o /dev/null http://127.0.0.1:8080/
```

以降の `docker compose exec` は `-f` を並べ直さなくても実行できます。

> [!IMPORTANT]
> **`eccube:cache:build` はアクセスを受ける前に実行してください。** 初回起動直後は `var/build/{env}/twig` が空です（`BuildDirCacheWarmerPass` が `twig.template_cache_warmer` のタグを外しているため、`composer install` の `cache:warmup` では事前コンパイルされません）。この状態で Web サーバーがページを描画すると、コンパイル結果がレーン W の `var/runtime/{env}/twig` へ書かれます。
>
> レーン W は CLI ユーザーから削除できないため、後続の `eccube:cache:build` が「削除できない」旨の警告を出し続けることになります（消すには管理画面のキャッシュ管理か、Web サーバーのユーザーによる直接削除が必要）。先にビルドしておけば Web は読み取り専用キャッシュ側を使うので、この状態になりません。

#### 2. レーン分離と権限診断

```bash
# レーン W = www-data / レーン S = CLI ユーザー(eccube)
docker compose exec ec-cube sh -c 'cd /var/www/html && \
  stat -c "%n %U:%G" var/build var/cache var/runtime var/log var/sessions app/template html/user_data'

docker compose exec -u eccube ec-cube bin/console eccube:doctor:permissions
```

上の順序で実行していれば `OK: 22 / WARN: 0 / NG: 0`（終了コード 0）になります（真っさらな `var` ボリュームからの初回起動で実測）。

レーンごとの操作は実行ユーザーで分けます。

```bash
docker compose exec -u eccube   ec-cube bin/console eccube:cache:build      # レーン S
docker compose exec -u www-data ec-cube bin/console cache:pool:clear --all  # レーン W の cache pool
```

#### 3. ページ（`eccube:page:*`）

標準入力を使うので `docker compose exec` に `-T` を付けます。

```bash
cat <<'EOF' > guide.twig
{% extends 'default_frame.twig' %}
{% block main %}
<div class="ec-role">
  <h1>ご利用ガイド</h1>
  <p>CLI から登録しました。</p>
</div>
{% endblock %}
EOF

# 登録（created）
cat guide.twig | docker compose exec -T -u eccube ec-cube \
  bin/console eccube:page:apply --route=guide --name='ご利用ガイド' --body=-

# apply の逆操作（compose の警告は stderr なのでリダイレクトは汚れない）
docker compose exec -u eccube ec-cube bin/console eccube:page:show --route=guide

# 冪等（同じ入力を再適用すると unchanged・終了コード 0）
cat guide.twig | docker compose exec -T -u eccube ec-cube \
  bin/console eccube:page:apply --route=guide --body=-

# 差分だけ表示して適用しない
cat guide.twig | docker compose exec -T -u eccube ec-cube \
  bin/console eccube:page:apply --route=guide --body=- --dry-run

# 機械可読出力
docker compose exec -u eccube ec-cube bin/console eccube:page:list --format=json
```

Web サーバーは `app/template` を読み取りしかできませんが、CLI で登録したページを配信できます。

```bash
docker compose exec -u www-data ec-cube bin/console cache:pool:clear --all
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8080/user_data/guide   # => 200
```

#### 4. ブロック・メールテンプレート

```bash
printf '<div class="ec-cli-block"><p>CLI ブロック</p></div>\n' \
  | docker compose exec -T -u eccube ec-cube \
      bin/console eccube:block:apply --file-name=cli_block --name='CLI ブロック' --body=-

docker compose exec -u eccube ec-cube bin/console eccube:block:show --file-name=cli_block
docker compose exec -u eccube ec-cube bin/console eccube:mail-template:list
docker compose exec -u eccube ec-cube \
  bin/console eccube:mail-template:apply --id=1 --subject='【検証】ご注文ありがとうございます' --dry-run
```

#### 5. 安全側の既定と削除

```bash
# 既定ページは削除できない（終了コード 1）
docker compose exec -u eccube ec-cube bin/console eccube:page:remove --route=help_guide --force

# --force なしの非対話実行は中断する（終了コード 1）
docker compose exec -u eccube ec-cube bin/console eccube:page:remove --route=guide --no-interaction

# 不正な --format は Command::INVALID（終了コード 2）
docker compose exec -u eccube ec-cube bin/console eccube:page:list --format=yaml

# DB レコードと twig を対で削除する
docker compose exec -u eccube ec-cube bin/console eccube:page:remove --route=guide --force
docker compose exec -u eccube ec-cube bin/console eccube:block:remove --file-name=cli_block --force
```

#### 6. 実行ユーザーを誤った場合

レーン S を所有しない `www-data` で `apply` すると、DB を更新せずに中断し対処方法を表示します（終了コード 1）。`dtb_page` にレコードだけが残ってフロントが 500 になることはありません。

```bash
cat guide.twig | docker compose exec -T -u www-data ec-cube \
  bin/console eccube:page:apply --route=denied --name='拒否される' --body=-

# レコードが作られていないことの確認
docker compose exec -u eccube ec-cube \
  bin/console doctrine:query:sql "select id, url from dtb_page where url = 'denied'"
```

`cache:clear` は CLI ユーザーなら成功しますが、レーン W の実行時 cache pool は削除できないため警告で案内します（この挙動は #7100 で入れています）。

```bash
docker compose exec -u eccube ec-cube bin/console cache:clear
```

#### 7. 後片付け

既定モードへ戻すときはレーン W のボリュームを作り直します。切り替え前の `www-data` の uid で作成されたディレクトリが残ると、切り替え後の Web サーバーから書き込めなくなります。

```bash
docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml \
  -f docker-compose.permission-lanes.yml down -v

# レーン W のディレクトリはホスト側でも www-data の uid 所有になるため戻す
sudo chown -R $(id -u):$(id -g) html/upload
```

#### 既知の差異

`apply` は FormType を経由するため、本文の**末尾改行が落ちます**。`eccube:page:show > guide.twig` の往復では末尾改行 1 行の差分が出ます。管理画面も同じ Service を通るため CLI 固有の挙動ではありませんが、本 PR では未対応です。

## 相談（Discussion）

- `--body` の解釈を「リテラル、`-` なら標準入力」とし、ファイルからの読み込みは `--body-file` に分けました。issue の記載（`--body=-` またはパス）から変更しています。値がたまたまファイル名と一致したときに内容が置き換わる曖昧さを避けるためです。
- ページのレイアウト指定は `--pc-layout=<Layout ID>` の ID ベースにしています。Phase 5（`eccube:contents:export` / `import`）の yaml もこれに合わせる想定です。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

> [!NOTE]
> コントローラのコンストラクタ引数は変更しています（`*ContentService` の追加、および `BlockController` の `private readonly Filesystem $fs` の削除）。いずれも private な実装詳細で、`protected` プロパティやフックポイント、Service の公開関数のシグネチャは変更していません。

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHapP9uDURCdjAWR8gPwnc







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * WebサーバーとCLIの書き込み権限を分離する構成に対応しました。
  * 権限診断コマンドを追加しました。
  * ページ、ブロック、メールテンプレートをCLIから管理できます。
  * キャッシュを用途別に分離し、再構築コマンドを追加しました。
  * umaskとCLIのファイルログ出力を環境変数で設定できます。

* **改善**
  * キャッシュ削除や権限不足時の案内を改善しました。
  * 書き込みできないキャッシュでも処理を継続しやすくしました。

* **ドキュメント**
  * 権限分離、キャッシュ管理、コンテンツ管理の手順を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->