### PR TITLE
fix(agent-commerce): UCP discovery profile の services / capabilities をエントリの配列で出力する

### DIFF
--- a/src/Eccube/Service/AgentCommerce/Discovery/UcpProfileBuilder.php
+++ b/src/Eccube/Service/AgentCommerce/Discovery/UcpProfileBuilder.php
@@ -24,7 +24,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  * profile.json 構造:
  *   { "ucp": { version, services, payment_handlers, capabilities }, "signing_keys": [JWK...] }
  *
- * - services / capabilities / payment_handlers のキーは reverse-domain.
+ * - services / capabilities / payment_handlers は reverse-domain 名をキーとし、エントリの配列を値とするレジストリ (ucp.json の $defs.base).
  * - endpoint (絶対 URL) はパスをハードコードせず UrlGenerator (RequestContext) から動的生成する.
  * - signing_keys[] は EC 公開鍵 JWK のみ (秘密鍵パラメータ非混入). UcpMessageSigner の戻りをそのまま使う.
  *
@@ -90,7 +90,7 @@ class UcpProfileBuilder
     /**
      * services レジストリを組み立てる. Catalog REST service を常時宣言する.
      *
-     * @return array<string, array<string, mixed>> reverse-domain キーのレジストリ
+     * @return array<string, list<array<string, mixed>>> reverse-domain キーのレジストリ (値は service エントリの配列)
      */
     private function buildServices(): array
     {
@@ -106,9 +106,11 @@ class UcpProfileBuilder
 
         return [
             self::CATALOG_SERVICE_KEY => [
-                'version' => self::UCP_VERSION,
-                'transport' => 'rest',
-                'endpoint' => $endpoint,
+                [
+                    'version' => self::UCP_VERSION,
+                    'transport' => 'rest',
+                    'endpoint' => $endpoint,
+                ],
             ],
         ];
     }
@@ -116,18 +118,22 @@ class UcpProfileBuilder
     /**
      * capabilities レジストリを組み立てる. Catalog の search/lookup を常時宣言する.
      *
-     * @return array<string, array<string, mixed>> reverse-domain キーのレジストリ
+     * @return array<string, list<array<string, mixed>>> reverse-domain キーのレジストリ (値は capability エントリの配列)
      */
     private function buildCapabilities(): array
     {
         return [
             self::CATALOG_SEARCH_CAPABILITY => [
-                'version' => self::UCP_VERSION,
-                'schema' => 'https://ucp.dev/schemas/shopping/catalog_search.json',
+                [
+                    'version' => self::UCP_VERSION,
+                    'schema' => 'https://ucp.dev/schemas/shopping/catalog_search.json',
+                ],
             ],
             self::CATALOG_LOOKUP_CAPABILITY => [
-                'version' => self::UCP_VERSION,
-                'schema' => 'https://ucp.dev/schemas/shopping/catalog_lookup.json',
+                [
+                    'version' => self::UCP_VERSION,
+                    'schema' => 'https://ucp.dev/schemas/shopping/catalog_lookup.json',
+                ],
             ],
         ];
     }

--- a/tests/Eccube/Tests/Web/AgentCommerce/UcpDiscoveryControllerTest.php
+++ b/tests/Eccube/Tests/Web/AgentCommerce/UcpDiscoveryControllerTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
  * 一次仕様 (v2026-04-08, schemas/profile.json) の規範要件を検証する:
  *   - ラッパー = { "ucp": {...} (必須), "signing_keys": [JWK] (任意) }.
  *   - ucp.version は "YYYY-MM-DD" (= 2026-04-08), services / payment_handlers は object 必須.
- *   - services / capabilities / payment_handlers のキーは reverse-domain.
+ *   - services / capabilities / payment_handlers は reverse-domain 名をキーとし、エントリの配列を値とするレジストリ (ucp.json の $defs.base).
  *   - discovery は常時公開 (フラグ無効化なし)・catalog capability / service を常時宣言する.
  *   - signing_keys[] は EC 公開鍵 JWK のみ (秘密鍵パラメータ d/p/q/dp/dq/qi/oth/k 非混入).
  *   - 配信: Cache-Control public, max-age >= 60 (no-store/no-cache/private 禁止), HTTPS 想定・3xx 禁止.
