### PR TITLE
[4.4] 権限レーンの Skill を新設し AGENTS.md / llms.txt / 既存 Skill を最終状態へ揃える (#7072 Phase 7a)

### DIFF
--- a/.claude/skills/eccube-command/SKILL.md
+++ b/.claude/skills/eccube-command/SKILL.md
@@ -25,9 +25,15 @@ description: EC-CUBE 4.4 のコンソールコマンド（Symfony Console・#[As
   - 注: コマンドの場合 `parent::__construct()` の呼び出しが必須（後述）。トレイト経由で依存を渡したいときだけ
     `#[Required]` セッター注入を使う（`PluginCommandTrait` が `setPluginService()` 等で採用）。
 - **`configure()` で引数・オプションを宣言**する。`addArgument()` / `addOption()`、必要に応じて `setHelp()`。
-- **`execute(InputInterface $input, OutputInterface $output): int` に処理を書き、`int` を返す**。
-  正常終了は `0`、異常終了は非 0（`1` 等）。
-  `Command::SUCCESS` / `Command::FAILURE` 定数も使えるが、**EC-CUBE コアは一貫して `return 0;` のリテラルを使っている**ので踏襲する。
+- **`execute(InputInterface $input, OutputInterface $output): int` に処理を書き、`int` を返す**。終了コードの意味は固定:
+  - `0` = 正常終了（`Command::SUCCESS`。既存コマンドはリテラル `0` も使う）
+  - `1` = 失敗。本処理は完了していない（`Command::FAILURE`）
+  - `2` = 引数・オプション不正（`Command::INVALID`。`--format` の値不正など）
+  - **`3` = 本処理は完了したが手動操作が必要**（`EXIT_MANUAL_ACTION_REQUIRED`。`PluginCommandTrait` / `ContentCommandTrait` /
+    `CacheBuildCommand` / `EnvSetCommand` が定義）。キャッシュを削除できなかった・ビルドの再生成が別途要る・`.env.local.php` があって
+    変更が反映されない、など。**必要な操作（`bin/console eccube:cache:build` 等）を `$io->warning()` で必ず添える。**
+    `2` は `Command::INVALID` が使用済みのため避ける
+  - Symfony 標準の `cache:clear` 等に非ゼロを返させない。symfony/flex の auto-scripts が `composer install` を中断する
 - **出力は `SymfonyStyle`** を使う（`$io->success()` / `$io->error()` / `$io->comment()` / `$io->title()` 等）。
   低レベルに `$output->writeln()` を使う実装もあるが、ユーザ向けメッセージは `SymfonyStyle` に寄せる。
 - **業務ロジックはコマンドに直書きしない**。Service／Repository／PurchaseFlow へ委譲し、コマンドは
@@ -154,6 +160,80 @@ try {
 }
 ```
 
+### 書き込み系コマンド（`apply` / `--dry-run` / `--format=json` / 標準入力）
+
+ファイルや設定を書き換えるコマンドは `src/Eccube/Command/Content/*` の形に揃える（`ContentCommandTrait` を `use`）。
+CI・エージェントから扱えるよう、入出力と終了コードを機械可読にするのが目的。
+
+- **サブコマンドは `list` / `show` / `apply` / `remove`**（静的ファイルは `put`）。`new` / `edit` に分けず、**`apply` は upsert で冪等**にする
+  （指定しなかった項目は既存値を維持し、同じ入力を何度適用しても結果が同じ）。`show` は `apply` の逆操作
+  （`show --route=guide > guide.twig` → `apply --route=guide --body-file=guide.twig`）。
+- **`addWriteOptions()`** が `--body`（`-` で標準入力）/ `--body-file` / `--dry-run` / `--no-cache-clear` / `--format=table|json` を足す。
+  本文は `readBody()` で取る（`--body` と `--body-file` の同時指定はエラー。読み込み失敗の `false` を空文字列へ丸めない）。
+- **`--dry-run` は差分を表示して適用しない**。Service 側が `$dryRun` を受け取り、`ContentResult` に変更前後を載せる。
+- **`--format=json`** は `renderResult()` が `{"dry_run": bool, ...ContentResult}` を出力する。値不正は `Command::INVALID`。
+- **書き込み失敗は `ContentWriteException`** を受けて `reportWriteFailure()` に渡す（`eccube:doctor:permissions` を案内して `1`）。
+  権限を分離した構成では Web サーバーのユーザーで実行したときだけ失敗するため、実行ユーザーの誤りを最初に疑わせる。
+- 反映にキャッシュの削除が要るものは `clearContentCache()` を最後に呼び、`false` なら `EXIT_MANUAL_ACTION_REQUIRED`（`3`）。
+  削除できない理由と手順（`eccube:cache:build` / Web サーバーのユーザーで `cache:pool:clear`）はトレイトが案内する。
+- 分離した構成では**レーン W（`var/runtime` / `var/log`）へ CLI から書かない**。詳細は Skill `eccube-permission-lanes`。
+
+```php
+#[AsCommand(name: 'eccube:example:apply', description: '...')]
+final class ExampleApplyCommand extends Command
+{
+    use ContentCommandTrait;
+
+    protected function configure(): void
+    {
+        $this->addOption('key', null, InputOption::VALUE_REQUIRED, '登録・更新の鍵');
+        $this->addWriteOptions();   // --body / --body-file / --dry-run / --no-cache-clear / --format
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $format = (string) $input->getOption('format');
+        if (!$this->isValidFormat($format)) {
+            $this->invalidFormat($io);
+
+            return Command::INVALID;
+        }
+        try {
+            $body = $this->readBody($input);   // --body=- なら標準入力
+        } catch (\InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return Command::INVALID;
+        }
+        $dryRun = (bool) $input->getOption('dry-run');
+        try {
+            $result = $this->exampleContentService->apply([...], $dryRun);   // ContentResult
+        } catch (ContentValidationException $e) {
+            $io->error($e->getErrors());
+
+            return Command::FAILURE;
+        } catch (ContentWriteException $e) {
+            return $this->reportWriteFailure($io, '保存できません', $e);
+        }
+        $this->renderResult($io, $output, $format, $result, $dryRun);
+        if ($dryRun || ContentStatus::Unchanged === $result->status || $input->getOption('no-cache-clear')) {
+            return Command::SUCCESS;
+        }
+
+        return $this->clearContentCache($io) ? Command::SUCCESS : self::EXIT_MANUAL_ACTION_REQUIRED;
+    }
+}
+```
+
+### 子プロセスで `bin/console` を実行する
+
+`cache:clear` や `eccube:cache:build` を別プロセスで呼ぶときは **cwd に `kernel.project_dir` を渡し、`setTimeout(null)`** にする
+（`PluginCommandTrait::clearCache()` / `EnvSetCommand`）。cwd を省略するとプロジェクトルート以外から実行したときに `bin/console` を
+解決できず、`Process` の既定タイムアウト（60 秒）を超えると子プロセスが kill されてキャッシュが中途半端に消える。
+実行中のプロセスは自身のコンパイル済みコンテナを作り直せない（子が新しいコンテナを作ると親のディレクトリが消える）ため、
+コンテナの内容を変える操作の後は `eccube:cache:build` の実行を案内して `3` を返す。
+
 ### プラグイン／Customize のコマンド
 
 `#[AsCommand]` を付けて `app/Plugin/{Code}/Command/` または `app/Customize/Command/` に置くだけで、
@@ -175,7 +255,10 @@ try {
 - ❌ `execute()` に業務的な計算・判定・複数 Repository 横断処理を直書き → ✅ Service／Repository へ委譲し、コマンドは入出力と終了コードに徹する
 - ❌ コンストラクタで `parent::__construct()` を呼び忘れる → ✅ コマンドでは必須（呼ばないと実行時エラー）
 - ❌ サービス定義に手書きで `console.command` タグを足す → ✅ `#[AsCommand]` ＋ `autoconfigure` 任せ（手動登録不要）
-- ❌ `execute()` の戻り値を書かない／`void` にする → ✅ `int` を返す（正常 `0`、異常は非 0）
+- ❌ `execute()` の戻り値を書かない／`void` にする → ✅ `int` を返す（`0` 正常 / `1` 失敗 / `2` 引数不正 / `3` 完了したが手動操作が必要）
+- ❌ キャッシュ削除に失敗しても `$io->error()` を出して `return 0` → ✅ `3`（`EXIT_MANUAL_ACTION_REQUIRED`）と必要な操作の案内を返す
+- ❌ 書き込み系を `new` / `edit` に分ける、`--dry-run` / `--format=json` が無い → ✅ `apply`（upsert・冪等）＋ `ContentCommandTrait`
+- ❌ 子プロセスの `bin/console` を cwd 無し・既定タイムアウトで実行 → ✅ `kernel.project_dir` を cwd に、`setTimeout(null)`
 - ❌ ループ内で毎回 `flush()` してバッチが遅い → ✅ バッチサイズごとにまとめて `flush()`、端数も最後に flush
 - ❌ 「Symfony Scheduler で定期実行」と推測で書く → ✅ コアに機構は無い。OS の cron から `bin/console` を叩く前提で冪等に作る
 - ❌ コマンド名を独自の命名で付ける → ✅ `eccube:` 接頭辞のコロン区切り（既存コマンドに倣う）
@@ -190,6 +273,8 @@ bin/console list              # 登録済みコマンド一覧（自分のコマ
 bin/console list eccube       # eccube: 名前空間のコマンド一覧
 bin/console help <コマンド名>  # 引数・オプションの確認
 bin/console <コマンド名> --dry-run 等   # 副作用のあるバッチは小さい入力で試す
+bin/console <コマンド名> --format=json | jq .   # 機械可読出力の確認
+bin/console <コマンド名> ...; echo $?           # 終了コード (0 / 1 / 2 / 3) の確認
 ```
 
 新規コマンドが `bin/console list` に現れれば autoconfigure による登録は成功している。

--- a/.claude/skills/eccube-customize/SKILL.md
+++ b/.claude/skills/eccube-customize/SKILL.md
@@ -166,18 +166,31 @@ Twig の検索パスは **`app/template/...`（`eccube_theme_front_dir` / `eccub
 - 一部だけ差し込みたい場合は、コア改変や全文コピーより **テンプレートイベント**で挿入する方が壊れにくい（Skill `eccube-event-subscriber` / `eccube-twig-template`）。
 - XSS・`raw` の扱いは Skill `eccube-twig-template`。
 
+### 5. 実行時にレーン S へ書き込まない
+
+`app/Customize` のコードはリクエスト処理中に動く。Web サーバーと CLI の権限を分離した環境（Skill `eccube-permission-lanes`）では
+`app/template` / `html/user_data` / `.env` / `app/Customize` / `app/proxy` / `var/build` / `var/cache` / `app/keystore` は
+**CLI ユーザー所有で Web サーバーは読み取りのみ（レーン S）**。ここへ書くコードは分離した環境で `Permission denied` になる。
+
+- **リクエスト処理中に生成するファイルは `eccube_runtime_dir`（`var/runtime/{env}`）配下**に置く。アップロード物は既存の `html/upload/**`。
+  パスはパラメータ（`eccube_runtime_dir` 等）から解決し、`var/...` をリテラルで書かない。
+- レーン S を書き換える必要のある機能（テンプレートや設定の書き換え、生成コードの配置）は **`app/Customize/Command/` のコンソールコマンドとして実装する**
+  （Skill `eccube-command`）。管理画面から実行させたい場合も、画面はコマンドを案内するに留める。
+- `mkdir()` は `0755`。`0777` / `umask(0)` を書かない。
+- Web サーバーから書けるかどうかを `is_writable()` で判定しない（実行ユーザーから見た可否しか分からない）。
+
 ## よくある間違い
 
 - ❌ コア（`src/Eccube/`）を直接書き換える → ✅ `app/Customize/` で拡張・上書きし、アップグレード安全にする
 - ❌ プロジェクト固有の 1 回限りの改変をプラグイン化 → ✅ それは `app/Customize/`。着脱・再配布するものだけ `app/Plugin/`
 - ❌ 名前空間を `Plugin\{Code}\` と混同 → ✅ Customize は **`Customize\` ＝ `app/Customize/`**
-- ❌ エンティティ拡張の trait に `#[EntityExtension(対象::class)]` を付け忘れ → ✅ 付けないと proxy に乗らずカラムが認識されない
-- ❌ trait 追加後に proxy 再生成を忘れる → ✅ `bin/console eccube:generate:proxies`
+- ❌ trait に `#[EntityExtension(対象::class)]` を付け忘れる／追加後に proxy を再生成しない → ✅ 付けて `bin/console eccube:generate:proxies`
 - ❌ カラム追加に ALTER マイグレーションを書く → ✅ 属性が源泉。`schema:update --force` が反映（マイグレーションは INSERT・型変更等に限る。Skill `eccube-migration`）
 - ❌ 既存フォームを直接改変 → ✅ `AbstractTypeExtension` ＋ `getExtendedTypes()`（`app/Customize/Form/Extension/`）で拡張
 - ❌ サービスを `#[AsDecorator]` で包む（コアの作法と不一致） → ✅ `services.yaml` で `decorates` ＋ `@.inner` 委譲
 - ❌ テンプレートを上書こうとしてコア原本側を編集 → ✅ `app/template/` に同じ相対パスで同名ファイルを置く（app 側が優先）
 - ❌ 上書きパスのテーマ名を間違える → ✅ フロントは `app/template/{ECCUBE_TEMPLATE_CODE}/`（既定 `default`）、管理画面は `app/template/admin/`
+- ❌ リクエスト処理中に `app/template` / `html/user_data` / `.env` / `var/build` へ書く → ✅ `eccube_runtime_dir` 配下に置くか、コンソールコマンドにする
 
 ## 実行・確認方法
 
@@ -187,7 +200,8 @@ Twig の検索パスは **`app/template/...`（`eccube_theme_front_dir` / `eccub
 bin/console eccube:generate:proxies      # エンティティ拡張(trait)を足したら proxy 再生成
 bin/console doctrine:schema:update --dump-sql   # 追加カラムの差分プレビュー
 bin/console doctrine:schema:update --force      # 属性差分を反映（単純なカラム追加）
-bin/console cache:clear                  # services.yaml / テンプレート上書きの反映確認
+bin/console cache:clear                  # services.yaml / テンプレート上書きの反映確認（dev）
+bin/console eccube:cache:build           # prod: コンパイル済みコンテナと事前コンパイル済みテンプレートを再生成
 bin/console doctrine:schema:validate     # スキーマ整合確認
 ```
 

--- a/.claude/skills/eccube-permission-lanes/SKILL.md
+++ b/.claude/skills/eccube-permission-lanes/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: eccube-permission-lanes
+description: EC-CUBE 4.4 で Web サーバーと CLI の書き込み権限を分離した構成（レーン W / レーン S）を扱うときの規約。「権限を分離した環境で動かして」「www-data で書き込めない / Permission denied を直して」「eccube:doctor:permissions の結果を読んで」「どのユーザーで bin/console を実行すべきか」「デプロイ手順を書いて」「実行時にファイルへ書き込む処理を追加して」などと言われたとき、または src/Eccube/Service/Permission・src/Eccube/Command/Content・src/Eccube/Util/CacheUtil.php・src/Eccube/Kernel.php のディレクトリ定義・docker-compose.permission-lanes.yml・dockerbuild/docker-php-entrypoint を作成・編集するときに使用する。
+---
+
+# 権限レーン規約 — Web サーバーと CLI の書き込み分離（EC-CUBE 4.4）
+
+**対象**: 実行時にファイルへ書き込むコード全般、`src/Eccube/Service/Permission/**`、`src/Eccube/Command/Content/**`、
+`src/Eccube/Util/CacheUtil.php`、`src/Eccube/Kernel.php`、`docker-compose.permission-lanes.yml`、`dockerbuild/docker-php-entrypoint`
+**前提**: Symfony 7.4 / PHP 8.2+。**分離は任意で、既定は分離しない構成**（Web サーバーと CLI が同じユーザー、または全体に書き込み権限を与える従来どおりの運用）。
+
+> 目的: Web サーバーに最小限の書き込み権限しか与えずに運用できる状態を**壊さない**こと。
+> 書き込み先の分類（レーン）を守り、レーン S へ書く操作は CLI に置き、Web サーバーのユーザー名を固定しない。
+> 運用手順（本番のパーミッション設定・デプロイ・4.3 からの移行）の正本は https://doc4.ec-cube.net/permission 。本 Skill は開発時の判断基準に絞る。
+
+## レーンの判断基準
+
+判定は 1 つだけ: **リクエスト処理中に書き込みが発生するか**。発生するならレーン W、CLI へ移せるならレーン S。
+
+| レーン | 所有者 | 対象（`PermissionRequirementProvider` の定義） |
+|---|---|---|
+| **W**（Web サーバー所有） | Web サーバー。CLI からは書かない | `var/runtime/{env}`（`eccube_runtime_dir`）・`var/log`・`var/sessions/{env}`・`html/upload/save_image`・`html/upload/temp_image`・`html/upload/refund_request/{save,temp}`・メンテナンスファイルの生成先（`ECCUBE_MAINTENANCE_FILE_PATH`） |
+| **S**（CLI ユーザー所有） | CLI（SSH ログインユーザー）。Web サーバーは**読み取りのみ** | `var`（自体）・`var/build/{env}`・`var/cache/{env}`・`app/template`・`html/user_data`・`app/Plugin`・`app/PluginData`・`app/proxy`・`html/plugin`・`vendor`・`composer.json`・`composer.lock`・`app/keystore`・`.env` |
+
+- **レーン定義の唯一の置き場所は `src/Eccube/Service/Permission/PermissionRequirementProvider.php`**。書き込み先を増やす・移すときは必ずここへ登録する。登録しないパスは `eccube:doctor:permissions` が診断しない。
+- パスは設定パラメータ（`eccube_runtime_dir` / `kernel.logs_dir` / `kernel.build_dir` / `kernel.cache_dir` / `eccube_theme_app_dir` / `eccube_save_image_dir` 等）から解決する。`var/...` のリテラルをコードに書かない。
+- 注意が要るもの: `app/PluginData` はプラグインが実行時に書く場合だけ Web サーバーの権限が要る（`optional`）。`app/proxy` は `ReloadSafeAttributeDriver` がプラグイン操作時に一時プロキシを書くため、プラグイン操作を CLI に寄せることが読み取り専用化の前提。`app/keystore` は秘密鍵がデプロイ成果物で、Web サーバーから書けると署名鍵の差し替えを許すためレーン S。ただし Web サーバーは**署名のために読む**必要があるので鍵は `0755` / `0644` で作る（`chgrp` できない環境があるため。所有者専用にするなら `ECCUBE_KEYSTORE_STRICT_PERMISSIONS=1`）。鍵は `eccube:keystore:generate` で事前配置し、実行時の自動生成は CLI を使えない環境向けのフォールバックとして残す。
+- 共有グループ（CLI ユーザーと Web サーバーを同じグループに入れて `g+w` で共有する）を前提にしない。セキュリティポリシーでグループを作れない環境があるため、再現環境も作らない。
+
+## 実装規約 — 実行時にレーン S へ書き込まない
+
+- **リクエスト処理中に作るファイルは `eccube_runtime_dir` 配下**に置く（例: CSV の一時領域 `eccube_csv_temp_realdir` = `%eccube_runtime_dir%/eccube`）。`kernel.cache_dir` / `kernel.build_dir` は CLI が生成するビルド生成物の置き場で、リクエスト処理中は読み取りのみ。
+- **レーン S を書き換える機能は CLI コマンドとして実装する**（Skill `eccube-command`）。管理画面側は `ECCUBE_RESTRICT_FILE_UPLOAD=1` の読み取り専用モードで代替コマンドを案内する（`eccube.yaml` の `eccube_restrict_file_upload_urls` にルート名 → コマンドを登録。レーン S へ書く管理画面ルートの全数は `tests/Eccube/Tests/EventListener/RestrictFileUploadListenerTest.php` が固定しているので、ルートを足したらそちらも更新する）。
+- DB レコードとファイルを対で扱う処理は Service に置き、管理画面と CLI が同じ経路を通す（Skill `eccube-service`）。
+- **`is_writable()` で「Web サーバーから書けるか」を判定しない**。返るのは実行ユーザー（CLI）から見た可否だけ。可否の推定は `PathOwnership` / `PermissionDiagnostic` に集約されている（所有者 uid・gid・パーミッションビットから owner / group / other の一致する 1 クラスだけを見る）。
+- **`mkdir()` のモードは `0755`**。`0777` を書かない。`umask()` を呼ばない（`ECCUBE_UMASK` で運用側が決め、`apply_umask()` は `bin/console` / `index.php` が呼ぶ）。
+- **書き込み失敗を握りつぶさない**。`Symfony\Component\Filesystem` の `IOException` は `ContentWriteException::forWrite()` / `forRemove()` に包んで投げ、コマンド側は `reportWriteFailure()` で `eccube:doctor:permissions` を案内して `1` を返す。
+- キャッシュの削除は `Eccube\Util\CacheUtil` を通す。`clearCache()` は `kernel.terminate` で実行され、build ディレクトリへ書けない場合は実行時キャッシュだけ削除して `eccube:cache:build` を案内する（`clearRuntimeCache()`）。`clearTwigCache()` は build 側の twig も削除する（prod では build 側が読み取り専用キャッシュとして優先されるため）。リクエスト処理中のコードから `cache:clear` を直接実行しない。
+- 子プロセスで `bin/console` を実行するときは cwd に `kernel.project_dir` を渡し `setTimeout(null)` にする（`PluginCommandTrait::clearCache()` / `EnvSetCommand` の形）。
+- **Web サーバーのユーザー名（`www-data` 等）をコード・設定に固定しない**。環境ごとに異なるため、`WebServerUserResolver` が Web でしか生成されないファイル（`var/sessions/{env}` → `html/upload/temp_image` 等 → `var/log`）の所有者から実測する。実行ユーザーは `posix_geteuid()`（`getmyuid()` はスクリプトファイルの所有者を返すため不可）。
+
+## CLI の実行ユーザーの選び方
+
+**操作対象のレーンで決める。** 分離した構成では 1 つのユーザーですべてを実行することはできない。
+
+| 操作 | 実行ユーザー | 例 |
+|---|---|---|
+| レーン S を書く（ビルド生成・コンテンツ・プラグイン・`.env`・鍵） | CLI ユーザー | `bin/console eccube:cache:build` / `eccube:page:apply` / `eccube:plugin:install` / `eccube:env:set` / `eccube:keystore:generate` |
+| レーン W を書く（実行時キャッシュの削除） | Web サーバーのユーザー | `sudo -u www-data bin/console cache:pool:clear --all` |
+
+- Docker の再現環境では `docker compose exec -u eccube`（レーン S）/ `-u www-data`（レーン W）で使い分ける（起動手順は AGENTS.md「権限を分離した環境」）。
+- **root で実行して乗り切らない。** 診断は uid 0 を常に可とみなすので通ってしまうが、root 所有で作られたファイルは以後どちらのユーザーからも書けなくなる。
+- **`cache:clear --no-warmup` を使わない。** `cache:clear` 自体は build と cache の双方がレーン S なので CLI ユーザーなら成功するが、`--no-warmup` ではコンパイル済みコンテナが再生成されず、次のリクエストで Web サーバーが `Unable to write in the "cache" directory` で 500 になる。復旧は `eccube:cache:build` のみ。
+- **`eccube:plugin:*` の後は `eccube:cache:build` を別途実行する。** `PluginCommandTrait::clearCache()` は `cache:clear --no-warmup` を子プロセスで実行するだけで、実行中のプロセスは自身のコンパイル済みコンテナを作り直せない（作り直すと親のコンテナディレクトリが消え `console.terminate` で異常終了する）。
+- 分離した構成は **`APP_ENV=prod` 固定**。dev はリクエスト処理中にコンテナを再生成するため `Kernel::buildContainer()` が `var/cache` と `var/build`（レーン S）への書き込みを要求して 500 になる。
+- `var/log` はレーン W なので CLI からログファイルへ書けない。ログ出力の失敗で本来のエラーが隠れるため、分離した構成では `ECCUBE_CLI_LOG_TO_FILE=0` を設定して CLI のログをコンソールへ寄せる。
+- Web サーバーのユーザーで `bin/console` を実行しても、レーン S を書く操作は `ContentWriteException` で失敗する（終了コード `1`）。エラーメッセージが案内するとおり、実行ユーザーを変える。
+
+## `eccube:doctor:permissions` の読み方
+
+3 レーンの期待値と実際の所有者・パーミッションを突き合わせる。判定は **uid / gid / パーミッションビットからの推定**で、補助グループ・ACL・SELinux は考慮しない。
+
+- 終了コード: `0` = NG なし / `1` = NG あり / `2` = オプション不正。**WARN は終了コードに影響しない。**
+- 機械可読は `--format=json`（`web_server` / `cli` / `summary.{ok,warn,ng}` / `findings[]`）。CI で「分離できている」を固定するときは NG 0 件に加えて **`.web_server != null` と `.cli.uid != .web_server.uid`** まで見る。セッションファイルが無いと Web サーバーの uid を特定できず全件 WARN・終了コード `0` で見かけ上成功する。
+- 「Web サーバーの実行ユーザーを特定できませんでした」は、Web でしか生成されないファイルがまだ無い状態。サイトへ一度アクセス（`curl -s -o /dev/null http://.../`）してから再実行する。
+- 「Web サーバーと診断の実行ユーザーが同じ uid」の note は、共有ホスティング（suexec 等）では分離不可を意味する。別ユーザーで運用しているはずの環境では、判定に使ったファイルが CLI で生成された疑い。
+
+| 判定 | 意味 | 対処 |
+|---|---|---|
+| NG `Web サーバーから書き込み可能です (想定: 読み取りのみ)` | レーン S を Web サーバーが書ける | 所有者を CLI ユーザーへ変え、group / other の `w` を落とす |
+| NG `任意のローカルユーザーから書き込めます` | レーン S が world-writable。Web サーバーの uid が不明でも NG | `ECCUBE_UMASK` を空にし、`chmod o-w` |
+| NG `Web サーバーから書き込めません` | レーン W を Web サーバーが書けない | 所有者を Web サーバーのユーザーへ |
+| NG `Web サーバーから到達できません` | 祖先ディレクトリに `x` が無い（`/home/{user}` が `0700` 等）。ヒントに塞いでいる祖先のパスと権限が出る | 祖先へ `x` を付与するか所有者を変える |
+| NG `存在しません` | 必須パスが無い | 作成する（`optional` なパスは「未作成」で OK） |
+| WARN `Web サーバーは読み取りのみですが, 診断の実行ユーザーからも書き込めません` | レーン S の所有者が診断の実行ユーザーと違う | そのパスを書くコマンドは所有者のユーザーで実行する |
+| WARN `事前コンパイルされていないテンプレートがリクエスト処理中にコンパイルされています` | `var/runtime/{env}/twig` に生成物がある = `eccube:cache:build` の warmup 漏れ（prod のみ） | `eccube:cache:build` を実行する |
+| WARN `Web サーバーから書き込めますが, 任意のローカルユーザーからも書き込めます` | レーン W が world-writable | 権限を分離できる環境では `ECCUBE_UMASK` を空にする |
+| WARN `祖先ディレクトリの権限を確認できないため到達可否を判定できません` | `open_basedir` 等で上位を参照できない | 到達不能とは断定していない。手動で確認する |
+
+## キャッシュの 3 分割とテンプレート更新後の操作
+
+| ディレクトリ | レーン | 内容 | 生成 |
+|---|---|---|---|
+| `var/build/{env}`（`kernel.build_dir`） | S | コンパイル済みコンテナ・ルーティング・メタデータ・prod の twig | `eccube:cache:build` |
+| `var/cache/{env}`（`kernel.cache_dir`） | S | 翻訳カタログ・HTMLPurifier | 同上 |
+| `var/runtime/{env}`（`eccube_runtime_dir`） | W | cache pool・twig のフォールバック・CSV 一時領域・MCP セッション・プロファイラ | リクエスト処理中 |
+
+- prod の twig は `[build/twig（読み取り専用）, runtime/twig]` の 2 層。build に無いテンプレートだけが実行時に runtime へコンパイルされる。dev は `auto_reload` が有効で従来どおり単層。
+- テンプレートを更新したら prod では `eccube:cache:build`。`eccube:page:apply` 等のコンテンツ操作は自動で削除を試み、build へ書けなければ本処理を完了させたうえで終了コード `3` と `eccube:cache:build` の案内を返す。
+- 実行時キャッシュ（cache pool）の削除は `cache:pool:clear --all` を Web サーバーのユーザーで。`var/runtime/{env}/twig` は `cache:pool:clear` の対象外なので、消すなら Web サーバーのユーザーで `rm -rf` するか管理画面のキャッシュ管理から。
+
+## よくある間違い
+
+- ❌ リクエスト処理中に `app/template` / `html/user_data` / `.env` / `var/build` へ書く → ✅ CLI コマンド化し、管理画面は読み取り専用モードで代替コマンドを案内する
+- ❌ 実行時の一時ファイルを `kernel.cache_dir` や `var/` 直下に作る → ✅ `eccube_runtime_dir` 配下（レーン W）に置く
+- ❌ `cache:clear --no-warmup` を分離した構成で実行する → ✅ `eccube:cache:build`。コンテナが再生成されず次のリクエストで 500 になる
+- ❌ `eccube:plugin:*` の終了コード `0` で完了扱いにする → ✅ 続けて `eccube:cache:build`。`3` は「完了したが手動操作が必要」
+- ❌ `is_writable()` で Web サーバーから書けるかを判定する → ✅ 実行ユーザーの可否しか分からない。`PermissionDiagnostic` に任せる
+- ❌ `mkdir($dir, 0777)` / `umask(0000)` を書く → ✅ `0755`。umask は `ECCUBE_UMASK` で運用側が決める
+- ❌ 書き込み先を増やしたのに `PermissionRequirementProvider` へ登録しない → ✅ 登録しないパスは診断されない
+- ❌ `www-data` をコード・設定・テストに固定する → ✅ 環境ごとに異なる。所有者から実測し、テストは所有者 +1 等の相対値で書く
+- ❌ WARN だけの診断結果を「分離できている」と読む → ✅ `.web_server != null` と uid の不一致まで確認する
+- ❌ root で `bin/console` を実行して権限エラーを回避する → ✅ 対象レーンの所有者で実行する。root 所有のファイルは双方から書けなくなる
+
+## 実行・確認方法
+
+QA ツール（PHPUnit / PHPStan / PHP-CS-Fixer）の実行方法は AGENTS.md「開発コマンド」を参照。
+
+```bash
+# 分離した構成の再現 (--build 必須, DB サーバー必須。詳細は AGENTS.md「権限を分離した環境」)
+docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml \
+  -f docker-compose.permission-lanes.yml up -d --build --wait
+curl -s -o /dev/null http://127.0.0.1:8080/
+docker compose exec -u eccube ec-cube bin/console eccube:doctor:permissions
+docker compose exec -u eccube ec-cube bin/console eccube:doctor:permissions --format=json \
+  | jq -e '.summary.ng == 0 and .web_server != null and .cli.uid != .web_server.uid'
+
+# 判定ロジックの単体テスト
+vendor/bin/phpunit tests/Eccube/Tests/Service/Permission tests/Eccube/Tests/Command/DoctorPermissionsCommandTest.php
+```
+
+- 分離した構成の結合検証は CI ジョブ `permission-lanes-test`（`.github/workflows/permission-lanes-test.yml`）が行う。レーンの境界を両方向から、診断の判定、読み取り専用モードの応答、CLI からのプラグイン導入までを固定する。Web サーバーと CLI が別 uid で Apache（mod_php）経由でしか再現しない挙動（`PassEnv` に無い環境変数が Web 側にだけ届かない等）は単体テストでは検出できないため、書き込み先やレーン定義を変えたときはこのジョブを通す。
+- 既定モードと分離モードを切り替えるときは `docker compose ... down -v` でレーン W のボリュームを作り直す。切り替え前の `www-data` の uid で作られたディレクトリが残り、切り替え後の Web サーバーから書けなくなる。`html/upload/**` はホスト側でも `www-data` の uid 所有になるため、戻すときは `sudo chown -R $(id -u):$(id -g) html/upload`。
+
+---
+
+実装・改修後は、Skill `eccube-command`（終了コードと入出力）・`eccube-service`（DB とファイルの対）・`eccube-review-responsibility` で点検すること。

--- a/.claude/skills/eccube-plugin/SKILL.md
+++ b/.claude/skills/eccube-plugin/SKILL.md
@@ -94,7 +94,7 @@ class PluginManager extends AbstractPluginManager
 ```
 
 - メソッドのシグネチャは **`(array $meta, ContainerInterface $container)`**。`$meta['code']` は composer.json の `extra.code`。
-- **install 直後はデフォルト無効（enabled=false）**。有効化は `eccube:plugin:enable` コマンドか管理画面で行う（無効化はコンソールコマンドが無く、管理画面から行う）。
+- **install 直後はデフォルト無効（enabled=false）**。有効化は `eccube:plugin:enable --code=<Code>`、無効化は `eccube:plugin:disable --code=<Code>`（管理画面からも可）。
 
 ## 拡張パターン（プラグインから何を足すか）
 
@@ -134,6 +134,22 @@ bin/console eccube:generate:proxies   # app/proxy/entity/ を再生成
 
 トレイトに `#[EntityExtension]` を付け忘れるとプロキシに反映されず、カラムが認識されない。
 
+## 権限を分離した構成では CLI が正
+
+`app/Plugin` / `app/proxy` / `vendor` / `composer.json` は**レーン S**（CLI ユーザー所有、Web サーバーは読み取りのみ。Skill `eccube-permission-lanes`）。
+Web サーバーと CLI の権限を分離した環境では管理画面からのプラグイン操作（導入・有効化・無効化・アップデート・削除、オーナーズストア経由を含む）は
+`ECCUBE_RESTRICT_FILE_UPLOAD=1` で 403 になり、画面は代替コマンドを案内する。**`eccube:plugin:*` / `eccube:composer:*` が正の導線**。
+
+- **操作の後は `bin/console eccube:cache:build` を別途実行する。** `eccube:plugin:*` は `cache:clear --no-warmup` を子プロセスで実行するだけで
+  コンパイル済みコンテナを作り直せない（実行中のプロセスは自身のコンテナを差し替えられない）。分離した構成では Web サーバーが
+  `var/build` へ書けないため、再生成せずにアクセスを受けると 500 になる。
+- 終了コード **`3` = 本処理は完了したが手動操作が必要**（キャッシュを削除できなかった等）。`0` 以外を失敗と決めつけず、案内された操作を行う。
+  `1` は本処理が完了していない。
+- **プラグインが実行時に書き込むファイルは `app/PluginData` に置かない。** `app/PluginData` はレーン S で、リクエスト処理中に書くなら
+  Web サーバーの書き込み権限が要る（分離した構成で動かなくなる）。実行時に生成するものは `eccube_runtime_dir`（`var/runtime/{env}`）配下か
+  DB に置く。`app/PluginData` に書かざるを得ない場合は、プラグインの README にその旨と必要な権限を明記する。
+- `mkdir()` は `0755`。`0777` / `umask(0)` を書かない（umask は `ECCUBE_UMASK` で運用側が決める）。
+
 ## よくある間違い
 
 - ❌ 雛形を手で一から作る → ✅ `bin/console eccube:plugin:generate <name> <code> <ver>` で骨組みを生成し、不要分を削る
@@ -144,6 +160,8 @@ bin/console eccube:generate:proxies   # app/proxy/entity/ を再生成
 - ❌ トレイト追加後にプロキシ再生成を忘れる → ✅ `bin/console eccube:generate:proxies`
 - ❌ プロジェクト固有の 1 回限りの改変をプラグイン化 → ✅ それは `app/Customize/`。着脱・再配布するものだけプラグイン
 - ❌ `app/Customize`（`Eccube\` を直接拡張）と `app/Plugin`（`Plugin\{Code}\` 独立名前空間）の名前空間を混同 → ✅ 置き場所で名前空間を使い分ける
+- ❌ `eccube:plugin:*` の後にそのままアクセスを受ける → ✅ `eccube:cache:build` を実行する。分離した構成ではコンテナ未生成で 500
+- ❌ プラグインが実行時に `app/PluginData` へ書く → ✅ `eccube_runtime_dir` 配下か DB へ。`app/PluginData` はレーン S
 
 ## 実行・確認方法
 
@@ -153,8 +171,10 @@ bin/console eccube:generate:proxies   # app/proxy/entity/ を再生成
 bin/console eccube:plugin:generate "My Plugin" Example 1.0.0   # 雛形生成（name code ver）
 bin/console eccube:plugin:install --code=Example   # 既存ディレクトリからインストール
 bin/console eccube:plugin:enable  --code=Example   # 有効化
+bin/console eccube:plugin:disable --code=Example   # 無効化
 bin/console eccube:plugin:update  Example          # 更新（PluginManager::update を呼ぶ）
 bin/console eccube:generate:proxies                # プロキシ再生成
+bin/console eccube:cache:build                     # プラグイン操作後のコンパイル済みコンテナ再生成
 bin/console doctrine:schema:validate               # スキーマ整合確認
 ```
 

--- a/.claude/skills/eccube-service/SKILL.md
+++ b/.claude/skills/eccube-service/SKILL.md
@@ -59,6 +59,33 @@ class ExampleService
 - 設定は `app/config/eccube/packages/purchaseflow.yaml`。
 - 受注に直接関わらない業務ロジック（商品管理・会員管理・メール送信等）は通常の Service に置いてよい。
 
+## DB レコードとファイルを対で扱う Service
+
+ページ・ブロック・メールテンプレート（`dtb_page` / `dtb_block` / `dtb_mail_template` と `app/template/**` の twig）のように
+**DB レコードとファイルが対**になるものは、`src/Eccube/Service/Content/*ContentService` の形に揃える。
+管理画面のコントローラと CLI（`eccube:page:*` 等）が**同じ Service を通る**ことで、検証・書き出し・キャッシュ削除が二重にならない。
+
+- **検証は管理画面と同じ FormType を submit して行う**（`PageContentService::apply()` は `MainEditType` を組み立てて submit）。
+  CLI 専用の検証を書かない。失敗は `ContentValidationException`（エラー一覧を持つ）で返す。
+- **順序は DB → ファイル、しかもトランザクションの中**。`EntityManager::wrapInTransaction()` の中で `persist` / `flush` してから
+  `dumpFile()` する。ファイルの書き出しに失敗したら例外でロールバックし、**レコードだけが残る状態を作らない**
+  （残ると参照先の無いテンプレートとして画面が「Unable to find template」で落ちる）。権限を分離した構成では
+  `app/template` への書き込みだけが失敗し得るので、この順序が効く。
+- **削除は退避 → DB 削除 → 退避ファイルの削除**（`TemplateRemovalTrait::removeTemplatesAround()`）。ファイルを先に消すと DB 削除の失敗で
+  レコードだけが残り、後に消すとファイル削除の失敗でファイルだけが残る。同じディレクトリへ `.removing-<乱数>` で rename して退避し、
+  失敗時は戻す。
+- **本文が現在の内容と同じならファイルを書き出さない**（`TemplateBodyTrait::shouldWriteTemplate()`）。`app/template/{theme}` は
+  `src/Eccube/Resource/template/default` より twig の探索で優先されるため、内容が同じ写しを作ると upstream のテンプレート修正
+  （脆弱性パッチを含む）が画面へ反映されなくなる。比較は FormType の `trim` に合わせて正規化する。
+  ただしどこからも解決できないテンプレートは必ず書き出す。
+- **本文を指定しない新規登録は配置先に既にあるテンプレートを初期値にする**（`readExistingTemplate()`）。Git でコミット済みのテンプレートから
+  レコードを作れるようにするため。
+- **I/O の失敗は `ContentWriteException::forWrite()` / `forRemove()` に包んで投げる**。握りつぶすと「保存できました」と出て反映されない。
+- 結果は `ContentResult`（`status` = `Created` / `Updated` / `Unchanged` / `Removed`、書き出した・削除したパス、`--dry-run` 用の変更前後）で返す。
+  `dryRun` を引数で受け、`true` なら DB もファイルも触らずに `ContentResult` だけ返す。
+- キャッシュの削除は Service に書かず、呼び出し側（コマンドは `ContentCommandTrait::clearContentCache()`、管理画面は
+  `CacheUtil::clearCache()`）に任せる。分離した構成では削除できないことがあり、その扱いは入口ごとに異なる（Skill `eccube-permission-lanes`）。
+
 ## やってはいけないこと
 
 - **上位層（Controller）への依存**: Service が `Eccube\Controller\...` を `use` / 型ヒントするのは
@@ -94,6 +121,9 @@ vendor/bin/php-cs-fixer fix                     # PSR-12 整形・ライセン�
 - ❌ 1 つの Service に無関係な処理を寄せ集める → ✅ 単一責任で分割
 - ❌ `Request` を Service に渡す → ✅ 必要な値だけを引数で渡す
 - ❌ ループ内で毎回 `flush()` → ✅ まとめて `flush()`（トランザクション境界を意識）
+- ❌ DB を commit してからテンプレートを `dumpFile()` する → ✅ トランザクションの中で DB → ファイルの順。失敗はロールバック
+- ❌ テンプレートを無条件に `dumpFile()` する → ✅ 本文が同じなら書かない（`app/template` の写しが upstream の修正を隠す）
+- ❌ 管理画面と CLI で検証や書き出しを別々に実装する → ✅ 同じ `*ContentService` を通し、検証は FormType の submit で行う
 
 ---
 

--- a/.claude/skills/eccube-twig-template/SKILL.md
+++ b/.claude/skills/eccube-twig-template/SKILL.md
@@ -68,6 +68,10 @@ class ExampleExtension extends AbstractExtension
 
 - **管理画面テンプレートを参照するときは `@admin` 名前空間**を付ける（例: `{{ include('@admin/...') }}`）。名前空間を忘れると探索先を誤る。
 - 上書きは `app/template/` 直下ではなく、**`admin/` か `default(テーマ)/` の正しいサブディレクトリ**に置く。
+- **変更しないテンプレートを `app/template/` にコピーしない**。`app/template/{theme}` は探索で `src/Eccube/Resource/template/default` より
+  優先されるため、内容が同じ写しがあるだけで upstream のテンプレート修正（脆弱性パッチを含む）が画面へ反映されなくなる。
+  管理画面・CLI（`eccube:page:apply` 等）の保存は本文が変わらない限り書き出さない（`*ContentService`）。コードで `dumpFile()` するときも同じ判定を入れる。
+  コアを直接カスタマイズして `git merge` で追従する運用では、`app/template` を使わず `src/Eccube/Resource/template/**` を編集する。
 - **ユーザーが編集できるテンプレート文字列（CMS コンテンツ・フリーエリア・メール本文等）を描画するときは Twig サンドボックスを通す**。
   文字列テンプレートは `template_from_string(...)` ＋ `sandboxed = true` で描画する（コアの定石。例: `default_frame.twig` の CMS メタタグ）。
   許可するタグ/フィルタ/関数はコアの `SecurityPolicyDecorator`（`src/Eccube/Twig/Sandbox/`）で制御されており、**サンドボックスを外すとテンプレートインジェクションになる**（過去の脆弱性修正の中心領域）。
@@ -98,6 +102,8 @@ public function onTemplateCart(TemplateEvent $event): void
 - ❌ **管理画面テンプレートだから安全**と油断して `|raw` する → ✅ admin 配下も XSS シンク（過去の XSS 修正は管理画面テンプレートに多い）。DB/入力由来の値は admin でも必ずエスケープする
 - ❌ テンプレートイベントにエンティティ永続化など業務処理を書く → ✅ 見た目調整のみ。業務は対応するコントローライベントへ
 - ❌ inline `<script>` に素の `json_encode` で埋める → ✅ `</script>` で XSS。`|json_encode_safe`（JSON-LD は `|json_ld`）を使う。属性値には不可
+- ❌ 変更しないコアテンプレートを `app/template/` にコピーして置く → ✅ 写しが upstream の修正を隠す。変えるものだけ置く
+- ❌ prod で `var/runtime/{env}/twig` を消して反映したつもりになる → ✅ 優先されるのは `var/build/{env}/twig`。`eccube:cache:build`
 
 ## 実行・確認方法
 
@@ -105,10 +111,16 @@ QA ツール（PHPUnit / PHPStan / PHP-CS-Fixer）の実行方法は AGENTS.md�
 
 ```bash
 bin/console lint:twig src/Eccube/Resource/template/   # Twig 構文チェック
-bin/console cache:clear                                # テンプレート変更の反映（var/cache/{env} クリア）
+bin/console eccube:cache:build                         # prod: テンプレートを事前コンパイルし直す（var/build/{env}/twig）
+bin/console cache:clear                                # 従来どおり全体を削除（build と cache の双方に書き込み権限が必要）
 ```
 
-- 上書きが効かない／変更が反映されない場合は、まず `cache:clear` と上書きパス・名前空間を疑う。
+- コンパイル済みテンプレートの置き場所は環境で異なる。**dev** は `auto_reload` が有効で `var/runtime/{env}/twig` に単層、
+  ファイルを直せばそのまま反映される。**prod** は `var/build/{env}/twig`（読み取り専用。`eccube:cache:build` が事前コンパイル）を優先し、
+  無いものだけ `var/runtime/{env}/twig` へ実行時にコンパイルする 2 層。**prod でテンプレートを変えたら `eccube:cache:build`**。
+  `var/runtime` 側だけ消しても build 側が優先されるため反映されない。
+- 上書きが効かない／変更が反映されない場合は、まず上記のキャッシュと上書きパス・名前空間を疑う。
+  権限を分離した構成では `cache:clear --no-warmup` を使わない（コンテナが再生成されず Web サーバーが 500 になる。Skill `eccube-permission-lanes`）。
 - `|raw` を追加・改修したら、その値の出所（ユーザー入力か固定か）を必ず確認する。
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,8 +108,15 @@ bin/console eccube:install
 
 #### Web サーバーと CLI の権限を分離した環境
 
-Web サーバー（`www-data`）と CLI（SSH ログインユーザー相当）の書き込み権限を分けた状態を再現するには、
-`docker-compose.permission-lanes.yml` を重ねる。`eccube:doctor:permissions` の動作確認に使う。
+書き込み先を **レーン W**（リクエスト処理中に書く。Web サーバー所有: `var/runtime`・`var/sessions`・`var/log`・`html/upload/**`）と
+**レーン S**（CLI へ移せる。CLI ユーザー所有で Web サーバーは読み取りのみ: `var/build`・`var/cache`・`app/template`・`html/user_data`・
+`app/Plugin`・`app/keystore`・`vendor`・`.env` 等）に分け、Web サーバーへ最小限の書き込み権限しか与えずに運用できる。
+**分離は任意で、既定は分離しない構成。** レーンの判断基準・実行ユーザーの選び方・`eccube:doctor:permissions` の読み方・
+実行時にレーン S へ書かないための実装規約は Skill `eccube-permission-lanes`
+（[`.claude/skills/eccube-permission-lanes/SKILL.md`](./.claude/skills/eccube-permission-lanes/SKILL.md)）。
+本番のパーミッション設定・デプロイ・4.3 からの移行手順の正本は https://doc4.ec-cube.net/permission （ここには書かない）。
+
+分離した状態を再現するには `docker-compose.permission-lanes.yml` を重ねる。
 
 ```bash
 # --build は必須。 公開イメージ (ghcr) には dockerbuild/docker-php-entrypoint のレーン分離が
@@ -121,50 +128,35 @@ curl -s -o /dev/null http://127.0.0.1:8080/   # セッションを生成し Web 
 docker compose exec -u eccube ec-cube bin/console eccube:doctor:permissions
 ```
 
-レーン W（`var/runtime`、`var/sessions`、`var/log`、`html/upload/**`）は `www-data` 所有とし、
-共有グループは作らない。CLI からレーン W を触る操作は Web サーバーのユーザーで実行する。
-本番の `sudo -u www-data` に相当する。
-`app/keystore` はレーン S。秘密鍵はデプロイ成果物で、Web サーバーから書き込めると署名鍵の
-差し替えを許すため読み取りのみとする。分離した構成では Web サーバーが実行時に鍵を生成できないため、
-アクセスを受ける前に `bin/console eccube:keystore:generate` で配置しておく。
+CLI の実行ユーザーは操作対象のレーンで決める（本番の `sudo -u www-data` に相当）。
 
 ```bash
 docker compose exec -u eccube   ec-cube bin/console eccube:cache:build        # レーン S を触る操作
 docker compose exec -u www-data ec-cube bin/console cache:pool:clear --all    # レーン W を触る操作
 ```
 
-`cache:clear` は `var/build` と `var/cache` の双方へ書き込む。3 分割ではどちらもレーン S のため
-CLI ユーザーなら成功する（Web サーバーのユーザーでは失敗する）。ただし `--no-warmup` を付けると
-コンパイル済みコンテナが再生成されず、次のリクエストで Web サーバーが 500 になる。
-コンパイル済みコンテナとテンプレートの再生成は `eccube:cache:build` を使う。
+- 分離した構成は `APP_ENV=prod` 固定（dev はリクエスト処理中にコンテナを再生成するため 500 になる）。
+  アクセスを受ける前に `eccube:cache:build` と `eccube:keystore:generate` を実行しておく。
+- `cache:clear --no-warmup` は使わない（コンパイル済みコンテナが再生成されず Web サーバーが 500 になる）。
+  `eccube:plugin:*` の後は `eccube:cache:build` を別途実行する。
+- 分離すると、レーン S へ書き込む管理画面の機能（プラグイン導入・有効化・無効化・アップデート・削除、
+  ページ/ブロック/メールテンプレート編集、CSS/JS 編集、ファイル管理、セキュリティ管理、テンプレート選択・追加）は
+  動作しなくなる。`ECCUBE_RESTRICT_FILE_UPLOAD=1` を設定すると、これらの画面は**読み取り専用**になり、現在の内容を
+  表示したまま保存・削除だけを無効化して代替の CLI コマンドを案内する（対応表は `app/config/eccube/packages/eccube.yaml` の
+  `eccube_restrict_file_upload_urls`）。未設定（既定）なら従来どおり、画面は動作し保存時に書き込みエラーになる。
+  テンプレートのアップロードは CLI 未整備。
+- 関連する環境変数: `ECCUBE_UMASK`（8 進数。既定は空で OS / PHP-FPM の既定に従う。`0000` で 4.3 以前と同じ
+  0777 / 0666）、`ECCUBE_CLI_LOG_TO_FILE=0`（`var/log` はレーン W のため CLI のログをコンソールへ寄せる）、
+  `ECCUBE_MAINTENANCE_FILE_PATH`（既定はプロジェクトルート直下。分離時は `var/runtime` 配下へ）、
+  `ECCUBE_KEYSTORE_STRICT_PERMISSIONS=1`（鍵を 0700 / 0600 にする。既定は Web サーバーが読めるよう 0755 / 0644）、
+  `ECCUBE_PERMISSION_LANES=1`（Docker イメージのエントリポイントがユーザーを分けるためのスイッチ）。
+  `docker-compose.permission-lanes.yml` では設定済み。
+- 既定モードと分離モードを切り替えるときは `docker compose ... down -v` でレーン W のボリュームを作り直す
+  （切り替え前の `www-data` の uid で作成されたディレクトリが残り、切り替え後の Web サーバーから書き込めなくなる）。
+- この構成は CI でも起動して検証する（`.github/workflows/permission-lanes-test.yml`。Playwright は
+  `permission-lanes-tests` project で `e2e/tests/permission-lanes.spec.ts` だけを実行し、HTTPS `4430` を使う）。
 
-`var/log` はレーン W のため、CLI からはログファイルへ書き込めない。ログの出力に失敗すると本来のエラーが
-ログ書き込みエラーへすり替わるため、分離した構成では `ECCUBE_CLI_LOG_TO_FILE=0` を設定し、CLI のログを
-コンソール出力に寄せる（記録が必要な場合はリダイレクトする）。未設定なら従来どおりファイルへ書く。
-`docker-compose.permission-lanes.yml` では既に設定済み。
-
-アプリケーションが作成するファイルの umask は環境変数 `ECCUBE_UMASK`（8 進数表記）で設定する。
-未設定なら OS / PHP-FPM の既定に従う（推奨）。Web サーバーと CLI が別ユーザーで、かつ双方が同じ
-ファイルへ書き込む必要がある環境では `0000` を設定すると 4.3 以前と同じ挙動（ディレクトリ 0777 /
-ファイル 0666）に戻せるが、同一サーバーの他ユーザーからも書き換え可能になる。
-
-鍵はディレクトリ 0755 / ファイル 0644 で作成する。Web サーバーは署名のために鍵を読む必要があり、
-所有者専用（0700 / 0600）にすると `chgrp` できない環境で読めなくなるため。同一サーバーの他ユーザーからも
-読ませたくない場合は `ECCUBE_KEYSTORE_STRICT_PERMISSIONS=1` を設定する（この場合 Web サーバーへ
-読み取りを許す手当ては運用側で行う。`eccube:keystore:generate` は読めない状態を検出してエラーにする）。
-
-分離すると、`app/template` や `html/user_data`、`.env`、`app/Plugin` へ書き込む管理画面の機能
-（プラグイン導入・有効化・無効化・アップデート・削除、ページ/ブロック/メールテンプレート編集、
-CSS/JS 編集、ファイル管理、セキュリティ管理、テンプレート選択・追加）は動作しなくなる。
-下記の CLI が代替導線になる。テンプレートのアップロードは未整備。
-
-`ECCUBE_RESTRICT_FILE_UPLOAD=1` を設定すると、これらの画面は**読み取り専用**になる。現在の内容は
-表示したまま保存・削除の操作だけを無効化し、画面上に代替の CLI コマンドを案内する。書き込みを伴う
-リクエストはサーバー側で 403 を返すため、UI を経由しない経路も塞がる。対象の一覧は
-`app/config/eccube/packages/eccube.yaml` の `eccube_restrict_file_upload_urls`（ルート名 → CLI コマンド）。
-未設定（既定）なら従来どおり、画面は動作し保存時に書き込みエラーになる。
-
-`apply` / `put` は upsert で冪等。いずれも `--dry-run` / `--format=json` に対応し、
+分離した構成でレーン S を書き換える導線は下記の CLI。`apply` / `put` は upsert で冪等。いずれも `--dry-run` / `--format=json` に対応し、
 `--body=-` で標準入力から本文を読み込む。
 
 | 対象 | サブコマンド | 書き込み先 |
@@ -177,6 +169,7 @@ CSS/JS 編集、ファイル管理、セキュリティ管理、テンプレー�
 | `bin/console eccube:env:*` | `get` / `set` | `.env` |
 | `bin/console eccube:keystore:*` | `list` / `show` / `generate` | `app/keystore/**` |
 | `bin/console eccube:contents:*` | `export` / `import` | `app/contents/*.yaml`（書き出し）／上記の DB とファイル（取り込み） |
+| `bin/console eccube:plugin:*` | `install` / `enable` / `disable` / `uninstall` / `update` / `schema-update` | `app/Plugin` / `app/proxy` / `vendor` |
 
 ```bash
 bin/console eccube:page:list
@@ -192,7 +185,7 @@ bin/console eccube:keystore:generate      # 未生成の鍵だけを作る（冪
 ページ・ブロック・メールテンプレートの入力値の検証は管理画面と同じ FormType を通すため、
 重複チェックや twig の構文チェックも同じものが効く。
 `apply` / `remove` は build ディレクトリへ書き込めない場合、本処理を完了させたうえで終了コード `3` と
-`eccube:cache:build` の案内を返す。
+`eccube:cache:build` の案内を返す（`3` = 完了したが手動操作が必要。`eccube:plugin:*` / `eccube:cache:build` / `eccube:env:set` も同じ）。
 
 `html/` はドキュメントルートのため、`eccube:user-data:put` は管理画面のファイル管理と同じ
 ファイル名・拡張子の検証（`eccube_file_uploadable_extensions`）を通す。`.php` 等は配置できない。
@@ -234,14 +227,6 @@ app/contents/
   削除可能なブロック・メールテンプレート、どのページからも参照されていないレイアウトだけ
 - `html/user_data` は `customize.css` / `customize.js` 以外が `.gitignore` で除外されているため
   既定では扱わない。リポジトリ丸ごと管理する構成では `--include=user_data` を指定する
-
-既定モードと分離モードを切り替えるときはレーン W のボリュームを作り直す。切り替え前の `www-data` の
-uid で作成されたディレクトリが残り、切り替え後の Web サーバーから書き込めなくなる
-（例: `var/runtime/{env}/mcp-sessions`）。
-
-```bash
-docker compose ... down -v
-```
 
 ### テスト
 
@@ -288,12 +273,14 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose
 キャッシュは 3 つのディレクトリに分かれる。`var/build/{env}`（コンパイル済みコンテナ・ルーティング・
 メタデータ・prod の twig）と `var/cache/{env}`（翻訳カタログ・htmlpurifier）は CLI が生成し、
 リクエスト処理中は読み取りのみ。`var/runtime/{env}`（cache pool・mcp-sessions・事前コンパイル漏れの
-twig のフォールバック等）はリクエスト処理中に生成される。
+twig のフォールバック等）はリクエスト処理中に生成される。prod は `var/build/{env}/twig` を読み取り専用で
+優先するため、**prod でテンプレートを変えたら `eccube:cache:build`**（dev は `auto_reload` で自動反映）。
+権限を分離した環境での使い分けは上記「権限を分離した環境」と Skill `eccube-permission-lanes`。
 
 ```bash
-bin/console eccube:cache:build   # var/build を再生成（テンプレートの事前コンパイルを含む）
+bin/console eccube:cache:build   # var/build を再生成（テンプレートの事前コンパイルを含む）。デプロイ後・プラグイン操作後にも実行する
 bin/console cache:pool:clear --all   # 実行時キャッシュ（cache pool）を削除
-bin/console cache:clear          # 従来どおり全体を削除（build と cache の双方に書き込み権限が必要）
+bin/console cache:clear          # 従来どおり全体を削除（build と cache の双方に書き込み権限が必要。--no-warmup は付けない）
 
 # スキーマは Entity 属性が源泉。アップデートは 2 段構え:
 bin/console doctrine:schema:update --dump-sql        # 属性差分の SQL プレビュー
@@ -385,6 +372,7 @@ frontmatter の `description` がトリガ条件で、該当レイヤを触る�
 | カスタマイズ（app/Customize での拡張・上書き・デコレーション） | [`.claude/skills/eccube-customize/SKILL.md`](./.claude/skills/eccube-customize/SKILL.md) | `eccube-customize` |
 | CSV 入出力（CsvImport/Export・CSV 定義） | [`.claude/skills/eccube-csv/SKILL.md`](./.claude/skills/eccube-csv/SKILL.md) | `eccube-csv` |
 | コンソールコマンド（Symfony Console・バッチ） | [`.claude/skills/eccube-command/SKILL.md`](./.claude/skills/eccube-command/SKILL.md) | `eccube-command` |
+| 権限レーン（Web サーバー / CLI の書き込み分離・`eccube:doctor:permissions`・実行ユーザー） | [`.claude/skills/eccube-permission-lanes/SKILL.md`](./.claude/skills/eccube-permission-lanes/SKILL.md) | `eccube-permission-lanes` |
 | 責務分離レビュー（実装直後の自己チェック・全層） | [`.claude/skills/eccube-review-responsibility/SKILL.md`](./.claude/skills/eccube-review-responsibility/SKILL.md) | `eccube-review-responsibility` |
 
 > 規約は必要になった時点で `.claude/skills/eccube-<name>/SKILL.md` を 1 ファイル追加して足す（`.codex`/`.agents` は symlink で自動共有）。

--- a/llms.txt
+++ b/llms.txt
@@ -167,12 +167,72 @@ bin/console cache:pool:clear --all  # Clear the runtime cache pools
 bin/console cache:clear             # Clear everything (needs write access to build and cache)
 ```
 
+In production the compiled container and the precompiled templates live in `var/build/{env}`
+and are read-only at request time, so run `eccube:cache:build` after deploying or changing
+templates. Never use `cache:clear --no-warmup` on a host where the web server cannot write to
+`var/build`: the container is not rebuilt and the next request fails with 500.
+
+### Permission Lanes
+
+EC-CUBE can run with the web server holding write access to only a small part of the tree.
+Every path the application writes to belongs to one of two lanes:
+
+- **Lane W** (owned by the web server, written during requests): `var/runtime/{env}`,
+  `var/sessions/{env}`, `var/log`, `html/upload/**` and the maintenance file
+  (`ECCUBE_MAINTENANCE_FILE_PATH`).
+- **Lane S** (owned by the CLI / SSH user, read-only for the web server): `var/build`,
+  `var/cache`, `app/template`, `html/user_data`, `app/Plugin`, `app/PluginData`, `app/proxy`,
+  `html/plugin`, `vendor`, `composer.json`, `composer.lock`, `app/keystore` and `.env`.
+
+Separating the lanes is **optional**; the default setup keeps a single user. The lane
+definitions live in `src/Eccube/Service/Permission/PermissionRequirementProvider.php`, and the
+rule for new code is simple: nothing that runs during a request may write to lane S. Runtime
+files go under `eccube_runtime_dir`; anything that changes lane S is a console command.
+
+`bin/console eccube:doctor:permissions` compares the expected lanes with the actual owners and
+modes and prints what to fix. The verdict is an estimate from uid, gid and permission bits
+(supplementary groups, ACLs and SELinux are not considered); the web server's uid is measured
+from files only the web server creates (session files first), so hit the site once before
+running it. Exit codes: `0` no NG, `1` at least one NG, `2` invalid option — WARN never
+changes the exit code, so a CI check should also assert `.web_server != null` and
+`.cli.uid != .web_server.uid` on the `--format=json` output.
+
+Pick the user from the lane you are touching: lane S commands (`eccube:cache:build`,
+`eccube:page:apply`, `eccube:plugin:*`, `eccube:env:set`, `eccube:keystore:generate`) run as
+the CLI user; lane W maintenance (`cache:pool:clear --all`) runs as the web server user
+(`sudo -u www-data bin/console ...`). Run `eccube:cache:build` after any `eccube:plugin:*`
+command — a running process cannot rebuild its own compiled container. A separated setup runs
+with `APP_ENV=prod`; in `dev` the kernel rebuilds the container during requests and needs write
+access to `var/cache` and `var/build`.
+
+Related environment variables: `ECCUBE_UMASK` (octal; empty by default so the OS / PHP-FPM
+umask applies, `0000` restores the 4.3 behaviour of 0777 / 0666), `ECCUBE_CLI_LOG_TO_FILE=0`
+(`var/log` is lane W, so CLI logging goes to the console), `ECCUBE_MAINTENANCE_FILE_PATH`
+(move it under `var/runtime` when separating), `ECCUBE_KEYSTORE_STRICT_PERMISSIONS=1`
+(0700 / 0600 keys; the default 0755 / 0644 lets the web server read them on hosts where the
+deploy user cannot `chgrp`) and `ECCUBE_PERMISSION_LANES=1` (switch for the Docker image
+entrypoint). `docker-compose.permission-lanes.yml` reproduces the separated setup locally
+(`--build` is required, and a PostgreSQL or MySQL service must be added).
+
+CI starts the separated setup and verifies it
+(`.github/workflows/permission-lanes-test.yml`): the lane boundaries, the
+`eccube:doctor:permissions` verdict, the read-only responses, and installing a plugin from the
+CLI. Behaviour that only shows up when the web server and the CLI have different uids and the
+app runs behind Apache (mod_php) — an environment variable missing from `PassEnv` reaching the
+CLI but not the web server, for instance — cannot be caught by unit tests. That setup pins
+`APP_ENV=prod`, whose session cookie uses `SameSite=None`, so the admin is unreachable over
+plain HTTP; the job talks to the self-signed HTTPS port (`4430`) instead. The operational
+guide (production permissions, deployment, upgrading from 4.3) is at
+https://doc4.ec-cube.net/permission .
+
 ### Content Management
 
 Pages, blocks and mail templates pair a database record with a Twig file, so they are managed
 through dedicated commands rather than by copying files. The same commands are the CLI
-alternative for admin screens that write outside the web server's lane. `apply` and `put` are
-idempotent upserts and support `--dry-run` and `--format=json`; `--body=-` reads from stdin.
+alternative for admin screens that write to lane S (see *Permission Lanes*). `apply` and `put`
+are idempotent upserts and support `--dry-run` and `--format=json`; `--body=-` reads from
+stdin. Exit code `3` means the change was applied but a manual step remains — typically
+`eccube:cache:build`, because the build directory is not writable by the current user.
 
 `eccube:page:*` and `eccube:block:*` provide `list`, `show`, `apply` and `remove`;
 `eccube:mail-template:*` provides `list`, `show`, `apply` and `remove`;


### PR DESCRIPTION
## 概要

#7072 Phase 7a。Web サーバーと CLI の書き込み権限を分離した構成（レーン W / レーン S）について、AI エージェント向けの Skill を新設し、`AGENTS.md` / `llms.txt` と既存 Skill を Phase 1〜6 の最終状態へ揃えます。ドキュメントのみの変更で、コードには触れていません。

Phase 7b（doc4.ec-cube.net）は別リポジトリのため別 PR にします。

## 方針

- **`AGENTS.md` は要約に留め、判断基準は Skill へ、運用手順は doc4 へ**（#7072 の受入基準「運用手順の正本は doc4、`AGENTS.md` は開発時に必要な要約」）。`AGENTS.md` の「権限を分離した環境」節は Phase ごとに追記されて 95 行まで伸び、keystore のパーミッションや umask の互換性など運用寄りの説明が混ざっていました。再現環境の起動・実行ユーザーの使い分け・CLI の一覧・環境変数の一覧に絞り、根拠と判断基準は Skill `eccube-permission-lanes` に移しています。落とした記述はすべて Skill 側に残しています（共有グループを作らない理由、keystore を 0755 / 0644 にする理由、`ECCUBE_CLI_LOG_TO_FILE` の理由、`down -v` が要る理由）。
- **Skill は `src/Eccube/` の実コードで裏取り**。レーンの一覧は `PermissionRequirementProvider::webLane()` / `sshLane()`、判定メッセージは `PermissionDiagnostic`、終了コードと入出力の作法は `ContentCommandTrait` / `PluginCommandTrait` / `CacheBuildCommand` / `EnvSetCommand`、DB とファイルを対で扱う手順は `PageContentService::save()` / `TemplateRemovalTrait` / `TemplateBodyTrait` から起こしています。
- **「よくある間違い」の上限（10 項）を守る**。`eccube-customize` は既に 10 項だったため、`#[EntityExtension]` と proxy 再生成の 2 項を統合して 1 項を足しています。`eccube-command` / `eccube-plugin` / `eccube-twig-template` は 10 項ちょうど、新設の `eccube-permission-lanes` も 10 項です。
- **`eccube-plugin` の誤記を修正**。「無効化はコンソールコマンドが無く、管理画面から行う」とありましたが `eccube:plugin:disable` は存在します（`src/Eccube/Command/PluginDisableCommand.php`）。

## 変更内容

| ファイル | 内容 |
|---|---|
| `.claude/skills/eccube-permission-lanes/SKILL.md`（新設） | レーンの判断基準、実行時にレーン S へ書かないための実装規約、CLI の実行ユーザーの選び方、`eccube:doctor:permissions` の判定と対処の対応表、キャッシュの 3 分割とテンプレート更新後の操作、よくある間違い、確認方法 |
| `AGENTS.md` | Skill 索引へ 1 行追加。「権限を分離した環境」節を要約へ書き換え。`eccube:contents:*` 節の末尾に紛れていた `down -v` の段落を権限分離節へ移動。「キャッシュ / データベース」節に prod でのテンプレート更新手順（`eccube:cache:build`）を追記。CLI 一覧に `eccube:plugin:*` を追加 |
| `llms.txt` | `Permission Lanes` 節を追加（レーン・診断・実行ユーザー・環境変数・CI）。Cache / Content Management を追従 |
| `eccube-command` | 終了コード `0` / `1` / `2` / `3` の意味を固定（`3` = 完了したが手動操作が必要）。`apply` / `--dry-run` / `--format=json` / 標準入力の作法（`ContentCommandTrait`）。子プロセスで `bin/console` を実行するときの cwd と timeout |
| `eccube-service` | DB レコードとファイルを対で扱う Service の書き方（トランザクション内で DB → ファイル、削除は退避 → DB → 退避ファイル、本文が同じなら書き出さない、検証は FormType の submit） |
| `eccube-twig-template` | `var/build/{env}/twig` と `var/runtime/{env}/twig` の 2 層構成と prod でのテンプレート更新手順。変更しないテンプレートを `app/template` に置かないこと |
| `eccube-plugin` | 分離した構成では `eccube:plugin:*` が正であること、操作後の `eccube:cache:build`、`app/PluginData` へ実行時に書かないこと。`eccube:plugin:disable` の誤記を修正 |
| `eccube-customize` | `app/Customize` から実行時にレーン S へ書き込まないこと |

## 実装に関する補足

- `AGENTS.md` と `llms.txt` には、#7124（Phase 6）が追加する CI ジョブ `permission-lanes-test` の記述を含めています。**#7124 のマージ後にこの PR をマージする前提**です。#7124 が同じ節に段落を足すため、マージ順が逆になると `AGENTS.md` / `llms.txt` で衝突しますが、その場合は本 PR 側の記述を採ればよい状態にしてあります。
- `ECCUBE_PERMISSION_LANES` はアプリケーションの `.env` ではなく Docker イメージのエントリポイント（`dockerbuild/docker-php-entrypoint`）のスイッチです。`AGENTS.md` / `llms.txt` ではそのように書き分けています。doc4 の `dotenv.md` に載せるときも同じ扱いにします。
- `.codex/skills` / `.agents/skills` は `.claude/skills` への symlink のため、新設 Skill は同期作業なしで共有されます。

## テスト

- 各 Skill の「よくある間違い」の項数・字数を `AGENTS.md` 記載のスクリプトで確認（すべて 10 項以内）
- Skill 本文の記述はすべて `src/Eccube/` の実コードと突き合わせ（`PermissionRequirementProvider` / `PermissionDiagnostic` / `DoctorPermissionsCommand` / `ContentCommandTrait` / `PluginCommandTrait` / `CacheBuildCommand` / `EnvSetCommand` / `CacheUtil` / `RuntimeCacheDirPass` / `PageContentService` / `TemplateRemovalTrait` / `TemplateBodyTrait` / `WebServerUserResolver` / `eccube.yaml`）
- Claude Code が新設 Skill を認識することを確認（Skill 一覧に `eccube-permission-lanes` が現れる）
- コード変更なし。CI のユニットテスト・静的解析には影響しません

## 相談

- `AGENTS.md` の Skill 索引には `eccube-contributing` が載っていません（本 PR 以前からの漏れ）。本 PR のスコープ外としましたが、必要なら別途足します。

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - コマンドの終了コード、JSON出力、手動対応が必要な場合の運用ルールを整理しました。
  - WebサーバーとCLIの書き込み権限を分離する運用ガイドを追加しました。
  - 本番環境のキャッシュ生成やテンプレート反映手順を更新しました。
  - プラグインの有効化・無効化や、権限分離環境での操作手順を明確化しました。
  - コンテンツ、サービス、Twigテンプレートに関する開発規約を拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->