### PR TITLE
symfony/mcp-bundle 0.13 の servers スキーマへ MCP 設定を移行する

### DIFF
--- a/app/config/eccube/packages/mcp.yaml
+++ b/app/config/eccube/packages/mcp.yaml
@@ -1,11 +1,17 @@
 mcp:
-    app: 'EC-CUBE MCP Server'
-    version: '4.4.0'
-    description: 'EC-CUBE 4.4 の管理データ (商品/在庫・注文・顧客会員・プラグイン管理) を AI クライアントから自然言語で参照する読み取り専用 MCP サーバ。 認証認可は API プラグイン (api44) の OAuth2 / scope に委譲する。'
-    client_transports:
-        http: true
-        stdio: true
-    http:
-        path: '/%eccube_admin_route%/mcp'
-        session:
-            store: file
+    servers:
+        # サーバ名。 mcp-bundle はこの名前からサービス ID (mcp.server.eccube.*) とルート名を組む。
+        # PHP 側の参照は Eccube\Service\Mcp\McpServerDefinition に集約している。
+        eccube:
+            name: 'EC-CUBE MCP Server'
+            version: '4.4.0'
+            description: 'EC-CUBE 4.4 の管理データ (商品/在庫・注文・顧客会員・プラグイン管理) を AI クライアントから自然言語で参照する読み取り専用 MCP サーバ。 認証認可は API プラグイン (api44) の OAuth2 / scope に委譲する。'
+            transports:
+                http: true
+                stdio: true
+            http:
+                path: '/%eccube_admin_route%/mcp'
+            session:
+                store: file
+            # コンテナに登録された全 MCP 要素 (tools / prompts / resources / resource_templates / apps) をこのサーバで公開する
+            registry: '*'

--- a/app/config/eccube/packages/mcp.yaml
+++ b/app/config/eccube/packages/mcp.yaml
@@ -13,5 +13,7 @@ mcp:
                 path: '/%eccube_admin_route%/mcp'
             session:
                 store: file
-            # コンテナに登録された全 MCP 要素 (tools / prompts / resources / resource_templates / apps) をこのサーバで公開する
-            registry: '*'
+            # 公開するのは Tool だけ。 scope 検査 (ScopeEnforcingReferenceHandler / ScopeFilteringRegistry) は
+            # Tool にしか掛からないため、 prompts / resources / resource_templates / apps はこのサーバに登録しない
+            registry:
+                tools: '*'

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -255,7 +255,8 @@ services:
     # MCP: tools/list を現トークンの scope で絞る (呼べない Tool を一覧から隠す = 最小権限)。
     # call 時の fail-closed 拒否は ScopeEnforcingReferenceHandler が担う二重防御。
     Eccube\Service\Mcp\ScopeFilteringRegistry:
-        decorates: mcp.registry
+        # decorates 先は mcp.yaml の mcp.servers キー (McpServerDefinition::NAME) から mcp-bundle が組む ID
+        decorates: mcp.server.eccube.registry
         arguments:
             $inner: '@.inner'
 

--- a/app/config/eccube/services.yaml
+++ b/app/config/eccube/services.yaml
@@ -255,8 +255,8 @@ services:
     # MCP: tools/list を現トークンの scope で絞る (呼べない Tool を一覧から隠す = 最小権限)。
     # call 時の fail-closed 拒否は ScopeEnforcingReferenceHandler が担う二重防御。
     Eccube\Service\Mcp\ScopeFilteringRegistry:
-        # decorates 先は mcp.yaml の mcp.servers キー (McpServerDefinition::NAME) から mcp-bundle が組む ID
-        decorates: mcp.server.eccube.registry
+        # decorates 先は mcp-bundle がサーバ名 (mcp.yaml の mcp.servers キー) から組む registry ID
+        decorates: !php/const Eccube\Service\Mcp\McpServerDefinition::REGISTRY_SERVICE_ID
         arguments:
             $inner: '@.inner'
 

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "symfony/lock": "^7.4",
         "symfony/mailer": "^7.4",
         "symfony/maker-bundle": "^1.0",
-        "symfony/mcp-bundle": "^0.12",
+        "symfony/mcp-bundle": "^0.13",
         "symfony/monolog-bridge": "^7.4",
         "symfony/monolog-bundle": "^3.1",
         "symfony/options-resolver": "^7.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c69a31f51f1f36e0e2cff1ea1fe6ca07",
