### PR TITLE
[4.4] 権限を分離した構成を CI で起動して検証する (#7072 Phase 6)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,12 @@ jobs:
     uses: ./.github/workflows/plugin-test.yml
     with:
       php-versions: "['8.5']"
+  permission-lanes-test:
+    needs: [ unit-test, e2e-test ]
+    # Web サーバーと CLI の書き込み権限を分けた構成 (docker-compose.permission-lanes.yml) を
+    # 起動して検証する。 別 uid かつ Apache 経由でしか再現しない挙動 (読み取り専用モード・
+    # レーン境界・CLI 導線) は単体テストでは検出できない (#7072 Phase 6)。
+    uses: ./.github/workflows/permission-lanes-test.yml
   e2e-test-throttling:
     needs: [ plugin-test ]
     uses: ./.github/workflows/e2e-test-throttling.yml
@@ -65,7 +71,7 @@ jobs:
     # 全ジョブを直接 needs する。チェーン依存(success←throttling←plugin-test←unit-test)だと
     # 上流の failure が各ホップで skipped に化けて末端へ届かず、必須チェック success が
     # skipped=パス扱いとなって赤テストのまま auto-merge されてしまうため(#6840)。
-    needs: [ rector, phpstan, php-cs-fixer, unit-test, e2e-test, plugin-test, e2e-test-throttling, dockerbuild, agentic-commerce-e2e ]
+    needs: [ rector, phpstan, php-cs-fixer, unit-test, e2e-test, plugin-test, e2e-test-throttling, permission-lanes-test, dockerbuild, agentic-commerce-e2e ]
     # 上流が失敗しても success 自体は必ず実行する(skip させない)
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/permission-lanes-test.yml
+++ b/.github/workflows/permission-lanes-test.yml
@@ -1,0 +1,363 @@
+name: Permission Lanes Test
+
+## Web サーバー (www-data) と CLI (SSH ログインユーザー相当) の書き込み権限を分けた構成
+## (docker-compose.permission-lanes.yml) を起動し、 分離した状態でしか再現しない挙動を固定する。
+##
+## Web サーバーと CLI が別 uid で、 かつ Apache (mod_php) 経由で動く構成でしか再現しない不具合
+## (例: PassEnv に載っていない環境変数が Web 側にだけ届かない) は単体テストでは検出できないため、
+## 実際にコンテナを起動して確認する。 issue #7072 Phase 6。
+
+on:
+  workflow_call:
+    inputs:
+      php-tag:
+        description: 'ベースイメージ php:<TAG> と docker-compose.yml の TAG'
+        type: string
+        default: '8.5-apache'
+  workflow_dispatch:
+    inputs:
+      php-tag:
+        description: 'ベースイメージ php:<TAG> と docker-compose.yml の TAG'
+        type: string
+        default: '8.5-apache'
+
+permissions:
+  contents: read
+
+jobs:
+  permission-lanes:
+    name: Permission Lanes
+    runs-on: ubuntu-latest
+    ## compose のビルドとコンテナ内 composer install を含むため、 既存ワークフローと違い明示する
+    timeout-minutes: 45
+    env:
+      ## AGENTS.md に記載の 4 枚重ねと同じ構成。 以降の docker compose はすべてこれを見る
+      COMPOSE_FILE: docker-compose.yml:docker-compose.dev.yml:docker-compose.pgsql.yml:docker-compose.permission-lanes.yml
+      TAG: ${{ inputs.php-tag }}
+      ## 分離モードは APP_ENV=prod 固定 (docker-compose.permission-lanes.yml)。
+      ## prod のセッション cookie は SameSite=None のため、 HTTP だとブラウザに破棄され
+      ## 管理画面へログインできない。 自己署名証明書の HTTPS (4430) を使う
+      BASE_URL: https://127.0.0.1:4430
+      ADMIN_ROUTE: admin
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: 20
+
+      - name: Cache npm dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v5
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: Cache build artifacts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v5
+        id: build-cache
+        with:
+          path: |
+            html/template/**/css
+            html/bundle
+          key: ${{ runner.os }}-build-${{ hashFiles('html/template/**/scss/**/*.scss', 'html/template/**/js/**/*.js', 'package-lock.json', 'esbuild.config.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+
+      ## アセットはホスト側でビルドする。 コンテナ内で npm run build すると生成物が root 所有で
+      ## バインドマウント越しにホストへ残り、 次のホスト側ビルドが EACCES で落ちる。
+      ## docker-compose.dev.yml のバインドマウント経由でコンテナから見える
+      - name: Build Sass and JavaScript
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: |
+          npm ci
+          npm run build
+
+      ## --build は必須。 ghcr の公開イメージには dockerbuild/docker-php-entrypoint の
+      ## レーン分離が含まれず、 pull されたイメージのままだと www-data がホストユーザーへ
+      ## リマップされて分離が成立しない
+      - name: Start permission-lanes environment
+        run: docker compose up -d --build
+
+      ## --wait は使わない。 ec-cube の healthcheck は Dockerfile の `pgrep apache` だけで、
+      ## その 30 回 x 10 秒 (= 300 秒) の枠内にコンテナ内の composer install と
+      ## installer-scripts と eccube:cache:build が収まらないと unhealthy 扱いになる。
+      ## 実応答をポーリングして待つ
+      - name: Wait for EC-CUBE to respond
+        run: |
+          for _ in $(seq 1 90); do
+            if curl -fsS -k -o /dev/null "${BASE_URL}/"; then
+              echo "EC-CUBE is ready."
+              exit 0
+            fi
+            if [ -n "$(docker compose ps --status=exited --quiet ec-cube)" ]; then
+              echo "::error::ec-cube container exited during startup"
+              docker compose logs ec-cube --tail=300
+              exit 1
+            fi
+            sleep 10
+          done
+          echo "::error::EC-CUBE did not respond within 15 minutes"
+          docker compose logs ec-cube --tail=300
+          exit 1
+
+      ## CLI ユーザーの名前は uid 依存。 イメージ内に同じ uid のユーザーが既にいると
+      ## `eccube` にならないため、 決め打ちせず引く (dockerbuild/docker-php-entrypoint)
+      - name: Resolve the CLI user
+        run: |
+          CLI_UID=$(docker compose exec -T ec-cube stat -c %u composer.json | tr -d '\r')
+          CLI_USER=$(docker compose exec -T ec-cube getent passwd "${CLI_UID}" | cut -d: -f1 | tr -d '\r')
+          if [ -z "${CLI_USER}" ]; then
+            echo "::error::could not resolve the CLI user (uid=${CLI_UID})"
+            exit 1
+          fi
+          echo "CLI_UID=${CLI_UID}" >> "$GITHUB_ENV"
+          echo "CLI_USER=${CLI_USER}" >> "$GITHUB_ENV"
+          echo "CLI user: ${CLI_USER} (uid=${CLI_UID})"
+
+      ## entrypoint 側に「分離できているか」の自己検査は無い。 分離に失敗した環境では
+      ## 以降のテストがすべて通ってしまい、 検証が空虚になるためここで確かめる
+      - name: Verify the lanes are actually separated
+        run: |
+          WEB_UID=$(docker compose exec -T ec-cube id -u www-data | tr -d '\r')
+          if [ "${WEB_UID}" != "33" ]; then
+            echo "::error::www-data has been remapped to uid ${WEB_UID}; the lanes are not separated (--build を忘れていませんか)"
+            exit 1
+          fi
+          if [ "${CLI_UID}" = "${WEB_UID}" ]; then
+            echo "::error::the CLI user and www-data share uid ${WEB_UID}"
+            exit 1
+          fi
+          ## レーン W はディレクトリだけ www-data 所有、 レーン S は CLI ユーザー所有
+          for dir in var/runtime var/sessions var/log html/upload; do
+            OWNER=$(docker compose exec -T ec-cube stat -c %u "${dir}" | tr -d '\r')
+            [ "${OWNER}" = "33" ] || { echo "::error::${dir} (レーン W) の所有者が ${OWNER} です"; exit 1; }
+          done
+          for dir in var/build var/cache app/template app/keystore html/user_data app/Plugin vendor; do
+            OWNER=$(docker compose exec -T ec-cube stat -c %u "${dir}" | tr -d '\r')
+            [ "${OWNER}" = "${CLI_UID}" ] || { echo "::error::${dir} (レーン S) の所有者が ${OWNER} です"; exit 1; }
+          done
+
+      ## ECCUBE_RESTRICT_FILE_UPLOAD は docker-php-entrypoint の PassEnv に含まれていない。
+      ## php.ini-production は variables_order=GPCS で $_ENV が空のため、 Symfony 側は
+      ## EnvVarProcessor の getenv() フォールバックで拾うことになる。 実際に Apache の
+      ## プロセス環境へ渡っているかを確かめる (渡っていなければ読み取り専用モードが
+      ## Web からは効かず、 Phase 4 が Apache 経由で成立していないことになる)
+      - name: Verify ECCUBE_RESTRICT_FILE_UPLOAD reaches the web server
+        run: |
+          APACHE_ENV=$(docker compose exec -T ec-cube sh -c 'tr "\0" "\n" < /proc/$(pgrep -o apache2)/environ')
+          echo "${APACHE_ENV}" | grep -E '^ECCUBE_RESTRICT_FILE_UPLOAD=1$' || {
+            echo "::error::ECCUBE_RESTRICT_FILE_UPLOAD が Apache のプロセス環境に見当たりません"
+            echo "${APACHE_ENV}" | grep -E '^(APP_ENV|ECCUBE_)' || true
+            exit 1
+          }
+
+      - name: Verify the front and admin screens respond
+        run: |
+          set -e
+          ## セッションを作る。 eccube:doctor:permissions は var/sessions のセッションファイルから
+          ## Web サーバーの uid を判定するため、 これが無いと全 finding が WARN・終了コード 0 になり
+          ## 「見かけ上成功」してしまう
+          curl -fsS -k -o /dev/null "${BASE_URL}/"
+          curl -fsS -k -o /dev/null "${BASE_URL}/products/list"
+          curl -fsS -k -o /dev/null "${BASE_URL}/${ADMIN_ROUTE}/login"
+
+      - name: Run eccube:doctor:permissions
+        run: |
+          docker compose exec -T -u "${CLI_USER}" ec-cube \
+            bin/console eccube:doctor:permissions --format=json > doctor.json
+          cat doctor.json
+          ## NG が無いことに加えて、 Web サーバーの uid を判定できていること (判定できないと
+          ## すべて WARN になり終了コード 0 で通ってしまう) と、 CLI と別 uid であることを見る
+          jq -e '.summary.ng == 0' doctor.json > /dev/null
+          jq -e '.web_server != null' doctor.json > /dev/null
+          jq -e '.cli != null and (.cli.uid != .web_server.uid)' doctor.json > /dev/null
+          ## 表形式でも読めるようにログへ残す
+          docker compose exec -T -u "${CLI_USER}" ec-cube bin/console eccube:doctor:permissions
+
+      ## entrypoint は eccube:cache:build の失敗を握り潰して警告を出すだけなので、
+      ## 明示的に実行して終了コードを見る
+      - name: Verify eccube:cache:build succeeds as the CLI user
+        run: |
+          docker compose exec -T -u "${CLI_USER}" ec-cube bin/console eccube:cache:build
+          if docker compose logs ec-cube | grep -q 'eccube:cache:build に失敗しました'; then
+            echo "::error::起動時の eccube:cache:build が失敗しています"
+            docker compose logs ec-cube --tail=300
+            exit 1
+          fi
+
+      ## ファイルシステムの素の境界。 アプリを経由しないため解釈の余地がなく、
+      ## 分離が形だけになったときにここで落ちる
+      - name: Verify the raw lane boundaries
+        run: |
+          set -u
+          fail() { echo "::error::$1"; exit 1; }
+          denied() {  # $1=user $2=path  書き込めないことを確かめる
+            if docker compose exec -T -u "$1" ec-cube sh -c "touch '$2/.lane-probe' 2>/dev/null"; then
+              docker compose exec -T -u "$1" ec-cube sh -c "rm -f '$2/.lane-probe'" || true
+              fail "$1 が $2 へ書き込めてしまいました"
+            fi
+          }
+          allowed() {
+            docker compose exec -T -u "$1" ec-cube sh -c "touch '$2/.lane-probe' && rm -f '$2/.lane-probe'" \
+              || fail "$1 が $2 へ書き込めません"
+          }
+          ## レーン S: CLI ユーザーだけが書ける
+          for dir in app/template html/user_data app/keystore var/build; do
+            allowed "${CLI_USER}" "${dir}"
+            denied www-data "${dir}"
+          done
+          ## レーン W: Web サーバーだけが書ける
+          for dir in var/log var/runtime html/upload; do
+            allowed www-data "${dir}"
+            denied "${CLI_USER}" "${dir}"
+          done
+
+      - name: Verify the lane boundaries through the CLI
+        run: |
+          set -u
+          fail() { echo "::error::$1"; exit 1; }
+          ## インストーラや assets:install が app/template に何か置いている可能性があるため、
+          ## 「変化しないこと」を基準線との差で見る
+          BASELINE=$(git status --porcelain app/template)
+          changed() { [ "$(git status --porcelain app/template)" != "${BASELINE}" ]; }
+
+          ## (1) メタ情報だけの更新は app/template に影を作らない (Phase 5)。
+          ##     app/template は src/Eccube/Resource/template より優先されるため、
+          ##     同じ内容の写しを置くと upstream のテンプレート修正 (脆弱性パッチを含む) が
+          ##     画面へ反映されなくなる
+          docker compose exec -T -u "${CLI_USER}" ec-cube \
+            bin/console eccube:page:apply --route=entry --name='会員登録 (permission lanes CI)'
+          ! changed || fail "メタ情報だけの更新で app/template が変化しました: $(git status --porcelain app/template)"
+
+          ## (2) レーン S への書き込みは Web サーバーのユーザーでは失敗し、 doctor を案内する
+          set +e
+          OUT=$(printf '<p>lane test</p>' | docker compose exec -T -u www-data ec-cube \
+            bin/console eccube:page:apply --route=lane_test --name='レーン境界テスト' --body=- 2>&1)
+          STATUS=$?
+          set -e
+          echo "${OUT}"
+          [ "${STATUS}" -eq 1 ] || fail "www-data でのページ作成が終了コード ${STATUS} で終わりました (1 を期待)"
+          echo "${OUT}" | grep -q 'eccube:doctor:permissions' \
+            || fail "書き込み失敗時に eccube:doctor:permissions が案内されていません"
+          ! changed || fail "失敗したはずの書き込みでファイルが残りました"
+
+          ## (3) 同じ操作が CLI ユーザーでは成功し、 削除で元に戻る
+          printf '<p>lane test</p>' | docker compose exec -T -u "${CLI_USER}" ec-cube \
+            bin/console eccube:page:apply --route=lane_test --name='レーン境界テスト' --body=-
+          changed || fail "CLI ユーザーでのページ作成でテンプレートが書き出されていません"
+          docker compose exec -T -u "${CLI_USER}" ec-cube \
+            bin/console eccube:page:remove --route=lane_test --force
+          ! changed || fail "ページ削除後もテンプレートが残っています: $(git status --porcelain app/template)"
+
+          ## (4) 鍵はレーン S。 CLI ユーザーで冪等に生成でき、 所有者も CLI ユーザーになる
+          docker compose exec -T -u "${CLI_USER}" ec-cube bin/console eccube:keystore:generate
+          docker compose exec -T -u "${CLI_USER}" ec-cube bin/console eccube:keystore:generate
+          KEY_OWNER=$(docker compose exec -T ec-cube stat -c %u app/keystore | tr -d '\r')
+          [ "${KEY_OWNER}" = "${CLI_UID}" ] || fail "app/keystore の所有者が ${KEY_OWNER} です"
+
+          ## (5) レーン W の実行時キャッシュは Web サーバーのユーザーで削除する
+          docker compose exec -T -u www-data ec-cube bin/console cache:pool:clear --all
+
+      ## 管理画面からのプラグイン操作は分離すると使えない。 CLI が代替導線として成立することと、
+      ## eccube:plugin:* のあと eccube:cache:build を実行すればサイトが 500 にならないことを固定する
+      ## (eccube:plugin:* は cache:clear --no-warmup しかしないため、 挟まないと次のリクエストで
+      ##  Web サーバーがコンテナを生成しようとして var/build へ書けず 500 になる)
+      - name: Install a plugin from the CLI
+        run: |
+          set -e
+          ## アーカイブの直下にプラグインの中身が並ぶ形にする (e2e/helpers/tar-helper.ts と同じ)。
+          ## `-C dir .` だと `./` 付きのエントリになり PharData::extractTo() の展開が不安定になる
+          SRC=codeception/_data/plugins/Boomerang-1.0.0
+          tar -czf "${PWD}/Boomerang-1.0.0.tgz" -C "${SRC}" $(ls "${SRC}")
+          docker compose exec -T -u "${CLI_USER}" ec-cube \
+            bin/console eccube:plugin:install --path=Boomerang-1.0.0.tgz
+          docker compose exec -T -u "${CLI_USER}" ec-cube \
+            bin/console eccube:plugin:enable --code=Boomerang
+          docker compose exec -T -u "${CLI_USER}" ec-cube bin/console eccube:cache:build
+          curl -fsS -k -o /dev/null "${BASE_URL}/"
+          curl -fsS -k -o /dev/null "${BASE_URL}/${ADMIN_ROUTE}/login"
+
+      - name: Install Playwright dependencies
+        working-directory: e2e
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('e2e/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: e2e
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: e2e
+        run: npx playwright install-deps chromium
+
+      - name: Cache apt packages
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9  # latest
+        with:
+          packages: fonts-ipafont fonts-ipaexfont
+          version: 1.0
+
+      - name: Run Playwright tests
+        working-directory: e2e
+        env:
+          ECCUBE_ADMIN_ROUTE: ${{ env.ADMIN_ROUTE }}
+          ADMIN_USER: 'admin'
+          ADMIN_PASSWORD: 'password'
+          CI: 'true'
+          ## globalSetup のフィクスチャ投入はコンテナ内で実行する。 アプリはコンテナ側にあり、
+          ## ホストの php では DB もカーネルも解決できない。 -u を省くと root で走り
+          ## レーンの所有者が壊れるため必ず CLI ユーザーを指定する
+          PHP_BIN: docker compose exec -T -u ${{ env.CLI_USER }} ec-cube php
+        run: npx playwright test --project=setup --project=permission-lanes-tests permission-lanes.spec.ts
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: permission-lanes-report
+          path: e2e/playwright-report/
+
+      - name: Upload ScreenShots
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: permission-lanes-results
+          path: e2e/test-results/
+
+      ## var は名前付きボリュームでホストから見えないため、 コンテナから取り出す
+      - name: Collect logs
+        if: failure()
+        run: |
+          mkdir -p logs
+          docker compose logs ec-cube --tail=1000 > logs/container.log 2>&1 || true
+          docker compose exec -T ec-cube sh -c 'ls -1 var/log/prod 2>/dev/null' || true
+          docker compose cp ec-cube:/var/www/html/var/log logs/var-log || true
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: permission-lanes-logs
+          path: logs/
+
+      ## down -v でレーン W のボリュームを捨てる。 加えて html/upload はバインドマウント越しに
+      ## ホスト側でも uid 33 所有になるため、 ワークスペースの後片付けが刺さらないよう戻す
+      - name: Tear down
+        if: always()
+        run: |
+          docker compose down -v || true
+          sudo chown -R "$(id -u):$(id -g)" html/upload || true

--- a/.github/workflows/permission-lanes-test.yml
+++ b/.github/workflows/permission-lanes-test.yml
@@ -9,17 +9,7 @@ name: Permission Lanes Test
 
 on:
   workflow_call:
-    inputs:
-      php-tag:
-        description: 'ベースイメージ php:<TAG> と docker-compose.yml の TAG'
-        type: string
-        default: '8.5-apache'
   workflow_dispatch:
-    inputs:
-      php-tag:
-        description: 'ベースイメージ php:<TAG> と docker-compose.yml の TAG'
-        type: string
-        default: '8.5-apache'
 
 permissions:
   contents: read
@@ -33,7 +23,11 @@ jobs:
     env:
       ## AGENTS.md に記載の 4 枚重ねと同じ構成。 以降の docker compose はすべてこれを見る
       COMPOSE_FILE: docker-compose.yml:docker-compose.dev.yml:docker-compose.pgsql.yml:docker-compose.permission-lanes.yml
-      TAG: ${{ inputs.php-tag }}
+      ## 他のジョブ (main.yml の php-versions) と同じ PHP で回す。
+      ## 8.5 は opcache がコア組み込みのため docker-php-ext-install の対象から外す
+      ## (dockerbuild.yml の matrix と同じ値)
+      TAG: '8.5-apache'
+      EXT_INSTALL_ARGS: 'zip gd mysqli pdo_mysql intl'
       ## 分離モードは APP_ENV=prod 固定 (docker-compose.permission-lanes.yml)。
       ## prod のセッション cookie は SameSite=None のため、 HTTP だとブラウザに破棄され
       ## 管理画面へログインできない。 自己署名証明書の HTTPS (4430) を使う

--- a/.github/workflows/permission-lanes-test.yml
+++ b/.github/workflows/permission-lanes-test.yml
@@ -313,6 +313,21 @@ jobs:
           curl -fsS -k -o /dev/null "${BASE_URL}/"
           curl -fsS -k -o /dev/null "${BASE_URL}/${ADMIN_ROUTE}/login"
 
+      ## 管理画面からは作れないページを CLI で作っておき、 Playwright から
+      ## 「反映されること」と「削除操作が無効化されていること」を確認する。
+      ## 削除の UI はユーザーが作成したページ (EDIT_TYPE_USER) にしか出ないため、
+      ## 標準のフィクスチャだけでは検証できない
+      - name: Create a page from the CLI for the E2E
+        run: |
+          set +e
+          printf '<p>permission lanes</p>' | docker compose exec -T -u "${CLI_USER}" ec-cube \
+            bin/console eccube:page:apply --route=permission_lanes --name='権限分離テストページ' --body=-
+          STATUS=$?
+          set -e
+          [ "${STATUS}" -eq 0 ] || [ "${STATUS}" -eq 3 ] \
+            || { echo "::error::eccube:page:apply が終了コード ${STATUS} で終わりました"; exit 1; }
+          docker compose exec -T -u "${CLI_USER}" ec-cube bin/console eccube:cache:build
+
       - name: Install Playwright dependencies
         working-directory: e2e
         run: npm ci
@@ -347,10 +362,10 @@ jobs:
           ADMIN_USER: 'admin'
           ADMIN_PASSWORD: 'password'
           CI: 'true'
-          ## globalSetup のフィクスチャ投入はコンテナ内で実行する。 アプリはコンテナ側にあり、
-          ## ホストの php では DB もカーネルも解決できない。 -u を省くと root で走り
-          ## レーンの所有者が壊れるため必ず CLI ユーザーを指定する
-          PHP_BIN: docker compose exec -T -u ${{ env.CLI_USER }} ec-cube php
+          ## 追加フィクスチャの生成は Eccube\Tests\Fixture\Generator を必要とするが、
+          ## これはテスト環境専用のサービスで APP_ENV=prod では解決できない。
+          ## 本 spec は eccube:fixtures:load が入れた管理者とデモデータで足りるため省略する
+          SKIP_FIXTURES: '1'
         run: npx playwright test --project=setup --project=permission-lanes-tests permission-lanes.spec.ts
 
       - name: Upload Playwright report

--- a/.github/workflows/permission-lanes-test.yml
+++ b/.github/workflows/permission-lanes-test.yml
@@ -222,12 +222,21 @@ jobs:
           BASELINE=$(git status --porcelain app/template)
           changed() { [ "$(git status --porcelain app/template)" != "${BASELINE}" ]; }
 
+          ## 分離した構成ではレーン W (var/runtime/{env}/pools) を CLI から削除できないため、
+          ## コンテンツ系コマンドは本処理を完了したうえで終了コード 3
+          ## (EXIT_MANUAL_ACTION_REQUIRED) を返す。 これは想定どおりの成功系
+          ok3() { [ "$1" -eq 0 ] || [ "$1" -eq 3 ] || fail "$2 が終了コード $1 で終わりました (0 か 3 を期待)"; }
+
           ## (1) メタ情報だけの更新は app/template に影を作らない (Phase 5)。
           ##     app/template は src/Eccube/Resource/template より優先されるため、
           ##     同じ内容の写しを置くと upstream のテンプレート修正 (脆弱性パッチを含む) が
           ##     画面へ反映されなくなる
+          set +e
           docker compose exec -T -u "${CLI_USER}" ec-cube \
             bin/console eccube:page:apply --route=entry --name='会員登録 (permission lanes CI)'
+          STATUS=$?
+          set -e
+          ok3 "${STATUS}" 'eccube:page:apply (メタ情報のみ)'
           ! changed || fail "メタ情報だけの更新で app/template が変化しました: $(git status --porcelain app/template)"
 
           ## (2) レーン S への書き込みは Web サーバーのユーザーでは失敗し、 doctor を案内する
@@ -243,11 +252,20 @@ jobs:
           ! changed || fail "失敗したはずの書き込みでファイルが残りました"
 
           ## (3) 同じ操作が CLI ユーザーでは成功し、 削除で元に戻る
+          set +e
           printf '<p>lane test</p>' | docker compose exec -T -u "${CLI_USER}" ec-cube \
             bin/console eccube:page:apply --route=lane_test --name='レーン境界テスト' --body=-
+          STATUS=$?
+          set -e
+          ok3 "${STATUS}" 'eccube:page:apply (CLI ユーザー)'
           changed || fail "CLI ユーザーでのページ作成でテンプレートが書き出されていません"
+
+          set +e
           docker compose exec -T -u "${CLI_USER}" ec-cube \
             bin/console eccube:page:remove --route=lane_test --force
+          STATUS=$?
+          set -e
+          ok3 "${STATUS}" 'eccube:page:remove'
           ! changed || fail "ページ削除後もテンプレートが残っています: $(git status --porcelain app/template)"
 
           ## (4) 鍵はレーン S。 CLI ユーザーで冪等に生成でき、 所有者も CLI ユーザーになる
@@ -270,10 +288,27 @@ jobs:
           ## `-C dir .` だと `./` 付きのエントリになり PharData::extractTo() の展開が不安定になる
           SRC=codeception/_data/plugins/Boomerang-1.0.0
           tar -czf "${PWD}/Boomerang-1.0.0.tgz" -C "${SRC}" $(ls "${SRC}")
+
+          ## 3 は「本処理は完了したがキャッシュの削除に手動操作が必要」。 分離した構成では
+          ## レーン W を CLI から削除できないため想定どおりの成功系
+          ok3() { [ "$1" -eq 0 ] || [ "$1" -eq 3 ] || { echo "::error::$2 が終了コード $1 で終わりました"; exit 1; }; }
+
+          set +e
           docker compose exec -T -u "${CLI_USER}" ec-cube \
             bin/console eccube:plugin:install --path=Boomerang-1.0.0.tgz
+          STATUS=$?
+          set -e
+          ok3 "${STATUS}" 'eccube:plugin:install'
+
+          set +e
           docker compose exec -T -u "${CLI_USER}" ec-cube \
             bin/console eccube:plugin:enable --code=Boomerang
+          STATUS=$?
+          set -e
+          ok3 "${STATUS}" 'eccube:plugin:enable'
+
+          ## eccube:plugin:* は cache:clear --no-warmup しかしないため、 ここで作り直さないと
+          ## 次のリクエストで Web サーバーが var/build へ書けず 500 になる
           docker compose exec -T -u "${CLI_USER}" ec-cube bin/console eccube:cache:build
           curl -fsS -k -o /dev/null "${BASE_URL}/"
           curl -fsS -k -o /dev/null "${BASE_URL}/${ADMIN_ROUTE}/login"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,14 @@ curl -s -o /dev/null http://127.0.0.1:8080/   # セッションを生成し Web 
 docker compose exec -u eccube ec-cube bin/console eccube:doctor:permissions
 ```
 
+この構成は CI でも起動して検証する（`.github/workflows/permission-lanes-test.yml`）。レーンの境界、
+`eccube:doctor:permissions` の判定、読み取り専用モードの応答、CLI からのプラグイン導入までを固定する。
+Web サーバーと CLI が別 uid で、かつ Apache（mod_php）経由で動く構成でしか再現しない挙動
+（例: `PassEnv` に載っていない環境変数が Web 側にだけ届かない）は単体テストでは検出できないため。
+Playwright は `permission-lanes-tests` project で `e2e/tests/permission-lanes.spec.ts` だけを実行する。
+分離モードは `APP_ENV=prod` 固定で、prod のセッション cookie は `SameSite=None` のため
+**HTTP では管理画面にログインできない**。CI は `4430` の HTTPS（自己署名）を使う。
+
 レーン W（`var/runtime`、`var/sessions`、`var/log`、`html/upload/**`）は `www-data` 所有とし、
 共有グループは作らない。CLI からレーン W を触る操作は Web サーバーのユーザーで実行する。
 本番の `sudo -u www-data` に相当する。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,12 @@ services:
       context: .
       args:
         TAG: ${TAG:-8.2-apache}
+        ## PHP 8.5 以降は opcache がコア組み込みのため docker-php-ext-install の対象から外す必要がある
+        ## (残したままだとイメージのビルドが `cp: cannot stat 'modules/*'` で失敗する)。
+        ## TAG を 8.5-apache 以降にする場合は EXT_INSTALL_ARGS も併せて指定する。
+        ## 既定値は Dockerfile と同じ (8.2〜8.4 向け)。 バージョンごとの値は
+        ## .github/workflows/dockerbuild.yml の matrix が正。
+        EXT_INSTALL_ARGS: "${EXT_INSTALL_ARGS:-zip gd mysqli pdo_mysql opcache intl}"
       pull: true
     pull_policy: missing
     ports:

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -7,6 +7,15 @@ import path from 'path';
  * Codeception の _bootstrap.php と同等のデータ（会員、商品、受注）を作成。
  */
 export default function globalSetup() {
+  // フィクスチャの生成には Eccube\Tests\Fixture\Generator が要る。これはテスト環境専用の
+  // サービスのため、APP_ENV=prod で動く環境 (permission-lanes) では解決できない。
+  // そこでは eccube:fixtures:load が入れた基本データだけで足りるので、実行自体を省く
+  // (省かないと毎回スタックトレースが出て、本当の失敗が埋もれる)。
+  if (process.env.SKIP_FIXTURES === '1') {
+    console.log('SKIP_FIXTURES=1 のためフィクスチャの生成を省略します。');
+    return;
+  }
+
   const projectDir = path.resolve(__dirname, '..');
   const phpBin = process.env.PHP_BIN || 'php';
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -34,6 +34,11 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         storageState: undefined,
+        // The permission-lanes environment runs as APP_ENV=prod behind Apache with a
+        // self-signed certificate (see the `permission-lanes-tests` project below).
+        // Logging in there requires HTTPS, so accept the certificate here too.
+        // This has no effect on the plain HTTP runs used by the other projects.
+        ignoreHTTPSErrors: true,
       },
     },
     {
@@ -71,6 +76,24 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         storageState: path.join(__dirname, '.auth', 'admin.json'),
+      },
+    },
+    {
+      // Runs against the environment started by docker-compose.permission-lanes.yml,
+      // where the web server and the CLI have different uids. Kept out of the
+      // `admin-tests` glob on purpose: with ECCUBE_RESTRICT_FILE_UPLOAD=1 the admin
+      // screens that write to lane S are read-only, so the regular admin specs cannot
+      // pass there.
+      name: 'permission-lanes-tests',
+      testMatch: /permission-lanes\.spec\.ts/,
+      dependencies: ['setup'],
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: path.join(__dirname, '.auth', 'admin.json'),
+        // That environment is APP_ENV=prod, whose session cookie uses SameSite=None:
+        // browsers drop it without the Secure flag, so the admin has to be reached over
+        // HTTPS. Apache serves it with the snakeoil certificate baked into the image.
+        ignoreHTTPSErrors: true,
       },
     },
     {

--- a/e2e/tests/permission-lanes.spec.ts
+++ b/e2e/tests/permission-lanes.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from '@playwright/test';
+import { ADMIN_ROUTE } from '../config/default.config';
+
+/**
+ * 権限を分離した構成 (docker-compose.permission-lanes.yml) の管理画面。
+ *
+ * Web サーバー (www-data) は app/template・html/user_data・.env・app/Plugin へ書き込めないため、
+ * 該当する管理画面は ECCUBE_RESTRICT_FILE_UPLOAD=1 で読み取り専用になる。
+ * 内容の表示は残したまま保存操作だけを無効化し、代替の CLI コマンドを案内する、という
+ * Phase 4 の設計が Apache + mod_php 経由でも成立していることを固定する。
+ *
+ * この spec は permission-lanes-tests project でのみ実行する
+ * (.github/workflows/permission-lanes-test.yml)。 通常の CI では
+ * ECCUBE_RESTRICT_FILE_UPLOAD が未設定のため成立しない。
+ */
+
+const adminRoute = ADMIN_ROUTE;
+
+/** notice_read_only.twig が表示する警告 (admin.common.restrict_file_upload_read_only) */
+const READ_ONLY_NOTICE = 'この画面は読み取り専用です。';
+
+/** CLI で導入するプラグイン。 ワークフローが eccube:plugin:install/enable で入れておく */
+const CLI_PLUGIN_CODE = 'Boomerang';
+
+test.describe('権限を分離した構成の管理画面', () => {
+  test('CSS 管理は内容を表示したまま保存だけ無効化される', async ({ page }) => {
+    await page.goto(`/${adminRoute}/content/css`);
+
+    await expect(page.getByText(READ_ONLY_NOTICE)).toBeVisible();
+    // 代替の CLI コマンドを案内する
+    await expect(page.getByText('bin/console eccube:asset:apply --type=css')).toBeVisible();
+    // 403 で塞がず内容は表示する (Phase 3b で読み取りを書き込み権限から切り離した)
+    await expect(page.locator('#editor')).toBeVisible();
+    await expect(page.locator('#save-button')).toBeDisabled();
+  });
+
+  test('ページ管理は一覧を表示したまま削除だけ無効化される', async ({ page }) => {
+    await page.goto(`/${adminRoute}/content/page`);
+
+    await expect(page.getByText(READ_ONLY_NOTICE)).toBeVisible();
+    await expect(page.getByText('bin/console eccube:page:apply')).toBeVisible();
+    // 一覧は読める
+    const rows = page.locator('tr[id^="ex-page-"]');
+    expect(await rows.count()).toBeGreaterThan(0);
+    // 削除リンクは押せない (a 要素のため disabled クラスと aria-disabled で無効化する)
+    const deleteLink = page.locator('a.btn-ec-delete[href*="/delete"]').first();
+    await expect(deleteLink).toHaveClass(/disabled/);
+    await expect(deleteLink).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  test('ファイル管理はアップロードと新規作成が無効化される', async ({ page }) => {
+    await page.goto(`/${adminRoute}/content/file_manager`);
+
+    await expect(page.getByText(READ_ONLY_NOTICE)).toBeVisible();
+    await expect(page.getByText('bin/console eccube:user-data:put')).toBeVisible();
+    for (const selector of ['a.action-upload', 'a.action-create']) {
+      await expect(page.locator(selector)).toHaveClass(/disabled/);
+      await expect(page.locator(selector)).toHaveAttribute('aria-disabled', 'true');
+    }
+  });
+
+  test('メールテンプレートは内容を表示したまま登録だけ無効化される', async ({ page }) => {
+    await page.goto(`/${adminRoute}/setting/shop/mail`);
+
+    await expect(page.getByText(READ_ONLY_NOTICE)).toBeVisible();
+    await expect(page.getByText('bin/console eccube:mail-template:apply')).toBeVisible();
+    await expect(page.locator('#mail_template')).toBeVisible();
+    await expect(page.locator('button.btn-ec-conversion[type="submit"]')).toBeDisabled();
+  });
+
+  test('プラグイン管理は一覧を表示したまま操作だけ無効化される', async ({ page }) => {
+    await page.goto(`/${adminRoute}/store/plugin`);
+
+    await expect(page.getByText(READ_ONLY_NOTICE)).toBeVisible();
+    await expect(page.getByText('bin/console eccube:plugin:enable')).toBeVisible();
+  });
+
+  test('CLI で導入したプラグインが管理画面へ反映される', async ({ page }) => {
+    await page.goto(`/${adminRoute}/store/plugin`);
+
+    // eccube:plugin:install --path=... → eccube:plugin:enable --code=... で導入済み。
+    // 管理画面からのプラグイン操作が塞がれていても CLI が代替導線として成立していること
+    const row = page.locator('tr').filter({ hasText: CLI_PLUGIN_CODE }).first();
+    await expect(row).toContainText('有効');
+    // 有効なプラグインの行には無効化リンクが出る。 それが押せないこと
+    const disableLink = row.locator('a[href*="/disable"]');
+    await expect(disableLink).toHaveClass(/disabled/);
+    await expect(disableLink).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  test('制限中でもナビゲーションから対象画面へ辿れる', async ({ page }) => {
+    // 辿れないと「内容は表示する」が成立しないため、 Phase 4 でメニューの非表示化をやめた
+    await page.goto(`/${adminRoute}/`);
+
+    const nav = page.locator('.c-mainNavArea');
+    for (const path of ['content/css', 'content/js', 'content/file_manager']) {
+      await expect(nav.locator(`a[href$="/${adminRoute}/${path}"]`)).toHaveCount(1);
+    }
+  });
+
+  test('書き込みリクエストは UI を経由しなくても 403 になる', async ({ page }) => {
+    // page.request はブラウザと同じコンテキスト (ログイン済みのセッション) を使う。
+    // RestrictFileUploadListener は kernel.request で判定するため、 フォームを組み立てず
+    // 直接 POST しても 403 になる
+    await page.goto(`/${adminRoute}/`);
+
+    const css = await page.request.post(`/${adminRoute}/content/css`, { form: {} });
+    expect(css.status()).toBe(403);
+
+    const mail = await page.request.post(`/${adminRoute}/setting/shop/mail`, { form: {} });
+    expect(mail.status()).toBe(403);
+
+    // ファイル管理はディレクトリ移動も POST のため、 FileController が create / upload だけを拒否する
+    const create = await page.request.post(`/${adminRoute}/content/file_manager`, {
+      form: { mode: 'create' },
+    });
+    expect(create.status()).toBe(403);
+
+    const move = await page.request.post(`/${adminRoute}/content/file_manager`, {
+      form: { mode: 'move' },
+    });
+    expect(move.status()).not.toBe(403);
+  });
+
+  test('安全なメソッドは通る', async ({ page }) => {
+    // 書き込みを伴うメソッドだけを 403 にする (GET まで塞ぐと内容が読めなくなる)
+    const response = await page.request.get(`/${adminRoute}/content/css`);
+    expect(response.status()).toBe(200);
+  });
+});

--- a/e2e/tests/permission-lanes.spec.ts
+++ b/e2e/tests/permission-lanes.spec.ts
@@ -22,6 +22,9 @@ const READ_ONLY_NOTICE = 'この画面は読み取り専用です。';
 /** CLI で導入するプラグイン。 ワークフローが eccube:plugin:install/enable で入れておく */
 const CLI_PLUGIN_CODE = 'Boomerang';
 
+/** CLI で作成するページ名。 ワークフローが eccube:page:apply で作っておく */
+const CLI_PAGE_NAME = '権限分離テストページ';
+
 test.describe('権限を分離した構成の管理画面', () => {
   test('CSS 管理は内容を表示したまま保存だけ無効化される', async ({ page }) => {
     await page.goto(`/${adminRoute}/content/css`);
@@ -34,7 +37,7 @@ test.describe('権限を分離した構成の管理画面', () => {
     await expect(page.locator('#save-button')).toBeDisabled();
   });
 
-  test('ページ管理は一覧を表示したまま削除だけ無効化される', async ({ page }) => {
+  test('ページ管理は一覧を表示したまま保存操作だけ無効化される', async ({ page }) => {
     await page.goto(`/${adminRoute}/content/page`);
 
     await expect(page.getByText(READ_ONLY_NOTICE)).toBeVisible();
@@ -42,6 +45,17 @@ test.describe('権限を分離した構成の管理画面', () => {
     // 一覧は読める
     const rows = page.locator('tr[id^="ex-page-"]');
     expect(await rows.count()).toBeGreaterThan(0);
+  });
+
+  test('CLI で作成したページが管理画面へ反映され、削除が無効化されている', async ({ page }) => {
+    // eccube:page:apply --route=permission_lanes で作成済み (ワークフローが実行する)。
+    // 削除の UI はユーザーが作成したページ (EDIT_TYPE_USER) にしか出ないため、
+    // 標準のフィクスチャだけでは削除の無効化を検証できない
+    await page.goto(`/${adminRoute}/content/page`);
+
+    const row = page.locator('tr[id^="ex-page-"]').filter({ hasText: CLI_PAGE_NAME }).first();
+    await expect(row).toBeVisible();
+
     // 削除リンクは押せない (a 要素のため disabled クラスと aria-disabled で無効化する)
     const deleteLink = page.locator('a.btn-ec-delete[href*="/delete"]').first();
     await expect(deleteLink).toHaveClass(/disabled/);

--- a/e2e/tests/permission-lanes.spec.ts
+++ b/e2e/tests/permission-lanes.spec.ts
@@ -56,8 +56,10 @@ test.describe('権限を分離した構成の管理画面', () => {
     const row = page.locator('tr[id^="ex-page-"]').filter({ hasText: CLI_PAGE_NAME }).first();
     await expect(row).toBeVisible();
 
-    // 削除リンクは押せない (a 要素のため disabled クラスと aria-disabled で無効化する)
-    const deleteLink = page.locator('a.btn-ec-delete[href*="/delete"]').first();
+    // 削除リンクは押せない (a 要素のため disabled クラスと aria-disabled で無効化する)。
+    // 削除のモーダルは行の内側にあるため row を起点に取る。 画面全体から取ると、
+    // 別のページの削除リンクを検証して通ってしまう
+    const deleteLink = row.locator('a.btn-ec-delete[href*="/delete"]');
     await expect(deleteLink).toHaveClass(/disabled/);
     await expect(deleteLink).toHaveAttribute('aria-disabled', 'true');
   });
@@ -133,7 +135,9 @@ test.describe('権限を分離した構成の管理画面', () => {
     const move = await page.request.post(`/${adminRoute}/content/file_manager`, {
       form: { mode: 'move' },
     });
-    expect(move.status()).not.toBe(403);
+    // FileController::index() は create / upload 以外を素通しして画面を返すため 200 になる。
+    // 「403 でない」だと 404 や 500 も通ってしまうので、 成功したことまで確かめる
+    expect(move.ok()).toBeTruthy();
   });
 
   test('安全なメソッドは通る', async ({ page }) => {

--- a/llms.txt
+++ b/llms.txt
@@ -245,6 +245,15 @@ The screens and their CLI equivalents are listed in `eccube_restrict_file_upload
 templates, `.env`, templates and every plugin operation. When the variable is unset (the
 default) the screens behave as before and fail at save time.
 
+CI starts the separated setup and verifies it
+(`.github/workflows/permission-lanes-test.yml`): the lane boundaries, the
+`eccube:doctor:permissions` verdict, the read-only responses, and installing a plugin from the
+CLI. Behaviour that only shows up when the web server and the CLI have different uids and the
+app runs behind Apache (mod_php) — an environment variable missing from `PassEnv` reaching the
+CLI but not the web server, for instance — cannot be caught by unit tests. That setup pins
+`APP_ENV=prod`, whose session cookie uses `SameSite=None`, so the admin is unreachable over
+plain HTTP; the job talks to the self-signed HTTPS port (`4430`) instead.
+
 ## Community
 
 - [GitHub Repository](https://github.com/EC-CUBE/ec-cube)


### PR DESCRIPTION
## 概要

#7072 Phase 6。`docker-compose.permission-lanes.yml` を起動する CI ジョブを追加します。

Phase 1〜5（#7098 / #7100 / #7105 / #7114 / #7117 / #7119 / #7121）で 3 レーン権限モデルとレーン S への CLI 導線が揃いましたが、**これらは一度も CI で分離モードとして動かされていません**。`.github/workflows/` に `permission-lanes` / `ECCUBE_RESTRICT_FILE_UPLOAD` の参照はゼロで、確認は毎回ローカルの手動 `docker compose` に頼っていました。読み取り専用モードの E2E は `e2e/tests/plugin-misc.spec.ts` に 1 本ありますが、`ECCUBE_RESTRICT_FILE_UPLOAD` を設定するジョブが無いため CI では常にスキップされています。

Web サーバーと CLI が別 uid で、かつ Apache（mod_php）経由で動く構成でしか再現しない挙動（例: `PassEnv` に載っていない環境変数が Web 側にだけ届かない）は単体テストでは検出できないため、実際にコンテナを起動して確認します。

## 固定する内容

| 観点 | 検証 |
|---|---|
| 分離できていること自体 | `www-data` が uid 33 のままであること、レーン別の所有者。`--build` を落とすと ghcr の公開イメージが使われてレーン分離が入らないため、テストが「分離していない環境で全部通る」事故を防ぐ |
| レーン境界（素） | レーン S（`app/template` / `html/user_data` / `app/keystore` / `var/build`）は CLI ユーザーのみ、レーン W（`var/log` / `var/runtime` / `html/upload`）は Web サーバーのみが書き込める |
| `eccube:doctor:permissions` | `--format=json` で NG 0 件、かつ **Web サーバーの uid を判定できていること**。セッションファイルが無いと全 finding が WARN・終了コード 0 になり「見かけ上成功」するため、`.web_server != null` と `.cli.uid != .web_server.uid` まで見る |
| レーン境界（CLI） | レーン S への書き込みが `www-data` では終了コード 1 と `eccube:doctor:permissions` の案内で終わり、CLI ユーザーでは成功する |
| 影を作らない | メタ情報だけの更新で `app/template` が変化しないこと（Phase 5） |
| CLI 導線 | `eccube:plugin:install` → `enable` → `eccube:cache:build` のあとサイトが 500 にならず、管理画面のプラグイン一覧へ反映される |
| 読み取り専用モード | バナー・代替 CLI コマンドの案内・保存ボタンの無効化・書き込みリクエストの 403 が **Apache 経由でも**成立する |

## 設計上の判断

- **HTTPS（`4430`）で回す** — 分離モードは `APP_ENV=prod` 固定（`docker-compose.permission-lanes.yml`）で、prod のセッション cookie は `cookie_samesite: none`。HTTP では `Secure` が付かずブラウザが cookie を破棄するため、管理画面にログインできません。`app/config/eccube/packages/e2e/framework.yaml` の緩和は `APP_ENV=e2e` 専用で効きません。既に `install-tests` project が同じ理由で `ignoreHTTPSErrors` を使っています。
- **`--wait` を使わない** — `ec-cube` の healthcheck は `Dockerfile` の `pgrep apache` だけで、その 30 回 × 10 秒の枠内にコンテナ内の `composer install` と `installer-scripts` と `eccube:cache:build` が収まらないと unhealthy 扱いになります。実応答をポーリングします。
- **1 ジョブにまとめる** — `docker compose up --build` が重いため、スモークと E2E を分けると 2 回走ります。
- **専用の Playwright project** — 制限 ON では既存の `admin-contents.spec.ts` / `plugin-*.spec.ts` は成立しないため、`permission-lanes-tests` project で `permission-lanes.spec.ts` だけを実行します。既存 spec の挙動は変えていません。
- `docker-compose.permission-lanes.yml` は変更していません。CI 専用のオーバーレイも作らず、ドキュメントに書いてある構成そのままを回します。

## 変更内容

- `.github/workflows/permission-lanes-test.yml`（新規）
- `.github/workflows/main.yml` — ジョブを追加し、**`success` の `needs` にも登録**
- `e2e/playwright.config.ts` — `permission-lanes-tests` project を追加、`setup` に `ignoreHTTPSErrors`
- `e2e/tests/permission-lanes.spec.ts`（新規）
- `AGENTS.md` / `llms.txt` — CI ジョブの存在と HTTPS が必要な理由を追記

## 検証結果

CI で実走して確認しました（run 34455972675、`permission-lanes-test / Permission Lanes` は失敗ステップ 0 件・Playwright 11 passed）。

| 検証 | 実測 |
|---|---|
| 分離の成立 | `www-data` = uid 33、CLI = `eccube` uid 1001 |
| `ECCUBE_RESTRICT_FILE_UPLOAD` の到達 | Apache のプロセス環境に `ECCUBE_RESTRICT_FILE_UPLOAD=1`。`docker-php-ext-entrypoint` の `PassEnv` には含まれていませんが、`EnvVarProcessor` の `getenv()` フォールバックで届いており、**読み取り専用モードは mod_php 経由でも成立**しています |
| `eccube:doctor:permissions` | **OK 22 / WARN 0 / NG 0**。`web_server` は `var/sessions/prod/sess_...` から uid 33 を判定 |
| レーン境界（ファイルシステム直接） | レーン S は CLI ユーザーのみ、レーン W は `www-data` のみが書き込める（両方向） |
| レーン境界（CLI） | `www-data` でのページ作成は終了コード 1 と `eccube:doctor:permissions` の案内、CLI ユーザーでは成功し削除で元に戻る |
| 影を作らない | メタ情報だけの更新で `app/template` は不変（Phase 5 が分離環境でも効いている） |
| CLI 導線 | `eccube:plugin:install` → `enable` → `eccube:cache:build` のあとサイトは 200。CLI で作ったページ・プラグインが管理画面へ反映される |
| 読み取り専用モード | バナー・代替 CLI コマンドの案内・保存ボタンの無効化・書き込みの 403・安全なメソッドの 200 |

## 途中で見つけて直した既存の不具合

**`TAG=8.5-apache docker compose up -d --build` が通らなかった** — PHP 8.5 以降は opcache がコア組み込みのため `docker-php-ext-install opcache` が `cp: cannot stat 'modules/*'` で失敗します。`dockerbuild.yml` は matrix でバージョンごとに `ext_install_args` を分けていますが、compose の build args は `TAG` しか渡していなかったため、`docker-compose.yml` 自身がコメントで案内している使い方が壊れていました。build args に `EXT_INSTALL_ARGS`（既定値は Dockerfile と同じ）を追加しています。`TAG` を指定しない従来の使い方は変わりません。

なお `e2e/global-setup.ts` に追加した `SKIP_FIXTURES` は、フィクスチャ生成が `Eccube\Tests\Fixture\Generator`（テスト環境専用サービス）を必要とし `APP_ENV=prod` では解決できないためです。未設定なら従来どおり動きます。

Refs #7072

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **テスト**
  - Web サーバーと CLI の権限を分離した環境で、管理画面の読み取り専用動作を検証するテストを追加しました。
  - 保存操作、CLI 経由のページ・プラグイン操作、権限境界を確認する自動テストを追加しました。
  - HTTPS 環境を含むエンドツーエンドテストの実行条件を整備しました。
  - 権限分離テストを継続的インテグレーションの必須チェックに追加しました。

- **ドキュメント**
  - 権限分離構成と読み取り専用管理画面の検証方法を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->