### PR TITLE
test(entity): if(!class_exists()) ガードの再発防止ゲートを追加 (refs #6891)

### DIFF
--- a/src/Eccube/Command/PluginGenerateCommand.php
+++ b/src/Eccube/Command/PluginGenerateCommand.php
@@ -371,56 +371,54 @@ namespace Plugin\\{$code}\\Entity;
 
 use Doctrine\\ORM\\Mapping as ORM;
 
-if (!class_exists('\\Plugin\\{$code}\\Entity\\Config', false)) {
+/**
+ * Config
+ */
+#[ORM\Table(name: "plg_{$snakecased}_config")]
+#[ORM\Entity(repositoryClass: "Plugin\\{$code}\\Repository\\ConfigRepository")]
+class Config
+{
     /**
-     * Config
+     * @var int
+     *
      */
-    #[ORM\Table(name: "plg_{$snakecased}_config")]
-    #[ORM\Entity(repositoryClass: "Plugin\\{$code}\\Repository\\ConfigRepository")]
-    class Config
+    #[ORM\Id]
+    #[ORM\Column(name: "id", type: "integer", options: ["unsigned" => true])]
+    #[ORM\GeneratedValue(strategy: "IDENTITY")]
+    private \$id;
+
+    /**
+     * @var string
+     */
+    #[ORM\Column(name: "name", type: "string", length: 255)]
+    private \$name;
+
+    /**
+     * @return int
+     */
+    public function getId()
     {
-        /**
-         * @var int
-         *
-         */
-        #[ORM\Id]
-        #[ORM\Column(name: "id", type: "integer", options: ["unsigned" => true])]
-        #[ORM\GeneratedValue(strategy: "IDENTITY")]
-        private \$id;
+        return \$this->id;
+    }
 
-        /**
-         * @var string
-         */
-        #[ORM\Column(name: "name", type: "string", length: 255)]
-        private \$name;
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return \$this->name;
+    }
 
-        /**
-         * @return int
-         */
-        public function getId()
-        {
-            return \$this->id;
-        }
+    /**
+     * @param string \$name
+     *
+     * @return \$this;
+     */
+    public function setName(\$name)
+    {
+        \$this->name = \$name;
 
-        /**
-         * @return string
-         */
-        public function getName()
-        {
-            return \$this->name;
-        }
-
-        /**
-         * @param string \$name
-         *
-         * @return \$this;
-         */
-        public function setName(\$name)
-        {
-            \$this->name = \$name;
-
-            return \$this;
-        }
+        return \$this;
     }
 }
 

--- a/tests/Eccube/Tests/Command/PluginGenerateCommandTest.php
+++ b/tests/Eccube/Tests/Command/PluginGenerateCommandTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Command;
+
+use Eccube\Command\PluginGenerateCommand;
+use Eccube\Tests\EccubeTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * eccube:plugin:generate が旧 if (!class_exists()) ガード無しの Entity を生成すること (#6891).
+ *
+ * @see https://github.com/EC-CUBE/ec-cube/issues/6891
+ */
+final class PluginGenerateCommandTest extends EccubeTestCase
+{
+    private const PLUGIN_CODE = 'GuardTest6891';
+
+    private const CLASS_EXISTS_GUARD_PATTERN = '/if\s*\(\s*!class_exists\s*\(/';
+
+    private ?string $pluginDir = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->pluginDir !== null && is_dir($this->pluginDir)) {
+            (new Filesystem())->remove($this->pluginDir);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testGeneratedEntityHasNoClassExistsGuard(): void
+    {
+        $projectDir = static::getContainer()->getParameter('kernel.project_dir');
+        $this->pluginDir = $projectDir.'/app/Plugin/'.self::PLUGIN_CODE;
+
+        if (is_dir($this->pluginDir)) {
+            (new Filesystem())->remove($this->pluginDir);
+        }
+
+        /** @var PluginGenerateCommand $command */
+        $command = static::getContainer()->get(PluginGenerateCommand::class);
+
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([
+            'name' => 'Guard Test 6891',
+            'code' => self::PLUGIN_CODE,
+            'ver' => '1.0.0',
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $entityFile = $this->pluginDir.'/Entity/Config.php';
+        $this->assertFileExists($entityFile);
+
+        $contents = file_get_contents($entityFile);
+        $this->assertIsString($contents);
+
+        $this->assertDoesNotMatchRegularExpression(
+            self::CLASS_EXISTS_GUARD_PATTERN,
+            $contents,
+            '生成された Entity/Config.php に if (!class_exists()) ガードが含まれています。'
+            .' #6891 再発防止。Skill eccube-entity を参照してください。'
+        );
+    }
+}

--- a/tests/Eccube/Tests/Doctrine/ORM/Mapping/EntityClassExistsGuardRegressionTest.php
+++ b/tests/Eccube/Tests/Doctrine/ORM/Mapping/EntityClassExistsGuardRegressionTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Doctrine\ORM\Mapping;
+
+use Eccube\Tests\EccubeTestCase;
+
+/**
+ * Entity の if (!class_exists()) ガード再発防止テスト (#6891).
+ *
+ * #6895 / #7051 で core Entity からガードを全廃した後も、
+ * PluginGenerateCommand 雛形が旧パターンを出力し続ける再生産経路が残っていた。
+ * 本テストはコア Entity とジェネレータ雛形への再混入を CI で検知する。
+ *
+ * 意図的に検査しない:
+ * - codeception/_data/plugins (旧プラグイン再現用フィクスチャ)
+ * - tests/** (PluginServiceTest 等の意図的な旧パターン)
+ * - app/Customize/Entity (プロジェクト固有)
+ *
+ * @see https://github.com/EC-CUBE/ec-cube/issues/6891
+ * @see https://github.com/EC-CUBE/ec-cube/pull/6895 Entity の if(!class_exists()) ガード全廃
+ */
+final class EntityClassExistsGuardRegressionTest extends EccubeTestCase
+{
+    private const CLASS_EXISTS_GUARD_PATTERN = '/if\s*\(\s*!class_exists\s*\(/';
+
+    public function testCoreEntityDirectoryHasNoClassExistsGuard(): void
+    {
+        $projectDir = static::getContainer()->getParameter('kernel.project_dir');
+        $entityDir = $projectDir.'/src/Eccube/Entity';
+
+        $violations = $this->findClassExistsGuardViolations($entityDir);
+
+        $this->assertSame(
+            [],
+            $violations,
+            'src/Eccube/Entity に if (!class_exists()) ガードが見つかりました。'
+            .' #6891 再発防止。Skill eccube-entity を参照してください。'
+            ."\n".implode("\n", $violations)
+        );
+    }
+
+    public function testPluginGenerateCommandTemplateHasNoClassExistsGuard(): void
+    {
+        $projectDir = static::getContainer()->getParameter('kernel.project_dir');
+        $commandFile = $projectDir.'/src/Eccube/Command/PluginGenerateCommand.php';
+
+        $this->assertFileExists($commandFile);
+
+        $contents = file_get_contents($commandFile);
+        $this->assertIsString($contents);
+
+        $this->assertDoesNotMatchRegularExpression(
+            self::CLASS_EXISTS_GUARD_PATTERN,
+            $contents,
+            'PluginGenerateCommand の Entity 雛形に if (!class_exists()) ガードが含まれています。'
+            .' #6891 再発防止。Skill eccube-entity を参照してください。'
+        );
+    }
+
+    /**
+     * @return list<string> 違反ファイルの相対パス
+     */
+    private function findClassExistsGuardViolations(string $directory): array
+    {
+        $violations = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        /** @var \SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $contents = file_get_contents($file->getPathname());
+            if (!\is_string($contents)) {
+                continue;
+            }
+
+            if (preg_match(self::CLASS_EXISTS_GUARD_PATTERN, $contents)) {
+                $violations[] = $file->getPathname();
+            }
+        }
+
+        sort($violations);
+
+        return $violations;
+    }
+}


### PR DESCRIPTION
## Summary
- #6891 の再発防止ゲートのうち、未完了だった **(2) 走査テスト** と **(3) 雛形ジェネレータ修正** を実装
- Gate (1) Skill 規約は #7101 で成立済みのため本 PR では触らない

## 変更内容
1. **`PluginGenerateCommand.php`**: 生成 Entity から `if (!class_exists(...))` ラッパを除去
2. **`EntityClassExistsGuardRegressionTest`**: `src/Eccube/Entity/**` と `PluginGenerateCommand.php` に旧ガードが混入していないことを走査
3. **`PluginGenerateCommandTest`**: `eccube:plugin:generate` がガード無し Entity を生成することを統合テスト

## Test plan
- [x] `vendor/bin/phpunit tests/Eccube/Tests/Doctrine/ORM/Mapping/EntityClassExistsGuardRegressionTest.php`
- [x] `vendor/bin/phpunit tests/Eccube/Tests/Command/PluginGenerateCommandTest.php`
- [x] `vendor/bin/phpunit tests/Eccube/Tests/Doctrine/ORM/Mapping/EccubeEntityMetadataDriverTest.php`
- [x] php-cs-fixer dry-run（変更 3 ファイル）

Refs #6891

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - プラグイン生成時に作成される設定用エンティティから、不要なクラス重複定義ガードを削除しました。
  - 生成されたエンティティが直接定義されるようになり、クラス読み込み時の不整合を防止します。

- **テスト**
  - プラグイン生成結果に不要なガードが含まれないことを自動検証するテストを追加しました。
  - 既存エンティティや生成テンプレートへのガード再混入を検出する回帰テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->