@@ -117,7 +117,8 @@ final class UcpDiscoveryControllerTest extends AbstractWebTestCase
         $this->assertArrayHasKey('dev.ucp.shopping.catalog.lookup', $profile['ucp']['capabilities'], 'When Catalog API is enabled the lookup capability MUST be declared');
 
         $this->assertArrayHasKey('dev.ucp.shopping.catalog', $profile['ucp']['services'], 'When Catalog API is enabled the catalog REST service MUST be declared');
-        $service = $profile['ucp']['services']['dev.ucp.shopping.catalog'];
+        $service = $profile['ucp']['services']['dev.ucp.shopping.catalog'][0] ?? null;
+        $this->assertIsArray($service, 'The catalog service registry value MUST hold at least one entry');
         $this->assertSame('rest', $service['transport'], 'A REST service MUST declare transport "rest"');
         $this->assertArrayHasKey('endpoint', $service, 'A non-embedded service MUST declare an endpoint');
         $this->assertMatchesRegularExpression('#^https?://#', (string) $service['endpoint'], 'The service endpoint MUST be an absolute URL (RequestContext-derived, not a hardcoded path)');
@@ -136,6 +137,26 @@ final class UcpDiscoveryControllerTest extends AbstractWebTestCase
             }
             foreach (array_keys($entries) as $key) {
                 $this->assertMatchesRegularExpression(self::REVERSE_DOMAIN_PATTERN, (string) $key, sprintf('Key "%s" in ucp.%s MUST be a reverse-domain identifier', $key, $registry));
+            }
+        }
+    }
+
+    // --- レジストリの値の形 ------------------------------------------------
+
+    public function testRegistryValuesAreListsOfEntries(): void
+    {
+        // ucp.json の $defs.base は、services / capabilities / payment_handlers の値を
+        // エントリの配列 (JSON array) と定めている. 単一オブジェクトはスキーマ違反になる.
+        $profile = $this->requestProfile();
+
+        foreach (['services', 'capabilities', 'payment_handlers'] as $registry) {
+            $this->assertArrayHasKey($registry, $profile['ucp']);
+            foreach ($profile['ucp'][$registry] as $key => $entries) {
+                $this->assertIsArray($entries, sprintf('ucp.%s.%s MUST be an array of entries', $registry, $key));
+                $this->assertTrue(array_is_list($entries), sprintf('ucp.%s.%s MUST be a JSON array of entries, not a single object', $registry, $key));
+                foreach ($entries as $entry) {
+                    $this->assertIsArray($entry, sprintf('Each entry of ucp.%s.%s MUST be an object', $registry, $key));
+                }
             }
         }
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

UCP discovery profile（`GET /.well-known/ucp`）の `ucp.services` と `ucp.capabilities` が、UCP のスキーマに適合していません。

UCP の `source/schemas/ucp.json` の `$defs.base` は、`services` / `capabilities` / `payment_handlers` を、reverse-domain 名をキーとするレジストリとして定義しています。
レジストリの値は**エントリの配列**です。
この定義は v2026-01-23 以降のすべてのタグ（v2026-01-23、v2026-04-08、v2026-08-25）と `main` で同一です[^v20260111]。

一方、`UcpProfileBuilder` の `buildServices()` と `buildCapabilities()` は、値を単一オブジェクトとして出力しています。
そのため、スキーマを検証する UCP クライアントは、このプロファイルを拒否します。
たとえば Shopify の `ucp` CLI（0.8.0）で `ucp discover --business https://demo.ec-cube.net --format json` を実行すると、次の 3 か所で `PROFILE_SCHEMA_INVALID … expected array, received object` になります。

- `ucp.services.dev.ucp.shopping.catalog`
- `ucp.capabilities.dev.ucp.shopping.catalog.search`
- `ucp.capabilities.dev.ucp.shopping.catalog.lookup`

公式スキーマ（v2026-08-25 の `profile.json#/$defs/business_schema` と、v2026-04-08 の `ucp.json#/$defs/business_schema`）で検証しても、同じ 3 か所が `must be array` になります。

[^v20260111]: v2026-01-11 では形が異なり、`services` は単一オブジェクトを値とするマップ、`capabilities` はフラットな配列でした。

## 方針(Policy)

- `services` と `capabilities` の各値を、エントリ 1 件の配列で包みます。
  エントリの中身（`version` / `transport` / `endpoint` / `schema`）は変えません。
- `payment_handlers` は、`UcpPaymentHandlerDiscoveryRegistry` がすでに配列で出力しているため、変更しません。
- `UCP_VERSION`（`2026-04-08`）は変えません。
  バージョンの更新は、この PR の対象外です。

## 実装に関する補足(Appendix)

- `UcpProfileBuilder::buildServices()` と `buildCapabilities()` の値をエントリの配列にし、`@return` を `array<string, list<array<string, mixed>>>` に改めました。
  クラスの docblock にも、値がエントリの配列であることを追記しました。
- 変更したのは private メソッドだけで、public なシグネチャは変わりません。
- `UcpDiscoveryController::normalizeForJson()` は空のレジストリを `{}` にするだけで、値の形には依存しないため、変更していません。
- `src/`、`tests/`、`e2e/` を検索しましたが、プロファイルの `services` / `capabilities` のエントリを読むコードは、ほかにありませんでした。
  `e2e/agent/acp-checkout.php` は、`ucp.capabilities` があることだけを確認しています。

## テスト（Test)

- `UcpDiscoveryControllerTest` を次のように変更しました。
  - `testRegistryValuesAreListsOfEntries` を追加しました。
    配信されたプロファイルの `services` / `capabilities` / `payment_handlers` のすべての値が、エントリの配列（`array_is_list`）であることを確認します。
  - `testCatalogCapabilityAndServiceAlwaysDeclared` は、catalog service の先頭エントリを読むように改めました。
- 修正前の `UcpProfileBuilder` でテストを実行し、この 2 件が失敗することを確認しました。
  新しいテストの失敗メッセージは `ucp.services.dev.ucp.shopping.catalog MUST be a JSON array of entries, not a single object` です。
  修正後は、どちらも通ります。
- PHP 8.4 と SQLite で実行した結果は次のとおりです。
  - `UcpDiscoveryControllerTest` と `UcpDiscoveryConformanceTest`：`Tests: 16, Assertions: 77, Incomplete: 2`（Incomplete の 2 件は既存の `markTestIncomplete`）
  - `tests/Eccube/Tests/Web/AgentCommerce`：`OK (49 tests, 209 assertions)`
  - `tests/Eccube/Tests/Service/AgentCommerce`：`Tests: 324, Assertions: 1193, Skipped: 3, Incomplete: 13`
  - `php-cs-fixer fix --dry-run --diff`（変更した 2 ファイル）：`Found 0 of 2 files that can be fixed`
  - `phpstan analyse`（変更した 2 ファイル）：`[OK] No errors`
- テストスイート全体は、ローカルでは実行していません。
- アプリをローカルで起動し、`GET /.well-known/ucp` の本文を、概要と同じ 2 つの公式スキーマで検証しました。
  - 修正前：どちらのスキーマでも INVALID です。概要に挙げた 3 か所が `must be array` になります。
  - 修正後：どちらのスキーマでも VALID です。

## 相談（Discussion）

特になし

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません（4.4 は未リリースで、discovery profile を UCP の仕様どおりの形に直す修正です）
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません（変更したのは private メソッドだけです）
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - UCPディスカバリープロファイルのサービス、機能、決済ハンドラー情報を、各キーに対するエントリー配列として統一しました。
  - カタログサービスや機能情報を、複数エントリーに対応した形式で取得できるようになりました。

- **テスト**
  - 各レジストリの値がエントリー配列として提供されることを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->