+    "content-hash": "fe6657b45c7e5d6875ce33f5174b5431",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -3341,16 +3341,16 @@
         },
         {
             "name": "mcp/sdk",
-            "version": "v0.7.1",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/modelcontextprotocol/php-sdk.git",
-                "reference": "785fc3b9b7006ecc8a73322c939d96a4a7154345"
+                "reference": "c5dbfb64e5a2a30872ec3927b4cf13a2eb05e10e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/modelcontextprotocol/php-sdk/zipball/785fc3b9b7006ecc8a73322c939d96a4a7154345",
-                "reference": "785fc3b9b7006ecc8a73322c939d96a4a7154345",
+                "url": "https://api.github.com/repos/modelcontextprotocol/php-sdk/zipball/c5dbfb64e5a2a30872ec3927b4cf13a2eb05e10e",
+                "reference": "c5dbfb64e5a2a30872ec3927b4cf13a2eb05e10e",
                 "shasum": ""
             },
             "require": {
@@ -3368,6 +3368,7 @@
                 "psr/http-server-handler": "^1.0",
                 "psr/http-server-middleware": "^1.0",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
                 "symfony/uid": "^5.4 || ^6.4 || ^7.3 || ^8.0"
             },
             "require-dev": {
@@ -3419,9 +3420,9 @@
             "description": "Model Context Protocol SDK for Client and Server applications in PHP",
             "support": {
                 "issues": "https://github.com/modelcontextprotocol/php-sdk/issues",
-                "source": "https://github.com/modelcontextprotocol/php-sdk/tree/v0.7.1"
+                "source": "https://github.com/modelcontextprotocol/php-sdk/tree/v0.8.1"
             },
-            "time": "2026-08-10T20:09:23+00:00"
+            "time": "2026-08-29T23:10:56+00:00"
         },
         {
             "name": "mobiledetect/mobiledetectlib",
@@ -8749,20 +8750,20 @@
         },
         {
             "name": "symfony/mcp-bundle",
-            "version": "v0.12.0",
+            "version": "v0.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mcp-bundle.git",
-                "reference": "7ffd7bfab9d315a52a8224e35b32bd0db1765d44"
+                "reference": "a0d4443ff899803a4030ae24fbb1dfb961f0b6fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mcp-bundle/zipball/7ffd7bfab9d315a52a8224e35b32bd0db1765d44",
-                "reference": "7ffd7bfab9d315a52a8224e35b32bd0db1765d44",
+                "url": "https://api.github.com/repos/symfony/mcp-bundle/zipball/a0d4443ff899803a4030ae24fbb1dfb961f0b6fa",
+                "reference": "a0d4443ff899803a4030ae24fbb1dfb961f0b6fa",
                 "shasum": ""
             },
             "require": {
-                "mcp/sdk": "^0.7",
+                "mcp/sdk": "^0.8.1",
                 "php-http/discovery": "^1.20",
                 "symfony/config": "^7.3|^8.0",
                 "symfony/console": "^7.3|^8.0",
@@ -8812,7 +8813,7 @@
             ],
             "description": "Symfony integration bundle for Model Context Protocol (via official mcp/sdk)",
             "support": {
-                "source": "https://github.com/symfony/mcp-bundle/tree/v0.12.0"
+                "source": "https://github.com/symfony/mcp-bundle/tree/v0.13.0"
             },
             "funding": [
                 {
@@ -8832,7 +8833,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-21T01:04:45+00:00"
+            "time": "2026-08-30T00:16:19+00:00"
         },
         {
             "name": "symfony/mime",

--- a/docs/mcp/scope-denied-response.md
+++ b/docs/mcp/scope-denied-response.md
@@ -69,7 +69,7 @@ public function require(string $role): void
 
 上記の call 時拒否とは別に、 `tools/list` の応答自体を現在のトークンの scope で絞る。 呼べない Tool は一覧に出さない (最小権限: LLM に呼べない Tool を見せない)。
 
-- `Eccube\Service\Mcp\ScopeFilteringRegistry` が mcp-bundle の `mcp.registry` を装飾し、 `getTools()` だけを上書きする。 各 Tool の必要 scope を `McpToolScopeMap` で引き、 `AuthorizationCheckerInterface::isGranted()` で通ったものだけ返す。
+- `Eccube\Service\Mcp\ScopeFilteringRegistry` が mcp-bundle のサーバ registry (`mcp.server.eccube.registry`) を装飾し、 `getTools()` だけを上書きする。 各 Tool の必要 scope を `McpToolScopeMap` で引き、 `AuthorizationCheckerInterface::isGranted()` で通ったものだけ返す。
 - 中央マップ未登録の Tool (= call 時 fail-closed deny) は一覧からも隠す。
 - 認証トークンが無い経路 (CLI 等) は絞り込まず素通しする。
 

--- a/src/Eccube/DependencyInjection/Compiler/McpCliCommandPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/McpCliCommandPass.php
@@ -18,6 +18,7 @@ namespace Eccube\DependencyInjection\Compiler;
 use Eccube\Command\EccubeCliToolCommand;
 use Eccube\Service\Mcp\McpCliToolInvoker;
 use Eccube\Service\Mcp\McpMarkdownFormatter;
+use Eccube\Service\Mcp\McpServerDefinition;
 use Mcp\Capability\Attribute\McpTool;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -42,7 +43,7 @@ final class McpCliCommandPass implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         // MCP 未配線 (builder 不在) なら守る対象も呼ぶ対象も無いのでスキップ。
-        if (!$container->hasDefinition('mcp.server.builder')) {
+        if (!$container->hasDefinition(McpServerDefinition::BUILDER_SERVICE_ID)) {
             return;
         }
 

--- a/src/Eccube/DependencyInjection/Compiler/McpScopeEnforcementPass.php
+++ b/src/Eccube/DependencyInjection/Compiler/McpScopeEnforcementPass.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Eccube\DependencyInjection\Compiler;
 
+use Eccube\Service\Mcp\McpServerDefinition;
 use Eccube\Service\Mcp\ScopeEnforcingReferenceHandler;
 use Mcp\Capability\Registry\ReferenceHandler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -46,7 +47,7 @@ final class McpScopeEnforcementPass implements CompilerPassInterface
         // builder が無い (mcp-bundle 未配線) 環境では scope 強制を差し込む先が無い。 ここで先に
         // return しないと、 配線されない ReferenceHandler 定義だけが残り、 builder 不在構成の
         // コンテナコンパイルを乱す。 MCP サーバが無ければ守る対象も無いのでスキップしてよい。
-        if (!$container->hasDefinition('mcp.server.builder')) {
+        if (!$container->hasDefinition(McpServerDefinition::BUILDER_SERVICE_ID)) {
             return;
         }
 
@@ -60,7 +61,7 @@ final class McpScopeEnforcementPass implements CompilerPassInterface
         );
 
         // 全 Tool 呼び出しが通る referenceHandler を scope 強制版に差し替える。
-        $container->getDefinition('mcp.server.builder')
+        $container->getDefinition(McpServerDefinition::BUILDER_SERVICE_ID)
             ->addMethodCall('setReferenceHandler', [new Reference(ScopeEnforcingReferenceHandler::class)]);
     }
 
@@ -71,7 +72,7 @@ final class McpScopeEnforcementPass implements CompilerPassInterface
     private function resolveToolLocator(ContainerBuilder $container): Reference
     {
         // 呼び出し元 (process) が builder の存在を保証済み。
-        foreach ($container->getDefinition('mcp.server.builder')->getMethodCalls() as [$method, $arguments]) {
+        foreach ($container->getDefinition(McpServerDefinition::BUILDER_SERVICE_ID)->getMethodCalls() as [$method, $arguments]) {
             if ('setContainer' === $method && isset($arguments[0]) && $arguments[0] instanceof Reference) {
                 return $arguments[0];
             }

--- a/src/Eccube/Service/Mcp/McpCliToolInvoker.php
+++ b/src/Eccube/Service/Mcp/McpCliToolInvoker.php
@@ -37,9 +37,9 @@ final class McpCliToolInvoker
     private bool $primed = false;
 
     public function __construct(
-        #[Autowire(service: 'mcp.registry')]
+        #[Autowire(service: McpServerDefinition::REGISTRY_SERVICE_ID)]
         private readonly RegistryInterface $registry,
-        #[Autowire(service: 'mcp.server.builder')]
+        #[Autowire(service: McpServerDefinition::BUILDER_SERVICE_ID)]
         private readonly Builder $builder,
         #[Autowire(service: McpScopeEnforcementPass::INNER_REFERENCE_HANDLER_ID)]
         private readonly ReferenceHandlerInterface $handler,

--- a/src/Eccube/Service/Mcp/McpServerDefinition.php
+++ b/src/Eccube/Service/Mcp/McpServerDefinition.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Service\Mcp;
+
+/**
+ * mcp-bundle に登録する EC-CUBE の MCP サーバ (`mcp.servers.<NAME>`) と、 bundle がその名前から組むサービス ID。
+ *
+ * mcp-bundle はサーバ単位でサービスを登録し、 registry / builder のサービス ID にサーバ名を埋め込む
+ * (`mcp.server.<name>.registry` / `mcp.server.<name>.builder`)。 `NAME` は
+ * `app/config/eccube/packages/mcp.yaml` の `mcp.servers` キーと一致させる。
+ */
+final class McpServerDefinition
+{
+    public const NAME = 'eccube';
+
+    public const BUILDER_SERVICE_ID = 'mcp.server.'.self::NAME.'.builder';
+
+    public const REGISTRY_SERVICE_ID = 'mcp.server.'.self::NAME.'.registry';
+}

--- a/src/Eccube/Service/Mcp/ScopeFilteringRegistry.php
+++ b/src/Eccube/Service/Mcp/ScopeFilteringRegistry.php
@@ -33,7 +33,7 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
  * `tools/list` を、 現在の OAuth2 トークンが呼べる Tool だけに絞る {@see RegistryInterface} デコレータ。
  * 呼べない Tool を一覧に出さない (最小権限)。
  *
- * mcp-bundle の `mcp.registry` を装飾し、 `ListToolsHandler` が読む {@see getTools()} だけを上書きする。
+ * mcp-bundle のサーバ registry (`mcp.server.eccube.registry`) を装飾し、 `ListToolsHandler` が読む {@see getTools()} だけを上書きする。
  * 各 Tool の必要 scope ({@see McpToolScopeMap}) を {@see AuthorizationCheckerInterface} で検査する。
  *
  * これは可視性の制御であって、 呼び出しの拒否ではない。 実際の拒否は {@see ScopeEnforcingReferenceHandler}

--- a/tests/Eccube/Tests/DependencyInjection/Compiler/McpScopeEnforcementPassTest.php
+++ b/tests/Eccube/Tests/DependencyInjection/Compiler/McpScopeEnforcementPassTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Eccube\Tests\DependencyInjection\Compiler;
 
 use Eccube\DependencyInjection\Compiler\McpScopeEnforcementPass;
+use Eccube\Service\Mcp\McpServerDefinition;
 use Eccube\Service\Mcp\ScopeEnforcingReferenceHandler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -34,14 +35,14 @@ final class McpScopeEnforcementPassTest extends TestCase
     public function testWiresScopeEnforcingHandlerIntoBuilder(): void
     {
         $container = new ContainerBuilder();
-        $container->setDefinition('mcp.server.builder', new Definition(\stdClass::class));
+        $container->setDefinition(McpServerDefinition::BUILDER_SERVICE_ID, new Definition(\stdClass::class));
         // mcp.tool タグの Tool を 1 つ用意 (locator 構築対象)
         $container->setDefinition('dummy.tool', (new Definition(\stdClass::class))->addTag('mcp.tool'));
 
         (new McpScopeEnforcementPass())->process($container);
 
         // 1. builder に setReferenceHandler が ScopeEnforcingReferenceHandler 参照付きで差し込まれている
-        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
+        $calls = $container->getDefinition(McpServerDefinition::BUILDER_SERVICE_ID)->getMethodCalls();
         $setReferenceHandlerCalls = array_filter($calls, static fn (array $c): bool => 'setReferenceHandler' === $c[0]);
         $this->assertCount(1, $setReferenceHandlerCalls, 'builder に setReferenceHandler が 1 回差し込まれる');
 
@@ -64,7 +65,7 @@ final class McpScopeEnforcementPassTest extends TestCase
 
         (new McpScopeEnforcementPass())->process($container);
 
-        $this->assertFalse($container->hasDefinition('mcp.server.builder'));
+        $this->assertFalse($container->hasDefinition(McpServerDefinition::BUILDER_SERVICE_ID));
         // builder 不在なら配線されない inner ReferenceHandler 定義も残さない
         // (残すと builder 不在構成のコンテナコンパイルを乱す)
         $this->assertFalse(


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

Refs #7107

symfony/mcp-bundle を 0.12 → 0.13 に更新し、設定スキーマの変更に追従します。
0.13 では `mcp:` 直下が `servers` / `clients` の 2 キーに再編され、旧スキーマの `app` / `version` / `description` / `client_transports` / `http` は受理されません。
現状の `mcp.yaml` のままだと `cache:clear` が `Unrecognized options ... under "mcp"` で失敗します。

## 方針(Policy)

0.12 で有効だった挙動を 1:1 で新スキーマへ移し替えています。

| 項目 | 0.12 | 0.13（本 PR） |
|---|---|---|
| サーバ名 / version / description | `app` / `version` / `description` | `servers.eccube.name` / `version` / `description` |
| トランスポート | `client_transports: {http, stdio}` | `servers.eccube.transports: {http, stdio}` |
| エンドポイント | `http.path: /%eccube_admin_route%/mcp` | `servers.eccube.http.path`（同値） |
| セッション | `http.session.store: file` | `servers.eccube.session.store: file` |
| 公開する要素 | 暗黙で全要素 | `registry: { tools: '*' }` |

`registry` は 0.13 で必須になった項目です。
Tool に限定したのは、scope 検査（`ScopeEnforcingReferenceHandler` / `ScopeFilteringRegistry`）が Tool にしか掛からないためです。
現時点で `src/` `app/` に Tool 以外の MCP 要素は無く、今日の挙動は `'*'` と同じです。

0.13 はサービスをサーバ単位で登録するため、`mcp.server.builder` / `mcp.registry` が `mcp.server.eccube.builder` / `mcp.server.eccube.registry` になります。
参照箇所（compiler pass 2 つ・`McpCliToolInvoker`・`ScopeFilteringRegistry` の `decorates`）を `McpServerDefinition` の定数に集約しました。

## 実装に関する補足(Appendix)

- `mcp/sdk` は mcp-bundle 0.13 の要求で 0.7.1 → 0.8.1 に上がります。EC-CUBE 側が使う `RegistryInterface` / `ReferenceHandlerInterface` のメソッド集合に変化はありません
- `ScopeFilteringRegistry` の `decorates` は `!php/const McpServerDefinition::REGISTRY_SERVICE_ID` で解決します。`mcp.yaml` の `mcp.servers` キーと定数がズレた場合、`DecoratorServicePass` が `ServiceNotFoundException` でコンテナのコンパイルを止めます（ローカルでキーを変えて確認済み）
- セッションの file ストア既定ディレクトリは `%kernel.cache_dir%/mcp-sessions` から `%kernel.cache_dir%/mcp-sessions/eccube` に変わります。cache 配下のため設定では固定していません
- HTTP のルート名は `_mcp_endpoint` から `_mcp_endpoint_eccube` に変わります。リポジトリ内に参照はありません
- 0.13 は同一エンドポイントで MCP 2026-07-28 リビジョンも受け付けます。scope 強制と registry 装飾は両リビジョンで共有される builder に掛かります

## テスト（Test)

ローカルで確認したもの
- `bin/console cache:clear` / `cache:warmup` の成功
- `debug:config mcp` で新スキーマの解決値、`debug:router` で `/admin/mcp`、`debug:mcp` で 11 Tool、`eccube:cli:*` 11 コマンドと `mcp:server` の登録
- stdio 経由で `initialize` と `tools/list` を流し、serverInfo（name / version / description）と 11 Tool が返ること
- phpstan（level 6）/ php-cs-fixer / rector
- `tests/Eccube/Tests/DependencyInjection` `tests/Eccube/Tests/EventListener/Mcp` `EccubeCliToolCommandTest` と、`tests/Eccube/Tests/Service/Mcp` の `mcp` グループ外の全テスト

CI に委ねるもの
- `--group mcp` の PHPUnit と Playwright の `mcp.spec.ts`（Api44 前提の専用ジョブ）

## 相談（Discussion）

- Api44 の `feat/mcp-server-scorp` が Resource / Prompt を提供している場合、`registry: { tools: '*' }` により公開対象から外れます。ローカルに Api44 が無いため未確認です

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - MCPサーバーを名前付き構成で管理できるようになりました。
  - EC-CUBEのMCPサーバー名が明確化され、ツールのみを公開する構成になりました。
  - HTTPパスやセッション保存設定をサーバー単位で指定できるようになりました。

- **ドキュメント**
  - MCPのスコープフィルタリングに関するサービス参照情報を、現在の構成に合わせて更新しました。

- **改善**
  - MCP関連の設定や登録処理におけるサーバー識別を統一し、構成変更時の整合性を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->